### PR TITLE
[AutoPR network/resource-manager] Fix Usages' validation to allow display names like "West US"

### DIFF
--- a/azure-mgmt-network/azure/mgmt/network/v2018_07_01/operations/usages_operations.py
+++ b/azure-mgmt-network/azure/mgmt/network/v2018_07_01/operations/usages_operations.py
@@ -59,7 +59,7 @@ class UsagesOperations(object):
                 # Construct URL
                 url = self.list.metadata['url']
                 path_format_arguments = {
-                    'location': self._serialize.url("location", location, 'str', pattern=r'^[-\w\._]+$'),
+                    'location': self._serialize.url("location", location, 'str', pattern=r'^[-\w\._ ]+$'),
                     'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
                 }
                 url = self._client.format_url(url, **path_format_arguments)


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/3583