### PR TITLE
Add CLI credentials,subscription,base_url support in SDK

### DIFF
--- a/azure-common/azure/common/client_factory.py
+++ b/azure-common/azure/common/client_factory.py
@@ -1,0 +1,47 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+from .credentials import get_azure_cli_credentials, get_cli_profile
+from .cloud import get_cli_active_cloud
+
+def get_client_from_cli_profile(clientclass, **kwargs):
+    """Return a SDK client initialized with current CLI credentials, CLI default subscription and CLI default cloud.
+
+    This method will fill automatically the following client parameters:
+    - credentials
+    - subscription_id
+    - base_url
+
+    Parameters provided in kwargs will override CLI parameters and be passed directly to the client.
+
+    :Example:
+
+    .. code:: python
+
+        from azure.common.client_factory import get_client_from_cli_profile
+        from azure.mgmt.compute import ComputeManagementClient
+        client = get_client_from_cli_profile(ComputeManagementClient)
+
+    .. versionadded:: 1.1.6
+
+    :param clientclass: A SDK client class
+    :return: An instanciated client
+    :raises: ImportError if azure-cli-core package is not available
+    """
+
+    parameters = {}
+    if 'credentials' not in kwargs or 'subscription_id' not in kwargs:
+        credentials, subscription_id = get_azure_cli_credentials()
+        parameters.update({
+            'credentials': kwargs.get('credentials', credentials),
+            'subscription_id': kwargs.get('subscription_id', subscription_id)
+        })
+    if 'base_url' not in kwargs:
+        cloud = get_cli_active_cloud()
+        # api_version_profile = cloud.profile # TBC using _shared
+        parameters['base_url'] = cloud.endpoints.resource_manager
+    parameters.update(kwargs)
+    return clientclass(**parameters)

--- a/azure-common/azure/common/cloud.py
+++ b/azure-common/azure/common/cloud.py
@@ -1,0 +1,22 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+def get_cli_active_cloud():
+    """Return a CLI active cloud.
+
+    .. versionadded:: 1.1.6
+
+    :return: A CLI Cloud
+    :rtype: azure.cli.core.cloud.Cloud
+    :raises: ImportError if azure-cli-core package is not available
+    """
+
+    try:
+        from azure.cli.core.cloud import get_active_cloud
+    except ImportError:
+        raise ImportError("You need to install 'azure-cli-core' to load CLI active Cloud")
+    return get_active_cloud()
+

--- a/azure-common/azure/common/credentials.py
+++ b/azure-common/azure/common/credentials.py
@@ -4,6 +4,49 @@
 # license information.
 #--------------------------------------------------------------------------
 
+import os.path
+
+def get_cli_profile():
+    """Return a CLI profile class.
+
+    .. versionadded:: 1.1.6
+
+    :return: A CLI Profile
+    :rtype: azure.cli.core._profile.Profile
+    :raises: ImportError if azure-cli-core package is not available
+    """
+
+    try:
+        from azure.cli.core._profile import Profile
+        from azure.cli.core._session import ACCOUNT
+        from azure.cli.core._environment import get_config_dir
+    except ImportError:
+        raise ImportError("You need to install 'azure-cli-core' to load CLI credentials")
+
+
+    azure_folder = get_config_dir()
+    ACCOUNT.load(os.path.join(azure_folder, 'azureProfile.json'))
+    return Profile(ACCOUNT)
+
+def get_azure_cli_credentials():
+    """Return Credentials and default SubscriptionID of current loaded profile of the CLI.
+
+    Credentials will be the "az login" command: 
+    https://docs.microsoft.com/cli/azure/authenticate-azure-cli
+
+    Default subscription ID is either the only one you have, or you can define it:
+    https://docs.microsoft.com/cli/azure/manage-azure-subscriptions-azure-cli
+
+    .. versionadded:: 1.1.6
+
+    :return: tuple of Credentials and SubscriptionID
+    :rtype: tuple
+    """
+    profile = get_cli_profile()
+    cred, subscription_id, _ = profile.get_login_credentials()
+    return cred, subscription_id
+
+
 try:
     from msrest.authentication import (
         BasicAuthentication,


### PR DESCRIPTION
This add the ability to load configuration from CLI, i.e. execute a SDK script delegating authentication and cloud selection to CLI

Example:
```python
from azure.common.client_factory import get_client_from_cli_profile
from azure.mgmt.compute import ComputeManagementClient
client = get_client_from_cli_profile(ComputeManagementClient)
client.virtual_machines.get()
```

Configuration from the CLI is
- [az login](https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli): access to credentials
- [az account set --subscriptions](https://docs.microsoft.com/en-us/cli/azure/manage-azure-subscriptions-azure-cli): access to subscription_id
- [az cloud set --name](https://docs.microsoft.com/en-us/cli/azure/cloud#set): access to base_url (sovereign cloud)

This PR does not support ApiVersion profile yet.

This allows customers to do incredible things:
- Simplify A LOT configuration of tests at the SDK level
- Allow to write script credentials independant (will be determined by CLI)
- Allow amazing scenario for tools like Ansible:

```console
$ az login
$ ansible-playbook myplaybook.yaml
```
[See current complex documentation about authenticating to Azure for Ansible](https://docs.ansible.com/ansible/guide_azure.html#providing-credentials-to-azure-modules).

Simple usage is to install `azure-cli` in the same env than the SDK (or even better, let the CLI install the SDK for us). However, it's not a requirement. The only requirement at the SDK level is to have `azure-cli-core` installed. Since this code is just reading the configuration, nothing else is required. This permits advanced scenario like having SDK version different from CLI fixed SDK:
- One venv with AzureCLI to do az command (will save config in $HOME)
- One venv pure SDK with only `azure-cli-core` (will read config in $HOME)

@yugangw-msft @derekbekoe I would like your review on this
@johanste Looking at this code, I still thing at least half of cli core should be in the SDK or a common neutral lib like "azure-common" but outside of this repo. It's obvious for me for the `cloud.py` file for instance, that has nothing specific to CLI ([see in NodeJS, it's in the SDK](https://github.com/Azure/azure-sdk-for-node/blob/8be6d3676b6e76c53fe353b7a4341904539c1b43/runtime/ms-rest-azure/lib/azureEnvironment.js)).

@devigned FYI for Ansible scenario.

