### PR TITLE
Prepare KV tests for msrest 0.4.15

### DIFF
--- a/azure-mgmt/tests/test_key_vault_data.py
+++ b/azure-mgmt/tests/test_key_vault_data.py
@@ -308,7 +308,7 @@ class KeyVaultKeyTest(AzureKeyVaultTestCase):
             self.client.get_key(key_id.vault, key_id.name, '')
             self.fail('Get should fail')
         except Exception as ex:
-            if not hasattr(ex, 'message') or 'Not Found' not in ex.message:
+            if not hasattr(ex, 'message') or 'not found' not in ex.message.lower():
                 raise ex
 
     @sharedvault
@@ -614,7 +614,7 @@ class KeyVaultSecretTest(AzureKeyVaultTestCase):
         try:
             self.client.get_secret(secret_id.vault, secret_id.name, '')
         except Exception as ex:
-            if not hasattr(ex, 'message') or 'Not Found' not in ex.message:
+            if not hasattr(ex, 'message') or 'not found' not in ex.message.lower():
                 raise ex
 
     @sharedvault
@@ -892,7 +892,7 @@ class KeyVaultCertificateTest(AzureKeyVaultTestCase):
             self.client.get_certificate(cert_id.vault, cert_id.name, '')
             self.fail('Get should fail')
         except Exception as ex:
-            if not hasattr(ex, 'message') or 'Not Found' not in ex.message:
+            if not hasattr(ex, 'message') or 'not found' not in ex.message.lower():
                 raise ex
 
     @sharedvault
@@ -997,7 +997,7 @@ class KeyVaultCertificateTest(AzureKeyVaultTestCase):
             self.client.get_certificate_issuer(vault_uri, issuer_name)
             self.fail('Get should fail')
         except Exception as ex:
-            if not hasattr(ex, 'message') or 'Not Found' not in ex.message:
+            if not hasattr(ex, 'message') or 'not found' not in ex.message.lower():
                 raise ex
 
     @sharedvault
@@ -1073,7 +1073,7 @@ class KeyVaultCertificateTest(AzureKeyVaultTestCase):
             self.client.get_certificate_operation(vault_uri, cert_name)
             self.fail('Get should fail')
         except Exception as ex:
-            if not hasattr(ex, 'message') or 'Not Found' not in ex.message:
+            if not hasattr(ex, 'message') or 'not found' not in ex.message.lower():
                 raise ex
 
         # delete cancelled certificate operation
@@ -1106,7 +1106,7 @@ class KeyVaultCertificateTest(AzureKeyVaultTestCase):
             contacts = self.client.get_certificate_contacts(vault_uri)
             self.fail('Get should fail')
         except Exception as ex:
-            if not hasattr(ex, 'message') or 'Not Found' not in ex.message:
+            if not hasattr(ex, 'message') or 'not found' not in ex.message.lower():
                 raise ex
 
     @sharedvault


### PR DESCRIPTION
@schaabs I'm releasing a new version of msrest that improves the exception message when the JSON is correct OData v4 (i.e. error/code and error/message). This changes slightly the exception message your the KV exception, and requires a tiny fix your in your test case. I think this is ok, but need you for confirm.
This version works both with current and future msrest (so CI should be green).

Thanks