### PR TITLE
[AutoPR containerservice/resource-manager] Revert node public ip support from 2019-04-01 model.

### DIFF
--- a/azure-mgmt-containerservice/azure/mgmt/containerservice/v2019_04_30/models/agent_pool.py
+++ b/azure-mgmt-containerservice/azure/mgmt/containerservice/v2019_04_30/models/agent_pool.py
@@ -117,8 +117,6 @@ class AgentPool(SubResource):
     :param availability_zones: (PREVIEW) Availability zones for nodes. Must
      use VirtualMachineScaleSets AgentPoolType.
     :type availability_zones: list[str]
-    :param enable_node_public_ip: Enable public IP for nodes
-    :type enable_node_public_ip: bool
     """
 
     _validation = {
@@ -147,7 +145,6 @@ class AgentPool(SubResource):
         'orchestrator_version': {'key': 'properties.orchestratorVersion', 'type': 'str'},
         'provisioning_state': {'key': 'properties.provisioningState', 'type': 'str'},
         'availability_zones': {'key': 'properties.availabilityZones', 'type': '[str]'},
-        'enable_node_public_ip': {'key': 'properties.enableNodePublicIP', 'type': 'bool'},
     }
 
     def __init__(self, **kwargs):
@@ -165,4 +162,3 @@ class AgentPool(SubResource):
         self.orchestrator_version = kwargs.get('orchestrator_version', None)
         self.provisioning_state = None
         self.availability_zones = kwargs.get('availability_zones', None)
-        self.enable_node_public_ip = kwargs.get('enable_node_public_ip', None)

--- a/azure-mgmt-containerservice/azure/mgmt/containerservice/v2019_04_30/models/agent_pool_py3.py
+++ b/azure-mgmt-containerservice/azure/mgmt/containerservice/v2019_04_30/models/agent_pool_py3.py
@@ -117,8 +117,6 @@ class AgentPool(SubResource):
     :param availability_zones: (PREVIEW) Availability zones for nodes. Must
      use VirtualMachineScaleSets AgentPoolType.
     :type availability_zones: list[str]
-    :param enable_node_public_ip: Enable public IP for nodes
-    :type enable_node_public_ip: bool
     """
 
     _validation = {
@@ -147,10 +145,9 @@ class AgentPool(SubResource):
         'orchestrator_version': {'key': 'properties.orchestratorVersion', 'type': 'str'},
         'provisioning_state': {'key': 'properties.provisioningState', 'type': 'str'},
         'availability_zones': {'key': 'properties.availabilityZones', 'type': '[str]'},
-        'enable_node_public_ip': {'key': 'properties.enableNodePublicIP', 'type': 'bool'},
     }
 
-    def __init__(self, *, vm_size, count: int=1, os_disk_size_gb: int=None, vnet_subnet_id: str=None, max_pods: int=None, os_type="Linux", max_count: int=None, min_count: int=None, enable_auto_scaling: bool=None, agent_pool_type=None, orchestrator_version: str=None, availability_zones=None, enable_node_public_ip: bool=None, **kwargs) -> None:
+    def __init__(self, *, vm_size, count: int=1, os_disk_size_gb: int=None, vnet_subnet_id: str=None, max_pods: int=None, os_type="Linux", max_count: int=None, min_count: int=None, enable_auto_scaling: bool=None, agent_pool_type=None, orchestrator_version: str=None, availability_zones=None, **kwargs) -> None:
         super(AgentPool, self).__init__(**kwargs)
         self.count = count
         self.vm_size = vm_size
@@ -165,4 +162,3 @@ class AgentPool(SubResource):
         self.orchestrator_version = orchestrator_version
         self.provisioning_state = None
         self.availability_zones = availability_zones
-        self.enable_node_public_ip = enable_node_public_ip

--- a/azure-mgmt-containerservice/azure/mgmt/containerservice/v2019_04_30/models/managed_cluster_agent_pool_profile.py
+++ b/azure-mgmt-containerservice/azure/mgmt/containerservice/v2019_04_30/models/managed_cluster_agent_pool_profile.py
@@ -110,8 +110,6 @@ class ManagedClusterAgentPoolProfile(ManagedClusterAgentPoolProfileProperties):
     :param availability_zones: (PREVIEW) Availability zones for nodes. Must
      use VirtualMachineScaleSets AgentPoolType.
     :type availability_zones: list[str]
-    :param enable_node_public_ip: Enable public IP for nodes
-    :type enable_node_public_ip: bool
     :param name: Required. Unique name of the agent pool profile in the
      context of the subscription and resource group.
     :type name: str
@@ -138,7 +136,6 @@ class ManagedClusterAgentPoolProfile(ManagedClusterAgentPoolProfileProperties):
         'orchestrator_version': {'key': 'orchestratorVersion', 'type': 'str'},
         'provisioning_state': {'key': 'provisioningState', 'type': 'str'},
         'availability_zones': {'key': 'availabilityZones', 'type': '[str]'},
-        'enable_node_public_ip': {'key': 'enableNodePublicIP', 'type': 'bool'},
         'name': {'key': 'name', 'type': 'str'},
     }
 

--- a/azure-mgmt-containerservice/azure/mgmt/containerservice/v2019_04_30/models/managed_cluster_agent_pool_profile_properties.py
+++ b/azure-mgmt-containerservice/azure/mgmt/containerservice/v2019_04_30/models/managed_cluster_agent_pool_profile_properties.py
@@ -110,8 +110,6 @@ class ManagedClusterAgentPoolProfileProperties(Model):
     :param availability_zones: (PREVIEW) Availability zones for nodes. Must
      use VirtualMachineScaleSets AgentPoolType.
     :type availability_zones: list[str]
-    :param enable_node_public_ip: Enable public IP for nodes
-    :type enable_node_public_ip: bool
     """
 
     _validation = {
@@ -134,7 +132,6 @@ class ManagedClusterAgentPoolProfileProperties(Model):
         'orchestrator_version': {'key': 'orchestratorVersion', 'type': 'str'},
         'provisioning_state': {'key': 'provisioningState', 'type': 'str'},
         'availability_zones': {'key': 'availabilityZones', 'type': '[str]'},
-        'enable_node_public_ip': {'key': 'enableNodePublicIP', 'type': 'bool'},
     }
 
     def __init__(self, **kwargs):
@@ -152,4 +149,3 @@ class ManagedClusterAgentPoolProfileProperties(Model):
         self.orchestrator_version = kwargs.get('orchestrator_version', None)
         self.provisioning_state = None
         self.availability_zones = kwargs.get('availability_zones', None)
-        self.enable_node_public_ip = kwargs.get('enable_node_public_ip', None)

--- a/azure-mgmt-containerservice/azure/mgmt/containerservice/v2019_04_30/models/managed_cluster_agent_pool_profile_properties_py3.py
+++ b/azure-mgmt-containerservice/azure/mgmt/containerservice/v2019_04_30/models/managed_cluster_agent_pool_profile_properties_py3.py
@@ -110,8 +110,6 @@ class ManagedClusterAgentPoolProfileProperties(Model):
     :param availability_zones: (PREVIEW) Availability zones for nodes. Must
      use VirtualMachineScaleSets AgentPoolType.
     :type availability_zones: list[str]
-    :param enable_node_public_ip: Enable public IP for nodes
-    :type enable_node_public_ip: bool
     """
 
     _validation = {
@@ -134,10 +132,9 @@ class ManagedClusterAgentPoolProfileProperties(Model):
         'orchestrator_version': {'key': 'orchestratorVersion', 'type': 'str'},
         'provisioning_state': {'key': 'provisioningState', 'type': 'str'},
         'availability_zones': {'key': 'availabilityZones', 'type': '[str]'},
-        'enable_node_public_ip': {'key': 'enableNodePublicIP', 'type': 'bool'},
     }
 
-    def __init__(self, *, vm_size, count: int=1, os_disk_size_gb: int=None, vnet_subnet_id: str=None, max_pods: int=None, os_type="Linux", max_count: int=None, min_count: int=None, enable_auto_scaling: bool=None, type=None, orchestrator_version: str=None, availability_zones=None, enable_node_public_ip: bool=None, **kwargs) -> None:
+    def __init__(self, *, vm_size, count: int=1, os_disk_size_gb: int=None, vnet_subnet_id: str=None, max_pods: int=None, os_type="Linux", max_count: int=None, min_count: int=None, enable_auto_scaling: bool=None, type=None, orchestrator_version: str=None, availability_zones=None, **kwargs) -> None:
         super(ManagedClusterAgentPoolProfileProperties, self).__init__(**kwargs)
         self.count = count
         self.vm_size = vm_size
@@ -152,4 +149,3 @@ class ManagedClusterAgentPoolProfileProperties(Model):
         self.orchestrator_version = orchestrator_version
         self.provisioning_state = None
         self.availability_zones = availability_zones
-        self.enable_node_public_ip = enable_node_public_ip

--- a/azure-mgmt-containerservice/azure/mgmt/containerservice/v2019_04_30/models/managed_cluster_agent_pool_profile_py3.py
+++ b/azure-mgmt-containerservice/azure/mgmt/containerservice/v2019_04_30/models/managed_cluster_agent_pool_profile_py3.py
@@ -110,8 +110,6 @@ class ManagedClusterAgentPoolProfile(ManagedClusterAgentPoolProfileProperties):
     :param availability_zones: (PREVIEW) Availability zones for nodes. Must
      use VirtualMachineScaleSets AgentPoolType.
     :type availability_zones: list[str]
-    :param enable_node_public_ip: Enable public IP for nodes
-    :type enable_node_public_ip: bool
     :param name: Required. Unique name of the agent pool profile in the
      context of the subscription and resource group.
     :type name: str
@@ -138,10 +136,9 @@ class ManagedClusterAgentPoolProfile(ManagedClusterAgentPoolProfileProperties):
         'orchestrator_version': {'key': 'orchestratorVersion', 'type': 'str'},
         'provisioning_state': {'key': 'provisioningState', 'type': 'str'},
         'availability_zones': {'key': 'availabilityZones', 'type': '[str]'},
-        'enable_node_public_ip': {'key': 'enableNodePublicIP', 'type': 'bool'},
         'name': {'key': 'name', 'type': 'str'},
     }
 
-    def __init__(self, *, vm_size, name: str, count: int=1, os_disk_size_gb: int=None, vnet_subnet_id: str=None, max_pods: int=None, os_type="Linux", max_count: int=None, min_count: int=None, enable_auto_scaling: bool=None, type=None, orchestrator_version: str=None, availability_zones=None, enable_node_public_ip: bool=None, **kwargs) -> None:
-        super(ManagedClusterAgentPoolProfile, self).__init__(count=count, vm_size=vm_size, os_disk_size_gb=os_disk_size_gb, vnet_subnet_id=vnet_subnet_id, max_pods=max_pods, os_type=os_type, max_count=max_count, min_count=min_count, enable_auto_scaling=enable_auto_scaling, type=type, orchestrator_version=orchestrator_version, availability_zones=availability_zones, enable_node_public_ip=enable_node_public_ip, **kwargs)
+    def __init__(self, *, vm_size, name: str, count: int=1, os_disk_size_gb: int=None, vnet_subnet_id: str=None, max_pods: int=None, os_type="Linux", max_count: int=None, min_count: int=None, enable_auto_scaling: bool=None, type=None, orchestrator_version: str=None, availability_zones=None, **kwargs) -> None:
+        super(ManagedClusterAgentPoolProfile, self).__init__(count=count, vm_size=vm_size, os_disk_size_gb=os_disk_size_gb, vnet_subnet_id=vnet_subnet_id, max_pods=max_pods, os_type=os_type, max_count=max_count, min_count=min_count, enable_auto_scaling=enable_auto_scaling, type=type, orchestrator_version=orchestrator_version, availability_zones=availability_zones, **kwargs)
         self.name = name


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5841