### PR TITLE
Remove me from CDN codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,6 @@
 /azure-loganalytics/ @alexeldeib
 /azure-mgmt-batch/ @annatisch @matthchr
 /azure-mgmt-batchai/ @AlexanderYukhanov
-/azure-mgmt-cdn/ @tjprescott
 /azure-mgmt-consumption/ @sandeepnl
 /azure-mgmt-containerinstance/ @samkreter @xizhamsft
 /azure-mgmt-containerregistry/ @djyou 


### PR DESCRIPTION
No one from CLI team owns the CDN commands or SDK.