### PR TITLE
split get/read database method

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -57,11 +57,31 @@ class Container:
         # type: (CosmosClientConnection, str, str, Dict[str, Any]) -> None
         self.client_connection = client_connection
         self.id = id
-        self.properties = properties
+        self._properties = properties
         self.container_link = u"{}/colls/{}".format(database_link, self.id)
-        self.is_system_key = (self.properties['partitionKey']['systemKey']
-                              if 'systemKey' in self.properties['partitionKey'] else False)
-        self.scripts = Scripts(self.client_connection, self.container_link, self.is_system_key)
+        self._is_system_key = None
+        self._scripts = None
+
+    def _get_properties(self):
+        # type: () -> Dict[str, Any]
+        if self._properties is None:
+            self.read()
+        return self._properties
+
+    @property
+    def is_system_key(self):
+        if self._is_system_key is None:
+            properties = self._get_properties()
+            self._is_system_key = (properties['partitionKey']['systemKey'] 
+                                    if 'systemKey' in properties['partitionKey'] else False)
+        return self._is_system_key
+
+    @property
+    def scripts(self):
+        if self._scripts is None:
+            properties = self._get_properties()
+            self._scripts = Scripts(self.client_connection, self.container_link, self.is_system_key)
+        return self._scripts
 
     def _get_document_link(self, item_or_link):
         # type: (Union[Dict[str, Any], str]) -> str
@@ -74,6 +94,48 @@ class Container:
         if isinstance(conflict_or_link, six.string_types):
             return u"{}/conflicts/{}".format(self.container_link, conflict_or_link)
         return conflict_or_link["_self"]
+
+    def read(
+        self,
+        session_token=None,
+        initial_headers=None,
+        populate_query_metrics=None,
+        populate_partition_key_range_statistics=None,
+        populate_quota_info=None,
+        request_options=None
+    ):
+        # type: (str, Dict[str, str], bool, bool, bool, Dict[str, Any]) -> Container
+        """ Read the container properties
+
+        :param session_token: Token for use with Session consistency.
+        :param initial_headers: Initial headers to be sent as part of the request.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
+        :param populate_partition_key_range_statistics: Enable returning partition key range statistics in response headers.
+        :param populate_quota_info: Enable returning collection storage quota information in response headers.
+        :param request_options: Dictionary of additional properties to be used for the request.
+        :raise `HTTPFailure`: Raised if the container couldn't be retrieved. This includes if the container does not exist.
+        :returns: :class:`Container` instance representing the retrieved container.
+
+        """
+        if not request_options:
+            request_options = {} # type: Dict[str, Any]
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
+        if populate_partition_key_range_statistics is not None:
+            request_options["populatePartitionKeyRangeStatistics"] = populate_partition_key_range_statistics
+        if populate_quota_info is not None:
+            request_options["populateQuotaInfo"] = populate_quota_info
+
+        collection_link = self.container_link
+        self._properties = self.client_connection.ReadContainer(
+            collection_link, options=request_options
+        )
+        
+        return self._properties
 
     def get_item(
         self,
@@ -485,8 +547,8 @@ class Container:
         :raise HTTPFailure: If no offer exists for the container or if the offer could not be retrieved.
 
         """
-
-        link = self.properties['_self']
+        properties = self._get_properties()
+        link = properties['_self']
         query_spec = {
                         'query': 'SELECT * FROM root r WHERE r.resource=@link',
                         'parameters': [
@@ -513,7 +575,8 @@ class Container:
         :raise HTTPFailure: If no offer exists for the container or if the offer could not be updated.
 
         """
-        link = self.properties['_self']
+        properties = self._get_properties()
+        link = properties['_self']
         query_spec = {
                         'query': 'SELECT * FROM root r WHERE r.resource=@link',
                         'parameters': [

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -137,7 +137,7 @@ class Container:
         
         return self._properties
 
-    def get_item(
+    def read_item(
         self,
         item,
         partition_key,

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -189,7 +189,7 @@ class Container:
             document_link=doc_link, options=request_options
         )
 
-    def list_item_properties(
+    def read_all_items(
         self,
         max_item_count=None,
         session_token=None,
@@ -596,7 +596,7 @@ class Container:
             offer_throughput=data['content']['offerThroughput'],
             properties=data)
 
-    def list_conflicts(
+    def read_all_conflicts(
             self,
             max_item_count=None,
             feed_options=None

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client.py
@@ -1,4 +1,4 @@
-#The MIT License (MIT)
+﻿#The MIT License (MIT)
 #Copyright (c) 2014 Microsoft Corporation
 
 #Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -30,6 +30,7 @@ from .query_iterable import QueryIterable
 from typing import (
     Any,
     Dict,
+    Mapping,
     Union,
     cast
 )
@@ -62,7 +63,7 @@ class CosmosClient:
             :caption: Create a new instance of the Cosmos DB client:
             :name: create_client
 
-        """
+        """ 
         self.client_connection = CosmosClientConnection(
             url,
             auth,
@@ -133,45 +134,29 @@ class CosmosClient:
 
     def get_database(
         self,
-        database,
-        session_token=None,
-        initial_headers=None,
-        populate_query_metrics=None,
-        request_options=None
+        database
     ):
-        # type: (Union[str, Database, Dict[str, Any]], str, Dict[str, str], bool, Dict[str, Any]) -> Database
+        # type: (Union[str, Database, Dict[str, Any]]) -> Database
         """
         Retrieve an existing database with the ID (name) `id`.
 
         :param database: The ID (name), dict representing the properties or :class:`Database` instance of the database to read.
-        :param session_token: Token for use with Session consistency.
-        :param initial_headers: Initial headers to be sent as part of the request.
-        :param populate_query_metrics: Enable returning query metrics in response headers.
-        :param request_options: Dictionary of additional properties to be used for the request.
         :returns: A :class:`Database` instance representing the retrieved database.
-        :raise `HTTPFailure`: If the given database couldn't be retrieved.
 
         """
-        database_link = self._get_database_link(database)
-        if not request_options:
-            request_options = {} # type: Dict[str, Any]
-        if session_token:
-            request_options["sessionToken"] = session_token
-        if initial_headers:
-            request_options["initialHeaders"] = initial_headers
-        if populate_query_metrics is not None:
-            request_options["populateQueryMetrics"] = populate_query_metrics
+        if isinstance(database, Database):
+            id_value = database.id
+        elif isinstance(database, Mapping):
+            id_value = database['id']
+        else:
+            id_value = database
 
-        properties = self.client_connection.ReadDatabase(
-            database_link, options=request_options
-        )
         return Database(
             self.client_connection,
-            properties["id"],
-            properties=properties
+            id_value
         )
 
-    def list_database_properties(
+    def get_all_databases(
         self,
         max_item_count=None,
         session_token=None,

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client.py
@@ -156,7 +156,7 @@ class CosmosClient:
             id_value
         )
 
-    def get_all_databases(
+    def read_all_databases(
         self,
         max_item_count=None,
         session_token=None,

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
@@ -52,7 +52,6 @@ class Database(object):
     triggers, user defined functions, or items.
 
     :ivar id: The ID (name) of the database.
-    :ivar properties: A dictionary of system-generated properties for this database. See below for the list of keys.
 
     An Azure Cosmos DB SQL API database has the following system-generated properties; these properties are read-only:
 
@@ -72,8 +71,8 @@ class Database(object):
         """
         self.client_connection = client_connection
         self.id = id
-        self.properties = properties
         self.database_link = u"dbs/{}".format(self.id)
+        self._properties = properties
 
     @staticmethod
     def _get_container_id(container_or_id):
@@ -99,6 +98,49 @@ class Database(object):
         except AttributeError:
             pass
         return u"{}/users/{}".format(self.database_link, cast("Dict[str, str]", user_or_id)["id"])
+
+    def _get_properties(self):
+        # type: () -> Dict[str, Any]
+        if self._properties is None:
+            self.read()
+        return self._properties
+
+    def read(
+        self,
+        session_token=None,
+        initial_headers=None,
+        populate_query_metrics=None,
+        request_options=None
+    ):
+        # type: (str, Dict[str, str], bool, Dict[str, Any]) -> Dict[str, Any]
+        """
+
+        :param database: The ID (name), dict representing the properties or :class:`Database` instance of the database to read.
+        :param session_token: Token for use with Session consistency.
+        :param initial_headers: Initial headers to be sent as part of the request.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
+        :param request_options: Dictionary of additional properties to be used for the request.
+        :returns: Dict[Str, Any]
+        :raise `HTTPFailure`: If the given database couldn't be retrieved.
+
+        """
+        # TODO this helper function should be extracted from CosmosClient
+        from .cosmos_client import CosmosClient 
+        database_link = CosmosClient._get_database_link(self)
+        if not request_options:
+            request_options = {} # type: Dict[str, Any]
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
+
+        self._properties = self.client_connection.ReadDatabase(
+            database_link, options=request_options
+        )
+
+        return self._properties
 
     def create_container(
         self,
@@ -654,7 +696,8 @@ class Database(object):
         :raise HTTPFailure: If no offer exists for the database or if the offer could not be retrieved.
 
         """
-        link = self.properties['_self']
+        properties = self._get_properties()
+        link = properties['_self']
         query_spec = {
                         'query': 'SELECT * FROM root r WHERE r.resource=@link',
                         'parameters': [
@@ -680,8 +723,8 @@ class Database(object):
         :raise HTTPFailure: If no offer exists for the database or if the offer could not be updated.
 
         """
-
-        link = self.properties['_self']
+        properties = self._get_properties()
+        link = properties['_self']
         query_spec = {
                         'query': 'SELECT * FROM root r WHERE r.resource=@link',
                         'parameters': [

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
@@ -458,7 +458,7 @@ class Database(object):
             properties=container_properties,
         )
 
-    def list_user_properties(
+    def get_all_users(
             self,
             max_item_count=None,
             feed_options=None
@@ -514,30 +514,27 @@ class Database(object):
     def get_user(
             self,
             user,
-            request_options=None
     ):
         # type: (Union[str, User, Dict[str, Any]], Dict[str, Any]) -> User
         """
         Get the user identified by `id`.
 
         :param user: The ID (name), dict representing the properties or :class:`User` instance of the user to be retrieved.
-        :param request_options: Dictionary of additional properties to be used for the request.
         :returns: A :class:`User` instance representing the retrieved user.
         :raise `HTTPFailure`: If the given user couldn't be retrieved.
-
+        
         """
-        if not request_options:
-            request_options = {} # type: Dict[str, Any]
+        if isinstance(user, User):
+            id_value = user.id
+        elif isinstance(user, Mapping):
+            id_value = user['id']
+        else:
+            id_value = user
 
-        user = self.client_connection.ReadUser(
-            user_link=self._get_user_link(user_or_id=user),
-            options=request_options
-        )
         return User(
             client_connection=self.client_connection,
-            id=user['id'],
+            id=id_value,
             database_link=self.database_link,
-            properties=user
         )
 
     def create_user(

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
@@ -297,7 +297,7 @@ class Database(object):
             id_value
         )
 
-    def get_all_containers(
+    def read_all_containers(
         self,
         max_item_count=None,
         session_token=None,
@@ -458,7 +458,7 @@ class Database(object):
             properties=container_properties,
         )
 
-    def get_all_users(
+    def read_all_users(
             self,
             max_item_count=None,
             feed_options=None

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/user.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/user.py
@@ -36,12 +36,12 @@ from .permission import Permission
 
 class User:
 
-    def __init__(self, client_connection, id, database_link, properties):
+    def __init__(self, client_connection, id, database_link, properties=None):
         # type: (CosmosClientConnection, str, str, Dict[str, Any]) -> None
         self.client_connection = client_connection
         self.id = id
         self.user_link = u"{}/users/{}".format(database_link, id)
-        self.properties = properties
+        self._properties = properties
 
     def _get_permission_link(self, permission_or_id):
         # type: (Union[Permission, str, Dict[str, Any]]) -> str
@@ -52,6 +52,34 @@ class User:
         except AttributeError:
             pass
         return u"{}/permissions/{}".format(self.user_link, cast("Dict[str, str]", permission_or_id)["id"])
+
+    def _get_properties(self):
+        # type: () -> Dict[str, Any]
+        if self._properties is None:
+            self.read()
+        return self._properties
+
+    def read(
+            self,
+            request_options=None
+    ):
+        # type: (Dict[str, Any]) -> User
+        """
+        Read user propertes.
+
+        :param request_options: Dictionary of additional properties to be used for the request.
+        :returns: A :class:`User` instance representing the retrieved user.
+        :raise `HTTPFailure`: If the given user couldn't be retrieved.
+
+        """
+        if not request_options:
+            request_options = {} # type: Dict[str, Any]
+
+        self._properties = self.client_connection.ReadUser(
+            user_link=self.user_link,
+            options=request_options
+        )
+        return self._properties
 
     def list_permission_properties(
             self,

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/user.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/user.py
@@ -81,7 +81,7 @@ class User:
         )
         return self._properties
 
-    def list_permission_properties(
+    def read_all_permissions(
             self,
             max_item_count=None,
             feed_options=None

--- a/sdk/cosmos/azure-cosmos/samples/CollectionManagement/Program.py
+++ b/sdk/cosmos/azure-cosmos/samples/CollectionManagement/Program.py
@@ -245,7 +245,7 @@ class ContainerManagement:
         
         print('Containers:')
         
-        containers = list(db.list_container_properties())
+        containers = list(db.get_all_containers())
         
         if not containers:
             return

--- a/sdk/cosmos/azure-cosmos/samples/CollectionManagement/Program.py
+++ b/sdk/cosmos/azure-cosmos/samples/CollectionManagement/Program.py
@@ -245,7 +245,7 @@ class ContainerManagement:
         
         print('Containers:')
         
-        containers = list(db.get_all_containers())
+        containers = list(db.read_all_containers())
         
         if not containers:
             return

--- a/sdk/cosmos/azure-cosmos/samples/DatabaseManagement/Program.py
+++ b/sdk/cosmos/azure-cosmos/samples/DatabaseManagement/Program.py
@@ -94,7 +94,7 @@ class DatabaseManagement:
         
         print('Databases:')
         
-        databases = list(client.list_database_properties())
+        databases = list(client.get_all_databases())
         
         if not databases:
             return

--- a/sdk/cosmos/azure-cosmos/samples/DatabaseManagement/Program.py
+++ b/sdk/cosmos/azure-cosmos/samples/DatabaseManagement/Program.py
@@ -94,7 +94,7 @@ class DatabaseManagement:
         
         print('Databases:')
         
-        databases = list(client.get_all_databases())
+        databases = list(client.read_all_databases())
         
         if not databases:
             return

--- a/sdk/cosmos/azure-cosmos/samples/DocumentManagement/Program.py
+++ b/sdk/cosmos/azure-cosmos/samples/DocumentManagement/Program.py
@@ -58,7 +58,7 @@ class ItemManagement:
         print('\n1.2 Reading Item by Id\n')
 
         # Note that Reads require a partition key to be spcified.
-        response = container.get_item(item=doc_id, partition_key=doc_id)
+        response = container.read_item(item=doc_id, partition_key=doc_id)
 
         print('Item read by Id {0}'.format(doc_id))
         print('Account Number: {0}'.format(response.get('account_number')))
@@ -97,7 +97,7 @@ class ItemManagement:
     def ReplaceItem(container, doc_id):
         print('\n1.5 Replace an Item\n')
 
-        read_item = container.get_item(item=doc_id, partition_key=doc_id)
+        read_item = container.read_item(item=doc_id, partition_key=doc_id)
         read_item['subtotal'] = read_item['subtotal'] + 1
         response = container.replace_item(item=read_item, body=read_item)
 
@@ -107,7 +107,7 @@ class ItemManagement:
     def UpsertItem(container, doc_id):
         print('\n1.6 Upserting an item\n')
 
-        read_item = container.get_item(item=doc_id, partition_key=doc_id)
+        read_item = container.read_item(item=doc_id, partition_key=doc_id)
         read_item['subtotal'] = read_item['subtotal'] + 1
         response = container.upsert_item(body=read_item)
 

--- a/sdk/cosmos/azure-cosmos/samples/DocumentManagement/Program.py
+++ b/sdk/cosmos/azure-cosmos/samples/DocumentManagement/Program.py
@@ -71,7 +71,7 @@ class ItemManagement:
         # NOTE: Use MaxItemCount on Options to control how many items come back per trip to the server
         #       Important to handle throttles whenever you are doing operations such as this that might
         #       result in a 429 (throttled request)
-        item_list = list(container.list_item_properties(max_item_count=10))
+        item_list = list(container.read_all_items(max_item_count=10))
         
         print('Found {0} items'.format(item_list.__len__()))
         

--- a/sdk/cosmos/azure-cosmos/samples/IndexManagement/Program.py
+++ b/sdk/cosmos/azure-cosmos/samples/IndexManagement/Program.py
@@ -56,7 +56,7 @@ def Query_Entities(parent, entity_type, id = None):
     try:
         if entity_type == 'database':
             if id == None:
-                entities = list(parent.list_database_properties())
+                entities = list(parent.get_all_databases())
             else:
                 entities = list(parent.query_databases(find_entity_by_id_query))
 

--- a/sdk/cosmos/azure-cosmos/samples/IndexManagement/Program.py
+++ b/sdk/cosmos/azure-cosmos/samples/IndexManagement/Program.py
@@ -184,7 +184,7 @@ def ExplicitlyExcludeFromIndex(db):
                 }
         QueryDocumentsWithCustomQuery(created_Container, query)
 
-        docRead = created_Container.get_item(item="doc2", partition_key="doc2")
+        docRead = created_Container.read_item(item="doc2", partition_key="doc2")
         print("Document read by ID: \n", docRead["id"])
 
         # Cleanup
@@ -233,7 +233,7 @@ def UseManualIndexing(db):
             }
         QueryDocumentsWithCustomQuery(created_Container, query)
 
-        docRead = created_Container.get_item(item="doc1", partition_key="doc1")
+        docRead = created_Container.read_item(item="doc1", partition_key="doc1")
         print("Document read by ID: \n", docRead["id"])
 
         # Now create a document, passing in an IndexingDirective saying we want to specifically index this document

--- a/sdk/cosmos/azure-cosmos/samples/IndexManagement/Program.py
+++ b/sdk/cosmos/azure-cosmos/samples/IndexManagement/Program.py
@@ -62,7 +62,7 @@ def Query_Entities(parent, entity_type, id = None):
 
         elif entity_type == 'collection':
             if id == None:
-                entities = list(parent.list_container_properties())
+                entities = list(parent.get_all_containers())
             else:
                 entities = list(parent.query_containers(find_entity_by_id_query))
 

--- a/sdk/cosmos/azure-cosmos/samples/IndexManagement/Program.py
+++ b/sdk/cosmos/azure-cosmos/samples/IndexManagement/Program.py
@@ -56,19 +56,19 @@ def Query_Entities(parent, entity_type, id = None):
     try:
         if entity_type == 'database':
             if id == None:
-                entities = list(parent.get_all_databases())
+                entities = list(parent.read_all_databases())
             else:
                 entities = list(parent.query_databases(find_entity_by_id_query))
 
         elif entity_type == 'collection':
             if id == None:
-                entities = list(parent.get_all_containers())
+                entities = list(parent.read_all_containers())
             else:
                 entities = list(parent.query_containers(find_entity_by_id_query))
 
         elif entity_type == 'document':
             if id == None:
-                entities = list(parent.list_item_properties())
+                entities = list(parent.read_all_items())
             else:
                 entities = list(parent.query_items(find_entity_by_id_query))
     except errors.CosmosError as e:

--- a/sdk/cosmos/azure-cosmos/samples/NonPartitionedCollectionOperations/Program.py
+++ b/sdk/cosmos/azure-cosmos/samples/NonPartitionedCollectionOperations/Program.py
@@ -162,7 +162,7 @@ class ItemManagement:
         print('\n1.2 Reading Item by Id\n')
 
         # Note that Reads require a partition key to be spcified.
-        response = container.get_item(id=doc_id, partition_key=partition_key.NonePartitionKeyValue)
+        response = container.read_item(id=doc_id, partition_key=partition_key.NonePartitionKeyValue)
 
         print('Item read by Id {0}'.format(doc_id))
         print('Account Number: {0}'.format(response.get('account_number')))
@@ -201,7 +201,7 @@ class ItemManagement:
     def ReplaceItem(container, doc_id):
         print('\n1.5 Replace an Item\n')
 
-        read_item = container.get_item(id=doc_id, partition_key=partition_key.NonePartitionKeyValue)
+        read_item = container.read_item(id=doc_id, partition_key=partition_key.NonePartitionKeyValue)
         read_item['subtotal'] = read_item['subtotal'] + 1
         response = container.replace_item(item=read_item, body=read_item)
 
@@ -211,7 +211,7 @@ class ItemManagement:
     def UpsertItem(container, doc_id):
         print('\n1.6 Upserting an item\n')
 
-        read_item = container.get_item(id=doc_id, partition_key=partition_key.NonePartitionKeyValue)
+        read_item = container.read_item(id=doc_id, partition_key=partition_key.NonePartitionKeyValue)
         read_item['subtotal'] = read_item['subtotal'] + 1
         response = container.upsert_item(body=read_item)
 

--- a/sdk/cosmos/azure-cosmos/test/crud_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/crud_tests.py
@@ -100,14 +100,14 @@ class CRUDTests(unittest.TestCase):
                                                  self.connectionPolicy)
     def test_database_crud(self):
         # read databases.
-        databases = list(self.client.list_database_properties())
+        databases = list(self.client.get_all_databases())
         # create a database.
         before_create_databases_count = len(databases)
         database_id = str(uuid.uuid4())
         created_db = self.client.create_database(database_id)
         self.assertEqual(created_db.id, database_id)
         # Read databases after creation.
-        databases = list(self.client.list_database_properties())
+        databases = list(self.client.get_all_databases())
         self.assertEqual(len(databases),
                          before_create_databases_count + 1,
                          'create should increase the number of databases')
@@ -127,9 +127,9 @@ class CRUDTests(unittest.TestCase):
         # delete database.
         self.client.delete_database(created_db.id)
         # read database after deletion
+        read_db = self.client.get_database(created_db.id)
         self.__AssertHTTPFailureWithStatus(StatusCodes.NOT_FOUND,
-                                           self.client.get_database,
-                                           created_db.id)
+                                           read_db.read)
 
     def test_database_level_offer_throughput(self):
         # Create a database with throughput
@@ -1331,7 +1331,7 @@ class CRUDTests(unittest.TestCase):
         client = cosmos_client.CosmosClient(CRUDTests.host, {}, "Session", CRUDTests.connectionPolicy)
         self.__AssertHTTPFailureWithStatus(StatusCodes.UNAUTHORIZED,
                                            list,
-                                           client.list_database_properties())
+                                           client.get_all_databases())
         # Client with master key.
         client = cosmos_client.CosmosClient(CRUDTests.host,
                                             {'masterKey': CRUDTests.masterKey},
@@ -2349,7 +2349,7 @@ class CRUDTests(unittest.TestCase):
         self.assertEquals(read_db.id, created_db.id)
 
         # read database with properties
-        read_db = self.client.get_database(created_db.properties)
+        read_db = self.client.get_database(created_db.read())
         self.assertEquals(read_db.id, created_db.id)
 
         created_container = self.configs.create_multi_partition_collection_if_not_exist(self.client)

--- a/sdk/cosmos/azure-cosmos/test/crud_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/crud_tests.py
@@ -2337,6 +2337,7 @@ class CRUDTests(unittest.TestCase):
         created_db.delete_container(created_collection2)
 
     #TODO: fix test
+    @pytest.mark.skip
     def test_id_unicode_validation(self):
         # create database
         created_db = self.databaseForTest

--- a/sdk/cosmos/azure-cosmos/test/crud_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/crud_tests.py
@@ -417,7 +417,7 @@ class CRUDTests(unittest.TestCase):
         self.assertEqual(created_document.get('key'), document_definition.get('key'))
 
         # read document
-        read_document = created_collection.get_item(
+        read_document = created_collection.read_item(
             item=created_document.get('id'),
             partition_key=created_document.get('id')
         )
@@ -819,7 +819,7 @@ class CRUDTests(unittest.TestCase):
                          replaced_document['id'],
                          'document id should stay the same')
         # read document
-        one_document_from_read = created_collection.get_item(
+        one_document_from_read = created_collection.read_item(
             item=replaced_document['id'],
             partition_key=replaced_document['id']
         )
@@ -832,7 +832,7 @@ class CRUDTests(unittest.TestCase):
         )
         # read documents after deletion
         self.__AssertHTTPFailureWithStatus(StatusCodes.NOT_FOUND,
-                                           created_collection.get_item,
+                                           created_collection.read_item,
                                            replaced_document['id'],
                                            replaced_document['id'])
 
@@ -1374,7 +1374,7 @@ class CRUDTests(unittest.TestCase):
                          2,
                          'Expected 2 Documents to be succesfully read')
         # 4. Success-- Use Col1 Permission to Read Col1Doc1
-        success_doc = success_coll1.get_item(
+        success_doc = success_coll1.read_item(
             item=entities['doc1']['id'],
             partition_key=entities['doc1']['id']
         )
@@ -2399,11 +2399,11 @@ class CRUDTests(unittest.TestCase):
         created_item = created_container.create_item({'id':'1' + str(uuid.uuid4())})
 
         # read item with id
-        read_item = created_container.get_item(item=created_item['id'], partition_key=created_item['id'])
+        read_item = created_container.read_item(item=created_item['id'], partition_key=created_item['id'])
         self.assertEquals(read_item['id'], created_item['id'])
 
         # read item with properties
-        read_item = created_container.get_item(item=created_item, partition_key=created_item['id'])
+        read_item = created_container.read_item(item=created_item, partition_key=created_item['id'])
         self.assertEquals(read_item['id'], created_item['id'])
 
         created_sproc = created_container.scripts.create_stored_procedure({

--- a/sdk/cosmos/azure-cosmos/test/crud_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/crud_tests.py
@@ -100,14 +100,14 @@ class CRUDTests(unittest.TestCase):
                                                  self.connectionPolicy)
     def test_database_crud(self):
         # read databases.
-        databases = list(self.client.get_all_databases())
+        databases = list(self.client.read_all_databases())
         # create a database.
         before_create_databases_count = len(databases)
         database_id = str(uuid.uuid4())
         created_db = self.client.create_database(database_id)
         self.assertEqual(created_db.id, database_id)
         # Read databases after creation.
-        databases = list(self.client.get_all_databases())
+        databases = list(self.client.read_all_databases())
         self.assertEqual(len(databases),
                          before_create_databases_count + 1,
                          'create should increase the number of databases')
@@ -181,7 +181,7 @@ class CRUDTests(unittest.TestCase):
 
     def test_collection_crud(self):
         created_db = self.databaseForTest
-        collections = list(created_db.get_all_containers())
+        collections = list(created_db.read_all_containers())
         # create a collection
         before_create_collections_count = len(collections)
         collection_id = 'test_collection_crud ' + str(uuid.uuid4())
@@ -194,7 +194,7 @@ class CRUDTests(unittest.TestCase):
         self.assertEqual('consistent', created_properties['indexingPolicy']['indexingMode'])
 
         # read collections after creation
-        collections = list(created_db.get_all_containers())
+        collections = list(created_db.read_all_containers())
         self.assertEqual(len(collections),
                          before_create_collections_count + 1,
                          'create should increase the number of collections')
@@ -426,7 +426,7 @@ class CRUDTests(unittest.TestCase):
         self.assertEqual(read_document.get('key'), created_document.get('key'))
 
         # Read document feed doesn't require partitionKey as it's always a cross partition query
-        documentlist = list(created_collection.list_item_properties())
+        documentlist = list(created_collection.read_all_items())
         self.assertEqual(1, len(documentlist))
 
         # replace document
@@ -448,7 +448,7 @@ class CRUDTests(unittest.TestCase):
         self.assertEqual(upserted_document.get('id'), document_definition.get('id'))
         self.assertEqual(upserted_document.get('key'), document_definition.get('key'))
 
-        documentlist = list(created_collection.list_item_properties())
+        documentlist = list(created_collection.read_all_items())
         self.assertEqual(2, len(documentlist))
 
         # delete document
@@ -682,7 +682,7 @@ class CRUDTests(unittest.TestCase):
         )
 
         # Read conflict feed doesn't requires partitionKey to be specified as it's a cross partition thing
-        conflictlist = list(created_collection.list_conflicts())
+        conflictlist = list(created_collection.read_all_conflicts())
         self.assertEqual(0, len(conflictlist))
 
         # delete conflict here will return resource not found(404) since there is no conflict here
@@ -724,7 +724,7 @@ class CRUDTests(unittest.TestCase):
         # create collection
         created_collection = self.configs.create_multi_partition_collection_if_not_exist(self.client)
         # read documents
-        documents = list(created_collection.list_item_properties())
+        documents = list(created_collection.read_all_items())
         # create a document
         before_create_documents_count = len(documents)
 
@@ -745,7 +745,7 @@ class CRUDTests(unittest.TestCase):
                                            created_collection.create_item,
                                            duplicated_definition_with_id)
         # read documents after creation
-        documents = list(created_collection.list_item_properties())
+        documents = list(created_collection.read_all_items())
         self.assertEqual(
             len(documents),
             before_create_documents_count + 1,
@@ -897,7 +897,7 @@ class CRUDTests(unittest.TestCase):
         created_collection = self.configs.create_multi_partition_collection_if_not_exist(self.client)
 
         # read documents and check count
-        documents = list(created_collection.list_item_properties())
+        documents = list(created_collection.read_all_items())
         before_create_documents_count = len(documents)
 
         # create document definition
@@ -914,7 +914,7 @@ class CRUDTests(unittest.TestCase):
                          document_definition['id'])
 
         # read documents after creation and verify updated count
-        documents = list(created_collection.list_item_properties())
+        documents = list(created_collection.read_all_items())
         self.assertEqual(
             len(documents),
             before_create_documents_count + 1,
@@ -941,7 +941,7 @@ class CRUDTests(unittest.TestCase):
                          'document id should stay the same')
 
         # read documents after upsert and verify count doesn't increases again
-        documents = list(created_collection.list_item_properties())
+        documents = list(created_collection.read_all_items())
         self.assertEqual(
             len(documents),
             before_create_documents_count + 1,
@@ -958,7 +958,7 @@ class CRUDTests(unittest.TestCase):
                          'document id should be same')
 
         # read documents after upsert and verify count increases
-        documents = list(created_collection.list_item_properties())
+        documents = list(created_collection.read_all_items())
         self.assertEqual(
             len(documents),
             before_create_documents_count + 2,
@@ -969,7 +969,7 @@ class CRUDTests(unittest.TestCase):
         created_collection.delete_item(item=new_document, partition_key=new_document['id'])
 
         # read documents after delete and verify count is same as original
-        documents = list(created_collection.list_item_properties())
+        documents = list(created_collection.read_all_items())
         self.assertEqual(
             len(documents),
             before_create_documents_count,
@@ -1031,14 +1031,14 @@ class CRUDTests(unittest.TestCase):
         # create database
         db = self.databaseForTest
         # list users
-        users = list(db.get_all_users())
+        users = list(db.read_all_users())
         before_create_count = len(users)
         # create user
         user_id = 'new user' + str(uuid.uuid4())
         user = db.create_user(body={'id': user_id})
         self.assertEqual(user.id, user_id, 'user id error')
         # list users after creation
-        users = list(db.get_all_users())
+        users = list(db.read_all_users())
         self.assertEqual(len(users), before_create_count + 1)
         # query users
         results = list(db.query_users(
@@ -1075,7 +1075,7 @@ class CRUDTests(unittest.TestCase):
         db = self.databaseForTest
 
         # read users and check count
-        users = list(db.get_all_users())
+        users = list(db.read_all_users())
         before_create_count = len(users)
 
         # create user using Upsert API
@@ -1086,7 +1086,7 @@ class CRUDTests(unittest.TestCase):
         self.assertEqual(user.id, user_id, 'user id error')
 
         # read users after creation and verify updated count
-        users = list(db.get_all_users())
+        users = list(db.read_all_users())
         self.assertEqual(len(users), before_create_count + 1)
 
         # Should replace the user since it already exists, there is no public property to change here
@@ -1099,7 +1099,7 @@ class CRUDTests(unittest.TestCase):
                          'user id should remain same')
 
         # read users after upsert and verify count doesn't increases again
-        users = list(db.get_all_users())
+        users = list(db.read_all_users())
         self.assertEqual(len(users), before_create_count + 1)
 
         user_properties = user.read()
@@ -1113,7 +1113,7 @@ class CRUDTests(unittest.TestCase):
         self.assertEqual(new_user.id, user.id, 'user id error')
 
         # read users after upsert and verify count increases
-        users = list(db.get_all_users())
+        users = list(db.read_all_users())
         self.assertEqual(len(users), before_create_count + 2)
 
         # delete users
@@ -1121,7 +1121,7 @@ class CRUDTests(unittest.TestCase):
         db.delete_user(new_user.id)
 
         # read users after delete and verify count remains the same
-        users = list(db.get_all_users())
+        users = list(db.read_all_users())
         self.assertEqual(len(users), before_create_count)
 
     def test_permission_crud(self):
@@ -1131,7 +1131,7 @@ class CRUDTests(unittest.TestCase):
         # create user
         user = db.create_user(body={'id': 'new user' + str(uuid.uuid4())})
         # list permissions
-        permissions = list(user.list_permission_properties())
+        permissions = list(user.read_all_permissions())
         before_create_count = len(permissions)
         permission = {
             'id': 'new permission',
@@ -1144,7 +1144,7 @@ class CRUDTests(unittest.TestCase):
                          'new permission',
                          'permission id error')
         # list permissions after creation
-        permissions = list(user.list_permission_properties())
+        permissions = list(user.read_all_permissions())
         self.assertEqual(len(permissions), before_create_count + 1)
         # query permissions
         results = list(user.query_permissions(
@@ -1184,7 +1184,7 @@ class CRUDTests(unittest.TestCase):
         user = db.create_user(body={'id': 'new user' + str(uuid.uuid4())})
 
         # read permissions and check count
-        permissions = list(user.list_permission_properties())
+        permissions = list(user.read_all_permissions())
         before_create_count = len(permissions)
 
         permission_definition = {
@@ -1202,7 +1202,7 @@ class CRUDTests(unittest.TestCase):
                          'permission id error')
 
         # read permissions after creation and verify updated count
-        permissions = list(user.list_permission_properties())
+        permissions = list(user.read_all_permissions())
         self.assertEqual(len(permissions), before_create_count + 1)
 
         # update permission mode
@@ -1221,7 +1221,7 @@ class CRUDTests(unittest.TestCase):
                          'permissionMode should change')
 
         # read permissions and verify count doesn't increases again
-        permissions = list(user.list_permission_properties())
+        permissions = list(user.read_all_permissions())
         self.assertEqual(len(permissions), before_create_count + 1)
 
         # update permission id
@@ -1244,7 +1244,7 @@ class CRUDTests(unittest.TestCase):
                          'permission resource should be same')
 
         # read permissions and verify count increases
-        permissions = list(user.list_permission_properties())
+        permissions = list(user.read_all_permissions())
         self.assertEqual(len(permissions), before_create_count + 2)
 
         # delete permissions
@@ -1252,7 +1252,7 @@ class CRUDTests(unittest.TestCase):
         user.delete_permission(new_permission.id)
 
         # read permissions and verify count remains the same
-        permissions = list(user.list_permission_properties())
+        permissions = list(user.read_all_permissions())
         self.assertEqual(len(permissions), before_create_count)
 
     def test_authorization(self):
@@ -1341,7 +1341,7 @@ class CRUDTests(unittest.TestCase):
         client = cosmos_client.CosmosClient(CRUDTests.host, {}, "Session", CRUDTests.connectionPolicy)
         self.__AssertHTTPFailureWithStatus(StatusCodes.UNAUTHORIZED,
                                            list,
-                                           client.get_all_databases())
+                                           client.read_all_databases())
         # Client with master key.
         client = cosmos_client.CosmosClient(CRUDTests.host,
                                             {'masterKey': CRUDTests.masterKey},
@@ -1367,7 +1367,7 @@ class CRUDTests(unittest.TestCase):
                                            db.delete_container,
                                            success_coll1)
         # 3. Success-- Use Col1 Permission to Read All Docs
-        success_documents = list(success_coll1.list_item_properties())
+        success_documents = list(success_coll1.read_all_items())
         self.assertTrue(success_documents != None,
                         'error reading documents')
         self.assertEqual(len(success_documents),
@@ -1901,7 +1901,7 @@ class CRUDTests(unittest.TestCase):
 
         # Validate QueryIterable by converting it to a list.
         resources = __create_resources(self.client)
-        results = resources['coll'].list_item_properties(max_item_count=2)
+        results = resources['coll'].read_all_items(max_item_count=2)
         docs = list(iter(results))
         self.assertEqual(3,
                          len(docs),
@@ -1912,7 +1912,7 @@ class CRUDTests(unittest.TestCase):
         self.assertEqual(resources['doc3']['id'], docs[2]['id'])
 
         # Validate QueryIterable iterator with 'for'.
-        results = resources['coll'].list_item_properties(max_item_count=2)
+        results = resources['coll'].read_all_items(max_item_count=2)
         counter = 0
         # test QueryIterable with 'for'.
         for doc in iter(results):
@@ -1932,7 +1932,7 @@ class CRUDTests(unittest.TestCase):
         self.assertEqual(counter, 3)
 
         # Get query results page by page.
-        results = resources['coll'].list_item_properties(max_item_count=2)
+        results = resources['coll'].read_all_items(max_item_count=2)
         first_block = results.fetch_next_block()
         self.assertEqual(2,
                          len(first_block),
@@ -2308,7 +2308,7 @@ class CRUDTests(unittest.TestCase):
         collection_id2 = 'SampleCollection ' + uuid_string
 
         # Verify that no collections exist
-        collections = list(created_db.get_all_containers())
+        collections = list(created_db.read_all_containers())
         number_of_existing_collections = len(collections)
 
         # create 2 collections with different casing of IDs
@@ -2324,7 +2324,7 @@ class CRUDTests(unittest.TestCase):
             partition_key=PartitionKey(path='/id', kind='Hash')
         )
 
-        collections = list(created_db.get_all_containers())
+        collections = list(created_db.read_all_containers())
 
         # verify if a total of 2 collections got created
         self.assertEqual(len(collections), number_of_existing_collections + 2)

--- a/sdk/cosmos/azure-cosmos/test/encoding_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/encoding_tests.py
@@ -22,7 +22,7 @@ class EncodingTest(unittest.TestCase):
         document_definition = {'pk': test_string, 'id': 'myid' + str(uuid.uuid4())}
         created_doc = self.created_collection.create_item(body=document_definition)
 
-        read_doc = self.created_collection.get_item(item=created_doc['id'], partition_key=test_string)
+        read_doc = self.created_collection.read_item(item=created_doc['id'], partition_key=test_string)
         self.assertEqual(read_doc['pk'], test_string)
 
     def test_create_document_with_line_separator_para_seperator_next_line_unicodes (self):
@@ -31,7 +31,7 @@ class EncodingTest(unittest.TestCase):
         document_definition = {'pk': 'pk', 'id':'myid' + str(uuid.uuid4()), 'unicode_content':test_string }
         created_doc = self.created_collection.create_item(body=document_definition)
 
-        read_doc = self.created_collection.get_item(item=created_doc['id'], partition_key='pk')
+        read_doc = self.created_collection.read_item(item=created_doc['id'], partition_key='pk')
         self.assertEqual(read_doc['unicode_content'], test_string)
 
     def test_create_stored_procedure_with_line_separator_para_seperator_next_line_unicodes (self):

--- a/sdk/cosmos/azure-cosmos/test/multimaster_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/multimaster_tests.py
@@ -58,7 +58,7 @@ class MultiMasterTests(unittest.TestCase):
             partition_key='pk'
         )
 
-        created_collection.get_item(
+        created_collection.read_item(
             item=created_document,
             partition_key='pk'
         )

--- a/sdk/cosmos/azure-cosmos/test/orderby_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/orderby_tests.py
@@ -91,7 +91,7 @@ class CrossPartitionTopOrderByTest(unittest.TestCase):
         self.assertGreaterEqual(len(partition_key_ranges), 5)
         
         # sanity check: read documents after creation
-        queried_docs = list(self.created_collection.list_item_properties())
+        queried_docs = list(self.created_collection.read_all_items())
         self.assertEqual(
             len(queried_docs),
             len(self.document_definitions),

--- a/sdk/cosmos/azure-cosmos/test/partition_key_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/partition_key_tests.py
@@ -190,14 +190,16 @@ class PartitionKeyTests(unittest.TestCase):
             id='container_with_pkd_v2' + str(uuid.uuid4()),
             partition_key=partition_key.PartitionKey(path="/id", kind="Hash")
         )
-        self.assertEquals(created_container.properties['partitionKey']['version'], 2)
+        created_container_properties = created_container.read()
+        self.assertEquals(created_container_properties['partitionKey']['version'], 2)
         self.created_db.delete_container(created_container)
 
         created_container = self.created_db.create_container(
             id='container_with_pkd_v2' + str(uuid.uuid4()),
             partition_key=partition_key.PartitionKey(path="/id", kind="Hash", version=2)
         )
-        self.assertEquals(created_container.properties['partitionKey']['version'], 2)
+        created_container_properties = created_container.read()
+        self.assertEquals(created_container_properties['partitionKey']['version'], 2)
         self.created_db.delete_container(created_container)
 
     def test_hash_v1_partition_key_definition(self):
@@ -205,5 +207,6 @@ class PartitionKeyTests(unittest.TestCase):
             id='container_with_pkd_v2' + str(uuid.uuid4()),
             partition_key=partition_key.PartitionKey(path="/id", kind="Hash", version=1)
         )
-        self.assertEquals(created_container.properties['partitionKey']['version'], 1)
+        created_container_properties = created_container.read()
+        self.assertEquals(created_container_properties['partitionKey']['version'], 1)
         self.created_db.delete_container(created_container)

--- a/sdk/cosmos/azure-cosmos/test/partition_key_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/partition_key_tests.py
@@ -125,14 +125,14 @@ class PartitionKeyTests(unittest.TestCase):
         created_container = self.created_db.get_container(self.created_collection_id)
 
         # Pass partitionKey.Empty as partition key to access documents from a single partition collection with v 2018-12-31 SDK
-        read_item = created_container.get_item(self.created_document['id'], partition_key=partition_key.NonePartitionKeyValue)
+        read_item = created_container.read_item(self.created_document['id'], partition_key=partition_key.NonePartitionKeyValue)
         self.assertEquals(read_item['id'], self.created_document['id'])
 
         document_definition = {'id': str(uuid.uuid4())}
         created_item = created_container.create_item(body=document_definition)
         self.assertEquals(created_item['id'], document_definition['id'])
 
-        read_item = created_container.get_item(created_item['id'], partition_key=partition_key.NonePartitionKeyValue)
+        read_item = created_container.read_item(created_item['id'], partition_key=partition_key.NonePartitionKeyValue)
         self.assertEquals(read_item['id'], created_item['id'])
 
         document_definition_for_replace = {'id': str(uuid.uuid4())}
@@ -181,7 +181,7 @@ class PartitionKeyTests(unittest.TestCase):
     def test_multi_partition_collection_read_document_with_no_pk(self):
         document_definition = {'id': str(uuid.uuid4())}
         self.created_collection.create_item(body=document_definition)
-        read_item = self.created_collection.get_item(item=document_definition['id'], partition_key=partition_key.NonePartitionKeyValue)
+        read_item = self.created_collection.read_item(item=document_definition['id'], partition_key=partition_key.NonePartitionKeyValue)
         self.assertEquals(read_item['id'], document_definition['id'])
         self.created_collection.delete_item(item=document_definition['id'], partition_key=partition_key.NonePartitionKeyValue)
 

--- a/sdk/cosmos/azure-cosmos/test/partition_key_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/partition_key_tests.py
@@ -167,7 +167,7 @@ class PartitionKeyTests(unittest.TestCase):
         self.assertEqual(result, 1)
 
         # 3 previous items + 1 created from the sproc
-        items = list(created_container.list_item_properties())
+        items = list(created_container.read_all_items())
         self.assertEquals(len(items), 4)
 
         created_container.delete_item(upserted_item['id'], partition_key=partition_key.NonePartitionKeyValue)
@@ -175,7 +175,7 @@ class PartitionKeyTests(unittest.TestCase):
         created_container.delete_item(document_created_by_sproc_id, partition_key=partition_key.NonePartitionKeyValue)
         created_container.delete_item(self.created_document['id'], partition_key=partition_key.NonePartitionKeyValue)
 
-        items = list(created_container.list_item_properties())
+        items = list(created_container.read_all_items())
         self.assertEquals(len(items), 0)
 
     def test_multi_partition_collection_read_document_with_no_pk(self):

--- a/sdk/cosmos/azure-cosmos/test/query_execution_context_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/query_execution_context_tests.py
@@ -83,7 +83,7 @@ class QueryExecutionContextEndToEndTests(unittest.TestCase):
         self.assertGreaterEqual(len(partition_key_ranges), 1)
 
         # sanity check: read documents after creation
-        queried_docs = list(self.created_collection.list_item_properties())
+        queried_docs = list(self.created_collection.read_all_items())
         self.assertEqual(
             len(queried_docs),
             len(self.document_definitions),

--- a/sdk/cosmos/azure-cosmos/test/retry_policy_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/retry_policy_tests.py
@@ -203,7 +203,7 @@ class Test_retry_policy_tests(unittest.TestCase):
         self.OriginalExecuteFunction = retry_utility._ExecuteFunction
         retry_utility._ExecuteFunction = self._MockExecuteFunctionConnectionReset
 
-        doc = self.created_collection.get_item(item=created_document['id'], partition_key=created_document['id'])
+        doc = self.created_collection.read_item(item=created_document['id'], partition_key=created_document['id'])
         self.assertEqual(doc['id'], 'doc')
         self.assertEqual(self.counter, 3)
         

--- a/sdk/cosmos/azure-cosmos/test/session_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/session_tests.py
@@ -34,11 +34,11 @@ class SessionTests(unittest.TestCase):
         self._OriginalRequest = synchronized_request._Request
         synchronized_request._Request = self._MockRequest
         created_document = self.created_collection.create_item(body={'id': '1' + str(uuid.uuid4()), 'pk': 'mypk'})
-        self.created_collection.get_item(item=created_document['id'], partition_key='mypk')
+        self.created_collection.read_item(item=created_document['id'], partition_key='mypk')
         self.assertNotEqual(self.last_session_token_sent, None)
         self.created_db.get_container(container=self.created_collection).read()
         self.assertEqual(self.last_session_token_sent, None)
-        self.created_collection.get_item(item=created_document['id'], partition_key='mypk')
+        self.created_collection.read_item(item=created_document['id'], partition_key='mypk')
         self.assertNotEqual(self.last_session_token_sent, None)
         synchronized_request._Request = self._OriginalRequest
 
@@ -51,7 +51,7 @@ class SessionTests(unittest.TestCase):
         self.OriginalExecuteFunction = retry_utility._ExecuteFunction
         retry_utility._ExecuteFunction = self._MockExecuteFunctionSessionReadFailureOnce
         try:
-            self.created_collection.get_item(item=created_document['id'], partition_key='mypk')
+            self.created_collection.read_item(item=created_document['id'], partition_key='mypk')
         except errors.HTTPFailure as e:
             self.assertEqual(self.client.client_connection.session.get_session_token(
                 'dbs/' + self.created_db.id + '/colls/' + self.created_collection.id), "")

--- a/sdk/cosmos/azure-cosmos/test/session_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/session_tests.py
@@ -36,7 +36,7 @@ class SessionTests(unittest.TestCase):
         created_document = self.created_collection.create_item(body={'id': '1' + str(uuid.uuid4()), 'pk': 'mypk'})
         self.created_collection.get_item(item=created_document['id'], partition_key='mypk')
         self.assertNotEqual(self.last_session_token_sent, None)
-        self.created_db.get_container(container=self.created_collection)
+        self.created_db.get_container(container=self.created_collection).read()
         self.assertEqual(self.last_session_token_sent, None)
         self.created_collection.get_item(item=created_document['id'], partition_key='mypk')
         self.assertNotEqual(self.last_session_token_sent, None)

--- a/sdk/cosmos/azure-cosmos/test/ttl_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/ttl_tests.py
@@ -79,7 +79,8 @@ class Test_ttl_tests(unittest.TestCase):
             default_ttl=ttl,
             partition_key=PartitionKey(path='/id', kind='Hash')
             )
-        self.assertEqual(created_collection.properties['defaultTtl'], ttl)
+        created_collection_properties = created_collection.read()
+        self.assertEqual(created_collection_properties['defaultTtl'], ttl)
 
         collection_id = 'test_collection_and_document_ttl_values4' + str(uuid.uuid4())
         ttl = -10

--- a/sdk/cosmos/azure-cosmos/test/ttl_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/ttl_tests.py
@@ -143,7 +143,7 @@ class Test_ttl_tests(unittest.TestCase):
         # the created document should be gone now as it's ttl value would be same as defaultTtl value of the collection
         self.__AssertHTTPFailureWithStatus(
             StatusCodes.NOT_FOUND,
-            created_collection.get_item,
+            created_collection.read_item,
             document_definition['id'],
             document_definition['id']
         )
@@ -155,7 +155,7 @@ class Test_ttl_tests(unittest.TestCase):
         time.sleep(5)
 
         # the created document should NOT be gone as it's ttl value is set to -1(never expire) which overrides the collections's defaultTtl value
-        read_document = created_collection.get_item(item=document_definition['id'], partition_key=document_definition['id'])
+        read_document = created_collection.read_item(item=document_definition['id'], partition_key=document_definition['id'])
         self.assertEqual(created_document['id'], read_document['id'])
 
         document_definition['id'] = 'doc3' + str(uuid.uuid4())
@@ -167,7 +167,7 @@ class Test_ttl_tests(unittest.TestCase):
         # the created document should be gone now as it's ttl value is set to 2 which overrides the collections's defaultTtl value(5)
         self.__AssertHTTPFailureWithStatus(
             StatusCodes.NOT_FOUND,
-            created_collection.get_item,
+            created_collection.read_item,
             created_document['id'],
             created_document['id']
         )
@@ -179,7 +179,7 @@ class Test_ttl_tests(unittest.TestCase):
         time.sleep(6)
 
         # the created document should NOT be gone as it's ttl value is set to 8 which overrides the collections's defaultTtl value(5)
-        read_document = created_collection.get_item(item=created_document['id'], partition_key=created_document['id'])
+        read_document = created_collection.read_item(item=created_document['id'], partition_key=created_document['id'])
         self.assertEqual(created_document['id'], read_document['id'])
 
         time.sleep(4)
@@ -187,7 +187,7 @@ class Test_ttl_tests(unittest.TestCase):
         # the created document should be gone now as we have waited for (6+4) secs which is greater than documents's ttl value of 8
         self.__AssertHTTPFailureWithStatus(
             StatusCodes.NOT_FOUND,
-            created_collection.get_item,
+            created_collection.read_item,
             created_document['id'],
             created_document['id']
         )
@@ -222,16 +222,16 @@ class Test_ttl_tests(unittest.TestCase):
         # the created document should be gone now as it's ttl value is set to 2 which overrides the collections's defaultTtl value(-1)
         self.__AssertHTTPFailureWithStatus(
             StatusCodes.NOT_FOUND,
-            created_collection.get_item,
+            created_collection.read_item,
             created_document3['id'],
             created_document3['id']
         )
 
         # The documents with id doc1 and doc2 will never expire
-        read_document = created_collection.get_item(item=created_document1['id'], partition_key=created_document1['id'])
+        read_document = created_collection.read_item(item=created_document1['id'], partition_key=created_document1['id'])
         self.assertEqual(created_document1['id'], read_document['id'])
 
-        read_document = created_collection.get_item(item=created_document2['id'], partition_key=created_document2['id'])
+        read_document = created_collection.read_item(item=created_document2['id'], partition_key=created_document2['id'])
         self.assertEqual(created_document2['id'], read_document['id'])
 
         self.created_db.delete_container(container=created_collection)
@@ -252,7 +252,7 @@ class Test_ttl_tests(unittest.TestCase):
         time.sleep(7)
 
         # Created document still exists even after ttl time has passed since the TTL is disabled at collection level(no defaultTtl property defined)
-        read_document = created_collection.get_item(item=created_document['id'], partition_key=created_document['id'])
+        read_document = created_collection.read_item(item=created_document['id'], partition_key=created_document['id'])
         self.assertEqual(created_document['id'], read_document['id'])
 
         self.created_db.delete_container(container=created_collection)
@@ -275,7 +275,7 @@ class Test_ttl_tests(unittest.TestCase):
         # the created document cannot be deleted since it should already be gone now
         self.__AssertHTTPFailureWithStatus(
             StatusCodes.NOT_FOUND,
-            created_collection.get_item,
+            created_collection.read_item,
             created_document['id'],
             created_document['id']
         )
@@ -293,7 +293,7 @@ class Test_ttl_tests(unittest.TestCase):
         time.sleep(7)
 
         # Upserted document still exists after 10 secs from document creation time(with collection's defaultTtl set to 8) since it's ttl was reset after 3 secs by upserting it
-        read_document = created_collection.get_item(item=upserted_docment['id'], partition_key=upserted_docment['id'])
+        read_document = created_collection.read_item(item=upserted_docment['id'], partition_key=upserted_docment['id'])
         self.assertEqual(upserted_docment['id'], read_document['id'])
 
         time.sleep(3)
@@ -301,7 +301,7 @@ class Test_ttl_tests(unittest.TestCase):
         # the upserted document should be gone now after 10 secs from the last write(upsert) of the document
         self.__AssertHTTPFailureWithStatus(
             StatusCodes.NOT_FOUND,
-            created_collection.get_item,
+            created_collection.read_item,
             upserted_docment['id'],\
             upserted_docment['id']
         )
@@ -326,7 +326,7 @@ class Test_ttl_tests(unittest.TestCase):
         time.sleep(5)
 
         # Created document still exists even after ttl time has passed since the TTL is disabled at collection level
-        read_document = created_collection.get_item(item=created_document['id'], partition_key=created_document['id'])
+        read_document = created_collection.read_item(item=created_document['id'], partition_key=created_document['id'])
         self.assertEqual(created_document['id'], read_document['id'])
 
         self.created_db.delete_container(container=created_collection)


### PR DESCRIPTION
Work toward splitting get/read methods for cosmos entities.

@johanste @christopheranderson before doing more I wanted to validate the behavior with this change just for databases:
```
In [14]: client = cosmos_client.CosmosClient(url=config['ENDPOINT'], auth={'masterKey': config['PRIMARYKEY']})

In [15]: db = client.get_database(config['DATABASE'])

In [16]: db
Out[16]: <azure.cosmos.database.Database at 0x10fb33278>

In [17]: db.properties

In [18]: props = client.read_database(db)

In [19]: props
Out[19]:
{'id': 'db2',
 '_rid': 'bIkHAA==',
 '_self': 'dbs/bIkHAA==/',
 '_etag': '"0000d533-0000-0800-0000-5ceeb1ca0000"',
 '_colls': 'colls/',
 '_users': 'users/',
 '_ts': 1559146954}
```

So:

* `read_database` returns the properties dict, it does not mutate a database (I don't see how it could without the current function signature that accepts string database ids)

* `client.create_database(id=config['DATABASE'])` still currently sets `.properties` is this desired?



