### PR TITLE
expand test matrix to validate across different operating systems and…

### DIFF
--- a/.azure-pipelines/tests.yml
+++ b/.azure-pipelines/tests.yml
@@ -5,14 +5,20 @@ jobs:
   - job: 'Test'
 
     timeoutInMinutes: 120
-    # Will be adding more elements to the matrix, once this has couple of succesful runs
     strategy:
       matrix:
-        Linux_Python37:
+        Linux_Python35:
           OSName: 'Linux'
           OSVmImage: 'ubuntu-16.04'
+          PythonVersion: '3.5'
+        MacOs_Python37:
+          OSName: 'MacOS'
+          OSVmImage: 'macOS-10.14'
           PythonVersion: '3.7'
-      maxParallel: 1
+        Windows_Python27:
+          OSName: 'Windows'
+          OSVmImage: 'vs2017-win2016'
+          PythonVersion: '2.7'
     continueOnError: false
 
     pool:


### PR DESCRIPTION
Expand the live test matrix to include 2 more OS and Python version combinations: 
* Lowest supported 2.x
* Highest supported 3.x
* Lowest supported 3.x

Python 3.5.3 testing is not presently supported by the pipelines as is. Adding Python 3.5.3 is tracked in #5336. 