### PR TITLE
Provide tox.ini to run across multiple versions of Python

### DIFF
--- a/azure-core/tox.ini
+++ b/azure-core/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist={py27,py34,py35,py36,pypy3.6-7.1.0,py37}
+
+[testenv]
+setenv =
+    PythonLogLevel=30
+deps=
+    pytest
+    mock
+    futures; python_version == '2.7'
+    trio; python_version >= '3.5'
+    aiohttp; python_version >= '3.5'
+    aiodns; python_version >= '3.5'
+    pytest-asyncio; python_version >= '3.5'
+commands=
+    pytest 


### PR DESCRIPTION
Runs across 2.7.16 up to 3.7.3 and latest version of PyPy. I included specific test dependencies in the tox.ini. Alternatively, we can update dev_requirements.txt to include everything that is needed to keep a single source of truth. 