### PR TITLE
add support got global settings

### DIFF
--- a/azure-core/azure/core/settings.py
+++ b/azure-core/azure/core/settings.py
@@ -30,7 +30,7 @@
 
 import logging
 import os
-from typing import Any
+from typing import Any, Union
 
 
 __all__ = ("settings",)
@@ -41,13 +41,19 @@ class _Unset(object):
 
 
 def convert_bool(value):
-    # type: (str) -> bool
-    """Convert a string to a Python logging level
+    # type: (Union[str, bool]) -> bool
+    """Convert a string to True or False
+
+    If a boolean is passed in, it is returned as-is. Otherwise the function
+    maps the following strings, ignoring case:
+
+    * "yes", "1", "on" -> True
+    " "no", "0", "off" -> False
 
     :param value: the value to convert
     :type value: string
     :returns: int
-    :raises ValueError: Ii conversion to bool fails
+    :raises ValueError: If conversion to bool fails
     
     """
     if value in (True, False):
@@ -71,13 +77,22 @@ _levels = {
 
 
 def convert_logging(value):
-    # type: (str) -> int
+    # type: (Union[str, int]) -> int
     """Convert a string to a Python logging level
+
+    If a log level is passed in, it is returned as-is. Otherwise the function
+    understands the following strings, ignoring case:
+
+    * "critical"
+    * "error"
+    * "warning"
+    * "info"
+    * "debug"
 
     :param value: the value to convert
     :type value: string
     :returns: int
-    :raises ValueError: Ii conversion to log level fails
+    :raises ValueError: If conversion to log level fails
 
     """
     if value in set(_levels.values()):
@@ -190,6 +205,10 @@ class PrioritizedSetting(object):
         """
         self._user_value = value
 
+    @property
+    def env_var(self):
+        return self._env_var
+
 
 class Settings(object):
     """Settings for globally used Azure configuration values.
@@ -257,8 +276,12 @@ class Settings(object):
         default=logging.INFO,
     )
 
-    proxy_settings = PrioritizedSetting(
-        "proxy_settings", env_var="AZURE_PROXY_SETTINGS"
+    http_proxy_settings = PrioritizedSetting(
+        "http_proxy_settings", env_var="AZURE_HTTP_PROXY_SETTINGS"
+    )
+
+    https_proxy_settings = PrioritizedSetting(
+        "https_proxy_settings", env_var="AZURE_HTTPS_PROXY_SETTINGS"
     )
 
     telemetry_enabled = PrioritizedSetting(

--- a/azure-core/azure/core/settings.py
+++ b/azure-core/azure/core/settings.py
@@ -1,0 +1,200 @@
+# --------------------------------------------------------------------------
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the ""Software""), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# --------------------------------------------------------------------------
+"""Provide access to settings for globally used Azure configuration values.
+
+
+"""
+
+import logging
+import os
+
+
+__all__ = ("settings",)
+
+
+class _Unset(object):
+    pass
+
+
+class PrioritizedSetting(object):
+    """Return a value for a global setting according to configuration precedence.
+
+    The following methods are searched in order for the setting:
+
+    4. immediate values
+    3. previously user-set value
+    2. environment variable
+    1. system setting
+    0. implicit default
+
+    If a value cannot be determined, a RuntimeError is raised.
+
+    The ``env_var`` argument specifies the name of an environmen to check for
+    setting values, e.g. ``"AZURE_LOG_LEVEL"``.
+
+    The optional ``system_hook`` can be used to specify a function that will
+    attempt to look up a value for the setting from system-wide configurations.
+
+    The optional ``default`` argument specified an implicit default value for
+    the setting that is returned if no other methods provide a value.
+
+    A ``convert`` agument may be provided to convert values before they are
+    returned. For instance to concert log levels in environement variables
+    to ``logging`` module values.
+
+    """
+
+    def __init__(
+        self, name, env_var=None, system_hook=None, default=_Unset, convert=None
+    ):
+
+        self._name = name
+        self._env_var = env_var
+        self._system_hook = system_hook
+        self._default = default
+        self._convert = convert if convert else lambda x: x
+        self._user_value = _Unset
+
+    def __repr__(self):
+        return "PrioritizedSetting(%r)" % self._name
+
+    def __call__(self, value=None):
+        """Return the setting value according to the standard precedence.
+
+        :param time: value
+        :type time: str or int or float or None (default: None)
+        :returns: the value of the setting
+        :rtype: str or int or float
+        :raises: RuntimeError
+
+        """
+        # 4. immediate values
+        if value is not None:
+            return self._convert(value)
+
+        # 3. previously user-set value
+        if self._user_value is not _Unset:
+            return self._convert(self._user_value)
+
+        # 2. environment variable
+        if self._env_var and self._env_var in os.environ:
+            return self._convert(os.environ[self._env_var])
+
+        # 1. system setting
+        if self._system_hook:
+            return self._convert(self._system_hook())
+
+        # 0. implicit default
+        if self._default is not _Unset:
+            return self._convert(self._default)
+
+        raise RuntimeError("No configured value found for setting %r" % self._name)
+
+    def __get__(self, instance, owner):
+        return self
+
+    def __set__(self, instance, value):
+        self.set_value(value)
+
+    def set_value(self, value):
+        """Specify a value for this setting programmatically.
+
+        A value set this way takes precedence over all other methods except
+        immediate values.
+
+        :param time: a user-set value for this setting
+        :type time: str or int or float
+        :returns: None
+
+        """
+        self._user_value = value
+
+
+class Settings(object):
+    """Settings for globally used Azure configuration values.
+
+    The following methods are searched in order for a setting:
+
+    4. immediate values
+    3. previously user-set value
+    2. environment variable
+    1. system setting
+    0. implicit default
+
+    An implicit default is (optionally) defined by the setting attribute itself.
+
+    A system setting value can be obtained from registries or other OS configuration
+    for settings that support that method.
+
+    An environment variable value is obtained from ``os.nviron``
+
+    User-set values many be specified by assigning to the attribute:
+
+    .. code-block:: python
+
+        settings.log_level = log_level = logging.DEBUG
+
+    Immediate values are (optionally) provided when the setting is retrieved:
+
+    .. code-block:: python
+
+        settings.log_level(logging.DEBUG()
+
+    Immediate values are most often useful to provide from optional arguments
+    to client functions. If the argument value is not None, it will be returned
+    as-is. Otherwise, the setting searches other methods according to the
+    precedence rules.
+
+    :Attributes:
+
+    :cvar log_level: a log level to use across all Azure client SDKs (AZURE_LOG_LEVEL)
+    :type log_level: PrioritizedSetting
+    :cvar proxy_settings: proxy settings to use across all Axure client SDKs (AZURE_PROXY_SETTINGS)
+    :type proxy_settings: PrioritizedSetting
+
+    :Example:
+
+    >>> import logging
+    >>> from azure.core.settings import settings
+    >>> settings.log_level = logging.DEBUG
+    >>> settings.log_level()
+    10
+
+    >>> settings.log_level(logging.WARN)
+    30
+
+    """
+
+    log_level = PrioritizedSetting(
+        "log_level", env_var="AZURE_LOG_LEVEL", convert=int, default=logging.INFO
+    )
+
+    proxy_settings = PrioritizedSetting(
+        "proxy_settings", env_var="AZURE_PROXY_SETTINGS"
+    )
+
+
+settings = Settings()

--- a/azure-core/tests/test_settings.py
+++ b/azure-core/tests/test_settings.py
@@ -33,6 +33,10 @@ import azure.core.settings as m
 
 
 class TestPrioritizedSetting(object):
+    def test_env_var_property(self):
+        ps = m.PrioritizedSetting("foo", env_var="AZURE_FOO")
+        assert ps.env_var == "AZURE_FOO"
+
     def test_everything_unset_raises(self):
         ps = m.PrioritizedSetting("foo")
         with pytest.raises(RuntimeError):
@@ -159,9 +163,23 @@ class TestConverters(object):
             m.convert_logging("junk")
 
 
+_standard_settings = [
+    "log_level",
+    "http_proxy_settings",
+    "https_proxy_settings",
+    "telemetry_enabled",
+    "tracing_enabled",
+]
+
+
 class TestStandardSettings(object):
-    @pytest.mark.parametrize(
-        "name", ["log_level", "proxy_settings", "telemetry_enabled", "tracing_enabled"]
-    )
+    @pytest.mark.parametrize("name", _standard_settings)
     def test_setting_exists(self, name):
         assert hasattr(m.settings, name)
+
+    # XXX: This test will need to become more sophisticated if the assumption
+    # settings.foo -> AZURE_FOO for env vars ever becomes invalidated.
+    @pytest.mark.parametrize("name", _standard_settings)
+    def test_setting_env_var(self, name):
+        ps = getattr(m.settings, name)
+        assert ps.env_var == "AZURE_" + name.upper()

--- a/azure-core/tests/test_settings.py
+++ b/azure-core/tests/test_settings.py
@@ -1,0 +1,124 @@
+# --------------------------------------------------------------------------
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the ""Software""), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# --------------------------------------------------------------------------
+import os
+
+import pytest
+
+# module under test
+import azure.core.settings as m
+
+
+class TestPrioritizedSetting(object):
+    def test_everything_unset_raises(self):
+        ps = m.PrioritizedSetting("foo")
+        with pytest.raises(RuntimeError):
+            ps()
+
+    def test_implict_default(self):
+        ps = m.PrioritizedSetting("foo", default=10)
+        assert ps() == 10
+
+    def test_implict_default_converts(self):
+        ps = m.PrioritizedSetting("foo", convert=int, default="10")
+        assert ps() == 10
+
+    def test_system_hook(self):
+        ps = m.PrioritizedSetting("foo", system_hook=lambda: 20)
+        assert ps() == 20
+
+    def test_system_hook_converts(self):
+        ps = m.PrioritizedSetting("foo", convert=int, system_hook=lambda: "20")
+        assert ps() == 20
+
+    def test_env_var(self):
+        os.environ["AZURE_FOO"] = "30"
+        ps = m.PrioritizedSetting("foo", env_var="AZURE_FOO")
+        assert ps() == "30"
+        del os.environ["AZURE_FOO"]
+
+    def test_env_var_converts(self):
+        os.environ["AZURE_FOO"] = "30"
+        ps = m.PrioritizedSetting("foo", convert=int, env_var="AZURE_FOO")
+        assert ps() == 30
+        del os.environ["AZURE_FOO"]
+
+    def test_user_set(self):
+        ps = m.PrioritizedSetting("foo")
+        ps.set_value(40)
+        assert ps() == 40
+
+    def test_user_set_converts(self):
+        ps = m.PrioritizedSetting("foo", convert=int)
+        ps.set_value("40")
+        assert ps() == 40
+
+    def test_immediate(self):
+        ps = m.PrioritizedSetting("foo")
+        assert ps(50) == 50
+
+    def test_immediate_converts(self):
+        ps = m.PrioritizedSetting("foo", convert=int)
+        assert ps("50") == 50
+
+    def test_precedence(self):
+        # 0. implicit default
+        ps = m.PrioritizedSetting("foo", env_var="AZURE_FOO", convert=int, default=10)
+        assert ps() == 10
+
+        # 1. system value
+        ps = m.PrioritizedSetting(
+            "foo", env_var="AZURE_FOO", convert=int, default=10, system_hook=lambda: 20
+        )
+        assert ps() == 20
+
+        # 2. environment variable
+        os.environ["AZURE_FOO"] = "30"
+        assert ps() == 30
+
+        # 3. previously user-set value
+        ps.set_value(40)
+        assert ps() == 40
+
+        # 4. immediate values
+        assert ps(50) == 50
+
+        del os.environ["AZURE_FOO"]
+
+    def test___str__(self):
+        ps = m.PrioritizedSetting("foo")
+        assert str(ps) == "PrioritizedSetting(%r)" % "foo"
+
+    def test_descriptors(self):
+        class FakeSettings(object):
+            foo = m.PrioritizedSetting("foo", env_var="AZURE_FOO")
+            bar = m.PrioritizedSetting("bar", env_var="AZURE_BAR", default=10)
+
+        s = FakeSettings()
+        assert s.foo is FakeSettings.foo
+
+        assert s.bar() == 10
+        s.bar = 20
+        assert s.bar() == 20


### PR DESCRIPTION
cc @johanste @annatisch 

* closes #5126 

Absent other considerations, I created a tool I would personally use in a project. A few notes:

* As it stands, `None` is not a valid value for "immediate" values (it signals the absence of a value). I  considered using `Unset` for this purpose, but that places a burden on all users of this class, and absent optional function arguments are regularly denoted by `None` anyway.

* There's an asymmetry between user-setting a value, and getting the computed value:

    ```
    settings.log_level = logging.DEBUG  # set, assignmemt

    level = settings.log_level(...)  # get, function
    ```
    This is necessitated by having `settings` arbitrate case 4) itself. It's well within my comfort zone  (especially since I suspect case 3) is not common), but thoughts welcome. 

* With this descriptor approach, it would be simple to add an argument to `PrioritizedSetting` to add a `__doc__` for the attributes. 

* Do we want to allow fail-through if, e.g. a system hook raises an exception or otherwise does not succeed?