### PR TITLE
Basic update_site with state (allows to start/stop website)

### DIFF
--- a/azure/servicemanagement/__init__.py
+++ b/azure/servicemanagement/__init__.py
@@ -3122,6 +3122,12 @@ class _XmlSerializer(object):
         return _XmlSerializer.doc_from_xml('Site', xml)
 
     @staticmethod
+    def update_website_to_xml(state):
+        xml = _XmlSerializer.data_to_xml(
+            [('State', state)])
+        return _XmlSerializer.doc_from_xml('Site', xml)
+
+    @staticmethod
     def create_reserved_ip_to_xml(name, label, location):
         return _XmlSerializer.doc_from_data(
             'ReservedIP',

--- a/azure/servicemanagement/websitemanagementservice.py
+++ b/azure/servicemanagement/websitemanagementservice.py
@@ -174,6 +174,22 @@ class WebsiteManagementService(_ServiceManagementClient):
             path = path + '?' + query.lstrip('&')
         return self._perform_delete(path)
 
+    def update_site(self, webspace_name, website_name, state=None):
+        '''
+        Update a web site.
+
+        webspace_name:
+            The name of the webspace.
+        website_name:
+            The name of the website.
+        state:
+            The wanted state ('Running' or 'Stopped' accepted)
+        '''
+        xml = _XmlSerializer.update_website_to_xml(state)
+        return self._perform_put(
+            self._get_sites_details_path(webspace_name, website_name),
+            xml, async=True)
+
     def restart_site(self, webspace_name, website_name):
         '''
         Restart a web site.

--- a/tests/test_websitemanagementservice.py
+++ b/tests/test_websitemanagementservice.py
@@ -223,6 +223,26 @@ class WebsiteManagementServiceTest(AzureTestCase):
         # Assert
         self.assertTrue(hasattr(result, 'request_id'))
 
+    def test_shutdown_start_site(self):
+        # Arrange
+        self._create_site()
+
+        # Act
+        result = self.wss.update_site(self.webspace_name, self.created_site, state="Stopped")
+        self.wss.wait_for_operation_status(result.request_id)
+
+        # Assert
+        result = self.wss.get_site(self.webspace_name, self.created_site)
+        self.assertEqual(result.state, 'Stopped')
+
+        # Act
+        result = self.wss.update_site(self.webspace_name, self.created_site, state="Running")
+        self.wss.wait_for_operation_status(result.request_id)
+
+        # Assert
+        result = self.wss.get_site(self.webspace_name, self.created_site)
+        self.assertEqual(result.state, 'Running')
+
     def test_get_web_site_metrics(self):
         # Arrange
         self._create_site()


### PR DESCRIPTION
Hi,

This is a very simple implementation of "update_site":
https://msdn.microsoft.com/en-us/library/dn448781.aspx

Currently, it handles only "state" parameter, but can be easily enhanced to other settings in future.

This allows us to start/stop a Website (see the unittest):
```python
self.wss.update_site(self.webspace_name, self.created_site, state="Stopped")
```

If it's too much incomplete and experimental, I can keep it in my own application.

Thank you!
