### PR TITLE
Revert "3.4 allowed failure to workaround vcrpy 2.0.0"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ matrix:
 #    - python: "pypy2.7-5.8.0"
     - python: "pypy3.5-5.8.0"
     - python: "nightly"
-    - python: "3.4"
   fast_finish: true
 # Perform the manual steps on osx to install python3 and activate venv
 before_install:


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-python#3405