### PR TITLE
Restart website not declared as a async operation

### DIFF
--- a/azure/servicemanagement/servicemanagementservice.py
+++ b/azure/servicemanagement/servicemanagementservice.py
@@ -12,16 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
-import sys
-import time
-
 from azure import (
     WindowsAzureError,
-    WindowsAzureAsyncOperationError,
     DEFAULT_HTTP_TIMEOUT,
     MANAGEMENT_HOST,
-    _ERROR_ASYNC_OP_FAILURE,
-    _ERROR_ASYNC_OP_TIMEOUT,
     _str,
     _validate_not_none,
     )
@@ -36,7 +30,6 @@ from azure.servicemanagement import (
     Disk,
     Disks,
     Locations,
-    Operation,
     HostedService,
     HostedServices,
     Images,
@@ -1111,87 +1104,6 @@ class ServiceManagementService(_ServiceManagementClient):
         return self._perform_get('/' + self.subscription_id + '/locations',
                                  Locations)
 
-    #--Operations for tracking asynchronous requests ---------------------
-    def wait_for_operation_status_progress_default_callback(elapsed):
-        sys.stdout.write('.')
-
-    def wait_for_operation_status_success_default_callback(elapsed):
-        sys.stdout.write('\n')
-
-    def wait_for_operation_status_failure_default_callback(elapsed, ex):
-        sys.stdout.write('\n')
-        print(vars(ex.result))
-        raise ex
-
-    def wait_for_operation_status(self,
-        request_id, wait_for_status='Succeeded', timeout=30, sleep_interval=5,
-        progress_callback=wait_for_operation_status_progress_default_callback,
-        success_callback=wait_for_operation_status_success_default_callback,
-        failure_callback=wait_for_operation_status_failure_default_callback):
-        '''
-        Waits for an asynchronous operation to complete.
-
-        This calls get_operation_status in a loop and returns when the expected
-        status is reached. The result of get_operation_status is returned. By
-        default, an exception is raised on timeout or error status.
-
-        request_id:
-            The request ID for the request you wish to track.
-        wait_for_status:
-            Status to wait for. Default is 'Succeeded'.
-        timeout:
-            Total timeout in seconds. Default is 30s.
-        sleep_interval:
-            Sleep time in seconds for each iteration. Default is 5s.
-        progress_callback:
-            Callback for each iteration.
-            Default prints '.'.
-            Set it to None for no progress notification.
-        success_callback:
-            Callback on success. Default prints newline.
-            Set it to None for no success notification.
-        failure_callback:
-            Callback on failure. Default prints newline+error details then
-            raises exception.
-            Set it to None for no failure notification.
-        '''
-        loops = timeout // sleep_interval + 1
-        start_time = time.time()
-        for _ in range(loops):
-            result = self.get_operation_status(request_id)
-            elapsed = time.time() - start_time
-            if result.status == wait_for_status:
-                if success_callback is not None:
-                    success_callback(elapsed)
-                return result
-            elif result.error:
-                if failure_callback is not None:
-                    ex = WindowsAzureAsyncOperationError(_ERROR_ASYNC_OP_FAILURE, result)
-                    failure_callback(elapsed, ex)
-                return result
-            else:
-                if progress_callback is not None:
-                    progress_callback(elapsed)
-                time.sleep(sleep_interval)
-
-        if failure_callback is not None:
-            ex = WindowsAzureAsyncOperationError(_ERROR_ASYNC_OP_TIMEOUT, result)
-            failure_callback(elapsed, ex)
-        return result
-
-    def get_operation_status(self, request_id):
-        '''
-        Returns the status of the specified operation. After calling an
-        asynchronous operation, you can call Get Operation Status to determine
-        whether the operation has succeeded, failed, or is still in progress.
-
-        request_id:
-            The request ID for the request you wish to track.
-        '''
-        _validate_not_none('request_id', request_id)
-        return self._perform_get(
-            '/' + self.subscription_id + '/operations/' + _str(request_id),
-            Operation)
 
     #--Operations for retrieving operating system information ------------
     def list_operating_systems(self):

--- a/azure/servicemanagement/websitemanagementservice.py
+++ b/azure/servicemanagement/websitemanagementservice.py
@@ -185,7 +185,7 @@ class WebsiteManagementService(_ServiceManagementClient):
         '''
         return self._perform_post(
             self._get_restart_path(webspace_name, website_name),
-            '')
+            None, async=True)
 
     def get_historical_usage_metrics(self, webspace_name, website_name,
                                      metrics = None, start_time=None, end_time=None, time_grain=None):

--- a/tests/test_websitemanagementservice.py
+++ b/tests/test_websitemanagementservice.py
@@ -221,7 +221,7 @@ class WebsiteManagementServiceTest(AzureTestCase):
         result = self.wss.restart_site(self.webspace_name, self.created_site)
 
         # Assert
-        self.assertIsNone(result)
+        self.assertTrue(hasattr(result, 'request_id'))
 
     def test_get_web_site_metrics(self):
         # Arrange


### PR DESCRIPTION
Hi,

According to:
https://msdn.microsoft.com/en-us/library/dn448601.aspx
Restart a Website is a async operation which returns a `x-ms-request-id` (and actually it does). My first commit changes the return type of `restart_site` to return the `AsynchronousOperationResult` object and not `None`.

My second commit is more optional, but I think it's important. Currently, handling async wait is managed by `ServiceManagementService` directly. But async requests may be common to all services (in fact, declaring a request async is handled in `_ServiceManagementClient`, thus common to all services).
My second commit pull-up `wait_for_operation_status` from `ServiceManagementService` to `_ServiceManagementClient` to make it available for all services.
Then I can write something like:
```python
wsms = WebsiteManagementService(...)
result = wsms.restart_site(webspace.name, site.name)
wsms.wait_for_operation_status(result.request_id)
```

Thank you!
