### PR TITLE
nspkg 3.0.2

### DIFF
--- a/azure-mgmt-nspkg/MANIFEST.in
+++ b/azure-mgmt-nspkg/MANIFEST.in
@@ -1,1 +1,3 @@
 include *.rst
+include azure/__init__.py
+include azure/mgmt/__init__.py

--- a/azure-mgmt-nspkg/setup.py
+++ b/azure-mgmt-nspkg/setup.py
@@ -32,7 +32,7 @@ if sys.version_info[0] < 3:
 
 setup(
     name='azure-mgmt-nspkg',
-    version='3.0.1',
+    version='3.0.2',
     description='Microsoft Azure Resource Management Namespace Package [Internal]',
     long_description=open('README.rst', 'r').read(),
     license='MIT License',

--- a/azure-nspkg/MANIFEST.in
+++ b/azure-nspkg/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.rst
+include azure/__init__.py

--- a/azure-nspkg/setup.py
+++ b/azure-nspkg/setup.py
@@ -32,7 +32,7 @@ if sys.version_info[0] < 3:
 
 setup(
     name='azure-nspkg',
-    version='3.0.1',
+    version='3.0.2',
     description='Microsoft Azure Namespace Package [Internal]',
     long_description=open('README.rst', 'r').read(),
     license='MIT License',


### PR DESCRIPTION
Fix https://github.com/Azure/azure-sdk-for-python/issues/3485

Root issue was I messed up the sdist, and didn't uploaded the wheel fast enough for Python 2 (otherwise the problem would have been unnoticed).

Even if wheels of 3.0.1 are corrects, I cannot replace the sdist, so need another bug fixes release with the correct sdist.