### PR TITLE
Add CreationTime in StorageAccountProperties

### DIFF
--- a/azure/servicemanagement/__init__.py
+++ b/azure/servicemanagement/__init__.py
@@ -81,6 +81,7 @@ class StorageAccountProperties(WindowsAzureData):
         self.geo_secondary_region = u''
         self.status_of_secondary = u''
         self.last_geo_failover_time = u''
+        self.creation_time = u''
 
 
 class StorageServiceKeys(WindowsAzureData):


### PR DESCRIPTION
CreationTime is available from 2012-03-01 version of the RestAPI:
http://msdn.microsoft.com/en-us/library/azure/gg592580.aspx

Storage properties documentation:
http://msdn.microsoft.com/en-us/library/azure/ee460802.aspx
