### PR TITLE
Changes blob tests so that headers are returned with a lowercase name. T...

### DIFF
--- a/tests/test_blobservice.py
+++ b/tests/test_blobservice.py
@@ -339,7 +339,7 @@ class BlobServiceTest(AzureTestCase):
                 connection.send(content)
 
             resp = connection.getresponse()
-            respheaders = resp.getheaders()
+            respheaders = [(name.lower(), val) for name, val in resp.getheaders()]
             respbody = None
             if resp.length is None:
                 respbody = resp.read()


### PR DESCRIPTION
...his matches the behavior of the SDK, which does this to ensure consistency across httplib on python 2.x and 3.x, winhttp, as well as other platforms.