### PR TITLE
Update minimum msrestazure package to 0.4.9

### DIFF
--- a/azure-common/setup.py
+++ b/azure-common/setup.py
@@ -53,8 +53,8 @@ setup(
     ],
     extras_require={
         'autorest':[
-            'msrestazure>=0.4.0,<0.5.0',
-            'msrest>=0.4.0,<0.5.0'
+            'msrestazure>=0.4.9,<0.5.0',
+            'msrest>=0.4.8,<0.5.0'
         ]
     }
 )


### PR DESCRIPTION
The Azure SDK for Python, 2.0.0rc6, has an implicit dependency on
python module requests 2.8.0+.

The msrestazure module 0.4.9 changes its dependency on msrest from
0.4.4 to 0.4.10; however, the Azure SDK for Python defines its
minimum version of msrestazure as 0.4.0.

Further, version 0.4.8 of the msrest module changes its minimum
version requirement of requests from 2.7.0 to 2.14.1.

If one uses the request module prior to 2.8.0 then they are likely
to see this exception:
  SysCallError: (32, 'EPIPE')

The exception can be triggered by doing the following:
  1. Use the Azure SDK to store a copy of the compute and network clients
  2. Create a VM
  3. Create a NIC
  4. Deallocate VM and attach NIC to VM
  5. Start VM
  6. The next use of the compute or network clients will trigger a
     SysCallError: (32, 'EPIPE') error.

The EPIPE error is gracefully handled by the requests module in 2.8.0.

Without this change, any user on a system that is running an older
version of requests and installs the 2.0.0rc6 Azure SDK via pip
will encounter this issue because the minimum dependencies will be
satisfied and requests will not be upgraded.