### PR TITLE
fix parsing of feeds that include unicode characters

### DIFF
--- a/src/azure/__init__.py
+++ b/src/azure/__init__.py
@@ -276,7 +276,7 @@ def _convert_response_to_feeds(response, convert_func):
         xml_entries = _get_children_from_path(xmldoc, 'entry') #in some cases, response contains only entry but no feed
     for xml_entry in xml_entries:
         new_node = _clone_node_with_namespaces(xml_entry, xmldoc)
-        feeds.append(convert_func(new_node.toxml()))
+        feeds.append(convert_func(new_node.toxml('utf-8')))
 
     return feeds
 


### PR DESCRIPTION
Note that I haven't tested this extensively... I've pretty much only tried it with the simple case below:

```
# -*- coding: utf-8 -*-
import azure
from azure.storage import TableService
ts = TableService('<ACCOUNT>', '<KEY>')
ts.create_table('test')
try: ts.insert_entity('test', {'PartitionKey': 'test', 'RowKey': 'test', 'Description': 'ꀕ'})
except azure.WindowsAzureConflictError: pass
print ts.get_entity('test', 'test', 'test').Description
for e in ts.query_entities('test', "PartitionKey eq 'test'"):
    print e.Description # blows up with encoding error
```
