### PR TITLE
Fixes redis export operation

### DIFF
--- a/azure-mgmt-redis/azure/mgmt/redis/operations/redis_operations.py
+++ b/azure-mgmt-redis/azure/mgmt/redis/operations/redis_operations.py
@@ -877,7 +877,7 @@ class RedisOperations(object):
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
 
-    def export_data(
+    def export(
             self, resource_group_name, name, parameters, custom_headers=None, raw=False, **operation_config):
         """Export data from the redis cache to blobs in a container.
 


### PR DESCRIPTION
Changed `export_data` to `export` to fix error described in #3198