### PR TITLE
Fix #547 - Add FormatDeadLetterPath to Python

### DIFF
--- a/azure-servicebus/azure/servicebus/servicebusservice.py
+++ b/azure-servicebus/azure/servicebus/servicebusservice.py
@@ -154,6 +154,16 @@ class ServiceBusService(object):
         )
         self._filter = self._httpclient.perform_request
 
+    @staticmethod
+    def format_dead_letter_queue_name(queue_name):
+        """Get the dead letter name of this queue"""
+        return queue_name + '/$DeadLetterQueue'
+
+    @staticmethod
+    def format_dead_letter_subscription_name(subscription_name):
+        """Get the dead letter name of this subscription"""
+        return subscription_name + '/$DeadLetterQueue'
+
     # Backwards compatibility:
     # account_key and issuer used to be stored on the service class, they are
     # now stored on the authentication class.

--- a/azure-servicebus/tests/recordings/test_servicebus_servicebus.test_get_dead_letter_queue.yaml
+++ b/azure-servicebus/tests/recordings/test_servicebus_servicebus.test_get_dead_letter_queue.yaml
@@ -1,0 +1,47 @@
+interactions:
+- request:
+    body: <?xml version="1.0" encoding="utf-8" standalone="yes"?><entry xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices"
+      xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns="http://www.w3.org/2005/Atom"><title></title><updated>2016-08-11T22:21:36.782954+00:00</updated><author><name></name></author><id></id><content
+      type="application/xml"><QueueDescription xmlns:i="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"></QueueDescription></content></entry>
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['555']
+      Content-Type: [application/atom+xml;type=entry;charset=utf-8]
+      User-Agent: [pyazure/0.20.2]
+    method: PUT
+    uri: https://fakesbnamespace.servicebus.windows.net/utqueue51c815e2
+  response:
+    body: {string: '<entry xmlns="http://www.w3.org/2005/Atom"><id>https://fakesbnamespace.servicebus.windows.net/utqueue51c815e2</id><title
+        type="text">utqueue51c815e2</title><published>2016-08-11T22:21:39Z</published><updated>2016-08-11T22:21:40Z</updated><author><name>fakesbnamespace</name></author><link
+        rel="self" href="https://fakesbnamespace.servicebus.windows.net/utqueue51c815e2"/><content
+        type="application/xml"><QueueDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+        xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><LockDuration>PT1M</LockDuration><MaxSizeInMegabytes>1024</MaxSizeInMegabytes><RequiresDuplicateDetection>false</RequiresDuplicateDetection><RequiresSession>false</RequiresSession><DefaultMessageTimeToLive>P10675199DT2H48M5.4775807S</DefaultMessageTimeToLive><DeadLetteringOnMessageExpiration>false</DeadLetteringOnMessageExpiration><DuplicateDetectionHistoryTimeWindow>PT10M</DuplicateDetectionHistoryTimeWindow><MaxDeliveryCount>10</MaxDeliveryCount><EnableBatchedOperations>true</EnableBatchedOperations><SizeInBytes>0</SizeInBytes><MessageCount>0</MessageCount><CreatedAt>2016-08-11T22:21:39.973</CreatedAt><UpdatedAt>2016-08-11T22:21:40.093</UpdatedAt></QueueDescription></content></entry>'}
+    headers:
+      Content-Type: [application/atom+xml;type=entry;charset=utf-8]
+      Date: ['Thu, 11 Aug 2016 22:21:39 GMT']
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000]
+      Transfer-Encoding: [chunked]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/atom+xml;type=entry;charset=utf-8]
+      User-Agent: [pyazure/0.20.2]
+    method: POST
+    uri: https://fakesbnamespace.servicebus.windows.net/utqueue51c815e2/$DeadLetterQueue/messages/head?timeout=2
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Content-Type: [application/xml; charset=utf-8]
+      Date: ['Thu, 11 Aug 2016 22:21:41 GMT']
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000]
+    status: {code: 204, message: No Content}
+version: 1

--- a/azure-servicebus/tests/recordings/test_servicebus_servicebus.test_get_dead_letter_subscription.yaml
+++ b/azure-servicebus/tests/recordings/test_servicebus_servicebus.test_get_dead_letter_subscription.yaml
@@ -1,0 +1,73 @@
+interactions:
+- request:
+    body: <?xml version="1.0" encoding="utf-8" standalone="yes"?><entry xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices"
+      xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns="http://www.w3.org/2005/Atom"><title></title><updated>2016-08-11T22:21:31.014399+00:00</updated><author><name></name></author><id></id><content
+      type="application/xml"><TopicDescription xmlns:i="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"></TopicDescription></content></entry>
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['555']
+      Content-Type: [application/atom+xml;type=entry;charset=utf-8]
+      User-Agent: [pyazure/0.20.2]
+    method: PUT
+    uri: https://fakesbnamespace.servicebus.windows.net/uttopicf6e918e2
+  response:
+    body: {string: '<entry xmlns="http://www.w3.org/2005/Atom"><id>https://fakesbnamespace.servicebus.windows.net/uttopicf6e918e2</id><title
+        type="text">uttopicf6e918e2</title><published>2016-08-11T22:21:32Z</published><updated>2016-08-11T22:21:32Z</updated><author><name>fakesbnamespace</name></author><link
+        rel="self" href="https://fakesbnamespace.servicebus.windows.net/uttopicf6e918e2"/><content
+        type="application/xml"><TopicDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+        xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><DefaultMessageTimeToLive>P10675199DT2H48M5.4775807S</DefaultMessageTimeToLive><MaxSizeInMegabytes>1024</MaxSizeInMegabytes><RequiresDuplicateDetection>false</RequiresDuplicateDetection><DuplicateDetectionHistoryTimeWindow>PT10M</DuplicateDetectionHistoryTimeWindow><EnableBatchedOperations>true</EnableBatchedOperations><SizeInBytes>0</SizeInBytes><CreatedAt>2016-08-11T22:21:32.527</CreatedAt><UpdatedAt>2016-08-11T22:21:32.623</UpdatedAt></TopicDescription></content></entry>'}
+    headers:
+      Content-Type: [application/atom+xml;type=entry;charset=utf-8]
+      Date: ['Thu, 11 Aug 2016 22:21:31 GMT']
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000]
+      Transfer-Encoding: [chunked]
+    status: {code: 201, message: Created}
+- request:
+    body: <?xml version="1.0" encoding="utf-8" standalone="yes"?><entry xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices"
+      xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns="http://www.w3.org/2005/Atom"><title></title><updated>2016-08-11T22:21:32.396104+00:00</updated><author><name></name></author><id></id><content
+      type="application/xml"><SubscriptionDescription xmlns:i="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"></SubscriptionDescription></content></entry>
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['569']
+      Content-Type: [application/atom+xml;type=entry;charset=utf-8]
+      User-Agent: [pyazure/0.20.2]
+    method: PUT
+    uri: https://fakesbnamespace.servicebus.windows.net/uttopicf6e918e2/subscriptions/MySubscription
+  response:
+    body: {string: '<entry xmlns="http://www.w3.org/2005/Atom"><id>https://fakesbnamespace.servicebus.windows.net/uttopicf6e918e2/subscriptions/MySubscription</id><title
+        type="text">MySubscription</title><published>2016-08-11T22:21:32Z</published><updated>2016-08-11T22:21:32Z</updated><link
+        rel="self" href="https://fakesbnamespace.servicebus.windows.net/uttopicf6e918e2/subscriptions/MySubscription"/><content
+        type="application/xml"><SubscriptionDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+        xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><LockDuration>PT1M</LockDuration><RequiresSession>false</RequiresSession><DefaultMessageTimeToLive>P10675199DT2H48M5.4775807S</DefaultMessageTimeToLive><DeadLetteringOnMessageExpiration>false</DeadLetteringOnMessageExpiration><DeadLetteringOnFilterEvaluationExceptions>true</DeadLetteringOnFilterEvaluationExceptions><MessageCount>0</MessageCount><MaxDeliveryCount>10</MaxDeliveryCount><EnableBatchedOperations>true</EnableBatchedOperations></SubscriptionDescription></content></entry>'}
+    headers:
+      Content-Type: [application/atom+xml;type=entry;charset=utf-8]
+      Date: ['Thu, 11 Aug 2016 22:21:32 GMT']
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000]
+      Transfer-Encoding: [chunked]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/atom+xml;type=entry;charset=utf-8]
+      User-Agent: [pyazure/0.20.2]
+    method: POST
+    uri: https://fakesbnamespace.servicebus.windows.net/uttopicf6e918e2/subscriptions/MySubscription/$DeadLetterQueue/messages/head?timeout=2
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Content-Type: [application/xml; charset=utf-8]
+      Date: ['Thu, 11 Aug 2016 22:21:34 GMT']
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000]
+    status: {code: 204, message: No Content}
+version: 1

--- a/azure-servicebus/tests/test_servicebus_servicebus.py
+++ b/azure-servicebus/tests/test_servicebus_servicebus.py
@@ -465,6 +465,20 @@ class ServiceBusServiceBusTest(ServiceBusTestCase):
         self.assertEqual(received_again_msg.body, received_msg.body)
 
     @record
+    def test_get_dead_letter_queue(self):
+        # Arrange
+        self._create_queue(self.queue_name)
+
+        # Act
+        dead_letter_name = ServiceBusService.format_dead_letter_queue_name(
+            self.queue_name)
+        try:
+            self.sbs.receive_queue_message(dead_letter_name, timeout=2)
+        except Exception:
+            # Assert
+            self.fail("Dead Letter queue not found")
+
+    @record
     def test_send_queue_message_with_custom_message_type(self):
         # Arrange
         self._create_queue(self.queue_name)
@@ -1285,6 +1299,21 @@ class ServiceBusServiceBusTest(ServiceBusTestCase):
         # Assert
         self.assertIsNotNone(received_msg)
         self.assertEqual(sent_msg.body, received_msg.body)
+
+    @record
+    def test_get_dead_letter_subscription(self):
+        # Arrange
+        self._create_topic_and_subscription(self.topic_name, 'MySubscription')
+
+        # Act
+        dead_letter_name = ServiceBusService.format_dead_letter_subscription_name(
+            'MySubscription')
+        try:
+            self.sbs.receive_subscription_message(
+                self.topic_name, dead_letter_name, timeout=2)
+        except Exception:
+            # Assert
+            self.fail("Dead Letter subscription not found")
 
     @record
     def test_receive_subscription_message_delete(self):


### PR DESCRIPTION
Add the equivalent of FormatDeadLetterPath of C# in Python.
[Topic in C#](https://msdn.microsoft.com/en-us/library/microsoft.servicebus.messaging.subscriptionclient.formatdeadletterpath.aspx)
[Queue in C#](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.queueclient.formatdeadletterpath.aspx)

```python
dead_letter_name = ServiceBusService.format_dead_letter_subscription_name(
    'MySubscription')
dead_letter_name = ServiceBusService.format_dead_letter_queue_name(
    'MyQueue')
```

Fix #547 