### PR TITLE
Ignore mypy errors

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/authentication.py
@@ -61,5 +61,5 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, HTTPPolicy):
         :rtype: ~azure.core.pipeline.PipelineResponse
         """
         token = self._credential.get_token(*self._scopes)
-        self._update_headers(request.http_request.headers, token)
+        self._update_headers(request.http_request.headers, token)  # type: ignore
         return self.next.send(request)

--- a/sdk/core/azure-core/azure/core/pipeline/policies/authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/authentication_async.py
@@ -25,6 +25,6 @@ class AsyncBearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, AsyncHT
         :return: The pipeline response object
         :rtype: ~azure.core.pipeline.PipelineResponse
         """
-        token = await self._credential.get_token(*self._scopes)
-        self._update_headers(request.http_request.headers, token)
-        return await self.next.send(request) # type: ignore
+        token = await self._credential.get_token(*self._scopes)  # type: ignore
+        self._update_headers(request.http_request.headers, token)  # type: ignore
+        return await self.next.send(request)  # type: ignore


### PR DESCRIPTION
Ignoring a few mypy errors in `authentication` and `authentication_async`:
- `self._update_headers(request.http_request.headers, token)` raises an error because the type variable `HTTPRequestType` doesn't have a `headers` attribute. Tracked by #5796.
- `await self._credential.get_token(*self._scopes)` raises an error because the credential's `Protocol` defines `get_token` as returning a string. At runtime however, `self._credential` will be an async credential and `get_token` will return a coroutine.
- `await self.next.send(request)` raises an error because `self.next` is typed `Optional[Any]`. Looks like this should be something else, e.g. `Optional[AsyncHTTPPolicy]`. Tracked by #5797.