### PR TITLE
[KeyVault] Reverting changes to KeyVaultAuthBase

### DIFF
--- a/azure-keyvault/azure/keyvault/custom/key_vault_authentication.py
+++ b/azure-keyvault/azure/keyvault/custom/key_vault_authentication.py
@@ -31,7 +31,7 @@ class KeyVaultAuthBase(AuthBase):
                 # send the request to retrieve the challenge, then request the token and update
                 # the request
                 # TODO: wire up commons flag for things like Fiddler, logging, etc.
-                response = requests.Session().send(request, verify=os.environ.get('REQUESTS_CA_BUNDLE') or os.environ.get('CURL_CA_BUNDLE'))
+                response = requests.Session().send(request)
                 if response.status_code == 401:
                     auth_header = response.headers['WWW-Authenticate']
                     if HttpBearerChallenge.is_bearer_challenge(auth_header):


### PR DESCRIPTION
Reverting changes made to KeyVaultAuthBase by https://github.com/Azure/azure-sdk-for-python/commit/b3a242dc513ce3dd53be2c0f0073acf36a7f1038#commitcomment-22093579 and https://github.com/Azure/azure-sdk-for-python/commit/da435aa346b20fbeac6514711b9c6a81a759f1da as both changes are broken.  Reverting these changes will fix the issue: [[Key Vault] InsecureRequestWarning #1162](https://github.com/Azure/azure-sdk-for-python/issues/1162#issuecomment-300617165)

While a fix to better handle session state is still needed we will revert to the original behavior in version 0.3.0 until a comprehensive fix is available.