### PR TITLE
use iso8601 to parse datetime of azure storage entity

### DIFF
--- a/azure/storage/__init__.py
+++ b/azure/storage/__init__.py
@@ -16,6 +16,7 @@ import hashlib
 import hmac
 import sys
 import types
+import iso8601
 
 from datetime import datetime
 from xml.dom import minidom
@@ -607,12 +608,7 @@ def _from_entity_int(value):
 
 
 def _from_entity_datetime(value):
-    format = '%Y-%m-%dT%H:%M:%S'
-    if '.' in value:
-        format = format + '.%f'
-    if value.endswith('Z'):
-        format = format + 'Z'
-    return datetime.strptime(value, format)
+    return iso8601.parse_date(value)
 
 _ENTITY_TO_PYTHON_CONVERSIONS = {
     'Edm.Binary': _from_entity_binary,

--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,6 @@ setup(name='azure',
                 'azure.http',
                 'azure.servicebus',
                 'azure.storage',
-                'azure.servicemanagement']
+                'azure.servicemanagement'],
+      install_requires=['iso8601']
      )


### PR DESCRIPTION
In docs for [Python 2.7.5](https://docs.python.org/2.7/library/datetime.html#datetime-objects) and [Python 3.4.1](https://docs.python.org/3.4/library/datetime.html#datetime-objects) it is said that

`class datetime.datetime(year, month, day[, hour[, minute[, second[, microsecond[, tzinfo]]]]])`

> `0 <= microsecond < 1000000`
> If an argument outside those ranges is given, _ValueError_ is raised.

The main thing here, is that _microsecond_ shouldn't be greater than 1000000

I was trying to access entities, that were saved into storage by back-end written in C# where DateTime property was set with `DateTime.UtcNow.ToString("o");` value. So the resolution down to 1/10^7 of a second

And with that 1/10^7 of a second, I got _ValueError_:
`ValueError: time data '2014-09-04T22:11:05.5269341Z' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'`

With iso8601 module everything worked like a charm since there is no such limitations for microseconds part.
