### PR TITLE
Changing Ubuntu sku to 16.04-LTS

### DIFF
--- a/doc/sample_azure-mgmt-manageddisks.rst
+++ b/doc/sample_azure-mgmt-manageddisks.rst
@@ -110,7 +110,7 @@ precondition to create a Virtual Machine.
                     image_reference = azure.mgmt.compute.models.ImageReference(
                         publisher='Canonical',
                         offer='UbuntuServer',
-                        sku='16.04.0-LTS',
+                        sku='16.04-LTS',
                         version='latest'
                     )
                 )
@@ -164,7 +164,7 @@ can now be exactly the same as the one used in VM creation:
                             'image_reference': {
                                 "publisher": "Canonical",
                                 "offer": "UbuntuServer",
-                                "sku": "16.04.0-LTS",
+                                "sku": "16.04-LTS",
                                 "version": "latest"
                             }
                         },
@@ -190,7 +190,7 @@ The full sample being:
                             'image_reference': {
                                 "publisher": "Canonical",
                                 "offer": "UbuntuServer",
-                                "sku": "16.04.0-LTS",
+                                "sku": "16.04-LTS",
                                 "version": "latest"
                             }
                         },


### PR DESCRIPTION
UbuntuServer 16.04-LTS now works for VMs skus, and is more future-proof than putting 16.04.0-LTS.