### PR TITLE
[WIP] Add some initial support for network security groups

### DIFF
--- a/azure/servicemanagement/__init__.py
+++ b/azure/servicemanagement/__init__.py
@@ -226,6 +226,28 @@ class VirtualNetworkSite(WindowsAzureData):
         self.affinity_group = u''
         self.subnets = Subnets()
 
+class NetworkSecurityGroups(WindowsAzureData):
+
+    def __init__(self):
+        self.network_security_groups = _list_of(NetworkSecurityGroup)
+
+    def __iter__(self):
+        return iter(self.network_security_groups)
+
+    def __len__(self):
+        return len(self.network_security_groups)
+
+    def __getitem__(self, index):
+        return self.network_security_groups[index]
+
+
+class NetworkSecurityGroup(WindowsAzureData):
+
+    def __init__(self):
+        self.name = u''
+        self.label=u''
+        self.location=u''
+
 
 class Subnets(WindowsAzureData):
 
@@ -3227,6 +3249,14 @@ class _XmlSerializer(object):
                                '</ExtendedProperty>'])
             xml += '</ExtendedProperties>'
         return xml
+    
+    @staticmethod
+    def create_network_security_group_to_xml(name, label, location):
+        return _XmlSerializer.doc_from_data(
+            'NetworkSecurityGroup',
+            [('Name', name),
+             ('Label', label),
+             ('Location', location)])
 
 
 class _SqlManagementXmlSerializer(object):

--- a/azure/servicemanagement/servicemanagementservice.py
+++ b/azure/servicemanagement/servicemanagementservice.py
@@ -33,6 +33,7 @@ from azure.servicemanagement import (
     HostedService,
     HostedServices,
     Images,
+    NetworkSecurityGroups,
     OperatingSystems,
     OperatingSystemFamilies,
     OSImage,
@@ -2386,6 +2387,34 @@ class ServiceManagementService(_ServiceManagementClient):
         Retrieves a list of the virtual networks.
         '''
         return self._perform_get(self._get_virtual_network_site_path(), VirtualNetworkSites)
+
+    #--Operations for network security groups  ---------------------------
+    def list_network_security_groups(self):
+        '''
+        Retrieves a list of the network security groups.
+        '''
+        return self._perform_get(self._get_network_security_group_path(), NetworkSecurityGroups)
+    
+    def create_network_security_group(self, name, label=None, location=None):
+        '''
+        Creates a network security group for the specified subscription.
+
+        name:
+            Required. Specifies the name for the security group.
+        label:
+            Optional. Specifies a label for the network security group. 
+            The label can be up to 1024 characters long and can be used 
+            for your tracking purposes.
+        location:
+            Required. Specifies the location of the network security 
+            group.
+        '''
+        _validate_not_none('name', name)
+        _validate_not_none('location', location)
+        return self._perform_post(
+            self._get_network_security_group_path(),
+            _XmlSerializer.create_network_security_group_to_xml(name, label, location),
+            async=True)
   
       #--Helper functions --------------------------------------------------
     def _get_role_sizes_path(self):
@@ -2467,3 +2496,7 @@ class ServiceManagementService(_ServiceManagementClient):
 
     def _get_image_path(self, image_name=None):
         return self._get_path('services/images', image_name)
+    
+    def _get_network_security_group_path(self):
+        return self._get_path('services/networking/networksecuritygroups', None)
+        

--- a/azure/servicemanagement/servicemanagementservice.py
+++ b/azure/servicemanagement/servicemanagementservice.py
@@ -2415,6 +2415,18 @@ class ServiceManagementService(_ServiceManagementClient):
             self._get_network_security_group_path(),
             _XmlSerializer.create_network_security_group_to_xml(name, label, location),
             async=True)
+    
+    def delete_network_security_group(self, network_security_group_name):
+        '''
+        Deletes a network security group in the specified subscription.
+
+        network_security_group_name:
+            The name of the network security group.
+        '''
+        _validate_not_none('network_security_group_name', network_security_group_name)
+        return self._perform_delete('/' + self.subscription_id + \
+                                    '/services/networking/networksecuritygroups/' + \
+                                    _str(network_security_group_name))
   
       #--Helper functions --------------------------------------------------
     def _get_role_sizes_path(self):


### PR DESCRIPTION
Hi

I've added a start on support for network security groups.  I really need them for a project I'm working on so I started writing some code rather than creating an issue.

This pull request allows creating, deleting and listing network security groups.  This isn't really useful yet as at the very least you also need to be able to add the security group to a subnet and add some rules to it.

If this isn't up to the project standards, please let me know and I'll do what I can to fix it.
Cheers :)
Andre
