### PR TITLE
Fix kwarg mistake in example code

### DIFF
--- a/doc/resourcemanagement.rst
+++ b/doc/resourcemanagement.rst
@@ -112,7 +112,7 @@ This creates an availability set using the generic resource API.
         resource_type="availabilitySets",
         resource_name=resource_name,
         api_version="2015-05-01-preview",
-        GenericResource(
+        parameters=GenericResource(
             location='West US',
             properties={},
         ),


### PR DESCRIPTION
@lmazuel just a tiny fix. the example code doesn't work, but it was missing a kwarg..

Also, FWIW, the long module names make it quite tough to keep to PEP8