### PR TITLE
Added the exclusion of 'strict-transport-security' in header parsing

### DIFF
--- a/azure-servicebus/azure/servicebus/_serialization.py
+++ b/azure-servicebus/azure/servicebus/_serialization.py
@@ -83,7 +83,8 @@ def _create_message(response, service_instance):
                                   'transfer-encoding',
                                   'server',
                                   'location',
-                                  'date']:
+                                  'date'
+                                  'strict-transport-security']:
             if '"' in value:
                 value = value[1:-1]
                 try:

--- a/azure-servicebus/azure/servicebus/_serialization.py
+++ b/azure-servicebus/azure/servicebus/_serialization.py
@@ -83,7 +83,7 @@ def _create_message(response, service_instance):
                                   'transfer-encoding',
                                   'server',
                                   'location',
-                                  'date'
+                                  'date',
                                   'strict-transport-security']:
             if '"' in value:
                 value = value[1:-1]


### PR DESCRIPTION
Looks like MSFT did an update to the Service Bus infrastructure that resulted in the addition of an extra header property, which wasn't excluded yet. I simply added this exclusion, and now everything works again.