### PR TITLE
[AutoPR network/resource-manager] Model ContainerNic refs under ContainerNicConfig as sub resources

### DIFF
--- a/azure-mgmt-network/azure/mgmt/network/v2018_08_01/models/container_network_interface_configuration.py
+++ b/azure-mgmt-network/azure/mgmt/network/v2018_08_01/models/container_network_interface_configuration.py
@@ -27,7 +27,7 @@ class ContainerNetworkInterfaceConfiguration(SubResource):
     :param container_network_interfaces: A list of container network
      interfaces created from this container network interface configuration.
     :type container_network_interfaces:
-     list[~azure.mgmt.network.v2018_08_01.models.ContainerNetworkInterface]
+     list[~azure.mgmt.network.v2018_08_01.models.SubResource]
     :ivar provisioning_state: The provisioning state of the resource.
     :vartype provisioning_state: str
     :param name: The name of the resource. This name can be used to access the
@@ -48,7 +48,7 @@ class ContainerNetworkInterfaceConfiguration(SubResource):
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},
         'ip_configurations': {'key': 'properties.ipConfigurations', 'type': '[IPConfigurationProfile]'},
-        'container_network_interfaces': {'key': 'properties.containerNetworkInterfaces', 'type': '[ContainerNetworkInterface]'},
+        'container_network_interfaces': {'key': 'properties.containerNetworkInterfaces', 'type': '[SubResource]'},
         'provisioning_state': {'key': 'properties.provisioningState', 'type': 'str'},
         'name': {'key': 'name', 'type': 'str'},
         'type': {'key': 'type', 'type': 'str'},

--- a/azure-mgmt-network/azure/mgmt/network/v2018_08_01/models/container_network_interface_configuration_py3.py
+++ b/azure-mgmt-network/azure/mgmt/network/v2018_08_01/models/container_network_interface_configuration_py3.py
@@ -27,7 +27,7 @@ class ContainerNetworkInterfaceConfiguration(SubResource):
     :param container_network_interfaces: A list of container network
      interfaces created from this container network interface configuration.
     :type container_network_interfaces:
-     list[~azure.mgmt.network.v2018_08_01.models.ContainerNetworkInterface]
+     list[~azure.mgmt.network.v2018_08_01.models.SubResource]
     :ivar provisioning_state: The provisioning state of the resource.
     :vartype provisioning_state: str
     :param name: The name of the resource. This name can be used to access the
@@ -48,7 +48,7 @@ class ContainerNetworkInterfaceConfiguration(SubResource):
     _attribute_map = {
         'id': {'key': 'id', 'type': 'str'},
         'ip_configurations': {'key': 'properties.ipConfigurations', 'type': '[IPConfigurationProfile]'},
-        'container_network_interfaces': {'key': 'properties.containerNetworkInterfaces', 'type': '[ContainerNetworkInterface]'},
+        'container_network_interfaces': {'key': 'properties.containerNetworkInterfaces', 'type': '[SubResource]'},
         'provisioning_state': {'key': 'properties.provisioningState', 'type': 'str'},
         'name': {'key': 'name', 'type': 'str'},
         'type': {'key': 'type', 'type': 'str'},


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4459