### PR TITLE
Sql Databases Management Service list commands

### DIFF
--- a/azure/__init__.py
+++ b/azure/__init__.py
@@ -675,6 +675,13 @@ def _parse_response(response, return_type):
     '''
     return _parse_response_body_from_xml_text(response.body, return_type)
 
+def _parse_service_resources_response(response, return_type):
+    '''
+    Parse the HTTPResponse's body and fill all the data into a class of
+    return_type.
+    '''
+    return _parse_response_body_from_service_resources_xml_text(response.body, return_type)
+
 
 def _fill_data_to_return_object(node, return_obj):
     members = dict(vars(return_obj))
@@ -742,6 +749,18 @@ def _parse_response_body_from_xml_text(respbody, return_type):
 
     return return_obj
 
+def _parse_response_body_from_service_resources_xml_text(respbody, return_type):
+    '''
+    parse the xml and fill all the data into a class of return_type
+    '''
+    doc = minidom.parseString(respbody)
+    return_obj = _list_of(return_type)
+    for node in _get_children_from_path(doc, "ServiceResources", "ServiceResource"):
+        local_obj = return_type()
+        _fill_data_to_return_object(node, local_obj)
+        return_obj.append(local_obj)
+
+    return return_obj
 
 class _dict_of(dict):
 

--- a/azure/servicemanagement/__init__.py
+++ b/azure/servicemanagement/__init__.py
@@ -1019,7 +1019,46 @@ class HostNameSslState(WindowsAzureData):
     def __init__(self):
         self.name = u''
         self.ssl_state = u''
+
+class Servers(WindowsAzureData):
+
+    def __init__(self):
+        self.server = _list_of(Server)
+
+    def __iter__(self):
+        return iter(self.server)
+
+    def __len__(self):
+        return len(self.server)
+
+    def __getitem__(self, index):
+        return self.server[index]
     
+class Server(WindowsAzureData):
+    
+    def __init__(self):
+        self.name = u''
+        self.administrator_login = u''
+        self.location = u''
+        self.fully_qualified_domain_name = u''
+        self.version = u''
+        
+class Database(WindowsAzureData):
+
+    def __init__(self):
+        self.name = u''
+        self.type = u''
+        self.state = u''
+        self.self_link = u''
+        self.parent_link = u''
+        self.id = 0
+        self.edition = u''
+        self.collation_name = u''
+        self.creation_date = u''
+        self.is_federation_root = False
+        self.is_system_object = False
+        self.max_size_bytes = 0
+
 
 def _update_management_header(request):
     ''' Add additional headers for management. '''

--- a/azure/servicemanagement/sqldatabasemanagementservice.py
+++ b/azure/servicemanagement/sqldatabasemanagementservice.py
@@ -1,0 +1,64 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#--------------------------------------------------------------------------
+from azure import (
+    MANAGEMENT_HOST,
+    _parse_service_resources_response,
+    )
+from azure.servicemanagement import (
+    Servers,
+    Database,
+    )
+from azure.servicemanagement.servicemanagementclient import (
+    _ServiceManagementClient,
+    )
+
+class SqlDatabaseManagementService(_ServiceManagementClient):
+    ''' Note that this class is a preliminary work on SQL Database
+        management. Since it lack a lot a features, final version
+        can be slightly different from the current one.
+    '''
+
+    def __init__(self, subscription_id=None, cert_file=None,
+                 host=MANAGEMENT_HOST):
+        super(SqlDatabaseManagementService, self).__init__(
+            subscription_id, cert_file, host)
+
+    #--Operations for sql servers ----------------------------------------
+    def list_servers(self):
+        '''
+        List the SQL servers defined on the account.
+        '''
+        return self._perform_get(self._get_list_servers_path(),
+                                 Servers)
+
+    #--Operations for sql databases ----------------------------------------
+    def list_databases(self, name):
+        '''
+        List the SQL databases defined on the specified server name
+        '''
+        response = self._perform_get(self._get_list_databases_path(name),
+                                     None)
+        return _parse_service_resources_response(response, Database)
+
+
+    #--Helper functions --------------------------------------------------
+    def _get_list_servers_path(self):
+        return self._get_path('services/sqlservers/servers', None)
+
+    def _get_list_databases_path(self, name):
+        # *contentview=generic is mandatory*
+        return self._get_path('services/sqlservers/servers/',
+                              name) + '/databases?contentview=generic' 
+    

--- a/tests/test_sqldatabasemanagementservice.py
+++ b/tests/test_sqldatabasemanagementservice.py
@@ -1,0 +1,68 @@
+# coding: utf-8
+
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#--------------------------------------------------------------------------
+
+from azure.servicemanagement.sqldatabasemanagementservice import (
+    SqlDatabaseManagementService,
+    )
+
+from azure.servicemanagement import (
+    Servers,
+    Server,
+    Database,
+    )
+
+from .util import (
+    AzureTestCase,
+    credentials,
+    set_service_options,
+    )
+import unittest
+
+class SqlDatabaseServiceTest(AzureTestCase):
+
+    def setUp(self):
+        self.sqlms = SqlDatabaseManagementService(credentials.getSubscriptionId(),
+                                                  credentials.getManagementCertFile())
+        set_service_options(self.sqlms)
+
+    def tearDown(self):
+        self.cleanup()
+        return super(SqlDatabaseServiceTest, self).tearDown()
+
+    def cleanup(self):
+        pass # No clean needed by now
+    
+    def test_list_servers(self):
+        result = self.sqlms.list_servers()
+        
+        # Assert
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, Servers)
+        
+        for server in result:
+            self.assertIsInstance(server, Server)
+
+    @unittest.skip        
+    def test_list_databases(self):
+        result = self.sqlms.list_databases("TODO")
+        
+        # Assert
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, list)
+        
+        for db in result:
+            self.assertIsInstance(db, Database)


### PR DESCRIPTION
Create a SQL Database Service Management class

2 operations for now:
- list_servers : http://msdn.microsoft.com/en-us/library/azure/dn505702.aspx
- list_databases : http://msdn.microsoft.com/en-us/library/azure/dn505711.aspx

This commit adds a new parser for `ServiceResources` xml format used in SQL REST API with the method `_parse_service_resources_response`

Usage template:

``` python
response = self._perform_get(self._get_list_databases_path(name), None)
return _parse_service_resources_response(response, Database)
```

This can be used  to implement all remaining SQL REST API command
