### PR TITLE
Add "List subscription operations" implementation

### DIFF
--- a/azure/__init__.py
+++ b/azure/__init__.py
@@ -276,6 +276,10 @@ _KNOWN_SERIALIZATION_XFORMS = {
     'aad_tenant_id': 'AADTenantID',
     'start_ip_address': 'StartIPAddress',
     'end_ip_address': 'EndIPAddress',
+    'operation_id': 'OperationId',
+    'operation_object_id': 'OperationObjectId',
+    'client_ip': 'ClientIP',
+    'id': 'ID'
     }
 
 

--- a/azure/servicemanagement/__init__.py
+++ b/azure/servicemanagement/__init__.py
@@ -829,6 +829,61 @@ class Subscription(WindowsAzureData):
         self.created_time = u''
 
 
+class SubscriptionOperationCollection(WindowsAzureData):
+
+    def __init__(self):
+        self.subscription_operations = SubscriptionOperations()
+        self.continuation_token = u''
+
+
+class SubscriptionOperations(WindowsAzureData):
+
+    def __init__(self):
+        self.subscription_operations = _list_of(SubscriptionOperation)
+
+    def __iter__(self):
+        return iter(self.subscription_operations)
+
+    def __len__(self):
+        return len(self.subscription_operations)
+
+    def __getitem__(self, index):
+        return self.subscription_operations[index]
+
+
+class SubscriptionOperation(WindowsAzureData):
+
+    def __init__(self):
+        self.operation_id = u''
+        self.operation_object_id = u''
+        self.operation_name = u''
+        self.operation_parameters = _dict_of(
+            'OperationParameter', 'a:Name', 'a:Value')
+        self.operation_caller = OperationCaller()
+        self.operation_status = SubscriptionOperationStatus()
+        self.operation_started_time = u''
+        self.operation_completed_time = u''
+        self.operation_kind = u''
+
+
+class SubscriptionOperationStatus(WindowsAzureData):
+    _xml_name = 'OperationStatus'
+
+    def __init__(self):
+        self.id = u''
+        self.status = u''
+        self.http_status_code = 0
+
+
+class OperationCaller(WindowsAzureData):
+
+    def __init__(self):
+        self.used_service_management_api = False
+        self.user_email_address = u''
+        self.subscription_certificate_thumbprint = u''
+        self.client_ip = u''
+
+
 class AvailabilityResponse(WindowsAzureData):
 
     def __init__(self):

--- a/azure/servicemanagement/__init__.py
+++ b/azure/servicemanagement/__init__.py
@@ -33,6 +33,7 @@ from azure import (
     _xml_attribute,
     _get_serialization_name,
     _set_continuation_from_response_headers,
+    _get_readable_id,
     METADATA_NS,
     )
 

--- a/azure/servicemanagement/__init__.py
+++ b/azure/servicemanagement/__init__.py
@@ -2194,7 +2194,8 @@ class _MinidomXmlToObject(object):
                 values = _MinidomXmlToObject.get_child_nodes(pair, value_xml_element_name)
                 if keys and values:
                     key = keys[0].firstChild.nodeValue
-                    value = values[0].firstChild.nodeValue
+                    valueContentNode = values[0].firstChild
+                    value = valueContentNode.nodeValue if valueContentNode else None
                     return_obj[key] = value
 
         return return_obj

--- a/azure/servicemanagement/servicemanagementservice.py
+++ b/azure/servicemanagement/servicemanagementservice.py
@@ -54,6 +54,7 @@ from azure.servicemanagement import (
     Subscriptions,
     SubscriptionCertificate,
     SubscriptionCertificates,
+    SubscriptionOperationCollection,
     VirtualNetworkSites,
     VMImages,
     _XmlSerializer,
@@ -1147,6 +1148,32 @@ class ServiceManagementService(_ServiceManagementClient):
         '''
         return self._perform_get('/' + self.subscription_id + '',
                                  Subscription)
+
+    # Operations for retrieving subscription operations ------------------
+    def list_subscription_operations(self, start_time=None, end_time=None, object_id_filter=None,
+                                     operation_result_filter=None, continuation_token=None):
+        '''
+        List subscription operations.
+
+        start_time: Required. An ISO8601 date.
+        end_time: Required. An ISO8601 date.
+        object_id_filter: Optional. Returns subscription operations only for the specified object type and object ID
+        operation_result_filter: Optional. Returns subscription operations only for the specified result status, either Succeeded, Failed, or InProgress.
+        continuation_token: Optional.
+        More information at:
+        https://msdn.microsoft.com/en-us/library/azure/gg715318.aspx
+        '''
+        start_time = ('StartTime=' + start_time) if start_time else ''
+        end_time = ('EndTime=' + end_time) if end_time else ''
+        object_id_filter = ('ObjectIdFilter=' + object_id_filter) if object_id_filter else ''
+        operation_result_filter = ('OperationResultFilter=' + operation_result_filter) if operation_result_filter else ''
+        continuation_token = ('ContinuationToken=' + continuation_token) if continuation_token else ''
+
+        parameters = ('&'.join(v for v in (start_time, end_time, object_id_filter, operation_result_filter, continuation_token) if v))
+        parameters = '?' + parameters if parameters else ''
+
+        return self._perform_get(self._get_list_subscription_operations_path() + parameters,
+                                 SubscriptionOperationCollection)
 
     #--Operations for reserved ip addresses  -----------------------------
     def create_reserved_ip_address(self, name, label=None, location=None):
@@ -2302,6 +2329,9 @@ class ServiceManagementService(_ServiceManagementClient):
 
     def _get_subscriptions_path(self):
         return '/subscriptions'
+
+    def _get_list_subscription_operations_path(self):
+        return self._get_path('operations', None)
 
     def _get_virtual_network_site_path(self):
         return self._get_path('services/networking/virtualnetwork', None)

--- a/tests/test_servicemanagementservice.py
+++ b/tests/test_servicemanagementservice.py
@@ -17,6 +17,7 @@ import base64
 import os
 import time
 import unittest
+from datetime import datetime, timedelta
 
 import azure.http.httpclient
 
@@ -1357,6 +1358,20 @@ class ServiceManagementServiceTest(AzureTestCase):
         self.assertTrue(result.max_storage_accounts > 0)
         self.assertTrue(result.max_virtual_network_sites > 0)
         self.assertGreater(len(result.aad_tenant_id), 0)
+
+    #--Test cases for retrieving subscription operations --------------------
+    def test_list_subscription_operations(self):
+        # Arrange
+
+        # Act
+        now = datetime.now()
+        one_month_before = now - timedelta(30)
+        result = self.sms.list_subscription_operations(one_month_before.strftime("%Y-%m-%d"), now.strftime("%Y-%m-%d"))
+        # Assert
+        self.assertIsNotNone(result)
+        for operation in result.subscription_operations:
+            self.assertTrue(operation.operation_id)
+
 
     #--Test cases for reserved ip addresses  -----------------------------
     def test_create_reserved_ip_address(self):


### PR DESCRIPTION
Hi,

This pull request for the implementation of this:
https://msdn.microsoft.com/en-us/library/azure/gg715318.aspx

It's the way to get all operations for a given Azure subscription.

The first commit is a little fix to fill correctly the value of a dict with `_dict_of` for XML as:
```xml
<OperationParameter>
    <a:Name>input</a:Name>
    <a:Value i:nil="true"/>
</OperationParameter>
```
without the patch it crashes

I have added in your test file my unit test, but I was not able to launch it from your file (too much tests in your file). But I think it's ok.
I can add more commits if something wrong, just let me know! :-)
Thank you!

