### PR TITLE
azure-nspkg 3.0.1

### DIFF
--- a/azure-mgmt-nspkg/README.rst
+++ b/azure-mgmt-nspkg/README.rst
@@ -5,8 +5,8 @@ This is the Microsoft Azure Management namespace package.
 
 This package is not intended to be installed directly by the end user.
 
-Since version 3.0, this is Python 2 package only, Python 3.x SDKs will use `PEP420 <https://www.python.org/dev/peps/pep-0420/>` as namespace package strategy.
-This package will use `python_requires` to enforce Python 2 installation. This implies that you might see this package on Python 3 environment if you have pip < 9.0 or setuptools < 24.2.0.
+Since version 3.0, this is Python 2 package only, Python 3.x SDKs will use `PEP420 <https://www.python.org/dev/peps/pep-0420/>`__ as namespace package strategy.
+To avoid issues with package servers that does not support `python_requires`, a Python 3 package is installed but is empty.
 
 It provides the necessary files for other packages to extend the azure.mgmt namespace.
 

--- a/azure-mgmt-nspkg/setup.cfg
+++ b/azure-mgmt-nspkg/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/azure-mgmt-nspkg/setup.py
+++ b/azure-mgmt-nspkg/setup.py
@@ -5,7 +5,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 #--------------------------------------------------------------------------
-
+import sys
 from setuptools import setup
 
 # azure v0.x is not compatible with this package
@@ -23,6 +23,13 @@ try:
 except ImportError:
     pass
 
+PACKAGES = []
+# Do an empty package on Python 3 and not python_requires, since not everybody is ready
+# https://github.com/Azure/azure-sdk-for-python/issues/3447
+# https://github.com/Azure/azure-sdk-for-python/issues/3481
+if sys.version_info[0] < 3:
+    PACKAGES = ['azure.mgmt']
+
 setup(
     name='azure-mgmt-nspkg',
     version='3.0.0',
@@ -37,13 +44,15 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: MIT License',
     ],
     zip_safe=False,
-    packages=[
-        'azure.mgmt',
-    ],
-    python_requires='<3',
+    packages=PACKAGES,
     install_requires=[
         'azure-nspkg>=3.0.0',
     ]

--- a/azure-nspkg/README.rst
+++ b/azure-nspkg/README.rst
@@ -5,8 +5,8 @@ This is the Microsoft Azure namespace package.
 
 This package is not intended to be installed directly by the end user.
 
-Since version 3.0, this is Python 2 package only, Python 3.x SDKs will use `PEP420 <https://www.python.org/dev/peps/pep-0420/>` as namespace package strategy.
-This package will use `python_requires` to enforce Python 2 installation. This implies that you might see this package on Python 3 environment if you have pip < 9.0 or setuptools < 24.2.0.
+Since version 3.0, this is Python 2 package only, Python 3.x SDKs will use `PEP420 <https://www.python.org/dev/peps/pep-0420/>`__ as namespace package strategy.
+To avoid issues with package servers that does not support `python_requires`, a Python 3 package is installed but is empty.
 
 It provides the necessary files for other packages to extend the azure namespace.
 

--- a/azure-nspkg/setup.cfg
+++ b/azure-nspkg/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/azure-nspkg/setup.py
+++ b/azure-nspkg/setup.py
@@ -5,7 +5,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 #--------------------------------------------------------------------------
-
+import sys
 from setuptools import setup
 
 # azure v0.x is not compatible with this package
@@ -23,9 +23,16 @@ try:
 except ImportError:
     pass
 
+PACKAGES = []
+# Do an empty package on Python 3 and not python_requires, since not everybody is ready
+# https://github.com/Azure/azure-sdk-for-python/issues/3447
+# https://github.com/Azure/azure-sdk-for-python/issues/3481
+if sys.version_info[0] < 3:
+    PACKAGES = ['azure']
+
 setup(
     name='azure-nspkg',
-    version='3.0.0',
+    version='3.0.1',
     description='Microsoft Azure Namespace Package [Internal]',
     long_description=open('README.rst', 'r').read(),
     license='MIT License',
@@ -37,11 +44,13 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: MIT License',
     ],
-    python_requires='<3',
     zip_safe=False,
-    packages=[
-        'azure',
-    ],
+    packages=PACKAGES
 )


### PR DESCRIPTION
Fix #3481 #3447 

Even if the packaging is perfectly standard and installable with pip and PyPI, I discover there is too many implementation of setuptools dependency PEPs that are not accurate enough. Workaround it at my level (even if it makes me sad), by installing a empty packages with no file on Python 3, instead of using `python_requires`.

Anyway, this package is not a dependency anymore on Python 3, so this empty package installation will eventually stops by itself.