### PR TITLE
Updated RecoveryServicesBackup client and BackupStatusOperations

### DIFF
--- a/azure-mgmt-recoveryservicesbackup/azure/mgmt/recoveryservicesbackup/operations/backup_status_operations.py
+++ b/azure-mgmt-recoveryservicesbackup/azure/mgmt/recoveryservicesbackup/operations/backup_status_operations.py
@@ -27,13 +27,14 @@ class BackupStatusOperations(object):
     """
 
     models = models
+    default_api_version = "2017-07-01"
 
-    def __init__(self, client, config, serializer, deserializer):
+    def __init__(self, client, config, serializer, deserializer, api_version=default_api_version):
 
         self._client = client
         self._serialize = serializer
         self._deserialize = deserializer
-        self.api_version = "2017-07-01"
+        self.api_version = api_version
 
         self.config = config
 

--- a/azure-mgmt-recoveryservicesbackup/azure/mgmt/recoveryservicesbackup/recovery_services_backup_client.py
+++ b/azure-mgmt-recoveryservicesbackup/azure/mgmt/recoveryservicesbackup/recovery_services_backup_client.py
@@ -172,7 +172,7 @@ class RecoveryServicesBackupClient(SDKClient):
     """
 
     def __init__(
-            self, credentials, subscription_id, base_url=None):
+            self, credentials, subscription_id, base_url=None, api_version=None):
 
         self.config = RecoveryServicesBackupClientConfiguration(credentials, subscription_id, base_url)
         super(RecoveryServicesBackupClient, self).__init__(self.config.credentials, self.config)
@@ -184,7 +184,7 @@ class RecoveryServicesBackupClient(SDKClient):
         self.protection_intent = ProtectionIntentOperations(
             self._client, self.config, self._serialize, self._deserialize)
         self.backup_status = BackupStatusOperations(
-            self._client, self.config, self._serialize, self._deserialize)
+            self._client, self.config, self._serialize, self._deserialize, api_version=api_version)
         self.feature_support = FeatureSupportOperations(
             self._client, self.config, self._serialize, self._deserialize)
         self.backup_jobs = BackupJobsOperations(


### PR DESCRIPTION
Currently, the BackupStatusOperations class has a hard-coded API version which is not supported. This means that calling the get() method return an error: 

> Message: The resource type 'locations/backupStatus' could not be found in the namespace 'Microsoft.RecoveryServices' for api version '2017-07-01'. The supported api-versions are '2016-06-01,2016-08-10,2016-05-01,2015-12-15,2015-12-10,2015-11-10,2015-06-10,2015-08-10,2015-08-15,2015-03-15'

This edit allows for the API version to be passed as an optional argument in the constructor - the default value remains the same as the hard coded version ("2017-07-01"), but this allows users to optionally opt for an older version when creating the RecoveryServicesBackup client.