### PR TITLE
Storage track2 ci fixes

### DIFF
--- a/azure-sdk-tools/devtools_testutils/mgmt_settings_fake.py
+++ b/azure-sdk-tools/devtools_testutils/mgmt_settings_fake.py
@@ -38,6 +38,13 @@ def get_credentials(**kwargs):
     #    'user@myaddomain.onmicrosoft.com',
     #    'Password'
     #)
+    # note that UserCredential does not work any longer. Must use a ServicePrincipal. 
+    # for deprecated APIs I believe will still work.
+    # return ServicePrincipalCredentials(
+    #     client_id = '<AAD App client id>',
+    #     secret = '<secret for the aad app>',
+    #     tenant = '<microsoft aad tenant id>'
+    # )
     # Needed to play recorded tests
     return BasicTokenAuthentication(
         token = {

--- a/azure-sdk-tools/setup.py
+++ b/azure-sdk-tools/setup.py
@@ -17,7 +17,6 @@ DEPENDENCIES = [
     'pytest>=3.5.1',
     # 'azure-devtools>=0.4.1' override by packaging needs
     'readme_renderer',
-    'azure-storage-blob',
     'azure-storage-file<2.0',
     'azure-storage-common<1.4.1',
     'pyopenssl',

--- a/azure-servicemanagement-legacy/dev_requirements.txt
+++ b/azure-servicemanagement-legacy/dev_requirements.txt
@@ -1,1 +1,2 @@
 -e ../azure-sdk-tools
+-e ../azure-storage-blob

--- a/azure-servicemanagement-legacy/tests/legacy_mgmt_testcase.py
+++ b/azure-servicemanagement-legacy/tests/legacy_mgmt_testcase.py
@@ -85,11 +85,19 @@ class LegacyMgmtTestCase(RecordingTestCase):
         return service
 
     def _create_storage_service(self, service_class, settings, **kwargs):
-        account_name = account_name or settings.STORAGE_ACCOUNT_NAME
-        account_key = account_key or settings.STORAGE_ACCOUNT_KEY
+
+        try:
+            account_name_arg = account_name or settings.STORAGE_ACCOUNT_NAME
+        except NameError:
+            account_name_arg = settings.STORAGE_ACCOUNT_NAME
+        try:
+            account_key_arg = account_key or settings.STORAGE_ACCOUNT_KEY
+        except NameError:
+            account_key_arg = settings.STORAGE_ACCOUNT_KEY
+
         service = service_class(
-            "https://{}.blob.core.windows.net".format(account_name),
-            credentials=SharedKeyCredentials(account_name, account_key)
+            "https://{}.blob.core.windows.net".format(account_name_arg),
+            credentials=SharedKeyCredentials(account_name_arg, account_key_arg)
         )
         self._set_service_options(service, settings)
         return service

--- a/azure-servicemanagement-legacy/tests/test_legacy_mgmt_misc.py
+++ b/azure-servicemanagement-legacy/tests/test_legacy_mgmt_misc.py
@@ -14,8 +14,6 @@
 #--------------------------------------------------------------------------
 import unittest
 import pytest
-
-pytestmark = pytest.mark.skip
 import os
 import os.path
 import requests

--- a/azure-servicemanagement-legacy/tests/test_legacy_mgmt_misc.py
+++ b/azure-servicemanagement-legacy/tests/test_legacy_mgmt_misc.py
@@ -86,8 +86,6 @@ class LegacyMgmtMiscTest(LegacyMgmtTestCase):
         super(LegacyMgmtMiscTest, self).setUp()
 
         self.sms = self.create_service_management(ServiceManagementService)
-
-        
         self.bsc = self._create_storage_service(BlobServiceClient, self.settings)
 
         self.hosted_service_name = self.get_resource_name('utsvc')

--- a/scripts/dev_setup.py
+++ b/scripts/dev_setup.py
@@ -60,9 +60,13 @@ if 'azure-common' in content_packages:
     content_packages.remove('azure-common')
 content_packages.insert(0, 'azure-common')
 
+if 'azure-core' in content_packages:
+    content_packages.remove('azure-core')
+content_packages.insert(1, 'azure-core')
+
 if 'azure-sdk-tools' in content_packages:
     content_packages.remove('azure-sdk-tools')
-content_packages.insert(1, 'azure-sdk-tools')
+content_packages.insert(2, 'azure-sdk-tools')
 
 print('Running dev setup...')
 print('Root directory \'{}\'\n'.format(root_dir))

--- a/sdk/keyvault/azure-keyvault/dev_requirements.txt
+++ b/sdk/keyvault/azure-keyvault/dev_requirements.txt
@@ -1,3 +1,4 @@
 -e ../../../azure-mgmt-authorization
 -e ../../../azure-mgmt-keyvault
 -e ../../../azure-sdk-tools
+-e ../../../azure-storage-blob

--- a/sdk/keyvault/azure-keyvault/tests/test_storage.py
+++ b/sdk/keyvault/azure-keyvault/tests/test_storage.py
@@ -1,8 +1,6 @@
 import unittest
 import pytest
 
-pytestmark = pytest.mark.skip
-
 import uuid
 from devtools_testutils import AzureMgmtTestCase, ResourceGroupPreparer, StorageAccountPreparer
 from keyvault_preparer import KeyVaultPreparer

--- a/sdk/keyvault/azure-keyvault/tests/test_storage.py
+++ b/sdk/keyvault/azure-keyvault/tests/test_storage.py
@@ -12,11 +12,11 @@ from azure.keyvault.models import StorageAccountAttributes
 
 class KeyVaultSecretTest(KeyvaultTestCase):
 
+    @pytest.mark.skip(reason="Cannot use a ServicePrincipal to execute set_storage_account. See issue azure-sdk-for-python#5858.")
     @ResourceGroupPreparer()
     @StorageAccountPreparer(name_prefix='kvsa1')
     @KeyVaultPreparer()
     def test_e2e(self, vault, storage_account, resource_group, **kwargs):
-
         if not self.is_live:
             sa_id = '{}/providers/Microsoft.Storage/storageAccounts/{}'.format(resource_group.id, storage_account.name)
         else:


### PR DESCRIPTION
Highlights:

* Removes `azure-storage-blob` as a hard requirement for `azure-sdk-tools`
* Adds `azure-core` to default build list until we publish this guy to pypi and take a real dependency
* Updates `dev_requirements.txt` for both `azure-keyvault` and `azure-servicemanagement-legacy` to explicitly have a dev dependency on `azure-blob-storage`
* Updates the tests for `azure-keyvault` and `azure-servicemanagement-legacy` to leverage Track 2 blob code.

I repaired the KeyVault tests as far as I can tell, but I'm pretty certain that I'm missing something. Consistently getting `Cannot Override Cassette` error. That strikes me as me needing to re-record the test. Will talk to schaabs to figure this out.

@Azure/azure-sdk-eng 