### PR TITLE
Removing setup check from the travis build. Devops has it covered.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ install:
   - python scripts/dev_setup.py
 script: 
   - pytest
-  - python ./setup.py check -r -s
 after_success:
   - coverage report
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Devops is also a required check now.

@Azure/azure-sdk-eng 