### PR TITLE
[AutoPR trafficmanager/resource-manager] Do not omit type and name while serializing the resource object.

### DIFF
--- a/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/endpoint.py
+++ b/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/endpoint.py
@@ -15,17 +15,14 @@ from .proxy_resource import ProxyResource
 class Endpoint(ProxyResource):
     """Class representing a Traffic Manager endpoint.
 
-    Variables are only populated by the server, and will be ignored when
-    sending a request.
-
     :param id: Fully qualified resource Id for the resource. Ex -
      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
     :type id: str
-    :ivar name: The name of the resource
-    :vartype name: str
-    :ivar type: The type of the resource. Ex-
+    :param name: The name of the resource
+    :type name: str
+    :param type: The type of the resource. Ex-
      Microsoft.Network/trafficmanagerProfiles.
-    :vartype type: str
+    :type type: str
     :param target_resource_id: The Azure Resource URI of the of the endpoint.
      Not applicable to endpoints of type 'ExternalEndpoints'.
     :type target_resource_id: str
@@ -73,11 +70,6 @@ class Endpoint(ProxyResource):
     :type custom_headers:
      list[~azure.mgmt.trafficmanager.models.EndpointPropertiesCustomHeadersItem]
     """
-
-    _validation = {
-        'name': {'readonly': True},
-        'type': {'readonly': True},
-    }
 
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},

--- a/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/endpoint_py3.py
+++ b/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/endpoint_py3.py
@@ -15,17 +15,14 @@ from .proxy_resource_py3 import ProxyResource
 class Endpoint(ProxyResource):
     """Class representing a Traffic Manager endpoint.
 
-    Variables are only populated by the server, and will be ignored when
-    sending a request.
-
     :param id: Fully qualified resource Id for the resource. Ex -
      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
     :type id: str
-    :ivar name: The name of the resource
-    :vartype name: str
-    :ivar type: The type of the resource. Ex-
+    :param name: The name of the resource
+    :type name: str
+    :param type: The type of the resource. Ex-
      Microsoft.Network/trafficmanagerProfiles.
-    :vartype type: str
+    :type type: str
     :param target_resource_id: The Azure Resource URI of the of the endpoint.
      Not applicable to endpoints of type 'ExternalEndpoints'.
     :type target_resource_id: str
@@ -74,11 +71,6 @@ class Endpoint(ProxyResource):
      list[~azure.mgmt.trafficmanager.models.EndpointPropertiesCustomHeadersItem]
     """
 
-    _validation = {
-        'name': {'readonly': True},
-        'type': {'readonly': True},
-    }
-
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},
         'name': {'key': 'name', 'type': 'str'},
@@ -96,8 +88,8 @@ class Endpoint(ProxyResource):
         'custom_headers': {'key': 'properties.customHeaders', 'type': '[EndpointPropertiesCustomHeadersItem]'},
     }
 
-    def __init__(self, *, id: str=None, target_resource_id: str=None, target: str=None, endpoint_status=None, weight: int=None, priority: int=None, endpoint_location: str=None, endpoint_monitor_status=None, min_child_endpoints: int=None, geo_mapping=None, subnets=None, custom_headers=None, **kwargs) -> None:
-        super(Endpoint, self).__init__(id=id, **kwargs)
+    def __init__(self, *, id: str=None, name: str=None, type: str=None, target_resource_id: str=None, target: str=None, endpoint_status=None, weight: int=None, priority: int=None, endpoint_location: str=None, endpoint_monitor_status=None, min_child_endpoints: int=None, geo_mapping=None, subnets=None, custom_headers=None, **kwargs) -> None:
+        super(Endpoint, self).__init__(id=id, name=name, type=type, **kwargs)
         self.target_resource_id = target_resource_id
         self.target = target
         self.endpoint_status = endpoint_status

--- a/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/heat_map_model.py
+++ b/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/heat_map_model.py
@@ -15,17 +15,14 @@ from .proxy_resource import ProxyResource
 class HeatMapModel(ProxyResource):
     """Class representing a Traffic Manager HeatMap.
 
-    Variables are only populated by the server, and will be ignored when
-    sending a request.
-
     :param id: Fully qualified resource Id for the resource. Ex -
      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
     :type id: str
-    :ivar name: The name of the resource
-    :vartype name: str
-    :ivar type: The type of the resource. Ex-
+    :param name: The name of the resource
+    :type name: str
+    :param type: The type of the resource. Ex-
      Microsoft.Network/trafficmanagerProfiles.
-    :vartype type: str
+    :type type: str
     :param start_time: The beginning of the time window for this HeatMap,
      inclusive.
     :type start_time: datetime
@@ -38,11 +35,6 @@ class HeatMapModel(ProxyResource):
      calculation.
     :type traffic_flows: list[~azure.mgmt.trafficmanager.models.TrafficFlow]
     """
-
-    _validation = {
-        'name': {'readonly': True},
-        'type': {'readonly': True},
-    }
 
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},

--- a/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/heat_map_model_py3.py
+++ b/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/heat_map_model_py3.py
@@ -15,17 +15,14 @@ from .proxy_resource_py3 import ProxyResource
 class HeatMapModel(ProxyResource):
     """Class representing a Traffic Manager HeatMap.
 
-    Variables are only populated by the server, and will be ignored when
-    sending a request.
-
     :param id: Fully qualified resource Id for the resource. Ex -
      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
     :type id: str
-    :ivar name: The name of the resource
-    :vartype name: str
-    :ivar type: The type of the resource. Ex-
+    :param name: The name of the resource
+    :type name: str
+    :param type: The type of the resource. Ex-
      Microsoft.Network/trafficmanagerProfiles.
-    :vartype type: str
+    :type type: str
     :param start_time: The beginning of the time window for this HeatMap,
      inclusive.
     :type start_time: datetime
@@ -39,11 +36,6 @@ class HeatMapModel(ProxyResource):
     :type traffic_flows: list[~azure.mgmt.trafficmanager.models.TrafficFlow]
     """
 
-    _validation = {
-        'name': {'readonly': True},
-        'type': {'readonly': True},
-    }
-
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},
         'name': {'key': 'name', 'type': 'str'},
@@ -54,8 +46,8 @@ class HeatMapModel(ProxyResource):
         'traffic_flows': {'key': 'properties.trafficFlows', 'type': '[TrafficFlow]'},
     }
 
-    def __init__(self, *, id: str=None, start_time=None, end_time=None, endpoints=None, traffic_flows=None, **kwargs) -> None:
-        super(HeatMapModel, self).__init__(id=id, **kwargs)
+    def __init__(self, *, id: str=None, name: str=None, type: str=None, start_time=None, end_time=None, endpoints=None, traffic_flows=None, **kwargs) -> None:
+        super(HeatMapModel, self).__init__(id=id, name=name, type=type, **kwargs)
         self.start_time = start_time
         self.end_time = end_time
         self.endpoints = endpoints

--- a/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/profile.py
+++ b/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/profile.py
@@ -15,17 +15,14 @@ from .tracked_resource import TrackedResource
 class Profile(TrackedResource):
     """Class representing a Traffic Manager profile.
 
-    Variables are only populated by the server, and will be ignored when
-    sending a request.
-
     :param id: Fully qualified resource Id for the resource. Ex -
      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
     :type id: str
-    :ivar name: The name of the resource
-    :vartype name: str
-    :ivar type: The type of the resource. Ex-
+    :param name: The name of the resource
+    :type name: str
+    :param type: The type of the resource. Ex-
      Microsoft.Network/trafficmanagerProfiles.
-    :vartype type: str
+    :type type: str
     :param tags: Resource tags.
     :type tags: dict[str, str]
     :param location: The Azure Region where the resource lives
@@ -56,11 +53,6 @@ class Profile(TrackedResource):
      MultiValue routing type.
     :type max_return: long
     """
-
-    _validation = {
-        'name': {'readonly': True},
-        'type': {'readonly': True},
-    }
 
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},

--- a/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/profile_py3.py
+++ b/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/profile_py3.py
@@ -15,17 +15,14 @@ from .tracked_resource_py3 import TrackedResource
 class Profile(TrackedResource):
     """Class representing a Traffic Manager profile.
 
-    Variables are only populated by the server, and will be ignored when
-    sending a request.
-
     :param id: Fully qualified resource Id for the resource. Ex -
      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
     :type id: str
-    :ivar name: The name of the resource
-    :vartype name: str
-    :ivar type: The type of the resource. Ex-
+    :param name: The name of the resource
+    :type name: str
+    :param type: The type of the resource. Ex-
      Microsoft.Network/trafficmanagerProfiles.
-    :vartype type: str
+    :type type: str
     :param tags: Resource tags.
     :type tags: dict[str, str]
     :param location: The Azure Region where the resource lives
@@ -57,11 +54,6 @@ class Profile(TrackedResource):
     :type max_return: long
     """
 
-    _validation = {
-        'name': {'readonly': True},
-        'type': {'readonly': True},
-    }
-
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},
         'name': {'key': 'name', 'type': 'str'},
@@ -77,8 +69,8 @@ class Profile(TrackedResource):
         'max_return': {'key': 'properties.maxReturn', 'type': 'long'},
     }
 
-    def __init__(self, *, id: str=None, tags=None, location: str=None, profile_status=None, traffic_routing_method=None, dns_config=None, monitor_config=None, endpoints=None, traffic_view_enrollment_status=None, max_return: int=None, **kwargs) -> None:
-        super(Profile, self).__init__(id=id, tags=tags, location=location, **kwargs)
+    def __init__(self, *, id: str=None, name: str=None, type: str=None, tags=None, location: str=None, profile_status=None, traffic_routing_method=None, dns_config=None, monitor_config=None, endpoints=None, traffic_view_enrollment_status=None, max_return: int=None, **kwargs) -> None:
+        super(Profile, self).__init__(id=id, name=name, type=type, tags=tags, location=location, **kwargs)
         self.profile_status = profile_status
         self.traffic_routing_method = traffic_routing_method
         self.dns_config = dns_config

--- a/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/proxy_resource.py
+++ b/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/proxy_resource.py
@@ -16,23 +16,15 @@ class ProxyResource(Resource):
     """The resource model definition for a ARM proxy resource. It will have
     everything other than required location and tags.
 
-    Variables are only populated by the server, and will be ignored when
-    sending a request.
-
     :param id: Fully qualified resource Id for the resource. Ex -
      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
     :type id: str
-    :ivar name: The name of the resource
-    :vartype name: str
-    :ivar type: The type of the resource. Ex-
+    :param name: The name of the resource
+    :type name: str
+    :param type: The type of the resource. Ex-
      Microsoft.Network/trafficmanagerProfiles.
-    :vartype type: str
+    :type type: str
     """
-
-    _validation = {
-        'name': {'readonly': True},
-        'type': {'readonly': True},
-    }
 
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},

--- a/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/proxy_resource_py3.py
+++ b/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/proxy_resource_py3.py
@@ -16,23 +16,15 @@ class ProxyResource(Resource):
     """The resource model definition for a ARM proxy resource. It will have
     everything other than required location and tags.
 
-    Variables are only populated by the server, and will be ignored when
-    sending a request.
-
     :param id: Fully qualified resource Id for the resource. Ex -
      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
     :type id: str
-    :ivar name: The name of the resource
-    :vartype name: str
-    :ivar type: The type of the resource. Ex-
+    :param name: The name of the resource
+    :type name: str
+    :param type: The type of the resource. Ex-
      Microsoft.Network/trafficmanagerProfiles.
-    :vartype type: str
+    :type type: str
     """
-
-    _validation = {
-        'name': {'readonly': True},
-        'type': {'readonly': True},
-    }
 
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},
@@ -40,5 +32,5 @@ class ProxyResource(Resource):
         'type': {'key': 'type', 'type': 'str'},
     }
 
-    def __init__(self, *, id: str=None, **kwargs) -> None:
-        super(ProxyResource, self).__init__(id=id, **kwargs)
+    def __init__(self, *, id: str=None, name: str=None, type: str=None, **kwargs) -> None:
+        super(ProxyResource, self).__init__(id=id, name=name, type=type, **kwargs)

--- a/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/resource.py
+++ b/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/resource.py
@@ -15,23 +15,15 @@ from msrest.serialization import Model
 class Resource(Model):
     """The core properties of ARM resources.
 
-    Variables are only populated by the server, and will be ignored when
-    sending a request.
-
     :param id: Fully qualified resource Id for the resource. Ex -
      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
     :type id: str
-    :ivar name: The name of the resource
-    :vartype name: str
-    :ivar type: The type of the resource. Ex-
+    :param name: The name of the resource
+    :type name: str
+    :param type: The type of the resource. Ex-
      Microsoft.Network/trafficmanagerProfiles.
-    :vartype type: str
+    :type type: str
     """
-
-    _validation = {
-        'name': {'readonly': True},
-        'type': {'readonly': True},
-    }
 
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},
@@ -42,5 +34,5 @@ class Resource(Model):
     def __init__(self, **kwargs):
         super(Resource, self).__init__(**kwargs)
         self.id = kwargs.get('id', None)
-        self.name = None
-        self.type = None
+        self.name = kwargs.get('name', None)
+        self.type = kwargs.get('type', None)

--- a/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/resource_py3.py
+++ b/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/resource_py3.py
@@ -15,23 +15,15 @@ from msrest.serialization import Model
 class Resource(Model):
     """The core properties of ARM resources.
 
-    Variables are only populated by the server, and will be ignored when
-    sending a request.
-
     :param id: Fully qualified resource Id for the resource. Ex -
      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
     :type id: str
-    :ivar name: The name of the resource
-    :vartype name: str
-    :ivar type: The type of the resource. Ex-
+    :param name: The name of the resource
+    :type name: str
+    :param type: The type of the resource. Ex-
      Microsoft.Network/trafficmanagerProfiles.
-    :vartype type: str
+    :type type: str
     """
-
-    _validation = {
-        'name': {'readonly': True},
-        'type': {'readonly': True},
-    }
 
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},
@@ -39,8 +31,8 @@ class Resource(Model):
         'type': {'key': 'type', 'type': 'str'},
     }
 
-    def __init__(self, *, id: str=None, **kwargs) -> None:
+    def __init__(self, *, id: str=None, name: str=None, type: str=None, **kwargs) -> None:
         super(Resource, self).__init__(**kwargs)
         self.id = id
-        self.name = None
-        self.type = None
+        self.name = name
+        self.type = type

--- a/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/tracked_resource.py
+++ b/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/tracked_resource.py
@@ -15,27 +15,19 @@ from .resource import Resource
 class TrackedResource(Resource):
     """The resource model definition for a ARM tracked top level resource.
 
-    Variables are only populated by the server, and will be ignored when
-    sending a request.
-
     :param id: Fully qualified resource Id for the resource. Ex -
      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
     :type id: str
-    :ivar name: The name of the resource
-    :vartype name: str
-    :ivar type: The type of the resource. Ex-
+    :param name: The name of the resource
+    :type name: str
+    :param type: The type of the resource. Ex-
      Microsoft.Network/trafficmanagerProfiles.
-    :vartype type: str
+    :type type: str
     :param tags: Resource tags.
     :type tags: dict[str, str]
     :param location: The Azure Region where the resource lives
     :type location: str
     """
-
-    _validation = {
-        'name': {'readonly': True},
-        'type': {'readonly': True},
-    }
 
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},

--- a/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/tracked_resource_py3.py
+++ b/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/tracked_resource_py3.py
@@ -15,27 +15,19 @@ from .resource_py3 import Resource
 class TrackedResource(Resource):
     """The resource model definition for a ARM tracked top level resource.
 
-    Variables are only populated by the server, and will be ignored when
-    sending a request.
-
     :param id: Fully qualified resource Id for the resource. Ex -
      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
     :type id: str
-    :ivar name: The name of the resource
-    :vartype name: str
-    :ivar type: The type of the resource. Ex-
+    :param name: The name of the resource
+    :type name: str
+    :param type: The type of the resource. Ex-
      Microsoft.Network/trafficmanagerProfiles.
-    :vartype type: str
+    :type type: str
     :param tags: Resource tags.
     :type tags: dict[str, str]
     :param location: The Azure Region where the resource lives
     :type location: str
     """
-
-    _validation = {
-        'name': {'readonly': True},
-        'type': {'readonly': True},
-    }
 
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},
@@ -45,7 +37,7 @@ class TrackedResource(Resource):
         'location': {'key': 'location', 'type': 'str'},
     }
 
-    def __init__(self, *, id: str=None, tags=None, location: str=None, **kwargs) -> None:
-        super(TrackedResource, self).__init__(id=id, **kwargs)
+    def __init__(self, *, id: str=None, name: str=None, type: str=None, tags=None, location: str=None, **kwargs) -> None:
+        super(TrackedResource, self).__init__(id=id, name=name, type=type, **kwargs)
         self.tags = tags
         self.location = location

--- a/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/traffic_manager_geographic_hierarchy.py
+++ b/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/traffic_manager_geographic_hierarchy.py
@@ -16,26 +16,18 @@ class TrafficManagerGeographicHierarchy(ProxyResource):
     """Class representing the Geographic hierarchy used with the Geographic
     traffic routing method.
 
-    Variables are only populated by the server, and will be ignored when
-    sending a request.
-
     :param id: Fully qualified resource Id for the resource. Ex -
      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
     :type id: str
-    :ivar name: The name of the resource
-    :vartype name: str
-    :ivar type: The type of the resource. Ex-
+    :param name: The name of the resource
+    :type name: str
+    :param type: The type of the resource. Ex-
      Microsoft.Network/trafficmanagerProfiles.
-    :vartype type: str
+    :type type: str
     :param geographic_hierarchy: The region at the root of the hierarchy from
      all the regions in the hierarchy can be retrieved.
     :type geographic_hierarchy: ~azure.mgmt.trafficmanager.models.Region
     """
-
-    _validation = {
-        'name': {'readonly': True},
-        'type': {'readonly': True},
-    }
 
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},

--- a/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/traffic_manager_geographic_hierarchy_py3.py
+++ b/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/traffic_manager_geographic_hierarchy_py3.py
@@ -16,26 +16,18 @@ class TrafficManagerGeographicHierarchy(ProxyResource):
     """Class representing the Geographic hierarchy used with the Geographic
     traffic routing method.
 
-    Variables are only populated by the server, and will be ignored when
-    sending a request.
-
     :param id: Fully qualified resource Id for the resource. Ex -
      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
     :type id: str
-    :ivar name: The name of the resource
-    :vartype name: str
-    :ivar type: The type of the resource. Ex-
+    :param name: The name of the resource
+    :type name: str
+    :param type: The type of the resource. Ex-
      Microsoft.Network/trafficmanagerProfiles.
-    :vartype type: str
+    :type type: str
     :param geographic_hierarchy: The region at the root of the hierarchy from
      all the regions in the hierarchy can be retrieved.
     :type geographic_hierarchy: ~azure.mgmt.trafficmanager.models.Region
     """
-
-    _validation = {
-        'name': {'readonly': True},
-        'type': {'readonly': True},
-    }
 
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},
@@ -44,6 +36,6 @@ class TrafficManagerGeographicHierarchy(ProxyResource):
         'geographic_hierarchy': {'key': 'properties.geographicHierarchy', 'type': 'Region'},
     }
 
-    def __init__(self, *, id: str=None, geographic_hierarchy=None, **kwargs) -> None:
-        super(TrafficManagerGeographicHierarchy, self).__init__(id=id, **kwargs)
+    def __init__(self, *, id: str=None, name: str=None, type: str=None, geographic_hierarchy=None, **kwargs) -> None:
+        super(TrafficManagerGeographicHierarchy, self).__init__(id=id, name=name, type=type, **kwargs)
         self.geographic_hierarchy = geographic_hierarchy

--- a/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/user_metrics_model.py
+++ b/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/user_metrics_model.py
@@ -15,25 +15,17 @@ from .proxy_resource import ProxyResource
 class UserMetricsModel(ProxyResource):
     """Class representing Traffic Manager User Metrics.
 
-    Variables are only populated by the server, and will be ignored when
-    sending a request.
-
     :param id: Fully qualified resource Id for the resource. Ex -
      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
     :type id: str
-    :ivar name: The name of the resource
-    :vartype name: str
-    :ivar type: The type of the resource. Ex-
+    :param name: The name of the resource
+    :type name: str
+    :param type: The type of the resource. Ex-
      Microsoft.Network/trafficmanagerProfiles.
-    :vartype type: str
+    :type type: str
     :param key: The key returned by the User Metrics operation.
     :type key: str
     """
-
-    _validation = {
-        'name': {'readonly': True},
-        'type': {'readonly': True},
-    }
 
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},

--- a/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/user_metrics_model_py3.py
+++ b/azure-mgmt-trafficmanager/azure/mgmt/trafficmanager/models/user_metrics_model_py3.py
@@ -15,25 +15,17 @@ from .proxy_resource_py3 import ProxyResource
 class UserMetricsModel(ProxyResource):
     """Class representing Traffic Manager User Metrics.
 
-    Variables are only populated by the server, and will be ignored when
-    sending a request.
-
     :param id: Fully qualified resource Id for the resource. Ex -
      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
     :type id: str
-    :ivar name: The name of the resource
-    :vartype name: str
-    :ivar type: The type of the resource. Ex-
+    :param name: The name of the resource
+    :type name: str
+    :param type: The type of the resource. Ex-
      Microsoft.Network/trafficmanagerProfiles.
-    :vartype type: str
+    :type type: str
     :param key: The key returned by the User Metrics operation.
     :type key: str
     """
-
-    _validation = {
-        'name': {'readonly': True},
-        'type': {'readonly': True},
-    }
 
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},
@@ -42,6 +34,6 @@ class UserMetricsModel(ProxyResource):
         'key': {'key': 'properties.key', 'type': 'str'},
     }
 
-    def __init__(self, *, id: str=None, key: str=None, **kwargs) -> None:
-        super(UserMetricsModel, self).__init__(id=id, **kwargs)
+    def __init__(self, *, id: str=None, name: str=None, type: str=None, key: str=None, **kwargs) -> None:
+        super(UserMetricsModel, self).__init__(id=id, name=name, type=type, **kwargs)
         self.key = key


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4007