### PR TITLE
[AutoPR apimanagement/resource-manager] Fixing entities which should be per ApiRevision instead of just ApiId

### DIFF
--- a/azure-mgmt-apimanagement/azure/mgmt/apimanagement/models/api_create_or_update_parameter.py
+++ b/azure-mgmt-apimanagement/azure/mgmt/apimanagement/models/api_create_or_update_parameter.py
@@ -75,8 +75,8 @@ class ApiCreateOrUpdateParameter(Model):
      ~azure.mgmt.apimanagement.models.ApiCreateOrUpdatePropertiesWsdlSelector
     :param soap_api_type: Type of Api to create.
      * `http` creates a SOAP to REST API
-     * `soap` creates a SOAP pass-through API. Possible values include: 'http',
-     'soap'
+     * `soap` creates a SOAP pass-through API. Possible values include:
+     'SoapToRest', 'SoapPassThrough'
     :type soap_api_type: str or ~azure.mgmt.apimanagement.models.SoapApiType
     """
 

--- a/azure-mgmt-apimanagement/azure/mgmt/apimanagement/models/api_create_or_update_parameter_py3.py
+++ b/azure-mgmt-apimanagement/azure/mgmt/apimanagement/models/api_create_or_update_parameter_py3.py
@@ -75,8 +75,8 @@ class ApiCreateOrUpdateParameter(Model):
      ~azure.mgmt.apimanagement.models.ApiCreateOrUpdatePropertiesWsdlSelector
     :param soap_api_type: Type of Api to create.
      * `http` creates a SOAP to REST API
-     * `soap` creates a SOAP pass-through API. Possible values include: 'http',
-     'soap'
+     * `soap` creates a SOAP pass-through API. Possible values include:
+     'SoapToRest', 'SoapPassThrough'
     :type soap_api_type: str or ~azure.mgmt.apimanagement.models.SoapApiType
     """
 

--- a/azure-mgmt-apimanagement/azure/mgmt/apimanagement/models/api_management_client_enums.py
+++ b/azure-mgmt-apimanagement/azure/mgmt/apimanagement/models/api_management_client_enums.py
@@ -36,8 +36,8 @@ class ContentFormat(str, Enum):
 
 class SoapApiType(str, Enum):
 
-    http = "http"
-    soap = "soap"
+    soap_to_rest = "http"
+    soap_pass_through = "soap"
 
 
 class ApiType(str, Enum):

--- a/azure-mgmt-apimanagement/azure/mgmt/apimanagement/operations/api_export_operations.py
+++ b/azure-mgmt-apimanagement/azure/mgmt/apimanagement/operations/api_export_operations.py
@@ -47,8 +47,9 @@ class ApiExportOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param format: Format in which to export the Api Details to the
          Storage Blob with Sas Key valid for 5 minutes. Possible values
@@ -70,7 +71,7 @@ class ApiExportOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
         url = self._client.format_url(url, **path_format_arguments)

--- a/azure-mgmt-apimanagement/azure/mgmt/apimanagement/operations/api_operation_operations.py
+++ b/azure-mgmt-apimanagement/azure/mgmt/apimanagement/operations/api_operation_operations.py
@@ -142,8 +142,9 @@ class ApiOperationOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param operation_id: Operation identifier within an API. Must be
          unique in the current API Management service instance.
@@ -163,7 +164,7 @@ class ApiOperationOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'operationId': self._serialize.url("operation_id", operation_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }

--- a/azure-mgmt-apimanagement/azure/mgmt/apimanagement/operations/api_operation_policy_operations.py
+++ b/azure-mgmt-apimanagement/azure/mgmt/apimanagement/operations/api_operation_policy_operations.py
@@ -117,8 +117,9 @@ class ApiOperationPolicyOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param operation_id: Operation identifier within an API. Must be
          unique in the current API Management service instance.
@@ -138,7 +139,7 @@ class ApiOperationPolicyOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'operationId': self._serialize.url("operation_id", operation_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'policyId': self._serialize.url("self.policy_id", self.policy_id, 'str'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
@@ -349,8 +350,9 @@ class ApiOperationPolicyOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param operation_id: Operation identifier within an API. Must be
          unique in the current API Management service instance.
@@ -374,7 +376,7 @@ class ApiOperationPolicyOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'operationId': self._serialize.url("operation_id", operation_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'policyId': self._serialize.url("self.policy_id", self.policy_id, 'str'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')

--- a/azure-mgmt-apimanagement/azure/mgmt/apimanagement/operations/api_policy_operations.py
+++ b/azure-mgmt-apimanagement/azure/mgmt/apimanagement/operations/api_policy_operations.py
@@ -46,8 +46,9 @@ class ApiPolicyOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the
@@ -65,7 +66,7 @@ class ApiPolicyOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
         url = self._client.format_url(url, **path_format_arguments)
@@ -117,8 +118,9 @@ class ApiPolicyOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the
@@ -135,7 +137,7 @@ class ApiPolicyOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'policyId': self._serialize.url("self.policy_id", self.policy_id, 'str'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }

--- a/azure-mgmt-apimanagement/azure/mgmt/apimanagement/operations/api_schema_operations.py
+++ b/azure-mgmt-apimanagement/azure/mgmt/apimanagement/operations/api_schema_operations.py
@@ -44,8 +44,9 @@ class ApiSchemaOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the
@@ -66,7 +67,7 @@ class ApiSchemaOperations(object):
                 path_format_arguments = {
                     'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
                     'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-                    'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+                    'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
                     'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
                 }
                 url = self._client.format_url(url, **path_format_arguments)
@@ -119,8 +120,9 @@ class ApiSchemaOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param schema_id: Schema identifier within an API. Must be unique in
          the current API Management service instance.
@@ -140,7 +142,7 @@ class ApiSchemaOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'schemaId': self._serialize.url("schema_id", schema_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -183,8 +185,9 @@ class ApiSchemaOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param schema_id: Schema identifier within an API. Must be unique in
          the current API Management service instance.
@@ -205,7 +208,7 @@ class ApiSchemaOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'schemaId': self._serialize.url("schema_id", schema_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -257,8 +260,9 @@ class ApiSchemaOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param schema_id: Schema identifier within an API. Must be unique in
          the current API Management service instance.
@@ -291,7 +295,7 @@ class ApiSchemaOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'schemaId': self._serialize.url("schema_id", schema_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -346,8 +350,9 @@ class ApiSchemaOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param schema_id: Schema identifier within an API. Must be unique in
          the current API Management service instance.
@@ -371,7 +376,7 @@ class ApiSchemaOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'schemaId': self._serialize.url("schema_id", schema_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }

--- a/azure-mgmt-apimanagement/azure/mgmt/apimanagement/operations/operation_operations.py
+++ b/azure-mgmt-apimanagement/azure/mgmt/apimanagement/operations/operation_operations.py
@@ -45,8 +45,9 @@ class OperationOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param filter: | Field       | Supported operators    | Supported
          functions                         |
@@ -86,7 +87,7 @@ class OperationOperations(object):
                 path_format_arguments = {
                     'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
                     'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-                    'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+                    'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
                     'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
                 }
                 url = self._client.format_url(url, **path_format_arguments)

--- a/azure-mgmt-apimanagement/azure/mgmt/apimanagement/operations/tag_description_operations.py
+++ b/azure-mgmt-apimanagement/azure/mgmt/apimanagement/operations/tag_description_operations.py
@@ -46,8 +46,9 @@ class TagDescriptionOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param filter: | Field       | Supported operators    | Supported
          functions                         |
@@ -80,7 +81,7 @@ class TagDescriptionOperations(object):
                 path_format_arguments = {
                     'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
                     'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-                    'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+                    'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
                     'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
                 }
                 url = self._client.format_url(url, **path_format_arguments)
@@ -138,8 +139,9 @@ class TagDescriptionOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param tag_id: Tag identifier. Must be unique in the current API
          Management service instance.
@@ -159,7 +161,7 @@ class TagDescriptionOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'tagId': self._serialize.url("tag_id", tag_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -202,8 +204,9 @@ class TagDescriptionOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param tag_id: Tag identifier. Must be unique in the current API
          Management service instance.
@@ -224,7 +227,7 @@ class TagDescriptionOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'tagId': self._serialize.url("tag_id", tag_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -276,8 +279,9 @@ class TagDescriptionOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param tag_id: Tag identifier. Must be unique in the current API
          Management service instance.
@@ -304,7 +308,7 @@ class TagDescriptionOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'tagId': self._serialize.url("tag_id", tag_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -359,8 +363,9 @@ class TagDescriptionOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param tag_id: Tag identifier. Must be unique in the current API
          Management service instance.
@@ -384,7 +389,7 @@ class TagDescriptionOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'tagId': self._serialize.url("tag_id", tag_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }

--- a/azure-mgmt-apimanagement/azure/mgmt/apimanagement/operations/tag_operations.py
+++ b/azure-mgmt-apimanagement/azure/mgmt/apimanagement/operations/tag_operations.py
@@ -471,8 +471,9 @@ class TagOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param filter: | Field       | Supported operators    | Supported
          functions                         |
@@ -505,7 +506,7 @@ class TagOperations(object):
                 path_format_arguments = {
                     'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
                     'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-                    'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+                    'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
                     'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
                 }
                 url = self._client.format_url(url, **path_format_arguments)
@@ -563,8 +564,9 @@ class TagOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param tag_id: Tag identifier. Must be unique in the current API
          Management service instance.
@@ -584,7 +586,7 @@ class TagOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'tagId': self._serialize.url("tag_id", tag_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -627,8 +629,9 @@ class TagOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param tag_id: Tag identifier. Must be unique in the current API
          Management service instance.
@@ -649,7 +652,7 @@ class TagOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'tagId': self._serialize.url("tag_id", tag_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -701,8 +704,9 @@ class TagOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param tag_id: Tag identifier. Must be unique in the current API
          Management service instance.
@@ -726,7 +730,7 @@ class TagOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'tagId': self._serialize.url("tag_id", tag_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -777,8 +781,9 @@ class TagOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param tag_id: Tag identifier. Must be unique in the current API
          Management service instance.
@@ -802,7 +807,7 @@ class TagOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'tagId': self._serialize.url("tag_id", tag_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -843,8 +848,9 @@ class TagOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param operation_id: Operation identifier within an API. Must be
          unique in the current API Management service instance.
@@ -886,7 +892,7 @@ class TagOperations(object):
                 path_format_arguments = {
                     'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
                     'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-                    'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+                    'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
                     'operationId': self._serialize.url("operation_id", operation_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
                     'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
                 }
@@ -945,8 +951,9 @@ class TagOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param operation_id: Operation identifier within an API. Must be
          unique in the current API Management service instance.
@@ -969,7 +976,7 @@ class TagOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'operationId': self._serialize.url("operation_id", operation_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'tagId': self._serialize.url("tag_id", tag_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
@@ -1013,8 +1020,9 @@ class TagOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param operation_id: Operation identifier within an API. Must be
          unique in the current API Management service instance.
@@ -1038,7 +1046,7 @@ class TagOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'operationId': self._serialize.url("operation_id", operation_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'tagId': self._serialize.url("tag_id", tag_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
@@ -1091,8 +1099,9 @@ class TagOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param operation_id: Operation identifier within an API. Must be
          unique in the current API Management service instance.
@@ -1119,7 +1128,7 @@ class TagOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'operationId': self._serialize.url("operation_id", operation_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'tagId': self._serialize.url("tag_id", tag_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
@@ -1171,8 +1180,9 @@ class TagOperations(object):
         :type resource_group_name: str
         :param service_name: The name of the API Management service.
         :type service_name: str
-        :param api_id: API identifier. Must be unique in the current API
-         Management service instance.
+        :param api_id: API revision identifier. Must be unique in the current
+         API Management service instance. Non-current revision has ;rev=n as a
+         suffix where n is the revision number.
         :type api_id: str
         :param operation_id: Operation identifier within an API. Must be
          unique in the current API Management service instance.
@@ -1199,7 +1209,7 @@ class TagOperations(object):
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'serviceName': self._serialize.url("service_name", service_name, 'str', max_length=50, min_length=1, pattern=r'^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'),
-            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
+            'apiId': self._serialize.url("api_id", api_id, 'str', max_length=256, min_length=1, pattern=r'^[^*#&+:<>?]+$'),
             'operationId': self._serialize.url("operation_id", operation_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'tagId': self._serialize.url("tag_id", tag_id, 'str', max_length=80, min_length=1, pattern=r'(^[\w]+$)|(^[\w][\w\-]+[\w]$)'),
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/2622