### PR TITLE
Version 1.0.3: Wrong year on release date

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -62,7 +62,7 @@ We made our possible to document the breaking from ARM 1.0.0 version to 2.0.0 `h
 azure-storage 0.30.0
   * Major version. `Check the ChangeLog on storage github account for details<https://github.com/Azure/azure-storage-python/releases>`__.
 
-2015-01-20 Version 1.0.3
+2016-01-20 Version 1.0.3
 
   * #491 #502 #422 Update documentation
   * Update azure-storage dependency to 0.20.3


### PR DESCRIPTION
Should be 2016, not 2015