### PR TITLE
Prevent removal of Timestamp attribute on table storage entities.

### DIFF
--- a/azure/storage/__init__.py
+++ b/azure/storage/__init__.py
@@ -827,10 +827,6 @@ def _convert_xml_to_entity(xmlstr):
     # extract each property node and get the type from attribute and node value
     for xml_property in xml_properties[0].childNodes:
         name = _remove_prefix(xml_property.nodeName)
-        # exclude the Timestamp since it is auto added by azure when
-        # inserting entity. We don't want this to mix with real properties
-        if name in ['Timestamp']:
-            continue
 
         if xml_property.firstChild:
             value = xml_property.firstChild.nodeValue

--- a/tests/test_tableservice.py
+++ b/tests/test_tableservice.py
@@ -163,6 +163,7 @@ class TableServiceTest(AzureTestCase):
         self.assertEqual(entity.clsid.type, 'Edm.Guid')
         self.assertEqual(entity.clsid.value,
                          'c9da6455-213d-42c9-9a79-3e9149a57833')
+        self.assertTrue(hasattr(entity, "Timestamp"))
 
     def _assert_updated_entity(self, entity):
         '''
@@ -180,6 +181,7 @@ class TableServiceTest(AzureTestCase):
         self.assertEqual(entity.birthday, datetime(1991, 10, 4, tzinfo=tzutc()))
         self.assertFalse(hasattr(entity, "other"))
         self.assertFalse(hasattr(entity, "clsid"))
+        self.assertTrue(hasattr(entity, "Timestamp"))
 
     def _assert_merged_entity(self, entity):
         '''
@@ -201,6 +203,7 @@ class TableServiceTest(AzureTestCase):
         self.assertEqual(entity.clsid.type, 'Edm.Guid')
         self.assertEqual(entity.clsid.value,
                          'c9da6455-213d-42c9-9a79-3e9149a57833')
+        self.assertTrue(hasattr(entity, "Timestamp"))
 
     #--Test cases for table service -------------------------------------------
     def test_get_set_table_service_properties(self):


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-sdk-for-python/issues/234
