### PR TITLE
Specify the order of attributes when updating an OS Image

### DIFF
--- a/azure-servicemanagement-legacy/azure/servicemanagement/_serialization.py
+++ b/azure-servicemanagement-legacy/azure/servicemanagement/_serialization.py
@@ -1195,22 +1195,16 @@ class _XmlSerializer(object):
         xml = _XmlSerializer.data_to_xml(
             [
                 ('Label', image.label),
-                ('Description', image.description),
-                ('MediaLink', image.media_link),
-                ('Name', image.name),
-                ('OS', image.os)
-            ]
-        )
-        xml += _XmlSerializer.data_to_xml(
-            [
-                ('Language', image.language),
-                ('ImageFamily', image.image_family),
-                ('RecommendedVMSize', image.recommended_vm_size),
                 ('Eula', image.eula),
-                ('IconUri', image.icon_uri),
-                ('SmallIconUri', image.small_icon_uri),
+                ('Description', image.description),
+                ('ImageFamily', image.image_family),
+                ('PublishedDate', image.published_date),
+                ('ShowInGui', image.show_in_gui, _lower),
                 ('PrivacyUri', image.privacy_uri),
-                ('PublishedDate', image.published_date)
+                ('IconUri', image.icon_uri),
+                ('RecommendedVMSize', image.recommended_vm_size),
+                ('SmallIconUri', image.small_icon_uri),
+                ('Language', image.language)
             ]
         )
         return _XmlSerializer.doc_from_xml('OSImage', xml)


### PR DESCRIPTION
The first element that is out of the order defined in
https://msdn.microsoft.com/en-us/library/azure/jj157198.aspx
will be dropped.

For example, if the Eula element does not appear before Description,
Eula attribute will not be updated, although a 200 OK status is
returned.

This resolves https://github.com/SUSE/azurectl/issues/83