### PR TITLE
Test Results Publish - python script updates, making junit optional

### DIFF
--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -66,7 +66,6 @@ jobs:
 
   - task: PythonScript@0
     displayName: 'Analyze dependencies'
-    enabled: true
     inputs:
       scriptPath: 'scripts/analyze_deps.py'
       arguments: '--verbose --out "$(Build.ArtifactStagingDirectory)/dependencies.html"'
@@ -89,25 +88,32 @@ jobs:
 
   strategy:
     matrix:
-      Linux_Python27:       
+      Linux_Python27:
+        OSName: 'Linux'
         OSVmImage: 'ubuntu-16.04'
         PythonVersion: '2.7'
-      Linux_Python34:        
+      Linux_Python34:
+        OSName: 'Linux'
         OSVmImage: 'ubuntu-16.04'
         PythonVersion: '3.4'
-      Linux_Python35:      
+      Linux_Python35:
+        OSName: 'Linux'
         OSVmImage: 'ubuntu-16.04'
         PythonVersion: '3.5'
       Linux_Python36:
+        OSName: 'Linux'
         OSVmImage: 'ubuntu-16.04'
         PythonVersion: '3.6'
       Linux_Python37:
+        OSName: 'Linux'
         OSVmImage: 'ubuntu-16.04'
         PythonVersion: '3.7'
       Windows_Python35:
+        OSName: 'Windows'
         OSVmImage: 'vs2017-win2016'
         PythonVersion: '3.5'
       MacOS_Python27:
+        OSName: 'MacOS'
         OSVmImage: 'macOS-10.13'
         PythonVersion: '2.7'
 
@@ -128,7 +134,13 @@ jobs:
     displayName: 'Setup and Run Tests'
     inputs:
       scriptPath: 'scripts/devops_tasks/setup_execute_tests.py'
-      arguments: '"$(build_targeting_string)"'
+      arguments: '"$(build_targeting_string)" --junitxml="junit/test-results.xml"'
+    
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFiles: 'junit/test-results.xml'
+      testRunTitle: '$(OSName) Python $(PythonVersion)'
 
   - script: |
      coverage xml

--- a/scripts/devops_tasks/setup_execute_tests.py
+++ b/scripts/devops_tasks/setup_execute_tests.py
@@ -22,12 +22,13 @@ dev_setup_script_location = os.path.join(root_dir, 'scripts/dev_setup.py')
 # evaluating whether we want this or not.
 ALLOWED_RETURN_CODES = [] 
 
-def prep_and_run_tests(targeted_packages, python_version):
+def prep_and_run_tests(targeted_packages, python_version, test_res):
     print('running test setup for {}'.format(targeted_packages))
     run_check_call([python_version, dev_setup_script_location, '-p', ','.join([os.path.basename(package_path) for package_path in targeted_packages])], root_dir)
 
     print('Setup complete. Running pytest for {}'.format(targeted_packages))
     command_array = [python_version, '-m', 'pytest']
+    command_array.extend(test_res)
     command_array.extend(targeted_packages)
     run_check_call(command_array, root_dir, ALLOWED_RETURN_CODES)
 
@@ -43,10 +44,18 @@ if __name__ == '__main__':
     parser.add_argument(
         'glob_string',
         nargs='?',
-        help = ('A comma separated list of glob strings that will target the top level directories that contain packages. '
+        help = ('A comma separated list of glob strings that will target the top level directories that contain packages.'
                 'Examples: All = "azure-*", Single = "azure-keyvault", Targeted Multiple = "azure-keyvault,azure-mgmt-resource"'))
+
+    parser.add_argument(
+        '--junitxml',
+        dest = 'test_results',
+        help = ('The folder where the test results will be stored in xml format.'
+                'Example: --junitxml="junit/test-results.xml"'))
 
     args = parser.parse_args()
     targeted_packages = process_glob_string(args.glob_string, root_dir)
-
-    prep_and_run_tests(targeted_packages, args.python_version)
+    test_results_arg = []
+    if args.test_results:
+        test_results_arg.extend(['--junitxml', args.test_results])
+    prep_and_run_tests(targeted_packages, args.python_version, test_results_arg)


### PR DESCRIPTION
- For Publishing test results, passing junit xml path as an argument through client.yml
- Updates to client.yml to fix the OS name for publishing test results

@Azure/azure-sdk-eng 