### PR TITLE
Include Python 3.5 wherever we list the supported Python versions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Microsoft Azure SDK for Python
 This project provides a set of Python packages that make it easy to
 access the Microsoft Azure components such as ServiceManagement, Storage\*, and ServiceBus.
 
-The SDK supports Python 2.7, 3.3, 3.4.
+The SDK supports Python 2.7, 3.3, 3.4 and 3.5.
 
 \*Looking for the Azure Storage client library?  It moved to a `new GitHub repository <https://github.com/Azure/azure-storage-python>`__.
 

--- a/azure-common/setup.py
+++ b/azure-common/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'License :: OSI Approved :: Apache Software License',
     ],
     zip_safe=False,

--- a/azure-mgmt-common/setup.py
+++ b/azure-mgmt-common/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'License :: OSI Approved :: Apache Software License',
     ],
     zip_safe=False,

--- a/azure-mgmt-compute/README.rst
+++ b/azure-mgmt-compute/README.rst
@@ -6,7 +6,7 @@ This is the Microsoft Azure Compute Resource Management Client Library.
 Azure Resource Manager (ARM) is the next generation of management APIs that
 replace the old Azure Service Management (ASM).
 
-This package has been tested with Python 2.7, 3.3 and 3.4.
+This package has been tested with Python 2.7, 3.3, 3.4 and 3.5.
 
 For the older Azure Service Management (ASM) libraries, see
 `azure-servicemanagement-legacy <https://pypi.python.org/pypi/azure-servicemanagement-legacy>`__ library.

--- a/azure-mgmt-compute/setup.py
+++ b/azure-mgmt-compute/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'License :: OSI Approved :: Apache Software License',
     ],
     zip_safe=False,

--- a/azure-mgmt-network/README.rst
+++ b/azure-mgmt-network/README.rst
@@ -6,7 +6,7 @@ This is the Microsoft Azure Network Resource Management Client Library.
 Azure Resource Manager (ARM) is the next generation of management APIs that
 replace the old Azure Service Management (ASM).
 
-This package has been tested with Python 2.7, 3.3 and 3.4.
+This package has been tested with Python 2.7, 3.3, 3.4 and 3.5.
 
 For the older Azure Service Management (ASM) libraries, see
 `azure-servicemanagement-legacy <https://pypi.python.org/pypi/azure-servicemanagement-legacy>`__ library.

--- a/azure-mgmt-network/setup.py
+++ b/azure-mgmt-network/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'License :: OSI Approved :: Apache Software License',
     ],
     zip_safe=False,

--- a/azure-mgmt-nspkg/setup.py
+++ b/azure-mgmt-nspkg/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'License :: OSI Approved :: Apache Software License',
     ],
     zip_safe=False,

--- a/azure-mgmt-resource/README.rst
+++ b/azure-mgmt-resource/README.rst
@@ -6,7 +6,7 @@ This is the Microsoft Azure Resource Management Client Library.
 Azure Resource Manager (ARM) is the next generation of management APIs that
 replace the old Azure Service Management (ASM).
 
-This package has been tested with Python 2.7, 3.3 and 3.4.
+This package has been tested with Python 2.7, 3.3, 3.4 and 3.5.
 
 For the older Azure Service Management (ASM) libraries, see
 `azure-servicemanagement-legacy <https://pypi.python.org/pypi/azure-servicemanagement-legacy>`__ library.

--- a/azure-mgmt-resource/setup.py
+++ b/azure-mgmt-resource/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'License :: OSI Approved :: Apache Software License',
     ],
     zip_safe=False,

--- a/azure-mgmt-storage/README.rst
+++ b/azure-mgmt-storage/README.rst
@@ -6,7 +6,7 @@ This is the Microsoft Azure Storage Resource Management Client Library.
 Azure Resource Manager (ARM) is the next generation of management APIs that
 replace the old Azure Service Management (ASM).
 
-This package has been tested with Python 2.7, 3.3 and 3.4.
+This package has been tested with Python 2.7, 3.3, 3.4 and 3.5.
 
 For the older Azure Service Management (ASM) libraries, see
 `azure-servicemanagement-legacy <https://pypi.python.org/pypi/azure-servicemanagement-legacy>`__ library.

--- a/azure-mgmt-storage/setup.py
+++ b/azure-mgmt-storage/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'License :: OSI Approved :: Apache Software License',
     ],
     zip_safe=False,

--- a/azure-mgmt/README.rst
+++ b/azure-mgmt/README.rst
@@ -9,7 +9,7 @@ replace the old Azure Service Management (ASM).
 This package does not contain any code in itself. It installs a set
 of packages that provide management APIs for the various Azure services.
 
-All packages in this bundle have been tested with Python 2.7, 3.3 and 3.4.
+All packages in this bundle have been tested with Python 2.7, 3.3, 3.4 and 3.5.
 
 For a more complete set of Azure libraries, see the `azure <https://pypi.python.org/pypi/azure>`__ bundle package.
 

--- a/azure-mgmt/setup.py
+++ b/azure-mgmt/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'License :: OSI Approved :: Apache Software License',
     ],
     zip_safe=False,

--- a/azure-nspkg/setup.py
+++ b/azure-nspkg/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'License :: OSI Approved :: Apache Software License',
     ],
     zip_safe=False,

--- a/azure-servicebus/README.rst
+++ b/azure-servicebus/README.rst
@@ -3,7 +3,7 @@ Microsoft Azure SDK for Python
 
 This is the Microsoft Azure Service Bus Runtime Client Library.
 
-This package has been tested with Python 2.7, 3.3 and 3.4.
+This package has been tested with Python 2.7, 3.3, 3.4 and 3.5.
 
 For a more complete set of Azure libraries, see the `azure <https://pypi.python.org/pypi/azure>`__ bundle package.
 

--- a/azure-servicebus/setup.py
+++ b/azure-servicebus/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'License :: OSI Approved :: Apache Software License',
     ],
     zip_safe=False,

--- a/azure-servicemanagement-legacy/README.rst
+++ b/azure-servicemanagement-legacy/README.rst
@@ -3,7 +3,7 @@ Microsoft Azure SDK for Python
 
 This is the Microsoft Azure Service Management Legacy Client Library.
 
-All packages in this bundle have been tested with Python 2.7, 3.3 and 3.4.
+All packages in this bundle have been tested with Python 2.7, 3.3, 3.4 and 3.5.
 
 For the newer Azure Resource Management (ARM) libraries, see `azure-mgmt <https://pypi.python.org/pypi/azure-mgmt>`__.
 

--- a/azure-servicemanagement-legacy/setup.py
+++ b/azure-servicemanagement-legacy/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'License :: OSI Approved :: Apache Software License',
     ],
     zip_safe=False,

--- a/azure/README.rst
+++ b/azure/README.rst
@@ -6,7 +6,7 @@ This is the Microsoft Azure bundle.
 This package does not contain any code in itself. It installs a set
 of packages that provide Microsoft Azure functionality.
 
-All packages in this bundle have been tested with Python 2.7, 3.3 and 3.4.
+All packages in this bundle have been tested with Python 2.7, 3.3, 3.4 and 3.5.
 
 
 Features

--- a/azure/setup.py
+++ b/azure/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'License :: OSI Approved :: Apache Software License',
     ],
     zip_safe=False,

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -69,7 +69,7 @@ Features:
 System Requirements:
 --------------------
 
-The supported Python versions are 2.7.x, 3.3.x, and 3.4.x
+The supported Python versions are 2.7.x, 3.3.x, 3.4.x, and 3.5.x
 To download Python, please visit
 https://www.python.org/download/
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-python/issues/489