### PR TITLE
Fix: get_client_from_cli_profile and ADLA

### DIFF
--- a/azure-common/azure/common/client_factory.py
+++ b/azure-common/azure/common/client_factory.py
@@ -63,10 +63,11 @@ def get_client_from_cli_profile(client_class, **kwargs):
             'credentials': kwargs.get('credentials', credentials),
             'subscription_id': kwargs.get('subscription_id', subscription_id)
         })
-    if 'base_url' not in kwargs:
-        cloud = get_cli_active_cloud()
-        # api_version_profile = cloud.profile # TBC using _shared
-        parameters['base_url'] = cloud.endpoints.resource_manager
+    if client_class not in [DataLakeAnalyticsJobManagementClient]:
+        if 'base_url' not in kwargs:
+            cloud = get_cli_active_cloud()
+            # api_version_profile = cloud.profile # TBC using _shared
+            parameters['base_url'] = cloud.endpoints.resource_manager
     parameters.update(kwargs)
     return _instantiate_client(client_class, **parameters)
 


### PR DESCRIPTION
This fixes a bug when calling `get_client_from_cli_profile(DataLakeAnalyticsJobManagementClient)`.

The root cause is that `DataLakeAnalyticsJobManagementClient` does not accept a `base_url` argument, and the constructor does not test if this is a valid argument for the given `client_class` constructor.

I've testing this successfully and there do not seem to be any negative effects.