### PR TITLE
Add docstring to indicate only one agent_pool_profile can be in the list

### DIFF
--- a/azure-mgmt-containerservice/azure/mgmt/containerservice/models/managed_cluster.py
+++ b/azure-mgmt-containerservice/azure/mgmt/containerservice/models/managed_cluster.py
@@ -40,7 +40,7 @@ class ManagedCluster(Resource):
     :type dns_prefix: str
     :ivar fqdn: FDQN for the master pool.
     :vartype fqdn: str
-    :param agent_pool_profiles: Properties of the agent pool.
+    :param agent_pool_profiles: Properties of the agent pool. Currently only one agent_pool_profile can exist.
     :type agent_pool_profiles:
      list[~azure.mgmt.containerservice.models.ManagedClusterAgentPoolProfile]
     :param linux_profile: Profile for Linux VMs in the container service


### PR DESCRIPTION
Enhance documentation so limit of one agent_pool_profile per managed_cluster is more clear