### PR TITLE
Fix for issue #257: QueueDescription.CountDetails.* always come back 0

### DIFF
--- a/azure-servicemanagement-legacy/azure/servicemanagement/_serialization.py
+++ b/azure-servicemanagement-legacy/azure/servicemanagement/_serialization.py
@@ -217,9 +217,11 @@ class _MinidomXmlToObject(object):
 
     @staticmethod
     def get_child_nodes(node, tagName):
-        return [childNode for childNode in node.getElementsByTagName(tagName)
-                if childNode.parentNode == node]
-
+        if ':' not in tagName:
+            return _MinidomXmlToObject._get_child_nodesNS(node, '*', tagName)
+        else:
+            return [childNode for childNode in node.getElementsByTagName(tagName)
+                    if childNode.parentNode == node]
 
     @staticmethod
     def _get_child_nodesNS(node, ns, tagName):
@@ -1602,9 +1604,9 @@ class _ServiceBusManagementXmlSerializer(object):
                                                  'entry'):
             for node in _MinidomXmlToObject.get_children_from_path(xml_entry,
                                                 'content',
-                                                'm:properties'):
+                                                'properties'):
                 for name in members:
-                    xml_name = "d:" + _get_serialization_name(name)
+                    xml_name = _get_serialization_name(name)
                     children = _MinidomXmlToObject.get_child_nodes(node, xml_name)
                     if not children:
                         continue


### PR DESCRIPTION
Proposed fix for #257 .

Fixes issue by changing the default operation of get_child_nodes to be namespace-agnostic and falling back to previous operation if and only if the tagName argument contains a colon (:).  The colon is the condition because legal QNames can only contain a single colon in them, according to https://www.w3.org/TR/xml-names/#ns-qualnames .

Removed references where tagName was passed with a colon to further future-proof those methods as most people would consider renaming the xmlns alias a non-breaking (or minor risk) change.