### PR TITLE
[AutoPR containerinstance/resource-manager] Fixing Error in Naming Convention for Rows and Cols in Terminal Size

### DIFF
--- a/azure-mgmt-containerinstance/azure/mgmt/containerinstance/models/container_exec_request_terminal_size.py
+++ b/azure-mgmt-containerinstance/azure/mgmt/containerinstance/models/container_exec_request_terminal_size.py
@@ -15,18 +15,18 @@ from msrest.serialization import Model
 class ContainerExecRequestTerminalSize(Model):
     """The size of the terminal.
 
-    :param row: The row size of the terminal
-    :type row: int
-    :param column: The column size of the terminal
-    :type column: int
+    :param rows: The row size of the terminal
+    :type rows: int
+    :param cols: The column size of the terminal
+    :type cols: int
     """
 
     _attribute_map = {
-        'row': {'key': 'row', 'type': 'int'},
-        'column': {'key': 'column', 'type': 'int'},
+        'rows': {'key': 'rows', 'type': 'int'},
+        'cols': {'key': 'cols', 'type': 'int'},
     }
 
-    def __init__(self, row=None, column=None):
+    def __init__(self, rows=None, cols=None):
         super(ContainerExecRequestTerminalSize, self).__init__()
-        self.row = row
-        self.column = column
+        self.rows = rows
+        self.cols = cols


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/2651