### PR TITLE
revert the filter on python < 3.8 in service-bus dev_requirements.txt

### DIFF
--- a/azure-servicebus/dev_requirements.txt
+++ b/azure-servicebus/dev_requirements.txt
@@ -1,3 +1,3 @@
 -e ../azure-sdk-tools
-pylint==2.1.1; python_version >= '3.4' and python_version < '3.8'
+pylint==2.1.1; python_version >= '3.4'
 pylint==1.8.4; python_version < '3.4'


### PR DESCRIPTION
`typed-ast` has released an update. This should work now.