### PR TITLE
[CDN] Fix to EdgenodeResult definition to change type from object to array 

### DIFF
--- a/azure-mgmt-cdn/azure/mgmt/cdn/models/__init__.py
+++ b/azure-mgmt-cdn/azure/mgmt/cdn/models/__init__.py
@@ -30,10 +30,10 @@ from .check_name_availability_output import CheckNameAvailabilityOutput
 from .resource_usage import ResourceUsage
 from .operation_display import OperationDisplay
 from .operation import Operation
-from .edgenode_result import EdgenodeResult
 from .cidr_ip_address import CidrIpAddress
 from .ip_address_group import IpAddressGroup
 from .edge_node import EdgeNode
+from .edgenode_result import EdgenodeResult
 from .resource import Resource
 from .error_response import ErrorResponse, ErrorResponseException
 from .profile_paged import ProfilePaged
@@ -75,10 +75,10 @@ __all__ = [
     'ResourceUsage',
     'OperationDisplay',
     'Operation',
-    'EdgenodeResult',
     'CidrIpAddress',
     'IpAddressGroup',
     'EdgeNode',
+    'EdgenodeResult',
     'Resource',
     'ErrorResponse', 'ErrorResponseException',
     'ProfilePaged',

--- a/azure-mgmt-cdn/azure/mgmt/cdn/models/edgenode_result.py
+++ b/azure-mgmt-cdn/azure/mgmt/cdn/models/edgenode_result.py
@@ -17,11 +17,11 @@ class EdgenodeResult(Model):
     address group and a URL link to get the next set of results.
 
     :param value: Edge node of CDN service.
-    :type value: object
+    :type value: list of :class:`EdgeNode <azure.mgmt.cdn.models.EdgeNode>`
     """
 
     _attribute_map = {
-        'value': {'key': 'value', 'type': 'object'},
+        'value': {'key': 'value', 'type': '[EdgeNode]'},
     }
 
     def __init__(self, value=None):


### PR DESCRIPTION
Generated from RestAPI PR: https://github.com/Azure/azure-rest-api-specs/pull/807