### PR TITLE
Make 'delete_hosted_service' async

### DIFF
--- a/azure/servicemanagement/servicemanagementservice.py
+++ b/azure/servicemanagement/servicemanagementservice.py
@@ -418,7 +418,7 @@ class ServiceManagementService(_ServiceManagementClient):
             Name of the hosted service.
         '''
         _validate_not_none('service_name', service_name)
-        return self._perform_delete(self._get_hosted_service_path(service_name))
+        return self._perform_delete(self._get_hosted_service_path(service_name), async=True)
 
     def get_deployment_by_slot(self, service_name, deployment_slot):
         '''

--- a/tests/test_servicemanagementservice.py
+++ b/tests/test_servicemanagementservice.py
@@ -39,7 +39,7 @@ from azure.servicemanagement import (
     VMImage,
     WindowsConfigurationSet,
     parse_response_for_async_op,
-    )
+    AsynchronousOperationResult)
 from azure.storage.blobservice import BlobService
 from util import (
     AzureTestCase,
@@ -164,7 +164,8 @@ class ServiceManagementServiceTest(AzureTestCase):
                     self._wait_for_async(result.request_id)
                 except:
                     pass
-            self.sms.delete_hosted_service(self.hosted_service_name)
+            result = self.sms.delete_hosted_service(self.hosted_service_name)
+            self._wait_for_async(result.request_id)
         except:
             pass
 
@@ -900,7 +901,8 @@ class ServiceManagementServiceTest(AzureTestCase):
         result = self.sms.delete_hosted_service(self.hosted_service_name)
 
         # Assert
-        self.assertIsNone(result)
+        self.assertIsInstance(result, AsynchronousOperationResult)
+        self._wait_for_async(result.request_id)
         self.assertFalse(self._hosted_service_exists(self.hosted_service_name))
 
     def test_get_deployment_by_slot(self):


### PR DESCRIPTION
As https://msdn.microsoft.com/en-us/library/azure/gg441305.aspx says, `delete_hosted_service` should be async.
I came up with this when I saw in our logs:
```
e92f0d00-amegianeg: Terminating...
e92f0d00-amegianeg: Terminating deployment: tutum-e92f0d00
e92f0d00-amegianeg: Termination of deployment is: InProgress
e92f0d00-amegianeg: Termination of deployment is: InProgress
e92f0d00-amegianeg: Termination of deployment is: Succeeded
e92f0d00-amegianeg: Terminating cloud service: tutum-e92f0d00
e92f0d00-amegianeg: Deleting disk: tutum-e92f0d00-tutum-e92f0d00-0-201505061921270606
e92f0d00-amegianeg: Disk tutum-e92f0d00-tutum-e92f0d00-0-201505061921270606 cannot be deleted yet. Waiting...
e92f0d00-amegianeg: Disk tutum-e92f0d00-tutum-e92f0d00-0-201505061921270606 cannot be deleted yet. Waiting...
e92f0d00-amegianeg: Disk tutum-e92f0d00-tutum-e92f0d00-0-201505061921270606 cannot be deleted yet. Waiting...
e92f0d00-amegianeg: Disk tutum-e92f0d00-tutum-e92f0d00-0-201505061921270606 cannot be deleted yet. Waiting...
e92f0d00-amegianeg: Disk tutum-e92f0d00-tutum-e92f0d00-0-201505061921270606 cannot be deleted yet. Waiting...
e92f0d00-amegianeg: Disk tutum-e92f0d00-tutum-e92f0d00-0-201505061921270606 cannot be deleted yet. Waiting...
e92f0d00-amegianeg: Disk tutum-e92f0d00-tutum-e92f0d00-0-201505061921270606 cannot be deleted yet. Waiting...
e92f0d00-amegianeg: Disk tutum-e92f0d00-tutum-e92f0d00-0-201505061921270606 cannot be deleted yet. Waiting...
e92f0d00-amegianeg: Disk tutum-e92f0d00-tutum-e92f0d00-0-201505061921270606 cannot be deleted yet. Waiting...
ERROR: e92f0d00-amegianeg: Azure returned an error: Unknown error (Bad Request)
<Error xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><Code>BadRequest</Code><Message>A disk with name tutum-e92f0d00-tutum-e92f0d00-0-201505061921270606 is currently in use by virtual machine tutum-e92f0d00 running within hosted service tutum-e92f0d00, deployment tutum-e92f0d00.</Message></Error>
```

The deployment was successfully terminated, but the disk could not be deleted because of the hosted service.