### PR TITLE
[AutoPR marketplaceordering/resource-manager] Add missing MarketplaceOrdering operations to swagger

### DIFF
--- a/azure-mgmt-marketplaceordering/MANIFEST.in
+++ b/azure-mgmt-marketplaceordering/MANIFEST.in
@@ -1,3 +1,4 @@
+recursive-include tests *.py *.yaml
 include *.rst
 include azure/__init__.py
 include azure/mgmt/__init__.py

--- a/azure-mgmt-marketplaceordering/README.rst
+++ b/azure-mgmt-marketplaceordering/README.rst
@@ -14,25 +14,6 @@ For the older Azure Service Management (ASM) libraries, see
 For a more complete set of Azure libraries, see the `azure <https://pypi.python.org/pypi/azure>`__ bundle package.
 
 
-Compatibility
-=============
-
-**IMPORTANT**: If you have an earlier version of the azure package
-(version < 1.0), you should uninstall it before installing this package.
-
-You can check the version using pip:
-
-.. code:: shell
-
-    pip freeze
-
-If you see azure==0.11.0 (or any version below 1.0), uninstall it first:
-
-.. code:: shell
-
-    pip uninstall azure
-
-
 Usage
 =====
 

--- a/azure-mgmt-marketplaceordering/azure/mgmt/marketplaceordering/operations/marketplace_agreements_operations.py
+++ b/azure-mgmt-marketplaceordering/azure/mgmt/marketplaceordering/operations/marketplace_agreements_operations.py
@@ -179,3 +179,255 @@ class MarketplaceAgreementsOperations(object):
 
         return deserialized
     create.metadata = {'url': '/subscriptions/{subscriptionId}/providers/Microsoft.MarketplaceOrdering/offerTypes/{offerType}/publishers/{publisherId}/offers/{offerId}/plans/{planId}/agreements/current'}
+
+    def sign(
+            self, publisher_id, offer_id, plan_id, custom_headers=None, raw=False, **operation_config):
+        """Sign marketplace terms.
+
+        :param publisher_id: Publisher identifier string of image being
+         deployed.
+        :type publisher_id: str
+        :param offer_id: Offer identifier string of image being deployed.
+        :type offer_id: str
+        :param plan_id: Plan identifier string of image being deployed.
+        :type plan_id: str
+        :param dict custom_headers: headers that will be added to the request
+        :param bool raw: returns the direct response alongside the
+         deserialized response
+        :param operation_config: :ref:`Operation configuration
+         overrides<msrest:optionsforoperations>`.
+        :return: AgreementTerms or ClientRawResponse if raw=true
+        :rtype: ~azure.mgmt.marketplaceordering.models.AgreementTerms or
+         ~msrest.pipeline.ClientRawResponse
+        :raises:
+         :class:`ErrorResponseException<azure.mgmt.marketplaceordering.models.ErrorResponseException>`
+        """
+        # Construct URL
+        url = self.sign.metadata['url']
+        path_format_arguments = {
+            'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str'),
+            'publisherId': self._serialize.url("publisher_id", publisher_id, 'str'),
+            'offerId': self._serialize.url("offer_id", offer_id, 'str'),
+            'planId': self._serialize.url("plan_id", plan_id, 'str')
+        }
+        url = self._client.format_url(url, **path_format_arguments)
+
+        # Construct parameters
+        query_parameters = {}
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
+
+        # Construct headers
+        header_parameters = {}
+        header_parameters['Accept'] = 'application/json'
+        if self.config.generate_client_request_id:
+            header_parameters['x-ms-client-request-id'] = str(uuid.uuid1())
+        if custom_headers:
+            header_parameters.update(custom_headers)
+        if self.config.accept_language is not None:
+            header_parameters['accept-language'] = self._serialize.header("self.config.accept_language", self.config.accept_language, 'str')
+
+        # Construct and send request
+        request = self._client.put(url, query_parameters, header_parameters)
+        response = self._client.send(request, stream=False, **operation_config)
+
+        if response.status_code not in [200]:
+            raise models.ErrorResponseException(self._deserialize, response)
+
+        deserialized = None
+
+        if response.status_code == 200:
+            deserialized = self._deserialize('AgreementTerms', response)
+
+        if raw:
+            client_raw_response = ClientRawResponse(deserialized, response)
+            return client_raw_response
+
+        return deserialized
+    sign.metadata = {'url': '/subscriptions/{subscriptionId}/providers/Microsoft.MarketplaceOrdering/agreements/{publisherId}/offers/{offerId}/plans/{planId}/sign'}
+
+    def cancel(
+            self, publisher_id, offer_id, plan_id, custom_headers=None, raw=False, **operation_config):
+        """Cancel marketplace terms.
+
+        :param publisher_id: Publisher identifier string of image being
+         deployed.
+        :type publisher_id: str
+        :param offer_id: Offer identifier string of image being deployed.
+        :type offer_id: str
+        :param plan_id: Plan identifier string of image being deployed.
+        :type plan_id: str
+        :param dict custom_headers: headers that will be added to the request
+        :param bool raw: returns the direct response alongside the
+         deserialized response
+        :param operation_config: :ref:`Operation configuration
+         overrides<msrest:optionsforoperations>`.
+        :return: AgreementTerms or ClientRawResponse if raw=true
+        :rtype: ~azure.mgmt.marketplaceordering.models.AgreementTerms or
+         ~msrest.pipeline.ClientRawResponse
+        :raises:
+         :class:`ErrorResponseException<azure.mgmt.marketplaceordering.models.ErrorResponseException>`
+        """
+        # Construct URL
+        url = self.cancel.metadata['url']
+        path_format_arguments = {
+            'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str'),
+            'publisherId': self._serialize.url("publisher_id", publisher_id, 'str'),
+            'offerId': self._serialize.url("offer_id", offer_id, 'str'),
+            'planId': self._serialize.url("plan_id", plan_id, 'str')
+        }
+        url = self._client.format_url(url, **path_format_arguments)
+
+        # Construct parameters
+        query_parameters = {}
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
+
+        # Construct headers
+        header_parameters = {}
+        header_parameters['Accept'] = 'application/json'
+        if self.config.generate_client_request_id:
+            header_parameters['x-ms-client-request-id'] = str(uuid.uuid1())
+        if custom_headers:
+            header_parameters.update(custom_headers)
+        if self.config.accept_language is not None:
+            header_parameters['accept-language'] = self._serialize.header("self.config.accept_language", self.config.accept_language, 'str')
+
+        # Construct and send request
+        request = self._client.put(url, query_parameters, header_parameters)
+        response = self._client.send(request, stream=False, **operation_config)
+
+        if response.status_code not in [200]:
+            raise models.ErrorResponseException(self._deserialize, response)
+
+        deserialized = None
+
+        if response.status_code == 200:
+            deserialized = self._deserialize('AgreementTerms', response)
+
+        if raw:
+            client_raw_response = ClientRawResponse(deserialized, response)
+            return client_raw_response
+
+        return deserialized
+    cancel.metadata = {'url': '/subscriptions/{subscriptionId}/providers/Microsoft.MarketplaceOrdering/agreements/{publisherId}/offers/{offerId}/plans/{planId}/cancel'}
+
+    def get_agreement(
+            self, publisher_id, offer_id, plan_id, custom_headers=None, raw=False, **operation_config):
+        """Get marketplace agreement.
+
+        :param publisher_id: Publisher identifier string of image being
+         deployed.
+        :type publisher_id: str
+        :param offer_id: Offer identifier string of image being deployed.
+        :type offer_id: str
+        :param plan_id: Plan identifier string of image being deployed.
+        :type plan_id: str
+        :param dict custom_headers: headers that will be added to the request
+        :param bool raw: returns the direct response alongside the
+         deserialized response
+        :param operation_config: :ref:`Operation configuration
+         overrides<msrest:optionsforoperations>`.
+        :return: AgreementTerms or ClientRawResponse if raw=true
+        :rtype: ~azure.mgmt.marketplaceordering.models.AgreementTerms or
+         ~msrest.pipeline.ClientRawResponse
+        :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
+        """
+        # Construct URL
+        url = self.get_agreement.metadata['url']
+        path_format_arguments = {
+            'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str'),
+            'publisherId': self._serialize.url("publisher_id", publisher_id, 'str'),
+            'offerId': self._serialize.url("offer_id", offer_id, 'str'),
+            'planId': self._serialize.url("plan_id", plan_id, 'str')
+        }
+        url = self._client.format_url(url, **path_format_arguments)
+
+        # Construct parameters
+        query_parameters = {}
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
+
+        # Construct headers
+        header_parameters = {}
+        header_parameters['Accept'] = 'application/json'
+        if self.config.generate_client_request_id:
+            header_parameters['x-ms-client-request-id'] = str(uuid.uuid1())
+        if custom_headers:
+            header_parameters.update(custom_headers)
+        if self.config.accept_language is not None:
+            header_parameters['accept-language'] = self._serialize.header("self.config.accept_language", self.config.accept_language, 'str')
+
+        # Construct and send request
+        request = self._client.get(url, query_parameters, header_parameters)
+        response = self._client.send(request, stream=False, **operation_config)
+
+        if response.status_code not in [200]:
+            exp = CloudError(response)
+            exp.request_id = response.headers.get('x-ms-request-id')
+            raise exp
+
+        deserialized = None
+
+        if response.status_code == 200:
+            deserialized = self._deserialize('AgreementTerms', response)
+
+        if raw:
+            client_raw_response = ClientRawResponse(deserialized, response)
+            return client_raw_response
+
+        return deserialized
+    get_agreement.metadata = {'url': '/subscriptions/{subscriptionId}/providers/Microsoft.MarketplaceOrdering/agreements/{publisherId}/offers/{offerId}/plans/{planId}'}
+
+    def list(
+            self, custom_headers=None, raw=False, **operation_config):
+        """List marketplace agreements in the subscription.
+
+        :param dict custom_headers: headers that will be added to the request
+        :param bool raw: returns the direct response alongside the
+         deserialized response
+        :param operation_config: :ref:`Operation configuration
+         overrides<msrest:optionsforoperations>`.
+        :return: list or ClientRawResponse if raw=true
+        :rtype: list[~azure.mgmt.marketplaceordering.models.AgreementTerms] or
+         ~msrest.pipeline.ClientRawResponse
+        :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
+        """
+        # Construct URL
+        url = self.list.metadata['url']
+        path_format_arguments = {
+            'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
+        }
+        url = self._client.format_url(url, **path_format_arguments)
+
+        # Construct parameters
+        query_parameters = {}
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
+
+        # Construct headers
+        header_parameters = {}
+        header_parameters['Accept'] = 'application/json'
+        if self.config.generate_client_request_id:
+            header_parameters['x-ms-client-request-id'] = str(uuid.uuid1())
+        if custom_headers:
+            header_parameters.update(custom_headers)
+        if self.config.accept_language is not None:
+            header_parameters['accept-language'] = self._serialize.header("self.config.accept_language", self.config.accept_language, 'str')
+
+        # Construct and send request
+        request = self._client.get(url, query_parameters, header_parameters)
+        response = self._client.send(request, stream=False, **operation_config)
+
+        if response.status_code not in [200]:
+            exp = CloudError(response)
+            exp.request_id = response.headers.get('x-ms-request-id')
+            raise exp
+
+        deserialized = None
+
+        if response.status_code == 200:
+            deserialized = self._deserialize('[AgreementTerms]', response)
+
+        if raw:
+            client_raw_response = ClientRawResponse(deserialized, response)
+            return client_raw_response
+
+        return deserialized
+    list.metadata = {'url': '/subscriptions/{subscriptionId}/providers/Microsoft.MarketplaceOrdering/agreements'}


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5279