### PR TITLE
Require newer azure-common version

### DIFF
--- a/azure-mgmt-compute/setup.py
+++ b/azure-mgmt-compute/setup.py
@@ -78,7 +78,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     install_requires=[
         'msrestazure>=0.4.27,<2.0.0',
-        'azure-common~=1.1',
+        'azure-common~=1.1,>=1.1.9',
     ],
     cmdclass=cmdclass
 )

--- a/azure-mgmt-resource/setup.py
+++ b/azure-mgmt-resource/setup.py
@@ -78,7 +78,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     install_requires=[
         'msrestazure>=0.4.27,<2.0.0',
-        'azure-common~=1.1',
+        'azure-common~=1.1,>=1.1.9',
     ],
     cmdclass=cmdclass
 )


### PR DESCRIPTION
Resolves #2644. This tightens the dependencies for three packages, so that they now require a version of `azure-common` that includes `azure.profiles`. More information in #2644.

Sorry if this is already being worked on!