### PR TITLE
Added missing requests requirement to azure-mgmt-common package.

### DIFF
--- a/azure-mgmt-common/setup.py
+++ b/azure-mgmt-common/setup.py
@@ -60,5 +60,6 @@ setup(
     install_requires=[
         'azure-common',
         'azure-mgmt-nspkg',
+        'requests',
     ],
 )


### PR DESCRIPTION
As mentioned in PR #469, there is a missing `install_requires` entry for `requests` in the `setup.py` file of the `azure-mgmt-common` package.