### PR TITLE
Add support for the OSImage /details endpoint

### DIFF
--- a/azure-servicemanagement-legacy/azure/servicemanagement/models.py
+++ b/azure-servicemanagement-legacy/azure/servicemanagement/models.py
@@ -996,6 +996,52 @@ class OSImage(WindowsAzureData):
         self.language = u''
 
 
+class OSImageDetails(WindowsAzureData):
+
+    def __init__(self):
+        self.category = u''
+        self.label = u''
+        self.location = u''
+        self.logical_size_in_gb = 0
+        self.media_link = u''
+        self.name = u''
+        self.os = u''
+        self.eula = u''
+        self.description = u''
+        self.image_family = u''
+        self.show_in_gui = True
+        self.published_date = u''
+        self.is_premium = True
+        self.icon_uri = u''
+        self.privacy_uri = u''
+        self.recommended_vm_size = u''
+        self.small_icon_uri = u''
+        self.language = u''
+        self.replication_progress = ReplicationProgress()
+
+
+class ReplicationProgress(WindowsAzureData):
+
+    def __init__(self):
+        self.replication_progress_elements = _list_of(ReplicationProgressElement)
+
+    def __iter__(self):
+        return iter(self.replication_progress_elements)
+
+    def __len__(self):
+        return len(self.replication_progress_elements)
+
+    def __getitem__(self, index):
+        return self.replication_progress_elements[index]
+
+
+class ReplicationProgressElement(WindowsAzureData):
+
+    def __init__(self):
+        self.location = u''
+        self.progress = 0
+
+
 class Disks(WindowsAzureData):
 
     def __init__(self):

--- a/azure-servicemanagement-legacy/azure/servicemanagement/servicemanagementclient.py
+++ b/azure-servicemanagement-legacy/azure/servicemanagement/servicemanagementclient.py
@@ -397,10 +397,12 @@ class _ServiceManagementClient(object):
 
         return None
 
-    def _get_path(self, resource, name):
+    def _get_path(self, resource, name, suffix=None):
         path = '/' + self.subscription_id + '/' + resource
         if name is not None:
             path += '/' + _str(name)
+        if suffix is not None:
+            path += '/' + suffix
         return path
 
     def _get_cloud_services_path(self, cloud_service_id, resource=None, name=None):

--- a/azure-servicemanagement-legacy/azure/servicemanagement/servicemanagementservice.py
+++ b/azure-servicemanagement-legacy/azure/servicemanagement/servicemanagementservice.py
@@ -33,10 +33,13 @@ from .models import (
     OperatingSystems,
     OperatingSystemFamilies,
     OSImage,
+    OSImageDetails,
     PersistentVMRole,
     ResourceExtensions,
     ReservedIP,
     ReservedIPs,
+    ReplicationProgress,
+    ReplicationProgressElement,
     RoleSize,
     RoleSizes,
     StorageService,
@@ -2150,6 +2153,14 @@ class ServiceManagementService(_ServiceManagementClient):
         return self._perform_get(self._get_image_path(image_name),
                                  OSImage)
 
+    def get_os_image_details(self, image_name):
+        '''
+        Retrieves an OS image from the image repository, including replication
+        progress.
+        '''
+        return self._perform_get(self._get_image_details_path(image_name),
+                                 OSImageDetails)
+
     def add_os_image(self, label, media_link, name, os):
         '''
         Adds an OS image that is currently stored in a storage account in your
@@ -2646,3 +2657,6 @@ class ServiceManagementService(_ServiceManagementClient):
 
     def _get_image_path(self, image_name=None):
         return self._get_path('services/images', image_name)
+
+    def _get_image_details_path(self, image_name=None):
+        return self._get_path('services/images', image_name, 'details')

--- a/azure-servicemanagement-legacy/tests/recordings/test_legacy_mgmt_misc.test_get_os_image_details.yaml
+++ b/azure-servicemanagement-legacy/tests/recordings/test_legacy_mgmt_misc.test_get_os_image_details.yaml
@@ -1,0 +1,138 @@
+interactions:
+- request:
+    body: <OSImage xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.microsoft.com/windowsazure"><Label>utosimgcd6e1329label</Label><MediaLink>http://storagename.blob.core.windows.net/inputtestdatadonotdelete/python-azure-sdk-test.vhd</MediaLink><Name>utosimgcd6e1329</Name><OS>Linux</OS></OSImage>
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['324']
+      Content-Type: [application/atom+xml;type=entry;charset=utf-8]
+      User-Agent: [pyazure/0.20.1]
+      x-ms-version: ['2014-10-01']
+    method: POST
+    uri: https://management.core.windows.net/00000000-0000-0000-0000-000000000000/services/images
+  response:
+    body: {string: !!python/unicode '<OSImage xmlns="http://schemas.microsoft.com/windowsazure"
+        xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><Category>User</Category><Label>utosimgcd6e1329label</Label><Location>West
+        US</Location><LogicalSizeInGB>4</LogicalSizeInGB><MediaLink>http://storagename.blob.core.windows.net/inputtestdatadonotdelete/python-azure-sdk-test.vhd</MediaLink><Name>utosimgcd6e1329</Name><OS>Linux</OS><IsPremium>false</IsPremium><OSState>Generalized</OSState><IOType>Standard</IOType></OSImage>'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['496']
+      content-type: [application/xml; charset=utf-8]
+      date: ['Thu, 28 Jan 2016 05:06:13 GMT']
+      server: [1.0.6198.306 (rd_rdfe_stable.160114-1616) Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [aa6c239c88196bc79af0e30ca3ec19e2]
+      x-ms-servedbyregion: [ussouth3]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [pyazure/0.20.1]
+      x-ms-version: ['2014-10-01']
+    method: GET
+    uri: https://management.core.windows.net/00000000-0000-0000-0000-000000000000/operations/aa6c239c88196bc79af0e30ca3ec19e2
+  response:
+    body: {string: !!python/unicode '<Operation xmlns="http://schemas.microsoft.com/windowsazure"
+        xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><ID>aa6c239c-8819-6bc7-9af0-e30ca3ec19e2</ID><Status>Succeeded</Status><HttpStatusCode>200</HttpStatusCode></Operation>'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['232']
+      content-type: [application/xml; charset=utf-8]
+      date: ['Thu, 28 Jan 2016 05:06:13 GMT']
+      server: [1.0.6198.306 (rd_rdfe_stable.160114-1616) Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [d6e7ba0d2ac76114b0e554b87deb54b2]
+      x-ms-servedbyregion: [ussouth3]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [pyazure/0.20.1]
+      x-ms-version: ['2014-10-01']
+    method: GET
+    uri: https://management.core.windows.net/00000000-0000-0000-0000-000000000000/services/images/utosimgcd6e1329
+  response:
+    body: {string: !!python/unicode '<OSImage xmlns="http://schemas.microsoft.com/windowsazure"
+        xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><Category>User</Category><Label>utosimgcd6e1329label</Label><Location>West
+        US</Location><LogicalSizeInGB>4</LogicalSizeInGB><MediaLink>http://storagename.blob.core.windows.net/inputtestdatadonotdelete/python-azure-sdk-test.vhd</MediaLink><Name>utosimgcd6e1329</Name><OS>Linux</OS><IsPremium>false</IsPremium><OSState>Generalized</OSState><IOType>Standard</IOType></OSImage>'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['496']
+      content-type: [application/xml; charset=utf-8]
+      date: ['Thu, 28 Jan 2016 05:06:14 GMT']
+      server: [1.0.6198.306 (rd_rdfe_stable.160114-1616) Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [a79bc4df8cbb66ecb77c56ca0a7eef0b]
+      x-ms-servedbyregion: [ussouth3]
+    status: {code: 200, message: OK}
+- request:
+    body: <ReplicationInput xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.microsoft.com/windowsazure"><TargetLocations><Region>West
+      US</Region><Region>West Europe</Region></TargetLocations><ComputeImageAttributes><Offer>utosimgcd6e1329</Offer><Sku>utosimgcd6e1329</Sku><Version>1.2.3</Version></ComputeImageAttributes></ReplicationInput>
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['365']
+      Content-Type: [application/atom+xml;type=entry;charset=utf-8]
+      User-Agent: [pyazure/0.20.1]
+      x-ms-version: ['2015-04-01']
+    method: PUT
+    uri: https://management.core.windows.net/00000000-0000-0000-0000-000000000000/services/images/utosimgcd6e1329/replicate
+  response:
+    body: {string: !!python/unicode '<string xmlns="http://schemas.microsoft.com/2003/10/Serialization/">b4590d9e3ed742e4a1d46e5424aa335e__utosimgcd6e1329</string>'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['131']
+      content-type: [application/xml; charset=utf-8]
+      date: ['Thu, 28 Jan 2016 05:06:22 GMT']
+      server: [1.0.6198.306 (rd_rdfe_stable.160114-1616) Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-request-id: [c0c5d518b4ad6b9e88a95f07a5a3b942]
+      x-ms-servedbyregion: [ussouth3]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [pyazure/0.20.1]
+      x-ms-version: ['2014-10-01']
+    method: GET
+    uri: https://management.core.windows.net/00000000-0000-0000-0000-000000000000/operations/c0c5d518b4ad6b9e88a95f07a5a3b942
+  response:
+    body: {string: !!python/unicode '<Operation xmlns="http://schemas.microsoft.com/windowsazure"
+        xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><ID>c0c5d518-b4ad-6b9e-88a9-5f07a5a3b942</ID><Status>Succeeded</Status><HttpStatusCode>200</HttpStatusCode></Operation>'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['232']
+      content-type: [application/xml; charset=utf-8]
+      date: ['Thu, 28 Jan 2016 05:06:22 GMT']
+      server: [1.0.6198.306 (rd_rdfe_stable.160114-1616) Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [e94591b02eee68d0b1e9971ff6035c13]
+      x-ms-servedbyregion: [ussouth3]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [pyazure/0.20.1]
+      x-ms-version: ['2014-10-01']
+    method: GET
+    uri: https://management.core.windows.net/00000000-0000-0000-0000-000000000000/services/images/utosimgcd6e1329/details
+  response:
+    body: {string: !!python/unicode '<OSImageDetails xmlns="http://schemas.microsoft.com/windowsazure"
+        xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><Category>User</Category><Label>utosimgcd6e1329label</Label><Location>West
+        US</Location><LogicalSizeInGB>4</LogicalSizeInGB><MediaLink>http://storagename.blob.core.windows.net/inputtestdatadonotdelete/python-azure-sdk-test.vhd</MediaLink><Name>utosimgcd6e1329</Name><OS>Linux</OS><IsPremium>false</IsPremium><ReplicationProgress><ReplicationProgressElement><Location>West
+        US</Location><Progress>0</Progress></ReplicationProgressElement><ReplicationProgressElement><Location>West
+        Europe</Location><Progress>0</Progress></ReplicationProgressElement></ReplicationProgress></OSImageDetails>'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['716']
+      content-type: [application/xml; charset=utf-8]
+      date: ['Thu, 28 Jan 2016 05:06:25 GMT']
+      server: [1.0.6198.306 (rd_rdfe_stable.160114-1616) Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [ba8e386e294f6a75a838fade09454e17]
+      x-ms-servedbyregion: [ussouth3]
+    status: {code: 200, message: OK}
+version: 1

--- a/azure-servicemanagement-legacy/tests/test_legacy_mgmt_misc.py
+++ b/azure-servicemanagement-legacy/tests/test_legacy_mgmt_misc.py
@@ -2130,6 +2130,32 @@ class LegacyMgmtMiscTest(LegacyMgmtTestCase):
         self.assertEqual(result.os, os)
 
     @record
+    def test_get_os_image_details(self):
+        # Arrange
+        media_url = self.settings.LINUX_OS_VHD
+        os = 'Linux'
+        self._create_os_image(self.os_image_name, media_url, os)
+        os_image = self.sms.get_os_image(self.os_image_name)
+        locations = ['West US', 'West Europe']
+        result = self.sms.replicate_vm_image(
+            self.os_image_name,
+            locations,
+            'test-offer',
+            'test-sku',
+            '1.2.3'
+        )
+        self._wait_for_async(result.request_id)
+
+        # Act
+        result = self.sms.get_os_image_details(self.os_image_name)
+
+        # Assert
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(result.replication_progress)
+        result_locations = [e.location for e in result.replication_progress]
+        self.assertEqual(locations.sort(), result_locations.sort())
+
+    @record
     def test_add_os_image(self):
         # Arrange
 

--- a/azure-servicemanagement-legacy/tests/test_legacy_mgmt_misc.py
+++ b/azure-servicemanagement-legacy/tests/test_legacy_mgmt_misc.py
@@ -2140,8 +2140,8 @@ class LegacyMgmtMiscTest(LegacyMgmtTestCase):
         result = self.sms.replicate_vm_image(
             self.os_image_name,
             locations,
-            'test-offer',
-            'test-sku',
+            self.os_image_name,
+            self.os_image_name,
             '1.2.3'
         )
         self._wait_for_async(result.request_id)


### PR DESCRIPTION
The OSImage representation return by the default API endpoint does not include any publishing data, such as replication regions and progress.
