### PR TITLE
Extended update_os_image method

### DIFF
--- a/azure-servicemanagement-legacy/azure/servicemanagement/_serialization.py
+++ b/azure-servicemanagement-legacy/azure/servicemanagement/_serialization.py
@@ -1191,6 +1191,31 @@ class _XmlSerializer(object):
         return _XmlSerializer.doc_from_xml('VMImage', xml)
 
     @staticmethod
+    def update_os_image_to_xml(image):
+        xml = _XmlSerializer.data_to_xml(
+            [
+                ('Label', image.label),
+                ('Description', image.description),
+                ('MediaLink', image.media_link),
+                ('Name', image.name),
+                ('OS', image.os)
+            ]
+        )
+        xml += _XmlSerializer.data_to_xml(
+            [
+                ('Language', image.language),
+                ('ImageFamily', image.image_family),
+                ('RecommendedVMSize', image.recommended_vm_size),
+                ('Eula', image.eula),
+                ('IconUri', image.icon_uri),
+                ('SmallIconUri', image.small_icon_uri),
+                ('PrivacyUri', image.privacy_uri),
+                ('PublishedDate', image.published_date)
+            ]
+        )
+        return _XmlSerializer.doc_from_xml('OSImage', xml)
+
+    @staticmethod
     def create_website_to_xml(webspace_name, website_name, geo_region, plan,
                               host_names, compute_mode, server_farm, site_mode):
         xml = '<HostNames xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays">'

--- a/azure-servicemanagement-legacy/azure/servicemanagement/servicemanagementservice.py
+++ b/azure-servicemanagement-legacy/azure/servicemanagement/servicemanagementservice.py
@@ -2206,6 +2206,58 @@ class ServiceManagementService(_ServiceManagementClient):
                                      label, media_link, name, os),
                                  async=True)
 
+    def update_os_image_from_image_reference(self, image_name, os_image):
+        '''
+        Updates metadata elements from a given OS image reference.
+
+        image_name:
+            The name of the image to update.
+        os_image:
+            An instance of OSImage class.
+        os_image.label: Optional. Specifies an identifier for the image.
+        os_image.description: Optional. Specifies the description of the image.
+        os_image.language: Optional. Specifies the language of the image.
+        os_image.image_family:
+            Optional. Specifies a value that can be used to group VM Images.
+        os_image.recommended_vm_size:
+            Optional. Specifies the size to use for the Virtual Machine that
+            is created from the VM Image.
+        os_image.eula:
+            Optional. Specifies the End User License Agreement that is
+            associated with the image. The value for this element is a string,
+            but it is recommended that the value be a URL that points to a EULA.
+        os_image.icon_uri:
+            Optional. Specifies the URI to the icon that is displayed for the
+            image in the Management Portal.
+        os_image.small_icon_uri:
+            Optional. Specifies the URI to the small icon that is displayed for
+            the image in the Management Portal.
+        os_image.privacy_uri:
+            Optional. Specifies the URI that points to a document that contains
+            the privacy policy related to the image.
+        os_image.published_date:
+            Optional. Specifies the date when the image was added to the image
+            repository.
+        os.image.media_link:
+            Required: Specifies the location of the blob in Windows Azure
+            blob store where the media for the image is located. The blob
+            location must belong to a storage account in the subscription
+            specified by the <subscription-id> value in the operation call.
+            Example:
+            http://example.blob.core.windows.net/disks/mydisk.vhd
+        os_image.name:
+            Specifies a name for the OS image that Windows Azure uses to
+            identify the image when creating one or more VM Roles.
+        os_image.os:
+            The operating system type of the OS image. Possible values are:
+            Linux, Windows
+        '''
+        _validate_not_none('image_name', image_name)
+        _validate_not_none('os_image', os_image)
+        return self._perform_put(self._get_image_path(image_name),
+            _XmlSerializer.update_os_image_to_xml(os_image), async=True
+        )
+
     def delete_os_image(self, image_name, delete_vhd=False):
         '''
         Deletes the specified OS image from your image repository.

--- a/azure-servicemanagement-legacy/tests/recordings/test_legacy_mgmt_misc.test_update_os_image_from_image_reference.yaml
+++ b/azure-servicemanagement-legacy/tests/recordings/test_legacy_mgmt_misc.test_update_os_image_from_image_reference.yaml
@@ -1,0 +1,146 @@
+interactions:
+- request:
+    body: !!binary |
+      PE9TSW1hZ2UgeG1sbnM6aT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFu
+      Y2UiIHhtbG5zPSJodHRwOi8vc2NoZW1hcy5taWNyb3NvZnQuY29tL3dpbmRvd3NhenVyZSI+PExh
+      YmVsPnV0b3NpbWczOGNjMTlhYWxhYmVsPC9MYWJlbD48TWVkaWFMaW5rPmh0dHA6Ly9zdG9yYWdl
+      bmFtZS5ibG9iLmNvcmUud2luZG93cy5uZXQvaW5wdXR0ZXN0ZGF0YWRvbm90ZGVsZXRlL3VidW50
+      dS52aGQ8L01lZGlhTGluaz48TmFtZT51dG9zaW1nMzhjYzE5YWE8L05hbWU+PE9TPkxpbnV4PC9P
+      Uz48L09TSW1hZ2U+
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['305']
+      Content-Type: [application/atom+xml;type=entry;charset=utf-8]
+      User-Agent: [pyazure/0.20.1]
+      x-ms-version: ['2014-10-01']
+    method: POST
+    uri: https://management.core.windows.net/00000000-0000-0000-0000-000000000000/services/images
+  response:
+    body: {string: '<OSImage xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><Category>User</Category><Label>utosimg38cc19aalabel</Label><Location>West
+        US</Location><LogicalSizeInGB>30</LogicalSizeInGB><MediaLink>http://storagename.blob.core.windows.net/inputtestdatadonotdelete/ubuntu.vhd</MediaLink><Name>utosimg38cc19aa</Name><OS>Linux</OS><IsPremium>false</IsPremium><OSState>Generalized</OSState><IOType>Standard</IOType></OSImage>'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['478']
+      Content-Type: [application/xml; charset=utf-8]
+      Date: ['Tue, 15 Dec 2015 19:01:41 GMT']
+      Server: [1.0.6198.292 (rd_rdfe_stable.151121-1554) Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [f16fdd1efb4c5a07ae22691a41d53d02]
+      x-ms-servedbyregion: [ussouth3]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [pyazure/0.20.1]
+      x-ms-version: ['2014-10-01']
+    method: GET
+    uri: https://management.core.windows.net/00000000-0000-0000-0000-000000000000/operations/f16fdd1efb4c5a07ae22691a41d53d02
+  response:
+    body: {string: '<Operation xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><ID>f16fdd1e-fb4c-5a07-ae22-691a41d53d02</ID><Status>Succeeded</Status><HttpStatusCode>200</HttpStatusCode></Operation>'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['232']
+      Content-Type: [application/xml; charset=utf-8]
+      Date: ['Tue, 15 Dec 2015 19:01:43 GMT']
+      Server: [1.0.6198.292 (rd_rdfe_stable.151121-1554) Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [497df8157b025e77a593df7dc04cfbb6]
+      x-ms-servedbyregion: [ussouth3]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [pyazure/0.20.1]
+      x-ms-version: ['2014-10-01']
+    method: GET
+    uri: https://management.core.windows.net/00000000-0000-0000-0000-000000000000/services/images/utosimg38cc19aa
+  response:
+    body: {string: '<OSImage xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><Category>User</Category><Label>utosimg38cc19aalabel</Label><Location>West
+        US</Location><LogicalSizeInGB>30</LogicalSizeInGB><MediaLink>http://storagename.blob.core.windows.net/inputtestdatadonotdelete/ubuntu.vhd</MediaLink><Name>utosimg38cc19aa</Name><OS>Linux</OS><IsPremium>false</IsPremium><OSState>Generalized</OSState><IOType>Standard</IOType></OSImage>'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['478']
+      Content-Type: [application/xml; charset=utf-8]
+      Date: ['Tue, 15 Dec 2015 19:01:43 GMT']
+      Server: [1.0.6198.292 (rd_rdfe_stable.151121-1554) Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [167f50b389395e74917f3da3289f3120]
+      x-ms-servedbyregion: [ussouth3]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PE9TSW1hZ2UgeG1sbnM6aT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFu
+      Y2UiIHhtbG5zPSJodHRwOi8vc2NoZW1hcy5taWNyb3NvZnQuY29tL3dpbmRvd3NhenVyZSI+PExh
+      YmVsPm5ld2xhYmVsPC9MYWJlbD48RGVzY3JpcHRpb24+PC9EZXNjcmlwdGlvbj48TWVkaWFMaW5r
+      Pmh0dHA6Ly9zdG9yYWdlbmFtZS5ibG9iLmNvcmUud2luZG93cy5uZXQvaW5wdXR0ZXN0ZGF0YWRv
+      bm90ZGVsZXRlL3VidW50dS52aGQ8L01lZGlhTGluaz48TmFtZT51dG9zaW1nMzhjYzE5YWE8L05h
+      bWU+PE9TPkxpbnV4PC9PUz48TGFuZ3VhZ2U+PC9MYW5ndWFnZT48SW1hZ2VGYW1pbHk+PC9JbWFn
+      ZUZhbWlseT48UmVjb21tZW5kZWRWTVNpemU+PC9SZWNvbW1lbmRlZFZNU2l6ZT48RXVsYT48L0V1
+      bGE+PEljb25Vcmk+PC9JY29uVXJpPjxTbWFsbEljb25Vcmk+PC9TbWFsbEljb25Vcmk+PFByaXZh
+      Y3lVcmk+PC9Qcml2YWN5VXJpPjxQdWJsaXNoZWREYXRlPjwvUHVibGlzaGVkRGF0ZT48L09TSW1h
+      Z2U+
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['524']
+      Content-Type: [application/atom+xml;type=entry;charset=utf-8]
+      User-Agent: [pyazure/0.20.1]
+      x-ms-version: ['2014-10-01']
+    method: PUT
+    uri: https://management.core.windows.net/00000000-0000-0000-0000-000000000000/services/images/utosimg38cc19aa
+  response:
+    body: {string: '<OSImage xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><Category>User</Category><Label>newlabel</Label><Location>West
+        US</Location><LogicalSizeInGB>30</LogicalSizeInGB><MediaLink>http://storagename.blob.core.windows.net/inputtestdatadonotdelete/ubuntu.vhd</MediaLink><Name>utosimg38cc19aa</Name><OS>Linux</OS><Description/><IsPremium>false</IsPremium><Language/><OSState>Generalized</OSState><IOType>Standard</IOType></OSImage>'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['491']
+      Content-Type: [application/xml; charset=utf-8]
+      Date: ['Tue, 15 Dec 2015 19:01:44 GMT']
+      Server: [1.0.6198.292 (rd_rdfe_stable.151121-1554) Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [8b35f3b7f1325a9a82d118f4c1a0aab5]
+      x-ms-servedbyregion: [ussouth3]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [pyazure/0.20.1]
+      x-ms-version: ['2014-10-01']
+    method: GET
+    uri: https://management.core.windows.net/00000000-0000-0000-0000-000000000000/operations/8b35f3b7f1325a9a82d118f4c1a0aab5
+  response:
+    body: {string: '<Operation xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><ID>8b35f3b7-f132-5a9a-82d1-18f4c1a0aab5</ID><Status>Succeeded</Status><HttpStatusCode>200</HttpStatusCode></Operation>'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['232']
+      Content-Type: [application/xml; charset=utf-8]
+      Date: ['Tue, 15 Dec 2015 19:01:44 GMT']
+      Server: [1.0.6198.292 (rd_rdfe_stable.151121-1554) Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [a2dd529c688f5eb080ee7e59fbb4b576]
+      x-ms-servedbyregion: [ussouth3]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [pyazure/0.20.1]
+      x-ms-version: ['2014-10-01']
+    method: GET
+    uri: https://management.core.windows.net/00000000-0000-0000-0000-000000000000/services/images/utosimg38cc19aa
+  response:
+    body: {string: '<OSImage xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><Category>User</Category><Label>newlabel</Label><Location>West
+        US</Location><LogicalSizeInGB>30</LogicalSizeInGB><MediaLink>http://storagename.blob.core.windows.net/inputtestdatadonotdelete/ubuntu.vhd</MediaLink><Name>utosimg38cc19aa</Name><OS>Linux</OS><Description/><IsPremium>false</IsPremium><Language/><OSState>Generalized</OSState><IOType>Standard</IOType></OSImage>'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['491']
+      Content-Type: [application/xml; charset=utf-8]
+      Date: ['Tue, 15 Dec 2015 19:01:44 GMT']
+      Server: [1.0.6198.292 (rd_rdfe_stable.151121-1554) Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [04ae39babf3f5e0a864ddffdfe3e1a23]
+      x-ms-servedbyregion: [ussouth3]
+    status: {code: 200, message: OK}
+version: 1

--- a/azure-servicemanagement-legacy/tests/test_legacy_mgmt_misc.py
+++ b/azure-servicemanagement-legacy/tests/test_legacy_mgmt_misc.py
@@ -2158,6 +2158,35 @@ class LegacyMgmtMiscTest(LegacyMgmtTestCase):
         self.assertEqual(image.os, 'Linux')
 
     @record
+    def test_update_os_image_from_image_reference(self):
+        # Arrange
+        self._create_os_image(
+            self.os_image_name, self.settings.LINUX_OS_VHD, 'Linux'
+        )
+
+        # Act
+        os_image = self.sms.get_os_image(self.os_image_name)
+        os_image.label = 'newlabel'
+        os_image.media_link = self.settings.LINUX_OS_VHD
+        os_image.os = 'Linux'
+        os_image.name = self.os_image_name
+        result = self.sms.update_os_image_from_image_reference(
+            self.os_image_name, os_image
+        )
+        self._wait_for_async(result.request_id)
+
+        # Assert
+        image = self.sms.get_os_image(
+            self.os_image_name
+        )
+        self.assertEqual(
+            image.label, 'newlabel'
+        )
+        self.assertEqual(
+            image.os, 'Linux'
+        )
+
+    @record
     def test_delete_os_image(self):
         # Arrange
         self._create_os_image(self.os_image_name, self.settings.LINUX_OS_VHD, 'Linux')


### PR DESCRIPTION
update_os_image now takes an instance of OSImage and allows to update
all elements of an OSImage in the same way as it can be done with
update_vm_image