### PR TITLE
Return expiry time with token

### DIFF
--- a/sdk/core/azure-core/azure/core/credentials.py
+++ b/sdk/core/azure-core/azure/core/credentials.py
@@ -2,16 +2,29 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
-# --------------------------------------------------------------------------
-from typing_extensions import Protocol
+# -------------------------------------------------------------------------
+from typing import TYPE_CHECKING
 
 
-class TokenCredential(Protocol):
-    """Protocol for classes able to provide OAuth tokens.
+if TYPE_CHECKING:
+    from typing import NamedTuple
+    from typing_extensions import Protocol
 
-    :param str scopes: Lets you specify the type of access needed.
-    """
-    # pylint:disable=too-few-public-methods
-    def get_token(self, *scopes):
-        # type: (*str) -> str
-        pass
+    AccessToken = NamedTuple("AccessToken", [("token", str), ("expires_on", int)])
+
+    class TokenCredential(Protocol):
+        """Protocol for classes able to provide OAuth tokens.
+
+        :param str scopes: Lets you specify the type of access needed.
+        """
+
+        # pylint:disable=too-few-public-methods
+        def get_token(self, *scopes):
+            # type: (*str) -> AccessToken
+            pass
+
+
+else:
+    from collections import namedtuple
+
+    AccessToken = namedtuple("AccessToken", ["token", "expires_on"])

--- a/sdk/core/azure-core/azure/core/pipeline/policies/authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/authentication.py
@@ -46,7 +46,7 @@ class _BearerTokenCredentialPolicyBase(object):
         headers["Authorization"] = "Bearer {}".format(token)
 
     @property
-    def _cached_token_expired(self):
+    def _need_new_token(self):
         # type: () -> bool
         return not self._token or self._token.expires_on - time.time() < 300
 
@@ -68,7 +68,7 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, HTTPPolicy):
         :return: The pipeline response object
         :rtype: ~azure.core.pipeline.PipelineResponse
         """
-        if self._cached_token_expired:
+        if self._need_new_token:
             self._token = self._credential.get_token(*self._scopes)
         self._update_headers(request.http_request.headers, self._token.token)  # type: ignore
         return self.next.send(request)

--- a/sdk/core/azure-core/azure/core/pipeline/policies/authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/authentication.py
@@ -2,7 +2,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
-# --------------------------------------------------------------------------
+# -------------------------------------------------------------------------
+import time
+
 from . import HTTPPolicy
 
 try:
@@ -12,8 +14,8 @@ except ImportError:
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import
-    from typing import Any, Dict, Iterable, Mapping
-    from azure.core.credentials import TokenCredential
+    from typing import Any, Dict, Mapping, Optional
+    from azure.core.credentials import AccessToken, TokenCredential
     from azure.core.pipeline import PipelineRequest, PipelineResponse
 
 
@@ -31,6 +33,7 @@ class _BearerTokenCredentialPolicyBase(object):
         super(_BearerTokenCredentialPolicyBase, self).__init__()
         self._scopes = scopes
         self._credential = credential
+        self._token = None  # type: Optional[AccessToken]
 
     @staticmethod
     def _update_headers(headers, token):
@@ -41,6 +44,11 @@ class _BearerTokenCredentialPolicyBase(object):
         :param str token: The OAuth token.
         """
         headers["Authorization"] = "Bearer {}".format(token)
+
+    @property
+    def _cached_token_expired(self):
+        # type: () -> bool
+        return not self._token or self._token.expires_on - time.time() < 300
 
 
 class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, HTTPPolicy):
@@ -60,6 +68,7 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, HTTPPolicy):
         :return: The pipeline response object
         :rtype: ~azure.core.pipeline.PipelineResponse
         """
-        token = self._credential.get_token(*self._scopes)
-        self._update_headers(request.http_request.headers, token)  # type: ignore
+        if self._cached_token_expired:
+            self._token = self._credential.get_token(*self._scopes)
+        self._update_headers(request.http_request.headers, self._token.token)  # type: ignore
         return self.next.send(request)

--- a/sdk/core/azure-core/azure/core/pipeline/policies/authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/authentication_async.py
@@ -27,7 +27,7 @@ class AsyncBearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, AsyncHT
         :return: The pipeline response object
         :rtype: ~azure.core.pipeline.PipelineResponse
         """
-        if self._cached_token_expired:
+        if self._need_new_token:
             # TODO: a race condition exists here
             # Given the default connection timeout is 100s, problems are unlikely, but if
             # they do arise we can forego caching here (credentials have a thread-safe cache)

--- a/sdk/core/azure-core/azure/core/pipeline/policies/authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/authentication_async.py
@@ -2,7 +2,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
-# --------------------------------------------------------------------------
+# -------------------------------------------------------------------------
+import time
+
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import AsyncHTTPPolicy
 from azure.core.pipeline.policies.authentication import _BearerTokenCredentialPolicyBase
@@ -18,13 +20,17 @@ class AsyncBearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, AsyncHT
     """
 
     async def send(self, request: PipelineRequest) -> PipelineResponse:
-        """Aync flavor that adds a bearer token Authorization header to request and sends request to next policy.
+        """Adds a bearer token Authorization header to request and sends request to next policy.
 
         :param request: The pipeline request object to be modified.
         :type request: ~azure.core.pipeline.PipelineRequest
         :return: The pipeline response object
         :rtype: ~azure.core.pipeline.PipelineResponse
         """
-        token = await self._credential.get_token(*self._scopes)  # type: ignore
-        self._update_headers(request.http_request.headers, token)  # type: ignore
+        if self._cached_token_expired:
+            # TODO: a race condition exists here
+            # Given the default connection timeout is 100s, problems are unlikely, but if
+            # they do arise we can forego caching here (credentials have a thread-safe cache)
+            self._token = await self._credential.get_token(*self._scopes)  # type: ignore
+        self._update_headers(request.http_request.headers, self._token.token)  # type: ignore
         return await self.next.send(request)  # type: ignore

--- a/sdk/core/azure-core/tests/azure_core_asynctests/test_authentication.py
+++ b/sdk/core/azure-core/tests/azure_core_asynctests/test_authentication.py
@@ -2,21 +2,25 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
-# --------------------------------------------------------------------------
+# -------------------------------------------------------------------------
+import asyncio
+import time
 from unittest.mock import Mock
-from azure.core.pipeline import AsyncPipeline, PipelineResponse
-from azure.core.pipeline.policies import AsyncBearerTokenCredentialPolicy, HTTPPolicy
-from azure.core.pipeline.transport import HttpRequest, AsyncHttpTransport
+
+from azure.core.credentials import AccessToken
+from azure.core.pipeline import AsyncPipeline
+from azure.core.pipeline.policies import AsyncBearerTokenCredentialPolicy
+from azure.core.pipeline.transport import HttpRequest
 import pytest
 
 
 @pytest.mark.asyncio
 async def test_bearer_policy_adds_header():
     """The bearer token policy should add a header containing a token from its credential"""
-    expected_token = "expected_token"
+    expected_token = AccessToken("expected_token", 0)
 
     async def verify_authorization_header(request):
-        assert request.http_request.headers["Authorization"] == "Bearer {}".format(expected_token)
+        assert request.http_request.headers["Authorization"] == "Bearer {}".format(expected_token.token)
 
     get_token_calls = 0
 
@@ -26,11 +30,8 @@ async def test_bearer_policy_adds_header():
         return expected_token
 
     fake_credential = Mock(get_token=get_token)
-    policies = [
-        AsyncBearerTokenCredentialPolicy(fake_credential, "scope"),
-        Mock(spec=HTTPPolicy, send=verify_authorization_header),
-    ]
-    pipeline = AsyncPipeline(transport=Mock(spec=AsyncHttpTransport), policies=policies)
+    policies = [AsyncBearerTokenCredentialPolicy(fake_credential, "scope"), Mock(send=verify_authorization_header)]
+    pipeline = AsyncPipeline(transport=Mock(), policies=policies)
 
     await pipeline.run(HttpRequest("GET", "https://spam.eggs"), context=None)
     assert get_token_calls == 1
@@ -40,22 +41,48 @@ async def test_bearer_policy_adds_header():
 async def test_bearer_policy_send():
     """The bearer token policy should invoke the next policy's send method and return the result"""
     expected_request = HttpRequest("GET", "https://spam.eggs")
-    expected_response = Mock(spec=PipelineResponse)
+    expected_response = Mock()
 
     async def verify_request(request):
         assert request.http_request is expected_request
         return expected_response
 
-    async def get_token(_):
-        return ""
-
-    fake_credential = Mock(get_token=get_token)
-    policies = [
-        AsyncBearerTokenCredentialPolicy(fake_credential, "scope"),
-        Mock(spec=HTTPPolicy, send=verify_request),
-    ]
-    pipeline = AsyncPipeline(transport=Mock(spec=AsyncHttpTransport), policies=policies)
-
-    response = await pipeline.run(expected_request)
+    fake_credential = Mock(get_token=asyncio.coroutine(lambda _: AccessToken("", 0)))
+    policies = [AsyncBearerTokenCredentialPolicy(fake_credential, "scope"), Mock(send=verify_request)]
+    response = await AsyncPipeline(transport=Mock(), policies=policies).run(expected_request)
 
     assert response is expected_response
+
+
+@pytest.mark.asyncio
+async def test_bearer_policy_token_caching():
+    good_for_one_hour = AccessToken("token", time.time() + 3600)
+    expected_token = good_for_one_hour
+    get_token_calls = 0
+
+    async def get_token(_):
+        nonlocal get_token_calls
+        get_token_calls += 1
+        return expected_token
+
+    credential = Mock(get_token=get_token)
+    policies = [AsyncBearerTokenCredentialPolicy(credential, "scope"), Mock(send=asyncio.coroutine(lambda _: Mock()))]
+    pipeline = AsyncPipeline(transport=Mock, policies=policies)
+
+    await pipeline.run(HttpRequest("GET", "https://spam.eggs"))
+    assert get_token_calls == 1  # policy has no token at first request -> it should call get_token
+
+    await pipeline.run(HttpRequest("GET", "https://spam.eggs"))
+    assert get_token_calls == 1  # token is good for an hour -> policy should return it from cache
+
+    expired_token = AccessToken("token", time.time())
+    get_token_calls = 0
+    expected_token = expired_token
+    policies = [AsyncBearerTokenCredentialPolicy(credential, "scope"), Mock(send=asyncio.coroutine(lambda _: Mock()))]
+    pipeline = AsyncPipeline(transport=Mock(), policies=policies)
+
+    await pipeline.run(HttpRequest("GET", "https://spam.eggs"))
+    assert get_token_calls == 1
+
+    await pipeline.run(HttpRequest("GET", "https://spam.eggs"))
+    assert get_token_calls == 2  # token expired -> policy should call get_token

--- a/sdk/core/azure-core/tests/test_authentication.py
+++ b/sdk/core/azure-core/tests/test_authentication.py
@@ -2,10 +2,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
-# --------------------------------------------------------------------------
-from azure.core.pipeline import Pipeline, PipelineResponse
-from azure.core.pipeline.policies import BearerTokenCredentialPolicy, HTTPPolicy
-from azure.core.pipeline.transport import HttpRequest, HttpTransport
+# -------------------------------------------------------------------------
+import time
+
+from azure.core.credentials import AccessToken
+from azure.core.pipeline import Pipeline
+from azure.core.pipeline.policies import BearerTokenCredentialPolicy
+from azure.core.pipeline.transport import HttpRequest
 
 try:
     from unittest.mock import Mock
@@ -16,18 +19,15 @@ except ImportError:
 
 def test_bearer_policy_adds_header():
     """The bearer token policy should add a header containing a token from its credential"""
-    expected_token = "expected_token"
+    expected_token = AccessToken("expected_token", 0)
 
     def verify_authorization_header(request):
-        assert request.http_request.headers["Authorization"] == "Bearer {}".format(expected_token)
+        assert request.http_request.headers["Authorization"] == "Bearer {}".format(expected_token.token)
 
     fake_credential = Mock(get_token=Mock(return_value=expected_token))
-    policies = [
-        BearerTokenCredentialPolicy(fake_credential, "scope"),
-        Mock(spec=HTTPPolicy, send=verify_authorization_header),
-    ]
+    policies = [BearerTokenCredentialPolicy(fake_credential, "scope"), Mock(send=verify_authorization_header)]
 
-    Pipeline(transport=Mock(spec=HttpTransport), policies=policies).run(HttpRequest("GET", "https://spam.eggs"))
+    Pipeline(transport=Mock(), policies=policies).run(HttpRequest("GET", "https://spam.eggs"))
 
     assert fake_credential.get_token.call_count == 1
 
@@ -35,17 +35,37 @@ def test_bearer_policy_adds_header():
 def test_bearer_policy_send():
     """The bearer token policy should invoke the next policy's send method and return the result"""
     expected_request = HttpRequest("GET", "https://spam.eggs")
-    expected_response = Mock(spec=PipelineResponse)
+    expected_response = Mock()
 
     def verify_request(request):
         assert request.http_request is expected_request
         return expected_response
 
-    fake_credential = Mock(get_token=lambda _: "")
-    policies = [
-        BearerTokenCredentialPolicy(fake_credential, "scope"),
-        Mock(spec=HTTPPolicy, send=verify_request),
-    ]
-    response = Pipeline(transport=Mock(spec=HttpTransport), policies=policies).run(expected_request)
+    fake_credential = Mock(get_token=lambda _: AccessToken("", 0))
+    policies = [BearerTokenCredentialPolicy(fake_credential, "scope"), Mock(send=verify_request)]
+    response = Pipeline(transport=Mock(), policies=policies).run(expected_request)
 
     assert response is expected_response
+
+
+def test_bearer_policy_token_caching():
+    good_for_one_hour = AccessToken("token", time.time() + 3600)
+    credential = Mock(get_token=Mock(return_value=good_for_one_hour))
+    pipeline = Pipeline(transport=Mock(), policies=[BearerTokenCredentialPolicy(credential, "scope")])
+
+    pipeline.run(HttpRequest("GET", "https://spam.eggs"))
+    assert credential.get_token.call_count == 1  # policy has no token at first request -> it should call get_token
+
+    pipeline.run(HttpRequest("GET", "https://spam.eggs"))
+    assert credential.get_token.call_count == 1  # token is good for an hour -> policy should return it from cache
+
+    expired_token = AccessToken("token", time.time())
+    credential.get_token.reset_mock()
+    credential.get_token.return_value = expired_token
+    pipeline = Pipeline(transport=Mock(), policies=[BearerTokenCredentialPolicy(credential, "scope")])
+
+    pipeline.run(HttpRequest("GET", "https://spam.eggs"))
+    assert credential.get_token.call_count == 1
+
+    pipeline.run(HttpRequest("GET", "https://spam.eggs"))
+    assert credential.get_token.call_count == 2  # token expired -> policy should call get_token

--- a/sdk/identity/azure-identity/azure/identity/_internal.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal.py
@@ -13,6 +13,7 @@ except ImportError:
 if TYPE_CHECKING:
     # pylint:disable=unused-import
     from typing import Any, Dict, Optional
+    from azure.core.credentials import AccessToken
 
 from azure.core import Configuration
 from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, NetworkTraceLoggingPolicy, RetryPolicy
@@ -45,14 +46,14 @@ class ImdsCredential:
         return config
 
     def get_token(self, *scopes):
-        # type: (*str) -> str
+        # type: (*str) -> AccessToken
         if len(scopes) != 1:
             raise ValueError("this credential supports one scope per request")
         token = self._client.get_cached_token(scopes)
         if not token:
             resource = scopes[0]
             if resource.endswith("/.default"):
-                resource = resource[:-len("/.default")]
+                resource = resource[: -len("/.default")]
             token = self._client.request_token(
                 scopes, method="GET", params={"api-version": "2018-02-01", "resource": resource}
             )
@@ -84,7 +85,7 @@ class MsiCredential:
         return config
 
     def get_token(self, *scopes):
-        # type: (*str) -> str
+        # type: (*str) -> AccessToken
         if len(scopes) != 1:
             raise ValueError("this credential supports only one scope per request")
         token = self._client.get_cached_token(scopes)
@@ -94,7 +95,7 @@ class MsiCredential:
                 raise AuthenticationError("{} environment variable has no value".format(MSI_SECRET))
             resource = scopes[0]
             if resource.endswith("/.default"):
-                resource = resource[:-len("/.default")]
+                resource = resource[: -len("/.default")]
             # TODO: support user-assigned client id
             token = self._client.request_token(
                 scopes,

--- a/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
@@ -6,6 +6,7 @@
 from typing import Any, Dict, Iterable, Mapping, Optional
 
 from azure.core import Configuration
+from azure.core.credentials import AccessToken
 from azure.core.pipeline import AsyncPipeline
 from azure.core.pipeline.policies import AsyncRetryPolicy, ContentDecodePolicy, HTTPPolicy, NetworkTraceLoggingPolicy
 from azure.core.pipeline.transport import AsyncHttpTransport
@@ -39,7 +40,7 @@ class AsyncAuthnClient(AuthnClientBase):
         headers: Optional[Mapping[str, str]] = None,
         form_data: Optional[Mapping[str, str]] = None,
         params: Optional[Dict[str, str]] = None,
-    ) -> str:
+    ) -> AccessToken:
         request = self._prepare_request(method, headers=headers, form_data=form_data, params=params)
         response = await self._pipeline.run(request, stream=False)
         token = self._deserialize_and_cache_token(response, scopes)

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal.py
@@ -7,6 +7,7 @@ import os
 from typing import Any, Dict, Optional
 
 from azure.core import Configuration
+from azure.core.credentials import AccessToken
 from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, NetworkTraceLoggingPolicy, AsyncRetryPolicy
 
 from ._authn_client import AsyncAuthnClient
@@ -20,7 +21,7 @@ class AsyncImdsCredential:
         policies = [config.header_policy, ContentDecodePolicy(), config.retry_policy, config.logging_policy]
         self._client = AsyncAuthnClient(Endpoints.IMDS, config, policies, **kwargs)
 
-    async def get_token(self, *scopes: str) -> str:
+    async def get_token(self, *scopes: str) -> AccessToken:
         if len(scopes) != 1:
             raise ValueError("this credential supports one scope per request")
         token = self._client.get_cached_token(scopes)
@@ -55,7 +56,7 @@ class AsyncMsiCredential:
             raise ValueError("expected environment variable {} has no value".format(MSI_ENDPOINT))
         self._client = AsyncAuthnClient(endpoint, config, policies, **kwargs)
 
-    async def get_token(self, *scopes: str) -> str:
+    async def get_token(self, *scopes: str) -> AccessToken:
         if len(scopes) != 1:
             raise ValueError("this credential supports only one scope per request")
         token = self._client.get_cached_token(scopes)

--- a/sdk/identity/azure-identity/azure/identity/aio/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/credentials.py
@@ -7,6 +7,7 @@ import os
 from typing import Any, Dict, Mapping, Optional, Union
 
 from azure.core import Configuration
+from azure.core.credentials import AccessToken
 from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, NetworkTraceLoggingPolicy, AsyncRetryPolicy
 
 from ._authn_client import AsyncAuthnClient
@@ -31,7 +32,7 @@ class AsyncClientSecretCredential(ClientSecretCredentialBase):
         super(AsyncClientSecretCredential, self).__init__(client_id, secret, tenant_id, **kwargs)
         self._client = AsyncAuthnClient(Endpoints.AAD_OAUTH2_V2_FORMAT.format(tenant_id), config, **kwargs)
 
-    async def get_token(self, *scopes: str) -> str:
+    async def get_token(self, *scopes: str) -> AccessToken:
         token = self._client.get_cached_token(scopes)
         if not token:
             data = dict(self._form_data, scope=" ".join(scopes))
@@ -51,7 +52,7 @@ class AsyncCertificateCredential(CertificateCredentialBase):
         super(AsyncCertificateCredential, self).__init__(client_id, tenant_id, certificate_path, **kwargs)
         self._client = AsyncAuthnClient(Endpoints.AAD_OAUTH2_V2_FORMAT.format(tenant_id), config, **kwargs)
 
-    async def get_token(self, *scopes: str) -> str:
+    async def get_token(self, *scopes: str) -> AccessToken:
         token = self._client.get_cached_token(scopes)
         if not token:
             data = dict(self._form_data, scope=" ".join(scopes))
@@ -78,7 +79,7 @@ class AsyncEnvironmentCredential:
                 **kwargs
             )
 
-    async def get_token(self, *scopes: str) -> str:
+    async def get_token(self, *scopes: str) -> AccessToken:
         if not self._credential:
             message = "Missing environment settings. To authenticate with a client secret, set {}. To authenticate with a certificate, set {}.".format(
                 ", ".join(EnvironmentVariables.CLIENT_SECRET_VARS), ", ".join(EnvironmentVariables.CERT_VARS)
@@ -99,14 +100,14 @@ class AsyncManagedIdentityCredential(object):
     def create_config(**kwargs: Dict[str, Any]) -> Configuration:
         pass
 
-    async def get_token(self, *scopes: str) -> str:
+    async def get_token(self, *scopes: str) -> AccessToken:
         pass
 
 
 class AsyncTokenCredentialChain(TokenCredentialChain):
     """A sequence of token credentials"""
 
-    async def get_token(self, *scopes: str) -> str:  # type: ignore
+    async def get_token(self, *scopes: str) -> AccessToken:  # type: ignore
         """Attempts to get a token from each credential, in order, returning the first token.
            If no token is acquired, raises an exception listing error messages.
         """

--- a/sdk/identity/azure-identity/azure/identity/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/credentials.py
@@ -6,6 +6,7 @@
 import os
 
 from azure.core import Configuration
+from azure.core.credentials import AccessToken
 from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, NetworkTraceLoggingPolicy, RetryPolicy
 
 from ._authn_client import AuthnClient
@@ -36,7 +37,7 @@ class ClientSecretCredential(ClientSecretCredentialBase):
         self._client = AuthnClient(Endpoints.AAD_OAUTH2_V2_FORMAT.format(tenant_id), config, **kwargs)
 
     def get_token(self, *scopes):
-        # type: (*str) -> str
+        # type (*str) -> AccessToken
         token = self._client.get_cached_token(scopes)
         if not token:
             data = dict(self._form_data, scope=" ".join(scopes))
@@ -53,7 +54,7 @@ class CertificateCredential(CertificateCredentialBase):
         super(CertificateCredential, self).__init__(client_id, tenant_id, certificate_path, **kwargs)
 
     def get_token(self, *scopes):
-        # type: (*str) -> str
+        # type (*str) -> AccessToken
         token = self._client.get_cached_token(scopes)
         if not token:
             data = dict(self._form_data, scope=" ".join(scopes))
@@ -84,7 +85,7 @@ class EnvironmentCredential:
             )
 
     def get_token(self, *scopes):
-        # type: (*str) -> str
+        # type (*str) -> AccessToken
         if not self._credential:
             message = "Missing environment settings. To authenticate with a client secret, set {}. To authenticate with a certificate, set {}.".format(
                 ", ".join(EnvironmentVariables.CLIENT_SECRET_VARS), ", ".join(EnvironmentVariables.CERT_VARS)
@@ -107,7 +108,7 @@ class ManagedIdentityCredential(object):
         pass
 
     def get_token(self, *scopes):
-        # type: (*str) -> str
+        # type (*str) -> AccessToken
         pass
 
 
@@ -121,7 +122,7 @@ class TokenCredentialChain(object):
         self._credentials = credentials
 
     def get_token(self, *scopes):
-        # type: (*str) -> str
+        # type (*str) -> AccessToken
         """Attempts to get a token from each credential, in order, returning the first token.
            If no token is acquired, raises an exception listing error messages.
         """

--- a/sdk/keyvault/azure-security-keyvault/tests/async_preparer.py
+++ b/sdk/keyvault/azure-security-keyvault/tests/async_preparer.py
@@ -6,6 +6,7 @@
 import asyncio
 from unittest.mock import Mock
 
+from azure.core.credentials import AccessToken
 from azure.identity.aio import AsyncEnvironmentCredential
 from azure.security.keyvault.aio import VaultClient
 
@@ -17,5 +18,5 @@ class AsyncVaultClientPreparer(VaultClientPreparer):
         if self.is_live:
             credential = AsyncEnvironmentCredential()
         else:
-            credential = Mock(get_token=asyncio.coroutine(lambda _: "fake-token"))
+            credential = Mock(get_token=asyncio.coroutine(lambda _: AccessToken("fake-token", 0)))
         return VaultClient(vault_uri, credential)

--- a/sdk/keyvault/azure-security-keyvault/tests/preparer.py
+++ b/sdk/keyvault/azure-security-keyvault/tests/preparer.py
@@ -10,6 +10,7 @@ try:
 except ImportError:  # python < 3.3
     from mock import Mock
 
+from azure.core.credentials import AccessToken
 from azure.identity import EnvironmentCredential
 from azure.security.keyvault import VaultClient
 
@@ -134,7 +135,7 @@ class VaultClientPreparer(AzureMgmtPreparer):
         if self.is_live:
             credential = EnvironmentCredential()
         else:
-            credential = Mock(get_token=lambda _: "fake-token")
+            credential = Mock(get_token=lambda _: AccessToken("fake-token", 0))
         return VaultClient(vault_uri, credential)
 
     def remove_resource(self, name, **kwargs):


### PR DESCRIPTION
The design for azure-identity has changed to have credentials return metadata from `get_token`. Presently that metadata is limited to the token's expiry time. This PR implements the revised design across azure-core and azure-identity.

Changes to azure-core:
- add `AccessToken`, a container for an access token and its metadata
- use the newly-exposed expiry time in simple caching within the bearer token policy

Changes to azure-identity:
- `get_token` returns `AccessToken`

Changes to azure-security-keyvault
- mock credential used in test replays returns `AccessToken`