### PR TITLE
Fix #628 - custom properties with double quote

### DIFF
--- a/azure-servicebus/azure/servicebus/_serialization.py
+++ b/azure-servicebus/azure/servicebus/_serialization.py
@@ -86,7 +86,7 @@ def _create_message(response, service_instance):
                                   'date',
                                   'strict-transport-security']:
             if '"' in value:
-                value = value[1:-1]
+                value = value[1:-1].replace('\\"', '"')
                 try:
                     custom_properties[name] = datetime.strptime(
                         value, '%a, %d %b %Y %H:%M:%S GMT')

--- a/azure-servicebus/azure/servicebus/models.py
+++ b/azure-servicebus/azure/servicebus/models.py
@@ -233,10 +233,12 @@ class Message(WindowsAzureData):
         if self.custom_properties:
             for name, value in self.custom_properties.items():
                 if sys.version_info < (3,) and isinstance(value, unicode):
+                    escaped_value = value.replace('"', '\\"')
                     request.headers.append(
-                        (name, '"' + value.encode('utf-8') + '"'))
+                        (name, '"' + escaped_value.encode('utf-8') + '"'))
                 elif isinstance(value, str):
-                    request.headers.append((name, '"' + str(value) + '"'))
+                    escaped_value = value.replace('"', '\\"')
+                    request.headers.append((name, '"' + escaped_value + '"'))
                 elif isinstance(value, datetime):
                     request.headers.append(
                         (name, '"' + value.strftime('%a, %d %b %Y %H:%M:%S GMT') + '"'))

--- a/azure-servicebus/tests/recordings/test_servicebus_servicebus.test_send_queue_message_with_custom_message_properties.yaml
+++ b/azure-servicebus/tests/recordings/test_servicebus_servicebus.test_send_queue_message_with_custom_message_properties.yaml
@@ -1,47 +1,38 @@
 interactions:
 - request:
-    body: !!binary |
-      PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiIHN0YW5kYWxvbmU9InllcyI/Pjxl
-      bnRyeSB4bWxuczpkPSJodHRwOi8vc2NoZW1hcy5taWNyb3NvZnQuY29tL2Fkby8yMDA3LzA4L2Rh
-      dGFzZXJ2aWNlcyIgeG1sbnM6bT0iaHR0cDovL3NjaGVtYXMubWljcm9zb2Z0LmNvbS9hZG8vMjAw
-      Ny8wOC9kYXRhc2VydmljZXMvbWV0YWRhdGEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDA1
-      L0F0b20iPjx0aXRsZT48L3RpdGxlPjx1cGRhdGVkPjIwMTUtMDYtMzBUMjA6NTU6MzEuMTkzOTQ0
-      KzAwOjAwPC91cGRhdGVkPjxhdXRob3I+PG5hbWU+PC9uYW1lPjwvYXV0aG9yPjxpZD48L2lkPjxj
-      b250ZW50IHR5cGU9ImFwcGxpY2F0aW9uL3htbCI+PFF1ZXVlRGVzY3JpcHRpb24geG1sbnM6aT0i
-      aHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8v
-      c2NoZW1hcy5taWNyb3NvZnQuY29tL25ldHNlcnZpY2VzLzIwMTAvMTAvc2VydmljZWJ1cy9jb25u
-      ZWN0Ij48L1F1ZXVlRGVzY3JpcHRpb24+PC9jb250ZW50PjwvZW50cnk+
+    body: <?xml version="1.0" encoding="utf-8" standalone="yes"?><entry xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices"
+      xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns="http://www.w3.org/2005/Atom"><title></title><updated>2016-08-11T20:43:27.886049+00:00</updated><author><name></name></author><id></id><content
+      type="application/xml"><QueueDescription xmlns:i="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"></QueueDescription></content></entry>
     headers:
-      Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['555']
       Content-Type: [application/atom+xml;type=entry;charset=utf-8]
-      User-Agent: [pyazure/0.20.0]
+      User-Agent: [pyazure/0.20.2]
     method: PUT
     uri: https://fakesbnamespace.servicebus.windows.net/utqueue652e21b9
   response:
     body: {string: '<entry xmlns="http://www.w3.org/2005/Atom"><id>https://fakesbnamespace.servicebus.windows.net/utqueue652e21b9</id><title
-        type="text">utqueue652e21b9</title><published>2015-06-30T20:55:33Z</published><updated>2015-06-30T20:55:33Z</updated><author><name>fakesbnamespace</name></author><link
+        type="text">utqueue652e21b9</title><published>2016-08-11T20:43:29Z</published><updated>2016-08-11T20:43:29Z</updated><author><name>fakesbnamespace</name></author><link
         rel="self" href="https://fakesbnamespace.servicebus.windows.net/utqueue652e21b9"/><content
         type="application/xml"><QueueDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
-        xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><LockDuration>PT1M</LockDuration><MaxSizeInMegabytes>1024</MaxSizeInMegabytes><RequiresDuplicateDetection>false</RequiresDuplicateDetection><RequiresSession>false</RequiresSession><DefaultMessageTimeToLive>P10675199DT2H48M5.4775807S</DefaultMessageTimeToLive><DeadLetteringOnMessageExpiration>false</DeadLetteringOnMessageExpiration><DuplicateDetectionHistoryTimeWindow>PT10M</DuplicateDetectionHistoryTimeWindow><MaxDeliveryCount>10</MaxDeliveryCount><EnableBatchedOperations>true</EnableBatchedOperations><SizeInBytes>0</SizeInBytes><MessageCount>0</MessageCount><CreatedAt>2015-06-30T20:55:33.617</CreatedAt><UpdatedAt>2015-06-30T20:55:33.687</UpdatedAt></QueueDescription></content></entry>'}
+        xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><LockDuration>PT1M</LockDuration><MaxSizeInMegabytes>1024</MaxSizeInMegabytes><RequiresDuplicateDetection>false</RequiresDuplicateDetection><RequiresSession>false</RequiresSession><DefaultMessageTimeToLive>P10675199DT2H48M5.4775807S</DefaultMessageTimeToLive><DeadLetteringOnMessageExpiration>false</DeadLetteringOnMessageExpiration><DuplicateDetectionHistoryTimeWindow>PT10M</DuplicateDetectionHistoryTimeWindow><MaxDeliveryCount>10</MaxDeliveryCount><EnableBatchedOperations>true</EnableBatchedOperations><SizeInBytes>0</SizeInBytes><MessageCount>0</MessageCount><CreatedAt>2016-08-11T20:43:29.45</CreatedAt><UpdatedAt>2016-08-11T20:43:29.637</UpdatedAt></QueueDescription></content></entry>'}
     headers:
       Content-Type: [application/atom+xml;type=entry;charset=utf-8]
-      Date: ['Tue, 30 Jun 2015 20:55:32 GMT']
+      Date: ['Thu, 11 Aug 2016 20:43:28 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000]
       Transfer-Encoding: [chunked]
     status: {code: 201, message: Created}
 - request:
-    body: !!binary |
-      bWVzc2FnZSB3aXRoIHByb3BlcnRpZXM=
+    body: message with properties
     headers:
-      Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['23']
       Content-Type: [application/atom+xml;type=entry;charset=utf-8]
-      User-Agent: [pyazure/0.20.0]
+      User-Agent: [pyazure/0.20.2]
       active: ['true']
       deceased: ['false']
       dob: ['"Wed, 14 Dec 2011 00:00:00 GMT"']
@@ -49,37 +40,39 @@ interactions:
       hello: ['"world"']
       large: ['8555111000']
       number: ['42']
+      quote_message: ['"This \"should\" work fine"']
     method: POST
     uri: https://fakesbnamespace.servicebus.windows.net/utqueue652e21b9/messages
   response:
     body: {string: ''}
     headers:
       Content-Type: [application/xml; charset=utf-8]
-      Date: ['Tue, 30 Jun 2015 20:55:33 GMT']
+      Date: ['Thu, 11 Aug 2016 20:43:28 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000]
       Transfer-Encoding: [chunked]
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
-      Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/atom+xml;type=entry;charset=utf-8]
-      User-Agent: [pyazure/0.20.0]
+      User-Agent: [pyazure/0.20.2]
     method: POST
     uri: https://fakesbnamespace.servicebus.windows.net/utqueue652e21b9/messages/head?timeout=5
   response:
     body: {string: message with properties}
     headers:
-      BrokerProperties: ['{"DeliveryCount":1,"EnqueuedSequenceNumber":0,"EnqueuedTimeUtc":"Tue,
-          30 Jun 2015 20:55:33 GMT","LockToken":"84923582-a1dd-43d8-b177-237aa8fd7d39","LockedUntilUtc":"Tue,
-          30 Jun 2015 20:56:33 GMT","MessageId":"b71ea803411e41bc999cf13dc11c94cd","SequenceNumber":1,"State":"Active","TimeToLive":922337203685.47754}']
+      BrokerProperties: ['{"DeliveryCount":1,"EnqueuedSequenceNumber":0,"EnqueuedTimeUtc":"Thu,
+          11 Aug 2016 20:43:30 GMT","LockToken":"0e80aa4d-a5d1-4a99-b09e-d118f8c5972c","LockedUntilUtc":"Thu,
+          11 Aug 2016 20:44:30 GMT","MessageId":"3bd936e9551c4187bfffa8a3809254d9","SequenceNumber":1,"State":"Active","TimeToLive":922337203685.47754}']
       Content-Type: [application/atom+xml;type=entry;charset=utf-8]
-      Date: ['Tue, 30 Jun 2015 20:55:33 GMT']
-      Location: ['https://fakesbnamespace.servicebus.windows.net/utqueue652e21b9/messages/1/84923582-a1dd-43d8-b177-237aa8fd7d39']
+      Date: ['Thu, 11 Aug 2016 20:43:28 GMT']
+      Location: ['https://fakesbnamespace.servicebus.windows.net/utqueue652e21b9/messages/1/0e80aa4d-a5d1-4a99-b09e-d118f8c5972c']
       Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000]
       Transfer-Encoding: [chunked]
       active: ['true']
       deceased: ['false']
@@ -88,24 +81,25 @@ interactions:
       hello: ['"world"']
       large: ['8555111000']
       number: ['42']
+      quote_message: ['"This \"should\" work fine"']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
-      Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/atom+xml;type=entry;charset=utf-8]
-      User-Agent: [pyazure/0.20.0]
+      User-Agent: [pyazure/0.20.2]
     method: DELETE
-    uri: https://fakesbnamespace.servicebus.windows.net/utqueue652e21b9/messages/1/84923582-a1dd-43d8-b177-237aa8fd7d39
+    uri: https://fakesbnamespace.servicebus.windows.net/utqueue652e21b9/messages/1/0e80aa4d-a5d1-4a99-b09e-d118f8c5972c
   response:
     body: {string: ''}
     headers:
       Content-Type: [application/xml; charset=utf-8]
-      Date: ['Tue, 30 Jun 2015 20:55:33 GMT']
+      Date: ['Thu, 11 Aug 2016 20:43:28 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000]
       Transfer-Encoding: [chunked]
     status: {code: 200, message: OK}
 version: 1

--- a/azure-servicebus/tests/test_servicebus_servicebus.py
+++ b/azure-servicebus/tests/test_servicebus_servicebus.py
@@ -493,7 +493,8 @@ class ServiceBusServiceBusTest(ServiceBusTestCase):
                  'deceased': False,
                  'large': 8555111000,
                  'floating': 3.14,
-                 'dob': datetime(2011, 12, 14)}
+                 'dob': datetime(2011, 12, 14),
+                 'quote_message': 'This "should" work fine'}
         sent_msg = Message(b'message with properties', custom_properties=props)
         self.sbs.send_queue_message(self.queue_name, sent_msg)
         received_msg = self.sbs.receive_queue_message(self.queue_name, True, 5)
@@ -509,6 +510,8 @@ class ServiceBusServiceBusTest(ServiceBusTestCase):
         self.assertEqual(received_msg.custom_properties['floating'], 3.14)
         self.assertEqual(
             received_msg.custom_properties['dob'], datetime(2011, 12, 14))
+        self.assertEqual(
+            received_msg.custom_properties['quote_message'], 'This "should" work fine')
 
     @unittest.skip('flaky')
     def test_receive_queue_message_timeout_5(self):

--- a/azure.pyproj
+++ b/azure.pyproj
@@ -1818,8 +1818,6 @@
     <Content Include="azure-servicebus\tests\recordings\test_servicebus_servicebus.test_unicode_receive_subscription_message_binary_data.yaml" />
     <Content Include="azure-servicebus\tests\recordings\test_servicebus_servicebus.test_unicode_receive_subscription_message_unicode_data.yaml" />
     <Content Include="azure-servicebus\tests\recordings\test_servicebus_servicebus.test_with_filter.yaml" />
-    <Content Include="azure-servicebus\tests\run-servicebus" />
-    <Content Include="azure-servicebus\tests\run-servicebus.bat" />
     <Content Include="azure-servicemanagement-legacy\MANIFEST.in" />
     <Content Include="azure-servicemanagement-legacy\README.rst" />
     <Content Include="azure-servicemanagement-legacy\setup.cfg" />


### PR DESCRIPTION
Fix #628 

Tested Python from/to Python, and C# from/to Python with [ServiceBusExplorer](https://github.com/paolosalvatori/ServiceBusExplorer). So, I think the escaping strategy is correct if C# handles correctly the message from Python.

Both sender and receiver parts had to be fixed, then the Python lib needs to be updated on both side to be able to send/receive messages with double quotes inside. No impact on string message with no double quotes.

Will be happy to have review from @huguesv and @brettcannon :)