### PR TITLE
Fix dependency bug in azure-batch

### DIFF
--- a/azure-batch/setup.py
+++ b/azure-batch/setup.py
@@ -71,7 +71,6 @@ setup(
     zip_safe=False,
     packages=find_packages(),
     install_requires=[
-        'azure-mgmt-nspkg',
         'azure-common[autorest]==1.1.4',
     ],
 )


### PR DESCRIPTION
azure-batch was incorrectly depending on azure-mgmt-nskpg.

azure-batch is not a mgmt package, does only need to depends on azure-common

FYI @annatisch 