### PR TITLE
[KeyVault] Work around for authentication failure in Azure Stack using ADFS

### DIFF
--- a/azure-keyvault/azure/keyvault/custom/key_vault_authentication.py
+++ b/azure-keyvault/azure/keyvault/custom/key_vault_authentication.py
@@ -123,7 +123,11 @@ class KeyVaultAuthBase(AuthBase):
             challenge.get_authorization_server(),
             challenge.get_resource(),
             challenge.get_scope())
-        request.headers['Authorization'] = '{} {}'.format(auth[0], auth[1])
+
+        # Due to limitations in the service we hard code the auth scheme to 'Bearer' as the service will fail with any other
+        # scheme or a different casing such as 'bearer', once this is fixed the following line should be replace with:
+        # request.headers['Authorization'] = '{} {}'.format(auth[0], auth[1])
+        request.headers['Authorization'] = '{} {}'.format('Bearer', auth[1])
 
 
 class KeyVaultAuthentication(OAuthTokenAuthentication):


### PR DESCRIPTION
Hard coded Authorization header auth-scheme to 'Bearer' to work around a server side bug in validating the Authorization header