### PR TITLE
DO NOT MERGE - Ensure Twine Check Fails on Invalid RST

### DIFF
--- a/azure-keyvault/README.rst
+++ b/azure-keyvault/README.rst
@@ -36,7 +36,7 @@ on docs.microsoft.com.
 
 
 Provide Feedback
-================
+===========
 
 If you encounter any bugs or have suggestions, please file an issue in the
 `Issues <https://github.com/Azure/azure-sdk-for-python/issues>`__


### PR DESCRIPTION
See title. Will close after build correctly fails out.