### PR TITLE
Use requests library by default

### DIFF
--- a/azure-servicebus/azure/servicebus/_http/requestsclient.py
+++ b/azure-servicebus/azure/servicebus/_http/requestsclient.py
@@ -61,6 +61,8 @@ class _RequestsConnection(object):
     def set_tunnel(self, host, port=None, headers=None):
         self.session.proxies['http'] = 'http://{}:{}'.format(host, port)
         self.session.proxies['https'] = 'https://{}:{}'.format(host, port)
+        if headers:
+            self.session.headers.update(headers)
 
     def set_proxy_credentials(self, user, password):
         pass

--- a/azure-servicebus/azure/servicebus/servicebusservice.py
+++ b/azure-servicebus/azure/servicebus/servicebusservice.py
@@ -16,6 +16,8 @@ import datetime
 import os
 import time
 
+import requests
+
 from azure.common import (
     AzureHttpError,
 )
@@ -112,8 +114,7 @@ class ServiceBusService(object):
         timeout:
             Optional. Timeout for the http request, in seconds.
         request_session:
-            Optional. Session object to use for http requests. If this is
-            specified, it replaces the default use of httplib.
+            Optional. Session object to use for http requests.
         '''
         self.requestid = None
         self.service_namespace = service_namespace
@@ -148,7 +149,7 @@ class ServiceBusService(object):
         self._httpclient = _HTTPClient(
             service_instance=self,
             timeout=timeout,
-            request_session=request_session,
+            request_session=request_session or requests.Session(),
             user_agent=_USER_AGENT_STRING,
         )
         self._filter = self._httpclient.perform_request

--- a/azure-servicebus/tests/test_servicebus_servicebus.py
+++ b/azure-servicebus/tests/test_servicebus_servicebus.py
@@ -22,7 +22,6 @@ import time
 import unittest
 
 from datetime import datetime
-from requests import Session
 from azure.common import (
     AzureHttpError,
     AzureMissingResourceHttpError,
@@ -62,14 +61,12 @@ class ServiceBusServiceBusTest(ServiceBusTestCase):
                 self.settings.SERVICEBUS_NAME,
                 shared_access_key_name=self.settings.SERVICEBUS_SAS_KEY_NAME,
                 shared_access_key_value=self.settings.SERVICEBUS_SAS_KEY_VALUE,
-                request_session=Session(),
             )
         else:
             self.sbs = ServiceBusService(
                 self.settings.SERVICEBUS_NAME,
                 account_key=self.settings.SERVICEBUS_ACS_KEY,
                 issuer='owner',
-                request_session=Session(),
             )
 
         self._set_service_options(self.sbs, self.settings)

--- a/azure-servicemanagement-legacy/azure/servicemanagement/_http/requestsclient.py
+++ b/azure-servicemanagement-legacy/azure/servicemanagement/_http/requestsclient.py
@@ -61,6 +61,8 @@ class _RequestsConnection(object):
     def set_tunnel(self, host, port=None, headers=None):
         self.session.proxies['http'] = 'http://{}:{}'.format(host, port)
         self.session.proxies['https'] = 'https://{}:{}'.format(host, port)
+        if headers:
+            self.session.headers.update(headers)
 
     def set_proxy_credentials(self, user, password):
         pass

--- a/azure-servicemanagement-legacy/setup.py
+++ b/azure-servicemanagement-legacy/setup.py
@@ -59,6 +59,7 @@ setup(
     ],
     install_requires=[
         'azure-common',
+        'requests',
     ],
     extras_require = { 
         'get_certificate_from_publish_settings' : ['pyopenssl'] 

--- a/azure-servicemanagement-legacy/tests/legacy_mgmt_testcase.py
+++ b/azure-servicemanagement-legacy/tests/legacy_mgmt_testcase.py
@@ -54,29 +54,26 @@ class LegacyMgmtTestCase(RecordingTestCase):
     def create_service_management(self, service_class):
         conn_type = self.settings.CONNECTION_TYPE
         if conn_type == 'requests_with_token' or conn_type == 'requests_with_cert':
-            import requests
-            session = requests.Session()
             if conn_type == 'requests_with_token':
+                import requests
+                session = requests.Session()
                 auth = 'Bearer {}'.format(self.settings.get_token())
                 session.headers['authorization'] = auth
+                service = service_class(
+                    self.settings.SUBSCRIPTION_ID,
+                    request_session=session,
+                )
             else:
                 # Note this works only with RunLiveNoRecord
-                session.cert = self.settings.PEM_PATH
-            service = service_class(
-                self.settings.SUBSCRIPTION_ID,
-                request_session=session,
-            )
+                service = service_class(
+                    self.settings.SUBSCRIPTION_ID,
+                    self.settings.PEM_PATH,
+                )
         elif conn_type == 'winhttp':
             # Note this works only with RunLiveNoRecord
             service = service_class(
                 self.settings.SUBSCRIPTION_ID,
                 self.settings.PFX_LOCATION,
-            )
-        elif conn_type == 'httplib':
-            # Note this works only with RunLiveNoRecord
-            service = service_class(
-                self.settings.SUBSCRIPTION_ID,
-                self.settings.PEM_PATH,
             )
         else:
             raise ValueError('Insupported value for "connectiontype" in settings:"{}"'.format(conn_type))


### PR DESCRIPTION
For azure-servicemanagement-legacy, we now use either requests library or winhttp, depending on whether the certfile passed in is a file or not.  We no longer use httplib directly.
For azure-servicebus, we always use requests.
In both cases, you still have the ability of creating the requests.Session() object yourself and pass that in when creating the service instance.
