### PR TITLE
Swapping to Twine Check - Support .md in Readme

### DIFF
--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -19,20 +19,32 @@ jobs:
       versionSpec: 3.6
 
   - script: |
-     pip install wheel setuptools pathlib Jinja2
+     pip install wheel setuptools pathlib Jinja2 twine readme-renderer[md]
     displayName: 'Prep Environment'
 
   - task: PythonScript@0
     displayName: 'Analyze dependencies'
     inputs:
       scriptPath: 'scripts/analyze_deps.py'
-      arguments: '--verbose --out "$(Build.ArtifactStagingDirectory)/dependencies.html"'
+      arguments: '--verbose --out "$(Build.SourcesDirectory)/dependencies.html"'
 
   - task: PythonScript@0
     displayName: 'Generate Packages'
     inputs:
       scriptPath: 'scripts/devops_tasks/build_packages.py'
       arguments: '-d "$(Build.ArtifactStagingDirectory)" "$(build_targeting_string)"'
+
+  - script: |
+      twine check $(Build.ArtifactStagingDirectory)/*
+    displayName: 'Verify Readme'
+
+  - task: CopyFiles@2
+    displayName: 'Move Dependencies Report to Build Artifacts'
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)'
+      Contents: dependencies.html
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+    condition: always()
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifacts'

--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -12,6 +12,7 @@ import glob
 from pathlib import Path
 from subprocess import check_call, CalledProcessError
 import os
+import sys
 
 DEFAULT_BUILD_PACKAGES = ['azure-keyvault', 'azure-servicebus'] 
 
@@ -32,10 +33,11 @@ def process_glob_string(glob_string, target_root_dir):
     # dedup, in case we have double coverage from the glob strings. Example: "azure-mgmt-keyvault,azure-mgmt-*"
     return list(set(collected_top_level_directories))
 
-def run_check_call(command_array, working_directory):
+def run_check_call(command_array, working_directory, acceptable_return_codes = []):
     print('Command Array: {0}, Target Working Directory: {1}'.format(command_array, working_directory))
     try:
         check_call(command_array, cwd = working_directory)
     except CalledProcessError as err:
         print(err) #, file = sys.stderr
-        sys.exit(1)
+        if err.returncode not in acceptable_return_codes:
+            sys.exit(1)

--- a/scripts/devops_tasks/setup_execute_tests.py
+++ b/scripts/devops_tasks/setup_execute_tests.py
@@ -18,6 +18,10 @@ from common_tasks import process_glob_string, run_check_call
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), '..', '..', '..'))
 dev_setup_script_location = os.path.join(root_dir, 'scripts/dev_setup.py')
 
+# a return code of 5 from pytest == no tests run
+# evaluating whether we want this or not.
+ALLOWED_RETURN_CODES = [] 
+
 def prep_and_run_tests(targeted_packages, python_version):
     print('running test setup for {}'.format(targeted_packages))
     run_check_call([python_version, dev_setup_script_location, '-p', ','.join([os.path.basename(package_path) for package_path in targeted_packages])], root_dir)
@@ -25,12 +29,7 @@ def prep_and_run_tests(targeted_packages, python_version):
     print('Setup complete. Running pytest for {}'.format(targeted_packages))
     command_array = [python_version, '-m', 'pytest']
     command_array.extend(targeted_packages)
-    run_check_call(command_array, root_dir)
-
-    for package_path in targeted_packages:
-        print('Checking setup.py for {}'.format(os.path.join(package_path, 'setup.py')))
-        run_check_call([python_version, 'setup.py', 'check', '-r', '-s'], package_path)
-
+    run_check_call(command_array, root_dir, ALLOWED_RETURN_CODES)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description = 'Install Dependencies, Install Packages, Test Azure Packages, Called from DevOps YAML Pipeline')


### PR DESCRIPTION
Example build: https://dev.azure.com/azure-sdk/playground/_build/results?buildId=4163

Also adding capability to ignore specific warnings during `run_check_call` in the helper scripts. However, at this time, I believe that it is valuable information to discover a test class with no tests present. (As test cases being present but unrun is a legitimate problem)

#4325 
#4183 

