### PR TITLE
Bugfix on serialization order for OSImage update

### DIFF
--- a/azure-servicemanagement-legacy/azure/servicemanagement/_serialization.py
+++ b/azure-servicemanagement-legacy/azure/servicemanagement/_serialization.py
@@ -1200,8 +1200,8 @@ class _XmlSerializer(object):
                 ('ImageFamily', image.image_family),
                 ('PublishedDate', image.published_date),
                 ('ShowInGui', image.show_in_gui, _lower),
-                ('PrivacyUri', image.privacy_uri),
                 ('IconUri', image.icon_uri),
+                ('PrivacyUri', image.privacy_uri),
                 ('RecommendedVMSize', image.recommended_vm_size),
                 ('SmallIconUri', image.small_icon_uri),
                 ('Language', image.language)


### PR DESCRIPTION
4bcd0d0539 was added to work with an undocumented XML element order requirement
on updating an OSImage's metadata. The order was based on the existing
documentation for the associated REST API call.

Due to a testing flaw, I discovered today that the documented order does not
work in all cases; in particular, IconUri frequently fails.

Moving the IconUri element up one position, before PrivacyUri, appears to
resolve the issue in all known cases, without any side effects.*

* I have not tested comprehensively with the RecommendedVMSize or Language
  attributes, as _none_ of the published images have any data in these
  attributes.

This patch resolves the following `azurectl` issue:
https://github.com/SUSE/azurectl/issues/85