### PR TITLE
[Cogs Face] Update Face SDK test aligning with latest Swagger changes.

### DIFF
--- a/azure-cognitiveservices-vision-face/tests/test_face.py
+++ b/azure-cognitiveservices-vision-face/tests/test_face.py
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------
 from os.path import dirname, join, realpath
 
-from azure.cognitiveservices.vision.face import FaceAPI
+from azure.cognitiveservices.vision.face import FaceClient
 from azure.cognitiveservices.vision.face.models import Gender
 from msrest.authentication import CognitiveServicesCredentials
 
@@ -48,9 +48,9 @@ class FaceTest(ReplayableTest):
         credentials = CognitiveServicesCredentials(
             self.settings.CS_SUBSCRIPTION_KEY
         )
-        face_api = FaceAPI("westus2", credentials=credentials)
+        face_client = FaceClient("https://westus2.api.cognitive.microsoft.com", credentials=credentials)
         with open(join(CWD, "facefindsimilar.queryface.jpg"), "rb") as face_fd:
-            result = face_api.face.detect_with_stream(
+            result = face_client.face.detect_with_stream(
                 face_fd,
                 return_face_attributes=['age','gender','headPose','smile','facialHair','glasses','emotion','hair','makeup','occlusion','accessories','blur','exposure','noise']
             )


### PR DESCRIPTION
I am from Face team and recently updated the latest Face Swagger by Azure/azure-rest-api-specs#3552. 

As you can see from the endpoint change [`vision/face/__init__.py`](https://github.com/Azure/azure-sdk-for-python/pull/3011/files#diff-d89710181787ef8083f0b7a338d13a93), I raise this PR to update the face test so as to make this branch pass build tests.