### PR TITLE
Cast authorization code from unicode to string

### DIFF
--- a/examples/AzureResourceViewer/AzureResourceViewer/auth.py
+++ b/examples/AzureResourceViewer/AzureResourceViewer/auth.py
@@ -48,7 +48,7 @@ def get_tokens(auth_code):
         authorityUrl,
         app_creds.CLIENT_ID,
         app_creds.CLIENT_SECRET,
-        auth_code,
+        str(auth_code),
         url_for('authorized_view', _external=True),
         resource,
     )


### PR DESCRIPTION
I was getting a 500 on the the authorization code token exchange flow because adal was expecting a string type for the authorization code but received a unicode object. This was fixed by casting auth code to a string 