### PR TITLE
Prevent installation when azure<1.0 is present.

### DIFF
--- a/azure-common/setup.py
+++ b/azure-common/setup.py
@@ -17,6 +17,21 @@
 
 from setuptools import setup
 
+# azure v0.x is not compatible with this package
+# azure v0.x used to have a __version__ attribute (newer versions don't)
+try:
+    import azure
+    try:
+        ver = azure.__version__
+        raise Exception(
+            'This package is incompatible with azure=={}. '.format(ver) +
+            'Uninstall it with "pip uninstall azure".'
+        )
+    except AttributeError:
+        pass
+except ImportError:
+    pass
+
 setup(
     name='azure-common',
     version='1.0.0rc1',

--- a/azure-mgmt-common/setup.py
+++ b/azure-mgmt-common/setup.py
@@ -17,6 +17,21 @@
 
 from setuptools import setup
 
+# azure v0.x is not compatible with this package
+# azure v0.x used to have a __version__ attribute (newer versions don't)
+try:
+    import azure
+    try:
+        ver = azure.__version__
+        raise Exception(
+            'This package is incompatible with azure=={}. '.format(ver) +
+            'Uninstall it with "pip uninstall azure".'
+        )
+    except AttributeError:
+        pass
+except ImportError:
+    pass
+
 setup(
     name='azure-mgmt-common',
     version='0.20.0rc1',

--- a/azure-mgmt-compute/setup.py
+++ b/azure-mgmt-compute/setup.py
@@ -17,6 +17,21 @@
 
 from setuptools import setup
 
+# azure v0.x is not compatible with this package
+# azure v0.x used to have a __version__ attribute (newer versions don't)
+try:
+    import azure
+    try:
+        ver = azure.__version__
+        raise Exception(
+            'This package is incompatible with azure=={}. '.format(ver) +
+            'Uninstall it with "pip uninstall azure".'
+        )
+    except AttributeError:
+        pass
+except ImportError:
+    pass
+
 setup(
     name='azure-mgmt-compute',
     version='0.20.0rc1',

--- a/azure-mgmt-network/setup.py
+++ b/azure-mgmt-network/setup.py
@@ -17,6 +17,21 @@
 
 from setuptools import setup
 
+# azure v0.x is not compatible with this package
+# azure v0.x used to have a __version__ attribute (newer versions don't)
+try:
+    import azure
+    try:
+        ver = azure.__version__
+        raise Exception(
+            'This package is incompatible with azure=={}. '.format(ver) +
+            'Uninstall it with "pip uninstall azure".'
+        )
+    except AttributeError:
+        pass
+except ImportError:
+    pass
+
 setup(
     name='azure-mgmt-network',
     version='0.20.0rc1',

--- a/azure-mgmt-nspkg/setup.py
+++ b/azure-mgmt-nspkg/setup.py
@@ -17,6 +17,21 @@
 
 from setuptools import setup
 
+# azure v0.x is not compatible with this package
+# azure v0.x used to have a __version__ attribute (newer versions don't)
+try:
+    import azure
+    try:
+        ver = azure.__version__
+        raise Exception(
+            'This package is incompatible with azure=={}. '.format(ver) +
+            'Uninstall it with "pip uninstall azure".'
+        )
+    except AttributeError:
+        pass
+except ImportError:
+    pass
+
 setup(
     name='azure-mgmt-nspkg',
     version='1.0.0rc1',

--- a/azure-mgmt-resource/setup.py
+++ b/azure-mgmt-resource/setup.py
@@ -17,6 +17,21 @@
 
 from setuptools import setup
 
+# azure v0.x is not compatible with this package
+# azure v0.x used to have a __version__ attribute (newer versions don't)
+try:
+    import azure
+    try:
+        ver = azure.__version__
+        raise Exception(
+            'This package is incompatible with azure=={}. '.format(ver) +
+            'Uninstall it with "pip uninstall azure".'
+        )
+    except AttributeError:
+        pass
+except ImportError:
+    pass
+
 setup(
     name='azure-mgmt-resource',
     version='0.20.0rc1',

--- a/azure-mgmt-storage/setup.py
+++ b/azure-mgmt-storage/setup.py
@@ -17,6 +17,21 @@
 
 from setuptools import setup
 
+# azure v0.x is not compatible with this package
+# azure v0.x used to have a __version__ attribute (newer versions don't)
+try:
+    import azure
+    try:
+        ver = azure.__version__
+        raise Exception(
+            'This package is incompatible with azure=={}. '.format(ver) +
+            'Uninstall it with "pip uninstall azure".'
+        )
+    except AttributeError:
+        pass
+except ImportError:
+    pass
+
 setup(
     name='azure-mgmt-storage',
     version='0.20.0rc1',

--- a/azure-mgmt/setup.py
+++ b/azure-mgmt/setup.py
@@ -17,6 +17,21 @@
 
 from setuptools import setup
 
+# azure v0.x is not compatible with this package
+# azure v0.x used to have a __version__ attribute (newer versions don't)
+try:
+    import azure
+    try:
+        ver = azure.__version__
+        raise Exception(
+            'This package is incompatible with azure=={}. '.format(ver) +
+            'Uninstall it with "pip uninstall azure".'
+        )
+    except AttributeError:
+        pass
+except ImportError:
+    pass
+
 setup(
     name='azure-mgmt',
     version='0.20.0rc1',

--- a/azure-nspkg/setup.py
+++ b/azure-nspkg/setup.py
@@ -17,6 +17,21 @@
 
 from setuptools import setup
 
+# azure v0.x is not compatible with this package
+# azure v0.x used to have a __version__ attribute (newer versions don't)
+try:
+    import azure
+    try:
+        ver = azure.__version__
+        raise Exception(
+            'This package is incompatible with azure=={}. '.format(ver) +
+            'Uninstall it with "pip uninstall azure".'
+        )
+    except AttributeError:
+        pass
+except ImportError:
+    pass
+
 setup(
     name='azure-nspkg',
     version='1.0.0rc1',

--- a/azure-servicebus/setup.py
+++ b/azure-servicebus/setup.py
@@ -17,6 +17,21 @@
 
 from setuptools import setup
 
+# azure v0.x is not compatible with this package
+# azure v0.x used to have a __version__ attribute (newer versions don't)
+try:
+    import azure
+    try:
+        ver = azure.__version__
+        raise Exception(
+            'This package is incompatible with azure=={}. '.format(ver) +
+            'Uninstall it with "pip uninstall azure".'
+        )
+    except AttributeError:
+        pass
+except ImportError:
+    pass
+
 setup(
     name='azure-servicebus',
     version='0.20.0rc1',

--- a/azure-servicemanagement-legacy/setup.py
+++ b/azure-servicemanagement-legacy/setup.py
@@ -17,6 +17,21 @@
 
 from setuptools import setup
 
+# azure v0.x is not compatible with this package
+# azure v0.x used to have a __version__ attribute (newer versions don't)
+try:
+    import azure
+    try:
+        ver = azure.__version__
+        raise Exception(
+            'This package is incompatible with azure=={}. '.format(ver) +
+            'Uninstall it with "pip uninstall azure".'
+        )
+    except AttributeError:
+        pass
+except ImportError:
+    pass
+
 setup(
     name='azure-servicemanagement-legacy',
     version='0.20.0rc1',

--- a/azure/setup.py
+++ b/azure/setup.py
@@ -16,7 +16,6 @@
 #--------------------------------------------------------------------------
 
 from setuptools import setup
-import sys
 
 # Upgrading from 0.x is not supported
 # azure v0.x used to have a __version__ attribute (newer versions don't)


### PR DESCRIPTION
This will help some users avoid getting into trouble.
This check won't trigger when installing from a .whl, but it will for installing from sdist (on Linux)  or directly from source.

