### PR TITLE
Fix capitalization in the 'Fingerprint' tag for XML of serialization of SSH keys configuration

### DIFF
--- a/src/azure/servicemanagement/__init__.py
+++ b/src/azure/servicemanagement/__init__.py
@@ -880,14 +880,14 @@ class _XmlSerializer(object):
             xml += '<PublicKeys>'
             for key in configuration.ssh.public_keys:
                 xml += '<PublicKey>'
-                xml += _XmlSerializer.data_to_xml([('FingerPrint', key.finger_print),
+                xml += _XmlSerializer.data_to_xml([('Fingerprint', key.finger_print),
                                                    ('Path', key.path)])
                 xml += '</PublicKey>'
             xml += '</PublicKeys>'
             xml += '<KeyPairs>'
             for key in configuration.ssh.key_pairs:
                 xml += '<KeyPair>'
-                xml += _XmlSerializer.data_to_xml([('FingerPrint', key.finger_print),
+                xml += _XmlSerializer.data_to_xml([('Fingerprint', key.finger_print),
                                                    ('Path', key.path)])
                 xml += '</KeyPair>'
             xml += '</KeyPairs>'


### PR DESCRIPTION
There seem to be capitalization typo for the `<Fingerprint/>` tag of the SSH keys config serialization.

Apparently there is no test for this part of the SDK so I did not update the tests.

However I am not sure whether the error is in the Python SDK or on the server side as the [documentation of the API](http://msdn.microsoft.com/en-us/library/windowsazure/jj157194.aspx) has the same typo.

Without my fix I get a BadRequest complaining about empty or null fingerprint similar to the one reported by this user:

http://social.msdn.microsoft.com/Forums/en-US/WAVirtualMachinesforWindows/thread/8cc8210c-cff2-42b8-a68c-f9df3116e7b2
