### PR TITLE
Remove deprecated method

### DIFF
--- a/azure-mgmt/tests/test_mgmt_compute.py
+++ b/azure-mgmt/tests/test_mgmt_compute.py
@@ -209,13 +209,13 @@ class MgmtComputeTest(AzureMgmtTestCase):
             params_create,
         )
         vm_result = result_create.result()
-        self.assertEquals(vm_result.name, names.vm)
+        self.assertEqual(vm_result.name, names.vm)
         
         result_get = self.compute_client.virtual_machines.get(
             self.group_name,
             names.vm
         )
-        self.assertEquals(result_get.name, names.vm)
+        self.assertEqual(result_get.name, names.vm)
         self.assertIsNone(result_get.instance_view)
         result_iv = self.compute_client.virtual_machines.get(
             self.group_name,

--- a/azure-mgmt/tests/test_mgmt_redis.py
+++ b/azure-mgmt/tests/test_mgmt_redis.py
@@ -49,7 +49,7 @@ class MgmtRedisTest(AzureMgmtTestCase):
             self.group_name, 
             cache_name,
         )
-        self.assertEquals(result.name, cache_name)
+        self.assertEqual(result.name, cache_name)
 
 
 

--- a/azure-mgmt/tests/test_mgmt_resource.py
+++ b/azure-mgmt/tests/test_mgmt_resource.py
@@ -63,7 +63,7 @@ class MgmtResourceTest(AzureMgmtTestCase):
 
         result_list_top = self.resource_client.resource_groups.list(top=2)
         result_list_top = result_list_top.next()
-        self.assertEquals(len(result_list_top), 2)
+        self.assertEqual(len(result_list_top), 2)
 
         params_patch = azure.mgmt.resource.resources.models.ResourceGroup(
             location=self.region,

--- a/azure-mgmt/tests/test_mgmt_storage.py
+++ b/azure-mgmt/tests/test_mgmt_storage.py
@@ -66,7 +66,7 @@ class MgmtStorageTest(AzureMgmtTestCase):
             account_name,
         )
         keys = {v.key_name: (v.value, v.permissions) for v in result_list_keys.keys}
-        self.assertEquals(len(keys), 2)
+        self.assertEqual(len(keys), 2)
         self.assertGreater(len(keys['key1'][0]), 0)
         self.assertGreater(len(keys['key1'][0]), 0)
 
@@ -76,7 +76,7 @@ class MgmtStorageTest(AzureMgmtTestCase):
             "key1"
         )
         new_keys = {v.key_name: (v.value, v.permissions) for v in result_regen_keys.keys}
-        self.assertEquals(len(new_keys), 2)
+        self.assertEqual(len(new_keys), 2)
         self.assertNotEqual(
             new_keys['key1'][0],
             keys['key1'][0],


### PR DESCRIPTION
While building with Python 3 on Windows, I ran into deprecation warnings about `assertEquals`. I swapped `assertEquals` for `assertEqual`.