### PR TITLE
resolve pytest ignoring mark argument

### DIFF
--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -33,10 +33,14 @@ def process_glob_string(glob_string, target_root_dir):
     # dedup, in case we have double coverage from the glob strings. Example: "azure-mgmt-keyvault,azure-mgmt-*"
     return list(set(collected_top_level_directories))
 
-def run_check_call(command_array, working_directory, acceptable_return_codes = []):
-    print('Command Array: {0}, Target Working Directory: {1}'.format(command_array, working_directory))
+def run_check_call(command_array, working_directory, acceptable_return_codes = [], run_as_shell = False):
     try:
-        check_call(command_array, cwd = working_directory)
+        if run_as_shell:
+            print('Command Array: {0}, Target Working Directory: {1}'.format(' '.join(command_array), working_directory))
+            check_call(' '.join(command_array), cwd = working_directory, shell = True)
+        else:
+            print('Command Array: {0}, Target Working Directory: {1}'.format(command_array, working_directory))
+            check_call(command_array, cwd = working_directory)
     except CalledProcessError as err:
         if err.returncode not in acceptable_return_codes:
             print(err) #, file = sys.stderr

--- a/scripts/devops_tasks/setup_execute_tests.py
+++ b/scripts/devops_tasks/setup_execute_tests.py
@@ -38,7 +38,7 @@ def prep_and_run_tests(targeted_packages, python_version, test_res):
     command_array = [python_version, '-m', 'pytest']
     command_array.extend(test_res)
     command_array.extend(targeted_packages)
-    run_check_call(command_array, root_dir, ALLOWED_RETURN_CODES)
+    run_check_call(command_array, root_dir, ALLOWED_RETURN_CODES, True)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description = 'Install Dependencies, Install Packages, Test Azure Packages, Called from DevOps YAML Pipeline')


### PR DESCRIPTION
On linux boxes, the command array of `['python', '-m', 'pytest', '-m', '"not cosmosEmulator"']` was dropping the marker argument. Not deselecting properly.

This PR combines them into single execution.