### PR TITLE
AzureHttpError exception fix

### DIFF
--- a/azure-common/azure/common/__init__.py
+++ b/azure-common/azure/common/__init__.py
@@ -27,10 +27,11 @@ class AzureHttpError(AzureException):
         self.status_code = status_code
 
     def __new__(cls, message, status_code, *args, **kwargs):
-        if status_code == 404:
-            cls = AzureMissingResourceHttpError
-        elif status_code == 409:
-            cls = AzureConflictHttpError
+        if cls is AzureHttpError:
+            if status_code == 404:
+                cls = AzureMissingResourceHttpError
+            elif status_code == 409:
+                cls = AzureConflictHttpError
         return AzureException.__new__(cls, message, status_code, *args, **kwargs)
 
 


### PR DESCRIPTION
Swap the AzureHttpError exception for a more specific exception only if the error that was raised is AzureHttpError.  This allows for someone to raise their own AzureHttpError derived class directly.

@zooba please confirm this is correct.