### PR TITLE
Service bus doc comments

### DIFF
--- a/azure/servicebus/servicebusservice.py
+++ b/azure/servicebus/servicebusservice.py
@@ -95,8 +95,6 @@ class ServiceBusService(object):
             Instance of authentication class. If this is specified, then
             ACS and SAS parameters are ignored.
         '''
-        # x_ms_version is not used, but the parameter is kept for backwards
-        # compatibility
         self.requestid = None
         self.service_namespace = service_namespace
         self.host_base = host_base


### PR DESCRIPTION
Add documentation for ServiceBusService **init** parameters.
Move service_namespace validation out of authentication validation, as it always needs to be specified regardless of the authentication.
