### PR TITLE
Update networkresourceprovider.py

### DIFF
--- a/azure-mgmt-network/azure/mgmt/network/networkresourceprovider.py
+++ b/azure-mgmt-network/azure/mgmt/network/networkresourceprovider.py
@@ -7121,7 +7121,7 @@ class NetworkInterfaceOperations(object):
             time.sleep(delay_in_seconds)
             result = client2.get_long_running_operation_status(response.azure_async_operation)
             delay_in_seconds = result.retry_after
-            if delay_in_seconds == 0:
+            if delay_in_seconds == 0 or delay_in_seconds == None:
                 delay_in_seconds = 15
             
             if client2.long_running_operation_retry_timeout >= 0:

--- a/azure-mgmt-network/azure/mgmt/network/networkresourceprovider.py
+++ b/azure-mgmt-network/azure/mgmt/network/networkresourceprovider.py
@@ -83,7 +83,7 @@ class RetriableOperationResponse(ResourceProviderErrorResponse):
     
     def __init__(self, **kwargs):
         super(RetriableOperationResponse, self).__init__(**kwargs)
-        self._retry_after = kwargs.get('retry_after')
+        self._retry_after = kwargs.get('retry_after', 0)
     
     @property
     def retry_after(self):
@@ -7121,7 +7121,7 @@ class NetworkInterfaceOperations(object):
             time.sleep(delay_in_seconds)
             result = client2.get_long_running_operation_status(response.azure_async_operation)
             delay_in_seconds = result.retry_after
-            if delay_in_seconds == 0 or delay_in_seconds == None:
+            if delay_in_seconds == 0:
                 delay_in_seconds = 15
             
             if client2.long_running_operation_retry_timeout >= 0:


### PR DESCRIPTION
In line 7121, time.sleep(delay_in_seconds) requires an integer. The first pass works fine, however, in line 7123, delay_in_seconds is set to result.retry_after, which sometimes returns NoneType and causes time.sleep(delay_in_seconds) to fail. By modifying line 7124 to look for 0 or None, it will properly set delay_in_seconds to the integer required.