### PR TITLE
Remove appveyor badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,17 +7,14 @@ Microsoft Azure SDK for Python
 .. image:: https://img.shields.io/pypi/pyversions/azure.svg?maxAge=2592000
     :target: https://pypi.python.org/pypi/azure/
 
+.. image:: https://dev.azure.com/azure-sdk/public/_apis/build/status/46?branchName=master
+    :target: https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=46&branchName=master
+
 .. image:: https://travis-ci.org/Azure/azure-sdk-for-python.svg?branch=master
     :target: https://travis-ci.org/Azure/azure-sdk-for-python
 
-.. image:: https://ci.appveyor.com/api/projects/status/m51hrgewcxknxhsd/branch/master?svg=true
-    :target: https://ci.appveyor.com/project/lmazuel/azure-sdk-for-python/branch/master
-
 .. image:: https://img.shields.io/badge/dependencies-analyzed-blue.svg
     :target: https://azuresdkartifacts.blob.core.windows.net/azure-sdk-for-python/dependencies/dependencies.html
-
-.. image:: https://dev.azure.com/azure-sdk/public/_apis/build/status/46?branchName=master
-    :target: https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=46&branchName=master
 
 This project provides a set of Python packages that make it easy to
 access Management (Virtual Machines, ...) or Runtime (ServiceBus using HTTP, Batch, Monitor) components of


### PR DESCRIPTION
We don't use it. It hasn't produced a build in two years.