### PR TITLE
Bearer token credential policies

### DIFF
--- a/sdk/core/azure-core/azure/core/credentials.py
+++ b/sdk/core/azure-core/azure/core/credentials.py
@@ -1,0 +1,16 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from typing import Iterable  # pylint:disable=unused-import
+from typing_extensions import Protocol
+
+
+class SupportsGetToken(Protocol):
+    """Protocol for classes able to provide OAuth tokens"""
+
+    # pylint:disable=too-few-public-methods
+    def get_token(self, scopes):
+        # type: (Iterable[str]) -> str
+        pass

--- a/sdk/core/azure-core/azure/core/pipeline/policies/__init__.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/__init__.py
@@ -25,10 +25,9 @@
 # --------------------------------------------------------------------------
 
 from .base import HTTPPolicy, SansIOHTTPPolicy
-from .credentials import CredentialsPolicy
+from .credentials import BearerTokenCredentialPolicy
 from .redirect import RedirectPolicy
 from .retry import RetryPolicy
-from .custom_hook import CustomHookPolicy
 from .universal import (
     HeadersPolicy,
     UserAgentPolicy,
@@ -40,7 +39,7 @@ from .universal import (
 __all__ = [
     'HTTPPolicy',
     'SansIOHTTPPolicy',
-    'CredentialsPolicy',
+    'BearerTokenCredentialPolicy',
     'HeadersPolicy',
     'UserAgentPolicy',
     'NetworkTraceLoggingPolicy',
@@ -53,12 +52,12 @@ __all__ = [
 
 try:
     from .base_async import AsyncHTTPPolicy
-    from .credentials_async import AsyncCredentialsPolicy
+    from .credentials_async import AsyncBearerTokenCredentialPolicy
     from .redirect_async import AsyncRedirectPolicy
     from .retry_async import AsyncRetryPolicy
     __all__.extend([
         'AsyncHTTPPolicy',
-        'AsyncCredentialsPolicy',
+        'AsyncBearerTokenCredentialPolicy',
         'AsyncRedirectPolicy',
         'AsyncRetryPolicy'
     ])

--- a/sdk/core/azure-core/azure/core/pipeline/policies/credentials_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/credentials_async.py
@@ -1,41 +1,18 @@
-# --------------------------------------------------------------------------
-#
+# -------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
-#
-# The MIT License (MIT)
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the ""Software""), to
-# deal in the Software without restriction, including without limitation the
-# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-# sell copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-# IN THE SOFTWARE.
-#
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
 # --------------------------------------------------------------------------
-import asyncio
-from collections.abc import AsyncIterator
-import functools
-import logging
-from typing import Any, Callable, Optional, AsyncIterator as AsyncIteratorType
-
-import requests
-from requests.models import CONTENT_CHUNK_SIZE
-
+from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import AsyncHTTPPolicy
+from azure.core.pipeline.policies.credentials import _BearerTokenCredentialPolicyBase
 
 
-class AsyncCredentialsPolicy(AsyncHTTPPolicy):
-    """Implementation of request-oauthlib except and retry logic.
-    """
-    pass  # TODO
+class AsyncBearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, AsyncHTTPPolicy):
+    # pylint:disable=too-few-public-methods
+    """Adds a bearer token Authorization header to requests."""
+
+    async def send(self, request: PipelineRequest) -> PipelineResponse:
+        token = await self._credential.get_token(self._scopes)
+        self._update_headers(request.http_request.headers, token)
+        return await self.next.send(request)

--- a/sdk/core/azure-core/dev_requirements.txt
+++ b/sdk/core/azure-core/dev_requirements.txt
@@ -1,3 +1,4 @@
 trio; python_version >= '3.5'
 aiohttp>=3.0; python_version >= '3.5'
 aiodns>=2.0; python_version >= '3.5'
+typing_extensions>=3.7.2

--- a/sdk/core/azure-core/tests/azure_core_asynctests/test_credentials.py
+++ b/sdk/core/azure-core/tests/azure_core_asynctests/test_credentials.py
@@ -1,0 +1,62 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from unittest.mock import Mock
+from azure.core.pipeline import AsyncPipeline, PipelineResponse
+from azure.core.pipeline.policies import HTTPPolicy
+from azure.core.pipeline.policies.credentials_async import AsyncBearerTokenCredentialPolicy
+from azure.core.pipeline.transport import HttpRequest, AsyncHttpTransport
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_bearer_policy_adds_header():
+    """The bearer token policy should add a header containing a token from its credential"""
+    expected_token = "expected_token"
+
+    async def verify_authorization_header(request):
+        assert request.http_request.headers["Authorization"] == "Bearer {}".format(expected_token)
+
+    get_token_calls = 0
+
+    async def get_token(_):
+        nonlocal get_token_calls
+        get_token_calls += 1
+        return expected_token
+
+    fake_credential = Mock(get_token=get_token)
+    policies = [
+        AsyncBearerTokenCredentialPolicy(credential=fake_credential, scopes=("",)),
+        Mock(spec=HTTPPolicy, send=verify_authorization_header),
+    ]
+    pipeline = AsyncPipeline(transport=Mock(spec=AsyncHttpTransport), policies=policies)
+
+    await pipeline.run(HttpRequest("GET", "https://spam.eggs"), context=None)
+    assert get_token_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_bearer_policy_send():
+    """The bearer token policy should invoke the next policy's send method and return the result"""
+    expected_request = HttpRequest("GET", "https://spam.eggs")
+    expected_response = Mock(spec=PipelineResponse)
+
+    async def verify_request(request):
+        assert request.http_request is expected_request
+        return expected_response
+
+    async def get_token(_):
+        return ""
+
+    fake_credential = Mock(get_token=get_token)
+    policies = [
+        AsyncBearerTokenCredentialPolicy(credential=fake_credential, scopes=("",)),
+        Mock(spec=HTTPPolicy, send=verify_request),
+    ]
+    pipeline = AsyncPipeline(transport=Mock(spec=AsyncHttpTransport), policies=policies)
+
+    response = await pipeline.run(expected_request)
+
+    assert response is expected_response

--- a/sdk/core/azure-core/tests/test_credentials.py
+++ b/sdk/core/azure-core/tests/test_credentials.py
@@ -1,0 +1,51 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from azure.core.pipeline import Pipeline, PipelineResponse
+from azure.core.pipeline.policies import BearerTokenCredentialPolicy, HTTPPolicy
+from azure.core.pipeline.transport import HttpRequest, HttpTransport
+
+try:
+    from unittest.mock import Mock
+except ImportError:
+    # python < 3.3
+    from mock import Mock
+
+
+def test_bearer_policy_adds_header():
+    """The bearer token policy should add a header containing a token from its credential"""
+    expected_token = "expected_token"
+
+    def verify_authorization_header(request):
+        assert request.http_request.headers["Authorization"] == "Bearer {}".format(expected_token)
+
+    fake_credential = Mock(get_token=Mock(return_value=expected_token))
+    policies = [
+        BearerTokenCredentialPolicy(credential=fake_credential, scopes=("",)),
+        Mock(spec=HTTPPolicy, send=verify_authorization_header),
+    ]
+
+    Pipeline(transport=Mock(spec=HttpTransport), policies=policies).run(HttpRequest("GET", "https://spam.eggs"))
+
+    assert fake_credential.get_token.call_count == 1
+
+
+def test_bearer_policy_send():
+    """The bearer token policy should invoke the next policy's send method and return the result"""
+    expected_request = HttpRequest("GET", "https://spam.eggs")
+    expected_response = Mock(spec=PipelineResponse)
+
+    def verify_request(request):
+        assert request.http_request is expected_request
+        return expected_response
+
+    fake_credential = Mock(get_token=lambda _: "")
+    policies = [
+        BearerTokenCredentialPolicy(credential=fake_credential, scopes=("",)),
+        Mock(spec=HTTPPolicy, send=verify_request),
+    ]
+    response = Pipeline(transport=Mock(spec=HttpTransport), policies=policies).run(expected_request)
+
+    assert response is expected_response


### PR DESCRIPTION
Here are a/sync policies for adding bearer tokens to HTTP requests, a/sync ABCs for things able to provide auth tokens, and a few tests to ensure everything works as it should.

Closes #5146 