### PR TITLE
Without subnet it is impossible to create a Network Interface

### DIFF
--- a/azure-mgmt-network/azure/mgmt/network/models/network_interface_ip_configuration.py
+++ b/azure-mgmt-network/azure/mgmt/network/models/network_interface_ip_configuration.py
@@ -57,13 +57,13 @@ class NetworkInterfaceIPConfiguration(SubResource):
         'etag': {'key': 'etag', 'type': 'str'},
     }
 
-    def __init__(self, id=None, load_balancer_backend_address_pools=None, load_balancer_inbound_nat_rules=None, private_ip_address=None, private_ip_allocation_method=None, public_ip_address=None, provisioning_state=None, name=None, etag=None, **kwargs):
+    def __init__(self, id=None, load_balancer_backend_address_pools=None, load_balancer_inbound_nat_rules=None, private_ip_address=None, private_ip_allocation_method=None, public_ip_address=None, subnet=None, provisioning_state=None, name=None, etag=None, **kwargs):
         super(NetworkInterfaceIPConfiguration, self).__init__(id=id, **kwargs)
         self.load_balancer_backend_address_pools = load_balancer_backend_address_pools
         self.load_balancer_inbound_nat_rules = load_balancer_inbound_nat_rules
         self.private_ip_address = private_ip_address
         self.private_ip_allocation_method = private_ip_allocation_method
-        self.subnet = None
+        self.subnet = subnet
         self.public_ip_address = public_ip_address
         self.provisioning_state = provisioning_state
         self.name = name


### PR DESCRIPTION
When try use without this commit, I receive error from azure api server:
```
....
  File "/Library/Python/2.7/site-packages/msrestazure/azure_operation.py", line 629, in result
    raise self._exception
msrestazure.azure_exceptions.CloudError: Subnet reference is required for ipconfiguration /subscriptions/49d0145c-3194-47eb-81d8-0845a97f3377/resourceGroups/jEugene-je/providers/Microsoft.Network/networkInterfaces/jEugene-je/ipConfigurations/default.
```