### PR TITLE
Support non seekable streams when uploading/downloading blob chunks with max_connections=1

### DIFF
--- a/azure/storage/__init__.py
+++ b/azure/storage/__init__.py
@@ -900,7 +900,7 @@ class _BlobChunkDownloader(object):
         self.blob_size = blob_size
         self.chunk_size = chunk_size
         self.stream = stream
-        self.stream_start = stream.tell()
+        self.stream_start = stream.tell() if parallel else None
         self.stream_lock = threading.Lock() if parallel else None
         self.progress_callback = progress_callback
         self.progress_total = 0
@@ -938,7 +938,6 @@ class _BlobChunkDownloader(object):
                 self.stream.seek(self.stream_start + chunk_offset)
                 self.stream.write(chunk_data)
         else:
-            self.stream.seek(self.stream_start + chunk_offset)
             self.stream.write(chunk_data)
 
     def _download_chunk_with_retries(self, chunk_offset):

--- a/azure/storage/blobservice.py
+++ b/azure/storage/blobservice.py
@@ -911,6 +911,7 @@ class BlobService(_StorageClient):
             Set to 1 to upload the blob chunks sequentially.
             Set to 2 or more to upload the blob chunks in parallel. This uses
             more system resources but will upload faster.
+            Note that parallel upload requires the stream to be seekable.
         max_retries:
             Number of times to retry upload of blob chunk if an error occurs.
         retry_wait:
@@ -1392,6 +1393,7 @@ class BlobService(_StorageClient):
             Set to 1 to upload the blob chunks sequentially.
             Set to 2 or more to upload the blob chunks in parallel. This uses
             more system resources but will upload faster.
+            Note that parallel upload requires the stream to be seekable.
         max_retries:
             Number of times to retry upload of blob chunk if an error occurs.
         retry_wait:


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-python/issues/338

Note that when using parallel connections, stream must be seekable.  Use max_connections=1 if your stream isn't.
