### PR TITLE
Makes dev_setup.py script more portable

### DIFF
--- a/scripts/dev_setup.py
+++ b/scripts/dev_setup.py
@@ -15,6 +15,15 @@ from subprocess import check_call, CalledProcessError
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), '..', '..'))
 
 
+def pip_command(command):
+    try:
+        print('Executing: ' + command)
+        check_call([sys.executable, '-m', 'pip'] + command.split(), cwd=root_dir)
+        print()
+    except CalledProcessError as err:
+        print(err, file=sys.stderr)
+        sys.exit(1)
+
 def exec_command(command):
     try:
         print('Executing: ' + command)
@@ -42,24 +51,24 @@ print('Running dev setup...')
 print('Root directory \'{}\'\n'.format(root_dir))
 
 # install general requirements
-exec_command('pip install -r requirements.txt')
+pip_command('install -r requirements.txt')
 
 # install packages
 for package_list in [nspkg_packages, content_packages]:
     for package_name in package_list:
-        exec_command('pip install -e {}'.format(package_name))
+        pip_command('install -e {}'.format(package_name))
 
 # install test requirements
-exec_command('pip install -r azure-sdk-testutils/test-requirements.txt')
+pip_command('install -r azure-sdk-testutils/test-requirements.txt')
 
-# isntall packaging requirements
-exec_command('pip install -r scripts/packaging_requirements.txt')
+# install packaging requirements
+pip_command('install -r scripts/packaging_requirements.txt')
 
 # install storage for tests
-exec_command('pip install azure-storage')
+pip_command('install azure-storage')
 
 # Ensure that the site package's azure/__init__.py has the old style namespace
 # package declaration by installing the old namespace package
-exec_command('pip install --force-reinstall azure-nspkg==1.0.0')
-exec_command('pip install --force-reinstall azure-mgmt-nspkg==1.0.0')
+pip_command('install --force-reinstall azure-nspkg==1.0.0')
+pip_command('install --force-reinstall azure-mgmt-nspkg==1.0.0')
 print('Finished dev setup.')

--- a/scripts/dev_setup.py
+++ b/scripts/dev_setup.py
@@ -24,15 +24,6 @@ def pip_command(command):
         print(err, file=sys.stderr)
         sys.exit(1)
 
-def exec_command(command):
-    try:
-        print('Executing: ' + command)
-        check_call(command.split(), cwd=root_dir)
-        print()
-    except CalledProcessError as err:
-        print(err, file=sys.stderr)
-        sys.exit(1)
-
 packages = [os.path.dirname(p) for p in glob.glob('azure*/setup.py')]
 
 # Extract nspkg and sort nspkg by number of "-"


### PR DESCRIPTION
This will avoid problems where `pip` on PATH does not map to the version of Python that the script was started with.

I believe the `exec_command` function is now unused, but didn't want to just delete it. LMK if you want it gone and I'll take it out.