### PR TITLE
expires_on is not present in all responses

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+import time
 from typing import Any, Dict, Iterable, Mapping, Optional
 
 from azure.core import Configuration
@@ -42,8 +43,9 @@ class AsyncAuthnClient(AuthnClientBase):
         params: Optional[Dict[str, str]] = None,
     ) -> AccessToken:
         request = self._prepare_request(method, headers=headers, form_data=form_data, params=params)
+        request_time = int(time.time())
         response = await self._pipeline.run(request, stream=False)
-        token = self._deserialize_and_cache_token(response, scopes)
+        token = self._deserialize_and_cache_token(response, scopes, request_time)
         return token
 
     @staticmethod

--- a/sdk/identity/azure-identity/tests/test_authn_client.py
+++ b/sdk/identity/azure-identity/tests/test_authn_client.py
@@ -1,0 +1,103 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+import json
+import time
+
+try:
+    from unittest.mock import Mock, patch
+except ImportError:  # python < 3.3
+    from mock import Mock, patch  # type: ignore
+
+from azure.core.credentials import AccessToken
+from azure.identity._authn_client import AuthnClient
+
+
+def test_authn_client_deserialization():
+    # using the synchronous AuthnClient to drive this test but the functionality tested is
+    # in the sans I/O AuthnClientBase, shared with AsyncAuthnClient
+    now = 6
+    expires_in = 1800
+    expires_on = now + expires_in
+    expected_token = "token"
+
+    mock_response = Mock(
+        headers={"content-type": "application/json"}, status_code=200, content_type=["application/json"]
+    )
+    mock_send = Mock(return_value=mock_response)
+
+    # response with expires_on only
+    mock_response.text = lambda: json.dumps(
+        {"access_token": expected_token, "expires_on": expires_on, "token_type": "Bearer"}
+    )
+    token = AuthnClient("http://foo", transport=Mock(send=mock_send)).request_token("scope")
+    assert token.token == expected_token
+    assert token.expires_on == expires_on
+
+    # response with expires_in and expires_on
+    mock_response.text = lambda: json.dumps(
+        {"access_token": expected_token, "expires_in": expires_in, "expires_on": expires_on, "token_type": "Bearer"}
+    )
+    token = AuthnClient("http://foo", transport=Mock(send=mock_send)).request_token("scope")
+    assert token.token == expected_token
+    assert token.expires_on == expires_on
+
+    # response with expires_in only
+    mock_response.text = lambda: json.dumps(
+        {"access_token": expected_token, "expires_in": expires_in, "token_type": "Bearer"}
+    )
+    with patch("azure.identity._authn_client.time.time") as mock_time:
+        mock_time.return_value = now
+        token = AuthnClient("http://foo", transport=Mock(send=mock_send)).request_token("scope")
+        assert token.token == expected_token
+        assert token.expires_on == expires_on
+
+
+def test_caching_when_only_expires_in_set():
+    """the cache should function when auth responses don't include an explicit expires_on"""
+
+    access_token = "token"
+    now = 42
+    expires_in = 1800
+    expires_on = now + expires_in
+    expected_token = AccessToken(access_token, expires_on)
+
+    mock_response = Mock(
+        text=lambda: json.dumps({"access_token": access_token, "expires_in": expires_in, "token_type": "Bearer"}),
+        headers={"content-type": "application/json"},
+        status_code=200,
+        content_type=["application/json"],
+    )
+    mock_send = Mock(return_value=mock_response)
+
+    client = AuthnClient("http://foo", transport=Mock(send=mock_send))
+    with patch("azure.identity._authn_client.time.time") as mock_time:
+        mock_time.return_value = 42
+        token = client.request_token(["scope"])
+        assert token.token == expected_token.token
+        assert token.expires_on == expected_token.expires_on
+
+        cached_token = client.get_cached_token(["scope"])
+        assert cached_token == expected_token
+
+
+def test_expires_in_strings():
+    expected_token = "token"
+
+    mock_response = Mock(
+        headers={"content-type": "application/json"}, status_code=200, content_type=["application/json"]
+    )
+    mock_send = Mock(return_value=mock_response)
+
+    mock_response.text = lambda: json.dumps(
+        {"access_token": expected_token, "expires_in": "42", "ext_expires_in": "42", "token_type": "Bearer"}
+    )
+
+    now = int(time.time())
+    with patch("azure.identity._authn_client.time.time") as mock_time:
+        mock_time.return_value = now
+        token = AuthnClient("http://foo", transport=Mock(send=mock_send)).request_token("scope")
+    assert token.token == expected_token
+    assert token.expires_on == now + 42


### PR DESCRIPTION
`AccessToken` includes a token's expiration time. Turns out that across the endpoints we intend to support, there are three cases for figuring out what that is:
1. response has only expires_on (App Service MSI) -> that's easy
1. response has only expires_in (AAD OAuth v2) -> use expires_in + time the request was sent
1. response has expires_on and expires_in (Cloud Shell) -> use expires_on

Also a fourth case which probably shouldn't ever occur but is handled by this code:

4. response has neither expires_on or expires_in -> set expires_on = 0
   - effectively a single-use token: the next call to `get_token` will provoke a request to the auth endpoint