### PR TITLE
Incorporate architecture board feedback

### DIFF
--- a/sdk/core/azure-core/azure/core/credentials.py
+++ b/sdk/core/azure-core/azure/core/credentials.py
@@ -3,16 +3,15 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-from typing import Iterable  # pylint:disable=unused-import
 from typing_extensions import Protocol
 
 
-class SupportsGetToken(Protocol):
+class TokenCredential(Protocol):
     """Protocol for classes able to provide OAuth tokens.
 
     :param str scopes: Lets you specify the type of access needed.
     """
     # pylint:disable=too-few-public-methods
-    def get_token(self, scopes):
-        # type: (Iterable[str]) -> str
+    def get_token(self, *scopes):
+        # type: (*str) -> str
         pass

--- a/sdk/core/azure-core/azure/core/pipeline/policies/credentials.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/credentials.py
@@ -13,7 +13,7 @@ except ImportError:
 if TYPE_CHECKING:
     # pylint:disable=unused-import
     from typing import Any, Dict, Iterable, Mapping
-    from azure.core.credentials import SupportsGetToken
+    from azure.core.credentials import TokenCredential
     from azure.core.pipeline import PipelineRequest, PipelineResponse
 
 
@@ -22,12 +22,12 @@ class _BearerTokenCredentialPolicyBase(object):
     """Base class for a Bearer Token Credential Policy.
 
     :param credential: The credential.
-    :type credential: ~azure.core.SupportsGetToken
+    :type credential: ~azure.core.credentials.TokenCredential
     :param str scopes: Lets you specify the type of access needed.
     """
 
     def __init__(self, credential, scopes, **kwargs):  # pylint:disable=unused-argument
-        # type: (SupportsGetToken, Iterable[str], Mapping[str, Any]) -> None
+        # type: (TokenCredential, Iterable[str], Mapping[str, Any]) -> None
         super(_BearerTokenCredentialPolicyBase, self).__init__()
         self._scopes = scopes
         self._credential = credential
@@ -47,7 +47,7 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, HTTPPolicy):
     """Adds a bearer token Authorization header to requests.
 
     :param credential: The credential.
-    :type credential: ~azure.core.SupportsGetToken
+    :type credential: ~azure.core.TokenCredential
     :param str scopes: Lets you specify the type of access needed.
     """
 

--- a/sdk/core/azure-core/azure/core/pipeline/policies/credentials_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/credentials_async.py
@@ -13,7 +13,7 @@ class AsyncBearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, AsyncHT
     """Adds a bearer token Authorization header to requests.
 
     :param credential: The credential.
-    :type credential: ~azure.core.SupportsGetToken
+    :type credential: ~azure.core.credentials.TokenCredential
     :param str scopes: Lets you specify the type of access needed.
     """
 

--- a/sdk/identity/azure-identity/azure/identity/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/__init__.py
@@ -8,9 +8,7 @@ from .credentials import (
     CertificateCredential,
     ClientSecretCredential,
     EnvironmentCredential,
-    ImdsCredential,
     ManagedIdentityCredential,
-    MsiCredential,
     TokenCredentialChain,
 )
 
@@ -30,9 +28,7 @@ __all__ = [
     "ClientSecretCredential",
     "DefaultAzureCredential",
     "EnvironmentCredential",
-    "ImdsCredential",
     "ManagedIdentityCredential",
-    "MsiCredential",
     "TokenCredentialChain",
 ]
 
@@ -42,9 +38,7 @@ try:
         AsyncClientSecretCredential,
         AsyncDefaultAzureCredential,
         AsyncEnvironmentCredential,
-        AsyncImdsCredential,
         AsyncManagedIdentityCredential,
-        AsyncMsiCredential,
         AsyncTokenCredentialChain,
     )
 
@@ -54,9 +48,7 @@ try:
             "AsyncClientSecretCredential",
             "AsyncDefaultAzureCredential",
             "AsyncEnvironmentCredential",
-            "AsyncImdsCredential",
             "AsyncManagedIdentityCredential",
-            "AsyncMsiCredential",
             "AsyncTokenCredentialChain",
         ]
     )

--- a/sdk/identity/azure-identity/azure/identity/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/__init__.py
@@ -14,10 +14,21 @@ from .credentials import (
     TokenCredentialChain,
 )
 
+
+class DefaultAzureCredential(TokenCredentialChain):
+    """default credential is environment followed by MSI/IMDS"""
+
+    def __init__(self, **kwargs):
+        super(DefaultAzureCredential, self).__init__(
+            EnvironmentCredential(**kwargs), ManagedIdentityCredential(**kwargs)
+        )
+
+
 __all__ = [
     "AuthenticationError",
     "CertificateCredential",
     "ClientSecretCredential",
+    "DefaultAzureCredential",
     "EnvironmentCredential",
     "ImdsCredential",
     "ManagedIdentityCredential",
@@ -29,6 +40,7 @@ try:
     from .aio import (
         AsyncCertificateCredential,
         AsyncClientSecretCredential,
+        AsyncDefaultAzureCredential,
         AsyncEnvironmentCredential,
         AsyncImdsCredential,
         AsyncManagedIdentityCredential,
@@ -40,6 +52,7 @@ try:
         [
             "AsyncCertificateCredential",
             "AsyncClientSecretCredential",
+            "AsyncDefaultAzureCredential",
             "AsyncEnvironmentCredential",
             "AsyncImdsCredential",
             "AsyncManagedIdentityCredential",
@@ -47,5 +60,5 @@ try:
             "AsyncTokenCredentialChain",
         ]
     )
-except SyntaxError:
+except (ImportError, SyntaxError):
     pass

--- a/sdk/identity/azure-identity/azure/identity/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/__init__.py
@@ -8,7 +8,9 @@ from .credentials import (
     CertificateCredential,
     ClientSecretCredential,
     EnvironmentCredential,
+    ImdsCredential,
     ManagedIdentityCredential,
+    MsiCredential,
     TokenCredentialChain,
 )
 
@@ -17,7 +19,9 @@ __all__ = [
     "CertificateCredential",
     "ClientSecretCredential",
     "EnvironmentCredential",
+    "ImdsCredential",
     "ManagedIdentityCredential",
+    "MsiCredential",
     "TokenCredentialChain",
 ]
 
@@ -26,7 +30,9 @@ try:
         AsyncCertificateCredential,
         AsyncClientSecretCredential,
         AsyncEnvironmentCredential,
+        AsyncImdsCredential,
         AsyncManagedIdentityCredential,
+        AsyncMsiCredential,
         AsyncTokenCredentialChain,
     )
 
@@ -35,7 +41,9 @@ try:
             "AsyncCertificateCredential",
             "AsyncClientSecretCredential",
             "AsyncEnvironmentCredential",
+            "AsyncImdsCredential",
             "AsyncManagedIdentityCredential",
+            "AsyncMsiCredential",
             "AsyncTokenCredentialChain",
         ]
     )

--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
-# --------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from time import time
 
 from azure.core import Configuration, HttpRequest
@@ -51,6 +51,14 @@ class AuthnClientBase(object):
             else:
                 payload = response.http_response.text()
             token = payload["access_token"]
+
+            # these values are strings in IMDS responses but msal.TokenCache requires they be integers
+            # https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/55
+            if payload.get("expires_in"):
+                payload["expires_in"] = int(payload["expires_in"])
+            if payload.get("ext_expires_in"):
+                payload["ext_expires_in"] = int(payload["ext_expires_in"])
+
             self._cache.add({"response": payload, "scope": scopes})
             return token
         except KeyError:

--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -58,9 +58,9 @@ class AuthnClientBase(object):
         except Exception as ex:
             raise AuthenticationError("Authentication failed: {}".format(str(ex)))
 
-    def _prepare_request(self, method="POST", form_data=None, params=None):
-        # type: (Optional[str], Optional[Mapping[str, str]], Optional[Dict[str, str]]) -> HttpRequest
-        request = HttpRequest(method, self._auth_url)
+    def _prepare_request(self, method="POST", headers=None, form_data=None, params=None):
+        # type: (Optional[str], Optional[Mapping[str, str]], Optional[Mapping[str, str]], Optional[Dict[str, str]]) -> HttpRequest
+        request = HttpRequest(method, self._auth_url, headers=headers)
         if form_data:
             request.headers["Content-Type"] = "application/x-www-form-urlencoded"
             request.set_formdata_body(form_data)
@@ -81,9 +81,9 @@ class AuthnClient(AuthnClientBase):
         self._pipeline = Pipeline(transport=transport, policies=policies)
         super(AuthnClient, self).__init__(auth_url, **kwargs)
 
-    def request_token(self, scopes, method="POST", form_data=None, params=None):
-        # type: (Iterable[str], Optional[str], Optional[Mapping[str, str]], Optional[Dict[str, str]]) -> str
-        request = self._prepare_request(method, form_data, params)
+    def request_token(self, scopes, method="POST", headers=None, form_data=None, params=None):
+        # type: (Iterable[str], Optional[str], Optional[Mapping[str, str]], Optional[Mapping[str, str]], Optional[Dict[str, str]]) -> str
+        request = self._prepare_request(method, headers=headers, form_data=form_data, params=params)
         response = self._pipeline.run(request, stream=False)
         token = self._deserialize_and_cache_token(response, scopes)
         return token

--- a/sdk/identity/azure-identity/azure/identity/_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_base.py
@@ -5,7 +5,7 @@
 # --------------------------------------------------------------------------
 from msal.oauth2cli import JwtSigner
 
-from .constants import OAUTH_ENDPOINT
+from .constants import Endpoints
 
 try:
     from typing import TYPE_CHECKING
@@ -38,7 +38,7 @@ class CertificateCredentialBase(object):
             raise ValueError("certificate_path must be the path to a PEM-encoded private key file")
 
         super(CertificateCredentialBase, self).__init__()
-        auth_url = OAUTH_ENDPOINT.format(tenant_id)
+        auth_url = Endpoints.AAD_OAUTH2_V2_FORMAT.format(tenant_id)
 
         with open(certificate_path) as pem:
             private_key = pem.read()

--- a/sdk/identity/azure-identity/azure/identity/_internal.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal.py
@@ -1,0 +1,105 @@
+# ------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# ------------------------------------------------------------------------
+import os
+
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import
+    from typing import Any, Dict, Optional
+
+from azure.core import Configuration
+from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, NetworkTraceLoggingPolicy, RetryPolicy
+
+from ._authn_client import AuthnClient
+from .constants import Endpoints, MSI_ENDPOINT, MSI_SECRET
+from .exceptions import AuthenticationError
+
+
+class ImdsCredential:
+    """Authenticates with a managed identity via the IMDS endpoint"""
+
+    def __init__(self, config=None, **kwargs):
+        # type: (Optional[Configuration], Dict[str, Any]) -> None
+        config = config or self.create_config(**kwargs)
+        policies = [config.header_policy, ContentDecodePolicy(), config.logging_policy, config.retry_policy]
+        self._client = AuthnClient(Endpoints.IMDS, config, policies, **kwargs)
+
+    @staticmethod
+    def create_config(**kwargs):
+        # type: (Dict[str, str]) -> Configuration
+        timeout = kwargs.pop("connection_timeout", 2)
+        config = Configuration(connection_timeout=timeout, **kwargs)
+        config.header_policy = HeadersPolicy(base_headers={"Metadata": "true"}, **kwargs)
+        config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
+        retries = kwargs.pop("retry_total", 5)
+        config.retry_policy = RetryPolicy(
+            retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
+        )
+        return config
+
+    def get_token(self, *scopes):
+        # type: (*str) -> str
+        if len(scopes) != 1:
+            raise ValueError("this credential supports one scope per request")
+        token = self._client.get_cached_token(scopes)
+        if not token:
+            resource = scopes[0]
+            if resource.endswith("/.default"):
+                resource = resource[:-len("/.default")]
+            token = self._client.request_token(
+                scopes, method="GET", params={"api-version": "2018-02-01", "resource": resource}
+            )
+        return token
+
+
+class MsiCredential:
+    """Authenticates via the MSI endpoint"""
+
+    def __init__(self, config=None, **kwargs):
+        # type: (Optional[Configuration], Dict[str, Any]) -> None
+        config = config or self.create_config(**kwargs)
+        policies = [ContentDecodePolicy(), config.retry_policy, config.logging_policy]
+        endpoint = os.environ.get(MSI_ENDPOINT)
+        if not endpoint:
+            raise ValueError("expected environment variable {} has no value".format(MSI_ENDPOINT))
+        self._client = AuthnClient(endpoint, config, policies, **kwargs)
+
+    @staticmethod
+    def create_config(**kwargs):
+        # type: (Dict[str, str]) -> Configuration
+        timeout = kwargs.pop("connection_timeout", 2)
+        config = Configuration(connection_timeout=timeout, **kwargs)
+        config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
+        retries = kwargs.pop("retry_total", 5)
+        config.retry_policy = RetryPolicy(
+            retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
+        )
+        return config
+
+    def get_token(self, *scopes):
+        # type: (*str) -> str
+        if len(scopes) != 1:
+            raise ValueError("this credential supports only one scope per request")
+        token = self._client.get_cached_token(scopes)
+        if not token:
+            secret = os.environ.get(MSI_SECRET)
+            if not secret:
+                raise AuthenticationError("{} environment variable has no value".format(MSI_SECRET))
+            resource = scopes[0]
+            if resource.endswith("/.default"):
+                resource = resource[:-len("/.default")]
+            # TODO: support user-assigned client id
+            token = self._client.request_token(
+                scopes,
+                method="GET",
+                headers={"secret": secret},
+                params={"api-version": "2017-09-01", "resource": resource},
+            )
+        return token

--- a/sdk/identity/azure-identity/azure/identity/aio/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/__init__.py
@@ -7,9 +7,7 @@ from .credentials import (
     AsyncCertificateCredential,
     AsyncClientSecretCredential,
     AsyncEnvironmentCredential,
-    AsyncImdsCredential,
     AsyncManagedIdentityCredential,
-    AsyncMsiCredential,
     AsyncTokenCredentialChain,
 )
 
@@ -26,8 +24,6 @@ __all__ = [
     "AsyncClientSecretCredential",
     "AsyncDefaultAzureCredential",
     "AsyncEnvironmentCredential",
-    "AsyncImdsCredential",
     "AsyncManagedIdentityCredential",
-    "AsyncMsiCredential",
     "AsyncTokenCredentialChain",
 ]

--- a/sdk/identity/azure-identity/azure/identity/aio/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/__init__.py
@@ -7,7 +7,9 @@ from .credentials import (
     AsyncCertificateCredential,
     AsyncClientSecretCredential,
     AsyncEnvironmentCredential,
+    AsyncImdsCredential,
     AsyncManagedIdentityCredential,
+    AsyncMsiCredential,
     AsyncTokenCredentialChain,
 )
 
@@ -15,6 +17,8 @@ __all__ = [
     "AsyncCertificateCredential",
     "AsyncClientSecretCredential",
     "AsyncEnvironmentCredential",
+    "AsyncImdsCredential",
     "AsyncManagedIdentityCredential",
+    "AsyncMsiCredential",
     "AsyncTokenCredentialChain",
 ]

--- a/sdk/identity/azure-identity/azure/identity/aio/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/__init__.py
@@ -1,8 +1,8 @@
-# -------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
-# --------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 from .credentials import (
     AsyncCertificateCredential,
     AsyncClientSecretCredential,
@@ -13,9 +13,18 @@ from .credentials import (
     AsyncTokenCredentialChain,
 )
 
+
+class AsyncDefaultAzureCredential(AsyncTokenCredentialChain):
+    """default credential is environment followed by MSI/IMDS"""
+
+    def __init__(self, **kwargs):
+        super().__init__(AsyncEnvironmentCredential(**kwargs), AsyncManagedIdentityCredential(**kwargs))
+
+
 __all__ = [
     "AsyncCertificateCredential",
     "AsyncClientSecretCredential",
+    "AsyncDefaultAzureCredential",
     "AsyncEnvironmentCredential",
     "AsyncImdsCredential",
     "AsyncManagedIdentityCredential",

--- a/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
@@ -36,10 +36,11 @@ class AsyncAuthnClient(AuthnClientBase):
         self,
         scopes: Iterable[str],
         method: Optional[str] = "POST",
+        headers: Optional[Mapping[str, str]] = None,
         form_data: Optional[Mapping[str, str]] = None,
         params: Optional[Dict[str, str]] = None,
     ) -> str:
-        request = self._prepare_request(method, form_data, params)
+        request = self._prepare_request(method, headers=headers, form_data=form_data, params=params)
         response = await self._pipeline.run(request, stream=False)
         token = self._deserialize_and_cache_token(response, scopes)
         return token

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal.py
@@ -1,0 +1,87 @@
+# ------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# ------------------------------------------------------------------------
+import os
+from typing import Any, Dict, Optional
+
+from azure.core import Configuration
+from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, NetworkTraceLoggingPolicy, AsyncRetryPolicy
+
+from ._authn_client import AsyncAuthnClient
+from ..constants import Endpoints, MSI_ENDPOINT, MSI_SECRET
+from ..exceptions import AuthenticationError
+
+
+class AsyncImdsCredential:
+    def __init__(self, config: Optional[Configuration] = None, **kwargs: Dict[str, Any]) -> None:
+        config = config or self.create_config(**kwargs)
+        policies = [config.header_policy, ContentDecodePolicy(), config.retry_policy, config.logging_policy]
+        self._client = AsyncAuthnClient(Endpoints.IMDS, config, policies, **kwargs)
+
+    async def get_token(self, *scopes: str) -> str:
+        if len(scopes) != 1:
+            raise ValueError("this credential supports one scope per request")
+        token = self._client.get_cached_token(scopes)
+        if not token:
+            resource = scopes[0]
+            if resource.endswith("/.default"):
+                resource = resource[:-len("/.default")]
+            token = await self._client.request_token(
+                scopes, method="GET", params={"api-version": "2018-02-01", "resource": resource}
+            )
+        return token
+
+    @staticmethod
+    def create_config(**kwargs: Dict[str, Any]) -> Configuration:
+        timeout = kwargs.pop("connection_timeout", 2)
+        config = Configuration(connection_timeout=timeout, **kwargs)
+        config.header_policy = HeadersPolicy(base_headers={"Metadata": "true"}, **kwargs)
+        config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
+        retries = kwargs.pop("retry_total", 5)
+        config.retry_policy = AsyncRetryPolicy(
+            retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
+        )
+        return config
+
+
+class AsyncMsiCredential:
+    def __init__(self, config: Optional[Configuration] = None, **kwargs: Dict[str, Any]) -> None:
+        config = config or self.create_config(**kwargs)
+        policies = [ContentDecodePolicy(), config.retry_policy, config.logging_policy]
+        endpoint = os.environ.get(MSI_ENDPOINT)
+        if not endpoint:
+            raise ValueError("expected environment variable {} has no value".format(MSI_ENDPOINT))
+        self._client = AsyncAuthnClient(endpoint, config, policies, **kwargs)
+
+    async def get_token(self, *scopes: str) -> str:
+        if len(scopes) != 1:
+            raise ValueError("this credential supports only one scope per request")
+        token = self._client.get_cached_token(scopes)
+        if not token:
+            resource = scopes[0]
+            if resource.endswith("/.default"):
+                resource = resource[:-len("/.default")]
+            secret = os.environ.get(MSI_SECRET)
+            if not secret:
+                raise AuthenticationError("{} environment variable has no value".format(MSI_SECRET))
+            # TODO: support user-assigned client id
+            token = await self._client.request_token(
+                scopes,
+                method="GET",
+                headers={"secret": secret},
+                params={"api-version": "2017-09-01", "resource": resource},
+            )
+        return token
+
+    @staticmethod
+    def create_config(**kwargs: Dict[str, Any]) -> Configuration:
+        timeout = kwargs.pop("connection_timeout", 2)
+        config = Configuration(connection_timeout=timeout, **kwargs)
+        config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
+        retries = kwargs.pop("retry_total", 5)
+        config.retry_policy = AsyncRetryPolicy(
+            retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
+        )
+        return config

--- a/sdk/identity/azure-identity/azure/identity/aio/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/credentials.py
@@ -100,7 +100,9 @@ class AsyncMsiCredential:
             raise ValueError("this credential supports only one scope per request")
         token = self._client.get_cached_token(scopes)
         if not token:
-            resource = scopes[0].rstrip("/.default")
+            resource = scopes[0]
+            if resource.endswith("/.default"):
+                resource = resource[:-len("/.default")]
             secret = os.environ.get(MSI_SECRET)
             if not secret:
                 raise AuthenticationError("{} environment variable has no value".format(MSI_SECRET))
@@ -133,10 +135,12 @@ class AsyncImdsCredential:
 
     async def get_token(self, *scopes: str) -> str:
         if len(scopes) != 1:
-            raise ValueError("Managed identity credential supports one scope per request")
+            raise ValueError("this credential supports one scope per request")
         token = self._client.get_cached_token(scopes)
         if not token:
-            resource = scopes[0].rstrip("/.default")
+            resource = scopes[0]
+            if resource.endswith("/.default"):
+                resource = resource[:-len("/.default")]
             token = await self._client.request_token(
                 scopes, method="GET", params={"api-version": "2018-02-01", "resource": resource}
             )

--- a/sdk/identity/azure-identity/azure/identity/aio/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/credentials.py
@@ -1,8 +1,8 @@
-# -------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
-# --------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 import os
 from typing import Any, Dict, Mapping, Optional, Union
 
@@ -173,10 +173,6 @@ class AsyncManagedIdentityCredential(object):
 
 class AsyncTokenCredentialChain(TokenCredentialChain):
     """A sequence of token credentials"""
-
-    @classmethod
-    def default(cls):
-        return cls(AsyncEnvironmentCredential(), AsyncManagedIdentityCredential())
 
     async def get_token(self, *scopes: str) -> str:
         """Attempts to get a token from each credential, in order, returning the first token.

--- a/sdk/identity/azure-identity/azure/identity/aio/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/credentials.py
@@ -10,6 +10,7 @@ from azure.core import Configuration
 from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, NetworkTraceLoggingPolicy, AsyncRetryPolicy
 
 from ._authn_client import AsyncAuthnClient
+from ._internal import AsyncImdsCredential, AsyncMsiCredential
 from .._base import ClientSecretCredentialBase, CertificateCredentialBase
 from ..constants import Endpoints, EnvironmentVariables, MSI_ENDPOINT, MSI_SECRET
 from ..credentials import TokenCredentialChain
@@ -84,79 +85,6 @@ class AsyncEnvironmentCredential:
             )
             raise AuthenticationError(message)
         return await self._credential.get_token(*scopes)
-
-
-class AsyncMsiCredential:
-    def __init__(self, config: Optional[Configuration] = None, **kwargs: Dict[str, Any]) -> None:
-        config = config or self.create_config(**kwargs)
-        policies = [ContentDecodePolicy(), config.retry_policy, config.logging_policy]
-        endpoint = os.environ.get(MSI_ENDPOINT)
-        if not endpoint:
-            raise ValueError("expected environment variable {} has no value".format(MSI_ENDPOINT))
-        self._client = AsyncAuthnClient(endpoint, config, policies, **kwargs)
-
-    async def get_token(self, *scopes: str) -> str:
-        if len(scopes) != 1:
-            raise ValueError("this credential supports only one scope per request")
-        token = self._client.get_cached_token(scopes)
-        if not token:
-            resource = scopes[0]
-            if resource.endswith("/.default"):
-                resource = resource[:-len("/.default")]
-            secret = os.environ.get(MSI_SECRET)
-            if not secret:
-                raise AuthenticationError("{} environment variable has no value".format(MSI_SECRET))
-            # TODO: support user-assigned client id
-            token = await self._client.request_token(
-                scopes,
-                method="GET",
-                headers={"secret": secret},
-                params={"api-version": "2017-09-01", "resource": resource},
-            )
-        return token
-
-    @staticmethod
-    def create_config(**kwargs: Dict[str, Any]) -> Configuration:
-        timeout = kwargs.pop("connection_timeout", 2)
-        config = Configuration(connection_timeout=timeout, **kwargs)
-        config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
-        retries = kwargs.pop("retry_total", 5)
-        config.retry_policy = AsyncRetryPolicy(
-            retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
-        )
-        return config
-
-
-class AsyncImdsCredential:
-    def __init__(self, config: Optional[Configuration] = None, **kwargs: Dict[str, Any]) -> None:
-        config = config or self.create_config(**kwargs)
-        policies = [config.header_policy, ContentDecodePolicy(), config.retry_policy, config.logging_policy]
-        self._client = AsyncAuthnClient(Endpoints.IMDS, config, policies, **kwargs)
-
-    async def get_token(self, *scopes: str) -> str:
-        if len(scopes) != 1:
-            raise ValueError("this credential supports one scope per request")
-        token = self._client.get_cached_token(scopes)
-        if not token:
-            resource = scopes[0]
-            if resource.endswith("/.default"):
-                resource = resource[:-len("/.default")]
-            token = await self._client.request_token(
-                scopes, method="GET", params={"api-version": "2018-02-01", "resource": resource}
-            )
-        return token
-
-    @staticmethod
-    def create_config(**kwargs: Dict[str, Any]) -> Configuration:
-        timeout = kwargs.pop("connection_timeout", 2)
-        config = Configuration(connection_timeout=timeout, **kwargs)
-        config.header_policy = HeadersPolicy(base_headers={"Metadata": "true"}, **kwargs)
-        config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
-        retries = kwargs.pop("retry_total", 5)
-        config.retry_policy = AsyncRetryPolicy(
-            retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
-        )
-        return config
 
 
 class AsyncManagedIdentityCredential(object):

--- a/sdk/identity/azure-identity/azure/identity/aio/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/credentials.py
@@ -178,7 +178,7 @@ class AsyncManagedIdentityCredential(object):
 class AsyncTokenCredentialChain(TokenCredentialChain):
     """A sequence of token credentials"""
 
-    async def get_token(self, *scopes: str) -> str:
+    async def get_token(self, *scopes: str) -> str:  # type: ignore
         """Attempts to get a token from each credential, in order, returning the first token.
            If no token is acquired, raises an exception listing error messages.
         """

--- a/sdk/identity/azure-identity/azure/identity/aio/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/credentials.py
@@ -11,7 +11,7 @@ from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, Net
 
 from ._authn_client import AsyncAuthnClient
 from .._base import ClientSecretCredentialBase, CertificateCredentialBase
-from ..constants import Endpoints, EnvironmentVariables
+from ..constants import Endpoints, EnvironmentVariables, MSI_ENDPOINT, MSI_SECRET
 from ..credentials import TokenCredentialChain
 from ..exceptions import AuthenticationError
 
@@ -86,11 +86,50 @@ class AsyncEnvironmentCredential:
         return await self._credential.get_token(*scopes)
 
 
-class AsyncManagedIdentityCredential:
+class AsyncMsiCredential:
     def __init__(self, config: Optional[Configuration] = None, **kwargs: Dict[str, Any]) -> None:
         config = config or self.create_config(**kwargs)
-        policies = [config.header_policy, ContentDecodePolicy(), config.logging_policy, config.retry_policy]
-        self._client = AsyncAuthnClient(Endpoints.IMDS, config, policies)
+        policies = [ContentDecodePolicy(), config.retry_policy, config.logging_policy]
+        endpoint = os.environ.get(MSI_ENDPOINT)
+        if not endpoint:
+            raise ValueError("expected environment variable {} has no value".format(MSI_ENDPOINT))
+        self._client = AsyncAuthnClient(endpoint, config, policies, **kwargs)
+
+    async def get_token(self, *scopes: str) -> str:
+        if len(scopes) != 1:
+            raise ValueError("this credential supports only one scope per request")
+        token = self._client.get_cached_token(scopes)
+        if not token:
+            resource = scopes[0].rstrip("/.default")
+            secret = os.environ.get(MSI_SECRET)
+            if not secret:
+                raise AuthenticationError("{} environment variable has no value".format(MSI_SECRET))
+            # TODO: support user-assigned client id
+            token = await self._client.request_token(
+                scopes,
+                method="GET",
+                headers={"secret": secret},
+                params={"api-version": "2017-09-01", "resource": resource},
+            )
+        return token
+
+    @staticmethod
+    def create_config(**kwargs: Dict[str, Any]) -> Configuration:
+        timeout = kwargs.pop("connection_timeout", 2)
+        config = Configuration(connection_timeout=timeout, **kwargs)
+        config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
+        retries = kwargs.pop("retry_total", 5)
+        config.retry_policy = AsyncRetryPolicy(
+            retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
+        )
+        return config
+
+
+class AsyncImdsCredential:
+    def __init__(self, config: Optional[Configuration] = None, **kwargs: Dict[str, Any]) -> None:
+        config = config or self.create_config(**kwargs)
+        policies = [config.header_policy, ContentDecodePolicy(), config.retry_policy, config.logging_policy]
+        self._client = AsyncAuthnClient(Endpoints.IMDS, config, policies, **kwargs)
 
     async def get_token(self, *scopes: str) -> str:
         if len(scopes) != 1:
@@ -101,7 +140,7 @@ class AsyncManagedIdentityCredential:
             token = await self._client.request_token(
                 scopes, method="GET", params={"api-version": "2018-02-01", "resource": resource}
             )
-        return token  # type: ignore
+        return token
 
     @staticmethod
     def create_config(**kwargs: Dict[str, Any]) -> Configuration:
@@ -110,8 +149,26 @@ class AsyncManagedIdentityCredential:
         config.header_policy = HeadersPolicy(base_headers={"Metadata": "true"}, **kwargs)
         config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
         retries = kwargs.pop("retry_total", 5)
-        config.retry_policy = AsyncRetryPolicy(retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs)
+        config.retry_policy = AsyncRetryPolicy(
+            retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
+        )
         return config
+
+
+class AsyncManagedIdentityCredential(object):
+    """factory for MSI and IMDS credentials"""
+
+    def __new__(cls, *args, **kwargs):
+        if os.environ.get(MSI_SECRET) and os.environ.get(MSI_ENDPOINT):
+            return AsyncMsiCredential(*args, **kwargs)
+        return AsyncImdsCredential(*args, **kwargs)
+
+    @staticmethod
+    def create_config(**kwargs: Dict[str, Any]) -> Configuration:
+        pass
+
+    async def get_token(self, *scopes: str) -> str:
+        pass
 
 
 class AsyncTokenCredentialChain(TokenCredentialChain):

--- a/sdk/identity/azure-identity/azure/identity/aio/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/credentials.py
@@ -11,7 +11,7 @@ from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, Net
 
 from ._authn_client import AsyncAuthnClient
 from .._base import ClientSecretCredentialBase, CertificateCredentialBase
-from ..constants import EnvironmentVariables, IMDS_ENDPOINT, OAUTH_ENDPOINT
+from ..constants import Endpoints, EnvironmentVariables
 from ..credentials import TokenCredentialChain
 from ..exceptions import AuthenticationError
 
@@ -28,7 +28,7 @@ class AsyncClientSecretCredential(ClientSecretCredentialBase):
         **kwargs: Mapping[str, Any]
     ) -> None:
         super(AsyncClientSecretCredential, self).__init__(client_id, secret, tenant_id, **kwargs)
-        self._client = AsyncAuthnClient(OAUTH_ENDPOINT.format(tenant_id), config, **kwargs)
+        self._client = AsyncAuthnClient(Endpoints.AAD_OAUTH2_V2_FORMAT.format(tenant_id), config, **kwargs)
 
     async def get_token(self, *scopes: str) -> str:
         token = self._client.get_cached_token(scopes)
@@ -48,7 +48,7 @@ class AsyncCertificateCredential(CertificateCredentialBase):
         **kwargs: Mapping[str, Any]
     ) -> None:
         super(AsyncCertificateCredential, self).__init__(client_id, tenant_id, certificate_path, **kwargs)
-        self._client = AsyncAuthnClient(OAUTH_ENDPOINT.format(tenant_id), config, **kwargs)
+        self._client = AsyncAuthnClient(Endpoints.AAD_OAUTH2_V2_FORMAT.format(tenant_id), config, **kwargs)
 
     async def get_token(self, *scopes: str) -> str:
         token = self._client.get_cached_token(scopes)
@@ -90,7 +90,7 @@ class AsyncManagedIdentityCredential:
     def __init__(self, config: Optional[Configuration] = None, **kwargs: Dict[str, Any]) -> None:
         config = config or self.create_config(**kwargs)
         policies = [config.header_policy, ContentDecodePolicy(), config.logging_policy, config.retry_policy]
-        self._client = AsyncAuthnClient(IMDS_ENDPOINT, config, policies)
+        self._client = AsyncAuthnClient(Endpoints.IMDS, config, policies)
 
     async def get_token(self, *scopes: str) -> str:
         if len(scopes) != 1:

--- a/sdk/identity/azure-identity/azure/identity/constants.py
+++ b/sdk/identity/azure-identity/azure/identity/constants.py
@@ -21,3 +21,8 @@ class Endpoints:
 
     # TODO: other clouds have other endpoints
     AAD_OAUTH2_V2_FORMAT = "https://login.microsoftonline.com/{}/oauth2/v2.0/token"
+
+    # https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity#obtaining-tokens-for-azure-resources
+
+MSI_ENDPOINT = "MSI_ENDPOINT"
+MSI_SECRET = "MSI_SECRET"

--- a/sdk/identity/azure-identity/azure/identity/constants.py
+++ b/sdk/identity/azure-identity/azure/identity/constants.py
@@ -15,8 +15,9 @@ class EnvironmentVariables:
     CERT_VARS = (AZURE_CLIENT_ID, AZURE_CLIENT_CERTIFICATE_PATH, AZURE_TENANT_ID)
 
 
-# https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http
-IMDS_ENDPOINT = "http://169.254.169.254/metadata/identity/oauth2/token"
+class Endpoints:
+    # https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http
+    IMDS = "http://169.254.169.254/metadata/identity/oauth2/token"
 
-# TODO: other clouds have other endpoints
-OAUTH_ENDPOINT = "https://login.microsoftonline.com/{}/oauth2/v2.0/token"
+    # TODO: other clouds have other endpoints
+    AAD_OAUTH2_V2_FORMAT = "https://login.microsoftonline.com/{}/oauth2/v2.0/token"

--- a/sdk/identity/azure-identity/azure/identity/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/credentials.py
@@ -10,7 +10,7 @@ from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, Net
 
 from ._authn_client import AuthnClient
 from ._base import ClientSecretCredentialBase, CertificateCredentialBase
-from .constants import EnvironmentVariables, IMDS_ENDPOINT, OAUTH_ENDPOINT
+from .constants import Endpoints, EnvironmentVariables
 from .exceptions import AuthenticationError
 
 try:
@@ -32,7 +32,7 @@ class ClientSecretCredential(ClientSecretCredentialBase):
     def __init__(self, client_id, secret, tenant_id, config=None, **kwargs):
         # type: (str, str, str, Optional[Configuration], Mapping[str, Any]) -> None
         super(ClientSecretCredential, self).__init__(client_id, secret, tenant_id, **kwargs)
-        self._client = AuthnClient(OAUTH_ENDPOINT.format(tenant_id), config, **kwargs)
+        self._client = AuthnClient(Endpoints.AAD_OAUTH2_V2_FORMAT.format(tenant_id), config, **kwargs)
 
     def get_token(self, *scopes):
         # type: (*str) -> str
@@ -48,7 +48,7 @@ class CertificateCredential(CertificateCredentialBase):
 
     def __init__(self, client_id, tenant_id, certificate_path, config=None, **kwargs):
         # type: (str, str, str, Optional[Configuration], Mapping[str, Any]) -> None
-        self._client = AuthnClient(OAUTH_ENDPOINT.format(tenant_id), config, **kwargs)
+        self._client = AuthnClient(Endpoints.AAD_OAUTH2_V2_FORMAT.format(tenant_id), config, **kwargs)
         super(CertificateCredential, self).__init__(client_id, tenant_id, certificate_path, **kwargs)
 
     def get_token(self, *scopes):
@@ -99,7 +99,7 @@ class ManagedIdentityCredential:
         # type: (Optional[Configuration], Dict[str, Any]) -> None
         config = config or self.create_config(**kwargs)
         policies = [config.header_policy, ContentDecodePolicy(), config.logging_policy, config.retry_policy]
-        self._client = AuthnClient(IMDS_ENDPOINT, config, policies)
+        self._client = AuthnClient(Endpoints.IMDS, config, policies)
 
     @staticmethod
     def create_config(**kwargs):

--- a/sdk/identity/azure-identity/azure/identity/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/credentials.py
@@ -10,6 +10,7 @@ from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, Net
 
 from ._authn_client import AuthnClient
 from ._base import ClientSecretCredentialBase, CertificateCredentialBase
+from ._internal import ImdsCredential, MsiCredential
 from .constants import Endpoints, EnvironmentVariables, MSI_ENDPOINT, MSI_SECRET
 from .exceptions import AuthenticationError
 
@@ -90,89 +91,6 @@ class EnvironmentCredential:
             )
             raise AuthenticationError(message)
         return self._credential.get_token(*scopes)
-
-
-class MsiCredential:
-    """Authenticates via the MSI endpoint"""
-
-    def __init__(self, config=None, **kwargs):
-        # type: (Optional[Configuration], Dict[str, Any]) -> None
-        config = config or self.create_config(**kwargs)
-        policies = [ContentDecodePolicy(), config.retry_policy, config.logging_policy]
-        endpoint = os.environ.get(MSI_ENDPOINT)
-        if not endpoint:
-            raise ValueError("expected environment variable {} has no value".format(MSI_ENDPOINT))
-        self._client = AuthnClient(endpoint, config, policies, **kwargs)
-
-    @staticmethod
-    def create_config(**kwargs):
-        # type: (Dict[str, str]) -> Configuration
-        timeout = kwargs.pop("connection_timeout", 2)
-        config = Configuration(connection_timeout=timeout, **kwargs)
-        config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
-        retries = kwargs.pop("retry_total", 5)
-        config.retry_policy = RetryPolicy(
-            retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
-        )
-        return config
-
-    def get_token(self, *scopes):
-        # type: (*str) -> str
-        if len(scopes) != 1:
-            raise ValueError("this credential supports only one scope per request")
-        token = self._client.get_cached_token(scopes)
-        if not token:
-            secret = os.environ.get(MSI_SECRET)
-            if not secret:
-                raise AuthenticationError("{} environment variable has no value".format(MSI_SECRET))
-            resource = scopes[0]
-            if resource.endswith("/.default"):
-                resource = resource[:-len("/.default")]
-            # TODO: support user-assigned client id
-            token = self._client.request_token(
-                scopes,
-                method="GET",
-                headers={"secret": secret},
-                params={"api-version": "2017-09-01", "resource": resource},
-            )
-        return token
-
-
-class ImdsCredential:
-    """Authenticates with a managed identity via the IMDS endpoint"""
-
-    def __init__(self, config=None, **kwargs):
-        # type: (Optional[Configuration], Dict[str, Any]) -> None
-        config = config or self.create_config(**kwargs)
-        policies = [config.header_policy, ContentDecodePolicy(), config.logging_policy, config.retry_policy]
-        self._client = AuthnClient(Endpoints.IMDS, config, policies, **kwargs)
-
-    @staticmethod
-    def create_config(**kwargs):
-        # type: (Dict[str, str]) -> Configuration
-        timeout = kwargs.pop("connection_timeout", 2)
-        config = Configuration(connection_timeout=timeout, **kwargs)
-        config.header_policy = HeadersPolicy(base_headers={"Metadata": "true"}, **kwargs)
-        config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
-        retries = kwargs.pop("retry_total", 5)
-        config.retry_policy = RetryPolicy(
-            retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
-        )
-        return config
-
-    def get_token(self, *scopes):
-        # type: (*str) -> str
-        if len(scopes) != 1:
-            raise ValueError("this credential supports one scope per request")
-        token = self._client.get_cached_token(scopes)
-        if not token:
-            resource = scopes[0]
-            if resource.endswith("/.default"):
-                resource = resource[:-len("/.default")]
-            token = self._client.request_token(
-                scopes, method="GET", params={"api-version": "2018-02-01", "resource": resource}
-            )
-        return token
 
 
 class ManagedIdentityCredential(object):

--- a/sdk/identity/azure-identity/azure/identity/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/credentials.py
@@ -10,7 +10,7 @@ from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, Net
 
 from ._authn_client import AuthnClient
 from ._base import ClientSecretCredentialBase, CertificateCredentialBase
-from .constants import Endpoints, EnvironmentVariables
+from .constants import Endpoints, EnvironmentVariables, MSI_ENDPOINT, MSI_SECRET
 from .exceptions import AuthenticationError
 
 try:
@@ -92,14 +92,58 @@ class EnvironmentCredential:
         return self._credential.get_token(*scopes)
 
 
-class ManagedIdentityCredential:
-    """Authenticates with a managed identity"""
+class MsiCredential:
+    """Authenticates via the MSI endpoint"""
+
+    def __init__(self, config=None, **kwargs):
+        # type: (Optional[Configuration], Dict[str, Any]) -> None
+        config = config or self.create_config(**kwargs)
+        policies = [ContentDecodePolicy(), config.retry_policy, config.logging_policy]
+        endpoint = os.environ.get(MSI_ENDPOINT)
+        if not endpoint:
+            raise ValueError("expected environment variable {} has no value".format(MSI_ENDPOINT))
+        self._client = AuthnClient(endpoint, config, policies, **kwargs)
+
+    @staticmethod
+    def create_config(**kwargs):
+        # type: (Dict[str, str]) -> Configuration
+        timeout = kwargs.pop("connection_timeout", 2)
+        config = Configuration(connection_timeout=timeout, **kwargs)
+        config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
+        retries = kwargs.pop("retry_total", 5)
+        config.retry_policy = RetryPolicy(
+            retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
+        )
+        return config
+
+    def get_token(self, *scopes):
+        # type: (*str) -> str
+        if len(scopes) != 1:
+            raise ValueError("this credential supports only one scope per request")
+        token = self._client.get_cached_token(scopes)
+        if not token:
+            resource = scopes[0].rstrip("/.default")
+            secret = os.environ.get(MSI_SECRET)
+            if not secret:
+                raise AuthenticationError("{} environment variable has no value".format(MSI_SECRET))
+            # TODO: support user-assigned client id
+            token = self._client.request_token(
+                scopes,
+                method="GET",
+                headers={"secret": secret},
+                params={"api-version": "2017-09-01", "resource": resource},
+            )
+        return token
+
+
+class ImdsCredential:
+    """Authenticates with a managed identity via the IMDS endpoint"""
 
     def __init__(self, config=None, **kwargs):
         # type: (Optional[Configuration], Dict[str, Any]) -> None
         config = config or self.create_config(**kwargs)
         policies = [config.header_policy, ContentDecodePolicy(), config.logging_policy, config.retry_policy]
-        self._client = AuthnClient(Endpoints.IMDS, config, policies)
+        self._client = AuthnClient(Endpoints.IMDS, config, policies, **kwargs)
 
     @staticmethod
     def create_config(**kwargs):
@@ -109,7 +153,9 @@ class ManagedIdentityCredential:
         config.header_policy = HeadersPolicy(base_headers={"Metadata": "true"}, **kwargs)
         config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
         retries = kwargs.pop("retry_total", 5)
-        config.retry_policy = RetryPolicy(retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs)
+        config.retry_policy = RetryPolicy(
+            retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
+        )
         return config
 
     def get_token(self, *scopes):
@@ -123,6 +169,24 @@ class ManagedIdentityCredential:
                 scopes, method="GET", params={"api-version": "2018-02-01", "resource": resource}
             )
         return token
+
+
+class ManagedIdentityCredential(object):
+    """factory for MSI and IMDS credentials"""
+
+    def __new__(cls, *args, **kwargs):
+        if os.environ.get(MSI_SECRET) and os.environ.get(MSI_ENDPOINT):
+            return MsiCredential(*args, **kwargs)
+        return ImdsCredential(*args, **kwargs)
+
+    @staticmethod
+    def create_config(**kwargs):
+        # type: (Dict[str, str]) -> Configuration
+        pass
+
+    def get_token(self, *scopes):
+        # type: (*str) -> str
+        pass
 
 
 class TokenCredentialChain:

--- a/sdk/identity/azure-identity/azure/identity/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/credentials.py
@@ -21,7 +21,7 @@ except ImportError:
 if TYPE_CHECKING:
     # pylint:disable=unused-import
     from typing import Any, Iterable, List, Mapping, Optional, Union
-    from azure.core.credentials import SupportsGetToken
+    from azure.core.credentials import TokenCredential
 
 # pylint:disable=too-few-public-methods
 
@@ -129,7 +129,7 @@ class TokenCredentialChain:
     """A sequence of token credentials"""
 
     def __init__(self, credentials):
-        # type: (Iterable[SupportsGetToken]) -> None
+        # type: (Iterable[TokenCredential]) -> None
         if not credentials:
             raise ValueError("at least one credential is required")
         self._credentials = credentials

--- a/sdk/identity/azure-identity/azure/identity/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/credentials.py
@@ -1,8 +1,8 @@
-# -------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
-# --------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 import os
 
 from azure.core import Configuration
@@ -189,7 +189,7 @@ class ManagedIdentityCredential(object):
         pass
 
 
-class TokenCredentialChain:
+class TokenCredentialChain(object):
     """A sequence of token credentials"""
 
     def __init__(self, *credentials):
@@ -197,10 +197,6 @@ class TokenCredentialChain:
         if not credentials:
             raise ValueError("at least one credential is required")
         self._credentials = credentials
-
-    @classmethod
-    def default(cls):
-        return cls(EnvironmentCredential(), ManagedIdentityCredential())
 
     def get_token(self, *scopes):
         # type: (*str) -> str

--- a/sdk/identity/azure-identity/azure/identity/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/credentials.py
@@ -122,10 +122,12 @@ class MsiCredential:
             raise ValueError("this credential supports only one scope per request")
         token = self._client.get_cached_token(scopes)
         if not token:
-            resource = scopes[0].rstrip("/.default")
             secret = os.environ.get(MSI_SECRET)
             if not secret:
                 raise AuthenticationError("{} environment variable has no value".format(MSI_SECRET))
+            resource = scopes[0]
+            if resource.endswith("/.default"):
+                resource = resource[:-len("/.default")]
             # TODO: support user-assigned client id
             token = self._client.request_token(
                 scopes,
@@ -161,10 +163,12 @@ class ImdsCredential:
     def get_token(self, *scopes):
         # type: (*str) -> str
         if len(scopes) != 1:
-            raise ValueError("Managed identity credential supports one scope per request")
+            raise ValueError("this credential supports one scope per request")
         token = self._client.get_cached_token(scopes)
         if not token:
-            resource = scopes[0].rstrip("/.default")
+            resource = scopes[0]
+            if resource.endswith("/.default"):
+                resource = resource[:-len("/.default")]
             token = self._client.request_token(
                 scopes, method="GET", params={"api-version": "2018-02-01", "resource": resource}
             )

--- a/sdk/identity/azure-identity/tests/test_identity.py
+++ b/sdk/identity/azure-identity/tests/test_identity.py
@@ -221,7 +221,7 @@ def test_msi_credential(monkeypatch):
 
     def validate_request(req, *args, **kwargs):
         assert req.url.startswith(os.environ[MSI_ENDPOINT])
-        assert req.headers["secret"] is msi_secret
+        assert req.headers["secret"] == msi_secret
         exception = Exception()
         exception.message = success_message
         raise exception

--- a/sdk/identity/azure-identity/tests/test_identity.py
+++ b/sdk/identity/azure-identity/tests/test_identity.py
@@ -18,6 +18,7 @@ import requests
 from azure.identity import (
     AuthenticationError,
     ClientSecretCredential,
+    DefaultAzureCredential,
     EnvironmentCredential,
     ImdsCredential,
     MsiCredential,
@@ -228,3 +229,7 @@ def test_msi_credential(monkeypatch):
     with pytest.raises(Exception) as ex:
         MsiCredential(transport=Mock(send=validate_request)).get_token("https://scope")
     assert ex.value.message is success_message
+
+
+def test_default_credential():
+    DefaultAzureCredential()

--- a/sdk/identity/azure-identity/tests/test_identity.py
+++ b/sdk/identity/azure-identity/tests/test_identity.py
@@ -19,10 +19,9 @@ from azure.identity import (
     ClientSecretCredential,
     DefaultAzureCredential,
     EnvironmentCredential,
-    ImdsCredential,
-    MsiCredential,
     TokenCredentialChain,
 )
+from azure.identity._internal import ImdsCredential, MsiCredential
 from azure.identity.constants import EnvironmentVariables, MSI_ENDPOINT, MSI_SECRET
 
 

--- a/sdk/identity/azure-identity/tests/test_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_identity_async.py
@@ -16,10 +16,9 @@ from azure.identity import (
     AsyncClientSecretCredential,
     AsyncDefaultAzureCredential,
     AsyncEnvironmentCredential,
-    AsyncImdsCredential,
-    AsyncMsiCredential,
     AsyncTokenCredentialChain,
 )
+from azure.identity.aio._internal import AsyncImdsCredential, AsyncMsiCredential
 from azure.identity.constants import EnvironmentVariables, MSI_ENDPOINT, MSI_SECRET
 
 

--- a/sdk/identity/azure-identity/tests/test_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_identity_async.py
@@ -230,7 +230,7 @@ async def test_msi_credential(monkeypatch):
 
     async def validate_request(req, *args, **kwargs):
         assert req.url.startswith(os.environ[MSI_ENDPOINT])
-        assert req.headers["secret"] is msi_secret
+        assert req.headers["secret"] == msi_secret
         exception = Exception()
         exception.message = success_message
         raise exception

--- a/sdk/identity/azure-identity/tests/test_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_identity_async.py
@@ -15,6 +15,7 @@ import requests
 from azure.identity import (
     AuthenticationError,
     AsyncClientSecretCredential,
+    AsyncDefaultAzureCredential,
     AsyncEnvironmentCredential,
     AsyncImdsCredential,
     AsyncMsiCredential,
@@ -237,3 +238,7 @@ async def test_msi_credential(monkeypatch):
     with pytest.raises(Exception) as ex:
         await AsyncMsiCredential(transport=Mock(send=validate_request)).get_token("https://scope")
     assert ex.value.message is success_message
+
+
+def test_default_credential():
+    AsyncDefaultAzureCredential()

--- a/sdk/identity/azure-identity/tests/test_imds.py
+++ b/sdk/identity/azure-identity/tests/test_imds.py
@@ -3,11 +3,10 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
-import sys
+from azure.identity.credentials import ImdsCredential
 
-# IMDS tests must be run explicitly
-collect_ignore_glob = ["*imds*"]
 
-# Ignore collection of async tests for Python 2
-if sys.version_info < (3, 5):
-    collect_ignore_glob.append("*_async.py")
+def test_imds_credential():
+    credential = ImdsCredential()
+    token = credential.get_token("https://management.azure.com/.default")
+    assert token

--- a/sdk/identity/azure-identity/tests/test_imds.py
+++ b/sdk/identity/azure-identity/tests/test_imds.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
-from azure.identity.credentials import ImdsCredential
+from azure.identity._internal import ImdsCredential
 
 
 def test_imds_credential():

--- a/sdk/identity/azure-identity/tests/test_imds_async.py
+++ b/sdk/identity/azure-identity/tests/test_imds_async.py
@@ -3,11 +3,13 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
-import sys
+import pytest
 
-# IMDS tests must be run explicitly
-collect_ignore_glob = ["*imds*"]
+from azure.identity.aio.credentials import AsyncImdsCredential
 
-# Ignore collection of async tests for Python 2
-if sys.version_info < (3, 5):
-    collect_ignore_glob.append("*_async.py")
+
+@pytest.mark.asyncio
+async def test_imds_credential_async():
+    credential = AsyncImdsCredential()
+    token = await credential.get_token("https://management.azure.com/.default")
+    assert token

--- a/sdk/identity/azure-identity/tests/test_imds_async.py
+++ b/sdk/identity/azure-identity/tests/test_imds_async.py
@@ -5,7 +5,7 @@
 # -------------------------------------------------------------------------
 import pytest
 
-from azure.identity.aio.credentials import AsyncImdsCredential
+from azure.identity.aio._internal import AsyncImdsCredential
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This closes #5631:
- `SupportsGetToken` renamed `TokenCredential`
- added `DefaultAzureCredential`, a chain of environment -> managed identity credentials
- `TokenCredentialChain.__init__` takes credentials as variadic arguments
- `get_token` takes scopes as variadic arguments

Some other changes:
- Added `ImdsCredential` and `MsiCredential` to support both flavors of managed identity
- `ManagedIdentityCredential` becomes a factory for `ImdsCredential` and `MsiCredential`. Its constructor returns `MsiCredential` if MSI environment variables are set, `ImdsCredential` otherwise.
- Some small fixes and minor tidying

Live tests (with recordings) and documentation updates are my next work items.