### PR TITLE
Allow for "Optional Long Running Tests" Public Build

### DIFF
--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -42,7 +42,7 @@ jobs:
           artifactName: packages
 
   - job: 'Analyze'
-
+    condition: or(eq(variables['long_running_tests'], True), eq(variables['long_running_tests'], ''))
     dependsOn:
       - 'Build'
 
@@ -85,6 +85,8 @@ jobs:
           artifactName: reports
 
   - job: 'Generic_Tests'
+  
+    condition: or(eq(variables['long_running_tests'], False), eq(variables['long_running_tests'], ''))
 
     dependsOn:
       - 'Build'
@@ -170,7 +172,9 @@ jobs:
   - job: Test_Alpha_Python
 
     timeoutInMinutes: 90
-    condition: eq(variables['long_running_tests'], True)
+    
+    condition: or(eq(variables['long_running_tests'], True), eq(variables['long_running_tests'], ''))
+
     dependsOn:
       - 'Build'
 
@@ -202,9 +206,11 @@ jobs:
   - job: Test_PyPy
 
     timeoutInMinutes: 90
-    condition: eq(variables['long_running_tests'], True)
+
+    condition: or(eq(variables['long_running_tests'], True), eq(variables['long_running_tests'], ''))
+    
     dependsOn:
-      - 'Build'
+      - 'Test_Alpha_Python'
 
     pool:
       vmImage: 'ubuntu-16.04'


### PR DESCRIPTION
This PR updates the build yaml  so that we can create another public build that will run only the Nightly and PyPy tests.

So, behavior is predicated based on the variable `long_running_tests`:
* Set to False, run only the regular test suite
* Set to True, run only the long running tests
* Left Blank, run both long running and regular tests

#4496 