### PR TITLE
Fix redirection so query strings are not added multiple times

### DIFF
--- a/azure/http/httpclient.py
+++ b/azure/http/httpclient.py
@@ -212,8 +212,6 @@ class _HTTPClient(object):
                 new_url = urlparse(dict(headers)['location'])
                 request.host = new_url.hostname
                 request.path = new_url.path
-                if new_url.query:
-                    request.path += '?' + new_url.query
                 request.path, request.query = _update_request_uri_query(request)
                 return self.perform_request(request)
             if self.status >= 300:


### PR DESCRIPTION
The previous fix caused the query string to be appended twice when a redirection happens. This fixes the problem.
