### PR TITLE
Added support for KeyVaultClient to get_client_from_cli_profile.

### DIFF
--- a/azure-common/azure/common/client_factory.py
+++ b/azure-common/azure/common/client_factory.py
@@ -34,13 +34,15 @@ def _instantiate_client(client_class, **kwargs):
     return client_class(**kwargs)
 
 
-def client_resource(client_class, cloud):
-    """Returns the resource (used to get the right access token) and base URL for the client"""
+def _client_resource(client_class, cloud):
+    """Return a tuple of the resource (used to get the right access token), and the base URL for the client.
+    Either or both can be None to signify that the default value should be used.
+    """
     if client_class.__name__ == 'GraphRbacManagementClient':
         return cloud.endpoints.active_directory_graph_resource_id, cloud.endpoints.active_directory_graph_resource_id
     if client_class.__name__ == 'KeyVaultClient':
         vault_host = cloud.suffixes.keyvault_dns[1:]
-        vault_url = 'https://%s' % vault_host
+        vault_url = 'https://{}'.format(vault_host)
         return vault_url, None
     return None, None
 
@@ -72,7 +74,7 @@ def get_client_from_cli_profile(client_class, **kwargs):
     cloud = get_cli_active_cloud()
     parameters = {}
     if 'credentials' not in kwargs or 'subscription_id' not in kwargs:
-        resource, _ = client_resource(client_class, cloud)
+        resource, _ = _client_resource(client_class, cloud)
         credentials, subscription_id, tenant_id = get_azure_cli_credentials(resource=resource,
                                                                             with_tenant=True)
         parameters.update({
@@ -86,7 +88,7 @@ def get_client_from_cli_profile(client_class, **kwargs):
         # ADL endpoint and no manual suffix was given
         parameters['adla_job_dns_suffix'] = cloud.suffixes.azure_datalake_analytics_catalog_and_job_endpoint
     elif 'base_url' in args and 'base_url' not in kwargs:
-        _, base_url = client_resource(client_class, cloud)
+        _, base_url = _client_resource(client_class, cloud)
         if base_url:
             parameters['base_url'] = base_url
         else:

--- a/azure-common/tests/test_client_factory.py
+++ b/azure-common/tests/test_client_factory.py
@@ -64,6 +64,13 @@ class TestCommon(unittest.TestCase):
                 self.tenant_id = tenant_id
                 self.base_url = base_url
 
+        class KeyVaultClient(object):
+            def __init__(self, credentials):
+                if credentials is None:
+                    raise ValueError("Parameter 'credentials' must not be None.")
+
+                self.credentials = credentials
+
         get_cli_active_cloud.return_value = AZURE_PUBLIC_CLOUD
         get_azure_cli_credentials.return_value = 'credentials', 'subscription_id', 'tenant_id'
 
@@ -83,6 +90,10 @@ class TestCommon(unittest.TestCase):
         assert client.credentials == 'credentials'
         assert client.tenant_id == 'tenant_id'
         assert client.base_url == "https://graph.windows.net/"
+
+        client = get_client_from_cli_profile(KeyVaultClient)
+        get_azure_cli_credentials.assert_called_with(resource="https://vault.azure.net", with_tenant=True)
+        assert client.credentials == 'credentials'
 
     def test_get_client_from_auth_file(self):
 


### PR DESCRIPTION
When you create a KeyVaultClient using get_client_from_cli_profile, it uses the wrong (default) resource URI, so you get the wrong access token and all requests are unauthorized. This fixes that by special casing KeyVaultClient just like GraphRbacManagementClient is special cased, but generalises the handling of that to make it easy to add any further client that needs a different resource and/or base_url.

I have only tested this against the public cloud, since I don't have accounts with the special clouds. 