### PR TITLE
Update setup.py for azure-keyvault

### DIFF
--- a/azure-keyvault/setup.py
+++ b/azure-keyvault/setup.py
@@ -79,7 +79,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'msrestazure>=0.4.15',
-        'msrest>=0.4.17'
+        'msrest>=0.4.17',
         'azure-common~=1.1.5',
     ],
     cmdclass=cmdclass


### PR DESCRIPTION
comma is missing in install_requires, so fixing it. Throws error "error in azure-keyvault setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected ',' or end-of-list in msrest>=0.4.17azure-common~=1.1.5 at ~=1.1.5"