### PR TITLE
Default testsettings cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ TestResults/
 # Credentials 
 credentials_real.json
 testsettings_local.json
+testsettings_local.cfg
 servicebus_settings_real.py
 storage_settings_real.py
 legacy_mgmt_settings_real.py

--- a/azure-sdk-testutils/devtools_testutils/mgmt_testcase.py
+++ b/azure-sdk-testutils/devtools_testutils/mgmt_testcase.py
@@ -64,9 +64,12 @@ class AzureMgmtTestCase(ReplayableTest):
         self._fake_settings, self._real_settings = self._load_settings()
         self.region = 'westus'
         self.scrubber = GeneralNameReplacer()
+        config_file = config_file or os.path.join(self.working_folder, TEST_SETTING_FILENAME)
+        if not os.path.exists(config_file):
+            config_file = None
         super(AzureMgmtTestCase, self).__init__(
             method_name,
-            config_file=config_file or os.path.join(self.working_folder, TEST_SETTING_FILENAME),
+            config_file=config_file,
             recording_dir=recording_dir,
             recording_name=recording_name or self.qualified_test_name,
             recording_processors=recording_processors or self._get_recording_processors(),

--- a/azure-sdk-testutils/devtools_testutils/testsettings_local.cfg
+++ b/azure-sdk-testutils/devtools_testutils/testsettings_local.cfg
@@ -1,1 +1,0 @@
-live-mode: false


### PR DESCRIPTION
This PR fixes #1257.

I failed to realize that the test framework gracefully fell back to defaults (i.e. running tests in playback mode) if `testsettings_local.json` didn't exist. So the new framework would crash if its equivalent `testsettings_local.cfg` didn't exist. Now it will behave like the old framework and run in playback mode in that case; this PR therefore also removes `testsettings_local.cfg` and adds it to `.gitignore`.