### PR TITLE
response hook history for iteration

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -140,7 +140,7 @@ class Container:
         )
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, self._properties)
         
         return self._properties
 
@@ -198,7 +198,7 @@ class Container:
             document_link=doc_link, options=request_options
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
         return result
 
     def read_all_items(
@@ -236,7 +236,7 @@ class Container:
             collection_link=self.container_link, feed_options=feed_options, response_hook=response_hook
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, items)
         return items
 
     def query_items_change_feed(
@@ -246,7 +246,7 @@ class Container:
             continuation=None,
             max_item_count=None,
             feed_options=None, 
-            response_hook=None
+            response_hook=None, 
     ):
         """ Get a sorted list of items that were changed, in the order in which they were modified.
 
@@ -273,10 +273,10 @@ class Container:
             feed_options["continuation"] = continuation
 
         result = self.client_connection.QueryItemsChangeFeed(
-            self.container_link, options=feed_options
+            self.container_link, options=feed_options, response_hook=response_hook
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
         return result
 
     def query_items(
@@ -358,7 +358,7 @@ class Container:
             response_hook=response_hook
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, items)
         return items
 
     def replace_item(
@@ -414,7 +414,7 @@ class Container:
             options=request_options
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
         return result
 
     def upsert_item(
@@ -468,7 +468,7 @@ class Container:
             document=body
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
         return result
 
     def create_item(
@@ -528,7 +528,7 @@ class Container:
             options=request_options
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
         return result
 
     def delete_item(
@@ -578,11 +578,11 @@ class Container:
             request_options["postTriggerInclude"] = post_trigger_include
 
         document_link = self._get_document_link(item)
-        self.client_connection.DeleteItem(
+        result = self.client_connection.DeleteItem(
             document_link=document_link, options=request_options
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result) 
 
     def read_offer(self, response_hook=None):
         # type: (Optional[Callable]) -> Offer
@@ -606,7 +606,7 @@ class Container:
             raise HTTPFailure(StatusCodes.NOT_FOUND, "Could not find Offer for container " + self.container_link)
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, offers)
 
         return Offer(
             offer_throughput=offers[0]['content']['offerThroughput'],
@@ -645,7 +645,7 @@ class Container:
         )
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, data)
 
         return Offer(
             offer_throughput=data['content']['offerThroughput'],
@@ -676,7 +676,7 @@ class Container:
             feed_options=feed_options
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
         return result
 
     def query_conflicts(
@@ -720,7 +720,7 @@ class Container:
             options=feed_options,
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
         return result
 
     def get_conflict(
@@ -751,7 +751,7 @@ class Container:
             options=request_options
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
         return result
 
     def delete_conflict(
@@ -776,12 +776,12 @@ class Container:
         if partition_key:
             request_options["partitionKey"] = self._set_partition_key(partition_key)
 
-        self.client_connection.DeleteConflict(
+        result = self.client_connection.DeleteConflict(
             conflict_link=self._get_conflict_link(conflict),
             options=request_options
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
 
     def _set_partition_key(self, partition_key):
         if partition_key == NonePartitionKeyValue:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -232,6 +232,9 @@ class Container:
         if populate_query_metrics is not None:
             feed_options["populateQueryMetrics"] = populate_query_metrics
 
+        if hasattr(response_hook, 'clear'):
+            response_hook.clear()
+
         items = self.client_connection.ReadItems(
             collection_link=self.container_link, feed_options=feed_options, response_hook=response_hook
         )
@@ -271,6 +274,9 @@ class Container:
             feed_options["maxItemCount"] = max_item_count
         if continuation is not None:
             feed_options["continuation"] = continuation
+
+        if hasattr(response_hook, 'clear'):
+            response_hook.clear()
 
         result = self.client_connection.QueryItemsChangeFeed(
             self.container_link, options=feed_options, response_hook=response_hook
@@ -347,6 +353,9 @@ class Container:
             feed_options["partitionKey"] = self._set_partition_key(partition_key)
         if enable_scan_in_query is not None:
             feed_options["enableScanInQuery"] = enable_scan_in_query
+
+        if hasattr(response_hook, 'clear'):
+            response_hook.clear()
 
         items = self.client_connection.QueryItems(
             database_or_Container_link=self.container_link,

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -233,7 +233,7 @@ class Container:
             feed_options["populateQueryMetrics"] = populate_query_metrics
 
         items = self.client_connection.ReadItems(
-            collection_link=self.container_link, feed_options=feed_options
+            collection_link=self.container_link, feed_options=feed_options, response_hook=response_hook
         )
         if response_hook:
             response_hook(self.client_connection.last_response_headers)
@@ -355,6 +355,7 @@ class Container:
             else dict(query=query, parameters=parameters),
             options=feed_options,
             partition_key=partition_key,
+            response_hook=response_hook
         )
         if response_hook:
             response_hook(self.client_connection.last_response_headers)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client_connection.py
@@ -877,7 +877,7 @@ class CosmosClientConnection(object):
                                         response_hook=response_hook), self.last_response_headers
             return query_iterable.QueryIterable(self, query, options, fetch_fn, database_or_Container_link)
 
-    def QueryItemsChangeFeed(self, collection_link, options=None):
+    def QueryItemsChangeFeed(self, collection_link, options=None, response_hook=None):
         """Queries documents change feed in a collection.
 
         :param str collection_link:
@@ -885,6 +885,8 @@ class CosmosClientConnection(object):
         :param dict options:
             The request options for the request.
             options may also specify partition key range id.
+        :param response_hook: 
+            A callable invoked with the response metadata
 
         :return:
             Query Iterable of Documents.
@@ -897,9 +899,9 @@ class CosmosClientConnection(object):
         if options is not None and 'partitionKeyRangeId' in options:
             partition_key_range_id = options['partitionKeyRangeId']
 
-        return self._QueryChangeFeed(collection_link, "Documents" , options, partition_key_range_id)
+        return self._QueryChangeFeed(collection_link, "Documents" , options, partition_key_range_id, response_hook=response_hook)
         
-    def _QueryChangeFeed(self, collection_link, resource_type, options=None, partition_key_range_id=None):
+    def _QueryChangeFeed(self, collection_link, resource_type, options=None, partition_key_range_id=None, response_hook=None):
         """Queries change feed of a resource in a collection.
 
         :param str collection_link:
@@ -910,6 +912,8 @@ class CosmosClientConnection(object):
             The request options for the request.
         :param str partition_key_range_id:
             Specifies partition key range id.
+        :param response_hook: 
+            A callable invoked with the response metadata
 
         :return:
             Query Iterable of Documents.
@@ -938,7 +942,8 @@ class CosmosClientConnection(object):
                                     lambda _, b: b,
                                     None,
                                     options,
-                                    partition_key_range_id), self.last_response_headers
+                                    partition_key_range_id,
+                                    response_hook=response_hook), self.last_response_headers
         return query_iterable.QueryIterable(self, None, options, fetch_fn, collection_link)
 
     def _ReadPartitionKeyRanges(self, collection_link, feed_options=None):
@@ -2791,7 +2796,7 @@ class CosmosClientConnection(object):
                                                             request,
                                                             headers)
             if response_hook:
-                response_hook(self.last_response_headers)
+                response_hook(self.last_response_headers, result)
             return __GetBodiesFromQueryResult(result)
         else:
             query = self.__CheckAndUnifyQueryFormat(query)
@@ -2822,7 +2827,7 @@ class CosmosClientConnection(object):
 
 
             if response_hook:
-                response_hook(self.last_response_headers)
+                response_hook(self.last_response_headers, result)
 
             return __GetBodiesFromQueryResult(result)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
@@ -145,7 +145,7 @@ class Database(object):
         )
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, self._properties)
 
         return self._properties
 
@@ -237,7 +237,7 @@ class Database(object):
         )
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, data)
 
         return Container(self.client_connection, self.database_link, data["id"], properties=data)
 
@@ -276,9 +276,9 @@ class Database(object):
             request_options["populateQueryMetrics"] = populate_query_metrics
 
         collection_link = self._get_container_link(container)
-        self.client_connection.DeleteContainer(collection_link, options=request_options)
+        result = self.client_connection.DeleteContainer(collection_link, options=request_options)
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
 
     def get_container(
         self,
@@ -356,7 +356,7 @@ class Database(object):
             options=feed_options
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
         return result
 
 
@@ -404,7 +404,7 @@ class Database(object):
                     options=feed_options,
                 )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
         return result
 
     def replace_container(
@@ -479,7 +479,7 @@ class Database(object):
         )
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, container_properties)
 
         return Container(
             self.client_connection,
@@ -513,7 +513,7 @@ class Database(object):
             options=feed_options
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
         return result
 
 
@@ -549,7 +549,7 @@ class Database(object):
             options=feed_options,
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
         return result
 
 
@@ -616,7 +616,7 @@ class Database(object):
         )
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, user)
 
         return User(
             client_connection=self.client_connection,
@@ -653,7 +653,7 @@ class Database(object):
         )
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, user)
 
         return User(
             client_connection=self.client_connection,
@@ -690,7 +690,7 @@ class Database(object):
         )
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, user)
 
         return User(
             client_connection=self.client_connection,
@@ -717,11 +717,11 @@ class Database(object):
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
-        self.client_connection.DeleteUser(
+        result = self.client_connection.DeleteUser(
             user_link=self._get_user_link(user), options=request_options
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
 
     def read_offer(self, response_hook=None):
         # type: (Optional[Callable]) -> Offer
@@ -745,7 +745,7 @@ class Database(object):
             raise HTTPFailure(StatusCodes.NOT_FOUND, "Could not find Offer for database " + self.database_link)
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, offers)
 
         return Offer(
             offer_throughput=offers[0]['content']['offerThroughput'],
@@ -783,7 +783,7 @@ class Database(object):
             offer=offers[0]
         )
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, data)
         return Offer(
             offer_throughput=data['content']['offerThroughput'],
             properties=data)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/diagnostics.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/diagnostics.py
@@ -58,13 +58,19 @@ class RecordDiagnostics(object):
 
     def __init__(self):
         self._headers = CaseInsensitiveDict()
+        self._history = []
         
     @property
     def headers(self):
         return CaseInsensitiveDict(self._headers)
+
+    @property
+    def history(self):
+        return [CaseInsensitiveDict(x) for x in self._history]
     
     def __call__(self, headers):
         self._headers = headers
+        self._history.append(headers)
         
     def __getattr__(self, name):
         key = "x-ms-" + name.replace("_", "-")

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/diagnostics.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/diagnostics.py
@@ -47,7 +47,6 @@ class RecordDiagnostics(object):
 
     _common = {
         'x-ms-activity-id',
-        'x-ms-request-charge',
         'x-ms-session-token',
 
         'x-ms-item-count',
@@ -59,6 +58,7 @@ class RecordDiagnostics(object):
     def __init__(self):
         self._headers = CaseInsensitiveDict()
         self._body = None
+        self._request_charge = 0
 
     @property
     def headers(self):
@@ -67,10 +67,19 @@ class RecordDiagnostics(object):
     @property
     def body(self):
         return self._body
+
+    @property
+    def request_charge(self):
+        return self._request_charge
+
+    def clear(self):
+        self._request_charge = 0
     
     def __call__(self, headers, body):
         self._headers = headers
         self._body = body
+        
+        self._request_charge += float(headers.get('x-ms-request-charge' , 0))
         
     def __getattr__(self, name):
         key = "x-ms-" + name.replace("_", "-")

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/diagnostics.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/diagnostics.py
@@ -58,19 +58,19 @@ class RecordDiagnostics(object):
 
     def __init__(self):
         self._headers = CaseInsensitiveDict()
-        self._history = []
-        
+        self._body = None
+
     @property
     def headers(self):
         return CaseInsensitiveDict(self._headers)
-
-    @property
-    def history(self):
-        return [CaseInsensitiveDict(x) for x in self._history]
     
-    def __call__(self, headers):
+    @property
+    def body(self):
+        return self._body
+    
+    def __call__(self, headers, body):
         self._headers = headers
-        self._history.append(headers)
+        self._body = body
         
     def __getattr__(self, name):
         key = "x-ms-" + name.replace("_", "-")

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/user.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/user.py
@@ -83,7 +83,7 @@ class User:
         )
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, self._properties)
 
         return self._properties
 
@@ -113,7 +113,7 @@ class User:
         )
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
 
         return result
 
@@ -150,7 +150,7 @@ class User:
         )
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
 
         return result
 
@@ -180,7 +180,7 @@ class User:
         )
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, permission)
 
         return Permission(
             id=permission['id'],
@@ -218,7 +218,7 @@ class User:
         )
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, permission)
 
         return Permission(
             id=permission['id'],
@@ -256,7 +256,7 @@ class User:
         )
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, permission)
 
         return Permission(
             id=permission['id'],
@@ -294,7 +294,7 @@ class User:
         )
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, permission)
 
         return Permission(
             id=permission['id'],
@@ -323,11 +323,11 @@ class User:
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
-        self.client_connection.DeletePermission(
+        result = self.client_connection.DeletePermission(
             permission_link=self._get_permission_link(permission),
             options=request_options
         )
 
         if response_hook:
-            response_hook(self.client_connection.last_response_headers)
+            response_hook(self.client_connection.last_response_headers, result)
 

--- a/sdk/cosmos/azure-cosmos/test/crud_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/crud_tests.py
@@ -196,6 +196,8 @@ class CRUDTests(unittest.TestCase):
         self.assertEqual(collection_id, created_collection.id)
         assert isinstance(created_recorder.headers, Mapping)
         assert 'Content-Type' in created_recorder.headers
+        assert isinstance(created_recorder.body, Mapping)
+        assert 'id' in created_recorder.body
 
         created_properties = created_collection.read()
         self.assertEqual('consistent', created_properties['indexingPolicy']['indexingMode'])

--- a/sdk/cosmos/azure-cosmos/test/diagnostics_unit_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/diagnostics_unit_tests.py
@@ -24,13 +24,13 @@ class BaseUnitTests(unittest.TestCase):
 
     def test_headers(self):
         rh = m.RecordDiagnostics()
-        rh(_headers)
+        rh(_headers, "body")
         assert rh.headers == _headers
         assert rh.headers is not _headers
 
     def test_headers_case(self):
         rh = m.RecordDiagnostics()
-        rh(_headers)
+        rh(_headers, "body")
         rh_headers = rh.headers
         for key in rh.headers.keys():
             assert key.upper() in rh_headers
@@ -38,7 +38,7 @@ class BaseUnitTests(unittest.TestCase):
 
     def test_common_attrs(self):
         rh = m.RecordDiagnostics()
-        rh(_headers)
+        rh(_headers, "body")
         for name in _common:
             assert rh.headers[name] == name
             attr = name.replace('x-ms-', '').replace('-', '_')
@@ -46,7 +46,7 @@ class BaseUnitTests(unittest.TestCase):
 
     def test_other_attrs(self):
         rh = m.RecordDiagnostics()
-        rh(_headers)
+        rh(_headers, "body")
         assert rh.headers['other'] == 'other'
         with pytest.raises(AttributeError):
             rh.other


### PR DESCRIPTION
cc @christopheranderson @johanste would like some feedback on this proof of concept approach before proceeding further (adding to more iteration methods, tests, docs). With this code a user can do:

```
In [1]: from azure.cosmos.partition_key import PartitionKey
   ...: import azure.cosmos.cosmos_client as cosmos_client
   ...: from azure.cosmos.diagnostics import RecordDiagnostics
   ...: config = {
   ...:     'ENDPOINT':   << url >>,
   ...:     'PRIMARYKEY': << key >>
   ...: }
   ...: client = cosmos_client.CosmosClient(url=config['ENDPOINT'],
   ...:                                     auth={'masterKey': config['PRIMARYKEY']})
   ...: db = client.get_database('paging')
   ...: cont = db.get_container('test')
   ...: recorder = RecordDiagnostics()
   ...: items = cont.read_all_items(response_hook=recorder)

In [2]: for item in items: pass

In [3]: len(recorder.history)
Out[3]: 9

In [4]: sum(float(x.get('x-ms-request-charge', 0)) for x in recorder.history)
Out[4]: 41.4
```

I don't really see any way around building up and storing a history of the response headers there is no way in general for a user to easily know when to look for a change in the current response hook headers in the middle of an iteration. Some ideas:

* could add convenience methods for summing or reporting aggregations of specific fields of the history
* if we really don't want to maintain explicit history we could also for configuring what to aggregate up front somehow, but this is more complicated and less flexible 