### PR TITLE
Update the list of possible role_size options in the add_role function

### DIFF
--- a/azure/servicemanagement/servicemanagementservice.py
+++ b/azure/servicemanagement/servicemanagementservice.py
@@ -1197,9 +1197,13 @@ class ServiceManagementService(_ServiceManagementClient):
             for a virtual machine.
         role_size:
             The size of the virtual machine to allocate. The default value is
-            Small. Possible values are: ExtraSmall, Small, Medium, Large,
-            ExtraLarge. The specified value must be compatible with the disk
-            selected in the OSVirtualHardDisk values.
+            Small. Possible values are: ExtraSmall,Small,Medium,Large,
+            ExtraLarge,A5,A6,A7,A8,A9,Basic_A0,Basic_A1,Basic_A2,Basic_A3,
+            Basic_A4,Standard_D1,Standard_D2,Standard_D3,Standard_D4,
+            Standard_D11,Standard_D12,Standard_D13,Standard_D14,Standard_G1,
+            Standard_G2,Sandard_G3,Standard_G4,Standard_G5. The specified
+            value must be compatible with the disk selected in the 
+            OSVirtualHardDisk values.
         role_type:
             The type of the role for the virtual machine. The only supported
             value is PersistentVMRole.


### PR DESCRIPTION
Previous role_size documentation included a limited number of vm types. It would be useful to have it in the function comments for easier lookup of the vm type code names.