### PR TITLE
Split requirements files and update CI scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,8 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source venv/bin/activate; fi
 install:
   - pip install -U pip
-  - pip install -r requirements.txt
+  - pip install -r azure-sdk-testutils/test-requirements.txt
   - pip install azure-storage
-  - pip install nose
   - pip uninstall -y azure-common  # Use azure-common from this repo, not the PyPI version azure-storage pulls in.
 script: 
   - python ./azure_nosetests.py */tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,8 @@ environment:
 
 install:
   - "%PYTHON%\\python.exe -m pip install -U pip"
-  - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
+  - "%PYTHON%\\python.exe -m pip install -r azure-sdk-testutils\\test-requirements.txt"
   - "%PYTHON%\\python.exe -m pip install azure-storage"
-  - "%PYTHON%\\python.exe -m pip install nose"
-  - "%PYTHON%\\python.exe -m pip install coveralls"
   - "%PYTHON%\\python.exe -m pip uninstall -y azure-common"
 
 build: off

--- a/azure-sdk-testutils/test-requirements.txt
+++ b/azure-sdk-testutils/test-requirements.txt
@@ -1,0 +1,6 @@
+-r ../requirements.txt
+
+coverage
+nose
+azure-devtools>=0.4.1
+vcrpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,4 @@
 futures
 python-dateutil
-requests
-vcrpy
-azure-devtools>=0.4.1
-coverage
 pyopenssl
-msrest>=0.4.0,<0.5.0
 msrestazure>=0.4.0,<0.5.0


### PR DESCRIPTION
This PR fixes #1256, cleaning up dependencies a bit, separating out the dev-only requirements and updating CI configs to reflect the changes.

If it's merged, we should make sure the docs in the wiki are updated to reflect the change to dependency installation.