### PR TITLE
Tests must now be run with the 'tests' folder as the working directory.

### DIFF
--- a/azure.pyproj
+++ b/azure.pyproj
@@ -7,7 +7,7 @@
     <ProjectHome>
     </ProjectHome>
     <StartupFile>tests\doctest_tableservice.py</StartupFile>
-    <WorkingDirectory>.</WorkingDirectory>
+    <WorkingDirectory>tests\</WorkingDirectory>
     <OutputPath>.</OutputPath>
     <Name>azure</Name>
     <RootNamespace>azure</RootNamespace>

--- a/tests/blob_performance.py
+++ b/tests/blob_performance.py
@@ -17,7 +17,7 @@ import datetime
 import sys
 
 from azure.storage import BlobService
-from . import storage_settings_real as settings
+import storage_settings_real as settings
 
 # Warning:
 # This script will take a while to run with everything enabled.

--- a/tests/common_auth.py
+++ b/tests/common_auth.py
@@ -15,7 +15,7 @@
 import json
 import os.path
 
-from .util import (
+from util import (
     get_test_file_path,
 )
 

--- a/tests/common_recordingtestcase.py
+++ b/tests/common_recordingtestcase.py
@@ -22,8 +22,8 @@ import time
 import vcr
 import zlib
 
-from .common_extendedtestcase import ExtendedTestCase
-from .util import get_test_file_path
+from common_extendedtestcase import ExtendedTestCase
+from util import get_test_file_path
 
 
 should_log = os.getenv('SDK_TESTS_LOG', '0')
@@ -60,7 +60,8 @@ class RecordingTestCase(ExtendedTestCase):
     def __init__(self, *args, **kwargs):
         super(RecordingTestCase, self).__init__(*args, **kwargs)
         try:
-            with open(os.path.join('tests', 'testsettings_local.json')) as testsettings_local_file:
+            path = get_test_file_path('testsettings_local.json')
+            with open(path) as testsettings_local_file:
                 test_settings = json.load(testsettings_local_file)
             self.test_mode = test_settings['mode']
         except:
@@ -112,7 +113,10 @@ class RecordingTestCase(ExtendedTestCase):
         # which is needed for playback.
         # Most resource names have a length limit, so we use a crc32
         self.checksum = zlib.adler32(self.qualified_test_name.encode()) & 0xffffffff
-        return '{}{}'.format(name, hex(self.checksum)[2:])
+        name = '{}{}'.format(name, hex(self.checksum)[2:])
+        if name.endswith('L'):
+            name = name[:-1]
+        return name
 
     def _scrub_sensitive_request_info(self, request):
         if not TestMode.is_playback(self.test_mode):

--- a/tests/doctest_blobservice.py
+++ b/tests/doctest_blobservice.py
@@ -55,7 +55,7 @@ True
 True
 
 """
-from tests import storage_settings_real as settings
+import storage_settings_real as settings
 
 name = settings.STORAGE_ACCOUNT_NAME
 key = settings.STORAGE_ACCOUNT_KEY

--- a/tests/doctest_queueservice.py
+++ b/tests/doctest_queueservice.py
@@ -71,7 +71,7 @@ How To: Delete a Queue
 True
 
 """
-from tests import storage_settings_real as settings
+import storage_settings_real as settings
 
 name = settings.STORAGE_ACCOUNT_NAME
 key = settings.STORAGE_ACCOUNT_KEY

--- a/tests/doctest_servicebusservicequeue.py
+++ b/tests/doctest_servicebusservicequeue.py
@@ -54,7 +54,7 @@ True
 True
 
 """
-from tests import servicebus_settings_real as settings
+import servicebus_settings_real as settings
 
 key_name = settings.SERVICEBUS_SAS_KEY_NAME
 key_value = settings.SERVICEBUS_SAS_KEY_VALUE

--- a/tests/doctest_servicebusservicetopic.py
+++ b/tests/doctest_servicebusservicetopic.py
@@ -85,7 +85,7 @@ True
 True
 
 """
-from tests import servicebus_settings_real as settings
+import servicebus_settings_real as settings
 
 key_name = settings.SERVICEBUS_SAS_KEY_NAME
 key_value = settings.SERVICEBUS_SAS_KEY_VALUE

--- a/tests/doctest_tableservice.py
+++ b/tests/doctest_tableservice.py
@@ -106,7 +106,7 @@ How to Delete a Table
 True
 
 """
-from tests import storage_settings_real as settings
+import storage_settings_real as settings
 
 name = settings.STORAGE_ACCOUNT_NAME
 key = settings.STORAGE_ACCOUNT_KEY

--- a/tests/legacy_mgmt_testcase.py
+++ b/tests/legacy_mgmt_testcase.py
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     RecordingTestCase,
     TestMode,
 )
-from . import legacy_mgmt_settings_fake as fake_settings
-from .util import (
+import legacy_mgmt_settings_fake as fake_settings
+from util import (
     set_service_options,
 )
 

--- a/tests/mgmt_testcase.py
+++ b/tests/mgmt_testcase.py
@@ -20,14 +20,14 @@ from azure.common import (
     AzureException,
     SubscriptionCloudCredentials,
 )
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     RecordingTestCase,
     TestMode,
 )
-from .util import (
+from util import (
     get_test_file_path,
 )
-from . import mgmt_settings_fake as fake_settings
+import mgmt_settings_fake as fake_settings
 
 
 class HttpStatusCode(object):

--- a/tests/run-legacy-mgmt.bat
+++ b/tests/run-legacy-mgmt.bat
@@ -23,10 +23,11 @@ if "%1%" == "" (
 )
 
 if "%PYTHONPATH%" == "" (
-	set PYTHONPATH=..
-) else (
-	set PYTHONPATH=%PYTHONPATH%;..
+	set PYTHONPATH=.
 )
+set PYTHONPATH=%PYTHONPATH%;..\azure-_core
+set PYTHONPATH=%PYTHONPATH%;..\azure-common
+set PYTHONPATH=%PYTHONPATH%;..\azure-servicemanagement-legacy
 
 echo Running tests using %PYTHONDIR%
 %PYTHONDIR%\python.exe -m unittest discover -p "test_legacy_mgmt_*.py"

--- a/tests/run-mgmt.bat
+++ b/tests/run-mgmt.bat
@@ -23,10 +23,15 @@ if "%1%" == "" (
 )
 
 if "%PYTHONPATH%" == "" (
-	set PYTHONPATH=..
-) else (
-	set PYTHONPATH=%PYTHONPATH%;..
+	set PYTHONPATH=.
 )
+set PYTHONPATH=%PYTHONPATH%;..\azure-_core
+set PYTHONPATH=%PYTHONPATH%;..\azure-common
+set PYTHONPATH=%PYTHONPATH%;..\azure-mgmt-_core
+set PYTHONPATH=%PYTHONPATH%;..\azure-mgmt-compute
+set PYTHONPATH=%PYTHONPATH%;..\azure-mgmt-network
+set PYTHONPATH=%PYTHONPATH%;..\azure-mgmt-resource
+set PYTHONPATH=%PYTHONPATH%;..\azure-mgmt-storage
 
 echo Running tests using %PYTHONDIR%
 %PYTHONDIR%\python.exe -m unittest discover -p "test_mgmt_*.py"

--- a/tests/run-servicebus.bat
+++ b/tests/run-servicebus.bat
@@ -23,10 +23,11 @@ if "%1%" == "" (
 )
 
 if "%PYTHONPATH%" == "" (
-	set PYTHONPATH=..
-) else (
-	set PYTHONPATH=%PYTHONPATH%;..
+	set PYTHONPATH=.
 )
+set PYTHONPATH=%PYTHONPATH%;..\azure-_core
+set PYTHONPATH=%PYTHONPATH%;..\azure-common
+set PYTHONPATH=%PYTHONPATH%;..\azure-servicebus
 
 echo Running tests using %PYTHONDIR%
 %PYTHONDIR%\python.exe -m unittest discover -p "test_servicebus_*.py"

--- a/tests/run-storage.bat
+++ b/tests/run-storage.bat
@@ -23,10 +23,12 @@ if "%1%" == "" (
 )
 
 if "%PYTHONPATH%" == "" (
-	set PYTHONPATH=..
-) else (
-	set PYTHONPATH=%PYTHONPATH%;..
+	set PYTHONPATH=.
 )
+set PYTHONPATH=%PYTHONPATH%;..\azure-_core
+set PYTHONPATH=%PYTHONPATH%;..\azure-common
+set PYTHONPATH=%PYTHONPATH%;..\azure-storage
+
 
 echo Running tests using %PYTHONDIR%
 %PYTHONDIR%\python.exe -m unittest discover -p "test_storage_*.py"

--- a/tests/run.bat
+++ b/tests/run.bat
@@ -23,10 +23,18 @@ if "%1%" == "" (
 )
 
 if "%PYTHONPATH%" == "" (
-	set PYTHONPATH=..
-) else (
-	set PYTHONPATH=%PYTHONPATH%;..
+	set PYTHONPATH=.
 )
+set PYTHONPATH=%PYTHONPATH%;..\azure-_core
+set PYTHONPATH=%PYTHONPATH%;..\azure-common
+set PYTHONPATH=%PYTHONPATH%;..\azure-servicemanagement-legacy
+set PYTHONPATH=%PYTHONPATH%;..\azure-mgmt-_core
+set PYTHONPATH=%PYTHONPATH%;..\azure-mgmt-compute
+set PYTHONPATH=%PYTHONPATH%;..\azure-mgmt-network
+set PYTHONPATH=%PYTHONPATH%;..\azure-mgmt-resource
+set PYTHONPATH=%PYTHONPATH%;..\azure-mgmt-storage
+set PYTHONPATH=%PYTHONPATH%;..\azure-servicebus
+set PYTHONPATH=%PYTHONPATH%;..\azure-storage
 
 echo Running tests using %PYTHONDIR%
 %PYTHONDIR%\python.exe -m unittest discover -p "test_*.py"

--- a/tests/servicebus_testcase.py
+++ b/tests/servicebus_testcase.py
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     RecordingTestCase,
     TestMode,
 )
-from . import servicebus_settings_fake as fake_settings
+import servicebus_settings_fake as fake_settings
 
 
 class ServiceBusTestCase(RecordingTestCase):

--- a/tests/storage_testcase.py
+++ b/tests/storage_testcase.py
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     RecordingTestCase,
     TestMode,
 )
-from . import storage_settings_fake as fake_settings
+import storage_settings_fake as fake_settings
 
 class StorageTestCase(RecordingTestCase):
 

--- a/tests/test_legacy_mgmt_affinitygroup.py
+++ b/tests/test_legacy_mgmt_affinitygroup.py
@@ -20,11 +20,11 @@ from azure.servicemanagement import (
     Locations,
     ServiceManagementService,
 )
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     TestMode,
     record,
 )
-from .legacy_mgmt_testcase import LegacyMgmtTestCase
+from legacy_mgmt_testcase import LegacyMgmtTestCase
 
 
 class LegacyMgmtAffinityGroupTest(LegacyMgmtTestCase):

--- a/tests/test_legacy_mgmt_managementcertificate.py
+++ b/tests/test_legacy_mgmt_managementcertificate.py
@@ -15,11 +15,11 @@
 import unittest
 
 from azure.servicemanagement import ServiceManagementService
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     TestMode,
     record,
 )
-from .legacy_mgmt_testcase import LegacyMgmtTestCase
+from legacy_mgmt_testcase import LegacyMgmtTestCase
 
 
 MANAGEMENT_CERT_PUBLICKEY = 'MIIBCgKCAQEAsjULNM53WPLkht1rbrDob/e4hZTHzj/hlLoBt2X3cNRc6dOPsMucxbMdchbCqAFa5RIaJvF5NDKqZuUSwq6bttD71twzy9bQ03EySOcRBad1VyqAZQ8DL8nUGSnXIUh+tpz4fDGM5f3Ly9NX8zfGqG3sT635rrFlUp3meJC+secCCwTLOOcIs3KQmuB+pMB5Y9rPhoxcekFfpq1pKtis6pmxnVbiL49kr6UUL6RQRDwik4t1jttatXLZqHETTmXl0Y0wS5AcJUXVAn5AL2kybULoThop2v01/E0NkPtFPAqLVs/kKBahniNn9uwUo+LS9FA8rWGu0FY4CZEYDfhb+QIDAQAB'

--- a/tests/test_legacy_mgmt_misc.py
+++ b/tests/test_legacy_mgmt_misc.py
@@ -40,14 +40,14 @@ from azure.servicemanagement import (
     get_certificate_from_publish_settings,
 )
 from azure.storage.blobservice import BlobService
-from .util import (
+from util import (
     create_storage_service,
 )
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     TestMode,
     record,
 )
-from .legacy_mgmt_testcase import LegacyMgmtTestCase
+from legacy_mgmt_testcase import LegacyMgmtTestCase
 
 
 SERVICE_CERT_FORMAT = 'pfx'

--- a/tests/test_legacy_mgmt_scheduler.py
+++ b/tests/test_legacy_mgmt_scheduler.py
@@ -23,11 +23,11 @@ from azure.servicemanagement import (
     CloudService,
     SchedulerManagementService,
 )
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     TestMode,
     record,
 )
-from .legacy_mgmt_testcase import LegacyMgmtTestCase
+from legacy_mgmt_testcase import LegacyMgmtTestCase
 
 
 class LegacyMgmtSchedulerTest(LegacyMgmtTestCase):

--- a/tests/test_legacy_mgmt_servicebus.py
+++ b/tests/test_legacy_mgmt_servicebus.py
@@ -20,11 +20,11 @@ from azure.common import (
     WindowsAzureMissingResourceError,
 )
 from azure.servicemanagement import ServiceBusManagementService
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     TestMode,
     record,
 )
-from .legacy_mgmt_testcase import LegacyMgmtTestCase
+from legacy_mgmt_testcase import LegacyMgmtTestCase
 
 
 class LegacyMgmtServiceBusTest(LegacyMgmtTestCase):

--- a/tests/test_legacy_mgmt_sqldatabase.py
+++ b/tests/test_legacy_mgmt_sqldatabase.py
@@ -27,11 +27,11 @@ from azure.servicemanagement import (
     FirewallRule,
     SqlDatabaseManagementService,
 )
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     TestMode,
     record,
 )
-from .legacy_mgmt_testcase import LegacyMgmtTestCase
+from legacy_mgmt_testcase import LegacyMgmtTestCase
 
 
 class LegacyMgmtSqlDatabaseTest(LegacyMgmtTestCase):

--- a/tests/test_legacy_mgmt_storage.py
+++ b/tests/test_legacy_mgmt_storage.py
@@ -19,11 +19,11 @@ import unittest
 
 from azure.common import WindowsAzureError
 from azure.servicemanagement import ServiceManagementService
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     TestMode,
     record,
 )
-from .legacy_mgmt_testcase import LegacyMgmtTestCase
+from legacy_mgmt_testcase import LegacyMgmtTestCase
 
 
 class LegacyMgmtStorageTest(LegacyMgmtTestCase):

--- a/tests/test_legacy_mgmt_website.py
+++ b/tests/test_legacy_mgmt_website.py
@@ -28,11 +28,11 @@ from azure.servicemanagement import (
     WebSpace,
     PublishData,
 )
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     TestMode,
     record,
 )
-from .legacy_mgmt_testcase import LegacyMgmtTestCase
+from legacy_mgmt_testcase import LegacyMgmtTestCase
 
 
 class LegacyMgmtWebsiteTest(LegacyMgmtTestCase):

--- a/tests/test_mgmt_compute.py
+++ b/tests/test_mgmt_compute.py
@@ -21,8 +21,8 @@ from collections import namedtuple
 import azure.mgmt.compute
 import azure.mgmt.network
 import azure.mgmt.storage
-from .common_recordingtestcase import record
-from .mgmt_testcase import HttpStatusCode, AzureMgmtTestCase
+from common_recordingtestcase import record
+from mgmt_testcase import HttpStatusCode, AzureMgmtTestCase
 
 ComputeResourceNames = namedtuple(
     'ComputeResourceNames',

--- a/tests/test_mgmt_network.py
+++ b/tests/test_mgmt_network.py
@@ -17,8 +17,8 @@
 import unittest
 
 import azure.mgmt.network
-from .common_recordingtestcase import record
-from .mgmt_testcase import HttpStatusCode, AzureMgmtTestCase
+from common_recordingtestcase import record
+from mgmt_testcase import HttpStatusCode, AzureMgmtTestCase
 
 class MgmtNetworkTest(AzureMgmtTestCase):
 

--- a/tests/test_mgmt_resource.py
+++ b/tests/test_mgmt_resource.py
@@ -18,8 +18,8 @@ import unittest
 
 import azure.mgmt.resource
 from azure.common import AzureException
-from .common_recordingtestcase import record
-from .mgmt_testcase import HttpStatusCode, AzureMgmtTestCase
+from common_recordingtestcase import record
+from mgmt_testcase import HttpStatusCode, AzureMgmtTestCase
 
 class MgmtResourceTest(AzureMgmtTestCase):
 

--- a/tests/test_mgmt_storage.py
+++ b/tests/test_mgmt_storage.py
@@ -17,8 +17,8 @@
 import unittest
 
 import azure.mgmt.storage
-from .common_recordingtestcase import record
-from .mgmt_testcase import HttpStatusCode, AzureMgmtTestCase
+from common_recordingtestcase import record
+from mgmt_testcase import HttpStatusCode, AzureMgmtTestCase
 
 
 class MgmtStorageTest(AzureMgmtTestCase):

--- a/tests/test_servicebus_eventhub.py
+++ b/tests/test_servicebus_eventhub.py
@@ -29,14 +29,14 @@ from azure.servicebus import (
     EventHub,
     ServiceBusService,
 )
-from .util import (
+from util import (
     set_service_options,
 )
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     TestMode,
     record,
 )
-from .servicebus_testcase import ServiceBusTestCase
+from servicebus_testcase import ServiceBusTestCase
 #------------------------------------------------------------------------------
 
 

--- a/tests/test_servicebus_servicebus.py
+++ b/tests/test_servicebus_servicebus.py
@@ -36,14 +36,14 @@ from azure.servicebus import (
     Subscription,
     Topic,
 )
-from .util import (
+from util import (
     set_service_options,
 )
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     TestMode,
     record,
 )
-from .servicebus_testcase import ServiceBusTestCase
+from servicebus_testcase import ServiceBusTestCase
 
 
 #------------------------------------------------------------------------------
@@ -510,7 +510,7 @@ class ServiceBusServiceBusTest(ServiceBusTestCase):
         self.assertEqual(
             received_msg.custom_properties['dob'], datetime(2011, 12, 14))
 
-    @unittest.skip
+    @unittest.skip('flaky')
     def test_receive_queue_message_timeout_5(self):
         # Arrange
         self._create_queue(self.queue_name)
@@ -526,7 +526,7 @@ class ServiceBusServiceBusTest(ServiceBusTestCase):
         self.assertIsNotNone(received_msg)
         self.assertIsNone(received_msg.body)
 
-    @unittest.skip
+    @unittest.skip('flaky')
     def test_receive_queue_message_timeout_50(self):
         # Arrange
         self._create_queue(self.queue_name)
@@ -543,7 +543,7 @@ class ServiceBusServiceBusTest(ServiceBusTestCase):
         self.assertIsNotNone(received_msg)
         self.assertIsNone(received_msg.body)
 
-    @unittest.skip
+    @unittest.skip('flaky')
     def test_receive_queue_message_timeout_50_http_timeout(self):
         # Arrange
         self._create_queue(self.queue_name)
@@ -630,6 +630,7 @@ class ServiceBusServiceBusTest(ServiceBusTestCase):
         self.assertTrue(created)
 
     @record
+    @unittest.skip('undesirable output, this is old enough, backwards compatibility can be deleted')
     def test_topic_backwards_compatibility_warning(self):
         # Arrange
         topic_options = Topic()
@@ -1372,7 +1373,7 @@ class ServiceBusServiceBusTest(ServiceBusTestCase):
 
         self.assertEqual(called, ['b', 'a', 'b', 'a'])
 
-    @unittest.skip
+    @unittest.skip('requires extra setup')
     def test_two_identities(self):
         # In order to run this test, 2 service bus service identities are
         # created using the sbaztool available at:

--- a/tests/test_storage_account.py
+++ b/tests/test_storage_account.py
@@ -21,7 +21,7 @@ from azure.storage import (
     QueueService,
     TableService,
 )
-from .common_extendedtestcase import (
+from common_extendedtestcase import (
     ExtendedTestCase,
 )
 

--- a/tests/test_storage_blob.py
+++ b/tests/test_storage_blob.py
@@ -52,15 +52,15 @@ from azure.storage.storageclient import (
     AZURE_STORAGE_ACCOUNT,
     EMULATED,
 )
-from .util import (
+from util import (
     create_storage_service,
     set_service_options,
 )
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     TestMode,
     record,
 )
-from .storage_testcase import StorageTestCase
+from storage_testcase import StorageTestCase
 
 
 #------------------------------------------------------------------------------

--- a/tests/test_storage_queue.py
+++ b/tests/test_storage_queue.py
@@ -27,15 +27,15 @@ from azure.storage import (
     QueueSharedAccessPermissions,
 )
 from azure.common import WindowsAzureError
-from .util import (
+from util import (
     create_storage_service,
     set_service_options,
 )
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     TestMode,
     record,
 )
-from .storage_testcase import StorageTestCase
+from storage_testcase import StorageTestCase
 
 #------------------------------------------------------------------------------
 TEST_QUEUE_PREFIX = 'mytestqueue'

--- a/tests/test_storage_sas.py
+++ b/tests/test_storage_sas.py
@@ -25,7 +25,7 @@ from azure.storage.sharedaccesssignature import (
     QueryStringConstants,
     ResourceType,
 )
-from .common_extendedtestcase import (
+from common_extendedtestcase import (
     ExtendedTestCase,
 )
 

--- a/tests/test_storage_table.py
+++ b/tests/test_storage_table.py
@@ -39,15 +39,15 @@ from azure.storage import (
     TableService,
     TableSharedAccessPermissions,
 )
-from .util import (
+from util import (
     create_storage_service,
     set_service_options,
 )
-from .common_recordingtestcase import (
+from common_recordingtestcase import (
     TestMode,
     record,
 )
-from .storage_testcase import StorageTestCase
+from storage_testcase import StorageTestCase
 
 #------------------------------------------------------------------------------
 


### PR DESCRIPTION
Tests now work from both command line and PTVS on Windows.
Add missing reason to unittest.skip in service bus tests.