### PR TITLE
[WIP] Get publisher's OS Image details

### DIFF
--- a/azure-servicemanagement-legacy/azure/servicemanagement/servicemanagementclient.py
+++ b/azure-servicemanagement-legacy/azure/servicemanagement/servicemanagementclient.py
@@ -397,10 +397,12 @@ class _ServiceManagementClient(object):
 
         return None
 
-    def _get_path(self, resource, name):
+    def _get_path(self, resource, name, suffix=None):
         path = '/' + self.subscription_id + '/' + resource
         if name is not None:
             path += '/' + _str(name)
+        if suffix is not None:
+            path += '/' + suffix
         return path
 
     def _get_cloud_services_path(self, cloud_service_id, resource=None, name=None):

--- a/azure-servicemanagement-legacy/azure/servicemanagement/servicemanagementservice.py
+++ b/azure-servicemanagement-legacy/azure/servicemanagement/servicemanagementservice.py
@@ -2150,6 +2150,14 @@ class ServiceManagementService(_ServiceManagementClient):
         return self._perform_get(self._get_image_path(image_name),
                                  OSImage)
 
+    def get_os_image_details(self, image_name):
+        '''
+        Retrieves an OS image from the image repository, including additional
+        publishing metadata.
+        '''
+        return self._perform_get(self._get_image_details_path(image_name),
+                                 OSImage)
+
     def add_os_image(self, label, media_link, name, os):
         '''
         Adds an OS image that is currently stored in a storage account in your
@@ -2646,3 +2654,6 @@ class ServiceManagementService(_ServiceManagementClient):
 
     def _get_image_path(self, image_name=None):
         return self._get_path('services/images', image_name)
+
+    def _get_image_details_path(self, image_name=None):
+        return self._get_path('services/images', image_name, 'details')

--- a/azure-servicemanagement-legacy/tests/test_legacy_mgmt_misc.py
+++ b/azure-servicemanagement-legacy/tests/test_legacy_mgmt_misc.py
@@ -2130,6 +2130,26 @@ class LegacyMgmtMiscTest(LegacyMgmtTestCase):
         self.assertEqual(result.os, os)
 
     @record
+    def test_get_os_image_details(self):
+        # Arrange
+        media_url = self.settings.LINUX_OS_VHD
+        os = 'Linux'
+        self._create_os_image(self.os_image_name, media_url, os)
+        os_image = self.sms.get_os_image(self.os_image_name)
+        os_image.image_family = 'test-image-family'
+        result = self.sms.update_os_image_from_image_reference(
+            self.os_image_name, os_image
+        )
+        self._wait_for_async(result.request_id)
+
+        # Act
+        result = self.sms.get_os_image_details(self.os_image_name)
+
+        # Assert
+        self.assertIsNotNone(result)
+        self.assertEqual(result.image_family, os_image.image_family)
+
+    @record
     def test_add_os_image(self):
         # Arrange
 


### PR DESCRIPTION
Along with commands for replicating and publishing (#497), and updating extended OSImage attributes (#501), fetching additional publisher-specific details closes the loop for publishers; allowing for clients to monitor replication progress, look up all published images in a particular image family, or list out SKUs.