### PR TITLE
Proper fix for #273

### DIFF
--- a/azure/servicemanagement/__init__.py
+++ b/azure/servicemanagement/__init__.py
@@ -30,6 +30,7 @@ from azure import (
     _scalar_list_of,
     _str,
     _strtype,
+    _unicode_type,
     _xml_attribute,
     _get_serialization_name,
     _validate_not_none,
@@ -76,7 +77,7 @@ class StorageService(WindowsAzureData):
         self.storage_service_keys = StorageServiceKeys()
         self.extended_properties = _dict_of(
             'ExtendedProperty', 'Name', 'Value')
-        self.capabilities = _scalar_list_of(str, 'Capability')
+        self.capabilities = _scalar_list_of(_unicode_type, 'Capability')
 
 
 class StorageAccountProperties(WindowsAzureData):
@@ -87,7 +88,7 @@ class StorageAccountProperties(WindowsAzureData):
         self.location = u''
         self.label = _Base64String()
         self.status = u''
-        self.endpoints = _scalar_list_of(str, 'Endpoint')
+        self.endpoints = _scalar_list_of(_unicode_type, 'Endpoint')
         self.geo_replication_enabled = False
         self.geo_primary_region = u''
         self.status_of_primary = u''
@@ -125,15 +126,15 @@ class Location(WindowsAzureData):
     def __init__(self):
         self.name = u''
         self.display_name = u''
-        self.available_services = _scalar_list_of(str, 'AvailableService')
+        self.available_services = _scalar_list_of(_unicode_type, 'AvailableService')
         self.compute_capabilities = ComputeCapabilities()
 
 
 class ComputeCapabilities(WindowsAzureData):
 
     def __init__(self):
-        self.web_worker_role_sizes = _scalar_list_of(str, 'RoleSize')
-        self.virtual_machines_role_sizes = _scalar_list_of(str, 'RoleSize')
+        self.web_worker_role_sizes = _scalar_list_of(_unicode_type, 'RoleSize')
+        self.virtual_machines_role_sizes = _scalar_list_of(_unicode_type, 'RoleSize')
 
 
 class AffinityGroup(WindowsAzureData):
@@ -145,7 +146,7 @@ class AffinityGroup(WindowsAzureData):
         self.location = u''
         self.hosted_services = HostedServices()
         self.storage_services = StorageServices()
-        self.capabilities = _scalar_list_of(str, 'Capability')
+        self.capabilities = _scalar_list_of(_unicode_type, 'Capability')
 
 
 class AffinityGroups(WindowsAzureData):
@@ -1030,7 +1031,7 @@ class ConfigurationSet(WindowsAzureData):
         self.configuration_set_type = u'NetworkConfiguration'
         self.role_type = u''
         self.input_endpoints = ConfigurationSetInputEndpoints()
-        self.subnet_names = _scalar_list_of(str, 'SubnetName')
+        self.subnet_names = _scalar_list_of(_unicode_type, 'SubnetName')
         self.public_ips = PublicIPs()
 
 
@@ -1419,9 +1420,9 @@ class Site(WindowsAzureData):
         self.availability_state = ''
         self.compute_mode = ''
         self.enabled = False
-        self.enabled_host_names = _scalar_list_of(str, 'a:string')
+        self.enabled_host_names = _scalar_list_of(_unicode_type, 'a:string')
         self.host_name_ssl_states = HostNameSslStates()
-        self.host_names = _scalar_list_of(str, 'a:string')
+        self.host_names = _scalar_list_of(_unicode_type, 'a:string')
         self.last_modified_time_utc = ''
         self.name = ''
         self.repository_site_name = ''
@@ -1556,7 +1557,7 @@ class AuthorizationRule(WindowsAzureData):
     def __init__(self):
         self.claim_type = u''
         self.claim_value = u''
-        self.rights = _scalar_list_of(str, 'AccessRights')
+        self.rights = _scalar_list_of(_unicode_type, 'AccessRights')
         self.created_time = u''
         self.modified_time = u''
         self.key_name = u''

--- a/tests/test_servicemanagementservice.py
+++ b/tests/test_servicemanagementservice.py
@@ -1680,7 +1680,7 @@ class ServiceManagementServiceTest(AzureTestCase):
         storage_name = 'utstoragedonotdelete'
         # virtual network in affinity group
         virtual_network_name = 'utnetdonotdelete'
-        subnet_name = 'Subnet-1'                  # subnet in virtual network
+        subnet_name = u'啊齄丂狛狜'                # subnet in virtual network
 
         # Arrange
         service_name = self.hosted_service_name
@@ -1706,8 +1706,10 @@ class ServiceManagementServiceTest(AzureTestCase):
         self._wait_for_role(service_name, deployment_name, role_name)
 
         # Assert
-        self.assertTrue(
-            self._role_exists(service_name, deployment_name, role_name))
+        role = self.sms.get_role(service_name, deployment_name, role_name)
+        self.assertIsNotNone(role)
+        self.assertEqual(role.configuration_sets.configuration_sets[0].subnet_names[0],
+                         subnet_name)
         deployment = self.sms.get_deployment_by_name(
             service_name, deployment_name)
         self.assertEqual(deployment.label, deployment_label)


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-sdk-for-python/issues/273

Fixes unicode subnet names, so that we return them as unicode strings instead of trying to convert to a str (and fail).

Adds a test for that use case.

The fix that was proposed earlier by the user that encountered the issue:
https://github.com/Azure/azure-sdk-for-python/pull/274

returns the data as encoded bytes (utf-8) which gets around the issue but we want to return Unicode strings like we generally do for strings in other places.

