### PR TITLE
Fix method add_face_from_url from FaceClient while using target_face optional parameter

### DIFF
--- a/azure-cognitiveservices-vision-face/azure/cognitiveservices/vision/face/operations/large_face_list_operations.py
+++ b/azure-cognitiveservices-vision-face/azure/cognitiveservices/vision/face/operations/large_face_list_operations.py
@@ -611,7 +611,7 @@ class LargeFaceListOperations(object):
         if user_data is not None:
             query_parameters['userData'] = self._serialize.query("user_data", user_data, 'str', max_length=1024)
         if target_face is not None:
-            query_parameters['targetFace'] = self._serialize.query("target_face", target_face, '[int]', div=',')
+            query_parameters['targetFace'] = self._serialize.query("target_face", target_face, '[str]', div=',')
 
         # Construct headers
         header_parameters = {}


### PR DESCRIPTION
Hello everyone,

first of all thank you for making the code open source. It greatly helps while deloping new features to be able to understand how things works under the hood.

I'm playing around with the code samples provided [here](https://github.com/Azure-Samples/cognitive-services-python-sdk-samples).

I found an issue that occurs while using the azure cognitive services and especially the face API.
The bug occurs when trying to add a face to a large face group while using the add_face_from_url method from the FaceClientin azure.cognitiveservices.vision.face and specifying the target_face optional parameter. The target_face is specified as 

> A face rectangle to specify the target face to be added to a person in the format of "targetFace=left,top,width,height". E.g. "targetFace=10,10,100,100". If there is more than one face in the image, targetFace is required to specify which face to add. No targetFace means there is only one face detected in the entire image.

in the [code](https://github.com/Azure/azure-sdk-for-python/blob/master/azure-cognitiveservices-vision-face/azure/cognitiveservices/vision/face/operations/large_face_list_operations.py) and the [API documentation](https://docs.microsoft.com/en-us/rest/api/cognitiveservices/face/largefacelist/addfacefromurl).

The bug that occurs is that when trying to serialize the list of integers it raises a TypeError with the message: `"sequence item 0: expected str instance, int found"`

Here is the complete stack trace:
   ```
Traceback (most recent call last):
     File "/usr/local/lib/python3.6/site-packages/msrest/serialization.py", line 708, in serialize_data
       data, data_type[1:-1], **kwargs)
     File "/usr/local/lib/python3.6/site-packages/msrest/serialization.py", line 789, in serialize_iter
       serialized = div.join(serialized)
   TypeError: sequence item 0: expected str instance, int found

   During handling of the above exception, another exception occurred:

   Traceback (most recent call last):
     File "/usr/local/lib/python3.6/site-packages/msrest/serialization.py", line 622, in query
       output = self.serialize_data(data, data_type, **kwargs)
     File "/usr/local/lib/python3.6/site-packages/msrest/serialization.py", line 713, in serialize_data
       SerializationError, msg.format(data, data_type), err)
     File "/usr/local/lib/python3.6/site-packages/msrest/exceptions.py", line 51, in raise_with_traceback
       raise error.with_traceback(exc_traceback)
     File "/usr/local/lib/python3.6/site-packages/msrest/serialization.py", line 708, in serialize_data
       data, data_type[1:-1], **kwargs)
     File "/usr/local/lib/python3.6/site-packages/msrest/serialization.py", line 789, in serialize_iter
       serialized = div.join(serialized)
   msrest.exceptions.SerializationError: Unable to serialize value: [588, 221, 482, 482] as type: '[int]'., TypeError: sequence item 0: expected str instance, int found

   During handling of the above exception, another exception occurred:

   Traceback (most recent call last):
     File "fail_example.py", line 87, in <module>
       target_face=face_rectangle
     File "/usr/local/lib/python3.6/site-packages/azure/cognitiveservices/vision/face/operations/large_face_list_operations.py", line 614, in add_face_from_url
       query_parameters['targetFace'] = self._serialize.query("target_face", target_face, '[int]', div=',')
     File "/usr/local/lib/python3.6/site-packages/msrest/serialization.py", line 630, in query
       raise TypeError("{} must be type {}.".format(name, data_type))
   TypeError: target_face must be type [int].

```

The solution I provide to the issue is that in the method add_face_from_url of the FaceClient I serialize the target_face to an list of string instead of a list of int. Doing this solves the issue.

Here is a code sample that reproduce the error:
```

# coding=utf-8
# --------------------------------------------------------------------------
# The goal of this sample is to expose an issue occuring while using the
# azure cognitive services and especially the face API.
# The bug occurs when trying to add a face to a large face group while
# using the add_face_from_url method from the FaceClient
# in azure.cognitiveservices.vision.face and specifying the target_face
# optional parameter.
# The bug that occurs is that when trying to serialize the list of integers
# it raises a TypeError with the message:
#   "sequence item 0: expected str instance, int found"
# Here is the complete stack trace:
#    Traceback (most recent call last):
#      File "/usr/local/lib/python3.6/site-packages/msrest/serialization.py", line 708, in serialize_data
#        data, data_type[1:-1], **kwargs)
#      File "/usr/local/lib/python3.6/site-packages/msrest/serialization.py", line 789, in serialize_iter
#        serialized = div.join(serialized)
#    TypeError: sequence item 0: expected str instance, int found
#
#    During handling of the above exception, another exception occurred:
#
#    Traceback (most recent call last):
#      File "/usr/local/lib/python3.6/site-packages/msrest/serialization.py", line 622, in query
#        output = self.serialize_data(data, data_type, **kwargs)
#      File "/usr/local/lib/python3.6/site-packages/msrest/serialization.py", line 713, in serialize_data
#        SerializationError, msg.format(data, data_type), err)
#      File "/usr/local/lib/python3.6/site-packages/msrest/exceptions.py", line 51, in raise_with_traceback
#        raise error.with_traceback(exc_traceback)
#      File "/usr/local/lib/python3.6/site-packages/msrest/serialization.py", line 708, in serialize_data
#        data, data_type[1:-1], **kwargs)
#      File "/usr/local/lib/python3.6/site-packages/msrest/serialization.py", line 789, in serialize_iter
#        serialized = div.join(serialized)
#    msrest.exceptions.SerializationError: Unable to serialize value: [588, 221, 482, 482] as type: '[int]'., TypeError: sequence item 0: expected str instance, int found
#
#    During handling of the above exception, another exception occurred:
#
#    Traceback (most recent call last):
#      File "fail_example.py", line 87, in <module>
#        target_face=face_rectangle
#      File "/usr/local/lib/python3.6/site-packages/azure/cognitiveservices/vision/face/operations/large_face_list_operations.py", line 614, in add_face_from_url
#        query_parameters['targetFace'] = self._serialize.query("target_face", target_face, '[int]', div=',')
#      File "/usr/local/lib/python3.6/site-packages/msrest/serialization.py", line 630, in query
#        raise TypeError("{} must be type {}.".format(name, data_type))
#    TypeError: target_face must be type [int].
#
#
#
# The solution I provide to the issue is that in the method add_face_from_url
# of the FaceClient I serialize the target_face to an list of string instead of
# a list of int. Doing this solves the issue.
# --------------------------------------------------------------------------

import os
import uuid

from azure.cognitiveservices.vision.face import FaceClient
from msrest.authentication import CognitiveServicesCredentials

SUBSCRIPTION_KEY = "YOUR_SUBSCRIPTION_KEY_HERE"
FACE_LOCATION = "westeurope"

IMAGE_URL = "https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Satya_smiling-print.jpg/1920px-Satya_smiling-print.jpg"

face_base_url = "https://{}.api.cognitive.microsoft.com".format(FACE_LOCATION)
face_client = FaceClient(endpoint=face_base_url, credentials=CognitiveServicesCredentials(SUBSCRIPTION_KEY))

large_face_list_id = "test-" + str(uuid.uuid4())

print("Create large face list with the id: {}.".format(large_face_list_id))
face_client.large_face_list.create(
    large_face_list_id=large_face_list_id,
    name=large_face_list_id,
    user_data=large_face_list_id
)

print("Detect the faces and their location in the image located at: {}.".format(IMAGE_URL))
detected_faces = face_client.face.detect_with_url(url=IMAGE_URL)
if not detected_faces:
    print("No faces detected from image {}".format(IMAGE_URL))
else:
    print("{} faces detected from image {}".format(len(detected_faces), IMAGE_URL))
    for detected_face in detected_faces:
        face_rectangle = [
            detected_face.face_rectangle.left,
            detected_face.face_rectangle.top,
            detected_face.face_rectangle.width,
            detected_face.face_rectangle.height
        ]
        print("Adding the face located at {} to the large face list with id {}.".format(str(face_rectangle), large_face_list_id))
        faces = face_client.large_face_list.add_face_from_url(
            large_face_list_id=large_face_list_id,
            url=IMAGE_URL,
            user_data=os.path.basename(IMAGE_URL),
            target_face=face_rectangle
        )

```

I'm not aware of all the implication of the change I made in the code. Can you review what I've done and let me know if anything needs to be modified? 

Let me know if you need more information or if I need to fix something regarding the code of conduct of the contributing guidelines.

Best regards,
Jonathan.