### PR TITLE
Incomplete string format in Batch Service Client

### DIFF
--- a/azure-batch/azure/batch/batch_service_client.py
+++ b/azure-batch/azure/batch/batch_service_client.py
@@ -45,7 +45,7 @@ class BatchServiceClientConfiguration(AzureConfiguration):
             raise ValueError("Parameter 'credentials' must not be None.")
         if batch_url is None:
             raise ValueError("Parameter 'batch_url' must not be None.")
-        base_url = '{batchUrl}'
+        base_url = '{}'.format(batch_url)
 
         super(BatchServiceClientConfiguration, self).__init__(base_url)
 


### PR DESCRIPTION
The `BatchServiceClientConfiguration` class in [batch/batch_service_client.py](https://github.com/Azure/azure-sdk-for-python/blob/master/azure-batch/azure/batch/batch_service_client.py) is instantiated with a property `base_url` which is assigned to an incomplete string formatting operation:

```
...
 def __init__(
            self, credentials, batch_url):

        if credentials is None:
            raise ValueError("Parameter 'credentials' must not be None.")
        if batch_url is None:
            raise ValueError("Parameter 'batch_url' must not be None.")
        base_url = '{batchUrl}'`
```
This error prevents using standardized config to provision batch pools & jobs.

Though the intended implementation appears to use f-strings, this PR uses the format function to support <3.5 instead.