### PR TITLE
Improve table service query result parsing performance

### DIFF
--- a/azure.pyproj
+++ b/azure.pyproj
@@ -22,6 +22,7 @@
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>
     <SccLocalPath>SAK</SccLocalPath>
+    <SearchPath>.;tests\</SearchPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>

--- a/azure.pyproj
+++ b/azure.pyproj
@@ -6,8 +6,9 @@
     <ProjectGuid>{25b2c65a-0553-4452-8907-8b5b17544e68}</ProjectGuid>
     <ProjectHome>
     </ProjectHome>
-    <StartupFile>storage\blobservice.py</StartupFile>
-    <WorkingDirectory>.</WorkingDirectory>
+    <StartupFile>
+    </StartupFile>
+    <WorkingDirectory>tests</WorkingDirectory>
     <OutputPath>.</OutputPath>
     <Name>azure</Name>
     <RootNamespace>azure</RootNamespace>
@@ -22,7 +23,8 @@
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>
     <SccLocalPath>SAK</SccLocalPath>
-    <SearchPath>.;tests\</SearchPath>
+    <SearchPath>
+    </SearchPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>

--- a/azure/__init__.py
+++ b/azure/__init__.py
@@ -32,7 +32,6 @@ else:
     _strtype = str
 
 from datetime import datetime
-from xml.dom import minidom
 from xml.sax.saxutils import escape as xml_escape
 
 try:
@@ -230,108 +229,6 @@ def _get_readable_id(id_name, id_prefix_to_skip):
     return id_name
 
 
-def _get_entry_properties_from_etree_element(element, include_id, id_prefix_to_skip=None, use_title_as_id=False):
-    ''' get properties from element tree element '''
-    properties = {}
-
-    etag = element.attrib.get(_make_etree_ns_attr_name(_etree_entity_feed_namespaces['m'], 'etag'), None)
-    if etag is not None:
-        properties['etag'] = etag
-
-    updated = element.find('./atom:updated', _etree_entity_feed_namespaces)
-    if updated is not None:
-        properties['updated'] = updated.text
-
-    author_name = element.find('./atom:author/atom:name', _etree_entity_feed_namespaces)
-    if author_name is not None:
-        properties['author'] = author_name.text
-
-    if include_id:
-        if use_title_as_id:
-            title = element.find('./atom:title', _etree_entity_feed_namespaces)
-            if title is not None:
-                properties['name'] = title.text
-        else:
-            id = element.find('./atom:id', _etree_entity_feed_namespaces)
-            if id is not None:
-                properties['name'] = _get_readable_id(id.text, id_prefix_to_skip)
-
-    return properties
-
-def _get_entry_properties_from_node(entry, include_id, id_prefix_to_skip=None, use_title_as_id=False):
-    ''' get properties from entry xml '''
-    properties = {}
-
-    etag = entry.getAttributeNS(METADATA_NS, 'etag')
-    if etag:
-        properties['etag'] = etag
-    for updated in _get_child_nodes(entry, 'updated'):
-        properties['updated'] = updated.firstChild.nodeValue
-    for name in _get_children_from_path(entry, 'author', 'name'):
-        if name.firstChild is not None:
-            properties['author'] = name.firstChild.nodeValue
-
-    if include_id:
-        if use_title_as_id:
-            for title in _get_child_nodes(entry, 'title'):
-                properties['name'] = title.firstChild.nodeValue
-        else:
-            for id in _get_child_nodes(entry, 'id'):
-                properties['name'] = _get_readable_id(
-                    id.firstChild.nodeValue, id_prefix_to_skip)
-
-    return properties
-
-
-def _get_entry_properties(xmlstr, include_id, id_prefix_to_skip=None):
-    ''' get properties from entry xml '''
-    xmldoc = minidom.parseString(xmlstr)
-    properties = {}
-
-    for entry in _get_child_nodes(xmldoc, 'entry'):
-        properties.update(_get_entry_properties_from_node(entry, include_id, id_prefix_to_skip))
-
-    return properties
-
-
-def _get_first_child_node_value(parent_node, node_name):
-    xml_attrs = _get_child_nodes(parent_node, node_name)
-    if xml_attrs:
-        xml_attr = xml_attrs[0]
-        if xml_attr.firstChild:
-            value = xml_attr.firstChild.nodeValue
-            return value
-
-
-def _get_child_nodes(node, tagName):
-    return [childNode for childNode in node.getElementsByTagName(tagName)
-            if childNode.parentNode == node]
-
-
-def _get_children_from_path(node, *path):
-    '''descends through a hierarchy of nodes returning the list of children
-    at the inner most level.  Only returns children who share a common parent,
-    not cousins.'''
-    cur = node
-    for index, child in enumerate(path):
-        if isinstance(child, _strtype):
-            next = _get_child_nodes(cur, child)
-        else:
-            next = _get_child_nodesNS(cur, *child)
-        if index == len(path) - 1:
-            return next
-        elif not next:
-            break
-
-        cur = next[0]
-    return []
-
-
-def _get_child_nodesNS(node, ns, tagName):
-    return [childNode for childNode in node.getElementsByTagNameNS(ns, tagName)
-            if childNode.parentNode == node]
-
-
 def _create_entry(entry_body):
     ''' Adds common part of entry to a given entry body and return the whole
     xml. '''
@@ -465,91 +362,13 @@ def _convert_class_to_xml(source, xml_prefix=True):
     return xmlstr
 
 
-def _find_namespaces_from_child(parent, child, namespaces):
-    """Recursively searches from the parent to the child,
-    gathering all the applicable namespaces along the way"""
-    for cur_child in parent.childNodes:
-        if cur_child is child:
-            return True
-        if _find_namespaces_from_child(cur_child, child, namespaces):
-            # we are the parent node
-            for key in cur_child.attributes.keys():
-                if key.startswith('xmlns:') or key == 'xmlns':
-                    namespaces[key] = cur_child.attributes[key]
-            break
-    return False
-
-
-def _find_namespaces(parent, child):
-    res = {}
-    for key in parent.documentElement.attributes.keys():
-        if key.startswith('xmlns:') or key == 'xmlns':
-            res[key] = parent.documentElement.attributes[key]
-    _find_namespaces_from_child(parent, child, res)
-    return res
-
-
-def _clone_node_with_namespaces(node_to_clone, original_doc):
-    clone = node_to_clone.cloneNode(True)
-
-    for key, value in _find_namespaces(original_doc, node_to_clone).items():
-        clone.attributes[key] = value
-
-    return clone
-
-
-def _set_continuation_from_response(feeds, response):
+def _set_continuation_from_response_headers(feeds, response):
     x_ms_continuation = HeaderDict()
     for name, value in response.headers:
         if 'x-ms-continuation' in name:
             x_ms_continuation[name[len('x-ms-continuation') + 1:]] = value
     if x_ms_continuation:
         setattr(feeds, 'x_ms_continuation', x_ms_continuation)
-
-
-def _convert_response_to_feeds_using_etree(response, convert_func):
-
-    if response is None:
-        return None
-
-    feeds = _list_of(Feed)
-
-    _set_continuation_from_response(feeds, response)
-
-    root = ETree.fromstring(response.body)
-
-    # some feeds won't have the 'feed' element, just a single 'entry' element
-    root_name = _get_etree_tag_name_without_ns(root.tag)
-    if root_name == 'feed':
-        entries = root.findall("./atom:entry", _etree_entity_feed_namespaces)
-    elif root_name == 'entry':
-        entries = [root]
-    else:
-        raise NotImplementedError()
-
-    for entry in entries:
-        feeds.append(convert_func(entry))
-
-    return feeds
-
-
-def _convert_xml_to_windows_azure_object(xmlstr, azure_type, include_id=True, use_title_as_id=True):
-    xmldoc = minidom.parseString(xmlstr)
-    return_obj = azure_type()
-    xml_name = azure_type._xml_name if hasattr(azure_type, '_xml_name') else azure_type.__name__
-
-    # Only one entry here
-    for xml_entry in _get_children_from_path(xmldoc,
-                                             'entry'):
-        for node in _get_children_from_path(xml_entry,
-                                            'content',
-                                            xml_name):
-            _fill_data_to_return_object(node, return_obj)
-        for name, value in _get_entry_properties_from_node(xml_entry,
-                                                           include_id=include_id,
-                                                           use_title_as_id=use_title_as_id).items():
-            setattr(return_obj, name, value)
-    return return_obj
 
 
 def _validate_type_bytes(param_name, param):
@@ -560,133 +379,6 @@ def _validate_type_bytes(param_name, param):
 def _validate_not_none(param_name, param):
     if param is None:
         raise TypeError(_ERROR_VALUE_NONE.format(param_name))
-
-
-def _fill_list_of(xmldoc, element_type, xml_element_name):
-    xmlelements = _get_child_nodes(xmldoc, xml_element_name)
-    return [_parse_response_body_from_xml_node(xmlelement, element_type) \
-        for xmlelement in xmlelements]
-
-
-def _fill_scalar_list_of(xmldoc, element_type, parent_xml_element_name,
-                         xml_element_name):
-    '''Converts an xml fragment into a list of scalar types.  The parent xml
-    element contains a flat list of xml elements which are converted into the
-    specified scalar type and added to the list.
-    Example:
-    xmldoc=
-<Endpoints>
-    <Endpoint>http://{storage-service-name}.blob.core.windows.net/</Endpoint>
-    <Endpoint>http://{storage-service-name}.queue.core.windows.net/</Endpoint>
-    <Endpoint>http://{storage-service-name}.table.core.windows.net/</Endpoint>
-</Endpoints>
-    element_type=str
-    parent_xml_element_name='Endpoints'
-    xml_element_name='Endpoint'
-    '''
-    xmlelements = _get_child_nodes(xmldoc, parent_xml_element_name)
-    if xmlelements:
-        xmlelements = _get_child_nodes(xmlelements[0], xml_element_name)
-        return [_get_node_value(xmlelement, element_type) \
-            for xmlelement in xmlelements]
-
-
-def _fill_dict(xmldoc, element_name):
-    xmlelements = _get_child_nodes(xmldoc, element_name)
-    if xmlelements:
-        return_obj = {}
-        for child in xmlelements[0].childNodes:
-            if child.firstChild:
-                return_obj[child.nodeName] = child.firstChild.nodeValue
-        return return_obj
-
-
-def _fill_dict_of(xmldoc, parent_xml_element_name, pair_xml_element_name,
-                  key_xml_element_name, value_xml_element_name):
-    '''Converts an xml fragment into a dictionary. The parent xml element
-    contains a list of xml elements where each element has a child element for
-    the key, and another for the value.
-    Example:
-    xmldoc=
-<ExtendedProperties>
-    <ExtendedProperty>
-        <Name>Ext1</Name>
-        <Value>Val1</Value>
-    </ExtendedProperty>
-    <ExtendedProperty>
-        <Name>Ext2</Name>
-        <Value>Val2</Value>
-    </ExtendedProperty>
-</ExtendedProperties>
-    element_type=str
-    parent_xml_element_name='ExtendedProperties'
-    pair_xml_element_name='ExtendedProperty'
-    key_xml_element_name='Name'
-    value_xml_element_name='Value'
-    '''
-    return_obj = {}
-
-    xmlelements = _get_child_nodes(xmldoc, parent_xml_element_name)
-    if xmlelements:
-        xmlelements = _get_child_nodes(xmlelements[0], pair_xml_element_name)
-        for pair in xmlelements:
-            keys = _get_child_nodes(pair, key_xml_element_name)
-            values = _get_child_nodes(pair, value_xml_element_name)
-            if keys and values:
-                key = keys[0].firstChild.nodeValue
-                value = values[0].firstChild.nodeValue
-                return_obj[key] = value
-
-    return return_obj
-
-
-def _fill_instance_child(xmldoc, element_name, return_type):
-    '''Converts a child of the current dom element to the specified type.
-    '''
-    xmlelements = _get_child_nodes(
-        xmldoc, _get_serialization_name(element_name))
-
-    if not xmlelements:
-        return None
-
-    return_obj = return_type()
-    _fill_data_to_return_object(xmlelements[0], return_obj)
-
-    return return_obj
-
-
-def _fill_instance_element(element, return_type):
-    """Converts a DOM element into the specified object"""
-    return _parse_response_body_from_xml_node(element, return_type)
-
-
-def _fill_data_minidom(xmldoc, element_name, data_member):
-    xmlelements = _get_child_nodes(
-        xmldoc, _get_serialization_name(element_name))
-
-    if not xmlelements or not xmlelements[0].childNodes:
-        return None
-
-    value = xmlelements[0].firstChild.nodeValue
-
-    if data_member is None:
-        return value
-    elif isinstance(data_member, datetime):
-        return _to_datetime(value)
-    elif type(data_member) is bool:
-        return value.lower() != 'false'
-    else:
-        return type(data_member)(value)
-
-
-def _get_node_value(xmlelement, data_type):
-    value = xmlelement.firstChild.nodeValue
-    if data_type is datetime:
-        return _to_datetime(value)
-    elif data_type is bool:
-        return value.lower() != 'false'
-    else:
-        return data_type(value)
 
 
 def _get_request_body_bytes_only(param_name, param_value):
@@ -732,166 +424,6 @@ def _get_request_body(request_body):
 
     return request_body
 
-
-def _parse_enum_results_list(response, return_type, resp_type, item_type):
-    """resp_body is the XML we received
-resp_type is a string, such as Containers,
-return_type is the type we're constructing, such as ContainerEnumResults
-item_type is the type object of the item to be created, such as Container
-
-This function then returns a ContainerEnumResults object with the
-containers member populated with the results.
-"""
-
-    # parsing something like:
-    # <EnumerationResults ... >
-    #   <Queues>
-    #       <Queue>
-    #           <Something />
-    #           <SomethingElse />
-    #       </Queue>
-    #   </Queues>
-    # </EnumerationResults>
-    respbody = response.body
-    return_obj = return_type()
-    doc = minidom.parseString(respbody)
-
-    items = []
-    for enum_results in _get_child_nodes(doc, 'EnumerationResults'):
-        # path is something like Queues, Queue
-        for child in _get_children_from_path(enum_results,
-                                             resp_type,
-                                             resp_type[:-1]):
-            items.append(_fill_instance_element(child, item_type))
-
-        for name, value in vars(return_obj).items():
-            # queues, Queues, this is the list its self which we populated
-            # above
-            if name == resp_type.lower():
-                # the list its self.
-                continue
-            value = _fill_data_minidom(enum_results, name, value)
-            if value is not None:
-                setattr(return_obj, name, value)
-
-    setattr(return_obj, resp_type.lower(), items)
-    return return_obj
-
-
-def _parse_simple_list(response, type, item_type, list_name):
-    respbody = response.body
-    res = type()
-    res_items = []
-    doc = minidom.parseString(respbody)
-    type_name = type.__name__
-    item_name = item_type.__name__
-    for item in _get_children_from_path(doc, type_name, item_name):
-        res_items.append(_fill_instance_element(item, item_type))
-
-    setattr(res, list_name, res_items)
-    return res
-
-
-def _parse_response(response, return_type):
-    '''
-    Parse the HTTPResponse's body and fill all the data into a class of
-    return_type.
-    '''
-    return _parse_response_body_from_xml_text(response.body, return_type)
-
-def _parse_service_resources_response(response, return_type):
-    '''
-    Parse the HTTPResponse's body and fill all the data into a class of
-    return_type.
-    '''
-    return _parse_response_body_from_service_resources_xml_text(response.body, return_type)
-
-
-def _fill_data_to_return_object(node, return_obj):
-    members = dict(vars(return_obj))
-    for name, value in members.items():
-        if isinstance(value, _list_of):
-            setattr(return_obj,
-                    name,
-                    _fill_list_of(node,
-                                  value.list_type,
-                                  value.xml_element_name))
-        elif isinstance(value, _scalar_list_of):
-            setattr(return_obj,
-                    name,
-                    _fill_scalar_list_of(node,
-                                         value.list_type,
-                                         _get_serialization_name(name),
-                                         value.xml_element_name))
-        elif isinstance(value, _dict_of):
-            setattr(return_obj,
-                    name,
-                    _fill_dict_of(node,
-                                  _get_serialization_name(name),
-                                  value.pair_xml_element_name,
-                                  value.key_xml_element_name,
-                                  value.value_xml_element_name))
-        elif isinstance(value, _xml_attribute):
-            real_value = None
-            if node.hasAttribute(value.xml_element_name):
-                real_value = node.getAttribute(value.xml_element_name)
-            if real_value is not None:
-                setattr(return_obj, name, real_value)
-        elif isinstance(value, WindowsAzureData):
-            setattr(return_obj,
-                    name,
-                    _fill_instance_child(node, name, value.__class__))
-        elif isinstance(value, dict):
-            setattr(return_obj,
-                    name,
-                    _fill_dict(node, _get_serialization_name(name)))
-        elif isinstance(value, _Base64String):
-            value = _fill_data_minidom(node, name, '')
-            if value is not None:
-                value = _decode_base64_to_text(value)
-            # always set the attribute, so we don't end up returning an object
-            # with type _Base64String
-            setattr(return_obj, name, value)
-        else:
-            value = _fill_data_minidom(node, name, value)
-            if value is not None:
-                setattr(return_obj, name, value)
-
-
-def _parse_response_body_from_xml_node(node, return_type):
-    '''
-    parse the xml and fill all the data into a class of return_type
-    '''
-    return_obj = return_type()
-    _fill_data_to_return_object(node, return_obj)
-
-    return return_obj
-
-
-def _parse_response_body_from_xml_text(respbody, return_type):
-    '''
-    parse the xml and fill all the data into a class of return_type
-    '''
-    doc = minidom.parseString(respbody)
-    return_obj = return_type()
-    xml_name = return_type._xml_name if hasattr(return_type, '_xml_name') else return_type.__name__ 
-    for node in _get_child_nodes(doc, xml_name):
-        _fill_data_to_return_object(node, return_obj)
-
-    return return_obj
-
-def _parse_response_body_from_service_resources_xml_text(respbody, return_type):
-    '''
-    parse the xml and fill all the data into a class of return_type
-    '''
-    doc = minidom.parseString(respbody)
-    return_obj = _list_of(return_type)
-    for node in _get_children_from_path(doc, "ServiceResources", "ServiceResource"):
-        local_obj = return_type()
-        _fill_data_to_return_object(node, local_obj)
-        return_obj.append(local_obj)
-
-    return return_obj
 
 class _dict_of(dict):
 
@@ -1080,6 +612,299 @@ def _sign_string(key, string_to_sign, key_is_base64=True):
 
 def _lower(text):
     return text.lower()
+
+
+class _ETreeXmlToObject(object):
+    @staticmethod
+    def parse_response(response, return_type):
+        '''
+        Parse the HTTPResponse's body and fill all the data into a class of
+        return_type.
+        '''
+        root = ETree.fromstring(response.body)
+        xml_name = return_type._xml_name if hasattr(return_type, '_xml_name') else return_type.__name__ 
+        if root.tag == xml_name:
+            return _ETreeXmlToObject._parse_response_body_from_xml_node(root, return_type)
+
+        return None
+
+
+    @staticmethod
+    def parse_enum_results_list(response, return_type, resp_type, item_type):
+        """resp_body is the XML we received
+    resp_type is a string, such as Containers,
+    return_type is the type we're constructing, such as ContainerEnumResults
+    item_type is the type object of the item to be created, such as Container
+
+    This function then returns a ContainerEnumResults object with the
+    containers member populated with the results.
+    """
+
+        # parsing something like:
+        # <EnumerationResults ... >
+        #   <Queues>
+        #       <Queue>
+        #           <Something />
+        #           <SomethingElse />
+        #       </Queue>
+        #   </Queues>
+        # </EnumerationResults>
+        return_obj = return_type()
+        root = ETree.fromstring(response.body)
+
+        items = []
+
+        for container_element in root.findall(resp_type):
+            for item_element in container_element.findall(resp_type[:-1]):
+                items.append(_ETreeXmlToObject.fill_instance_element(item_element, item_type))
+
+        for name, value in vars(return_obj).items():
+            # queues, Queues, this is the list its self which we populated
+            # above
+            if name == resp_type.lower():
+                # the list its self.
+                continue
+            value = _ETreeXmlToObject.fill_data_member(root, name, value)
+            if value is not None:
+                setattr(return_obj, name, value)
+
+        setattr(return_obj, resp_type.lower(), items)
+        return return_obj
+
+
+    @staticmethod
+    def parse_simple_list(response, type, item_type, list_name):
+        respbody = response.body
+        res = type()
+        res_items = []
+        root = ETree.fromstring(respbody)
+        type_name = type.__name__
+        item_name = item_type.__name__
+        for item in root.findall(item_name):
+            res_items.append(_ETreeXmlToObject.fill_instance_element(item, item_type))
+
+        setattr(res, list_name, res_items)
+        return res
+
+
+    @staticmethod
+    def convert_response_to_feeds(response, convert_func):
+
+        if response is None:
+            return None
+
+        feeds = _list_of(Feed)
+
+        _set_continuation_from_response_headers(feeds, response)
+
+        root = ETree.fromstring(response.body)
+
+        # some feeds won't have the 'feed' element, just a single 'entry' element
+        root_name = _get_etree_tag_name_without_ns(root.tag)
+        if root_name == 'feed':
+            entries = root.findall("./atom:entry", _etree_entity_feed_namespaces)
+        elif root_name == 'entry':
+            entries = [root]
+        else:
+            raise NotImplementedError()
+
+        for entry in entries:
+            feeds.append(convert_func(entry))
+
+        return feeds
+
+
+    @staticmethod
+    def get_entry_properties_from_element(element, include_id, id_prefix_to_skip=None, use_title_as_id=False):
+        ''' get properties from element tree element '''
+        properties = {}
+
+        etag = element.attrib.get(_make_etree_ns_attr_name(_etree_entity_feed_namespaces['m'], 'etag'), None)
+        if etag is not None:
+            properties['etag'] = etag
+
+        updated = element.find('./atom:updated', _etree_entity_feed_namespaces)
+        if updated is not None:
+            properties['updated'] = updated.text
+
+        author_name = element.find('./atom:author/atom:name', _etree_entity_feed_namespaces)
+        if author_name is not None:
+            properties['author'] = author_name.text
+
+        if include_id:
+            if use_title_as_id:
+                title = element.find('./atom:title', _etree_entity_feed_namespaces)
+                if title is not None:
+                    properties['name'] = title.text
+            else:
+                id = element.find('./atom:id', _etree_entity_feed_namespaces)
+                if id is not None:
+                    properties['name'] = _get_readable_id(id.text, id_prefix_to_skip)
+
+        return properties
+
+
+    @staticmethod
+    def fill_instance_element(element, return_type):
+        """Converts a DOM element into the specified object"""
+        return _ETreeXmlToObject._parse_response_body_from_xml_node(element, return_type)
+
+
+    @staticmethod
+    def fill_data_member(xmldoc, element_name, data_member):
+        element = xmldoc.find(_get_serialization_name(element_name))
+        if element is None:
+            return None
+
+        value = _get_etree_text(element)
+
+        if data_member is None:
+            return value
+        elif isinstance(data_member, datetime):
+            return _to_datetime(value)
+        elif type(data_member) is bool:
+            return value.lower() != 'false'
+        else:
+            return type(data_member)(value)
+
+
+    @staticmethod
+    def _parse_response_body_from_xml_node(node, return_type):
+        '''
+        parse the xml and fill all the data into a class of return_type
+        '''
+        return_obj = return_type()
+        _ETreeXmlToObject._fill_data_to_return_object(node, return_obj)
+
+        return return_obj
+
+
+    @staticmethod
+    def _fill_instance_child(xmldoc, element_name, return_type):
+        '''Converts a child of the current dom element to the specified type.
+        '''
+        element = xmldoc.find(_get_serialization_name(element_name))
+        if element is None:
+            return None
+
+        return_obj = return_type()
+        _ETreeXmlToObject._fill_data_to_return_object(element, return_obj)
+
+        return return_obj
+
+
+    @staticmethod
+    def _fill_data_to_return_object(node, return_obj):
+        members = dict(vars(return_obj))
+        for name, value in members.items():
+            if isinstance(value, _list_of):
+                setattr(return_obj,
+                        name,
+                        _ETreeXmlToObject._fill_list_of(node,
+                                      value.list_type,
+                                      value.xml_element_name))
+            elif isinstance(value, _scalar_list_of):
+                setattr(return_obj,
+                        name,
+                        _ETreeXmlToObject._fill_scalar_list_of(node,
+                                             value.list_type,
+                                             _get_serialization_name(name),
+                                             value.xml_element_name))
+            elif isinstance(value, _dict_of):
+                setattr(return_obj,
+                        name,
+                        _ETreeXmlToObject._fill_dict_of(node,
+                                      _get_serialization_name(name),
+                                      value.pair_xml_element_name,
+                                      value.key_xml_element_name,
+                                      value.value_xml_element_name))
+            elif isinstance(value, _xml_attribute):
+                real_value = node.attrib.get(value.xml_element_name, None)
+                if real_value is not None:
+                    setattr(return_obj, name, real_value)
+            elif isinstance(value, WindowsAzureData):
+                setattr(return_obj,
+                        name,
+                        _ETreeXmlToObject._fill_instance_child(node, name, value.__class__))
+            elif isinstance(value, dict):
+                setattr(return_obj,
+                        name,
+                        _ETreeXmlToObject._fill_dict(node, _get_serialization_name(name)))
+            elif isinstance(value, _Base64String):
+                value = _ETreeXmlToObject.fill_data_member(node, name, '')
+                if value is not None:
+                    value = _decode_base64_to_text(value)
+                # always set the attribute, so we don't end up returning an object
+                # with type _Base64String
+                setattr(return_obj, name, value)
+            else:
+                value = _ETreeXmlToObject.fill_data_member(node, name, value)
+                if value is not None:
+                    setattr(return_obj, name, value)
+
+
+    @staticmethod
+    def _fill_list_of(xmldoc, element_type, xml_element_name):
+        return [_ETreeXmlToObject._parse_response_body_from_xml_node(xmlelement, element_type) \
+            for xmlelement in xmldoc.findall(xml_element_name)]
+
+
+    @staticmethod
+    def _fill_scalar_list_of(xmldoc, element_type, parent_xml_element_name,
+                             xml_element_name):
+        '''Converts an xml fragment into a list of scalar types.  The parent xml
+        element contains a flat list of xml elements which are converted into the
+        specified scalar type and added to the list.
+        Example:
+        xmldoc=
+    <Endpoints>
+        <Endpoint>http://{storage-service-name}.blob.core.windows.net/</Endpoint>
+        <Endpoint>http://{storage-service-name}.queue.core.windows.net/</Endpoint>
+        <Endpoint>http://{storage-service-name}.table.core.windows.net/</Endpoint>
+    </Endpoints>
+        element_type=str
+        parent_xml_element_name='Endpoints'
+        xml_element_name='Endpoint'
+        '''
+        raise NotImplementedError('_scalar_list_of not supported')
+
+
+    @staticmethod
+    def _fill_dict(xmldoc, element_name):
+        container_element = xmldoc.find(element_name)
+        if container_element is not None:
+            return_obj = {}
+            for item_element in container_element.getchildren():
+                return_obj[item_element.tag] = _get_etree_text(item_element)
+            return return_obj
+        return None
+
+
+    @staticmethod
+    def _fill_dict_of(xmldoc, parent_xml_element_name, pair_xml_element_name,
+                      key_xml_element_name, value_xml_element_name):
+        '''Converts an xml fragment into a dictionary. The parent xml element
+        contains a list of xml elements where each element has a child element for
+        the key, and another for the value.
+        Example:
+        xmldoc=
+    <ExtendedProperties>
+        <ExtendedProperty>
+            <Name>Ext1</Name>
+            <Value>Val1</Value>
+        </ExtendedProperty>
+        <ExtendedProperty>
+            <Name>Ext2</Name>
+            <Value>Val2</Value>
+        </ExtendedProperty>
+    </ExtendedProperties>
+        element_type=str
+        parent_xml_element_name='ExtendedProperties'
+        pair_xml_element_name='ExtendedProperty'
+        key_xml_element_name='Name'
+        value_xml_element_name='Value'
+        '''
+        raise NotImplementedError('_dict_of not supported')
 
 
 class _XmlWriter(object):

--- a/azure/__init__.py
+++ b/azure/__init__.py
@@ -820,14 +820,14 @@ def _parse_response(response, return_type):
     Parse the HTTPResponse's body and fill all the data into a class of
     return_type.
     '''
-    return _parse_response_body_from_xml_text(response.body.decode('utf-8-sig'), return_type)
+    return _parse_response_body_from_xml_text(response.body, return_type)
 
 def _parse_service_resources_response(response, return_type):
     '''
     Parse the HTTPResponse's body and fill all the data into a class of
     return_type.
     '''
-    return _parse_response_body_from_service_resources_xml_text(response.body.decode('utf-8-sig'), return_type)
+    return _parse_response_body_from_service_resources_xml_text(response.body, return_type)
 
 
 def _fill_data_to_return_object(node, return_obj):

--- a/azure/__init__.py
+++ b/azure/__init__.py
@@ -208,6 +208,11 @@ def _get_etree_tag_name_without_ns(tag):
     return val
 
 
+def _get_etree_text(element):
+    text = element.text
+    return text if text is not None else ''
+
+
 def _get_readable_id(id_name, id_prefix_to_skip):
     """simplified an id to be more friendly for us people"""
     # id_name is in the form 'https://namespace.host.suffix/name'
@@ -230,25 +235,25 @@ def _get_entry_properties_from_etree_element(element, include_id, id_prefix_to_s
     properties = {}
 
     etag = element.attrib.get(_make_etree_ns_attr_name(_etree_entity_feed_namespaces['m'], 'etag'), None)
-    if etag:
+    if etag is not None:
         properties['etag'] = etag
 
     updated = element.find('./atom:updated', _etree_entity_feed_namespaces)
-    if updated:
+    if updated is not None:
         properties['updated'] = updated.text
 
     author_name = element.find('./atom:author/atom:name', _etree_entity_feed_namespaces)
-    if author_name:
+    if author_name is not None:
         properties['author'] = author_name.text
 
     if include_id:
         if use_title_as_id:
             title = element.find('./atom:title', _etree_entity_feed_namespaces)
-            if title:
+            if title is not None:
                 properties['name'] = title.text
         else:
             id = element.find('./atom:id', _etree_entity_feed_namespaces)
-            if id:
+            if id is not None:
                 properties['name'] = _get_readable_id(id.text, id_prefix_to_skip)
 
     return properties

--- a/azure/__init__.py
+++ b/azure/__init__.py
@@ -533,29 +533,6 @@ def _convert_response_to_feeds_using_etree(response, convert_func):
     return feeds
 
 
-def _convert_response_to_feeds(response, convert_func):
-    '''
-    OBSOLETE. New code should use _convert_response_to_feeds_using_etree.
-    '''
-    if response is None:
-        return None
-
-    feeds = _list_of(Feed)
-
-    _set_continuation_from_response(feeds, response)
-
-    xmldoc = minidom.parseString(response.body)
-    xml_entries = _get_children_from_path(xmldoc, 'feed', 'entry')
-    if not xml_entries:
-        # in some cases, response contains only entry but no feed
-        xml_entries = _get_children_from_path(xmldoc, 'entry')
-    for xml_entry in xml_entries:
-        new_node = _clone_node_with_namespaces(xml_entry, xmldoc)
-        feeds.append(convert_func(new_node.toxml('utf-8')))
-
-    return feeds
-
-
 def _convert_xml_to_windows_azure_object(xmlstr, azure_type, include_id=True, use_title_as_id=True):
     xmldoc = minidom.parseString(xmlstr)
     return_obj = azure_type()

--- a/azure/servicebus/__init__.py
+++ b/azure/servicebus/__init__.py
@@ -588,7 +588,7 @@ def _convert_etree_element_to_event_hub(entry_element):
             if _read_etree_element(hub_element, map[0], hub, map[1], map[2]):
                 invalid_event_hub = False
 
-        ids = hub_element.find('./sb:PartitionIds')
+        ids = hub_element.find('./sb:PartitionIds', _etree_sb_feed_namespaces)
         if ids is not None:
             for id_node in ids.findall('./arrays:string', _etree_sb_feed_namespaces):
                 value = _get_etree_text(id_node)

--- a/azure/servicebus/__init__.py
+++ b/azure/servicebus/__init__.py
@@ -17,16 +17,11 @@ import json
 import sys
 
 from datetime import datetime
-from xml.dom import minidom
 from azure import (
     WindowsAzureData,
     WindowsAzureError,
-    xml_escape,
     _general_error_handler,
-    _get_entry_properties,
-    _get_child_nodes,
-    _get_children_from_path,
-    _get_first_child_node_value,
+    _get_entry_properties_from_etree_element,
     _lower,
     _str,
     _ERROR_MESSAGE_NOT_PEEK_LOCKED_ON_DELETE,
@@ -35,6 +30,9 @@ from azure import (
     _ERROR_QUEUE_NOT_FOUND,
     _ERROR_TOPIC_NOT_FOUND,
     _XmlWriter,
+    _make_etree_ns_attr_name,
+    _get_etree_text,
+    ETree,
     )
 from azure.http import HTTPError
 
@@ -331,13 +329,21 @@ def _create_message(response, service_instance):
 
 # convert functions
 
+_etree_sb_feed_namespaces = {
+    'atom': _XmlSchemas.Atom,
+    'i': _XmlSchemas.SchemaInstance,
+    'sb': _XmlSchemas.ServiceBus,
+    'arrays': _XmlSchemas.SerializationArrays,
+}
+
 
 def _convert_response_to_rule(response):
-    return _convert_xml_to_rule(response.body)
+    root = ETree.fromstring(response.body)
+    return _convert_etree_element_to_rule(root)
 
 
-def _convert_xml_to_rule(xmlstr):
-    ''' Converts response xml to rule object.
+def _convert_etree_element_to_rule(entry_element):
+    ''' Converts entry element to rule object.
 
     The format of xml for rule:
 <entry xmlns='http://www.w3.org/2005/Atom'>
@@ -355,46 +361,42 @@ def _convert_xml_to_rule(xmlstr):
 </content>
 </entry>
     '''
-    xmldoc = minidom.parseString(xmlstr)
     rule = Rule()
 
-    for rule_desc in _get_children_from_path(xmldoc,
-                                             'entry',
-                                             'content',
-                                             'RuleDescription'):
-        for xml_filter in _get_child_nodes(rule_desc, 'Filter'):
-            filter_type = xml_filter.getAttributeNS(
-                _XmlSchemas.SchemaInstance, 'type')
-            setattr(rule, 'filter_type', str(filter_type))
-            if xml_filter.childNodes:
+    rule_element = entry_element.find('./atom:content/sb:RuleDescription', _etree_sb_feed_namespaces)
+    if rule_element is not None:
+        filter_element = rule_element.find('./sb:Filter', _etree_sb_feed_namespaces)
+        if filter_element is not None:
+            rule.filter_type = filter_element.attrib.get(
+                _make_etree_ns_attr_name(_etree_sb_feed_namespaces['i'], 'type'), None)
+            sql_exp_element = filter_element.find('./sb:SqlExpression', _etree_sb_feed_namespaces)
+            if sql_exp_element is not None:
+                rule.filter_expression = sql_exp_element.text
 
-                for expr in _get_child_nodes(xml_filter, 'SqlExpression'):
-                    setattr(rule, 'filter_expression',
-                            expr.firstChild.nodeValue)
+        action_element = rule_element.find('./sb:Action', _etree_sb_feed_namespaces)
+        if action_element is not None:
+            rule.action_type = action_element.attrib.get(
+                _make_etree_ns_attr_name(_etree_sb_feed_namespaces['i'], 'type'), None)
+            sql_exp_element = action_element.find('./sb:SqlExpression', _etree_sb_feed_namespaces)
+            if sql_exp_element is not None:
+                rule.action_expression = sql_exp_element.text
 
-        for xml_action in _get_child_nodes(rule_desc, 'Action'):
-            action_type = xml_action.getAttributeNS(
-                _XmlSchemas.SchemaInstance, 'type')
-            setattr(rule, 'action_type', str(action_type))
-            if xml_action.childNodes:
-                action_expression = xml_action.childNodes[0].firstChild
-                if action_expression:
-                    setattr(rule, 'action_expression',
-                            action_expression.nodeValue)
 
     # extract id, updated and name value from feed entry and set them of rule.
-    for name, value in _get_entry_properties(xmlstr, True, '/rules').items():
+    for name, value in _get_entry_properties_from_etree_element(entry_element, True, '/rules').items():
         setattr(rule, name, value)
 
     return rule
 
 
 def _convert_response_to_queue(response):
-    return _convert_xml_to_queue(response.body)
+    root = ETree.fromstring(response.body)
+    return _convert_etree_element_to_queue(root)
 
 
 def _convert_response_to_event_hub(response):
-    return _convert_xml_to_event_hub(response.body)
+    root = ETree.fromstring(response.body)
+    return _convert_etree_element_to_event_hub(root)
 
 
 def _parse_bool(value):
@@ -403,8 +405,19 @@ def _parse_bool(value):
     return False
 
 
-def _convert_xml_to_queue(xmlstr):
-    ''' Converts xml response to queue object.
+def _read_etree_element(parent_element, child_element_name, target_object, target_field_name, converter):
+    child_element = parent_element.find('./sb:{0}'.format(child_element_name), _etree_sb_feed_namespaces)
+    if child_element is not None:
+        field_value = _get_etree_text(child_element)
+        if converter is not None:
+            field_value = converter(field_value)
+        setattr(target_object, target_field_name, field_value)
+        return True
+    return False
+
+
+def _convert_etree_element_to_queue(entry_element):
+    ''' Converts entry element to queue object.
 
     The format of xml response for queue:
 <QueueDescription
@@ -418,92 +431,49 @@ def _convert_xml_to_queue(xmlstr):
 </QueueDescription>
 
     '''
-    xmldoc = minidom.parseString(xmlstr)
     queue = Queue()
 
-    invalid_queue = True
     # get node for each attribute in Queue class, if nothing found then the
     # response is not valid xml for Queue.
-    for desc in _get_children_from_path(xmldoc,
-                                        'entry',
-                                        'content',
-                                        'QueueDescription'):
-        node_value = _get_first_child_node_value(desc, 'LockDuration')
-        if node_value is not None:
-            queue.lock_duration = node_value
-            invalid_queue = False
+    invalid_queue = True
 
-        node_value = _get_first_child_node_value(desc, 'MaxSizeInMegabytes')
-        if node_value is not None:
-            queue.max_size_in_megabytes = int(node_value)
-            invalid_queue = False
+    queue_element = entry_element.find('./atom:content/sb:QueueDescription', _etree_sb_feed_namespaces)
+    if queue_element is not None:
+        mappings = [
+            ('LockDuration', 'lock_duration', None),
+            ('MaxSizeInMegabytes', 'max_size_in_megabytes', int),
+            ('RequiresDuplicateDetection', 'requires_duplicate_detection', _parse_bool),
+            ('RequiresSession', 'requires_session', _parse_bool),
+            ('DefaultMessageTimeToLive', 'default_message_time_to_live', None),
+            ('DeadLetteringOnMessageExpiration', 'dead_lettering_on_message_expiration', _parse_bool),
+            ('DuplicateDetectionHistoryTimeWindow', 'duplicate_detection_history_time_window', None),
+            ('EnableBatchedOperations', 'enable_batched_operations', _parse_bool),
+            ('MaxDeliveryCount', 'max_delivery_count', int),
+            ('MessageCount', 'message_count', int),
+            ('SizeInBytes', 'size_in_bytes', int),
+        ]
 
-        node_value = _get_first_child_node_value(
-            desc, 'RequiresDuplicateDetection')
-        if node_value is not None:
-            queue.requires_duplicate_detection = _parse_bool(node_value)
-            invalid_queue = False
-
-        node_value = _get_first_child_node_value(desc, 'RequiresSession')
-        if node_value is not None:
-            queue.requires_session = _parse_bool(node_value)
-            invalid_queue = False
-
-        node_value = _get_first_child_node_value(
-            desc, 'DefaultMessageTimeToLive')
-        if node_value is not None:
-            queue.default_message_time_to_live = node_value
-            invalid_queue = False
-
-        node_value = _get_first_child_node_value(
-            desc, 'DeadLetteringOnMessageExpiration')
-        if node_value is not None:
-            queue.dead_lettering_on_message_expiration = _parse_bool(node_value)
-            invalid_queue = False
-
-        node_value = _get_first_child_node_value(
-            desc, 'DuplicateDetectionHistoryTimeWindow')
-        if node_value is not None:
-            queue.duplicate_detection_history_time_window = node_value
-            invalid_queue = False
-
-        node_value = _get_first_child_node_value(
-            desc, 'EnableBatchedOperations')
-        if node_value is not None:
-            queue.enable_batched_operations = _parse_bool(node_value)
-            invalid_queue = False
-
-        node_value = _get_first_child_node_value(desc, 'MaxDeliveryCount')
-        if node_value is not None:
-            queue.max_delivery_count = int(node_value)
-            invalid_queue = False
-
-        node_value = _get_first_child_node_value(desc, 'MessageCount')
-        if node_value is not None:
-            queue.message_count = int(node_value)
-            invalid_queue = False
-
-        node_value = _get_first_child_node_value(desc, 'SizeInBytes')
-        if node_value is not None:
-            queue.size_in_bytes = int(node_value)
-            invalid_queue = False
+        for map in mappings:
+            if _read_etree_element(queue_element, map[0], queue, map[1], map[2]):
+                invalid_queue = False
 
     if invalid_queue:
         raise WindowsAzureError(_ERROR_QUEUE_NOT_FOUND)
 
     # extract id, updated and name value from feed entry and set them of queue.
-    for name, value in _get_entry_properties(xmlstr, True).items():
+    for name, value in _get_entry_properties_from_etree_element(entry_element, True).items():
         setattr(queue, name, value)
 
     return queue
 
 
 def _convert_response_to_topic(response):
-    return _convert_xml_to_topic(response.body)
+    root = ETree.fromstring(response.body)
+    return _convert_etree_element_to_topic(root)
 
 
-def _convert_xml_to_topic(xmlstr):
-    '''Converts xml response to topic
+def _convert_etree_element_to_topic(entry_element):
+    '''Converts entry element to topic
 
     The xml format for topic:
 <entry xmlns='http://www.w3.org/2005/Atom'>
@@ -520,62 +490,42 @@ def _convert_xml_to_topic(xmlstr):
     </content>
 </entry>
     '''
-    xmldoc = minidom.parseString(xmlstr)
     topic = Topic()
 
     invalid_topic = True
 
-    # get node for each attribute in Topic class, if nothing found then the
-    # response is not valid xml for Topic.
-    for desc in _get_children_from_path(xmldoc,
-                                        'entry',
-                                        'content',
-                                        'TopicDescription'):
-        invalid_topic = True
-        node_value = _get_first_child_node_value(
-            desc, 'DefaultMessageTimeToLive')
-        if node_value is not None:
-            topic.default_message_time_to_live = node_value
-            invalid_topic = False
-        node_value = _get_first_child_node_value(desc, 'MaxSizeInMegabytes')
-        if node_value is not None:
-            topic.max_size_in_megabytes = int(node_value)
-            invalid_topic = False
-        node_value = _get_first_child_node_value(
-            desc, 'RequiresDuplicateDetection')
-        if node_value is not None:
-            topic.requires_duplicate_detection = _parse_bool(node_value)
-            invalid_topic = False
-        node_value = _get_first_child_node_value(
-            desc, 'DuplicateDetectionHistoryTimeWindow')
-        if node_value is not None:
-            topic.duplicate_detection_history_time_window = node_value
-            invalid_topic = False
-        node_value = _get_first_child_node_value(
-            desc, 'EnableBatchedOperations')
-        if node_value is not None:
-            topic.enable_batched_operations = _parse_bool(node_value)
-            invalid_topic = False
-        node_value = _get_first_child_node_value(desc, 'SizeInBytes')
-        if node_value is not None:
-            topic.size_in_bytes = int(node_value)
-            invalid_topic = False
+    topic_element = entry_element.find('./atom:content/sb:TopicDescription', _etree_sb_feed_namespaces)
+    if topic_element is not None:
+        mappings = [
+            ('DefaultMessageTimeToLive', 'default_message_time_to_live', None),
+            ('MaxSizeInMegabytes', 'max_size_in_megabytes', int),
+            ('RequiresDuplicateDetection', 'requires_duplicate_detection', _parse_bool),
+            ('DuplicateDetectionHistoryTimeWindow', 'duplicate_detection_history_time_window', None),
+            ('EnableBatchedOperations', 'enable_batched_operations', _parse_bool),
+            ('SizeInBytes', 'size_in_bytes', int),
+        ]
+
+        for map in mappings:
+            if _read_etree_element(topic_element, map[0], topic, map[1], map[2]):
+                invalid_topic = False
 
     if invalid_topic:
         raise WindowsAzureError(_ERROR_TOPIC_NOT_FOUND)
 
     # extract id, updated and name value from feed entry and set them of topic.
-    for name, value in _get_entry_properties(xmlstr, True).items():
+    for name, value in _get_entry_properties_from_etree_element(entry_element, True).items():
         setattr(topic, name, value)
+
     return topic
 
 
 def _convert_response_to_subscription(response):
-    return _convert_xml_to_subscription(response.body)
+    root = ETree.fromstring(response.body)
+    return _convert_etree_element_to_subscription(root)
 
 
-def _convert_xml_to_subscription(xmlstr):
-    '''Converts xml response to subscription
+def _convert_etree_element_to_subscription(entry_element):
+    '''Converts entry element to subscription
 
     The xml format for subscription:
 <entry xmlns='http://www.w3.org/2005/Atom'>
@@ -592,152 +542,83 @@ def _convert_xml_to_subscription(xmlstr):
     </content>
 </entry>
     '''
-    xmldoc = minidom.parseString(xmlstr)
     subscription = Subscription()
 
-    for desc in _get_children_from_path(xmldoc,
-                                        'entry',
-                                        'content',
-                                        'SubscriptionDescription'):
-        node_value = _get_first_child_node_value(desc, 'LockDuration')
-        if node_value is not None:
-            subscription.lock_duration = node_value
+    subscription_element = entry_element.find('./atom:content/sb:SubscriptionDescription', _etree_sb_feed_namespaces)
+    if subscription_element is not None:
+        mappings = [
+            ('LockDuration', 'lock_duration', None),
+            ('RequiresSession', 'requires_session', _parse_bool),
+            ('DefaultMessageTimeToLive', 'default_message_time_to_live', None),
+            ('DeadLetteringOnFilterEvaluationExceptions', 'dead_lettering_on_filter_evaluation_exceptions', _parse_bool),
+            ('DeadLetteringOnMessageExpiration', 'dead_lettering_on_message_expiration', _parse_bool),
+            ('EnableBatchedOperations', 'enable_batched_operations', _parse_bool),
+            ('MaxDeliveryCount', 'max_delivery_count', int),
+            ('MessageCount', 'message_count', int),
+        ]
 
-        node_value = _get_first_child_node_value(
-            desc, 'RequiresSession')
-        if node_value is not None:
-            subscription.requires_session = _parse_bool(node_value)
+        for map in mappings:
+            _read_etree_element(subscription_element, map[0], subscription, map[1], map[2])
 
-        node_value = _get_first_child_node_value(
-            desc, 'DefaultMessageTimeToLive')
-        if node_value is not None:
-            subscription.default_message_time_to_live = node_value
-
-        node_value = _get_first_child_node_value(
-            desc, 'DeadLetteringOnFilterEvaluationExceptions')
-        if node_value is not None:
-            subscription.dead_lettering_on_filter_evaluation_exceptions = \
-                _parse_bool(node_value)
-
-        node_value = _get_first_child_node_value(
-            desc, 'DeadLetteringOnMessageExpiration')
-        if node_value is not None:
-            subscription.dead_lettering_on_message_expiration = \
-                _parse_bool(node_value)
-
-        node_value = _get_first_child_node_value(
-            desc, 'EnableBatchedOperations')
-        if node_value is not None:
-            subscription.enable_batched_operations = _parse_bool(node_value)
-
-        node_value = _get_first_child_node_value(
-            desc, 'MaxDeliveryCount')
-        if node_value is not None:
-            subscription.max_delivery_count = int(node_value)
-
-        node_value = _get_first_child_node_value(
-            desc, 'MessageCount')
-        if node_value is not None:
-            subscription.message_count = int(node_value)
-
-    for name, value in _get_entry_properties(xmlstr,
-                                             True,
-                                             '/subscriptions').items():
+    for name, value in _get_entry_properties_from_etree_element(entry_element, True, '/subscriptions').items():
         setattr(subscription, name, value)
 
     return subscription
 
 
-def _convert_xml_to_event_hub(xmlstr):
-    xmldoc = minidom.parseString(xmlstr)
+def _convert_etree_element_to_event_hub(entry_element):
     hub = EventHub()
 
     invalid_event_hub = True
     # get node for each attribute in EventHub class, if nothing found then the
     # response is not valid xml for EventHub.
-    for desc in _get_children_from_path(xmldoc,
-                                        'entry',
-                                        'content',
-                                        'EventHubDescription'):
-        node_value = _get_first_child_node_value(desc, 'SizeInBytes')
-        if node_value is not None:
-            hub.size_in_bytes = int(node_value)
+
+    hub_element = entry_element.find('./atom:content/sb:EventHubDescription', _etree_sb_feed_namespaces)
+    if hub_element is not None:
+        mappings = [
+            ('SizeInBytes', 'size_in_bytes', int),
+            ('MessageRetentionInDays', 'message_retention_in_days', int),
+            ('Status', 'status', None),
+            ('UserMetadata', 'user_metadata', None),
+            ('PartitionCount', 'partition_count', int),
+            ('EntityAvailableStatus', 'entity_available_status', None),
+        ]
+
+        for map in mappings:
+            if _read_etree_element(hub_element, map[0], hub, map[1], map[2]):
+                invalid_event_hub = False
+
+        ids = hub_element.find('./sb:PartitionIds')
+        if ids is not None:
+            for id_node in ids.findall('./arrays:string', _etree_sb_feed_namespaces):
+                value = _get_etree_text(id_node)
+                if value:
+                    hub.partition_ids.append(value)
+
+        rules_nodes = hub_element.find('./sb:AuthorizationRules', _etree_sb_feed_namespaces)
+        if rules_nodes is not None:
             invalid_event_hub = False
-
-        node_value = _get_first_child_node_value(desc, 'MessageRetentionInDays')
-        if node_value is not None:
-            hub.message_retention_in_days = int(node_value)
-            invalid_event_hub = False
-
-        node_value = _get_first_child_node_value(desc, 'Status')
-        if node_value is not None:
-            hub.status = node_value
-            invalid_event_hub = False
-
-        node_value = _get_first_child_node_value(desc, 'UserMetadata')
-        if node_value is not None:
-            hub.user_metadata = node_value
-            invalid_event_hub = False
-
-        node_value = _get_first_child_node_value(desc, 'PartitionCount')
-        if node_value is not None:
-            hub.partition_count = int(node_value)
-            invalid_event_hub = False
-
-        ids = desc.getElementsByTagName('PartitionIds')
-        if ids:
-            for id_node in ids[0].getElementsByTagNameNS(_XmlSchemas.SerializationArrays, 'string'):
-                if id_node.firstChild:
-                    value = id_node.firstChild.nodeValue
-                    if value is not None:
-                        hub.partition_ids.append(value)
-
-        node_value = _get_first_child_node_value(desc, 'EntityAvailableStatus')
-        if node_value is not None:
-            hub.entity_available_status = node_value
-            invalid_event_hub = False
-
-        rules_children = _get_children_from_path(desc, 'AuthorizationRules', 'Authorization')
-
-        rules_nodes = desc.getElementsByTagName('AuthorizationRules')
-        if rules_nodes:
-            invalid_event_hub = False
-            for rule_node in rules_nodes[0].getElementsByTagName('AuthorizationRule'):
+            for rule_node in rules_nodes.findall('./sb:AuthorizationRule', _etree_sb_feed_namespaces):
                 rule = AuthorizationRule()
 
-                node_value = _get_first_child_node_value(rule_node, 'ClaimType')
-                if node_value is not None:
-                    rule.claim_type = node_value
+                mappings = [
+                    ('ClaimType', 'claim_type', None),
+                    ('ClaimValue', 'claim_value', None),
+                    ('ModifiedTime', 'modified_time', None),
+                    ('CreatedTime', 'created_time', None),
+                    ('KeyName', 'key_name', None),
+                    ('PrimaryKey', 'primary_key', None),
+                    ('SecondaryKey', 'secondary_key', None),
+                ]
 
-                node_value = _get_first_child_node_value(rule_node, 'ClaimValue')
-                if node_value is not None:
-                    rule.claim_value = node_value
+                for map in mappings:
+                    _read_etree_element(rule_node, map[0], rule, map[1], map[2])
 
-                node_value = _get_first_child_node_value(rule_node, 'ModifiedTime')
-                if node_value is not None:
-                    rule.modified_time = node_value
-
-                node_value = _get_first_child_node_value(rule_node, 'CreatedTime')
-                if node_value is not None:
-                    rule.created_time = node_value
-
-                node_value = _get_first_child_node_value(rule_node, 'KeyName')
-                if node_value is not None:
-                    rule.key_name = node_value
-
-                node_value = _get_first_child_node_value(rule_node, 'PrimaryKey')
-                if node_value is not None:
-                    rule.primary_key = node_value
-
-                node_value = _get_first_child_node_value(rule_node, 'SecondaryKey')
-                if node_value is not None:
-                    rule.secondary_key = node_value
-
-                rights_nodes = rule_node.getElementsByTagName('Rights')
-                if rights_nodes:
-                    for access_rights_node in rights_nodes[0].getElementsByTagName('AccessRights'):
-                        if access_rights_node.firstChild:
-                            node_value = access_rights_node.firstChild.nodeValue
+                rights_nodes = rule_node.find('./sb:Rights', _etree_sb_feed_namespaces)
+                if rights_nodes is not None:
+                    for access_rights_node in rights_nodes.findall('./sb:AccessRights', _etree_sb_feed_namespaces):
+                        node_value = _get_etree_text(access_rights_node)
+                        if node_value:
                             rule.rights.append(node_value)
 
                 hub.authorization_rules.append(rule)
@@ -746,7 +627,7 @@ def _convert_xml_to_event_hub(xmlstr):
         raise WindowsAzureError(_ERROR_EVENT_HUB_NOT_FOUND)
 
     # extract id, updated and name value from feed entry and set them of queue.
-    for name, value in _get_entry_properties(xmlstr, True).items():
+    for name, value in _get_entry_properties_from_etree_element(entry_element, True).items():
         if name == 'name':
             value = value.partition('?')[0]
         setattr(hub, name, value)

--- a/azure/servicebus/__init__.py
+++ b/azure/servicebus/__init__.py
@@ -21,7 +21,6 @@ from azure import (
     WindowsAzureData,
     WindowsAzureError,
     _general_error_handler,
-    _get_entry_properties_from_etree_element,
     _lower,
     _str,
     _ERROR_MESSAGE_NOT_PEEK_LOCKED_ON_DELETE,
@@ -33,6 +32,7 @@ from azure import (
     _make_etree_ns_attr_name,
     _get_etree_text,
     ETree,
+    _ETreeXmlToObject,
     )
 from azure.http import HTTPError
 
@@ -383,7 +383,8 @@ def _convert_etree_element_to_rule(entry_element):
 
 
     # extract id, updated and name value from feed entry and set them of rule.
-    for name, value in _get_entry_properties_from_etree_element(entry_element, True, '/rules').items():
+    for name, value in _ETreeXmlToObject.get_entry_properties_from_element(
+        entry_element, True, '/rules').items():
         setattr(rule, name, value)
 
     return rule
@@ -461,7 +462,8 @@ def _convert_etree_element_to_queue(entry_element):
         raise WindowsAzureError(_ERROR_QUEUE_NOT_FOUND)
 
     # extract id, updated and name value from feed entry and set them of queue.
-    for name, value in _get_entry_properties_from_etree_element(entry_element, True).items():
+    for name, value in _ETreeXmlToObject.get_entry_properties_from_element(
+        entry_element, True).items():
         setattr(queue, name, value)
 
     return queue
@@ -513,7 +515,8 @@ def _convert_etree_element_to_topic(entry_element):
         raise WindowsAzureError(_ERROR_TOPIC_NOT_FOUND)
 
     # extract id, updated and name value from feed entry and set them of topic.
-    for name, value in _get_entry_properties_from_etree_element(entry_element, True).items():
+    for name, value in _ETreeXmlToObject.get_entry_properties_from_element(
+        entry_element, True).items():
         setattr(topic, name, value)
 
     return topic
@@ -560,7 +563,8 @@ def _convert_etree_element_to_subscription(entry_element):
         for map in mappings:
             _read_etree_element(subscription_element, map[0], subscription, map[1], map[2])
 
-    for name, value in _get_entry_properties_from_etree_element(entry_element, True, '/subscriptions').items():
+    for name, value in _ETreeXmlToObject.get_entry_properties_from_element(
+        entry_element, True, '/subscriptions').items():
         setattr(subscription, name, value)
 
     return subscription
@@ -627,7 +631,8 @@ def _convert_etree_element_to_event_hub(entry_element):
         raise WindowsAzureError(_ERROR_EVENT_HUB_NOT_FOUND)
 
     # extract id, updated and name value from feed entry and set them of queue.
-    for name, value in _get_entry_properties_from_etree_element(entry_element, True).items():
+    for name, value in _ETreeXmlToObject.get_entry_properties_from_element(
+        entry_element, True).items():
         if name == 'name':
             value = value.partition('?')[0]
         setattr(hub, name, value)

--- a/azure/servicebus/servicebusservice.py
+++ b/azure/servicebus/servicebusservice.py
@@ -19,7 +19,7 @@ import time
 from azure import (
     WindowsAzureError,
     SERVICE_BUS_HOST_BASE,
-    _convert_response_to_feeds,
+    _convert_response_to_feeds_using_etree,
     _dont_fail_not_exist,
     _dont_fail_on_exist,
     _encode_base64,
@@ -53,10 +53,10 @@ from azure.servicebus import (
     _convert_rule_to_xml,
     _convert_response_to_rule,
     _convert_response_to_event_hub,
-    _convert_xml_to_queue,
-    _convert_xml_to_topic,
-    _convert_xml_to_subscription,
-    _convert_xml_to_rule,
+    _convert_etree_element_to_queue,
+    _convert_etree_element_to_topic,
+    _convert_etree_element_to_subscription,
+    _convert_etree_element_to_rule,
     _create_message,
     _service_bus_error_handler,
     )
@@ -266,7 +266,7 @@ class ServiceBusService(object):
         request.headers = self._update_service_bus_header(request)
         response = self._perform_request(request)
 
-        return _convert_response_to_feeds(response, _convert_xml_to_queue)
+        return _convert_response_to_feeds_using_etree(response, _convert_etree_element_to_queue)
 
     def create_topic(self, topic_name, topic=None, fail_on_exist=False):
         '''
@@ -353,7 +353,7 @@ class ServiceBusService(object):
         request.headers = self._update_service_bus_header(request)
         response = self._perform_request(request)
 
-        return _convert_response_to_feeds(response, _convert_xml_to_topic)
+        return _convert_response_to_feeds_using_etree(response, _convert_etree_element_to_topic)
 
     def create_rule(self, topic_name, subscription_name, rule_name, rule=None,
                     fail_on_exist=False):
@@ -467,7 +467,7 @@ class ServiceBusService(object):
         request.headers = self._update_service_bus_header(request)
         response = self._perform_request(request)
 
-        return _convert_response_to_feeds(response, _convert_xml_to_rule)
+        return _convert_response_to_feeds_using_etree(response, _convert_etree_element_to_rule)
 
     def create_subscription(self, topic_name, subscription_name,
                             subscription=None, fail_on_exist=False):
@@ -568,8 +568,8 @@ class ServiceBusService(object):
         request.headers = self._update_service_bus_header(request)
         response = self._perform_request(request)
 
-        return _convert_response_to_feeds(response,
-                                          _convert_xml_to_subscription)
+        return _convert_response_to_feeds_using_etree(response,
+                                          _convert_etree_element_to_subscription)
 
     def send_topic_message(self, topic_name, message=None):
         '''

--- a/azure/servicebus/servicebusservice.py
+++ b/azure/servicebus/servicebusservice.py
@@ -17,9 +17,9 @@ import os
 import time
 
 from azure import (
+    _ETreeXmlToObject,
     WindowsAzureError,
     SERVICE_BUS_HOST_BASE,
-    _convert_response_to_feeds_using_etree,
     _dont_fail_not_exist,
     _dont_fail_on_exist,
     _encode_base64,
@@ -266,7 +266,8 @@ class ServiceBusService(object):
         request.headers = self._update_service_bus_header(request)
         response = self._perform_request(request)
 
-        return _convert_response_to_feeds_using_etree(response, _convert_etree_element_to_queue)
+        return _ETreeXmlToObject.convert_response_to_feeds(
+            response, _convert_etree_element_to_queue)
 
     def create_topic(self, topic_name, topic=None, fail_on_exist=False):
         '''
@@ -353,7 +354,8 @@ class ServiceBusService(object):
         request.headers = self._update_service_bus_header(request)
         response = self._perform_request(request)
 
-        return _convert_response_to_feeds_using_etree(response, _convert_etree_element_to_topic)
+        return _ETreeXmlToObject.convert_response_to_feeds(
+            response, _convert_etree_element_to_topic)
 
     def create_rule(self, topic_name, subscription_name, rule_name, rule=None,
                     fail_on_exist=False):
@@ -467,7 +469,8 @@ class ServiceBusService(object):
         request.headers = self._update_service_bus_header(request)
         response = self._perform_request(request)
 
-        return _convert_response_to_feeds_using_etree(response, _convert_etree_element_to_rule)
+        return _ETreeXmlToObject.convert_response_to_feeds(
+            response, _convert_etree_element_to_rule)
 
     def create_subscription(self, topic_name, subscription_name,
                             subscription=None, fail_on_exist=False):
@@ -568,8 +571,8 @@ class ServiceBusService(object):
         request.headers = self._update_service_bus_header(request)
         response = self._perform_request(request)
 
-        return _convert_response_to_feeds_using_etree(response,
-                                          _convert_etree_element_to_subscription)
+        return _ETreeXmlToObject.convert_response_to_feeds(
+            response, _convert_etree_element_to_subscription)
 
     def send_topic_message(self, topic_name, message=None):
         '''

--- a/azure/servicemanagement/__init__.py
+++ b/azure/servicemanagement/__init__.py
@@ -12,26 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
+from datetime import datetime
 from xml.dom import minidom
-import xml.etree.ElementTree
 import sys
 from azure import (
+    ETree,
+    Feed,
     WindowsAzureData,
     _Base64String,
     _create_entry,
     _dict_of,
+    _decode_base64_to_text,
     _encode_base64,
     _general_error_handler,
-    _get_children_from_path,
-    _get_first_child_node_value,
     _list_of,
     _lower,
     _scalar_list_of,
     _str,
+    _strtype,
     _xml_attribute,
-    _get_entry_properties_from_node,
-    _get_child_nodes,
     _get_serialization_name,
+    _set_continuation_from_response_headers,
     )
 
 
@@ -1903,7 +1904,7 @@ def get_certificate_from_publish_settings(publish_settings_path, path_to_write_c
         raise TypeError("path_to_write_certificate cannot be None")
 
     # parse the publishsettings file and find the ManagementCertificate Entry
-    tree = xml.etree.ElementTree.parse(publish_settings_path)
+    tree = ETree.parse(publish_settings_path)
     subscriptions = tree.getroot().findall("./PublishProfile/Subscription")
     
     if subscription_name is None:
@@ -1937,28 +1938,394 @@ def _management_error_handler(http_error):
     return _general_error_handler(http_error)
 
 
-def _convert_response_to_feeds(response, convert_func):
+class _MinidomXmlToObject(object):
     '''
-    DEPRECATED. Do not use outside of ServiceManagement.
-    New code should use _convert_response_to_feeds_using_etree.
+    DEPRECATED.
+    All calls to this class will eventually be removed.
+    Do not use outside of service management apis.
     '''
-    if response is None:
-        return None
 
-    feeds = _list_of(Feed)
+    @staticmethod
+    def parse_response(response, return_type):
+        '''
+        Parse the HTTPResponse's body and fill all the data into a class of
+        return_type.
+        '''
+        doc = minidom.parseString(response.body)
+        return_obj = return_type()
+        xml_name = return_type._xml_name if hasattr(return_type, '_xml_name') else return_type.__name__ 
+        for node in _MinidomXmlToObject.get_child_nodes(doc, xml_name):
+            _MinidomXmlToObject._fill_data_to_return_object(node, return_obj)
 
-    _set_continuation_from_response(feeds, response)
+        return return_obj
 
-    xmldoc = minidom.parseString(response.body)
-    xml_entries = _get_children_from_path(xmldoc, 'feed', 'entry')
-    if not xml_entries:
-        # in some cases, response contains only entry but no feed
-        xml_entries = _get_children_from_path(xmldoc, 'entry')
-    for xml_entry in xml_entries:
-        new_node = _clone_node_with_namespaces(xml_entry, xmldoc)
-        feeds.append(convert_func(new_node.toxml('utf-8')))
 
-    return feeds
+    @staticmethod
+    def parse_service_resources_response(response, return_type):
+        '''
+        Parse the HTTPResponse's body and fill all the data into a class of
+        return_type.
+        '''
+        doc = minidom.parseString(response.body)
+        return_obj = _list_of(return_type)
+        for node in _MinidomXmlToObject.get_children_from_path(doc, "ServiceResources", "ServiceResource"):
+            local_obj = return_type()
+            _MinidomXmlToObject._fill_data_to_return_object(node, local_obj)
+            return_obj.append(local_obj)
+
+        return return_obj
+
+
+    @staticmethod
+    def fill_data_member(xmldoc, element_name, data_member):
+        xmlelements = _MinidomXmlToObject.get_child_nodes(
+            xmldoc, _get_serialization_name(element_name))
+
+        if not xmlelements or not xmlelements[0].childNodes:
+            return None
+
+        value = xmlelements[0].firstChild.nodeValue
+
+        if data_member is None:
+            return value
+        elif isinstance(data_member, datetime):
+            return _to_datetime(value)
+        elif type(data_member) is bool:
+            return value.lower() != 'false'
+        else:
+            return type(data_member)(value)
+
+
+    @staticmethod
+    def convert_xml_to_azure_object(xmlstr, azure_type, include_id=True, use_title_as_id=True):
+        xmldoc = minidom.parseString(xmlstr)
+        return_obj = azure_type()
+        xml_name = azure_type._xml_name if hasattr(azure_type, '_xml_name') else azure_type.__name__
+
+        # Only one entry here
+        for xml_entry in _MinidomXmlToObject.get_children_from_path(xmldoc,
+                                                 'entry'):
+            for node in _MinidomXmlToObject.get_children_from_path(xml_entry,
+                                                'content',
+                                                xml_name):
+                _MinidomXmlToObject._fill_data_to_return_object(node, return_obj)
+            for name, value in _MinidomXmlToObject.get_entry_properties_from_node(
+                xml_entry,
+                include_id=include_id,
+                use_title_as_id=use_title_as_id).items():
+                setattr(return_obj, name, value)
+        return return_obj
+
+
+    @staticmethod
+    def get_entry_properties_from_node(entry, include_id, id_prefix_to_skip=None, use_title_as_id=False):
+        ''' get properties from entry xml '''
+        properties = {}
+
+        etag = entry.getAttributeNS(METADATA_NS, 'etag')
+        if etag:
+            properties['etag'] = etag
+        for updated in get_child_nodes(entry, 'updated'):
+            properties['updated'] = updated.firstChild.nodeValue
+        for name in get_children_from_path(entry, 'author', 'name'):
+            if name.firstChild is not None:
+                properties['author'] = name.firstChild.nodeValue
+
+        if include_id:
+            if use_title_as_id:
+                for title in get_child_nodes(entry, 'title'):
+                    properties['name'] = title.firstChild.nodeValue
+            else:
+                for id in get_child_nodes(entry, 'id'):
+                    properties['name'] = _get_readable_id(
+                        id.firstChild.nodeValue, id_prefix_to_skip)
+
+        return properties
+
+
+    @staticmethod
+    def convert_response_to_feeds(response, convert_func):
+        if response is None:
+            return None
+
+        feeds = _list_of(Feed)
+
+        _set_continuation_from_response_headers(feeds, response)
+
+        xmldoc = minidom.parseString(response.body)
+        xml_entries = _MinidomXmlToObject.get_children_from_path(xmldoc, 'feed', 'entry')
+        if not xml_entries:
+            # in some cases, response contains only entry but no feed
+            xml_entries = _MinidomXmlToObject.get_children_from_path(xmldoc, 'entry')
+        for xml_entry in xml_entries:
+            new_node = _MinidomXmlToObject._clone_node_with_namespaces(xml_entry, xmldoc)
+            feeds.append(convert_func(new_node.toxml('utf-8')))
+
+        return feeds
+
+
+    @staticmethod
+    def get_first_child_node_value(parent_node, node_name):
+        xml_attrs = _MinidomXmlToObject.get_child_nodes(parent_node, node_name)
+        if xml_attrs:
+            xml_attr = xml_attrs[0]
+            if xml_attr.firstChild:
+                value = xml_attr.firstChild.nodeValue
+                return value
+
+
+    @staticmethod
+    def get_children_from_path(node, *path):
+        '''descends through a hierarchy of nodes returning the list of children
+        at the inner most level.  Only returns children who share a common parent,
+        not cousins.'''
+        cur = node
+        for index, child in enumerate(path):
+            if isinstance(child, _strtype):
+                next = _MinidomXmlToObject.get_child_nodes(cur, child)
+            else:
+                next = _MinidomXmlToObject._get_child_nodesNS(cur, *child)
+            if index == len(path) - 1:
+                return next
+            elif not next:
+                break
+
+            cur = next[0]
+        return []
+
+
+    @staticmethod
+    def get_child_nodes(node, tagName):
+        return [childNode for childNode in node.getElementsByTagName(tagName)
+                if childNode.parentNode == node]
+
+
+    @staticmethod
+    def _get_child_nodesNS(node, ns, tagName):
+        return [childNode for childNode in node.getElementsByTagNameNS(ns, tagName)
+                if childNode.parentNode == node]
+
+
+    @staticmethod
+    def _parse_response_body_from_xml_node(node, return_type):
+        '''
+        parse the xml and fill all the data into a class of return_type
+        '''
+        return_obj = return_type()
+        _MinidomXmlToObject._fill_data_to_return_object(node, return_obj)
+
+        return return_obj
+
+
+    @staticmethod
+    def _fill_list_of(xmldoc, element_type, xml_element_name):
+        xmlelements = _MinidomXmlToObject.get_child_nodes(xmldoc, xml_element_name)
+        return [_MinidomXmlToObject._parse_response_body_from_xml_node(xmlelement, element_type) \
+            for xmlelement in xmlelements]
+
+
+    @staticmethod
+    def _fill_scalar_list_of(xmldoc, element_type, parent_xml_element_name,
+                             xml_element_name):
+        '''Converts an xml fragment into a list of scalar types.  The parent xml
+        element contains a flat list of xml elements which are converted into the
+        specified scalar type and added to the list.
+        Example:
+        xmldoc=
+    <Endpoints>
+        <Endpoint>http://{storage-service-name}.blob.core.windows.net/</Endpoint>
+        <Endpoint>http://{storage-service-name}.queue.core.windows.net/</Endpoint>
+        <Endpoint>http://{storage-service-name}.table.core.windows.net/</Endpoint>
+    </Endpoints>
+        element_type=str
+        parent_xml_element_name='Endpoints'
+        xml_element_name='Endpoint'
+        '''
+        xmlelements = _MinidomXmlToObject.get_child_nodes(xmldoc, parent_xml_element_name)
+        if xmlelements:
+            xmlelements = _MinidomXmlToObject.get_child_nodes(xmlelements[0], xml_element_name)
+            return [_MinidomXmlToObject._get_node_value(xmlelement, element_type) \
+                for xmlelement in xmlelements]
+
+
+    @staticmethod
+    def _fill_dict(xmldoc, element_name):
+        xmlelements = _MinidomXmlToObject.get_child_nodes(xmldoc, element_name)
+        if xmlelements:
+            return_obj = {}
+            for child in xmlelements[0].childNodes:
+                if child.firstChild:
+                    return_obj[child.nodeName] = child.firstChild.nodeValue
+            return return_obj
+
+
+    @staticmethod
+    def _fill_dict_of(xmldoc, parent_xml_element_name, pair_xml_element_name,
+                      key_xml_element_name, value_xml_element_name):
+        '''Converts an xml fragment into a dictionary. The parent xml element
+        contains a list of xml elements where each element has a child element for
+        the key, and another for the value.
+        Example:
+        xmldoc=
+    <ExtendedProperties>
+        <ExtendedProperty>
+            <Name>Ext1</Name>
+            <Value>Val1</Value>
+        </ExtendedProperty>
+        <ExtendedProperty>
+            <Name>Ext2</Name>
+            <Value>Val2</Value>
+        </ExtendedProperty>
+    </ExtendedProperties>
+        element_type=str
+        parent_xml_element_name='ExtendedProperties'
+        pair_xml_element_name='ExtendedProperty'
+        key_xml_element_name='Name'
+        value_xml_element_name='Value'
+        '''
+        return_obj = {}
+
+        xmlelements = _MinidomXmlToObject.get_child_nodes(xmldoc, parent_xml_element_name)
+        if xmlelements:
+            xmlelements = _MinidomXmlToObject.get_child_nodes(xmlelements[0], pair_xml_element_name)
+            for pair in xmlelements:
+                keys = _MinidomXmlToObject.get_child_nodes(pair, key_xml_element_name)
+                values = _MinidomXmlToObject.get_child_nodes(pair, value_xml_element_name)
+                if keys and values:
+                    key = keys[0].firstChild.nodeValue
+                    value = values[0].firstChild.nodeValue
+                    return_obj[key] = value
+
+        return return_obj
+
+
+    @staticmethod
+    def _fill_instance_child(xmldoc, element_name, return_type):
+        '''Converts a child of the current dom element to the specified type.
+        '''
+        xmlelements = _MinidomXmlToObject.get_child_nodes(
+            xmldoc, _get_serialization_name(element_name))
+
+        if not xmlelements:
+            return None
+
+        return_obj = return_type()
+        _MinidomXmlToObject._fill_data_to_return_object(xmlelements[0], return_obj)
+
+        return return_obj
+
+
+    @staticmethod
+    def _get_node_value(xmlelement, data_type):
+        value = xmlelement.firstChild.nodeValue
+        if data_type is datetime:
+            return _to_datetime(value)
+        elif data_type is bool:
+            return value.lower() != 'false'
+        else:
+            return data_type(value)
+
+
+    @staticmethod
+    def _fill_data_to_return_object(node, return_obj):
+        members = dict(vars(return_obj))
+        for name, value in members.items():
+            if isinstance(value, _list_of):
+                setattr(return_obj,
+                        name,
+                        _MinidomXmlToObject._fill_list_of(
+                            node,
+                            value.list_type,
+                            value.xml_element_name))
+            elif isinstance(value, _scalar_list_of):
+                setattr(return_obj,
+                        name,
+                        _MinidomXmlToObject._fill_scalar_list_of(
+                            node,
+                            value.list_type,
+                            _get_serialization_name(name),
+                            value.xml_element_name))
+            elif isinstance(value, _dict_of):
+                setattr(return_obj,
+                        name,
+                        _MinidomXmlToObject._fill_dict_of(
+                            node,
+                            _get_serialization_name(name),
+                            value.pair_xml_element_name,
+                            value.key_xml_element_name,
+                            value.value_xml_element_name))
+            elif isinstance(value, _xml_attribute):
+                real_value = None
+                if node.hasAttribute(value.xml_element_name):
+                    real_value = node.getAttribute(value.xml_element_name)
+                if real_value is not None:
+                    setattr(return_obj, name, real_value)
+            elif isinstance(value, WindowsAzureData):
+                setattr(return_obj,
+                        name,
+                        _MinidomXmlToObject._fill_instance_child(
+                            node,
+                            name,
+                            value.__class__))
+            elif isinstance(value, dict):
+                setattr(return_obj,
+                        name,
+                        _MinidomXmlToObject._fill_dict(
+                            node,
+                            _get_serialization_name(name)))
+            elif isinstance(value, _Base64String):
+                value = _MinidomXmlToObject.fill_data_minidom(
+                    node,
+                    name,
+                    '')
+                if value is not None:
+                    value = _decode_base64_to_text(value)
+                # always set the attribute, so we don't end up returning an object
+                # with type _Base64String
+                setattr(return_obj, name, value)
+            else:
+                value = _MinidomXmlToObject.fill_data_member(
+                    node,
+                    name,
+                    value)
+                if value is not None:
+                    setattr(return_obj, name, value)
+
+
+    @staticmethod
+    def _find_namespaces_from_child(parent, child, namespaces):
+        """Recursively searches from the parent to the child,
+        gathering all the applicable namespaces along the way"""
+        for cur_child in parent.childNodes:
+            if cur_child is child:
+                return True
+            if _MinidomXmlToObject._find_namespaces_from_child(cur_child, child, namespaces):
+                # we are the parent node
+                for key in cur_child.attributes.keys():
+                    if key.startswith('xmlns:') or key == 'xmlns':
+                        namespaces[key] = cur_child.attributes[key]
+                break
+        return False
+
+
+    @staticmethod
+    def _find_namespaces(parent, child):
+        res = {}
+        for key in parent.documentElement.attributes.keys():
+            if key.startswith('xmlns:') or key == 'xmlns':
+                res[key] = parent.documentElement.attributes[key]
+        _MinidomXmlToObject._find_namespaces_from_child(parent, child, res)
+        return res
+
+
+    @staticmethod
+    def _clone_node_with_namespaces(node_to_clone, original_doc):
+        clone = node_to_clone.cloneNode(True)
+
+        for key, value in _MinidomXmlToObject._find_namespaces(original_doc, node_to_clone).items():
+            clone.attributes[key] = value
+
+        return clone
 
 
 def _data_to_xml(data):
@@ -2915,12 +3282,13 @@ class _ServiceBusManagementXmlSerializer(object):
             ('Enabled', 'enabled', _parse_bool),
         )
 
-        for desc in _get_children_from_path(xmldoc,
-                                            'entry',
-                                            'content',
-                                            'NamespaceDescription'):
+        for desc in _MinidomXmlToObject.get_children_from_path(
+            xmldoc,
+            'entry',
+            'content',
+            'NamespaceDescription'):
             for xml_name, field_name, conversion_func in mappings:
-                node_value = _get_first_child_node_value(desc, xml_name)
+                node_value = _MinidomXmlToObject.get_first_child_node_value(desc, xml_name)
                 if node_value is not None:
                     if conversion_func is not None:
                         node_value = conversion_func(node_value)
@@ -2950,12 +3318,12 @@ class _ServiceBusManagementXmlSerializer(object):
         xmldoc = minidom.parseString(xmlstr)
         region = ServiceBusRegion()
 
-        for desc in _get_children_from_path(xmldoc, 'entry', 'content',
+        for desc in _MinidomXmlToObject.get_children_from_path(xmldoc, 'entry', 'content',
                                             'RegionCodeDescription'):
-            node_value = _get_first_child_node_value(desc, 'Code')
+            node_value = _MinidomXmlToObject.get_first_child_node_value(desc, 'Code')
             if node_value is not None:
                 region.code = node_value
-            node_value = _get_first_child_node_value(desc, 'FullName')
+            node_value = _MinidomXmlToObject.get_first_child_node_value(desc, 'FullName')
             if node_value is not None:
                 region.fullname = node_value
 
@@ -2983,9 +3351,9 @@ class _ServiceBusManagementXmlSerializer(object):
         xmldoc = minidom.parseString(xmlstr)
         availability = AvailabilityResponse()
 
-        for desc in _get_children_from_path(xmldoc, 'entry', 'content',
+        for desc in _MinidomXmlToObject.get_children_from_path(xmldoc, 'entry', 'content',
                                             'NamespaceAvailability'):
-            node_value = _get_first_child_node_value(desc, 'Result')
+            node_value = _MinidomXmlToObject.get_first_child_node_value(desc, 'Result')
             if node_value is not None:
                 availability.result = _parse_bool(node_value)
 
@@ -3054,23 +3422,24 @@ class _ServiceBusManagementXmlSerializer(object):
         members = dict(vars(return_obj))
 
         # Only one entry here
-        for xml_entry in _get_children_from_path(xmldoc,
+        for xml_entry in _MinidomXmlToObject.get_children_from_path(xmldoc,
                                                  'entry'):
-            for node in _get_children_from_path(xml_entry,
+            for node in _MinidomXmlToObject.get_children_from_path(xml_entry,
                                                 'content',
                                                 'm:properties'):
                 for name in members:
                     xml_name = "d:" + _get_serialization_name(name)
-                    children = _get_child_nodes(node, xml_name)
+                    children = _MinidomXmlToObject.get_child_nodes(node, xml_name)
                     if not children:
                         continue
                     child = children[0]
                     node_type = child.getAttributeNS("http://schemas.microsoft.com/ado/2007/08/dataservices/metadata", 'type')
                     node_value = _ServiceBusManagementXmlSerializer.odata_converter(child.firstChild.nodeValue, node_type)
                     setattr(return_obj, name, node_value)
-            for name, value in _get_entry_properties_from_node(xml_entry,
-                                                               include_id=True,
-                                                               use_title_as_id=False).items():
+            for name, value in _MinidomXmlToObject.get_entry_properties_from_node(
+                xml_entry,
+                include_id=True,
+                use_title_as_id=False).items():
                 if name in members:
                     continue  # Do not override if already members
                 setattr(return_obj, name, value)

--- a/azure/servicemanagement/__init__.py
+++ b/azure/servicemanagement/__init__.py
@@ -33,6 +33,7 @@ from azure import (
     _xml_attribute,
     _get_serialization_name,
     _set_continuation_from_response_headers,
+    METADATA_NS,
     )
 
 
@@ -2025,18 +2026,18 @@ class _MinidomXmlToObject(object):
         etag = entry.getAttributeNS(METADATA_NS, 'etag')
         if etag:
             properties['etag'] = etag
-        for updated in get_child_nodes(entry, 'updated'):
+        for updated in _MinidomXmlToObject.get_child_nodes(entry, 'updated'):
             properties['updated'] = updated.firstChild.nodeValue
-        for name in get_children_from_path(entry, 'author', 'name'):
+        for name in _MinidomXmlToObject.get_children_from_path(entry, 'author', 'name'):
             if name.firstChild is not None:
                 properties['author'] = name.firstChild.nodeValue
 
         if include_id:
             if use_title_as_id:
-                for title in get_child_nodes(entry, 'title'):
+                for title in _MinidomXmlToObject.get_child_nodes(entry, 'title'):
                     properties['name'] = title.firstChild.nodeValue
             else:
-                for id in get_child_nodes(entry, 'id'):
+                for id in _MinidomXmlToObject.get_child_nodes(entry, 'id'):
                     properties['name'] = _get_readable_id(
                         id.firstChild.nodeValue, id_prefix_to_skip)
 
@@ -2274,7 +2275,7 @@ class _MinidomXmlToObject(object):
                             node,
                             _get_serialization_name(name)))
             elif isinstance(value, _Base64String):
-                value = _MinidomXmlToObject.fill_data_minidom(
+                value = _MinidomXmlToObject.fill_data_member(
                     node,
                     name,
                     '')

--- a/azure/servicemanagement/servicebusmanagementservice.py
+++ b/azure/servicemanagement/servicebusmanagementservice.py
@@ -16,7 +16,6 @@ from azure import (
     MANAGEMENT_HOST,
     _str,
     _validate_not_none,
-    _convert_xml_to_windows_azure_object,
 )
 from azure.servicemanagement import (
     _ServiceBusManagementXmlSerializer,
@@ -27,7 +26,7 @@ from azure.servicemanagement import (
     MetricProperties,
     MetricValues,
     MetricRollups,
-    _convert_response_to_feeds,
+    _MinidomXmlToObject,
 )
 from azure.servicemanagement.servicemanagementclient import (
     _ServiceManagementClient,
@@ -75,7 +74,7 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_path('services/serviceBus/Regions/', None),
             None)
 
-        return _convert_response_to_feeds(
+        return _MinidomXmlToObject.convert_response_to_feeds(
             response,
             _ServiceBusManagementXmlSerializer.xml_to_region)
 
@@ -87,7 +86,7 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_path('services/serviceBus/Namespaces/', None),
             None)
 
-        return _convert_response_to_feeds(
+        return _MinidomXmlToObject.convert_response_to_feeds(
             response,
             _ServiceBusManagementXmlSerializer.xml_to_namespace)
 
@@ -157,9 +156,13 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_list_queues_path(name),
             None)
 
-        return _convert_response_to_feeds(response,
-                                          partial(_convert_xml_to_windows_azure_object,
-                                                  azure_type=QueueDescription))
+        return _MinidomXmlToObject.convert_response_to_feeds(
+            response,
+            partial(
+                _MinidomXmlToObject.convert_xml_to_azure_object,
+                azure_type=QueueDescription
+            )
+        )
 
     def list_topics(self, name):
         '''
@@ -171,9 +174,13 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_list_topics_path(name),
             None)
 
-        return _convert_response_to_feeds(response,
-                                          partial(_convert_xml_to_windows_azure_object,
-                                                  azure_type=TopicDescription))
+        return _MinidomXmlToObject.convert_response_to_feeds(
+            response,
+            partial(
+                _MinidomXmlToObject.convert_xml_to_azure_object,
+                azure_type=TopicDescription
+            )
+        )
 
     def list_notification_hubs(self, name):
         '''
@@ -185,9 +192,13 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_list_notification_hubs_path(name),
             None)
 
-        return _convert_response_to_feeds(response,
-                                          partial(_convert_xml_to_windows_azure_object,
-                                                  azure_type=NotificationHubDescription))
+        return _MinidomXmlToObject.convert_response_to_feeds(
+            response,
+            partial(
+                _MinidomXmlToObject.convert_xml_to_azure_object,
+                azure_type=NotificationHubDescription
+            )
+        )
 
     def list_relays(self, name):
         '''
@@ -199,9 +210,13 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_list_relays_path(name),
             None)
 
-        return _convert_response_to_feeds(response,
-                                          partial(_convert_xml_to_windows_azure_object,
-                                                  azure_type=RelayDescription))
+        return _MinidomXmlToObject.convert_response_to_feeds(
+            response,
+            partial(
+                _MinidomXmlToObject.convert_xml_to_azure_object,
+                azure_type=RelayDescription
+            )
+        )
 
     def get_supported_metrics_queue(self, name, queue_name):
         '''
@@ -214,9 +229,13 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_get_supported_metrics_queue_path(name, queue_name),
             None)
 
-        return _convert_response_to_feeds(response,
-                                          partial(_ServiceBusManagementXmlSerializer.xml_to_metrics,
-                                                  object_type=MetricProperties))
+        return _MinidomXmlToObject.convert_response_to_feeds(
+            response,
+            partial(
+                _ServiceBusManagementXmlSerializer.xml_to_metrics,
+                object_type=MetricProperties
+            )
+        )
 
     def get_supported_metrics_topic(self, name, topic_name):
         '''
@@ -229,9 +248,13 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_get_supported_metrics_topic_path(name, topic_name),
             None)
 
-        return _convert_response_to_feeds(response,
-                                          partial(_ServiceBusManagementXmlSerializer.xml_to_metrics,
-                                                  object_type=MetricProperties))
+        return _MinidomXmlToObject.convert_response_to_feeds(
+            response,
+            partial(
+                _ServiceBusManagementXmlSerializer.xml_to_metrics,
+                object_type=MetricProperties
+            )
+        )
 
     def get_supported_metrics_notification_hub(self, name, hub_name):
         '''
@@ -244,9 +267,13 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_get_supported_metrics_hub_path(name, hub_name),
             None)
 
-        return _convert_response_to_feeds(response,
-                                          partial(_ServiceBusManagementXmlSerializer.xml_to_metrics,
-                                                  object_type=MetricProperties))
+        return _MinidomXmlToObject.convert_response_to_feeds(
+            response,
+            partial(
+                _ServiceBusManagementXmlSerializer.xml_to_metrics,
+                object_type=MetricProperties
+            )
+        )
 
     def get_supported_metrics_relay(self, name, relay_name):
         '''
@@ -259,9 +286,13 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_get_supported_metrics_relay_path(name, relay_name),
             None)
 
-        return _convert_response_to_feeds(response,
-                                          partial(_ServiceBusManagementXmlSerializer.xml_to_metrics,
-                                                  object_type=MetricProperties))
+        return _MinidomXmlToObject.convert_response_to_feeds(
+            response,
+            partial(
+                _ServiceBusManagementXmlSerializer.xml_to_metrics,
+                object_type=MetricProperties
+            )
+        )
 
     def get_metrics_data_queue(self, name, queue_name, metric, rollup, filter_expresssion):
         '''
@@ -277,9 +308,13 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_get_metrics_data_queue_path(name, queue_name, metric, rollup, filter_expresssion),
             None)
 
-        return _convert_response_to_feeds(response,
-                                          partial(_ServiceBusManagementXmlSerializer.xml_to_metrics,
-                                                  object_type=MetricValues))
+        return _MinidomXmlToObject.convert_response_to_feeds(
+            response,
+            partial(
+                _ServiceBusManagementXmlSerializer.xml_to_metrics,
+                object_type=MetricValues
+            )
+        )
 
     def get_metrics_data_topic(self, name, topic_name, metric, rollup, filter_expresssion):
         '''
@@ -295,9 +330,13 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_get_metrics_data_topic_path(name, topic_name, metric, rollup, filter_expresssion),
             None)
 
-        return _convert_response_to_feeds(response,
-                                          partial(_ServiceBusManagementXmlSerializer.xml_to_metrics,
-                                                  object_type=MetricValues))
+        return _MinidomXmlToObject.convert_response_to_feeds(
+            response,
+            partial(
+                _ServiceBusManagementXmlSerializer.xml_to_metrics,
+                object_type=MetricValues
+            )
+        )
 
     def get_metrics_data_notification_hub(self, name, hub_name, metric, rollup, filter_expresssion):
         '''
@@ -313,9 +352,13 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_get_metrics_data_hub_path(name, hub_name, metric, rollup, filter_expresssion),
             None)
 
-        return _convert_response_to_feeds(response,
-                                          partial(_ServiceBusManagementXmlSerializer.xml_to_metrics,
-                                                  object_type=MetricValues))
+        return _MinidomXmlToObject.convert_response_to_feeds(
+            response,
+            partial(
+                _ServiceBusManagementXmlSerializer.xml_to_metrics,
+                object_type=MetricValues
+            )
+        )
 
     def get_metrics_data_relay(self, name, relay_name, metric, rollup, filter_expresssion):
         '''
@@ -331,9 +374,13 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_get_metrics_data_relay_path(name, relay_name, metric, rollup, filter_expresssion),
             None)
 
-        return _convert_response_to_feeds(response,
-                                          partial(_ServiceBusManagementXmlSerializer.xml_to_metrics,
-                                                  object_type=MetricValues))
+        return _MinidomXmlToObject.convert_response_to_feeds(
+            response,
+            partial(
+                _ServiceBusManagementXmlSerializer.xml_to_metrics,
+                object_type=MetricValues
+            )
+        )
 
     def get_metrics_rollups_queue(self, name, queue_name, metric):
         '''
@@ -349,9 +396,13 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_get_metrics_rollup_queue_path(name, queue_name, metric),
             None)
 
-        return _convert_response_to_feeds(response,
-                                          partial(_ServiceBusManagementXmlSerializer.xml_to_metrics,
-                                                  object_type=MetricRollups))
+        return _MinidomXmlToObject.convert_response_to_feeds(
+            response,
+            partial(
+                _ServiceBusManagementXmlSerializer.xml_to_metrics,
+                object_type=MetricRollups
+            )
+        )
 
     def get_metrics_rollups_topic(self, name, topic_name, metric):
         '''
@@ -367,9 +418,13 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_get_metrics_rollup_topic_path(name, topic_name, metric),
             None)
 
-        return _convert_response_to_feeds(response,
-                                          partial(_ServiceBusManagementXmlSerializer.xml_to_metrics,
-                                                  object_type=MetricRollups))
+        return _MinidomXmlToObject.convert_response_to_feeds(
+            response,
+            partial(
+                _ServiceBusManagementXmlSerializer.xml_to_metrics,
+                object_type=MetricRollups
+            )
+        )
 
     def get_metrics_rollups_notification_hub(self, name, hub_name, metric):
         '''
@@ -385,9 +440,13 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_get_metrics_rollup_hub_path(name, hub_name, metric),
             None)
 
-        return _convert_response_to_feeds(response,
-                                          partial(_ServiceBusManagementXmlSerializer.xml_to_metrics,
-                                                  object_type=MetricRollups))
+        return _MinidomXmlToObject.convert_response_to_feeds(
+            response,
+            partial(
+                _ServiceBusManagementXmlSerializer.xml_to_metrics,
+                object_type=MetricRollups
+            )
+        )
 
     def get_metrics_rollups_relay(self, name, relay_name, metric):
         '''
@@ -403,9 +462,13 @@ class ServiceBusManagementService(_ServiceManagementClient):
             self._get_get_metrics_rollup_relay_path(name, relay_name, metric),
             None)
 
-        return _convert_response_to_feeds(response,
-                                          partial(_ServiceBusManagementXmlSerializer.xml_to_metrics,
-                                                  object_type=MetricRollups))
+        return _MinidomXmlToObject.convert_response_to_feeds(
+            response,
+            partial(
+                _ServiceBusManagementXmlSerializer.xml_to_metrics,
+                object_type=MetricRollups
+            )
+        )
 
 
     # Helper functions --------------------------------------------------

--- a/azure/servicemanagement/servicebusmanagementservice.py
+++ b/azure/servicemanagement/servicebusmanagementservice.py
@@ -14,7 +14,6 @@
 #--------------------------------------------------------------------------
 from azure import (
     MANAGEMENT_HOST,
-    _convert_response_to_feeds,
     _str,
     _validate_not_none,
     _convert_xml_to_windows_azure_object,
@@ -28,6 +27,7 @@ from azure.servicemanagement import (
     MetricProperties,
     MetricValues,
     MetricRollups,
+    _convert_response_to_feeds,
 )
 from azure.servicemanagement.servicemanagementclient import (
     _ServiceManagementClient,

--- a/azure/servicemanagement/servicemanagementclient.py
+++ b/azure/servicemanagement/servicemanagementclient.py
@@ -18,7 +18,6 @@ from azure import (
     WindowsAzureError,
     MANAGEMENT_HOST,
     _get_request_body,
-    _parse_response,
     _str,
     _update_request_uri_query,
     )
@@ -30,6 +29,7 @@ from azure.http.httpclient import _HTTPClient
 from azure.servicemanagement import (
     AZURE_MANAGEMENT_CERTFILE,
     AZURE_MANAGEMENT_SUBSCRIPTIONID,
+    _MinidomXmlToObject,
     _management_error_handler,
     parse_response_for_async_op,
     X_MS_VERSION,
@@ -219,7 +219,7 @@ class _ServiceManagementClient(object):
         response = self.perform_get(path, x_ms_version)
 
         if response_type is not None:
-            return _parse_response(response, response_type)
+            return _MinidomXmlToObject.parse_response(response, response_type)
 
         return response
 
@@ -236,7 +236,7 @@ class _ServiceManagementClient(object):
         response = self.perform_post(path, body, x_ms_version)
 
         if response_type is not None:
-            return _parse_response(response, response_type)
+            return _MinidomXmlToObject.parse_response(response, response_type)
 
         if async:
             return parse_response_for_async_op(response)

--- a/azure/servicemanagement/sqldatabasemanagementservice.py
+++ b/azure/servicemanagement/sqldatabasemanagementservice.py
@@ -14,7 +14,6 @@
 #--------------------------------------------------------------------------
 from azure import (
     MANAGEMENT_HOST,
-    _parse_service_resources_response,
     _validate_not_none,
     )
 from azure.servicemanagement import (
@@ -25,6 +24,7 @@ from azure.servicemanagement import (
     Database,
     FirewallRule,
     _SqlManagementXmlSerializer,
+    _MinidomXmlToObject,
     )
 from azure.servicemanagement.servicemanagementclient import (
     _ServiceManagementClient,
@@ -129,7 +129,8 @@ class SqlDatabaseManagementService(_ServiceManagementClient):
         _validate_not_none('server_name', server_name)
         response = self._perform_get(self._get_quotas_path(server_name),
                                      None)
-        return _parse_service_resources_response(response, ServerQuota)
+        return _MinidomXmlToObject.parse_service_resources_response(
+            response, ServerQuota)
 
     def get_server_event_logs(self, server_name, start_date,
                               interval_size_in_minutes, event_types=''):
@@ -162,7 +163,8 @@ class SqlDatabaseManagementService(_ServiceManagementClient):
                '?startDate={0}&intervalSizeInMinutes={1}&eventTypes={2}'.format(
             start_date, interval_size_in_minutes, event_types)
         response = self._perform_get(path, None)
-        return _parse_service_resources_response(response, EventLog)
+        return _MinidomXmlToObject.parse_service_resources_response(
+            response, EventLog)
 
     #--Operations for firewall rules ------------------------------------------
     def create_firewall_rule(self, server_name, name, start_ip_address,
@@ -244,7 +246,8 @@ class SqlDatabaseManagementService(_ServiceManagementClient):
         _validate_not_none('server_name', server_name)
         response = self._perform_get(self._get_firewall_rules_path(server_name),
                                      None)
-        return _parse_service_resources_response(response, FirewallRule)
+        return _MinidomXmlToObject.parse_service_resources_response(
+            response, FirewallRule)
 
     def list_service_level_objectives(self, server_name):
         '''
@@ -255,7 +258,8 @@ class SqlDatabaseManagementService(_ServiceManagementClient):
         _validate_not_none('server_name', server_name)
         response = self._perform_get(
             self._get_service_objectives_path(server_name), None)
-        return _parse_service_resources_response(response, ServiceObjective)
+        return _MinidomXmlToObject.parse_service_resources_response(
+            response, ServiceObjective)
 
     #--Operations for sql databases ----------------------------------------
     def create_database(self, server_name, name, service_objective_id,
@@ -352,7 +356,8 @@ class SqlDatabaseManagementService(_ServiceManagementClient):
         '''
         response = self._perform_get(self._get_list_databases_path(name),
                                      None)
-        return _parse_service_resources_response(response, Database)
+        return _MinidomXmlToObject.parse_service_resources_response(
+            response, Database)
 
 
     #--Helper functions --------------------------------------------------

--- a/azure/storage/__init__.py
+++ b/azure/storage/__init__.py
@@ -736,11 +736,8 @@ def _create_blob_result(response):
 
 
 def _convert_block_etree_element_to_blob_block(block_element):
-    name_element = block_element.find('./Name')
-    size_element = block_element.find('./Size')
-
-    block_id = _decode_base64_to_text(_get_etree_text(name_element))
-    block_size = int(_get_etree_text(size_element))
+    block_id = _decode_base64_to_text(block_element.findtext('./Name', ''))
+    block_size = int(block_element.findtext('./Size'))
 
     return BlobBlock(block_id, block_size)
 
@@ -814,9 +811,7 @@ def _convert_etree_element_to_entity(entry_element):
     for prop in properties:
         for p in prop:
             name = _get_etree_tag_name_without_ns(p.tag)
-            value = p.text
-            if value is None:
-                value = ''
+            value = p.text or ''
             mtype = p.attrib.get(_make_etree_ns_attr_name(_etree_entity_feed_namespaces['m'], 'type'), None)
             isnull = p.attrib.get(_make_etree_ns_attr_name(_etree_entity_feed_namespaces['m'], 'null'), None)
 

--- a/azure/storage/blobservice.py
+++ b/azure/storage/blobservice.py
@@ -25,17 +25,15 @@ from azure import (
     _get_request_body,
     _get_request_body_bytes_only,
     _int_or_none,
-    _parse_enum_results_list,
-    _parse_response,
     _parse_response_for_dict,
     _parse_response_for_dict_filter,
     _parse_response_for_dict_prefix,
-    _parse_simple_list,
     _str,
     _str_or_none,
     _update_request_uri_query_local_storage,
     _validate_type_bytes,
     _validate_not_none,
+    _ETreeXmlToObject,
     )
 from azure.http import HTTPRequest
 from azure.storage import (
@@ -151,10 +149,8 @@ class BlobService(_StorageClient):
             request, self.account_name, self.account_key)
         response = self._perform_request(request)
 
-        return _parse_enum_results_list(response,
-                                        ContainerEnumResults,
-                                        "Containers",
-                                        Container)
+        return _ETreeXmlToObject.parse_enum_results_list(
+            response, ContainerEnumResults, "Containers", Container)
 
     def create_container(self, container_name, x_ms_meta_name_values=None,
                          x_ms_blob_public_access=None, fail_on_exist=False):
@@ -296,7 +292,8 @@ class BlobService(_StorageClient):
             request, self.account_name, self.account_key)
         response = self._perform_request(request)
 
-        return _parse_response(response, SignedIdentifiers)
+        return _ETreeXmlToObject.parse_response(
+            response, SignedIdentifiers)
 
     def set_container_acl(self, container_name, signed_identifiers=None,
                           x_ms_blob_public_access=None, x_ms_lease_id=None):
@@ -532,7 +529,8 @@ class BlobService(_StorageClient):
             request, self.account_name, self.account_key)
         response = self._perform_request(request)
 
-        return _parse_response(response, StorageServiceProperties)
+        return _ETreeXmlToObject.parse_response(
+            response, StorageServiceProperties)
 
     def get_blob_properties(self, container_name, blob_name,
                             x_ms_lease_id=None):
@@ -2175,4 +2173,4 @@ class BlobService(_StorageClient):
             request, self.account_name, self.account_key)
         response = self._perform_request(request)
 
-        return _parse_simple_list(response, PageList, PageRange, "page_ranges")
+        return _ETreeXmlToObject.parse_simple_list(response, PageList, PageRange, "page_ranges")

--- a/azure/storage/queueservice.py
+++ b/azure/storage/queueservice.py
@@ -23,8 +23,6 @@ from azure import (
     _dont_fail_on_exist,
     _get_request_body,
     _int_or_none,
-    _parse_enum_results_list,
-    _parse_response,
     _parse_response_for_dict_filter,
     _parse_response_for_dict_prefix,
     _str,
@@ -32,6 +30,7 @@ from azure import (
     _update_request_uri_query_local_storage,
     _validate_not_none,
     _ERROR_CONFLICT,
+    _ETreeXmlToObject,
     )
 from azure.http import (
     HTTPRequest,
@@ -85,7 +84,8 @@ class QueueService(_StorageClient):
             request, self.account_name, self.account_key)
         response = self._perform_request(request)
 
-        return _parse_response(response, StorageServiceProperties)
+        return _ETreeXmlToObject.parse_response(
+            response, StorageServiceProperties)
 
     def list_queues(self, prefix=None, marker=None, maxresults=None,
                     include=None):
@@ -125,7 +125,7 @@ class QueueService(_StorageClient):
             request, self.account_name, self.account_key)
         response = self._perform_request(request)
 
-        return _parse_enum_results_list(
+        return _ETreeXmlToObject.parse_enum_results_list(
             response, QueueEnumResults, "Queues", Queue)
 
     def create_queue(self, queue_name, x_ms_meta_name_values=None,
@@ -316,7 +316,8 @@ class QueueService(_StorageClient):
             request, self.account_name, self.account_key)
         response = self._perform_request(request)
 
-        return _parse_response(response, QueueMessagesList)
+        return _ETreeXmlToObject.parse_response(
+            response, QueueMessagesList)
 
     def peek_messages(self, queue_name, numofmessages=None):
         '''
@@ -341,7 +342,8 @@ class QueueService(_StorageClient):
             request, self.account_name, self.account_key)
         response = self._perform_request(request)
 
-        return _parse_response(response, QueueMessagesList)
+        return _ETreeXmlToObject.parse_response(
+            response, QueueMessagesList)
 
     def delete_message(self, queue_name, message_id, popreceipt):
         '''

--- a/azure/storage/tableservice.py
+++ b/azure/storage/tableservice.py
@@ -17,7 +17,7 @@ from azure import (
     TABLE_SERVICE_HOST_BASE,
     DEV_TABLE_HOST,
     _convert_class_to_xml,
-    _convert_response_to_feeds,
+    _convert_response_to_feeds_using_etree,
     _dont_fail_not_exist,
     _dont_fail_on_exist,
     _get_request_body,
@@ -35,10 +35,10 @@ from azure.http.batchclient import _BatchClient
 from azure.storage import (
     StorageServiceProperties,
     _convert_entity_to_xml,
+    _convert_etree_element_to_entity,
+    _convert_etree_element_to_table,
     _convert_response_to_entity,
     _convert_table_to_xml,
-    _convert_xml_to_entity,
-    _convert_xml_to_table,
     _sign_storage_table_request,
     _update_storage_table_header,
     )
@@ -148,7 +148,7 @@ class TableService(_StorageClient):
         request.headers = _update_storage_table_header(request)
         response = self._perform_request(request)
 
-        return _convert_response_to_feeds(response, _convert_xml_to_table)
+        return _convert_response_to_feeds_using_etree(response, _convert_etree_element_to_table)
 
     def create_table(self, table, fail_on_exist=False):
         '''
@@ -267,7 +267,7 @@ class TableService(_StorageClient):
         request.headers = _update_storage_table_header(request)
         response = self._perform_request(request)
 
-        return _convert_response_to_feeds(response, _convert_xml_to_entity)
+        return _convert_response_to_feeds_using_etree(response, _convert_etree_element_to_entity)
 
     def insert_entity(self, table_name, entity,
                       content_type='application/atom+xml'):

--- a/azure/storage/tableservice.py
+++ b/azure/storage/tableservice.py
@@ -17,18 +17,17 @@ from azure import (
     TABLE_SERVICE_HOST_BASE,
     DEV_TABLE_HOST,
     _convert_class_to_xml,
-    _convert_response_to_feeds_using_etree,
     _dont_fail_not_exist,
     _dont_fail_on_exist,
     _get_request_body,
     _int_or_none,
-    _parse_response,
     _parse_response_for_dict,
     _parse_response_for_dict_filter,
     _str,
     _str_or_none,
     _update_request_uri_query_local_storage,
     _validate_not_none,
+    _ETreeXmlToObject,
     )
 from azure.http import HTTPRequest
 from azure.http.batchclient import _BatchClient
@@ -97,7 +96,8 @@ class TableService(_StorageClient):
         request.headers = _update_storage_table_header(request)
         response = self._perform_request(request)
 
-        return _parse_response(response, StorageServiceProperties)
+        return _ETreeXmlToObject.parse_response(
+            response, StorageServiceProperties)
 
     def set_table_service_properties(self, storage_service_properties):
         '''
@@ -148,7 +148,8 @@ class TableService(_StorageClient):
         request.headers = _update_storage_table_header(request)
         response = self._perform_request(request)
 
-        return _convert_response_to_feeds_using_etree(response, _convert_etree_element_to_table)
+        return _ETreeXmlToObject.convert_response_to_feeds(
+            response, _convert_etree_element_to_table)
 
     def create_table(self, table, fail_on_exist=False):
         '''
@@ -267,7 +268,8 @@ class TableService(_StorageClient):
         request.headers = _update_storage_table_header(request)
         response = self._perform_request(request)
 
-        return _convert_response_to_feeds_using_etree(response, _convert_etree_element_to_entity)
+        return _ETreeXmlToObject.convert_response_to_feeds(
+            response, _convert_etree_element_to_entity)
 
     def insert_entity(self, table_name, entity,
                       content_type='application/atom+xml'):

--- a/tests/test_blobservice.py
+++ b/tests/test_blobservice.py
@@ -2349,6 +2349,12 @@ class BlobServiceTest(AzureTestCase):
         self.assertIsInstance(block_list, BlobBlockList)
         self.assertEqual(len(block_list.uncommitted_blocks), 3)
         self.assertEqual(len(block_list.committed_blocks), 0)
+        self.assertEqual(block_list.uncommitted_blocks[0].id, '1')
+        self.assertEqual(block_list.uncommitted_blocks[0].size, 3)
+        self.assertEqual(block_list.uncommitted_blocks[1].id, '2')
+        self.assertEqual(block_list.uncommitted_blocks[1].size, 3)
+        self.assertEqual(block_list.uncommitted_blocks[2].id, '3')
+        self.assertEqual(block_list.uncommitted_blocks[2].size, 3)
 
     def test_get_block_list_committed_blocks(self):
         # Arrange
@@ -2368,6 +2374,12 @@ class BlobServiceTest(AzureTestCase):
         self.assertIsInstance(block_list, BlobBlockList)
         self.assertEqual(len(block_list.uncommitted_blocks), 0)
         self.assertEqual(len(block_list.committed_blocks), 3)
+        self.assertEqual(block_list.committed_blocks[0].id, '1')
+        self.assertEqual(block_list.committed_blocks[0].size, 3)
+        self.assertEqual(block_list.committed_blocks[1].id, '2')
+        self.assertEqual(block_list.committed_blocks[1].size, 3)
+        self.assertEqual(block_list.committed_blocks[2].id, '3')
+        self.assertEqual(block_list.committed_blocks[2].size, 3)
 
     def test_put_page_update(self):
         # Arrange

--- a/tests/test_tableservice.py
+++ b/tests/test_tableservice.py
@@ -515,7 +515,7 @@ class TableServiceTest(AzureTestCase):
         total_entities_count = 1000
         entities_per_batch = 50
 
-        for j in range(total_entities_count / entities_per_batch):
+        for j in range(total_entities_count // entities_per_batch):
             self.ts.begin_batch()
             for i in range(entities_per_batch):
                 entity = Entity()

--- a/tests/test_tableservice.py
+++ b/tests/test_tableservice.py
@@ -509,6 +509,37 @@ class TableServiceTest(AzureTestCase):
         self.assertEqual(resp[0].RowKey, '1')
         self.assertEqual(resp[1].RowKey, '2')
 
+    def test_query_entities_large(self):
+        # Arrange
+        self._create_table(self.table_name)
+        total_entities_count = 1000
+        entities_per_batch = 50
+
+        for j in range(total_entities_count / entities_per_batch):
+            self.ts.begin_batch()
+            for i in range(entities_per_batch):
+                entity = Entity()
+                entity.PartitionKey = 'large'
+                entity.RowKey = 'batch{0}-item{1}'.format(j, i)
+                entity.test = EntityProperty('Edm.Boolean', 'true')
+                entity.test2 = 'hello world;' * 100
+                entity.test3 = 3
+                entity.test4 = EntityProperty('Edm.Int64', '1234567890')
+                entity.test5 = datetime.utcnow()
+                self.ts.insert_entity(self.table_name, entity)
+            self.ts.commit_batch()
+
+        # Act
+        start_time = datetime.now()
+        resp = self.ts.query_entities(self.table_name)
+        elapsed_time = datetime.now() - start_time
+
+        # Assert
+        print('query_entities took {0} secs.'.format(elapsed_time.total_seconds()))
+        # azure allocates 5 seconds to execute a query
+        # if it runs slowly, it will return fewer results and make the test fail
+        self.assertEqual(len(resp), total_entities_count)
+
     def test_query_entities_with_filter(self):
         # Arrange
         self._create_table_with_default_entities(self.table_name, 2)


### PR DESCRIPTION
Fix for: https://github.com/Azure/azure-sdk-for-python/issues/254
Parsing 1000 entities (the maximum you can query) has gone from taking 12 secs to 0.5 sec.

Storage and ServiceBus now use cElementTree/ElementTree exclusively.  Parsing of feed has been streamlined to avoid parsing the xml more than once.

All old minidom-based xml parsing code has been moved under ServiceManagement, which is now its only user.
