### PR TITLE
Doc Generation

### DIFF
--- a/.azure-pipelines/docs.yml
+++ b/.azure-pipelines/docs.yml
@@ -1,0 +1,36 @@
+trigger:
+  - master
+
+variables:
+  PythonVersion: '3.6'
+
+jobs:
+  - job: 'DocGen'
+    timeoutInMinutes: 120
+    pool:
+      vmImage: 'vs2017-win2016'
+
+    steps:
+      - task: UsePythonVersion@0
+        displayName: 'Use Python $(PythonVersion)'
+        inputs:
+          versionSpec: $(PythonVersion)
+
+      - task: PythonScript@0
+        displayName: 'Install All Packages'
+        inputs:
+          scriptPath: 'scripts/dev_setup.py'
+
+      - powershell: |
+          cd $(Build.SourcesDirectory)/doc/
+          pip install -r requirements.txt
+          ./make.bat html
+          mkdir $(Build.ArtifactStagingDirectory)/sphinx
+          Copy-Item -Path $(Build.SourcesDirectory)/doc/_build/html/* -Destination $(Build.ArtifactStagingDirectory)/sphinx -Recurse -Force
+        displayName: 'Generate Sphinx Docs'
+
+      - task: PublishBuildArtifacts@1
+        condition: succeededOrFailed()
+        displayName: 'Publish Artifacts'
+        inputs:
+          artifactName: docfolder


### PR DESCRIPTION
This is a first cut at getting the sphinx docs published on checkin to master. A further PR will be sent folding this code into the standard build after @scbedd figures out how to speed up the html generation.

Currently, the full generation takes about 1 hour 15 minutes. Most of this is spent on generating the files.  @scbedd has attempted the following to decrease build time:

* `html_theme_options`: 
     * `navigation_depth = 2` 
     * `collapse_navigation = False`
build argument of `-j auto`, `-j <n>` 

The magic bullets that others have leveraged to speed up sphinx gen simply don't work for a repository the size of ours. 

I believe the best solution is to re-use the last generated docs as a _start point_ for the current docs. This can be obtained by cloning the `gh-pages` branch and pulling in all the files from there. Follow-up issue:
#5147 
