### PR TITLE
Changing send method to request method so that REQUESTS_CA_BUNDLE var…

### DIFF
--- a/azure-keyvault/azure/keyvault/custom/key_vault_authentication.py
+++ b/azure-keyvault/azure/keyvault/custom/key_vault_authentication.py
@@ -30,7 +30,7 @@ class KeyVaultAuthBase(AuthBase):
                 # send the request to retrieve the challenge, then request the token and update
                 # the request
                 # TODO: wire up commons flag for things like Fiddler, logging, etc.
-                response = requests.Session().send(request)
+                response = requests.Session().request(request)
                 if response.status_code == 401:
                     auth_header = response.headers['WWW-Authenticate']
                     if HttpBearerChallenge.is_bearer_challenge(auth_header):


### PR DESCRIPTION
…iable is honored in requests package.  Azure stack uses a custom CA cert for the endpoints and if we use the request method instead of send REQUESTS_CA_BUNDLE environment variable will be honored by the requests package