### PR TITLE
Change queue service to automatically base-64 encode all messages that a...

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,9 @@ It is then possible to call the **get\_messages** method, process the message an
 from azure.storage import QueueService
 queue_service = QueueService(account_name, account_key)
 messages = queue_service.get_messages('taskqueue')
-queue_service.delete_message('taskqueue', messages[0].message_id, messages[0].pop_receipt)
+for message in messages:
+    print(message.as_text())
+    queue_service.delete_message('taskqueue', message.message_id, message.pop_receipt)
 ```
 
 ## ServiceBus Queues

--- a/azure/storage/__init__.py
+++ b/azure/storage/__init__.py
@@ -35,6 +35,7 @@ from azure import (WindowsAzureData,
                    _get_entry_properties,
                    _general_error_handler,
                    _list_of,
+                   _parse_response,
                    _parse_response_for_dict,
                    _unicode_type,
                    _ERROR_CANNOT_SERIALIZE_VALUE_TO_ENTITY,
@@ -354,8 +355,14 @@ class QueueMessage(WindowsAzureData):
         self.pop_receipt = u''
         self.time_next_visible = u''
         self.dequeue_count = u''
-        self.message_text = u''
+        self.message_text = u'' # temp storage for xml deserialization support
+        self.raw_string = u''
 
+    def as_text(self):
+        return _decode_base64_to_text(self.raw_string)
+
+    def as_bytes(self):
+        return _decode_base64_to_bytes(self.raw_string)
 
 class Entity(WindowsAzureData):
 
@@ -401,6 +408,20 @@ def _parse_blob_enum_results_list(response):
                 setattr(return_obj, name, value)
 
     return return_obj
+
+
+def _parse_queue_msg_list(response):
+    messages = _parse_response(response, QueueMessagesList)
+    for msg in messages:
+        msg.raw_string = msg.message_text
+        del msg.message_text
+
+    return messages
+
+
+def _create_queue_msg_xml(message):
+    xml = '<?xml version="1.0" encoding="utf-8"?><QueueMessage><MessageText>{0}</MessageText></QueueMessage>'
+    return xml.format(_encode_base64(message))
 
 
 def _update_storage_header(request):

--- a/tests/test_queueservice.py
+++ b/tests/test_queueservice.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
+import os
 import unittest
 
 from azure import WindowsAzureError
@@ -242,12 +243,26 @@ class QueueServiceTest(AzureTestCase):
         message = result[0]
         self.assertIsNotNone(message)
         self.assertNotEqual('', message.message_id)
-        self.assertEqual('message1', message.message_text)
+        self.assertEqual('message1', message.as_text())
         self.assertNotEqual('', message.pop_receipt)
         self.assertEqual('1', message.dequeue_count)
         self.assertNotEqual('', message.insertion_time)
         self.assertNotEqual('', message.expiration_time)
         self.assertNotEqual('', message.time_next_visible)
+
+    def test_get_messages_binary(self):
+        # Action
+        data = os.urandom(2048)
+        self.qs.put_message(self.test_queues[1], data)
+        result = self.qs.get_messages(self.test_queues[1])
+
+        # Asserts
+        self.assertIsNotNone(result)
+        self.assertEqual(1, len(result))
+        message = result[0]
+        self.assertIsNotNone(message)
+        self.assertNotEqual('', message.message_id)
+        self.assertEqual(data, message.as_bytes())
 
     def test_get_messages_with_options(self):
         # Action
@@ -265,7 +280,8 @@ class QueueServiceTest(AzureTestCase):
         for message in result:
             self.assertIsNotNone(message)
             self.assertNotEqual('', message.message_id)
-            self.assertNotEqual('', message.message_text)
+            self.assertNotEqual('', message.raw_string)
+            self.assertNotEqual('', message.as_text())
             self.assertNotEqual('', message.pop_receipt)
             self.assertEqual('1', message.dequeue_count)
             self.assertNotEqual('', message.insertion_time)
@@ -286,12 +302,27 @@ class QueueServiceTest(AzureTestCase):
         message = result[0]
         self.assertIsNotNone(message)
         self.assertNotEqual('', message.message_id)
-        self.assertNotEqual('', message.message_text)
+        self.assertNotEqual('', message.raw_string)
+        self.assertNotEqual('', message.as_text())
         self.assertEqual('', message.pop_receipt)
         self.assertEqual('0', message.dequeue_count)
         self.assertNotEqual('', message.insertion_time)
         self.assertNotEqual('', message.expiration_time)
         self.assertEqual('', message.time_next_visible)
+
+    def test_peek_messages_binary(self):
+        # Action
+        data = os.urandom(2048)
+        self.qs.put_message(self.test_queues[1], data)
+        result = self.qs.peek_messages(self.test_queues[1])
+
+        # Asserts
+        self.assertIsNotNone(result)
+        self.assertEqual(1, len(result))
+        message = result[0]
+        self.assertIsNotNone(message)
+        self.assertNotEqual('', message.message_id)
+        self.assertEqual(data, message.as_bytes())
 
     def test_peek_messages_with_options(self):
         # Action
@@ -307,7 +338,8 @@ class QueueServiceTest(AzureTestCase):
         for message in result:
             self.assertIsNotNone(message)
             self.assertNotEqual('', message.message_id)
-            self.assertNotEqual('', message.message_text)
+            self.assertNotEqual('', message.raw_string)
+            self.assertNotEqual('', message.as_text())
             self.assertEqual('', message.pop_receipt)
             self.assertEqual('0', message.dequeue_count)
             self.assertNotEqual('', message.insertion_time)
@@ -358,7 +390,7 @@ class QueueServiceTest(AzureTestCase):
         message = list_result2[0]
         self.assertIsNotNone(message)
         self.assertNotEqual('', message.message_id)
-        self.assertEqual('new text', message.message_text)
+        self.assertEqual('new text', message.as_text())
         self.assertNotEqual('', message.pop_receipt)
         self.assertEqual('2', message.dequeue_count)
         self.assertNotEqual('', message.insertion_time)
@@ -414,7 +446,7 @@ class QueueServiceTest(AzureTestCase):
         message = result[0]
         self.assertIsNotNone(message)
         self.assertNotEqual('', message.message_id)
-        self.assertEqual(u'message1㚈', message.message_text)
+        self.assertEqual(u'message1㚈', message.as_text())
         self.assertNotEqual('', message.pop_receipt)
         self.assertEqual('1', message.dequeue_count)
         self.assertNotEqual('', message.insertion_time)
@@ -437,7 +469,7 @@ class QueueServiceTest(AzureTestCase):
         message = list_result2[0]
         self.assertIsNotNone(message)
         self.assertNotEqual('', message.message_id)
-        self.assertEqual(u'啊齄丂狛狜', message.message_text)
+        self.assertEqual(u'啊齄丂狛狜', message.as_text())
         self.assertNotEqual('', message.pop_receipt)
         self.assertEqual('2', message.dequeue_count)
         self.assertNotEqual('', message.insertion_time)


### PR DESCRIPTION
...re sent to Azure.  When reading a message from Azure, the unprocessed base-64 message is stored in the raw_string field of the message object.  You can call message.as_text() and message.as_bytes() to decode the value to the desired type.  This is a breaking change!  This is required to achieve parity with the other Azure SDKs (C#, Node.js, etc)

#150 Storage queue service should automatically encode/decode base 64

