### PR TITLE
Proofreading 04272017

### DIFF
--- a/doc/quickstart_authentication.rst
+++ b/doc/quickstart_authentication.rst
@@ -47,9 +47,7 @@ Using AD User/Password
 ----------------------
 
 1. Connect to the Azure Classic Portal with your admin account
-2. `Create a user in your default AAD <https://azure.microsoft.com/en-us/documentation/articles/active-directory-create-users/>`__
-
-**You must NOT activate Multi-Factor Authentication**
+2. `Create a user in your default AAD <https://azure.microsoft.com/en-us/documentation/articles/active-directory-create-users/>`__. **You must NOT activate Multi-Factor Authentication!**
 
 3. Go to Settings - Administrators
 4. Click on Add and enter the email of the new user. Check the checkbox of the subscription you want to test with this user.

--- a/doc/quickstart_authentication.rst
+++ b/doc/quickstart_authentication.rst
@@ -26,8 +26,8 @@ At this point, you must have:
 * Your client id. Found in the "client id" box in the "Configure" page of your application in the Azure portal.
 * Your secret key. Generated when you have created the application. You cannot show the key after creation.
   If you've lost the current key, you must create a new one in the "Configure" page of your application.
-* You AD tenant id. It's an UUID (e.g. ABCDEFAB-1234-ABCD-1234-ABCDEFABCDEF) which point to the AD containing your application.
-  You will found it in the URL when you are in the Azure portal in your AD, or in the "view endpoints" in any of the given url.
+* Your AD tenant id. It's an UUID (e.g. ABCDEFAB-1234-ABCD-1234-ABCDEFABCDEF) which points to the AD containing your application.
+  You will find it in the URL when you are in the Azure portal in your AD, or in the "view endpoints" in any of the given url.
 
 Then, you can create your credentials instance:
 

--- a/doc/quickstart_authentication.rst
+++ b/doc/quickstart_authentication.rst
@@ -23,9 +23,9 @@ https://azure.microsoft.com/en-us/documentation/articles/resource-group-create-s
 
 At this point, you must have:
 
-* Your client id. Found in the "client id" box in the "Configure" page of your application in the Azure portal.
+* Your client id. Found in the "client id" box in the "Settings" page of your application in the Azure portal.
 * Your secret key. Generated when you have created the application. You cannot show the key after creation.
-  If you've lost the current key, you must create a new one in the "Configure" page of your application.
+  If you've lost the current key, you must create a new one in the "Settings" page of your application.
 * Your AD tenant id. It's an UUID (e.g. ABCDEFAB-1234-ABCD-1234-ABCDEFABCDEF) which points to the AD containing your application.
   You will find it in the URL when you are in the Azure portal in your AD, or in the "view endpoints" in any of the given url.
 

--- a/doc/quickstart_authentication.rst
+++ b/doc/quickstart_authentication.rst
@@ -18,7 +18,7 @@ And use it as credentials in your management configuration client. These three i
 Using Service Principal
 ------------------------
 
-There is now a detailled official tutorial to describe this:
+There is now a detailed official tutorial to describe this:
 https://azure.microsoft.com/en-us/documentation/articles/resource-group-create-service-principal-portal/
 
 At this point, you must have:

--- a/doc/quickstart_authentication.rst
+++ b/doc/quickstart_authentication.rst
@@ -5,14 +5,14 @@ For general information on resource management, see :doc:`Resource Management<re
 
 To be able to use use the ARM library, you need to obtain one of these instances:
 
-* azure.common.credentials.UserPassCredentials
 * azure.common.credentials.ServicePrincipalCredentials
+* azure.common.credentials.UserPassCredentials
 * msrestazure.azure_active_directory.AdalAuthentication
  
 And use it as credentials in your management configuration client. These three instances correspond to:
 
-* OAuth authentication using Azure Active Directory user/password
 * OAuth authentication using Active Directory application and service principal
+* OAuth authentication using Azure Active Directory user/password
 * A wrapper on top of `ADAL for Python <https://github.com/AzureAD/azure-activedirectory-library-for-python>`
 
 Using Service Principal
@@ -23,7 +23,7 @@ https://azure.microsoft.com/en-us/documentation/articles/resource-group-create-s
 
 At this point, you must have:
 
-* Your client id. Found in the "client id" box in the "Configure" page of your application in the Azure portal
+* Your client id. Found in the "client id" box in the "Configure" page of your application in the Azure portal.
 * Your secret key. Generated when you have created the application. You cannot show the key after creation.
   If you've lost the current key, you must create a new one in the "Configure" page of your application.
 * You AD tenant id. It's an UUID (e.g. ABCDEFAB-1234-ABCD-1234-ABCDEFABCDEF) which point to the AD containing your application.

--- a/doc/resourcemanagement.rst
+++ b/doc/resourcemanagement.rst
@@ -5,7 +5,7 @@ Resource Management
 Resource Management libraries
 -----------------------------
 
-The azure-mgmt-resource package is splitted into several sub-librairies:
+The azure-mgmt-resource package is split into several sub-librairies:
 
 * resources : manage resources groups, template, etc (`Introduction to ARM <https://azure.microsoft.com/en-us/documentation/articles/resource-group-overview/>`__)
 * features : manage features of provider (`RestAPI reference <https://msdn.microsoft.com/en-us/library/azure/mt592690.aspx>`__)

--- a/doc/resourcemanagement.rst
+++ b/doc/resourcemanagement.rst
@@ -7,7 +7,7 @@ Resource Management libraries
 
 The azure-mgmt-resource package is split into several sub-libraries:
 
-* resources : manage resources groups, template, etc (`Introduction to ARM <https://azure.microsoft.com/en-us/documentation/articles/resource-group-overview/>`__)
+* resources : manage resource groups, templates, etc (`Introduction to ARM <https://azure.microsoft.com/en-us/documentation/articles/resource-group-overview/>`__)
 * features : manage features of provider (`RestAPI reference <https://msdn.microsoft.com/en-us/library/azure/mt592690.aspx>`__)
 * locks : manage resource group lock (`RestAPI reference <https://msdn.microsoft.com/en-us/library/azure/mt204563.aspx>`__)
 * subscriptions : manage subscriptions (`RestAPI reference <https://msdn.microsoft.com/en-us/library/azure/dn790566.aspx>`__)

--- a/doc/resourcemanagement.rst
+++ b/doc/resourcemanagement.rst
@@ -5,7 +5,7 @@ Resource Management
 Resource Management libraries
 -----------------------------
 
-The azure-mgmt-resource package is split into several sub-librairies:
+The azure-mgmt-resource package is split into several sub-libraries:
 
 * resources : manage resources groups, template, etc (`Introduction to ARM <https://azure.microsoft.com/en-us/documentation/articles/resource-group-overview/>`__)
 * features : manage features of provider (`RestAPI reference <https://msdn.microsoft.com/en-us/library/azure/mt592690.aspx>`__)


### PR DESCRIPTION
Most changes here are grammar/spelling/syntax fixes. Other changes:
* The authentication methods in the lists in the beginning of `quickstart_authentication.rst` were not in the same order as the detailed descriptions below, which was confusing. I reordered them so they match.
* Information about getting the UUIDs for Service Principal authentication referred to the "Configure" page. In the new Azure portal this seems to be referred to as "Settings", not "Configure," so I changed it. I realized after doing so that maybe the docs don't target the new portal yet, but I couldn't find "Configure" in the old portal either, so I left it. Happy to revert this if I'm wrong.