### PR TITLE
Move paging to azure-core

### DIFF
--- a/azure-core/azure/core/async_paging.py
+++ b/azure-core/azure/core/async_paging.py
@@ -1,0 +1,79 @@
+# --------------------------------------------------------------------------
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the ""Software""), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+# --------------------------------------------------------------------------
+from collections.abc import AsyncIterator
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+class AsyncPagedMixin(AsyncIterator):
+
+    def __init__(self, *args, **kwargs):
+        """Bring async to Paging.
+
+        "async_command" is mandatory keyword argument for this mixin to work.
+        """
+        self._async_get_next = kwargs.get("async_command")
+        if not self._async_get_next:
+            _LOGGER.debug("Paging async iterator protocol is not available for %s",
+                          self.__class__.__name__)
+
+    async def async_get(self, url):
+        """Get an arbitrary page.
+
+        This resets the iterator and then fully consumes it to return the
+        specific page **only**.
+
+        :param str url: URL to arbitrary page results.
+        """
+        self.reset()
+        self.next_link = url
+        return await self.async_advance_page()
+
+    async def async_advance_page(self):
+        if not self._async_get_next:
+            raise NotImplementedError(
+                "The class %s does not support async paging at the moment.",
+                self.__class__.__name__
+            )
+        if self.next_link is None:
+            raise StopAsyncIteration("End of paging")
+        self._current_page_iter_index = 0
+        self._response = await self._async_get_next(self.next_link)
+        self._derserializer(self, self._response)
+        return self.current_page
+
+    async def __anext__(self):
+        """Iterate through responses."""
+        # Storing the list iterator might work out better, but there's no
+        # guarantee that some code won't replace the list entirely with a copy,
+        # invalidating an list iterator that might be saved between iterations.
+        if self.current_page and self._current_page_iter_index < len(self.current_page):
+            response = self.current_page[self._current_page_iter_index]
+            self._current_page_iter_index += 1
+            return response
+        else:
+            await self.async_advance_page()
+            return await self.__anext__()

--- a/azure-core/azure/core/async_paging.py
+++ b/azure-core/azure/core/async_paging.py
@@ -40,18 +40,6 @@ class AsyncPagedMixin(AsyncIterator):
             _LOGGER.debug("Paging async iterator protocol is not available for %s",
                           self.__class__.__name__)
 
-    async def async_get(self, url):
-        """Get an arbitrary page.
-
-        This resets the iterator and then fully consumes it to return the
-        specific page **only**.
-
-        :param str url: URL to arbitrary page results.
-        """
-        self.reset()
-        self.next_link = url
-        return await self.async_advance_page()
-
     async def async_advance_page(self):
         if not self._async_get_next:
             raise NotImplementedError(

--- a/azure-core/azure/core/async_paging.py
+++ b/azure-core/azure/core/async_paging.py
@@ -50,7 +50,7 @@ class AsyncPagedMixin(AsyncIterator):
             raise StopAsyncIteration("End of paging")
         self._current_page_iter_index = 0
         self._response = await self._async_get_next(self.next_link)
-        self._derserializer(self, self._response)
+        self._deserializer(self, self._response)
         return self.current_page
 
     async def __anext__(self):

--- a/azure-core/azure/core/async_paging.py
+++ b/azure-core/azure/core/async_paging.py
@@ -40,7 +40,7 @@ class AsyncPagedMixin(AsyncIterator):
             _LOGGER.debug("Paging async iterator protocol is not available for %s",
                           self.__class__.__name__)
 
-    async def async_advance_page(self):
+    async def _async_advance_page(self):
         if not self._async_get_next:
             raise NotImplementedError(
                 "The class %s does not support async paging at the moment.",
@@ -63,5 +63,5 @@ class AsyncPagedMixin(AsyncIterator):
             self._current_page_iter_index += 1
             return response
         else:
-            await self.async_advance_page()
+            await self._async_advance_page()
             return await self.__anext__()

--- a/azure-core/azure/core/async_paging.py
+++ b/azure-core/azure/core/async_paging.py
@@ -43,7 +43,7 @@ class AsyncPagedMixin(AsyncIterator):
     async def _async_advance_page(self):
         if not self._async_get_next:
             raise NotImplementedError(
-                "The class %s does not support async paging at the moment.",
+                "The class %s does not support async paging.",
                 self.__class__.__name__
             )
         if self.next_link is None:

--- a/azure-core/azure/core/paging.py
+++ b/azure-core/azure/core/paging.py
@@ -32,8 +32,6 @@ except ImportError:
 
 from typing import Dict, Any, List, Callable, Optional, TYPE_CHECKING  # pylint: disable=unused-import
 
-from msrest.serialization import Deserializer
-
 if TYPE_CHECKING:
     from .pipeline import HttpResponse  # pylint: disable=unused-import
     from msrest.serialization import Model  # pylint: disable=unused-import
@@ -57,14 +55,14 @@ class Paged(AsyncPagedMixin, Iterator):
     _validation = {}  # type: Dict[str, Dict[str, Any]]
     _attribute_map = {}  # type: Dict[str, Dict[str, Any]]
 
-    def __init__(self, command, classes, **kwargs):
-        # type: (Callable[[str], HttpResponse], Dict[str, Model], Any) -> None
+    def __init__(self, command, classes, deserializer**kwargs):
+        # type: (Callable[[str], HttpResponse], Dict[str, Model], Callable, Any) -> None
         super(Paged, self).__init__(**kwargs)  # type: ignore
         # Sets next_link, current_page, and _current_page_iter_index.
         self.next_link = ""
         self.current_page = []  # type: List[Model]
         self._current_page_iter_index = 0
-        self._deserializer = Deserializer(classes)
+        self._deserializer = deserializer(classes)
         self._get_next = command
         self._response = None  # type: Optional[HttpResponse]
 

--- a/azure-core/azure/core/paging.py
+++ b/azure-core/azure/core/paging.py
@@ -57,8 +57,8 @@ class Paged(AsyncPagedMixin, Iterator):
     _validation = {}  # type: Dict[str, Dict[str, Any]]
     _attribute_map = {}  # type: Dict[str, Dict[str, Any]]
 
-    def __init__(self, command, classes, raw_headers=None, **kwargs):
-        # type: (Callable[[str], HttpResponse], Dict[str, Model], Dict[str, str], Any) -> None
+    def __init__(self, command, classes, **kwargs):
+        # type: (Callable[[str], HttpResponse], Dict[str, Model], Any) -> None
         super(Paged, self).__init__(**kwargs)  # type: ignore
         # Sets next_link, current_page, and _current_page_iter_index.
         self.next_link = ""
@@ -67,7 +67,6 @@ class Paged(AsyncPagedMixin, Iterator):
         self._deserializer = Deserializer(classes)
         self._get_next = command
         self._response = None  # type: Optional[HttpResponse]
-        self._raw_headers = raw_headers
 
     def __iter__(self):
         """Return 'self'."""

--- a/azure-core/azure/core/paging.py
+++ b/azure-core/azure/core/paging.py
@@ -32,12 +32,12 @@ except ImportError:
 
 from typing import Dict, Any, List, Callable, Optional, TYPE_CHECKING  # pylint: disable=unused-import
 
-from .serialization import Deserializer
+from msrest.serialization import Deserializer
 from .pipeline import ClientRawResponse
 
 if TYPE_CHECKING:
     from .universal_http import ClientResponse  # pylint: disable=unused-import
-    from .serialization import Model  # pylint: disable=unused-import
+    from msrest.serialization import Model  # pylint: disable=unused-import
 
 if sys.version_info >= (3, 5, 2):
     # Not executed on old Python, no syntax error

--- a/azure-core/azure/core/paging.py
+++ b/azure-core/azure/core/paging.py
@@ -55,7 +55,7 @@ class Paged(AsyncPagedMixin, Iterator):
     _validation = {}  # type: Dict[str, Dict[str, Any]]
     _attribute_map = {}  # type: Dict[str, Dict[str, Any]]
 
-    def __init__(self, command, classes, deserializer**kwargs):
+    def __init__(self, command, deserializer, **kwargs):
         # type: (Callable[[str], HttpResponse], Dict[str, Model], Callable, Any) -> None
         super(Paged, self).__init__(**kwargs)  # type: ignore
         # Sets next_link, current_page, and _current_page_iter_index.

--- a/azure-core/azure/core/paging.py
+++ b/azure-core/azure/core/paging.py
@@ -35,7 +35,7 @@ from typing import Dict, Any, List, Callable, Optional, TYPE_CHECKING  # pylint:
 from msrest.serialization import Deserializer
 
 if TYPE_CHECKING:
-    from .pipeline.transport import HttpResponse  # pylint: disable=unused-import
+    from .pipeline import HttpResponse  # pylint: disable=unused-import
     from msrest.serialization import Model  # pylint: disable=unused-import
 
 if sys.version_info >= (3, 5, 2):

--- a/azure-core/azure/core/paging.py
+++ b/azure-core/azure/core/paging.py
@@ -34,7 +34,7 @@ from typing import Dict, Any, List, Callable, Optional, TYPE_CHECKING  # pylint:
 
 if TYPE_CHECKING:
     from .pipeline import HttpResponse  # pylint: disable=unused-import
-    from msrest.serialization import Model  # pylint: disable=unused-import
+    from msrest.serialization import Deserializer, Model  # pylint: disable=unused-import
 
 if sys.version_info >= (3, 5, 2):
     # Not executed on old Python, no syntax error
@@ -54,7 +54,7 @@ class Paged(AsyncPagedMixin, Iterator):
     _attribute_map = {}  # type: Dict[str, Dict[str, Any]]
 
     def __init__(self, command, deserializer, **kwargs):
-        # type: (Callable[[str], HttpResponse], Dict[str, Model], Callable, Any) -> None
+        # type: (Callable[[str], HttpResponse], Deserializer, Any) -> None
         super(Paged, self).__init__(**kwargs)  # type: ignore
         # Sets next_link, current_page, and _current_page_iter_index.
         self.next_link = ""

--- a/azure-core/azure/core/paging.py
+++ b/azure-core/azure/core/paging.py
@@ -80,7 +80,7 @@ class Paged(AsyncPagedMixin, Iterator):
         """Required for parity to Model object for deserialization."""
         return {}
 
-    def advance_page(self):
+    def _advance_page(self):
         # type: () -> List[Model]
         """Force moving the cursor to the next azure call.
 
@@ -107,7 +107,7 @@ class Paged(AsyncPagedMixin, Iterator):
             self._current_page_iter_index += 1
             return response
         else:
-            self.advance_page()
+            self._advance_page()
             return self.__next__()
 
     next = __next__  # Python 2 compatibility.

--- a/azure-core/azure/core/paging.py
+++ b/azure-core/azure/core/paging.py
@@ -48,9 +48,7 @@ class Paged(AsyncPagedMixin, Iterator):
 
     :param HttpResponse response: server response object.
     :param callable command: Function to retrieve the next page of items.
-    :param dict classes: A dictionary of class dependencies for
-     deserialization.
-    :param dict raw_headers: A dict of raw headers to add if "raw" is called
+    :param Deserializer deserializer: a Deserializer instance to use
     """
     _validation = {}  # type: Dict[str, Dict[str, Any]]
     _attribute_map = {}  # type: Dict[str, Dict[str, Any]]
@@ -62,7 +60,7 @@ class Paged(AsyncPagedMixin, Iterator):
         self.next_link = ""
         self.current_page = []  # type: List[Model]
         self._current_page_iter_index = 0
-        self._deserializer = deserializer(classes)
+        self._deserializer = deserializer
         self._get_next = command
         self._response = None  # type: Optional[HttpResponse]
 

--- a/azure-core/azure/core/paging.py
+++ b/azure-core/azure/core/paging.py
@@ -62,8 +62,8 @@ class Paged(AsyncPagedMixin, Iterator):
         super(Paged, self).__init__(**kwargs)  # type: ignore
         # Sets next_link, current_page, and _current_page_iter_index.
         self.next_link = ""
+        self.current_page = []  # type: List[Model]
         self._current_page_iter_index = 0
-        self.reset()
         self._derserializer = Deserializer(classes)
         self._get_next = command
         self._response = None  # type: Optional[ClientResponse]
@@ -79,13 +79,6 @@ class Paged(AsyncPagedMixin, Iterator):
     def _get_subtype_map(cls):
         """Required for parity to Model object for deserialization."""
         return {}
-
-    def reset(self):
-        # type: () -> None
-        """Reset iterator to first page."""
-        self.next_link = ""
-        self.current_page = []  # type: List[Model]
-        self._current_page_iter_index = 0
 
     def advance_page(self):
         # type: () -> List[Model]

--- a/azure-core/azure/core/paging.py
+++ b/azure-core/azure/core/paging.py
@@ -80,19 +80,6 @@ class Paged(AsyncPagedMixin, Iterator):
         """Required for parity to Model object for deserialization."""
         return {}
 
-    def get(self, url):
-        # type: (str) -> List[Model]
-        """Get an arbitrary page.
-
-        This resets the iterator and then fully consumes it to return the
-        specific page **only**.
-
-        :param str url: URL to arbitrary page results.
-        """
-        self.reset()
-        self.next_link = url
-        return self.advance_page()
-
     def reset(self):
         # type: () -> None
         """Reset iterator to first page."""

--- a/azure-core/azure/core/paging.py
+++ b/azure-core/azure/core/paging.py
@@ -35,7 +35,7 @@ from typing import Dict, Any, List, Callable, Optional, TYPE_CHECKING  # pylint:
 from msrest.serialization import Deserializer
 
 if TYPE_CHECKING:
-    from .universal_http import ClientResponse  # pylint: disable=unused-import
+    from .pipeline.transport import HttpResponse  # pylint: disable=unused-import
     from msrest.serialization import Model  # pylint: disable=unused-import
 
 if sys.version_info >= (3, 5, 2):
@@ -48,7 +48,7 @@ else:
 class Paged(AsyncPagedMixin, Iterator):
     """A container for paged REST responses.
 
-    :param ClientResponse response: server response object.
+    :param HttpResponse response: server response object.
     :param callable command: Function to retrieve the next page of items.
     :param dict classes: A dictionary of class dependencies for
      deserialization.
@@ -58,7 +58,7 @@ class Paged(AsyncPagedMixin, Iterator):
     _attribute_map = {}  # type: Dict[str, Dict[str, Any]]
 
     def __init__(self, command, classes, raw_headers=None, **kwargs):
-        # type: (Callable[[str], ClientResponse], Dict[str, Model], Dict[str, str], Any) -> None
+        # type: (Callable[[str], HttpResponse], Dict[str, Model], Dict[str, str], Any) -> None
         super(Paged, self).__init__(**kwargs)  # type: ignore
         # Sets next_link, current_page, and _current_page_iter_index.
         self.next_link = ""
@@ -66,7 +66,7 @@ class Paged(AsyncPagedMixin, Iterator):
         self._current_page_iter_index = 0
         self._deserializer = Deserializer(classes)
         self._get_next = command
-        self._response = None  # type: Optional[ClientResponse]
+        self._response = None  # type: Optional[HttpResponse]
         self._raw_headers = raw_headers
 
     def __iter__(self):

--- a/azure-core/azure/core/paging.py
+++ b/azure-core/azure/core/paging.py
@@ -1,0 +1,146 @@
+# --------------------------------------------------------------------------
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the ""Software""), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+# --------------------------------------------------------------------------
+import sys
+try:
+    from collections.abc import Iterator
+    xrange = range
+except ImportError:
+    from collections import Iterator
+
+from typing import Dict, Any, List, Callable, Optional, TYPE_CHECKING  # pylint: disable=unused-import
+
+from .serialization import Deserializer
+from .pipeline import ClientRawResponse
+
+if TYPE_CHECKING:
+    from .universal_http import ClientResponse  # pylint: disable=unused-import
+    from .serialization import Model  # pylint: disable=unused-import
+
+if sys.version_info >= (3, 5, 2):
+    # Not executed on old Python, no syntax error
+    from .async_paging import AsyncPagedMixin  # type: ignore
+else:
+    class AsyncPagedMixin(object):  # type: ignore
+        pass
+
+class Paged(AsyncPagedMixin, Iterator):
+    """A container for paged REST responses.
+
+    :param ClientResponse response: server response object.
+    :param callable command: Function to retrieve the next page of items.
+    :param dict classes: A dictionary of class dependencies for
+     deserialization.
+    :param dict raw_headers: A dict of raw headers to add if "raw" is called
+    """
+    _validation = {}  # type: Dict[str, Dict[str, Any]]
+    _attribute_map = {}  # type: Dict[str, Dict[str, Any]]
+
+    def __init__(self, command, classes, raw_headers=None, **kwargs):
+        # type: (Callable[[str], ClientResponse], Dict[str, Model], Dict[str, str], Any) -> None
+        super(Paged, self).__init__(**kwargs)  # type: ignore
+        # Sets next_link, current_page, and _current_page_iter_index.
+        self.next_link = ""
+        self._current_page_iter_index = 0
+        self.reset()
+        self._derserializer = Deserializer(classes)
+        self._get_next = command
+        self._response = None  # type: Optional[ClientResponse]
+        self._raw_headers = raw_headers
+
+    def __iter__(self):
+        """Return 'self'."""
+        # Since iteration mutates this object, consider it an iterator in-and-of
+        # itself.
+        return self
+
+    @classmethod
+    def _get_subtype_map(cls):
+        """Required for parity to Model object for deserialization."""
+        return {}
+
+    @property
+    def raw(self):
+        # type: () -> ClientRawResponse
+        """Get current page as ClientRawResponse.
+
+        :rtype: ClientRawResponse
+        """
+        raw = ClientRawResponse(self.current_page, self._response)
+        if self._raw_headers:
+            raw.add_headers(self._raw_headers)
+        return raw
+
+    def get(self, url):
+        # type: (str) -> List[Model]
+        """Get an arbitrary page.
+
+        This resets the iterator and then fully consumes it to return the
+        specific page **only**.
+
+        :param str url: URL to arbitrary page results.
+        """
+        self.reset()
+        self.next_link = url
+        return self.advance_page()
+
+    def reset(self):
+        # type: () -> None
+        """Reset iterator to first page."""
+        self.next_link = ""
+        self.current_page = []  # type: List[Model]
+        self._current_page_iter_index = 0
+
+    def advance_page(self):
+        # type: () -> List[Model]
+        """Force moving the cursor to the next azure call.
+
+        This method is for advanced usage, iterator protocol is prefered.
+
+        :raises: StopIteration if no further page
+        :return: The current page list
+        :rtype: list
+        """
+        if self.next_link is None:
+            raise StopIteration("End of paging")
+        self._current_page_iter_index = 0
+        self._response = self._get_next(self.next_link)
+        self._derserializer(self, self._response)
+        return self.current_page
+
+    def __next__(self):
+        """Iterate through responses."""
+        # Storing the list iterator might work out better, but there's no
+        # guarantee that some code won't replace the list entirely with a copy,
+        # invalidating an list iterator that might be saved between iterations.
+        if self.current_page and self._current_page_iter_index < len(self.current_page):
+            response = self.current_page[self._current_page_iter_index]
+            self._current_page_iter_index += 1
+            return response
+        else:
+            self.advance_page()
+            return self.__next__()
+
+    next = __next__  # Python 2 compatibility.

--- a/azure-core/azure/core/paging.py
+++ b/azure-core/azure/core/paging.py
@@ -64,7 +64,7 @@ class Paged(AsyncPagedMixin, Iterator):
         self.next_link = ""
         self.current_page = []  # type: List[Model]
         self._current_page_iter_index = 0
-        self._derserializer = Deserializer(classes)
+        self._deserializer = Deserializer(classes)
         self._get_next = command
         self._response = None  # type: Optional[ClientResponse]
         self._raw_headers = raw_headers
@@ -94,7 +94,7 @@ class Paged(AsyncPagedMixin, Iterator):
             raise StopIteration("End of paging")
         self._current_page_iter_index = 0
         self._response = self._get_next(self.next_link)
-        self._derserializer(self, self._response)
+        self._deserializer(self, self._response)
         return self.current_page
 
     def __next__(self):

--- a/azure-core/azure/core/paging.py
+++ b/azure-core/azure/core/paging.py
@@ -33,7 +33,6 @@ except ImportError:
 from typing import Dict, Any, List, Callable, Optional, TYPE_CHECKING  # pylint: disable=unused-import
 
 from msrest.serialization import Deserializer
-from .pipeline import ClientRawResponse
 
 if TYPE_CHECKING:
     from .universal_http import ClientResponse  # pylint: disable=unused-import
@@ -80,18 +79,6 @@ class Paged(AsyncPagedMixin, Iterator):
     def _get_subtype_map(cls):
         """Required for parity to Model object for deserialization."""
         return {}
-
-    @property
-    def raw(self):
-        # type: () -> ClientRawResponse
-        """Get current page as ClientRawResponse.
-
-        :rtype: ClientRawResponse
-        """
-        raw = ClientRawResponse(self.current_page, self._response)
-        if self._raw_headers:
-            raw.add_headers(self._raw_headers)
-        return raw
 
     def get(self, url):
         # type: (str) -> List[Model]


### PR DESCRIPTION
This PR migrates paging support from *msrest* to *azure-core*

* Tentatively removed `raw`, `get`, and `async_get` methods as unused or unneeded
* Merged `reset` method code back into the initializer
* Made `advance_page` and `async_advance_page` methods private
* Changed the return type specification for `command` and `async_command` to new `HttpResponse`

Miscellaneous questions:

* Do we want to inject a `Deserializer` explicitly instead of creating one internally? 

* I think the style guide line limit is long enough to join some of the lines here. I definitely prefer longer lines to more, but thought I'd ask first

* I think making `async_command=None` an optional arg to `AsyncPagedMixin ` would be preferable to a kwargs get from a docs POV

* It seem like `AsyncPagedMixin` should call `super` as a matter of form ("everywhere or nowhere")

cc @annatisch @chlowell