### PR TITLE
Skipping CG except where explicitly called out.

### DIFF
--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -10,7 +10,8 @@ variables:
   PythonVersion: '3.6'
   ReleaseTag: 'RELEASE_CANDIDATE'
   TestMarkArgument: 'not cosmosEmulator'
-
+  skipComponentGovernanceDetection: true
+  
 jobs:
   - job: 'Build'
 

--- a/.azure-pipelines/docs.yml
+++ b/.azure-pipelines/docs.yml
@@ -6,6 +6,8 @@ variables:
 
 jobs:
   - job: 'DocGen'
+    variables:
+      skipComponentGovernanceDetection: true
     timeoutInMinutes: 120
     pool:
       vmImage: 'vs2017-win2016'

--- a/.azure-pipelines/tests-nightly-python.yml
+++ b/.azure-pipelines/tests-nightly-python.yml
@@ -4,6 +4,8 @@ trigger:
 jobs:
 
   - job: Validate_Nightly_Python_Build
+    variables:
+      skipComponentGovernanceDetection: true
 
     timeoutInMinutes: 90
 

--- a/.azure-pipelines/tests.yml
+++ b/.azure-pipelines/tests.yml
@@ -3,7 +3,9 @@
 
 jobs:
   - job: 'Test'
-
+    variables:
+      skipComponentGovernanceDetection: true
+      
     timeoutInMinutes: 120
     strategy:
       matrix:

--- a/.azure-pipelines/update_pr.yml
+++ b/.azure-pipelines/update_pr.yml
@@ -6,6 +6,9 @@
 trigger:
 - master
 
+variables:
+  skipComponentGovernanceDetection: true
+
 pool:
   vmImage: 'ubuntu-latest'
 


### PR DESCRIPTION
This disables CG auto-injection in a few places. It was already in the new pipelines, but disabling in some of the other pipelines as well to avoid CG noise.