### PR TITLE
Try/Except to handle strict-transport-security header

### DIFF
--- a/azure-servicebus/azure/servicebus/_serialization.py
+++ b/azure-servicebus/azure/servicebus/_serialization.py
@@ -92,15 +92,18 @@ def _create_message(response, service_instance):
                 except ValueError:
                     custom_properties[name] = value
             else:  # only int, float or boolean
-                if value.lower() == 'true':
-                    custom_properties[name] = True
-                elif value.lower() == 'false':
-                    custom_properties[name] = False
-                # int('3.1') doesn't work so need to get float('3.14') first
-                elif str(int(float(value))) == value:
-                    custom_properties[name] = int(value)
-                else:
-                    custom_properties[name] = float(value)
+                try:
+                    if value.lower() == 'true':
+                        custom_properties[name] = True
+                    elif value.lower() == 'false':
+                        custom_properties[name] = False
+                    # int('3.1') doesn't work so need to get float('3.14') first
+                    elif str(int(float(value))) == value:
+                        custom_properties[name] = int(value)
+                    else:
+                        custom_properties[name] = float(value)
+                except ValueError:
+                    custom_properties[name] = value
 
     if message_type == None:
         message = Message(


### PR DESCRIPTION
Since 02:00 UTC this morning we started to receive the following ValueError from the ServiceBus API:

'could not convert string to float: max-age=31536000'

It appears that a change within the API has appended the `strict-transport-security` header which the SDK cannot serialise. 

I'm not sure if there's a better way of achieving this, I've just copied the try block from the if statement above.