### PR TITLE
Updated documentation to reflect need for zone_type parameter when creating a zone

### DIFF
--- a/doc/sample_azure-mgmt-dns.rst
+++ b/doc/sample_azure-mgmt-dns.rst
@@ -44,6 +44,7 @@ Create DNS zone
 		'MyResourceGroup',
 		'pydns.com',
 		{
+			'zone_type': 'Public', # or Private
 			'location': 'global'
 		}
 	)


### PR DESCRIPTION
With the inclusion of private DNS zones to the SDK, the documentation needs to reflect the additional parameter required when defining a zone.  Following the documentation in the examples results in the following exception:

...
  File "/usr/local/lib/python2.7/dist-packages/azure/mgmt/dns/operations/zones_operations.py", line 100, in create_or_update
    body_content = self._serialize.body(parameters, 'Zone')
  File "/usr/local/lib/python2.7/dist-packages/msrest/serialization.py", line 475, in body
    raise errors[0]
msrest.exceptions.ValidationError: Parameter 'Zone.zone_type' can not be None.