### PR TITLE
updating X_MS_VERSION to 2012-02-12

### DIFF
--- a/src/azure/storage/__init__.py
+++ b/src/azure/storage/__init__.py
@@ -37,7 +37,7 @@ from azure import (WindowsAzureData,
                    )
 
 #x-ms-version for storage service.
-X_MS_VERSION = '2011-08-18'
+X_MS_VERSION = '2012-02-12'
 
 class EnumResultsBase:
     ''' base class for EnumResults. '''


### PR DESCRIPTION
This enables cross account blob copy, which is prohibited by the 2011-08-18 version.
