### PR TITLE
Shared Access Signature support

### DIFF
--- a/azure.pyproj
+++ b/azure.pyproj
@@ -17,7 +17,7 @@
     <InterpreterPath />
     <InterpreterArguments />
     <InterpreterId>{2af0f10d-7135-4994-9156-5d01c9c11b7e}</InterpreterId>
-    <InterpreterVersion>3.4</InterpreterVersion>
+    <InterpreterVersion>2.7</InterpreterVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>

--- a/azure.pyproj
+++ b/azure.pyproj
@@ -17,7 +17,7 @@
     <InterpreterPath />
     <InterpreterArguments />
     <InterpreterId>{2af0f10d-7135-4994-9156-5d01c9c11b7e}</InterpreterId>
-    <InterpreterVersion>2.7</InterpreterVersion>
+    <InterpreterVersion>3.4</InterpreterVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>

--- a/azure/__init__.py
+++ b/azure/__init__.py
@@ -87,7 +87,7 @@ _ERROR_UNKNOWN = 'Unknown error ({0})'
 _ERROR_SERVICEBUS_MISSING_INFO = \
     'You need to provide servicebus namespace, access key and Issuer'
 _ERROR_STORAGE_MISSING_INFO = \
-    'You need to provide both account name and access key'
+    'You need to provide an account name'
 _ERROR_ACCESS_POLICY = \
     'share_access_policy must be either SignedIdentifier or AccessPolicy ' + \
     'instance'

--- a/azure/http/httpclient.py
+++ b/azure/http/httpclient.py
@@ -49,19 +49,16 @@ class _HTTPClient(object):
     Takes the request and sends it to cloud service and returns the response.
     '''
 
-    def __init__(self, service_instance, cert_file=None, account_name=None,
-                 account_key=None, protocol='https', request_session=None,
-                 timeout=DEFAULT_HTTP_TIMEOUT):
+    def __init__(self, service_instance, cert_file=None, protocol='https',
+                 request_session=None, timeout=DEFAULT_HTTP_TIMEOUT):
         '''
         service_instance:
             service client instance.
         cert_file:
             certificate file name/location. This is only used in hosted
             service management.
-        account_name:
-            the storage account.
-        account_key:
-            the storage account access key.
+        protocol:
+            http or https.
         request_session:
             session object created with requests library (or compatible).
         timeout:
@@ -72,8 +69,6 @@ class _HTTPClient(object):
         self.respheader = None
         self.message = None
         self.cert_file = cert_file
-        self.account_name = account_name
-        self.account_key = account_key
         self.protocol = protocol
         self.proxy_host = None
         self.proxy_port = None

--- a/azure/storage/__init__.py
+++ b/azure/storage/__init__.py
@@ -1154,58 +1154,78 @@ def _storage_error_handler(http_error):
     return _general_error_handler(http_error)
 
 
-class StorageSASAuthentication:
+class StorageSASAuthentication(object):
     def __init__(self, sas_token):
         self.sas_token = sas_token
 
     def sign_request(self, request):
-        if request.path.find('?') == -1:
-            request.path += '?'
-        else:
+        if '?' in request.path:
             request.path += '&'
+        else:
+            request.path += '?'
 
         request.path += self.sas_token
 
 
-class StorageSharedKeyAuthentication:
+class _StorageSharedKeyAuthentication(object):
     def __init__(self, account_name, account_key):
         self.account_name = account_name
         self.account_key = account_key
 
-    def sign_request(self, request):
+    def _get_headers(self, request, headers_to_sign):
+        headers = {
+            name.lower() : value for name, value in request.headers if value
+        }
+        return '\n'.join(headers.get(x, '') for x in headers_to_sign) + '\n'
+
+    def _get_verb(self, request):
+        return request.method + '\n'
+
+    def _get_canonicalized_resource(self, request):
         uri_path = request.path.split('?')[0]
+        return '/' + self.account_name + uri_path
 
-        # method to sign
-        string_to_sign = request.method + '\n'
-
-        # get headers to sign
-        headers_to_sign = [
-            'content-encoding', 'content-language', 'content-length',
-            'content-md5', 'content-type', 'date', 'if-modified-since',
-            'if-match', 'if-none-match', 'if-unmodified-since', 'range']
-
-        request_header_dict = dict((name.lower(), value)
-                                   for name, value in request.headers if value)
-        string_to_sign += '\n'.join(request_header_dict.get(x, '')
-                                    for x in headers_to_sign) + '\n'
-
-        # get x-ms header to sign
+    def _get_canonicalized_headers(self, request):
+        string_to_sign = ''
         x_ms_headers = []
         for name, value in request.headers:
-            if 'x-ms' in name:
+            if name.startswith('x-ms-'):
                 x_ms_headers.append((name.lower(), value))
         x_ms_headers.sort()
         for name, value in x_ms_headers:
             if value:
                 string_to_sign += ''.join([name, ':', value, '\n'])
+        return string_to_sign
 
-        # get account_name and uri path to sign
-        string_to_sign += '/' + self.account_name + uri_path
+    def _add_authorization_header(self, request, string_to_sign):
+        signature = _sign_string(self.account_key, string_to_sign)
+        auth_string = 'SharedKey ' + self.account_name + ':' + signature
+        request.headers.append(('Authorization', auth_string))
 
-        # get query string to sign if it is not table service
+
+class StorageSharedKeyAuthentication(_StorageSharedKeyAuthentication):
+    def sign_request(self, request):
+        string_to_sign = \
+            self._get_verb(request) + \
+            self._get_headers(
+                request,
+                [
+                    'content-encoding', 'content-language', 'content-length',
+                    'content-md5', 'content-type', 'date', 'if-modified-since',
+                    'if-match', 'if-none-match', 'if-unmodified-since', 'range'
+                ]
+            ) + \
+            self._get_canonicalized_headers(request) + \
+            self._get_canonicalized_resource(request) + \
+            self._get_canonicalized_resource_query(request)
+
+        self._add_authorization_header(request, string_to_sign)
+
+    def _get_canonicalized_resource_query(self, request):
         query_to_sign = request.query
         query_to_sign.sort()
 
+        string_to_sign = ''
         current_name = ''
         for name, value in query_to_sign:
             if value:
@@ -1215,44 +1235,30 @@ class StorageSharedKeyAuthentication:
                 else:
                     string_to_sign += '\n' + ',' + value
 
-        # sign the request
-        signature = _sign_string(self.account_key, string_to_sign)
-        auth_string = 'SharedKey ' + self.account_name + ':' + signature
-
-        request.headers.append(('Authorization', auth_string))
+        return string_to_sign
 
 
-class StorageTableSharedKeyAuthentication:
-    def __init__(self, account_name, account_key):
-        self.account_name = account_name
-        self.account_key = account_key
-
+class StorageTableSharedKeyAuthentication(_StorageSharedKeyAuthentication):
     def sign_request(self, request):
-        uri_path = request.path.split('?')[0]
+        string_to_sign = \
+            self._get_verb(request) + \
+            self._get_headers(
+                request,
+                ['content-md5', 'content-type', 'date'],
+            ) + \
+            self._get_canonicalized_resource(request) + \
+            self._get_canonicalized_resource_query(request)
 
-        string_to_sign = request.method + '\n'
-        headers_to_sign = ['content-md5', 'content-type', 'date']
-        request_header_dict = dict((name.lower(), value)
-                                   for name, value in request.headers if value)
-        string_to_sign += '\n'.join(request_header_dict.get(x, '')
-                                    for x in headers_to_sign) + '\n'
+        self._add_authorization_header(request, string_to_sign)
 
-        # get account_name and uri path to sign
-        string_to_sign += ''.join(['/', self.account_name, uri_path])
-
+    def _get_canonicalized_resource_query(self, request):
         for name, value in request.query:
             if name == 'comp':
-                string_to_sign += '?comp=' + value
-                break
-
-        # sign the request
-        auth_string = 'SharedKey ' + self.account_name + ':' + \
-            _sign_string(self.account_key, string_to_sign)
-
-        request.headers.append(('Authorization', auth_string))
+                return '?comp=' + value
+        return ''
 
 
-class StorageNoAuthentication:
+class StorageNoAuthentication(object):
     def sign_request(self, request):
         pass
 

--- a/azure/storage/__init__.py
+++ b/azure/storage/__init__.py
@@ -170,10 +170,15 @@ class AccessPolicy(WindowsAzureData):
 
     ''' Access Policy class in service properties. '''
 
-    def __init__(self, start=u'', expiry=u'', permission='u'):
+    def __init__(self, start=u'', expiry=u'', permission=u'',
+                 start_pk=u'', start_rk=u'', end_pk=u'', end_rk=u''):
         self.start = start
         self.expiry = expiry
         self.permission = permission
+        self.start_pk = start_pk
+        self.start_rk = start_rk
+        self.end_pk = end_pk
+        self.end_rk = end_rk
 
 
 class SignedIdentifier(WindowsAzureData):
@@ -396,8 +401,90 @@ class EntityProperty(WindowsAzureData):
 
 class Table(WindowsAzureData):
 
-    ''' Only for intellicens and telling user the return type. '''
+    ''' Only for IntelliSense and telling user the return type. '''
     pass
+
+
+class ContainerSharedAccessPermissions(object):
+    '''Permissions for a container.'''
+
+    '''
+    Read the content, properties, metadata or block list of any blob in
+    the container. Use any blob in the container as the source of a
+    copy operation.
+    '''
+    READ = 'r'
+
+    '''
+    For any blob in the container, create or write content, properties,
+    metadata, or block list. Snapshot or lease the blob. Resize the blob
+    (page blob only). Use the blob as the destination of a copy operation
+    within the same account.
+    You cannot grant permissions to read or write container properties or
+    metadata, nor to lease a container.
+    '''
+    WRITE = 'w'
+
+    '''Delete any blob in the container.'''
+    DELETE = 'd'
+
+    '''List blobs in the container.'''
+    LIST = 'l'
+
+
+class BlobSharedAccessPermissions(object):
+    '''Permissions for a blob.'''
+
+    '''
+    Read the content, properties, metadata and block list. Use the blob
+    as the source of a copy operation.
+    '''
+    READ = 'r'
+
+    '''
+    Create or write content, properties, metadata, or block list.
+    Snapshot or lease the blob. Resize the blob (page blob only). Use the
+    blob as the destination of a copy operation within the same account.
+    '''
+    WRITE = 'w'
+
+    '''Delete the blob.'''
+    DELETE = 'd'
+
+
+class TableSharedAccessPermissions(object):
+    '''Permissions for a table.'''
+
+    '''Get entities and query entities.'''
+    QUERY = 'r'
+
+    '''Add entities.'''
+    ADD = 'a'
+
+    '''Update entities.'''
+    UPDATE = 'u'
+
+    '''Delete entities.'''
+    DELETE = 'd'
+
+
+class QueueSharedAccessPermissions(object):
+    '''Permissions for a queue.'''
+
+    '''
+    Read metadata and properties, including message count.
+    Peek at messages.
+    '''
+    READ = 'r'
+
+    '''Add messages to the queue.'''
+    ADD = 'a'
+
+    '''Update messages in the queue.'''
+    UPDATE = 'u'
+
+    '''Get and delete messages from the queue.'''
+    PROCESS = 'p'
 
 
 def _parse_blob_enum_results_list(response):
@@ -444,7 +531,7 @@ def _update_storage_header(request):
     return request
 
 
-def _update_storage_blob_header(request, account_name, account_key):
+def _update_storage_blob_header(request, authentication):
     ''' add additional headers for storage blob request. '''
 
     request = _update_storage_header(request)
@@ -452,112 +539,31 @@ def _update_storage_blob_header(request, account_name, account_key):
     request.headers.append(('x-ms-date', current_time))
     request.headers.append(
         ('Content-Type', 'application/octet-stream Charset=UTF-8'))
-    request.headers.append(('Authorization',
-                            _sign_storage_blob_request(request,
-                                                       account_name,
-                                                       account_key)))
+    authentication.sign_request(request)
 
     return request.headers
 
 
-def _update_storage_queue_header(request, account_name, account_key):
-    ''' add additional headers for storage queue request. '''
-    return _update_storage_blob_header(request, account_name, account_key)
+def _update_storage_queue_header(request, authentication):
+    return _update_storage_blob_header(request, authentication)
 
 
-def _update_storage_table_header(request):
+def _update_storage_table_header(request, content_type='application/atom+xml'):
     ''' add additional headers for storage table request. '''
 
     request = _update_storage_header(request)
-    for name, _ in request.headers:
-        if name.lower() == 'content-type':
-            break
-    else:
-        request.headers.append(('Content-Type', 'application/atom+xml'))
+    if content_type:
+        for name, _ in request.headers:
+            if name.lower() == 'content-type':
+                break
+        else:
+            request.headers.append(('Content-Type', content_type))
     request.headers.append(('DataServiceVersion', '2.0;NetFx'))
     request.headers.append(('MaxDataServiceVersion', '2.0;NetFx'))
     current_time = datetime.utcnow().strftime('%a, %d %b %Y %H:%M:%S GMT')
     request.headers.append(('x-ms-date', current_time))
     request.headers.append(('Date', current_time))
     return request.headers
-
-
-def _sign_storage_blob_request(request, account_name, account_key):
-    '''
-    Returns the signed string for blob request which is used to set
-    Authorization header. This is also used to sign queue request.
-    '''
-
-    uri_path = request.path.split('?')[0]
-
-    # method to sign
-    string_to_sign = request.method + '\n'
-
-    # get headers to sign
-    headers_to_sign = [
-        'content-encoding', 'content-language', 'content-length',
-        'content-md5', 'content-type', 'date', 'if-modified-since',
-        'if-match', 'if-none-match', 'if-unmodified-since', 'range']
-
-    request_header_dict = dict((name.lower(), value)
-                               for name, value in request.headers if value)
-    string_to_sign += '\n'.join(request_header_dict.get(x, '')
-                                for x in headers_to_sign) + '\n'
-
-    # get x-ms header to sign
-    x_ms_headers = []
-    for name, value in request.headers:
-        if 'x-ms' in name:
-            x_ms_headers.append((name.lower(), value))
-    x_ms_headers.sort()
-    for name, value in x_ms_headers:
-        if value:
-            string_to_sign += ''.join([name, ':', value, '\n'])
-
-    # get account_name and uri path to sign
-    string_to_sign += '/' + account_name + uri_path
-
-    # get query string to sign if it is not table service
-    query_to_sign = request.query
-    query_to_sign.sort()
-
-    current_name = ''
-    for name, value in query_to_sign:
-        if value:
-            if current_name != name:
-                string_to_sign += '\n' + name + ':' + value
-                current_name = name
-            else:
-                string_to_sign += '\n' + ',' + value
-
-    # sign the request
-    auth_string = 'SharedKey ' + account_name + ':' + \
-        _sign_string(account_key, string_to_sign)
-    return auth_string
-
-
-def _sign_storage_table_request(request, account_name, account_key):
-    uri_path = request.path.split('?')[0]
-
-    string_to_sign = request.method + '\n'
-    headers_to_sign = ['content-md5', 'content-type', 'date']
-    request_header_dict = dict((name.lower(), value)
-                               for name, value in request.headers if value)
-    string_to_sign += '\n'.join(request_header_dict.get(x, '')
-                                for x in headers_to_sign) + '\n'
-
-    # get account_name and uri path to sign
-    string_to_sign += ''.join(['/', account_name, uri_path])
-
-    for name, value in request.query:
-        if name == 'comp' and uri_path == '/':
-            string_to_sign += '?comp=' + value
-            break
-
-    # sign the request
-    auth_string = 'SharedKey ' + account_name + ':' + \
-        _sign_string(account_key, string_to_sign)
-    return auth_string
 
 
 def _to_python_bool(value):
@@ -751,6 +757,26 @@ def _convert_block_list_to_xml(block_id_list):
         xml += '<Latest>{0}</Latest>'.format(_encode_base64(value))
 
     return xml + '</BlockList>'
+
+
+def _convert_signed_identifiers_to_xml(signed_identifiers):
+    if signed_identifiers is None:
+        return ''
+    xml = '<?xml version="1.0" encoding="utf-8"?><SignedIdentifiers>'
+    for signed_identifier in signed_identifiers:
+        xml += '<SignedIdentifier>'
+        xml += '<Id>{0}</Id>'.format(signed_identifier.id)
+        xml += '<AccessPolicy>'
+        if signed_identifier.access_policy.start:
+            xml += '<Start>{0}</Start>'.format(signed_identifier.access_policy.start)
+        if signed_identifier.access_policy.expiry:
+            xml += '<Expiry>{0}</Expiry>'.format(signed_identifier.access_policy.expiry)
+        if signed_identifier.access_policy.permission:
+            xml += '<Permission>{0}</Permission>'.format(signed_identifier.access_policy.permission)
+        xml += '</AccessPolicy>'
+        xml += '</SignedIdentifier>'
+
+    return xml + '</SignedIdentifiers>'
 
 
 def _create_blob_result(response):
@@ -1127,6 +1153,110 @@ def _storage_error_handler(http_error):
     ''' Simple error handler for storage service. '''
     return _general_error_handler(http_error)
 
+
+class StorageSASAuthentication:
+    def __init__(self, sas_token):
+        self.sas_token = sas_token
+
+    def sign_request(self, request):
+        if request.path.find('?') == -1:
+            request.path += '?'
+        else:
+            request.path += '&'
+
+        request.path += self.sas_token
+
+
+class StorageSharedKeyAuthentication:
+    def __init__(self, account_name, account_key):
+        self.account_name = account_name
+        self.account_key = account_key
+
+    def sign_request(self, request):
+        uri_path = request.path.split('?')[0]
+
+        # method to sign
+        string_to_sign = request.method + '\n'
+
+        # get headers to sign
+        headers_to_sign = [
+            'content-encoding', 'content-language', 'content-length',
+            'content-md5', 'content-type', 'date', 'if-modified-since',
+            'if-match', 'if-none-match', 'if-unmodified-since', 'range']
+
+        request_header_dict = dict((name.lower(), value)
+                                   for name, value in request.headers if value)
+        string_to_sign += '\n'.join(request_header_dict.get(x, '')
+                                    for x in headers_to_sign) + '\n'
+
+        # get x-ms header to sign
+        x_ms_headers = []
+        for name, value in request.headers:
+            if 'x-ms' in name:
+                x_ms_headers.append((name.lower(), value))
+        x_ms_headers.sort()
+        for name, value in x_ms_headers:
+            if value:
+                string_to_sign += ''.join([name, ':', value, '\n'])
+
+        # get account_name and uri path to sign
+        string_to_sign += '/' + self.account_name + uri_path
+
+        # get query string to sign if it is not table service
+        query_to_sign = request.query
+        query_to_sign.sort()
+
+        current_name = ''
+        for name, value in query_to_sign:
+            if value:
+                if current_name != name:
+                    string_to_sign += '\n' + name + ':' + value
+                    current_name = name
+                else:
+                    string_to_sign += '\n' + ',' + value
+
+        # sign the request
+        signature = _sign_string(self.account_key, string_to_sign)
+        auth_string = 'SharedKey ' + self.account_name + ':' + signature
+
+        request.headers.append(('Authorization', auth_string))
+
+
+class StorageTableSharedKeyAuthentication:
+    def __init__(self, account_name, account_key):
+        self.account_name = account_name
+        self.account_key = account_key
+
+    def sign_request(self, request):
+        uri_path = request.path.split('?')[0]
+
+        string_to_sign = request.method + '\n'
+        headers_to_sign = ['content-md5', 'content-type', 'date']
+        request_header_dict = dict((name.lower(), value)
+                                   for name, value in request.headers if value)
+        string_to_sign += '\n'.join(request_header_dict.get(x, '')
+                                    for x in headers_to_sign) + '\n'
+
+        # get account_name and uri path to sign
+        string_to_sign += ''.join(['/', self.account_name, uri_path])
+
+        for name, value in request.query:
+            if name == 'comp':
+                string_to_sign += '?comp=' + value
+                break
+
+        # sign the request
+        auth_string = 'SharedKey ' + self.account_name + ':' + \
+            _sign_string(self.account_key, string_to_sign)
+
+        request.headers.append(('Authorization', auth_string))
+
+
+class StorageNoAuthentication:
+    def sign_request(self, request):
+        pass
+
+
 # make these available just from storage.
 from azure.storage.blobservice import BlobService
 from azure.storage.queueservice import QueueService
@@ -1135,6 +1265,4 @@ from azure.storage.cloudstorageaccount import CloudStorageAccount
 from azure.storage.sharedaccesssignature import (
     SharedAccessSignature,
     SharedAccessPolicy,
-    Permission,
-    WebResource,
-    )
+)

--- a/azure/storage/blobservice.py
+++ b/azure/storage/blobservice.py
@@ -44,15 +44,24 @@ from azure.storage import (
     PageRange,
     SignedIdentifiers,
     StorageServiceProperties,
+    StorageSASAuthentication,
+    StorageSharedKeyAuthentication,
+    StorageNoAuthentication,
+    X_MS_VERSION,
     _BlockBlobChunkUploader,
     _PageBlobChunkUploader,
     _convert_block_list_to_xml,
     _convert_response_to_block_list,
+    _convert_signed_identifiers_to_xml,
     _create_blob_result,
     _download_blob_chunks,
     _parse_blob_enum_results_list,
     _update_storage_blob_header,
     _upload_blob_chunks,
+    )
+from azure.storage.sharedaccesssignature import (
+    SharedAccessSignature,
+    ResourceType,
     )
 from azure.storage.storageclient import _StorageClient
 from os import path
@@ -74,7 +83,7 @@ class BlobService(_StorageClient):
 
     def __init__(self, account_name=None, account_key=None, protocol='https',
                  host_base=BLOB_SERVICE_HOST_BASE, dev_host=DEV_BLOB_HOST,
-                 timeout=DEFAULT_HTTP_TIMEOUT):
+                 timeout=DEFAULT_HTTP_TIMEOUT, sas_token=None):
         '''
         account_name:
             your storage account name, required for all operations.
@@ -89,14 +98,26 @@ class BlobService(_StorageClient):
             Optional. Dev host url. Defaults to localhost.
         timeout:
             Optional. Timeout for the http request, in seconds.
+        sas_token:
+            Optional. Token to use to authenticate with shared access signature.
         '''
         self._BLOB_MAX_DATA_SIZE = 64 * 1024 * 1024
         self._BLOB_MAX_CHUNK_DATA_SIZE = 4 * 1024 * 1024
         super(BlobService, self).__init__(
-            account_name, account_key, protocol, host_base, dev_host, timeout)
+            account_name, account_key, protocol, host_base, dev_host, timeout, sas_token)
+
+        if self.account_key:
+            self.authentication = StorageSharedKeyAuthentication(
+                self.account_name,
+                self.account_key,
+            )
+        elif self.sas_token:
+            self.authentication = StorageSASAuthentication(self.sas_token)
+        else:
+            self.authentication = StorageNoAuthentication()
 
     def make_blob_url(self, container_name, blob_name, account_name=None,
-                      protocol=None, host_base=None):
+                      protocol=None, host_base=None, sas_token=None):
         '''
         Creates the url to access a blob.
 
@@ -113,6 +134,9 @@ class BlobService(_StorageClient):
         host_base:
             Live host base url.  If not specified, uses the host base specified
             when BlobService was initialized.
+        sas_token:
+            Shared access signature token created with
+            generate_shared_access_signature.
         '''
 
         if not account_name:
@@ -122,11 +146,83 @@ class BlobService(_StorageClient):
         if not host_base:
             host_base = self.host_base
 
-        return '{0}://{1}{2}/{3}/{4}'.format(protocol,
-                                             account_name,
-                                             host_base,
-                                             container_name,
-                                             blob_name)
+        url = '{0}://{1}{2}/{3}/{4}'.format(
+            protocol,
+            account_name,
+            host_base,
+            container_name,
+            blob_name,
+        )
+
+        if sas_token:
+            url += '?' + sas_token
+
+        return url
+
+    def generate_shared_access_signature(self,
+                                         container_name,
+                                         blob_name=None,
+                                         shared_access_policy=None,
+                                         sas_version=X_MS_VERSION,
+                                         cache_control=None,
+                                         content_disposition=None,
+                                         content_encoding=None,
+                                         content_language=None,
+                                         content_type=None):
+        '''
+        Generates a shared access signature for the container or blob.
+        Use the returned signature with the sas_token parameter of BlobService.
+
+        container_name:
+            Required. Name of container.
+        blob_name:
+            Optional. Name of blob.
+        shared_access_policy:
+            Instance of SharedAccessPolicy class.
+        sas_version:
+            x-ms-version for storage service, or None to get a signed query
+            string compatible with pre 2012-02-12 clients, where the version
+            is not included in the query string.
+        cache_control:
+            Response header value for Cache-Control when resource is accessed
+            using this shared access signature.
+        content_disposition:
+            Response header value for Content-Disposition when resource is accessed
+            using this shared access signature.
+        content_encoding:
+            Response header value for Content-Encoding when resource is accessed
+            using this shared access signature.
+        content_language:
+            Response header value for Content-Language when resource is accessed
+            using this shared access signature.
+        content_type:
+            Response header value for Content-Type when resource is accessed
+            using this shared access signature.
+        '''
+        _validate_not_none('container_name', container_name)
+        _validate_not_none('shared_access_policy', shared_access_policy)
+        _validate_not_none('self.account_name', self.account_name)
+        _validate_not_none('self.account_key', self.account_key)
+
+        if blob_name:
+            resource_type = ResourceType.RESOURCE_BLOB
+            resource_path = container_name + '/' + blob_name
+        else:
+            resource_type = ResourceType.RESOURCE_CONTAINER
+            resource_path = container_name
+
+        sas = SharedAccessSignature(self.account_name, self.account_key)
+        return sas.generate_signed_query_string(
+            resource_path,
+            resource_type,
+            shared_access_policy,
+            sas_version,
+            cache_control,
+            content_disposition,
+            content_encoding,
+            content_language,
+            content_type,
+        )
 
     def list_containers(self, prefix=None, marker=None, maxresults=None,
                         include=None):
@@ -160,7 +256,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         response = self._perform_request(request)
 
         return _ETreeXmlToObject.parse_enum_results_list(
@@ -194,7 +290,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         if not fail_on_exist:
             try:
                 self._perform_request(request)
@@ -226,7 +322,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         response = self._perform_request(request)
 
         return _parse_response_for_dict(response)
@@ -252,7 +348,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         response = self._perform_request(request)
 
         return _parse_response_for_dict_prefix(response, prefixes=['x-ms-meta'])
@@ -285,7 +381,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         self._perform_request(request)
 
     def get_container_acl(self, container_name, x_ms_lease_id=None):
@@ -308,7 +404,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         response = self._perform_request(request)
 
         return _ETreeXmlToObject.parse_response(
@@ -340,11 +436,11 @@ class BlobService(_StorageClient):
             ('x-ms-lease-id', _str_or_none(x_ms_lease_id)),
         ]
         request.body = _get_request_body(
-            _convert_class_to_xml(signed_identifiers))
+            _convert_signed_identifiers_to_xml(signed_identifiers))
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         self._perform_request(request)
 
     def delete_container(self, container_name, fail_not_exist=False,
@@ -369,7 +465,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         if not fail_not_exist:
             try:
                 self._perform_request(request)
@@ -435,7 +531,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         response = self._perform_request(request)
 
         return _parse_response_for_dict_filter(
@@ -506,7 +602,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         response = self._perform_request(request)
 
         return _parse_blob_enum_results_list(response)
@@ -536,7 +632,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         self._perform_request(request)
 
     def get_blob_service_properties(self, timeout=None):
@@ -555,7 +651,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         response = self._perform_request(request)
 
         return _ETreeXmlToObject.parse_response(
@@ -584,7 +680,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
 
         response = self._perform_request(request)
 
@@ -648,7 +744,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         self._perform_request(request)
 
     def put_blob(self, container_name, blob_name, blob, x_ms_blob_type,
@@ -750,7 +846,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         self._perform_request(request)
 
     def put_block_blob_from_path(self, container_name, blob_name, file_path,
@@ -1600,7 +1696,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         response = self._perform_request(request, None)
 
         return _create_blob_result(response)
@@ -1849,7 +1945,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         response = self._perform_request(request)
 
         return _parse_response_for_dict_prefix(response, prefixes=['x-ms-meta'])
@@ -1883,7 +1979,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         self._perform_request(request)
 
     def lease_blob(self, container_name, blob_name, x_ms_lease_action,
@@ -1940,7 +2036,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         response = self._perform_request(request)
 
         return _parse_response_for_dict_filter(
@@ -1990,7 +2086,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         response = self._perform_request(request)
 
         return _parse_response_for_dict_filter(
@@ -2094,7 +2190,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         response = self._perform_request(request)
 
         return _parse_response_for_dict(response)
@@ -2131,7 +2227,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         self._perform_request(request)
 
     def delete_blob(self, container_name, blob_name, snapshot=None,
@@ -2188,7 +2284,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         self._perform_request(request)
 
     def put_block(self, container_name, blob_name, block, blockid,
@@ -2231,7 +2327,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         self._perform_request(request)
 
     def put_block_list(self, container_name, blob_name, block_list,
@@ -2304,7 +2400,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         self._perform_request(request)
 
     def get_block_list(self, container_name, blob_name, snapshot=None,
@@ -2341,7 +2437,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         response = self._perform_request(request)
 
         return _convert_response_to_block_list(response)
@@ -2453,7 +2549,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         self._perform_request(request)
 
     def get_page_ranges(self, container_name, blob_name, snapshot=None,
@@ -2499,7 +2595,7 @@ class BlobService(_StorageClient):
         request.path, request.query = _update_request_uri_query_local_storage(
             request, self.use_local_storage)
         request.headers = _update_storage_blob_header(
-            request, self.account_name, self.account_key)
+            request, self.authentication)
         response = self._perform_request(request)
 
         return _ETreeXmlToObject.parse_simple_list(response, PageList, PageRange, "page_ranges")

--- a/azure/storage/storageclient.py
+++ b/azure/storage/storageclient.py
@@ -42,7 +42,8 @@ class _StorageClient(object):
     '''
 
     def __init__(self, account_name=None, account_key=None, protocol='https',
-                 host_base='', dev_host='', timeout=DEFAULT_HTTP_TIMEOUT):
+                 host_base='', dev_host='', timeout=DEFAULT_HTTP_TIMEOUT,
+                 sas_token=None):
         '''
         account_name:
             your storage account name, required for all operations.
@@ -57,6 +58,8 @@ class _StorageClient(object):
             Optional. Dev host url. Defaults to localhost.
         timeout:
             Optional. Timeout for the http request, in seconds.
+        sas_token:
+            Optional. Token to use to authenticate with shared access signature.
         '''
         self.account_name = account_name
         self.account_key = account_key
@@ -64,6 +67,7 @@ class _StorageClient(object):
         self.protocol = protocol
         self.host_base = host_base
         self.dev_host = dev_host
+        self.sas_token = sas_token
 
         # the app is not run in azure emulator or use default development
         # storage account and key if app is run in emulator.
@@ -79,7 +83,7 @@ class _StorageClient(object):
         # constructing, get the account and key from environment variables if
         # the app is not run in azure emulator or use default development
         # storage account and key if app is run in emulator.
-        if not self.account_name or not self.account_key:
+        if not self.account_name and not self.account_key:
             if self.is_emulated:
                 self.account_name = DEV_ACCOUNT_NAME
                 self.account_key = DEV_ACCOUNT_KEY
@@ -89,13 +93,11 @@ class _StorageClient(object):
                 self.account_name = os.environ.get(AZURE_STORAGE_ACCOUNT)
                 self.account_key = os.environ.get(AZURE_STORAGE_ACCESS_KEY)
 
-        if not self.account_name or not self.account_key:
+        if not self.account_name:
             raise WindowsAzureError(_ERROR_STORAGE_MISSING_INFO)
 
         self._httpclient = _HTTPClient(
             service_instance=self,
-            account_key=self.account_key,
-            account_name=self.account_name,
             protocol=self.protocol,
             timeout=timeout)
         self._batchclient = None

--- a/doc/storage.rst
+++ b/doc/storage.rst
@@ -9,17 +9,17 @@ To ensure a table exists, call **create\_table**:
 .. code:: python
 
     from azure.storage import TableService
-    ts = TableService(account_name, account_key)
-    ts.create_table('tasktable')
+    table_service = TableService(account_name, account_key)
+    table_service.create_table('tasktable')
 
 A new entity can be added by calling **insert\_entity**:
 
 .. code:: python
 
     from datetime import datetime
-    ts = TableService(account_name, account_key)
-    ts.create_table('tasktable')
-    ts.insert_entity(
+    table_service = TableService(account_name, account_key)
+    table_service.create_table('tasktable')
+    table_service.insert_entity(
          'tasktable',
          {
             'PartitionKey' : 'tasksSeattle',
@@ -34,8 +34,80 @@ just inserted:
 
 .. code:: python
 
-    ts = TableService(account_name, account_key)
-    entity = ts.get_entity('tasktable', 'tasksSeattle', '1')
+    table_service = TableService(account_name, account_key)
+    entity = table_service.get_entity('tasktable', 'tasksSeattle', '1')
+
+If you want to give access to a table to a third party without revealing
+your account key, you can use a shared access signature. The shared
+access signature includes an access policy, with optional start, expiry
+and permission.
+
+To generate a shared access signature, use:
+
+.. code:: python
+
+    from azure.storage import TableService, AccessPolicy, SharedAccessPolicy, TableSharedAccessPermissions
+    table_service = TableService(account_name, account_key)
+    ap = AccessPolicy(
+        expiry='2016-10-12',
+        permission=TableSharedAccessPermissions.QUERY,
+    )
+    sas_token = table_service.generate_shared_access_signature(
+        'tasktable',
+        SharedAccessPolicy(ap),
+    )
+
+Alternatively, you can define a named access policy on the server:
+
+.. code:: python
+
+    from azure.storage import TableService, SharedAccessPolicy, TableSharedAccessPermissions, SignedIdentifier
+    table_service = TableService(account_name, account_key)
+
+    policy_name = 'readonlyvaliduntilnextyear'
+
+    si = SignedIdentifier()
+    si.id = policy_name
+    si.access_policy.expiry = '2016-01-01'
+    si.access_policy.permission = TableSharedAccessPermissions.QUERY
+    identifiers = SignedIdentifiers()
+    identifiers.signed_identifiers.append(si)
+
+    table_service.set_queue_acl(
+        table_name='tasktable',
+        signed_identifiers=identifiers,
+    )
+
+And generate a shared access signature for that named access policy:
+
+.. code:: python
+
+    sas_token = table_service.generate_shared_access_signature(
+        'tasktable',
+        SharedAccessPolicy(signed_identifier=policy_name),
+    )
+
+Using a predefined access policy has the advantage that it can be
+revoked from the server side. To revoke, call ``set_table_acl`` with the
+new list of signed identifiers. You can pass in ``None`` or an empty
+list to remove all.
+
+.. code:: python
+
+    table_service.set_table_acl(
+        table_name='tasktable',
+        signed_identifiers=None,
+    )
+
+The third party can use the shared access signature token to
+authenticate, instead of an account key:
+
+.. code:: python
+
+    from azure.storage import TableService
+    table_service = TableService(account_name, sas_token=sas_token)
+    entity = table_service.get_entity('tasktable', 'tasksSeattle', '1')
+
 
 Blob Storage
 ------------
@@ -109,6 +181,162 @@ To download to an array of bytes, use **get\_blob\_to\_bytes**.
 
 To download to unicode text, use **get\_blob\_to\_text**.
 
+You can set public access to blobs in a container when the container is
+created:
+
+.. code:: python
+
+    blob_service.create_container(
+        container_name='images',
+        x_ms_blob_public_access='blob',
+    )
+
+Or after it's created:
+
+.. code:: python
+
+    blob_service.set_container_acl(
+        container_name='images',
+        x_ms_blob_public_access='blob',
+    )
+
+If ``x_ms_blob_public_access`` is set to ``'blob'``:
+
+-  Blob data within this container can be read via anonymous request,
+   but container data is not available. Clients cannot enumerate blobs
+   within the container via anonymous request.
+
+If it's set to ``'container'``:
+
+-  Container and blob data can be read via anonymous request. Clients
+   can enumerate blobs within the container via anonymous request, but
+   cannot enumerate containers within the storage account.
+
+The default is ``None``:
+
+-  Container and blob data can be read by the account owner only.
+
+You can use ``BlobService`` to access public containers and blobs by
+omitting the ``account_key`` parameter:
+
+.. code:: python
+
+    from azure.storage import BlobService
+    blob_service = BlobService(account_name)
+    blob = blob_service.get_blob_to_path(
+        'images',
+        'image.png',
+        'downloads/image.png',
+        max_connections=8,
+    )
+
+You can get a full URL for the blob (for use in a web browser, etc):
+
+.. code:: python
+
+    from azure.storage import BlobService
+    blob_service = BlobService(account_name)
+    url = blob_service.make_blob_url(
+        container_name='images',
+        blob_name='image.png',
+    )
+    # url is: https://<account_name>.blob.core.windows.net/images/image.png
+
+If you want to give access to a container or blob to a third party
+without revealing your account key or making the container or blob
+public, you can use a shared access signature. The shared access
+signature includes an access policy, with optional start, expiry and
+permission.
+
+To generate a shared access signature, use:
+
+.. code:: python
+
+    from azure.storage import BlobService, AccessPolicy, SharedAccessPolicy, BlobSharedAccessPermissions
+    blob_service = BlobService(account_name, account_key)
+    ap = AccessPolicy(
+        expiry='2016-10-12',
+        permission=BlobSharedAccessPermissions.READ,
+    )
+    sas_token = blob_service.generate_shared_access_signature(
+        container_name='images',
+        blob_name='image.png',
+        shared_access_policy=SharedAccessPolicy(ap),
+    )
+
+Note that a shared access signature can be created for a container, just
+pass ``None`` (which is the default) for the ``blob_name`` parameter.
+
+Alternatively, you can define a named access policy on the server:
+
+.. code:: python
+
+    from azure.storage import BlobService, AccessPolicy, SharedAccessPolicy, BlobSharedAccessPermissions, SignedIdentifier
+    blob_service = BlobService(account_name, account_key)
+
+    policy_name = 'readonlyvaliduntilnextyear'
+
+    si = SignedIdentifier()
+    si.id = policy_name
+    si.access_policy.expiry = '2016-01-01'
+    si.access_policy.permission = BlobSharedAccessPermissions.READ
+    identifiers = SignedIdentifiers()
+    identifiers.signed_identifiers.append(si)
+
+    blob_service.set_container_acl(
+        container_name='images',
+        signed_identifiers=identifiers,
+    )
+
+And generate a shared access signature for that named access policy:
+
+.. code:: python
+
+    sas_token = blob_service.generate_shared_access_signature(
+        container_name='images',
+        blob_name='image.png',
+        shared_access_policy=SharedAccessPolicy(signed_identifier=policy_name),
+    )
+
+Using a predefined access policy has the advantage that it can be
+revoked from the server side. To revoke, call ``set_container_acl`` with
+the new list of signed identifiers. You can pass in ``None`` or an empty
+list to remove all.
+
+.. code:: python
+
+    blob_service.set_container_acl(
+        container_name='images',
+        signed_identifiers=None,
+    )
+
+The third party can use the shared access signature token to
+authenticate, instead of an account key:
+
+.. code:: python
+
+    from azure.storage import BlobService
+    blob_service = BlobService(account_name, sas_token=sas_token)
+    blob = blob_service.get_blob_to_path(
+        'images',
+        'image.png',
+        'downloads/image.png',
+        max_connections=8,
+    )
+
+You can get a full URL for the blob (for use in a web browser, etc):
+
+.. code:: python
+
+    from azure.storage import BlobService
+    blob_service = BlobService(account_name)
+    url = blob_service.make_blob_url(
+        container_name='images',
+        blob_name='image.png',
+        sas_token=sas_token,
+    )
+
+
 Storage Queues
 --------------
 
@@ -141,7 +369,78 @@ are removed from the queue.
     messages = queue_service.get_messages('taskqueue')
     queue_service.delete_message('taskqueue', messages[0].message_id, messages[0].pop_receipt)
 
-    
+If you want to give access to a queue to a third party without revealing
+your account key, you can use a shared access signature. The shared
+access signature includes an access policy, with optional start, expiry
+and permission.
+
+To generate a shared access signature, use:
+
+.. code:: python
+
+    from azure.storage import QueueService, AccessPolicy, SharedAccessPolicy, QueueSharedAccessPermissions
+    queue_service = QueueService(account_name, account_key)
+    ap = AccessPolicy(
+        expiry='2016-10-12',
+        permission=QueueSharedAccessPermissions.READ,
+    )
+    sas_token = queue_service.generate_shared_access_signature(
+        'taskqueue',
+        SharedAccessPolicy(ap),
+    )
+
+Alternatively, you can define a named access policy on the server:
+
+.. code:: python
+
+    from azure.storage import QueueService, SharedAccessPolicy, QueueSharedAccessPermissions, SignedIdentifier
+    queue_service = QueueService(account_name, account_key)
+
+    policy_name = 'readonlyvaliduntilnextyear'
+
+    si = SignedIdentifier()
+    si.id = policy_name
+    si.access_policy.expiry = '2016-01-01'
+    si.access_policy.permission = QueueSharedAccessPermissions.READ
+    identifiers = SignedIdentifiers()
+    identifiers.signed_identifiers.append(si)
+
+    queue_service.set_queue_acl(
+        queue_name='taskqueue',
+        signed_identifiers=identifiers,
+    )
+
+And generate a shared access signature for that named access policy:
+
+.. code:: python
+
+    sas_token = queue_service.generate_shared_access_signature(
+        'taskqueue',
+        SharedAccessPolicy(signed_identifier=policy_name),
+    )
+
+Using a predefined access policy has the advantage that it can be
+revoked from the server side. To revoke, call ``set_queue_acl`` with the
+new list of signed identifiers. You can pass in ``None`` or an empty
+list to remove all.
+
+.. code:: python
+
+    queue_service.set_container_acl(
+        queue_name='taskqueue',
+        signed_identifiers=None,
+    )
+
+The third party can use the shared access signature token to
+authenticate, instead of an account key:
+
+.. code:: python
+
+    from azure.storage import QueueService
+    queue_service = QueueService(account_name, sas_token=sas_token)
+    messages = queue_service.peek_messages('taskqueue')
+
+
 Need Help?
 ==========
 


### PR DESCRIPTION
This enables producing and consuming SAS tokens for blob, table and queue storage.  Also allows consuming blob anonymously (for public blobs).  See doc/storage.rst for usage.