### PR TITLE
Fixed InvalidHeader error when using BlobService calls

### DIFF
--- a/azure/storage/__init__.py
+++ b/azure/storage/__init__.py
@@ -42,7 +42,7 @@ from azure import (WindowsAzureData,
                    )
 
 # x-ms-version for storage service.
-X_MS_VERSION = '2012-02-12'
+X_MS_VERSION = '2014-02-14'
 
 
 class EnumResultsBase(object):

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ from distutils.core import setup
 # python setup.py sdist upload
 
 setup(name='azure',
-      version='0.9.0',
+      version='0.9.0-1',
       description='Microsoft Azure client APIs',
       license='Apache License 2.0',
       author='Microsoft Corporation',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ from distutils.core import setup
 # python setup.py sdist upload
 
 setup(name='azure',
-      version='0.9.0-1',
+      version='0.9.0.head',
       description='Microsoft Azure client APIs',
       license='Apache License 2.0',
       author='Microsoft Corporation',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ from distutils.core import setup
 # python setup.py sdist upload
 
 setup(name='azure',
-      version='0.9.0.head',
+      version='0.9.0.post1',
       description='Microsoft Azure client APIs',
       license='Apache License 2.0',
       author='Microsoft Corporation',


### PR DESCRIPTION
Fixed bug as stated in issue #288.

A tiny pull request, and maybe it doesn't happen to everyone, but there's also an StackOverflow question describing the same issue: https://stackoverflow.com/questions/27044226/http-header-error-using-the-python-sdk-for-azure .