### PR TITLE
Fix bytes type error on httpcient set_proxy

### DIFF
--- a/azure/http/httpclient.py
+++ b/azure/http/httpclient.py
@@ -181,7 +181,7 @@ class _HTTPClient(object):
         if self.use_httplib:
             if self.proxy_host:
                 for i in connection._buffer:
-                    if i.startswith("Host: "):
+                    if i.startswith(b"Host: "):
                         connection._buffer.remove(i)
                 connection.putheader(
                     'Host', "{0}:{1}".format(connection._tunnel_host,


### PR DESCRIPTION
In python3.4 occured bytes type error when connect by setting proxy.

sample
```
>>> blob_service = BlobService(account_name=storage_account_name, account_key=storage_account_key)
>>> blob_servie.set_proxy('192.168.xx.x', 8080)
>>> [b.name for b in blob_service.list_blobs(storage_container_name)]
```

stacktrace
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/vagrant/venv/work340/lib/python3.4/site-packages/azure/storage/blobservice.py", line 606, in list_blobs
    response = self._perform_request(request)
  File "/home/vagrant/venv/work340/lib/python3.4/site-packages/azure/storage/storageclient.py", line 167, in _perform_request
    resp = self._filter(request)
  File "/home/vagrant/venv/work340/lib/python3.4/site-packages/azure/storage/storageclient.py", line 156, in _perform_request_worker
    return self._httpclient.perform_request(request)
  File "/home/vagrant/venv/work340/lib/python3.4/site-packages/azure/http/httpclient.py", line 216, in perform_request
    self.send_request_headers(connection, request.headers)
  File "/home/vagrant/venv/work340/lib/python3.4/site-packages/azure/http/httpclient.py", line 184, in send_request_headers
    if i.startswith("Host: "):
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```