### PR TITLE
[AutoPR cognitiveservices/data-plane/ComputerVision] Add Spanish as an option as ServiceLanguage for ComputerVision

### DIFF
--- a/azure-cognitiveservices-vision-computervision/azure/cognitiveservices/vision/computervision/computer_vision_api.py
+++ b/azure-cognitiveservices-vision-computervision/azure/cognitiveservices/vision/computervision/computer_vision_api.py
@@ -169,9 +169,9 @@ class ComputerVisionAPI(SDKClient):
          ~azure.cognitiveservices.vision.computervision.models.Details]
         :param language: The desired language for output generation. If this
          parameter is not specified, the default value is
-         &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese
-         pt - Portuguese zh - Simplified Chinese. Possible values include:
-         'en', 'ja', 'pt', 'zh'
+         &quot;en&quot;.Supported languages:en - English, Default. es -
+         Spanish, ja - Japanese, pt - Portuguese, zh - Simplified Chinese.
+         Possible values include: 'en', 'es', 'ja', 'pt', 'zh'
         :type language: str
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the
@@ -412,9 +412,9 @@ class ComputerVisionAPI(SDKClient):
         :type max_candidates: str
         :param language: The desired language for output generation. If this
          parameter is not specified, the default value is
-         &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese
-         pt - Portuguese zh - Simplified Chinese. Possible values include:
-         'en', 'ja', 'pt', 'zh'
+         &quot;en&quot;.Supported languages:en - English, Default. es -
+         Spanish, ja - Japanese, pt - Portuguese, zh - Simplified Chinese.
+         Possible values include: 'en', 'es', 'ja', 'pt', 'zh'
         :type language: str
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the
@@ -488,9 +488,9 @@ class ComputerVisionAPI(SDKClient):
         :type url: str
         :param language: The desired language for output generation. If this
          parameter is not specified, the default value is
-         &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese
-         pt - Portuguese zh - Simplified Chinese. Possible values include:
-         'en', 'ja', 'pt', 'zh'
+         &quot;en&quot;.Supported languages:en - English, Default. es -
+         Spanish, ja - Japanese, pt - Portuguese, zh - Simplified Chinese.
+         Possible values include: 'en', 'es', 'ja', 'pt', 'zh'
         :type language: str
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the
@@ -564,9 +564,9 @@ class ComputerVisionAPI(SDKClient):
         :type url: str
         :param language: The desired language for output generation. If this
          parameter is not specified, the default value is
-         &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese
-         pt - Portuguese zh - Simplified Chinese. Possible values include:
-         'en', 'ja', 'pt', 'zh'
+         &quot;en&quot;.Supported languages:en - English, Default. es -
+         Spanish, ja - Japanese, pt - Portuguese, zh - Simplified Chinese.
+         Possible values include: 'en', 'es', 'ja', 'pt', 'zh'
         :type language: str
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the
@@ -771,9 +771,9 @@ class ComputerVisionAPI(SDKClient):
         :type details: str
         :param language: The desired language for output generation. If this
          parameter is not specified, the default value is
-         &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese
-         pt - Portuguese zh - Simplified Chinese. Possible values include:
-         'en', 'ja', 'pt', 'zh'
+         &quot;en&quot;.Supported languages:en - English, Default. es -
+         Spanish, ja - Japanese, pt - Portuguese, zh - Simplified Chinese.
+         Possible values include: 'en', 'es', 'ja', 'pt', 'zh'
         :type language: str
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the
@@ -1018,9 +1018,9 @@ class ComputerVisionAPI(SDKClient):
         :type max_candidates: str
         :param language: The desired language for output generation. If this
          parameter is not specified, the default value is
-         &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese
-         pt - Portuguese zh - Simplified Chinese. Possible values include:
-         'en', 'ja', 'pt', 'zh'
+         &quot;en&quot;.Supported languages:en - English, Default. es -
+         Spanish, ja - Japanese, pt - Portuguese, zh - Simplified Chinese.
+         Possible values include: 'en', 'es', 'ja', 'pt', 'zh'
         :type language: str
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the
@@ -1097,9 +1097,9 @@ class ComputerVisionAPI(SDKClient):
         :type image: Generator
         :param language: The desired language for output generation. If this
          parameter is not specified, the default value is
-         &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese
-         pt - Portuguese zh - Simplified Chinese. Possible values include:
-         'en', 'ja', 'pt', 'zh'
+         &quot;en&quot;.Supported languages:en - English, Default. es -
+         Spanish, ja - Japanese, pt - Portuguese, zh - Simplified Chinese.
+         Possible values include: 'en', 'es', 'ja', 'pt', 'zh'
         :type language: str
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the
@@ -1176,9 +1176,9 @@ class ComputerVisionAPI(SDKClient):
         :type image: Generator
         :param language: The desired language for output generation. If this
          parameter is not specified, the default value is
-         &quot;en&quot;.Supported languages:en - English, Default.ja - Japanese
-         pt - Portuguese zh - Simplified Chinese. Possible values include:
-         'en', 'ja', 'pt', 'zh'
+         &quot;en&quot;.Supported languages:en - English, Default. es -
+         Spanish, ja - Japanese, pt - Portuguese, zh - Simplified Chinese.
+         Possible values include: 'en', 'es', 'ja', 'pt', 'zh'
         :type language: str
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3222