### PR TITLE
[AutoPR network/resource-manager] network: add https probe which was missing in the spec

### DIFF
--- a/azure-mgmt-network/azure/mgmt/network/v2018_02_01/models/network_management_client_enums.py
+++ b/azure-mgmt-network/azure/mgmt/network/v2018_02_01/models/network_management_client_enums.py
@@ -261,6 +261,7 @@ class ProbeProtocol(str, Enum):
 
     http = "Http"
     tcp = "Tcp"
+    https = "Https"
 
 
 class NetworkOperationStatus(str, Enum):

--- a/azure-mgmt-network/azure/mgmt/network/v2018_02_01/models/probe.py
+++ b/azure-mgmt-network/azure/mgmt/network/v2018_02_01/models/probe.py
@@ -26,10 +26,10 @@ class Probe(SubResource):
     :vartype load_balancing_rules:
      list[~azure.mgmt.network.v2018_02_01.models.SubResource]
     :param protocol: Required. The protocol of the end point. Possible values
-     are: 'Http' or 'Tcp'. If 'Tcp' is specified, a received ACK is required
-     for the probe to be successful. If 'Http' is specified, a 200 OK response
-     from the specifies URI is required for the probe to be successful.
-     Possible values include: 'Http', 'Tcp'
+     are: 'Http', 'Tcp' or 'Https'. If 'Tcp' is specified, a received ACK is
+     required for the probe to be successful. If 'Http' or 'Https' is
+     specified, a 200 OK response from the specifies URI is required for the
+     probe to be successful. Possible values include: 'Http', 'Tcp', 'Https'
     :type protocol: str or
      ~azure.mgmt.network.v2018_02_01.models.ProbeProtocol
     :param port: Required. The port for communicating the probe. Possible

--- a/azure-mgmt-network/azure/mgmt/network/v2018_02_01/models/probe_py3.py
+++ b/azure-mgmt-network/azure/mgmt/network/v2018_02_01/models/probe_py3.py
@@ -26,10 +26,10 @@ class Probe(SubResource):
     :vartype load_balancing_rules:
      list[~azure.mgmt.network.v2018_02_01.models.SubResource]
     :param protocol: Required. The protocol of the end point. Possible values
-     are: 'Http' or 'Tcp'. If 'Tcp' is specified, a received ACK is required
-     for the probe to be successful. If 'Http' is specified, a 200 OK response
-     from the specifies URI is required for the probe to be successful.
-     Possible values include: 'Http', 'Tcp'
+     are: 'Http', 'Tcp' or 'Https'. If 'Tcp' is specified, a received ACK is
+     required for the probe to be successful. If 'Http' or 'Https' is
+     specified, a 200 OK response from the specifies URI is required for the
+     probe to be successful. Possible values include: 'Http', 'Tcp', 'Https'
     :type protocol: str or
      ~azure.mgmt.network.v2018_02_01.models.ProbeProtocol
     :param port: Required. The port for communicating the probe. Possible

--- a/azure-mgmt-network/azure/mgmt/network/v2018_04_01/models/network_management_client_enums.py
+++ b/azure-mgmt-network/azure/mgmt/network/v2018_04_01/models/network_management_client_enums.py
@@ -261,6 +261,7 @@ class ProbeProtocol(str, Enum):
 
     http = "Http"
     tcp = "Tcp"
+    https = "Https"
 
 
 class NetworkOperationStatus(str, Enum):

--- a/azure-mgmt-network/azure/mgmt/network/v2018_04_01/models/probe.py
+++ b/azure-mgmt-network/azure/mgmt/network/v2018_04_01/models/probe.py
@@ -26,10 +26,10 @@ class Probe(SubResource):
     :vartype load_balancing_rules:
      list[~azure.mgmt.network.v2018_04_01.models.SubResource]
     :param protocol: Required. The protocol of the end point. Possible values
-     are: 'Http' or 'Tcp'. If 'Tcp' is specified, a received ACK is required
-     for the probe to be successful. If 'Http' is specified, a 200 OK response
-     from the specifies URI is required for the probe to be successful.
-     Possible values include: 'Http', 'Tcp'
+     are: 'Http', 'Tcp', or 'Https'. If 'Tcp' is specified, a received ACK is
+     required for the probe to be successful. If 'Http' or 'Https' is
+     specified, a 200 OK response from the specifies URI is required for the
+     probe to be successful. Possible values include: 'Http', 'Tcp', 'Https'
     :type protocol: str or
      ~azure.mgmt.network.v2018_04_01.models.ProbeProtocol
     :param port: Required. The port for communicating the probe. Possible

--- a/azure-mgmt-network/azure/mgmt/network/v2018_04_01/models/probe_py3.py
+++ b/azure-mgmt-network/azure/mgmt/network/v2018_04_01/models/probe_py3.py
@@ -26,10 +26,10 @@ class Probe(SubResource):
     :vartype load_balancing_rules:
      list[~azure.mgmt.network.v2018_04_01.models.SubResource]
     :param protocol: Required. The protocol of the end point. Possible values
-     are: 'Http' or 'Tcp'. If 'Tcp' is specified, a received ACK is required
-     for the probe to be successful. If 'Http' is specified, a 200 OK response
-     from the specifies URI is required for the probe to be successful.
-     Possible values include: 'Http', 'Tcp'
+     are: 'Http', 'Tcp', or 'Https'. If 'Tcp' is specified, a received ACK is
+     required for the probe to be successful. If 'Http' or 'Https' is
+     specified, a 200 OK response from the specifies URI is required for the
+     probe to be successful. Possible values include: 'Http', 'Tcp', 'Https'
     :type protocol: str or
      ~azure.mgmt.network.v2018_04_01.models.ProbeProtocol
     :param port: Required. The port for communicating the probe. Possible


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3230