### PR TITLE
Upgrade to storage x-ms-version '2014-02-14'.

### DIFF
--- a/azure/storage/__init__.py
+++ b/azure/storage/__init__.py
@@ -44,7 +44,7 @@ from azure import (WindowsAzureData,
                    )
 
 # x-ms-version for storage service.
-X_MS_VERSION = '2012-02-12'
+X_MS_VERSION = '2014-02-14'
 
 
 class EnumResultsBase(object):
@@ -127,9 +127,20 @@ class Logging(WindowsAzureData):
         self.retention_policy = RetentionPolicy()
 
 
-class Metrics(WindowsAzureData):
+class HourMetrics(WindowsAzureData):
 
-    ''' Metrics class in service properties. '''
+    ''' Hour Metrics class in service properties. '''
+
+    def __init__(self):
+        self.version = u'1.0'
+        self.enabled = False
+        self.include_apis = None
+        self.retention_policy = RetentionPolicy()
+
+
+class MinuteMetrics(WindowsAzureData):
+
+    ''' Minute Metrics class in service properties. '''
 
     def __init__(self):
         self.version = u'1.0'
@@ -144,7 +155,8 @@ class StorageServiceProperties(WindowsAzureData):
 
     def __init__(self):
         self.logging = Logging()
-        self.metrics = Metrics()
+        self.hour_metrics = HourMetrics()
+        self.minute_metrics = MinuteMetrics()
 
 
 class AccessPolicy(WindowsAzureData):

--- a/azure/storage/__init__.py
+++ b/azure/storage/__init__.py
@@ -158,6 +158,13 @@ class StorageServiceProperties(WindowsAzureData):
         self.hour_metrics = HourMetrics()
         self.minute_metrics = MinuteMetrics()
 
+    @property
+    def metrics(self):
+        import warnings
+        warnings.warn(
+            'The metrics attribute has been deprecated. Use hour_metrics and minute_metrics instead.')
+        return self.hour_metrics
+
 
 class AccessPolicy(WindowsAzureData):
 

--- a/azure/storage/sharedaccesssignature.py
+++ b/azure/storage/sharedaccesssignature.py
@@ -25,6 +25,11 @@ SIGNED_PERMISSION = 'sp'
 SIGNED_IDENTIFIER = 'si'
 SIGNED_SIGNATURE = 'sig'
 SIGNED_VERSION = 'sv'
+SIGNED_CACHE_CONTROL = 'rscc'
+SIGNED_CONTENT_DISPOSITION = 'rscd'
+SIGNED_CONTENT_ENCODING = 'rsce'
+SIGNED_CONTENT_LANGUAGE = 'rscl'
+SIGNED_CONTENT_TYPE = 'rsct'
 RESOURCE_BLOB = 'b'
 RESOURCE_CONTAINER = 'c'
 SIGNED_RESOURCE_TYPE = 'resource'
@@ -93,7 +98,10 @@ class SharedAccessSignature(object):
 
     def generate_signed_query_string(self, path, resource_type,
                                      shared_access_policy,
-                                     version=X_MS_VERSION):
+                                     version=X_MS_VERSION,
+                                     cache_control=None, content_disposition=None,
+                                     content_encoding=None, content_language=None,
+                                     content_type=None):
         '''
         Generates the query string for path, resource type and shared access
         policy.
@@ -105,6 +113,21 @@ class SharedAccessSignature(object):
             x-ms-version for storage service, or None to get a signed query
             string compatible with pre 2012-02-12 clients, where the version
             is not included in the query string.
+        cache_control:
+            Response header value for Cache-Control when resource is accessed
+            using this shared access signature.
+        content_disposition:
+            Response header value for Content-Disposition when resource is accessed
+            using this shared access signature.
+        content_encoding:
+            Response header value for Content-Encoding when resource is accessed
+            using this shared access signature.
+        content_language:
+            Response header value for Content-Language when resource is accessed
+            using this shared access signature.
+        content_type:
+            Response header value for Content-Type when resource is accessed
+            using this shared access signature.
         '''
 
         query_string = {}
@@ -122,8 +145,26 @@ class SharedAccessSignature(object):
         if shared_access_policy.id:
             query_string[SIGNED_IDENTIFIER] = shared_access_policy.id
 
+        if cache_control:
+            query_string[SIGNED_CACHE_CONTROL] = cache_control
+
+        if content_disposition:
+            query_string[SIGNED_CONTENT_DISPOSITION] = content_disposition
+
+        if content_encoding:
+            query_string[SIGNED_CONTENT_ENCODING] = content_encoding
+
+        if content_language:
+            query_string[SIGNED_CONTENT_LANGUAGE] = content_language
+
+        if content_type:
+            query_string[SIGNED_CONTENT_TYPE] = content_type
+
         query_string[SIGNED_SIGNATURE] = self._generate_signature(
-            path, shared_access_policy, version)
+            path, shared_access_policy, version, cache_control,
+            content_disposition, content_encoding, content_language,
+            content_type)
+
         return query_string
 
     def sign_request(self, web_resource):
@@ -168,20 +209,34 @@ class SharedAccessSignature(object):
         if SIGNED_VERSION in query_string:
             convert_str += SIGNED_VERSION + '=' + \
                 query_string[SIGNED_VERSION] + '&'
+        if SIGNED_CACHE_CONTROL in query_string:
+            convert_str += SIGNED_CACHE_CONTROL + '=' + \
+                query_string[SIGNED_CACHE_CONTROL] + '&'
+        if SIGNED_CONTENT_DISPOSITION in query_string:
+            convert_str += SIGNED_CONTENT_DISPOSITION + '=' + \
+                query_string[SIGNED_CONTENT_DISPOSITION] + '&'
+        if SIGNED_CONTENT_ENCODING in query_string:
+            convert_str += SIGNED_CONTENT_ENCODING + '=' + \
+                query_string[SIGNED_CONTENT_ENCODING] + '&'
+        if SIGNED_CONTENT_LANGUAGE in query_string:
+            convert_str += SIGNED_CONTENT_LANGUAGE + '=' + \
+                query_string[SIGNED_CONTENT_LANGUAGE] + '&'
+        if SIGNED_CONTENT_TYPE in query_string:
+            convert_str += SIGNED_CONTENT_TYPE + '=' + \
+                query_string[SIGNED_CONTENT_TYPE] + '&'
         convert_str += SIGNED_SIGNATURE + '=' + \
             url_quote(query_string[SIGNED_SIGNATURE]) + '&'
         return convert_str
 
-    def _generate_signature(self, path, shared_access_policy, version):
+    def _generate_signature(self, path, shared_access_policy, version,
+                            cache_control, content_disposition,
+                            content_encoding, content_language,
+                            content_type):
         ''' Generates signature for a given path and shared access policy. '''
 
-        def get_value_to_append(value, no_new_line=False):
-            return_value = ''
-            if value:
-                return_value = value
-            if not no_new_line:
-                return_value += '\n'
-            return return_value
+        def get_value_to_append(value):
+            return_value = value or ''
+            return return_value + '\n'
 
         if path[0] != '/':
             path = '/' + path
@@ -194,13 +249,17 @@ class SharedAccessSignature(object):
             (get_value_to_append(shared_access_policy.access_policy.permission) +
              get_value_to_append(shared_access_policy.access_policy.start) +
              get_value_to_append(shared_access_policy.access_policy.expiry) +
-             get_value_to_append(canonicalized_resource))
+             get_value_to_append(canonicalized_resource) +
+             get_value_to_append(shared_access_policy.id) +
+             get_value_to_append(version) +
+             get_value_to_append(cache_control) +
+             get_value_to_append(content_disposition) +
+             get_value_to_append(content_encoding) +
+             get_value_to_append(content_language) +
+             get_value_to_append(content_type))
 
-        if version:
-            string_to_sign += get_value_to_append(shared_access_policy.id)
-            string_to_sign += get_value_to_append(version, True)
-        else:
-            string_to_sign += get_value_to_append(shared_access_policy.id, True)
+        if string_to_sign[-1] == '\n':
+            string_to_sign = string_to_sign[:-1]
 
         return self._sign(string_to_sign)
 

--- a/tests/test_blobservice.py
+++ b/tests/test_blobservice.py
@@ -41,7 +41,8 @@ from azure.storage import (
     BlobBlockList,
     BlobResult,
     Logging,
-    Metrics,
+    HourMetrics,
+    MinuteMetrics,
     PageList,
     PageRange,
     SignedIdentifier,
@@ -64,6 +65,11 @@ from azure.storage.sharedaccesssignature import (
     RESOURCE_BLOB,
     RESOURCE_CONTAINER,
     SHARED_ACCESS_PERMISSION,
+    SIGNED_CACHE_CONTROL,
+    SIGNED_CONTENT_DISPOSITION,
+    SIGNED_CONTENT_ENCODING,
+    SIGNED_CONTENT_LANGUAGE,
+    SIGNED_CONTENT_TYPE,
     SIGNED_EXPIRY,
     SIGNED_IDENTIFIER,
     SIGNED_PERMISSION,
@@ -271,7 +277,10 @@ class BlobServiceTest(AzureTestCase):
 
         return text
 
-    def _get_permission(self, sas, resource_type, resource_path, permission):
+    def _get_permission(self, sas, resource_type, resource_path, permission,
+                        cache_control=None, content_disposition=None,
+                        content_encoding=None, content_language=None,
+                        content_type=None):
         date_format = "%Y-%m-%dT%H:%M:%SZ"
         start = datetime.datetime.utcnow() - datetime.timedelta(minutes=1)
         expiry = start + datetime.timedelta(hours=1)
@@ -279,9 +288,16 @@ class BlobServiceTest(AzureTestCase):
         sap = SharedAccessPolicy(AccessPolicy(start.strftime(date_format),
                                               expiry.strftime(date_format),
                                               permission))
-        signed_query = sas.generate_signed_query_string(resource_path,
-                                                        resource_type,
-                                                        sap)
+        signed_query = sas.generate_signed_query_string(
+            resource_path,
+            resource_type,
+            sap,
+            cache_control=cache_control,
+            content_disposition=content_disposition,
+            content_encoding=content_encoding,
+            content_language=content_language,
+            content_type=content_type,
+        )
 
         return Permission('/' + resource_path, signed_query)
 
@@ -323,14 +339,14 @@ class BlobServiceTest(AzureTestCase):
                 connection.send(content)
 
             resp = connection.getresponse()
-            resp.getheaders()
+            respheaders = resp.getheaders()
             respbody = None
             if resp.length is None:
                 respbody = resp.read()
             elif resp.length > 0:
                 respbody = resp.read(resp.length)
 
-            return respbody
+            return (respbody, respheaders)
         finally:
             connection.close()
 
@@ -1151,13 +1167,13 @@ class BlobServiceTest(AzureTestCase):
 
         # Act
         props = StorageServiceProperties()
-        props.metrics.enabled = False
+        props.hour_metrics.enabled = False
         resp = self.bs.set_blob_service_properties(props)
 
         # Assert
         self.assertIsNone(resp)
         received_props = self.bs.get_blob_service_properties()
-        self.assertFalse(received_props.metrics.enabled)
+        self.assertFalse(received_props.hour_metrics.enabled)
 
     def test_set_blob_service_properties_with_timeout(self):
         # Arrange
@@ -1181,7 +1197,8 @@ class BlobServiceTest(AzureTestCase):
         # Assert
         self.assertIsNotNone(props)
         self.assertIsInstance(props.logging, Logging)
-        self.assertIsInstance(props.metrics, Metrics)
+        self.assertIsInstance(props.minute_metrics, MinuteMetrics)
+        self.assertIsInstance(props.hour_metrics, HourMetrics)
 
     def test_get_blob_service_properties_with_timeout(self):
         # Arrange
@@ -1192,7 +1209,8 @@ class BlobServiceTest(AzureTestCase):
         # Assert
         self.assertIsNotNone(props)
         self.assertIsInstance(props.logging, Logging)
-        self.assertIsInstance(props.metrics, Metrics)
+        self.assertIsInstance(props.minute_metrics, MinuteMetrics)
+        self.assertIsInstance(props.hour_metrics, HourMetrics)
 
     #--Test cases for blobs ----------------------------------------------
     def test_make_blob_url(self):
@@ -2733,7 +2751,7 @@ class BlobServiceTest(AzureTestCase):
         # Act
         host = credentials.getStorageServicesName() + BLOB_SERVICE_HOST_BASE
         url = '/' + res_path
-        respbody = self._get_request(host, url)
+        respbody, _ = self._get_request(host, url)
 
         # Assert
         self.assertNotEqual(data, respbody)
@@ -2750,7 +2768,7 @@ class BlobServiceTest(AzureTestCase):
         # Act
         host = credentials.getStorageServicesName() + BLOB_SERVICE_HOST_BASE
         url = '/' + res_path
-        respbody = self._get_request(host, url)
+        respbody, _ = self._get_request(host, url)
 
         # Assert
         self.assertEqual(data, respbody)
@@ -2771,10 +2789,45 @@ class BlobServiceTest(AzureTestCase):
         web_rsrc = self._get_signed_web_resource(sas, res_type, res_path, 'r')
         host = credentials.getStorageServicesName() + BLOB_SERVICE_HOST_BASE
         url = web_rsrc.request_url
-        respbody = self._get_request(host, url)
+        respbody, _ = self._get_request(host, url)
 
         # Assert
         self.assertEqual(data, respbody)
+
+    def test_shared_read_access_blob_with_content_query_params(self):
+        # Arrange
+        data = b'shared access signature with read permission on blob'
+        self._create_container_and_block_blob(
+            self.container_name, 'blob1.txt', data)
+        sas = SharedAccessSignature(credentials.getStorageServicesName(),
+                                    credentials.getStorageServicesKey())
+        res_path = self.container_name + '/blob1.txt'
+        res_type = RESOURCE_BLOB
+
+        # Act
+        permission = self._get_permission(
+            sas,
+            res_type,
+            res_path,
+            'r',
+            cache_control='no-cache',
+            content_disposition='inline',
+            content_encoding='utf-8',
+            content_language='fr',
+            content_type='text')
+        sas.permission_set = [permission]
+        web_rsrc = self._get_signed_web_resource(sas, res_type, res_path, 'r')
+        host = credentials.getStorageServicesName() + BLOB_SERVICE_HOST_BASE
+        url = web_rsrc.request_url
+        respbody, respheaders = self._get_request(host, url)
+
+        # Assert
+        self.assertEqual(data, respbody)
+        self.assertIn(('cache-control', 'no-cache'), respheaders)
+        self.assertIn(('content-disposition', 'inline'), respheaders)
+        self.assertIn(('content-encoding', 'utf-8'), respheaders)
+        self.assertIn(('content-language', 'fr'), respheaders)
+        self.assertIn(('content-type', 'text'), respheaders)
 
     def test_shared_write_access_blob(self):
         # Arrange
@@ -2794,7 +2847,7 @@ class BlobServiceTest(AzureTestCase):
         host = credentials.getStorageServicesName() + BLOB_SERVICE_HOST_BASE
         url = web_rsrc.request_url
         headers = {'x-ms-blob-type': 'BlockBlob'}
-        respbody = self._put_request(host, url, updated_data, headers)
+        respbody, _ = self._put_request(host, url, updated_data, headers)
 
         # Assert
         blob = self.bs.get_blob(self.container_name, 'blob1.txt')
@@ -2816,7 +2869,7 @@ class BlobServiceTest(AzureTestCase):
         web_rsrc = self._get_signed_web_resource(sas, res_type, res_path, 'd')
         host = credentials.getStorageServicesName() + BLOB_SERVICE_HOST_BASE
         url = web_rsrc.request_url
-        respbody = self._del_request(host, url)
+        respbody, _ = self._del_request(host, url)
 
         # Assert
         with self.assertRaises(WindowsAzureError):
@@ -2839,7 +2892,7 @@ class BlobServiceTest(AzureTestCase):
             sas, res_type, res_path + '/blob1.txt', 'r')
         host = credentials.getStorageServicesName() + BLOB_SERVICE_HOST_BASE
         url = web_rsrc.request_url
-        respbody = self._get_request(host, url)
+        respbody, _ = self._get_request(host, url)
 
         # Assert
         self.assertEqual(data, respbody)

--- a/tests/test_queueservice.py
+++ b/tests/test_queueservice.py
@@ -76,9 +76,12 @@ class QueueServiceTest(AzureTestCase):
         self.assertIsNotNone(properties.logging)
         self.assertIsNotNone(properties.logging.retention_policy)
         self.assertIsNotNone(properties.logging.version)
-        self.assertIsNotNone(properties.metrics)
-        self.assertIsNotNone(properties.metrics.retention_policy)
-        self.assertIsNotNone(properties.metrics.version)
+        self.assertIsNotNone(properties.hour_metrics)
+        self.assertIsNotNone(properties.hour_metrics.retention_policy)
+        self.assertIsNotNone(properties.hour_metrics.version)
+        self.assertIsNotNone(properties.minute_metrics)
+        self.assertIsNotNone(properties.minute_metrics.retention_policy)
+        self.assertIsNotNone(properties.minute_metrics.version)
 
     def test_set_service_properties(self):
         # This api doesn't apply to local storage
@@ -96,9 +99,12 @@ class QueueServiceTest(AzureTestCase):
         self.assertIsNotNone(properties.logging)
         self.assertIsNotNone(properties.logging.retention_policy)
         self.assertIsNotNone(properties.logging.version)
-        self.assertIsNotNone(properties.metrics)
-        self.assertIsNotNone(properties.metrics.retention_policy)
-        self.assertIsNotNone(properties.metrics.version)
+        self.assertIsNotNone(properties.hour_metrics)
+        self.assertIsNotNone(properties.hour_metrics.retention_policy)
+        self.assertIsNotNone(properties.hour_metrics.version)
+        self.assertIsNotNone(properties.minute_metrics)
+        self.assertIsNotNone(properties.minute_metrics.retention_policy)
+        self.assertIsNotNone(properties.minute_metrics.version)
         self.assertTrue(properties.logging.read)
 
     def test_create_queue(self):
@@ -194,7 +200,6 @@ class QueueServiceTest(AzureTestCase):
         self.assertIsNotNone(queues_1[0])
         self.assertIsNone(queues_1[0].metadata)
         self.assertNotEqual('', queues_1[0].name)
-        self.assertNotEqual('', queues_1[0].url)
         # Asserts
         self.assertIsNotNone(queues_2)
         self.assertTrue(len(self.test_queues) - 3 <= len(queues_2))
@@ -203,7 +208,6 @@ class QueueServiceTest(AzureTestCase):
         self.assertIsNotNone(queues_2[0])
         self.assertIsNotNone(queues_2[0].metadata)
         self.assertNotEqual('', queues_2[0].name)
-        self.assertNotEqual('', queues_2[0].url)
 
     def test_set_queue_metadata(self):
         # Action

--- a/tests/test_sharedaccesssignature.py
+++ b/tests/test_sharedaccesssignature.py
@@ -62,9 +62,10 @@ class SharedAccessSignatureTest(AzureTestCase):
         sap = SharedAccessPolicy(accss_plcy, signed_identifier)
         signature = self.sas._generate_signature('images',
                                                  sap,
-                                                 X_MS_VERSION)
+                                                 X_MS_VERSION,
+                                                 None, None, None, None, None)
         self.assertEqual(signature,
-                         '1AWckmWSNrNCjh9krPXoD4exAgZWQQr38gG6z/ymkhQ=')
+                         'Md+SHy9BQNucdHnmDOEwlAkIWU5YxwlTq6gA9yJKE6w=')
 
     def test_generate_signature_blob(self):
         accss_plcy = AccessPolicy()
@@ -75,9 +76,14 @@ class SharedAccessSignatureTest(AzureTestCase):
 
         signature = self.sas._generate_signature('images/pic1.png',
                                                  sap,
-                                                 X_MS_VERSION)
+                                                 X_MS_VERSION,
+                                                 None,
+                                                 'file; attachment',
+                                                 None,
+                                                 None,
+                                                 'binary')
         self.assertEqual(signature,
-                         'ju4tX0G79vPxMOkBb7UfNVEgrj9+ZnSMutpUemVYHLY=')
+                         'uHckUC6T+BwUsc+DgrreyIS1k6au7uUd7LSSs/z+/+w=')
 
     def test_blob_signed_query_string(self):
         accss_plcy = AccessPolicy()
@@ -93,7 +99,7 @@ class SharedAccessSignatureTest(AzureTestCase):
         self.assertEqual(qry_str[SIGNED_RESOURCE], RESOURCE_BLOB)
         self.assertEqual(qry_str[SIGNED_PERMISSION], 'w')
         self.assertEqual(qry_str[SIGNED_SIGNATURE],
-                         '8I8E8TImfR2TIAcMDq8rF+IhhYyvowXpxSfF1kxnWLQ=')
+                         'Fqt8tNcyUOp30qYRtSFNcImrRMcxlk6IF17O4l96KT8=')
 
     def test_container_signed_query_string(self):
         accss_plcy = AccessPolicy()
@@ -111,7 +117,7 @@ class SharedAccessSignatureTest(AzureTestCase):
         self.assertEqual(qry_str[SIGNED_PERMISSION], 'r')
         self.assertEqual(qry_str[SIGNED_IDENTIFIER], 'YWJjZGVmZw==')
         self.assertEqual(qry_str[SIGNED_SIGNATURE],
-                         '1AWckmWSNrNCjh9krPXoD4exAgZWQQr38gG6z/ymkhQ=')
+                         'Md+SHy9BQNucdHnmDOEwlAkIWU5YxwlTq6gA9yJKE6w=')
 
     def test_sign_request(self):
         accss_plcy = AccessPolicy()


### PR DESCRIPTION
Add support for new SAS query parameters that control response headers (for Blob).
Breaking change: Metrics object used in blob, queue, table service properties is now split in two fields: 'hour_metrics' and 'minute_metrics' instead of the previous 'metrics'.