### PR TITLE
Improve managed identity support

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -79,6 +79,7 @@ class AuthnClientBase(object):
         except Exception as ex:
             raise AuthenticationError("Authentication failed: {}".format(str(ex)))
 
+    # TODO: public, factor out of request_token
     def _prepare_request(self, method="POST", headers=None, form_data=None, params=None):
         # type: (Optional[str], Optional[Mapping[str, str]], Optional[Mapping[str, str]], Optional[Dict[str, str]]) -> HttpRequest
         request = HttpRequest(method, self._auth_url, headers=headers)

--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -102,11 +102,11 @@ class AuthnClient(AuthnClientBase):
         self._pipeline = Pipeline(transport=transport, policies=policies)
         super(AuthnClient, self).__init__(auth_url, **kwargs)
 
-    def request_token(self, scopes, method="POST", headers=None, form_data=None, params=None):
-        # type: (Iterable[str], Optional[str], Optional[Mapping[str, str]], Optional[Mapping[str, str]], Optional[Dict[str, str]]) -> AccessToken
+    def request_token(self, scopes, method="POST", headers=None, form_data=None, params=None, **kwargs):
+        # type: (Iterable[str], Optional[str], Optional[Mapping[str, str]], Optional[Mapping[str, str]], Optional[Dict[str, str]], Any) -> AccessToken
         request = self._prepare_request(method, headers=headers, form_data=form_data, params=params)
         request_time = int(time.time())
-        response = self._pipeline.run(request, stream=False)
+        response = self._pipeline.run(request, stream=False, **kwargs)
         token = self._deserialize_and_cache_token(response, scopes, request_time)
         return token
 
@@ -115,5 +115,5 @@ class AuthnClient(AuthnClientBase):
         # type: (Mapping[str, Any]) -> Configuration
         config = Configuration(**kwargs)
         config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
-        config.retry_policy = RetryPolicy(retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs)
+        config.retry_policy = RetryPolicy(**kwargs)
         return config

--- a/sdk/identity/azure-identity/azure/identity/_internal.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal.py
@@ -19,7 +19,7 @@ from azure.core import Configuration
 from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, NetworkTraceLoggingPolicy, RetryPolicy
 
 from ._authn_client import AuthnClient
-from .constants import Endpoints, MSI_ENDPOINT, MSI_SECRET
+from .constants import Endpoints, EnvironmentVariables
 from .exceptions import AuthenticationError
 
 
@@ -103,7 +103,7 @@ class MsiCredential(_ManagedIdentityBase):
 
     def __init__(self, config=None, **kwargs):
         # type: (Optional[Configuration], Mapping[str, Any]) -> None
-        endpoint = os.environ.get(MSI_ENDPOINT)
+        endpoint = os.environ.get(EnvironmentVariables.MSI_ENDPOINT)
         self._endpoint_available = endpoint is not None
         if self._endpoint_available:
             super(MsiCredential, self).__init__(  # type: ignore
@@ -123,8 +123,7 @@ class MsiCredential(_ManagedIdentityBase):
             resource = scopes[0]
             if resource.endswith("/.default"):
                 resource = resource[: -len("/.default")]
-            # TODO: support user-assigned client id
-            secret = os.environ.get(MSI_SECRET)
+            secret = os.environ.get(EnvironmentVariables.MSI_SECRET)
             if secret:
                 # MSI_ENDPOINT and MSI_SECRET set -> App Service
                 token = self._client.request_token(

--- a/sdk/identity/azure-identity/azure/identity/_internal.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal.py
@@ -12,7 +12,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import
-    from typing import Any, Dict, Optional
+    from typing import Any, Mapping, Optional, Type
     from azure.core.credentials import AccessToken
 
 from azure.core import Configuration
@@ -23,32 +23,70 @@ from .constants import Endpoints, MSI_ENDPOINT, MSI_SECRET
 from .exceptions import AuthenticationError
 
 
-class ImdsCredential:
-    """Authenticates with a managed identity via the IMDS endpoint"""
-
-    def __init__(self, config=None, **kwargs):
-        # type: (Optional[Configuration], Dict[str, Any]) -> None
+class _ManagedIdentityBase(object):
+    def __init__(self, endpoint, client_cls, config=None, **kwargs):
+        # type: (str, Type, Optional[Configuration], Mapping[str, Any]) -> None
         config = config or self.create_config(**kwargs)
-        policies = [config.header_policy, ContentDecodePolicy(), config.logging_policy, config.retry_policy]
-        self._client = AuthnClient(Endpoints.IMDS, config, policies, **kwargs)
+        policies = [ContentDecodePolicy(), config.headers_policy, config.retry_policy, config.logging_policy]
+        self._client = client_cls(endpoint, config, policies, **kwargs)
 
     @staticmethod
     def create_config(**kwargs):
-        # type: (Dict[str, str]) -> Configuration
+        # type: (Mapping[str, Any]) -> Configuration
         timeout = kwargs.pop("connection_timeout", 2)
         config = Configuration(connection_timeout=timeout, **kwargs)
-        config.header_policy = HeadersPolicy(base_headers={"Metadata": "true"}, **kwargs)
+
+        # retry is the only IO policy, so its class is a kwarg to increase async code sharing
+        retry_policy = kwargs.pop("retry_policy", RetryPolicy)  # type: ignore
+        config.retry_policy = retry_policy(**_ManagedIdentityBase._retry_settings, **kwargs)  # type: ignore
+
+        # Metadata header is required by IMDS and in Cloud Shell; App Service ignores it
+        config.headers_policy = HeadersPolicy(base_headers={"Metadata": "true"}, **kwargs)
         config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
-        retries = kwargs.pop("retry_total", 5)
-        config.retry_policy = RetryPolicy(
-            retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
-        )
+
         return config
+
+    # given RetryPolicy's implementation, these settings most closely match the documented guidance for IMDS
+    # https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#retry-guidance
+    _retry_settings = {
+        "retry_total": 5,
+        "retry_status": 5,
+        "retry_backoff_factor": 4,
+        "retry_backoff_max": 60,
+        "retry_on_status_codes": [404, 429] + list(range(500, 600)),
+    }
+
+
+class ImdsCredential(_ManagedIdentityBase):
+    """Authenticates with a managed identity via the IMDS endpoint"""
+
+    def __init__(self, config=None, **kwargs):
+        # type: (Optional[Configuration], Mapping[str, Any]) -> None
+        super(ImdsCredential, self).__init__(endpoint=Endpoints.IMDS, client_cls=AuthnClient, config=config, **kwargs)
+        self._endpoint_available = None  # type: Optional[bool]
 
     def get_token(self, *scopes):
         # type: (*str) -> AccessToken
+        if self._endpoint_available is None:
+            # Lacking another way to determine whether the IMDS endpoint is listening,
+            # we send a request it would immediately reject (missing header, wrong verb),
+            # setting a short timeout. The timeout was chosen by benchmarking: of 2000
+            # requests, the slowest was 14ms, 99th percentile was 7ms, mean was 3.7ms.
+            try:
+                self._client.request_token(scopes, connection_timeout=0.17)
+                self._endpoint_available = True
+            except AuthenticationError:
+                # received a response that couldn't be deserialized because it was an error response)
+                self._endpoint_available = True
+            except Exception:  # pylint:disable=broad-except
+                self._endpoint_available = False
+
+        if not self._endpoint_available:
+            raise AuthenticationError("IMDS endpoint unavailable")
+
         if len(scopes) != 1:
             raise ValueError("this credential supports one scope per request")
+
         token = self._client.get_cached_token(scopes)
         if not token:
             resource = scopes[0]
@@ -60,47 +98,42 @@ class ImdsCredential:
         return token
 
 
-class MsiCredential:
+class MsiCredential(_ManagedIdentityBase):
     """Authenticates via the MSI endpoint"""
 
     def __init__(self, config=None, **kwargs):
-        # type: (Optional[Configuration], Dict[str, Any]) -> None
-        config = config or self.create_config(**kwargs)
-        policies = [ContentDecodePolicy(), config.retry_policy, config.logging_policy]
+        # type: (Optional[Configuration], Mapping[str, Any]) -> None
         endpoint = os.environ.get(MSI_ENDPOINT)
-        if not endpoint:
-            raise ValueError("expected environment variable {} has no value".format(MSI_ENDPOINT))
-        self._client = AuthnClient(endpoint, config, policies, **kwargs)
-
-    @staticmethod
-    def create_config(**kwargs):
-        # type: (Dict[str, str]) -> Configuration
-        timeout = kwargs.pop("connection_timeout", 2)
-        config = Configuration(connection_timeout=timeout, **kwargs)
-        config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
-        retries = kwargs.pop("retry_total", 5)
-        config.retry_policy = RetryPolicy(
-            retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
-        )
-        return config
+        self._endpoint_available = endpoint is not None
+        if self._endpoint_available:
+            super(MsiCredential, self).__init__(  # type: ignore
+                endpoint=endpoint, client_cls=AuthnClient, config=config, **kwargs
+            )
 
     def get_token(self, *scopes):
         # type: (*str) -> AccessToken
+        if not self._endpoint_available:
+            raise AuthenticationError("MSI endpoint unavailable")
+
         if len(scopes) != 1:
             raise ValueError("this credential supports only one scope per request")
+
         token = self._client.get_cached_token(scopes)
         if not token:
-            secret = os.environ.get(MSI_SECRET)
-            if not secret:
-                raise AuthenticationError("{} environment variable has no value".format(MSI_SECRET))
             resource = scopes[0]
             if resource.endswith("/.default"):
                 resource = resource[: -len("/.default")]
             # TODO: support user-assigned client id
-            token = self._client.request_token(
-                scopes,
-                method="GET",
-                headers={"secret": secret},
-                params={"api-version": "2017-09-01", "resource": resource},
-            )
+            secret = os.environ.get(MSI_SECRET)
+            if secret:
+                # MSI_ENDPOINT and MSI_SECRET set -> App Service
+                token = self._client.request_token(
+                    scopes,
+                    method="GET",
+                    headers={"secret": secret},
+                    params={"api-version": "2017-09-01", "resource": resource},
+                )
+            else:
+                # only MSI_ENDPOINT set -> legacy-style MSI (Cloud Shell)
+                token = self._client.request_token(scopes, method="POST", form_data={"resource": resource})
         return token

--- a/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
-# --------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import time
 from typing import Any, Dict, Iterable, Mapping, Optional
 
@@ -41,10 +41,11 @@ class AsyncAuthnClient(AuthnClientBase):
         headers: Optional[Mapping[str, str]] = None,
         form_data: Optional[Mapping[str, str]] = None,
         params: Optional[Dict[str, str]] = None,
+        **kwargs: Any
     ) -> AccessToken:
         request = self._prepare_request(method, headers=headers, form_data=form_data, params=params)
         request_time = int(time.time())
-        response = await self._pipeline.run(request, stream=False)
+        response = await self._pipeline.run(request, stream=False, **kwargs)
         token = self._deserialize_and_cache_token(response, scopes, request_time)
         return token
 
@@ -52,7 +53,5 @@ class AsyncAuthnClient(AuthnClientBase):
     def create_config(**kwargs: Mapping[str, Any]) -> Configuration:
         config = Configuration(**kwargs)
         config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
-        config.retry_policy = AsyncRetryPolicy(
-            retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
-        )
+        config.retry_policy = AsyncRetryPolicy(**kwargs)
         return config

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal.py
@@ -4,7 +4,7 @@
 # license information.
 # ------------------------------------------------------------------------
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from azure.core import Configuration
 from azure.core.credentials import AccessToken
@@ -13,76 +13,88 @@ from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, Net
 from ._authn_client import AsyncAuthnClient
 from ..constants import Endpoints, MSI_ENDPOINT, MSI_SECRET
 from ..exceptions import AuthenticationError
+from .._internal import _ManagedIdentityBase
 
 
-class AsyncImdsCredential:
-    def __init__(self, config: Optional[Configuration] = None, **kwargs: Dict[str, Any]) -> None:
-        config = config or self.create_config(**kwargs)
-        policies = [config.header_policy, ContentDecodePolicy(), config.retry_policy, config.logging_policy]
-        self._client = AsyncAuthnClient(Endpoints.IMDS, config, policies, **kwargs)
+class _AsyncManagedIdentityBase(_ManagedIdentityBase):
+    def __init__(self, endpoint: str, config: Optional[Configuration] = None, **kwargs: Any) -> None:
+        super().__init__(endpoint=endpoint, config=config, client_cls=AsyncAuthnClient, **kwargs)
+
+    @staticmethod
+    def create_config(**kwargs: Any) -> Configuration:  # type: ignore
+        return _ManagedIdentityBase.create_config(retry_policy=AsyncRetryPolicy, **kwargs)
+
+
+class AsyncImdsCredential(_AsyncManagedIdentityBase):
+    def __init__(self, config: Optional[Configuration] = None, **kwargs: Any) -> None:
+        super().__init__(endpoint=Endpoints.IMDS, config=config, **kwargs)
+        self._endpoint_available = None  # type: Optional[bool]
 
     async def get_token(self, *scopes: str) -> AccessToken:
+        if self._endpoint_available is None:
+            # Lacking another way to determine whether the IMDS endpoint is listening,
+            # we send a request it would immediately reject (missing header, wrong verb),
+            # setting a short timeout. The timeout was chosen by benchmarking: of 2000
+            # requests, the slowest was 14ms, 99th percentile was 7ms, mean was 3.7ms.
+            try:
+                await self._client.request_token(scopes, connection_timeout=0.17)
+                self._endpoint_available = True
+            except AuthenticationError:
+                # received a response that couldn't be deserialized (because it was an error response)
+                self._endpoint_available = True
+            except Exception:  # pylint:disable=broad-except
+                self._endpoint_available = False
+
+        if not self._endpoint_available:
+            raise AuthenticationError("IMDS endpoint unavailable")
+
         if len(scopes) != 1:
             raise ValueError("this credential supports one scope per request")
+
         token = self._client.get_cached_token(scopes)
         if not token:
             resource = scopes[0]
             if resource.endswith("/.default"):
-                resource = resource[:-len("/.default")]
+                resource = resource[: -len("/.default")]
             token = await self._client.request_token(
                 scopes, method="GET", params={"api-version": "2018-02-01", "resource": resource}
             )
         return token
 
-    @staticmethod
-    def create_config(**kwargs: Dict[str, Any]) -> Configuration:
-        timeout = kwargs.pop("connection_timeout", 2)
-        config = Configuration(connection_timeout=timeout, **kwargs)
-        config.header_policy = HeadersPolicy(base_headers={"Metadata": "true"}, **kwargs)
-        config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
-        retries = kwargs.pop("retry_total", 5)
-        config.retry_policy = AsyncRetryPolicy(
-            retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
-        )
-        return config
 
-
-class AsyncMsiCredential:
-    def __init__(self, config: Optional[Configuration] = None, **kwargs: Dict[str, Any]) -> None:
-        config = config or self.create_config(**kwargs)
-        policies = [ContentDecodePolicy(), config.retry_policy, config.logging_policy]
+class AsyncMsiCredential(_AsyncManagedIdentityBase):
+    def __init__(self, config: Optional[Configuration] = None, **kwargs: Any) -> None:
         endpoint = os.environ.get(MSI_ENDPOINT)
-        if not endpoint:
-            raise ValueError("expected environment variable {} has no value".format(MSI_ENDPOINT))
-        self._client = AsyncAuthnClient(endpoint, config, policies, **kwargs)
+        self._endpoint_available = endpoint is not None
+        if self._endpoint_available:
+            super(AsyncMsiCredential, self).__init__(endpoint=endpoint, config=config, **kwargs)  # type: ignore
 
     async def get_token(self, *scopes: str) -> AccessToken:
+        if not self._endpoint_available:
+            raise AuthenticationError("MSI endpoint unavailable")
+
         if len(scopes) != 1:
             raise ValueError("this credential supports only one scope per request")
+
         token = self._client.get_cached_token(scopes)
         if not token:
             resource = scopes[0]
             if resource.endswith("/.default"):
-                resource = resource[:-len("/.default")]
-            secret = os.environ.get(MSI_SECRET)
-            if not secret:
-                raise AuthenticationError("{} environment variable has no value".format(MSI_SECRET))
-            # TODO: support user-assigned client id
-            token = await self._client.request_token(
-                scopes,
-                method="GET",
-                headers={"secret": secret},
-                params={"api-version": "2017-09-01", "resource": resource},
-            )
-        return token
+                resource = resource[: -len("/.default")]
 
-    @staticmethod
-    def create_config(**kwargs: Dict[str, Any]) -> Configuration:
-        timeout = kwargs.pop("connection_timeout", 2)
-        config = Configuration(connection_timeout=timeout, **kwargs)
-        config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
-        retries = kwargs.pop("retry_total", 5)
-        config.retry_policy = AsyncRetryPolicy(
-            retry_total=retries, retry_on_status_codes=[404, 429] + list(range(500, 600)), **kwargs
-        )
-        return config
+            # TODO: support user-assigned client id
+            secret = os.environ.get(MSI_SECRET)
+            if secret:
+                # MSI_ENDPOINT and MSI_SECRET set -> app service
+                token = await self._client.request_token(
+                    scopes,
+                    method="GET",
+                    headers={"secret": secret},
+                    params={"api-version": "2017-09-01", "resource": resource},
+                )
+            else:
+                # only MSI_ENDPOINT set -> legacy-style MSI (Cloud Shell)
+                token = await self._client.request_token(
+                    scopes, method="POST", form_data={"resource": resource}, headers={"Metadata": "true"}
+                )
+        return token

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal.py
@@ -8,6 +8,7 @@ from typing import Any, Optional
 
 from azure.core import Configuration
 from azure.core.credentials import AccessToken
+from azure.core.exceptions import HttpResponseError
 from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, NetworkTraceLoggingPolicy, AsyncRetryPolicy
 
 from ._authn_client import AsyncAuthnClient
@@ -38,10 +39,12 @@ class AsyncImdsCredential(_AsyncManagedIdentityBase):
             try:
                 await self._client.request_token(scopes, method="GET", connection_timeout=0.3)
                 self._endpoint_available = True
-            except AuthenticationError:
-                # received a response that couldn't be deserialized (because it was an error response)
+            except (AuthenticationError, HttpResponseError):
+                # received a response a pipeline policy choked on (HttpResponseError)
+                # or that couldn't be deserialized by AuthnClient (AuthenticationError)
                 self._endpoint_available = True
             except Exception:  # pylint:disable=broad-except
+                # if anything else was raised, assume the endpoint is unavailable
                 self._endpoint_available = False
 
         if not self._endpoint_available:

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal.py
@@ -11,7 +11,7 @@ from azure.core.credentials import AccessToken
 from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, NetworkTraceLoggingPolicy, AsyncRetryPolicy
 
 from ._authn_client import AsyncAuthnClient
-from ..constants import Endpoints, MSI_ENDPOINT, MSI_SECRET
+from ..constants import Endpoints, EnvironmentVariables
 from ..exceptions import AuthenticationError
 from .._internal import _ManagedIdentityBase
 
@@ -64,7 +64,7 @@ class AsyncImdsCredential(_AsyncManagedIdentityBase):
 
 class AsyncMsiCredential(_AsyncManagedIdentityBase):
     def __init__(self, config: Optional[Configuration] = None, **kwargs: Any) -> None:
-        endpoint = os.environ.get(MSI_ENDPOINT)
+        endpoint = os.environ.get(EnvironmentVariables.MSI_ENDPOINT)
         self._endpoint_available = endpoint is not None
         if self._endpoint_available:
             super(AsyncMsiCredential, self).__init__(endpoint=endpoint, config=config, **kwargs)  # type: ignore
@@ -82,8 +82,7 @@ class AsyncMsiCredential(_AsyncManagedIdentityBase):
             if resource.endswith("/.default"):
                 resource = resource[: -len("/.default")]
 
-            # TODO: support user-assigned client id
-            secret = os.environ.get(MSI_SECRET)
+            secret = os.environ.get(EnvironmentVariables.MSI_SECRET)
             if secret:
                 # MSI_ENDPOINT and MSI_SECRET set -> app service
                 token = await self._client.request_token(

--- a/sdk/identity/azure-identity/azure/identity/aio/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/credentials.py
@@ -13,7 +13,7 @@ from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, Net
 from ._authn_client import AsyncAuthnClient
 from ._internal import AsyncImdsCredential, AsyncMsiCredential
 from .._base import ClientSecretCredentialBase, CertificateCredentialBase
-from ..constants import Endpoints, EnvironmentVariables, MSI_ENDPOINT
+from ..constants import Endpoints, EnvironmentVariables
 from ..credentials import TokenCredentialChain
 from ..exceptions import AuthenticationError
 
@@ -92,7 +92,7 @@ class AsyncManagedIdentityCredential(object):
     """factory for MSI and IMDS credentials"""
 
     def __new__(cls, *args, **kwargs):
-        if os.environ.get(MSI_ENDPOINT):
+        if os.environ.get(EnvironmentVariables.MSI_ENDPOINT):
             return AsyncMsiCredential(*args, **kwargs)
         return AsyncImdsCredential(*args, **kwargs)
 

--- a/sdk/identity/azure-identity/azure/identity/aio/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/credentials.py
@@ -96,9 +96,14 @@ class AsyncManagedIdentityCredential(object):
             return AsyncMsiCredential(*args, **kwargs)
         return AsyncImdsCredential(*args, **kwargs)
 
+    # the below methods are never called, because ManagedIdentityCredential can't be instantiated;
+    # they exist so tooling gets accurate signatures for Imds- and MsiCredential
+    def __init__(self, client_id: Optional[str] = None, config: Optional[Configuration] = None, **kwargs: Any) -> None:
+        pass
+
     @staticmethod
     def create_config(**kwargs: Dict[str, Any]) -> Configuration:
-        pass
+        return Configuration()
 
     async def get_token(self, *scopes: str) -> AccessToken:
         return AccessToken()

--- a/sdk/identity/azure-identity/azure/identity/aio/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/credentials.py
@@ -13,7 +13,7 @@ from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, Net
 from ._authn_client import AsyncAuthnClient
 from ._internal import AsyncImdsCredential, AsyncMsiCredential
 from .._base import ClientSecretCredentialBase, CertificateCredentialBase
-from ..constants import Endpoints, EnvironmentVariables, MSI_ENDPOINT, MSI_SECRET
+from ..constants import Endpoints, EnvironmentVariables, MSI_ENDPOINT
 from ..credentials import TokenCredentialChain
 from ..exceptions import AuthenticationError
 
@@ -92,7 +92,7 @@ class AsyncManagedIdentityCredential(object):
     """factory for MSI and IMDS credentials"""
 
     def __new__(cls, *args, **kwargs):
-        if os.environ.get(MSI_SECRET) and os.environ.get(MSI_ENDPOINT):
+        if os.environ.get(MSI_ENDPOINT):
             return AsyncMsiCredential(*args, **kwargs)
         return AsyncImdsCredential(*args, **kwargs)
 
@@ -101,7 +101,7 @@ class AsyncManagedIdentityCredential(object):
         pass
 
     async def get_token(self, *scopes: str) -> AccessToken:
-        pass
+        return AccessToken()
 
 
 class AsyncTokenCredentialChain(TokenCredentialChain):

--- a/sdk/identity/azure-identity/azure/identity/constants.py
+++ b/sdk/identity/azure-identity/azure/identity/constants.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
-# --------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 
 
 class EnvironmentVariables:
@@ -14,6 +14,9 @@ class EnvironmentVariables:
     AZURE_CLIENT_CERTIFICATE_PATH = "AZURE_CLIENT_CERTIFICATE_PATH"
     CERT_VARS = (AZURE_CLIENT_ID, AZURE_CLIENT_CERTIFICATE_PATH, AZURE_TENANT_ID)
 
+    MSI_ENDPOINT = "MSI_ENDPOINT"
+    MSI_SECRET = "MSI_SECRET"
+
 
 class Endpoints:
     # https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http
@@ -21,8 +24,3 @@ class Endpoints:
 
     # TODO: other clouds have other endpoints
     AAD_OAUTH2_V2_FORMAT = "https://login.microsoftonline.com/{}/oauth2/v2.0/token"
-
-    # https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity#obtaining-tokens-for-azure-resources
-
-MSI_ENDPOINT = "MSI_ENDPOINT"
-MSI_SECRET = "MSI_SECRET"

--- a/sdk/identity/azure-identity/azure/identity/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/credentials.py
@@ -12,7 +12,7 @@ from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, Net
 from ._authn_client import AuthnClient
 from ._base import ClientSecretCredentialBase, CertificateCredentialBase
 from ._internal import ImdsCredential, MsiCredential
-from .constants import Endpoints, EnvironmentVariables, MSI_ENDPOINT, MSI_SECRET
+from .constants import Endpoints, EnvironmentVariables, MSI_ENDPOINT
 from .exceptions import AuthenticationError
 
 try:
@@ -98,18 +98,23 @@ class ManagedIdentityCredential(object):
     """factory for MSI and IMDS credentials"""
 
     def __new__(cls, *args, **kwargs):
-        if os.environ.get(MSI_SECRET) and os.environ.get(MSI_ENDPOINT):
+        if os.environ.get(MSI_ENDPOINT):
             return MsiCredential(*args, **kwargs)
         return ImdsCredential(*args, **kwargs)
+
+    # the below methods are never called, because ManagedIdentityCredential can't be instantiated;
+    # they exist so tooling gets accurate signatures for Imds- and MsiCredential
+    def __init__(self, config=None, user_assigned_identity=None, **kwargs):
+        pass
 
     @staticmethod
     def create_config(**kwargs):
         # type: (Dict[str, str]) -> Configuration
-        pass
+        return Configuration()
 
     def get_token(self, *scopes):
         # type (*str) -> AccessToken
-        pass
+        return AccessToken()
 
 
 class TokenCredentialChain(object):

--- a/sdk/identity/azure-identity/azure/identity/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/credentials.py
@@ -104,7 +104,8 @@ class ManagedIdentityCredential(object):
 
     # the below methods are never called, because ManagedIdentityCredential can't be instantiated;
     # they exist so tooling gets accurate signatures for Imds- and MsiCredential
-    def __init__(self, config=None, user_assigned_identity=None, **kwargs):
+    def __init__(self, client_id=None, config=None, **kwargs):
+        # type: (Optional[str], Optional[Configuration], Any) -> None
         pass
 
     @staticmethod

--- a/sdk/identity/azure-identity/azure/identity/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/credentials.py
@@ -12,7 +12,7 @@ from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, Net
 from ._authn_client import AuthnClient
 from ._base import ClientSecretCredentialBase, CertificateCredentialBase
 from ._internal import ImdsCredential, MsiCredential
-from .constants import Endpoints, EnvironmentVariables, MSI_ENDPOINT
+from .constants import Endpoints, EnvironmentVariables
 from .exceptions import AuthenticationError
 
 try:
@@ -98,7 +98,7 @@ class ManagedIdentityCredential(object):
     """factory for MSI and IMDS credentials"""
 
     def __new__(cls, *args, **kwargs):
-        if os.environ.get(MSI_ENDPOINT):
+        if os.environ.get(EnvironmentVariables.MSI_ENDPOINT):
             return MsiCredential(*args, **kwargs)
         return ImdsCredential(*args, **kwargs)
 

--- a/sdk/identity/azure-identity/dev_requirements.txt
+++ b/sdk/identity/azure-identity/dev_requirements.txt
@@ -1,2 +1,5 @@
 -e ../../core/azure-core
 typing_extensions>=3.7.2
+httpretty
+pytest
+pytest-asyncio;python_full_version>="3.5.2"

--- a/sdk/identity/azure-identity/tests/test_identity.py
+++ b/sdk/identity/azure-identity/tests/test_identity.py
@@ -24,7 +24,7 @@ from azure.identity import (
     TokenCredentialChain,
 )
 from azure.identity._internal import ImdsCredential
-from azure.identity.constants import EnvironmentVariables, MSI_ENDPOINT, MSI_SECRET
+from azure.identity.constants import EnvironmentVariables
 
 
 def test_client_secret_credential_cache():
@@ -229,13 +229,13 @@ def test_imds_credential_retries():
 def test_managed_identity_app_service(monkeypatch):
     # in App Service, MSI_SECRET and MSI_ENDPOINT are set
     msi_secret = "secret"
-    monkeypatch.setenv(MSI_SECRET, msi_secret)
-    monkeypatch.setenv(MSI_ENDPOINT, "https://foo.bar")
+    monkeypatch.setenv(EnvironmentVariables.MSI_SECRET, msi_secret)
+    monkeypatch.setenv(EnvironmentVariables.MSI_ENDPOINT, "https://foo.bar")
 
     success_message = "test passed"
 
     def validate_request(req, *args, **kwargs):
-        assert req.url.startswith(os.environ[MSI_ENDPOINT])
+        assert req.url.startswith(os.environ[EnvironmentVariables.MSI_ENDPOINT])
         assert req.headers["secret"] == msi_secret
         exception = Exception()
         exception.message = success_message
@@ -249,13 +249,13 @@ def test_managed_identity_app_service(monkeypatch):
 def test_managed_identity_cloud_shell(monkeypatch):
     # in Cloud Shell, only MSI_ENDPOINT is set
     msi_endpoint = "https://localhost:50432"
-    monkeypatch.setenv(MSI_ENDPOINT, msi_endpoint)
+    monkeypatch.setenv(EnvironmentVariables.MSI_ENDPOINT, msi_endpoint)
 
     success_message = "test passed"
 
     def validate_request(req, *args, **kwargs):
         assert req.headers["Metadata"] == "true"
-        assert req.url.startswith(os.environ[MSI_ENDPOINT])
+        assert req.url.startswith(os.environ[EnvironmentVariables.MSI_ENDPOINT])
         exception = Exception()
         exception.message = success_message
         raise exception

--- a/sdk/identity/azure-identity/tests/test_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_identity_async.py
@@ -21,7 +21,7 @@ from azure.identity import (
     AsyncTokenCredentialChain,
 )
 from azure.identity.aio._internal import AsyncImdsCredential
-from azure.identity.constants import EnvironmentVariables, MSI_ENDPOINT, MSI_SECRET
+from azure.identity.constants import EnvironmentVariables
 
 
 @pytest.mark.asyncio
@@ -238,13 +238,13 @@ async def test_imds_credential_retries():
 async def test_managed_identity_app_service(monkeypatch):
     # in App Service, MSI_SECRET and MSI_ENDPOINT are set
     msi_secret = "secret"
-    monkeypatch.setenv(MSI_SECRET, msi_secret)
-    monkeypatch.setenv(MSI_ENDPOINT, "https://foo.bar")
+    monkeypatch.setenv(EnvironmentVariables.MSI_SECRET, msi_secret)
+    monkeypatch.setenv(EnvironmentVariables.MSI_ENDPOINT, "https://foo.bar")
 
     success_message = "test passed"
 
     async def validate_request(req, *args, **kwargs):
-        assert req.url.startswith(os.environ[MSI_ENDPOINT])
+        assert req.url.startswith(os.environ[EnvironmentVariables.MSI_ENDPOINT])
         assert req.headers["secret"] == msi_secret
         exception = Exception()
         exception.message = success_message
@@ -259,13 +259,13 @@ async def test_managed_identity_app_service(monkeypatch):
 async def test_managed_identity_cloud_shell(monkeypatch):
     # in Cloud Shell, only MSI_ENDPOINT is set
     msi_endpoint = "https://localhost:50432"
-    monkeypatch.setenv(MSI_ENDPOINT, msi_endpoint)
+    monkeypatch.setenv(EnvironmentVariables.MSI_ENDPOINT, msi_endpoint)
 
     success_message = "test passed"
 
     async def validate_request(req, *args, **kwargs):
         assert req.headers["Metadata"] == "true"
-        assert req.url.startswith(os.environ[MSI_ENDPOINT])
+        assert req.url.startswith(os.environ[EnvironmentVariables.MSI_ENDPOINT])
         exception = Exception()
         exception.message = success_message
         raise exception

--- a/sdk/identity/azure-identity/tests/test_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_identity_async.py
@@ -17,9 +17,10 @@ from azure.identity import (
     AsyncClientSecretCredential,
     AsyncDefaultAzureCredential,
     AsyncEnvironmentCredential,
+    AsyncManagedIdentityCredential,
     AsyncTokenCredentialChain,
 )
-from azure.identity.aio._internal import AsyncImdsCredential, AsyncMsiCredential
+from azure.identity.aio._internal import AsyncImdsCredential
 from azure.identity.constants import EnvironmentVariables, MSI_ENDPOINT, MSI_SECRET
 
 
@@ -191,7 +192,7 @@ async def test_imds_credential_cache():
     credential = AsyncImdsCredential(transport=Mock(send=asyncio.coroutine(mock_send)))
     token = await credential.get_token(scope)
     assert token.token == expired
-    assert mock_send.call_count == 1
+    assert mock_send.call_count == 2  # first request was probing for endpoint availability
 
     # calling get_token again should provoke another HTTP request
     good_for_an_hour = "this token's good for an hour"
@@ -200,12 +201,12 @@ async def test_imds_credential_cache():
     token_payload["access_token"] = good_for_an_hour
     token = await credential.get_token(scope)
     assert token.token == good_for_an_hour
-    assert mock_send.call_count == 2
+    assert mock_send.call_count == 3
 
     # get_token should return the cached token now
     token = await credential.get_token(scope)
     assert token.token == good_for_an_hour
-    assert mock_send.call_count == 2
+    assert mock_send.call_count == 3
 
 
 @pytest.mark.asyncio
@@ -218,8 +219,9 @@ async def test_imds_credential_retries():
     )
     mock_send = Mock(return_value=mock_response)
 
-    retry_total = 1
-    credential = AsyncImdsCredential(retry_total=retry_total, transport=Mock(send=asyncio.coroutine(mock_send)))
+    credential = AsyncImdsCredential(
+        transport=Mock(send=asyncio.coroutine(mock_send), sleep=asyncio.coroutine(lambda _: None))
+    )
 
     for status_code in (404, 429, 500):
         mock_response.status_code = status_code
@@ -227,12 +229,14 @@ async def test_imds_credential_retries():
             await credential.get_token("scope")
         except AuthenticationError:
             pass
-        assert mock_send.call_count is 1 + retry_total
+        # first call was availability probe, second the original request; there should be at least one retry thereafter
+        assert mock_send.call_count > 2
         mock_send.reset_mock()
 
 
 @pytest.mark.asyncio
-async def test_msi_credential(monkeypatch):
+async def test_managed_identity_app_service(monkeypatch):
+    # in App Service, MSI_SECRET and MSI_ENDPOINT are set
     msi_secret = "secret"
     monkeypatch.setenv(MSI_SECRET, msi_secret)
     monkeypatch.setenv(MSI_ENDPOINT, "https://foo.bar")
@@ -247,7 +251,27 @@ async def test_msi_credential(monkeypatch):
         raise exception
 
     with pytest.raises(Exception) as ex:
-        await AsyncMsiCredential(transport=Mock(send=validate_request)).get_token("https://scope")
+        await AsyncManagedIdentityCredential(transport=Mock(send=validate_request)).get_token("https://scope")
+    assert ex.value.message is success_message
+
+
+@pytest.mark.asyncio
+async def test_managed_identity_cloud_shell(monkeypatch):
+    # in Cloud Shell, only MSI_ENDPOINT is set
+    msi_endpoint = "https://localhost:50432"
+    monkeypatch.setenv(MSI_ENDPOINT, msi_endpoint)
+
+    success_message = "test passed"
+
+    async def validate_request(req, *args, **kwargs):
+        assert req.headers["Metadata"] == "true"
+        assert req.url.startswith(os.environ[MSI_ENDPOINT])
+        exception = Exception()
+        exception.message = success_message
+        raise exception
+
+    with pytest.raises(Exception) as ex:
+        await AsyncManagedIdentityCredential(transport=Mock(send=validate_request)).get_token("https://scope")
     assert ex.value.message is success_message
 
 

--- a/sdk/identity/azure-identity/tests/test_managed_identity.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity.py
@@ -9,12 +9,12 @@ import time
 try:
     from unittest import mock
 except ImportError:  # python < 3.3
-    import mock
+    import mock  # type: ignore
 
 import httpretty
 
 from azure.identity import ManagedIdentityCredential
-from azure.identity.constants import Endpoints, MSI_ENDPOINT, MSI_SECRET
+from azure.identity.constants import Endpoints, EnvironmentVariables
 
 
 @httpretty.activate
@@ -27,24 +27,30 @@ def test_cloud_shell():
     token_json = json.dumps({"access_token": access_token, "expires_on": int(time.time() + 3600)})
     httpretty.register_uri(httpretty.POST, url, body=token_json, content_type="application/json")
 
-    with mock.patch("os.environ", {MSI_ENDPOINT: url}):
+    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url}):
         token = ManagedIdentityCredential().get_token("scope")
-        assert token == access_token
-        assert httpretty.last_request().headers["Metadata"] == "true"
-        assert b"resource=scope" in httpretty.last_request().body
+        assert token.token == access_token
+        last_request = httpretty.last_request()
+        assert last_request.headers["Metadata"] == "true"
+        assert b"resource=scope" in last_request.body
 
-        # try user assigned identities
-        token = ManagedIdentityCredential(user_assigned_identity={"client_id": "some-guid"}).get_token("scope")
-        assert token == access_token
+
+@httpretty.activate
+def test_cloud_shell_user_assigned_identity():
+    """Cloud Shell environment: only MSI_ENDPOINT set"""
+
+    access_token = "AccessToken"
+    url = "http://localhost:42/token"
+
+    token_json = json.dumps({"access_token": access_token, "expires_on": int(time.time() + 3600)})
+    httpretty.register_uri(httpretty.POST, url, body=token_json, content_type="application/json")
+
+    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url}):
+        token = ManagedIdentityCredential(client_id="some-guid").get_token("scope")
+        assert token.token == access_token
         assert httpretty.last_request().headers["Metadata"] == "true"
         assert b"client_id=some-guid" in httpretty.last_request().body
         assert b"resource=scope" in httpretty.last_request().body
-
-        ManagedIdentityCredential(user_assigned_identity={"object_id": "some-guid"}).get_token("scope")
-        assert b"object_id=some-guid" in httpretty.last_request().body
-
-        ManagedIdentityCredential(user_assigned_identity={"msi_res_id": "some-guid"}).get_token("scope")
-        assert b"msi_res_id=some-guid" in httpretty.last_request().body
 
 
 @httpretty.activate
@@ -59,29 +65,43 @@ def test_app_service():
     token_json = json.dumps({"access_token": access_token, "expires_on": int(time.time() + 3600)})
     httpretty.register_uri(httpretty.GET, url, body=token_json, content_type="application/json")
 
-    with mock.patch("os.environ", {MSI_ENDPOINT: url, MSI_SECRET: expected_secret}):
+    with mock.patch(
+        "os.environ", {EnvironmentVariables.MSI_ENDPOINT: url, EnvironmentVariables.MSI_SECRET: expected_secret}
+    ):
         token = ManagedIdentityCredential().get_token("scope")
-        assert token == access_token
+        assert token.token == access_token
         assert httpretty.last_request().headers["secret"] == expected_secret
         assert len(httpretty.httpretty.latest_requests) == 1
 
-        # try a user assigned identity
-        httpretty.register_uri(
-            httpretty.GET,
-            url + "?client_id=some-guid",
-            body=token_json,
-            content_type="application/json",
-            match_query=True,
-        )
-        token = ManagedIdentityCredential(user_assigned_identity={"client_id": "some-guid"}).get_token("scope")
-        assert token == access_token
-        assert httpretty.last_request().headers["secret"] == expected_secret
-        assert len(httpretty.httpretty.latest_requests) == 2
+
+@httpretty.activate
+def test_app_service_user_assigned_identity():
+    """App Service environment: MSI_ENDPOINT, MSI_SECRET set"""
+
+    expected_secret = "expected-secret"
+    client_id = "some-guid"
+    access_token = "AccessToken"
+    url = "http://localhost:42/token"
+
+    token_json = json.dumps({"access_token": access_token, "expires_on": int(time.time() + 3600)})
+    httpretty.register_uri(httpretty.GET, url, body=token_json, content_type="application/json")
+
+    with mock.patch(
+        "os.environ", {EnvironmentVariables.MSI_ENDPOINT: url, EnvironmentVariables.MSI_SECRET: expected_secret}
+    ):
+        token = ManagedIdentityCredential(client_id=client_id).get_token("scope")
+        assert token.token == access_token
+        assert len(httpretty.httpretty.latest_requests) == 1
+        last_request = httpretty.last_request()
+        assert last_request.headers["secret"] == expected_secret
+        assert last_request.querystring.get("client_id") == [client_id]  # pylint:disable=no-member
 
 
 @httpretty.activate
 def test_imds():
     access_token = "AccessToken"
+    token_json = json.dumps({"access_token": access_token, "expires_on": int(time.time() + 3600)})
+    scope = "scope"
 
     class reqs:
         count = 0
@@ -91,12 +111,38 @@ def test_imds():
         if reqs.count == 1:
             # credential is probing to determine endpoint availability
             return 400, response_headers, json.dumps({})
-
         assert request.headers["Metadata"] == "true"
-        json_payload = {"access_token": access_token, "expires_on": int(time.time() + 3600)}
-        return 200, response_headers, json.dumps(json_payload)
+        assert request.querystring.get("resource") == [scope]
+        return 200, response_headers, token_json
 
     httpretty.register_uri(httpretty.GET, Endpoints.IMDS, body=request_callback, content_type="application/json")
 
     token = ManagedIdentityCredential().get_token("scope")
-    assert token == access_token
+    assert token.token == access_token
+
+
+@httpretty.activate
+def test_imds_user_assigned_identity():
+    access_token = "AccessToken"
+    token_json = json.dumps({"access_token": access_token, "expires_on": int(time.time() + 3600)})
+    scope = "scope"
+    client_id = "client-id"
+
+    class reqs:
+        count = 0
+
+    def request_callback(request, uri, response_headers):
+        reqs.count += 1
+        if reqs.count == 1:
+            # credential is probing to determine endpoint availability
+            return 400, response_headers, json.dumps({})
+        assert request.headers["Metadata"] == "true"
+        assert request.querystring.get("client_id") == [client_id]
+        assert request.querystring.get("resource") == [scope]
+        return 200, response_headers, token_json
+
+    httpretty.register_uri(httpretty.GET, Endpoints.IMDS, body=request_callback, content_type="application/json")
+
+    token = ManagedIdentityCredential(client_id=client_id).get_token(scope)
+    assert token.token == access_token
+    assert len(httpretty.httpretty.latest_requests) == 2

--- a/sdk/identity/azure-identity/tests/test_managed_identity.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity.py
@@ -1,0 +1,102 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+import json
+import time
+
+try:
+    from unittest import mock
+except ImportError:  # python < 3.3
+    import mock
+
+import httpretty
+
+from azure.identity import ManagedIdentityCredential
+from azure.identity.constants import Endpoints, MSI_ENDPOINT, MSI_SECRET
+
+
+@httpretty.activate
+def test_cloud_shell():
+    """Cloud Shell environment: only MSI_ENDPOINT set"""
+
+    access_token = "AccessToken"
+    url = "http://localhost:42/token"
+
+    token_json = json.dumps({"access_token": access_token, "expires_on": int(time.time() + 3600)})
+    httpretty.register_uri(httpretty.POST, url, body=token_json, content_type="application/json")
+
+    with mock.patch("os.environ", {MSI_ENDPOINT: url}):
+        token = ManagedIdentityCredential().get_token("scope")
+        assert token == access_token
+        assert httpretty.last_request().headers["Metadata"] == "true"
+        assert b"resource=scope" in httpretty.last_request().body
+
+        # try user assigned identities
+        token = ManagedIdentityCredential(user_assigned_identity={"client_id": "some-guid"}).get_token("scope")
+        assert token == access_token
+        assert httpretty.last_request().headers["Metadata"] == "true"
+        assert b"client_id=some-guid" in httpretty.last_request().body
+        assert b"resource=scope" in httpretty.last_request().body
+
+        ManagedIdentityCredential(user_assigned_identity={"object_id": "some-guid"}).get_token("scope")
+        assert b"object_id=some-guid" in httpretty.last_request().body
+
+        ManagedIdentityCredential(user_assigned_identity={"msi_res_id": "some-guid"}).get_token("scope")
+        assert b"msi_res_id=some-guid" in httpretty.last_request().body
+
+
+@httpretty.activate
+def test_app_service():
+    """App Service environment: MSI_ENDPOINT, MSI_SECRET set"""
+
+    expected_secret = "expected-secret"
+
+    access_token = "AccessToken"
+    url = "http://localhost:42/token"
+
+    token_json = json.dumps({"access_token": access_token, "expires_on": int(time.time() + 3600)})
+    httpretty.register_uri(httpretty.GET, url, body=token_json, content_type="application/json")
+
+    with mock.patch("os.environ", {MSI_ENDPOINT: url, MSI_SECRET: expected_secret}):
+        token = ManagedIdentityCredential().get_token("scope")
+        assert token == access_token
+        assert httpretty.last_request().headers["secret"] == expected_secret
+        assert len(httpretty.httpretty.latest_requests) == 1
+
+        # try a user assigned identity
+        httpretty.register_uri(
+            httpretty.GET,
+            url + "?client_id=some-guid",
+            body=token_json,
+            content_type="application/json",
+            match_query=True,
+        )
+        token = ManagedIdentityCredential(user_assigned_identity={"client_id": "some-guid"}).get_token("scope")
+        assert token == access_token
+        assert httpretty.last_request().headers["secret"] == expected_secret
+        assert len(httpretty.httpretty.latest_requests) == 2
+
+
+@httpretty.activate
+def test_imds():
+    access_token = "AccessToken"
+
+    class reqs:
+        count = 0
+
+    def request_callback(request, uri, response_headers):
+        reqs.count += 1
+        if reqs.count == 1:
+            # credential is probing to determine endpoint availability
+            return 400, response_headers, json.dumps({})
+
+        assert request.headers["Metadata"] == "true"
+        json_payload = {"access_token": access_token, "expires_on": int(time.time() + 3600)}
+        return 200, response_headers, json.dumps(json_payload)
+
+    httpretty.register_uri(httpretty.GET, Endpoints.IMDS, body=request_callback, content_type="application/json")
+
+    token = ManagedIdentityCredential().get_token("scope")
+    assert token == access_token


### PR DESCRIPTION
This refactors `MsiCredential` and `ImdsCredential` to support the three managed identity environments we've identified, and user-assigned identities:
- General VM (`ImdsCredential`)
  - Probing the endpoint is the only way to determine whether it's available. Currently we send an HTTP request with a short timeout. Trying to establish a TCP connection would be neater but would break the current tests.
  - GET static IMDS endpoint with header `Metadata: true`
  - client id of user-assigned identity is a query param
- App Service (`MsiCredential`)
  - `MSI_ENDPOINT` and `MSI_SECRET` are set
  - GET `MSI_ENDPOINT` with header `secret: $MSI_SECRET`
  - client id of user-assigned identity is a query param
- Cloud Shell (`MsiCredential`)
  - `MSI_ENDPOINT` alone is set
  - POST `MSI_ENDPOINT` with header `Metadata: true`
  - client id of user-assigned identity is form data

Both credentials follow the [retry guidance for the IMDS endpoint](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#retry-guidance).

This also adds some synchronous tests for managed identity scenarios, adapted from `msrestazure`. These use [`httpretty`](https://pypi.org/project/httpretty/) to validate requests and mock responses. There are no equivalent async tests yet because I can't get `httpretty` to work properly with async code. I'll probably rework these tests to use standard library `mock` instead or, failing that, some other library with async support (tracked by #5899).

Closes #5779