### PR TITLE
Pull PyPy into the normal matrix

### DIFF
--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -87,6 +87,8 @@ jobs:
   
     condition: or(eq(variables['long_running_tests'], False), eq(variables['long_running_tests'], ''))
 
+    timeoutInMinutes: 90
+
     dependsOn:
       - 'Build'
 

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -112,6 +112,10 @@ jobs:
           OSName: 'Linux'
           OSVmImage: 'ubuntu-16.04'
           PythonVersion: '3.7'
+        Linux_Pypy3:
+          OSName: 'Linux'
+          OSVmImage: 'ubuntu-16.04'
+          PythonVersion: 'pypy3'
         Windows_Python35:
           OSName: 'Windows'
           OSVmImage: 'vs2017-win2016'
@@ -213,38 +217,3 @@ jobs:
           python ./scripts/devops_tasks/setup_execute_tests.py -p python3 "$(build_targeting_string)"
         displayName: 'Setup - Run Filtered Tests "Nightly" Python'
         continueOnError: true
-
-  - job: Test_PyPy
-
-    timeoutInMinutes: 90
-
-    condition: or(eq(variables['long_running_tests'], True), eq(variables['long_running_tests'], ''))
-    
-    dependsOn:
-      - 'Test_Alpha_Python'
-
-    pool:
-      vmImage: 'ubuntu-16.04'
-
-    steps:
-      - task: UsePythonVersion@0
-        displayName: 'Use Python 3.7 For Build Tools'
-        inputs:
-          versionSpec: '3.7'
-
-      - script: |
-          pip install pathlib twine
-        displayName: 'Prep Environment'
-
-      - script: |
-          cd ~/
-          wget https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-linux64.tar.bz2
-          tar xf pypy3-v6.0.0-linux64.tar.bz2
-          cd $(Build.SourcesDirectory)
-          PATH=/home/vsts/pypy3-v6.0.0-linux64/bin/:$PATH
-          pypy3 -m ensurepip
-          python ./scripts/devops_tasks/setup_execute_tests.py -p pypy3 "$(build_targeting_string)" --disablecov
-        displayName: 'Setup and Run Filtered Tests PyPy3'
-        continueOnError: true
-
-


### PR DESCRIPTION
Hi there, PM from Azure Pipelines here. We've recently added `pypy2` and `pypy3` as valid targets for the `UsePythonVersion` task. You no longer have to special-case PyPy.

When I tested this on my fork, the Build job fails in exactly the same way with/without my changes, and the PyPy leg itself succeeds.