### PR TITLE
Use list examples to validate list models

### DIFF
--- a/sdk/keyvault/azure-security-keyvault/tests/recordings/test_examples_keys.test_example_key_list_operations.yaml
+++ b/sdk/keyvault/azure-security-keyvault/tests/recordings/test_examples_keys.test_example_key_list_operations.yaml
@@ -1,5 +1,421 @@
 interactions:
 - request:
+    body: '{"kty": "EC"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault262b1539.vault.azure.net/keys/key0/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vault262b1539.vault.azure.net/keys/key0/df7429b9985444d1af29694e0920b91f","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"cq5aq2KbQjby3SwnYjvHlFO8ifUbOEI9rwqMC4EOL9s","y":"0SdroJqc92tkGwlkDmfsAP0K5valk0r8O543t9qGf_M"},"attributes":{"enabled":true,"created":1560868652,"updated":1560868652,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '363'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "EC"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault262b1539.vault.azure.net/keys/key1/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vault262b1539.vault.azure.net/keys/key1/0eae4701c0de4343b143252a9b3b6f0d","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"G1wSc4QcpwVZFdDeXKnCHKjkFJZFOw_wQxched2OF8g","y":"dhcRRZMlqkma6Vf4qcNJvtVLOM9YeRjd0h0BRFqaJk8"},"attributes":{"enabled":true,"created":1560868652,"updated":1560868652,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '363'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "EC"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault262b1539.vault.azure.net/keys/key2/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vault262b1539.vault.azure.net/keys/key2/2a76a3295e0c4eebb95ea659fc892487","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"9wBt3EBRBGe9UnwpKrhh-1jQvOGMVqOzr_wQSfmp7Tw","y":"i-q4WPhaUxJCU6rfMB1aZfTS56Vta0UCn_jilryXU-Y"},"attributes":{"enabled":true,"created":1560868653,"updated":1560868653,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '363'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "EC"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault262b1539.vault.azure.net/keys/key3/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vault262b1539.vault.azure.net/keys/key3/3ae54cc681594b7aa4b0a881bb744984","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"ySkzDqjx8fr-MFCB9nX6lmtsRt8LHJA2nEnV-feTe8c","y":"zJswItKVhhSJc21LwGiJx7izLWjbT8-GkQXkL_Bq4wM"},"attributes":{"enabled":true,"created":1560868653,"updated":1560868653,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '363'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault262b1539.vault.azure.net/keys/key0/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vault262b1539.vault.azure.net/keys/key0/2acdec2bc7384e5a885d3013e91d616a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"vLl2o6mVqrnKVl4YXTOpGKt3uBYBVftSOF_70LS2a5nQARm-aSFdkWZpC7m5flOJsYCBpYrCzYdgpQhI5wVXrKd7DUDJA88tLZXaNMzd9I_yK7KdxIk4ukk9-cN5iOmCy-Lh7qnBQ5pp_18d0wuW38E6G4XZ2bQ0Y4JgjEa4Gb-gVwYNc8R-16FuvvKnUyuQtYMglTqYt1TpD_Iy-xhJMOCLVeEJegrbdyvN71_5Ro1lg4tEyXILHHCuCX8KXEBg-ot4WS19iHf1aHLGNI65hYkARn1Hod5qssYKLVd01g1aCmOsxmXXwda542pL6KXOiWrgXijDMFi1ZbE1de7_4Q","e":"AQAB"},"attributes":{"enabled":true,"created":1560868653,"updated":1560868653,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '652'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault262b1539.vault.azure.net/keys/key1/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vault262b1539.vault.azure.net/keys/key1/c80f904c5e584e56942c0c9a51442872","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"vgJ_7qWawOnUkCShdw4GXh1LxU60wsNc3LqvHxPr0toiBYCORHdaTbfnrm0uBsPJx4hccckyJsNCIFtYLTMESkoBQcRVCEOi4OCqIFcdigw2U4-3CC1W5tKdY2nMyb33G6WMncfMznuRBhslmRyk1JeBmXt92PnheD6p5jZtzGLsVTS7dyh3v4d1U_ETVjtB98hzkfZM6BMq_B-guRaSK7hiD6oKswoTaOYznLeK2gqvLy9F2RHeT3mbFQV0rOx6KdhCVxItiBeULXfvfMZtnMKV7qFZ_IQ52jDjat7a3N2EbLvjcENDT_JC2UOTOdBteGvdwnZL1NqL0yPufQ-p4w","e":"AQAB"},"attributes":{"enabled":true,"created":1560868653,"updated":1560868653,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '652'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault262b1539.vault.azure.net/keys/key2/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vault262b1539.vault.azure.net/keys/key2/b351a8afd44e4a65b4f7b4a7ea4d24ab","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ld2Y10OAHufiaeFaN8SoXJi_h9Vi9trWocFLtCDTHdoyBk9yPd-UCtpBLpnrYGU7jzzhqle4hawAJ-T9nLdF5ZX45Kf5v6bvPNp8wKnyabUC1Oy0s0nxkq_jOEIzUvKIbpzuOy7RrogwrgKND8R_YkFsF89j7GuPMFVH02AtYNwl1HYYmQp7ZzSlVfu73aySWfxvLp277ygUmX6J9rECM-8XeVopy2t3JxnIsQtLbZh9t_q7HIX3QhtBmfeFW24C_aMxJjrK4WADanu_dqs3hWJYs7zegKIhP65FL7MZK-sJmcYTm_Qsj2V9OeEzgq1OCHsNeNZUjJox1e6y_v0h7w","e":"AQAB"},"attributes":{"enabled":true,"created":1560868654,"updated":1560868654,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '652'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault262b1539.vault.azure.net/keys/key3/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vault262b1539.vault.azure.net/keys/key3/18b3a6105ef0414c8cf585818b699a33","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"04SY2mmj8SMUnqEXlpqZC-xwTtnQkZe-7uuCg1L6acP5jeNTWIVFotN0Qy5VwldfoMe-gD3PAWCXkOrmOimKchrA-RVKZP1lA9T3D_4V-I2R5VyXsJQJ_NqntokVhaWUehjZNTV8ukAHbWzerI0RcuB9CGDyOPAUU6wxtdN4q-i8HT-Zbs133YUgx0IwCniytd0YHA0zubup_dSjWGEnr85MH1xSDN32uxPsCjY81DUIT_88T9dUCbjgH7WDXSyrREf8Zq14eHfD1F3Y7s6a-eqd6-BX71o1nfL94llpVGWyzVbQYrM6TQTLQkh9cJodP3JPh3GpOPJuak3IsjXMiQ","e":"AQAB"},"attributes":{"enabled":true,"created":1560868654,"updated":1560868654,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '652'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
     body: null
     headers:
       Accept:
@@ -9,21 +425,21 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python/2.7.15 (Windows-10-10.0.18362) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
     method: GET
     uri: https://vault262b1539.vault.azure.net/keys?api-version=7.0
   response:
     body:
-      string: !!python/unicode '{"value":null,"nextLink":null}'
+      string: '{"value":[{"kid":"https://vault262b1539.vault.azure.net/keys/key0","attributes":{"enabled":true,"created":1560868653,"updated":1560868653,"recoveryLevel":"Recoverable+Purgeable"}},{"kid":"https://vault262b1539.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1560868653,"updated":1560868653,"recoveryLevel":"Recoverable+Purgeable"}},{"kid":"https://vault262b1539.vault.azure.net/keys/key2","attributes":{"enabled":true,"created":1560868654,"updated":1560868654,"recoveryLevel":"Recoverable+Purgeable"}},{"kid":"https://vault262b1539.vault.azure.net/keys/key3","attributes":{"enabled":true,"created":1560868654,"updated":1560868654,"recoveryLevel":"Recoverable+Purgeable"}}],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '30'
+      - '707'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Jun 2019 02:12:58 GMT
+      - Tue, 18 Jun 2019 14:37:34 GMT
       expires:
       - '-1'
       pragma:
@@ -37,7 +453,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=76.121.58.221;act_addr_fam=InterNetwork;
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
@@ -57,21 +473,21 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python/2.7.15 (Windows-10-10.0.18362) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
     method: GET
     uri: https://vault262b1539.vault.azure.net/keys/key-name/versions?api-version=7.0
   response:
     body:
-      string: !!python/unicode '{"value":null,"nextLink":null}'
+      string: '{"value":[],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '30'
+      - '28'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Jun 2019 02:12:58 GMT
+      - Tue, 18 Jun 2019 14:37:34 GMT
       expires:
       - '-1'
       pragma:
@@ -85,7 +501,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=76.121.58.221;act_addr_fam=InterNetwork;
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
@@ -105,21 +521,21 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python/2.7.15 (Windows-10-10.0.18362) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
     method: GET
     uri: https://vault262b1539.vault.azure.net/deletedkeys?api-version=7.0
   response:
     body:
-      string: !!python/unicode '{"value":null,"nextLink":null}'
+      string: '{"value":[],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '30'
+      - '28'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Jun 2019 02:12:58 GMT
+      - Tue, 18 Jun 2019 14:37:34 GMT
       expires:
       - '-1'
       pragma:
@@ -133,7 +549,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=76.121.58.221;act_addr_fam=InterNetwork;
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:

--- a/sdk/keyvault/azure-security-keyvault/tests/recordings/test_examples_keys_async.test_example_key_list_operations.yaml
+++ b/sdk/keyvault/azure-security-keyvault/tests/recordings/test_examples_keys_async.test_example_key_list_operations.yaml
@@ -1,5 +1,421 @@
 interactions:
 - request:
+    body: '{"kty": "EC"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vaultae7917b6.vault.azure.net/keys/key0/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultae7917b6.vault.azure.net/keys/key0/ac371018fde840a2879ea70958f4e8a2","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"aiiAFc8HAdC74TpqDvDD1OyHIHiEz7Ye0xUj_4aXohY","y":"v6l-0Jl9HVx-9DJEY9okueSteJWAxzeUj9ZPC6JZ3WQ"},"attributes":{"enabled":true,"created":1560868638,"updated":1560868638,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '363'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "EC"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vaultae7917b6.vault.azure.net/keys/key1/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultae7917b6.vault.azure.net/keys/key1/12d289a5ca334e7ea05e357eefeef198","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"gzo037jNQzoHoLtA9I7T9bln5-4lPI9l1j-ZhYBjmmI","y":"jfPQtSefzslu08MExw0CK8Jrl6hSr5JADFaJp8awdF0"},"attributes":{"enabled":true,"created":1560868639,"updated":1560868639,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '363'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "EC"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vaultae7917b6.vault.azure.net/keys/key2/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultae7917b6.vault.azure.net/keys/key2/98458c8d045149899e92e6b7dea6f41f","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"jz2JUxOinLraCpnZhYRopEFLUJMBdOYP-WXyRYrnYlg","y":"Bz8YjLqqr69nhBXiOeegKNCB1t9cu4qex7S62FxoMtw"},"attributes":{"enabled":true,"created":1560868639,"updated":1560868639,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '363'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "EC"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vaultae7917b6.vault.azure.net/keys/key3/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultae7917b6.vault.azure.net/keys/key3/8238556aa04b4e19a358850cadda4c32","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"nfwx7kL0RJwUS2NIM0L4WPNgQbr7dmK6AN4xGa-Xze4","y":"lGhVgwp-MI0ri8T9vctQa_JvS12x44RA5VpX6IfqmF4"},"attributes":{"enabled":true,"created":1560868639,"updated":1560868639,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '363'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vaultae7917b6.vault.azure.net/keys/key0/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultae7917b6.vault.azure.net/keys/key0/932910f52ed5467faa8515f9f38487df","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"7JZ1w0TpU-ChsutNe-L53azfEokW1SPTm83YT5qaMKcf_JTy-anNs1d8KAyXBwWIzaURNIz4qH9oh9jEYEwU3DX_zmFKoRdTtA1oi82oj56P1zFEhDXZjEFxWtfRQTqrQt7b0JIGucXrv9s0P4HRswIYzU6NpllyGCngiGBHLlKswqRwlIefMA2tgRIB88XMAZthfMxUhHF65s_u2ITde7OZs2gzJQ8tRV0cddGpfhmNkRDK_R3tIJahYO7h_Zr2vS6KKhNxa3YXpXpHRF9hm4JVKhycNzmvgHFN4V617FUJf_T5hbpJbYOpAZVrxNCUmY-xeZ_sBt0z2yq_Sq2h2w","e":"AQAB"},"attributes":{"enabled":true,"created":1560868639,"updated":1560868639,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '652'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vaultae7917b6.vault.azure.net/keys/key1/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultae7917b6.vault.azure.net/keys/key1/39ef7b966e764f6f96e89b83bee81d5f","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"t7tnT3cW2r3ULON2UIdsWHhJyuodMhuUvpr9DmOksDiHeVc8rfrAZmLwdgUdju725Jagi3L4V0pa3hpYEV0WBf02GL0QfpiBcav9wpTqkjnCc68lwuyCAPaWHkjD3upq8Y_PM_lL8UFwUTPkydnHXdeGZtBHNs4W1vwpSdENY6eB5xVL1JLdwhEnWO2gjucgt8MGkSaeeVUNhpnWSboZQtDS8l9gu6KrpLp5I0qvg3YF1jmz9tvMtdp6SUKSYrL98sE2NZTL2MO0DPlPO3AtOBFP3cP6tF2gpDQEuwyrJ0ZpNrRBv68BoO30ia_XpmjI7sxFGOZbygYz6NJkXEihRQ","e":"AQAB"},"attributes":{"enabled":true,"created":1560868640,"updated":1560868640,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '652'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vaultae7917b6.vault.azure.net/keys/key2/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultae7917b6.vault.azure.net/keys/key2/e42f0dcff9d341cb888b08c2f7c8f38e","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oIQQoOG03dcfqhulvVmrHRjRPRmah0d5ea2CAFGRR5OPT6c7w2rRcuXc3uL7j0MorsW6k_0Rrvml_qcqLfb8cwcBpjM8ydpIwSN8ZXPGWTPd8E71u1VEyP83681-QduUWOUgDePHdX6XaWhyyIZ5-XJHyO6Ie36lQvFmG_qyJOJ6_BbXvHRfwHPY_y2TCp_oXC8qESnowN3DJdWTnX0paSlnwod43FVBjmdKLcdLEr5mjyU8ZwdNZ_fXAHs4mhXuxoTbIyRd9qldw37lPdzzWdUpFJ4oI5jz4o1SR1ReU_Tv9SwN00p51hrDAzr6tZkoJpprkj7LSSBDFBv5yJaaKw","e":"AQAB"},"attributes":{"enabled":true,"created":1560868640,"updated":1560868640,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '652'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vaultae7917b6.vault.azure.net/keys/key3/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultae7917b6.vault.azure.net/keys/key3/75c83fe4311b4bcfb690583440ddb518","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wTJBOo86a8WempF1ZVp_0LzHFQ_pVLGI3yIAcChAhAzk_qx-8neWRLgcNvpmrYTAIRQMTOGvZg-IUv8myvoBxCFT39nOTr7oKAXYTB8TMLjFIS73bZM-4hyV3UucV4cti_ZAo6AkASAeYQCHCSyYaaBI0B0TCiyH20ZFfjnMNcr3gOuxipJ44d_c_H_AUf6uwKDU6o6Cx_C-YY6ZqWHn4n5QJTBCApWZTAAvrcUbwOYip6eTMrdd9cGD29aaI85YpotN092PTL6RxTD_eQGe5GuIkZmCwSPDKTUx3mN2Zm6nT7u9778WQf_vJUKaYp1EQIw-uuf1nFimsfz0dDBVzQ","e":"AQAB"},"attributes":{"enabled":true,"created":1560868640,"updated":1560868640,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '652'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
     body: null
     headers:
       Accept:
@@ -14,16 +430,16 @@ interactions:
     uri: https://vaultae7917b6.vault.azure.net/keys?api-version=7.0
   response:
     body:
-      string: '{"value":null,"nextLink":null}'
+      string: '{"value":[{"kid":"https://vaultae7917b6.vault.azure.net/keys/key0","attributes":{"enabled":true,"created":1560868639,"updated":1560868639,"recoveryLevel":"Recoverable+Purgeable"}},{"kid":"https://vaultae7917b6.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1560868640,"updated":1560868640,"recoveryLevel":"Recoverable+Purgeable"}},{"kid":"https://vaultae7917b6.vault.azure.net/keys/key2","attributes":{"enabled":true,"created":1560868640,"updated":1560868640,"recoveryLevel":"Recoverable+Purgeable"}},{"kid":"https://vaultae7917b6.vault.azure.net/keys/key3","attributes":{"enabled":true,"created":1560868640,"updated":1560868640,"recoveryLevel":"Recoverable+Purgeable"}}],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '30'
+      - '707'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Jun 2019 02:12:49 GMT
+      - Tue, 18 Jun 2019 14:37:19 GMT
       expires:
       - '-1'
       pragma:
@@ -37,7 +453,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=76.121.58.221;act_addr_fam=InterNetwork;
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
@@ -62,16 +478,16 @@ interactions:
     uri: https://vaultae7917b6.vault.azure.net/keys/key-name/versions?api-version=7.0
   response:
     body:
-      string: '{"value":null,"nextLink":null}'
+      string: '{"value":[],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '30'
+      - '28'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Jun 2019 02:12:49 GMT
+      - Tue, 18 Jun 2019 14:37:20 GMT
       expires:
       - '-1'
       pragma:
@@ -85,7 +501,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=76.121.58.221;act_addr_fam=InterNetwork;
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
@@ -110,16 +526,16 @@ interactions:
     uri: https://vaultae7917b6.vault.azure.net/deletedkeys?api-version=7.0
   response:
     body:
-      string: '{"value":null,"nextLink":null}'
+      string: '{"value":[],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '30'
+      - '28'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Jun 2019 02:12:49 GMT
+      - Tue, 18 Jun 2019 14:37:20 GMT
       expires:
       - '-1'
       pragma:
@@ -133,7 +549,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=76.121.58.221;act_addr_fam=InterNetwork;
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:

--- a/sdk/keyvault/azure-security-keyvault/tests/recordings/test_examples_secrets.test_example_secret_list_operations.yaml
+++ b/sdk/keyvault/azure-security-keyvault/tests/recordings/test_examples_secrets.test_example_secret_list_operations.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: null
+    body: '{"value": "value0"}'
     headers:
       Accept:
       - application/json
@@ -8,22 +8,26 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '19'
+      Content-Type:
+      - application/json; charset=utf-8
       User-Agent:
-      - python/2.7.15 (Windows-10-10.0.18362) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
-    method: GET
-    uri: https://vaultad8a17b3.vault.azure.net/secrets?api-version=7.0
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vaultad8a17b3.vault.azure.net/secrets/key0?api-version=7.0
   response:
     body:
-      string: !!python/unicode '{"value":null,"nextLink":null}'
+      string: '{"value":"value0","id":"https://vaultad8a17b3.vault.azure.net/secrets/key0/079d89c8498945e692364cd64a8ceaa9","attributes":{"enabled":true,"created":1560868637,"updated":1560868637,"recoveryLevel":"Recoverable+Purgeable"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '30'
+      - '221'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Jun 2019 02:12:57 GMT
+      - Tue, 18 Jun 2019 14:37:16 GMT
       expires:
       - '-1'
       pragma:
@@ -37,7 +41,319 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=76.121.58.221;act_addr_fam=InterNetwork;
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "value1"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '19'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vaultad8a17b3.vault.azure.net/secrets/key1?api-version=7.0
+  response:
+    body:
+      string: '{"value":"value1","id":"https://vaultad8a17b3.vault.azure.net/secrets/key1/a3a015ab3c9d47478da9419188f20d98","attributes":{"enabled":true,"created":1560868637,"updated":1560868637,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '221'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "value2"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '19'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vaultad8a17b3.vault.azure.net/secrets/key2?api-version=7.0
+  response:
+    body:
+      string: '{"value":"value2","id":"https://vaultad8a17b3.vault.azure.net/secrets/key2/9c4c7495590f4abc88904d70c4668bfc","attributes":{"enabled":true,"created":1560868637,"updated":1560868637,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '221'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "value3"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '19'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vaultad8a17b3.vault.azure.net/secrets/key3?api-version=7.0
+  response:
+    body:
+      string: '{"value":"value3","id":"https://vaultad8a17b3.vault.azure.net/secrets/key3/2be63f52535847fe89a95eaed361fdd7","attributes":{"enabled":true,"created":1560868638,"updated":1560868638,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '221'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "value4"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '19'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vaultad8a17b3.vault.azure.net/secrets/key4?api-version=7.0
+  response:
+    body:
+      string: '{"value":"value4","id":"https://vaultad8a17b3.vault.azure.net/secrets/key4/880ffe16435b473f93d50290bfb9f723","attributes":{"enabled":true,"created":1560868638,"updated":1560868638,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '221'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "value5"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '19'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vaultad8a17b3.vault.azure.net/secrets/key5?api-version=7.0
+  response:
+    body:
+      string: '{"value":"value5","id":"https://vaultad8a17b3.vault.azure.net/secrets/key5/7fc0d29c66dc4cd6995b43167df41421","attributes":{"enabled":true,"created":1560868638,"updated":1560868638,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '221'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "value6"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '19'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vaultad8a17b3.vault.azure.net/secrets/key6?api-version=7.0
+  response:
+    body:
+      string: '{"value":"value6","id":"https://vaultad8a17b3.vault.azure.net/secrets/key6/ae424561ae4d4b3e89d9912934d562dd","attributes":{"enabled":true,"created":1560868638,"updated":1560868638,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '221'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
@@ -57,21 +373,21 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python/2.7.15 (Windows-10-10.0.18362) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
     method: GET
-    uri: https://vaultad8a17b3.vault.azure.net/deletedsecrets?api-version=7.0
+    uri: https://vaultad8a17b3.vault.azure.net/secrets?api-version=7.0
   response:
     body:
-      string: !!python/unicode '{"value":null,"nextLink":null}'
+      string: '{"value":[{"id":"https://vaultad8a17b3.vault.azure.net/secrets/key0","attributes":{"enabled":true,"created":1560868637,"updated":1560868637,"recoveryLevel":"Recoverable+Purgeable"}},{"id":"https://vaultad8a17b3.vault.azure.net/secrets/key1","attributes":{"enabled":true,"created":1560868637,"updated":1560868637,"recoveryLevel":"Recoverable+Purgeable"}},{"id":"https://vaultad8a17b3.vault.azure.net/secrets/key2","attributes":{"enabled":true,"created":1560868637,"updated":1560868637,"recoveryLevel":"Recoverable+Purgeable"}},{"id":"https://vaultad8a17b3.vault.azure.net/secrets/key3","attributes":{"enabled":true,"created":1560868638,"updated":1560868638,"recoveryLevel":"Recoverable+Purgeable"}},{"id":"https://vaultad8a17b3.vault.azure.net/secrets/key4","attributes":{"enabled":true,"created":1560868638,"updated":1560868638,"recoveryLevel":"Recoverable+Purgeable"}},{"id":"https://vaultad8a17b3.vault.azure.net/secrets/key5","attributes":{"enabled":true,"created":1560868638,"updated":1560868638,"recoveryLevel":"Recoverable+Purgeable"}},{"id":"https://vaultad8a17b3.vault.azure.net/secrets/key6","attributes":{"enabled":true,"created":1560868638,"updated":1560868638,"recoveryLevel":"Recoverable+Purgeable"}}],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '30'
+      - '1231'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Jun 2019 02:12:57 GMT
+      - Tue, 18 Jun 2019 14:37:18 GMT
       expires:
       - '-1'
       pragma:
@@ -85,7 +401,55 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=76.121.58.221;act_addr_fam=InterNetwork;
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: GET
+    uri: https://vaultad8a17b3.vault.azure.net/deletedsecrets?api-version=7.0
+  response:
+    body:
+      string: '{"value":[],"nextLink":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '28'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:

--- a/sdk/keyvault/azure-security-keyvault/tests/recordings/test_examples_secrets_async.test_example_secret_list_operations.yaml
+++ b/sdk/keyvault/azure-security-keyvault/tests/recordings/test_examples_secrets_async.test_example_secret_list_operations.yaml
@@ -1,5 +1,369 @@
 interactions:
 - request:
+    body: '{"value": "value0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '19'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vault44cc1a30.vault.azure.net/secrets/key0?api-version=7.0
+  response:
+    body:
+      string: '{"value":"value0","id":"https://vault44cc1a30.vault.azure.net/secrets/key0/7d40eb235a2b4206877e9c812a432fb6","attributes":{"enabled":true,"created":1560868638,"updated":1560868638,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '221'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "value1"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '19'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vault44cc1a30.vault.azure.net/secrets/key1?api-version=7.0
+  response:
+    body:
+      string: '{"value":"value1","id":"https://vault44cc1a30.vault.azure.net/secrets/key1/3d9459302cab412ea3d63156966a0538","attributes":{"enabled":true,"created":1560868638,"updated":1560868638,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '221'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "value2"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '19'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vault44cc1a30.vault.azure.net/secrets/key2?api-version=7.0
+  response:
+    body:
+      string: '{"value":"value2","id":"https://vault44cc1a30.vault.azure.net/secrets/key2/822b227dadfc4ee181bf9981762a7954","attributes":{"enabled":true,"created":1560868638,"updated":1560868638,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '221'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "value3"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '19'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vault44cc1a30.vault.azure.net/secrets/key3?api-version=7.0
+  response:
+    body:
+      string: '{"value":"value3","id":"https://vault44cc1a30.vault.azure.net/secrets/key3/022d467f7aa6427e8623f85cfa7cf64b","attributes":{"enabled":true,"created":1560868639,"updated":1560868639,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '221'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "value4"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '19'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vault44cc1a30.vault.azure.net/secrets/key4?api-version=7.0
+  response:
+    body:
+      string: '{"value":"value4","id":"https://vault44cc1a30.vault.azure.net/secrets/key4/e43b99d4aa8647a081d14cbd4b21d506","attributes":{"enabled":true,"created":1560868639,"updated":1560868639,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '221'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "value5"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '19'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vault44cc1a30.vault.azure.net/secrets/key5?api-version=7.0
+  response:
+    body:
+      string: '{"value":"value5","id":"https://vault44cc1a30.vault.azure.net/secrets/key5/c1fe05d10c6640a1af8773e64363176a","attributes":{"enabled":true,"created":1560868639,"updated":1560868639,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '221'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "value6"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '19'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/0.0.1 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vault44cc1a30.vault.azure.net/secrets/key6?api-version=7.0
+  response:
+    body:
+      string: '{"value":"value6","id":"https://vault44cc1a30.vault.azure.net/secrets/key6/1405faddfdea4f6b9d7ca6da06cacf80","attributes":{"enabled":true,"created":1560868639,"updated":1560868639,"recoveryLevel":"Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '221'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Jun 2019 14:37:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.866
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
     body: null
     headers:
       Accept:
@@ -14,16 +378,16 @@ interactions:
     uri: https://vault44cc1a30.vault.azure.net/secrets?api-version=7.0
   response:
     body:
-      string: '{"value":null,"nextLink":null}'
+      string: '{"value":[{"id":"https://vault44cc1a30.vault.azure.net/secrets/key0","attributes":{"enabled":true,"created":1560868638,"updated":1560868638,"recoveryLevel":"Recoverable+Purgeable"}},{"id":"https://vault44cc1a30.vault.azure.net/secrets/key1","attributes":{"enabled":true,"created":1560868638,"updated":1560868638,"recoveryLevel":"Recoverable+Purgeable"}},{"id":"https://vault44cc1a30.vault.azure.net/secrets/key2","attributes":{"enabled":true,"created":1560868638,"updated":1560868638,"recoveryLevel":"Recoverable+Purgeable"}},{"id":"https://vault44cc1a30.vault.azure.net/secrets/key3","attributes":{"enabled":true,"created":1560868639,"updated":1560868639,"recoveryLevel":"Recoverable+Purgeable"}},{"id":"https://vault44cc1a30.vault.azure.net/secrets/key4","attributes":{"enabled":true,"created":1560868639,"updated":1560868639,"recoveryLevel":"Recoverable+Purgeable"}},{"id":"https://vault44cc1a30.vault.azure.net/secrets/key5","attributes":{"enabled":true,"created":1560868639,"updated":1560868639,"recoveryLevel":"Recoverable+Purgeable"}},{"id":"https://vault44cc1a30.vault.azure.net/secrets/key6","attributes":{"enabled":true,"created":1560868639,"updated":1560868639,"recoveryLevel":"Recoverable+Purgeable"}}],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '30'
+      - '1231'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Jun 2019 02:12:50 GMT
+      - Tue, 18 Jun 2019 14:37:19 GMT
       expires:
       - '-1'
       pragma:
@@ -37,7 +401,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=76.121.58.221;act_addr_fam=InterNetwork;
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
@@ -62,16 +426,16 @@ interactions:
     uri: https://vault44cc1a30.vault.azure.net/secrets/secret-name/versions?api-version=7.0
   response:
     body:
-      string: '{"value":null,"nextLink":null}'
+      string: '{"value":[],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '30'
+      - '28'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Jun 2019 02:12:50 GMT
+      - Tue, 18 Jun 2019 14:37:19 GMT
       expires:
       - '-1'
       pragma:
@@ -85,7 +449,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=76.121.58.221;act_addr_fam=InterNetwork;
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
@@ -110,16 +474,16 @@ interactions:
     uri: https://vault44cc1a30.vault.azure.net/deletedsecrets?api-version=7.0
   response:
     body:
-      string: '{"value":null,"nextLink":null}'
+      string: '{"value":[],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '30'
+      - '28'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Jun 2019 02:12:50 GMT
+      - Tue, 18 Jun 2019 14:37:20 GMT
       expires:
       - '-1'
       pragma:
@@ -133,7 +497,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=76.121.58.221;act_addr_fam=InterNetwork;
+      - addr=166.255.248.40;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:

--- a/sdk/keyvault/azure-security-keyvault/tests/test_examples_keys.py
+++ b/sdk/keyvault/azure-security-keyvault/tests/test_examples_keys.py
@@ -134,6 +134,12 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @VaultClientPreparer(enable_soft_delete=True)
     def test_example_key_list_operations(self, vault_client, **kwargs):
         key_client = vault_client.keys
+
+        for i in range(4):
+            key_client.create_ec_key("key{}".format(i), hsm=False)
+        for i in range(4):
+            key_client.create_rsa_key("key{}".format(i), hsm=False)
+
         # [START list_keys]
 
         # get an iterator of keys
@@ -142,7 +148,9 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         for key in keys:
             print(key.id)
             print(key.name)
-            print(key.key_material.kty)
+            print(key.created)
+            print(key.updated)
+            print(key.enabled)
 
         # [END list_keys]
 
@@ -153,8 +161,9 @@ class TestExamplesKeyVault(KeyVaultTestCase):
 
         for key in key_versions:
             print(key.id)
+            print(key.updated)
             print(key.version)
-            print(key.key_material.kty)
+            print(key.expires)
 
         # [END list_key_versions]
 
@@ -166,6 +175,9 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         for key in deleted_keys:
             print(key.id)
             print(key.name)
+            print(key.scheduled_purge_date)
+            print(key.recovery_id)
+            print(key.deleted_date)
 
         # [END list_deleted_keys]
 

--- a/sdk/keyvault/azure-security-keyvault/tests/test_examples_keys_async.py
+++ b/sdk/keyvault/azure-security-keyvault/tests/test_examples_keys_async.py
@@ -128,6 +128,12 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
     @AsyncKeyVaultTestCase.await_prepared_test
     async def test_example_key_list_operations(self, vault_client, **kwargs):
         key_client = vault_client.keys
+
+        for i in range(4):
+            await key_client.create_ec_key("key{}".format(i), hsm=False)
+        for i in range(4):
+            await key_client.create_rsa_key("key{}".format(i), hsm=False)
+
         # [START list_keys]
 
         # list keys
@@ -137,7 +143,8 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
             print(key.id)
             print(key.created)
             print(key.name)
-            print(key.key_material.kty)
+            print(key.updated)
+            print(key.enabled)
 
         # [END list_keys]
         # [START list_key_versions]
@@ -158,6 +165,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         deleted_keys = key_client.list_deleted_keys()
 
         async for key in deleted_keys:
+            print(key.id)
             print(key.name)
             print(key.scheduled_purge_date)
             print(key.recovery_id)

--- a/sdk/keyvault/azure-security-keyvault/tests/test_examples_secrets.py
+++ b/sdk/keyvault/azure-security-keyvault/tests/test_examples_secrets.py
@@ -98,6 +98,10 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @VaultClientPreparer(enable_soft_delete=True)
     def test_example_secret_list_operations(self, vault_client, **kwargs):
         secret_client = vault_client.secrets
+
+        for i in range(7):
+            secret_client.set_secret("key{}".format(i), "value{}".format(i))
+
         # [START list_secrets]
 
         # list secrets
@@ -107,6 +111,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
             # the list doesn't include values or versions of the secrets
             print(secret.id)
             print(secret.name)
+            print(secret.enabled)
 
         # [END list_secrets]
 
@@ -118,7 +123,9 @@ class TestExamplesKeyVault(KeyVaultTestCase):
 
         for secret in secrets:
             # the list doesn't include the values at each version
-            print(secret.version)
+            print(secret.id)
+            print(secret.enabled)
+            print(secret.updated)
 
         # [END list_secret_versions]
         # [START list_deleted_secrets]
@@ -130,6 +137,9 @@ class TestExamplesKeyVault(KeyVaultTestCase):
             # the list doesn't include values or versions of the deleted secrets
             print(secret.id)
             print(secret.name)
+            print(secret.scheduled_purge_date)
+            print(secret.recovery_id)
+            print(secret.deleted_date)
 
         # [END list_deleted_secrets]
 

--- a/sdk/keyvault/azure-security-keyvault/tests/test_examples_secrets_async.py
+++ b/sdk/keyvault/azure-security-keyvault/tests/test_examples_secrets_async.py
@@ -100,6 +100,9 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
     async def test_example_secret_list_operations(self, vault_client, **kwargs):
         secret_client = vault_client.secrets
 
+        for i in range(7):
+            await secret_client.set_secret("key{}".format(i), "value{}".format(i))
+
         # [START list_secrets]
 
         # gets a list of secrets in the vault
@@ -109,6 +112,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
             # the list doesn't include values or versions of the secrets
             print(secret.id)
             print(secret.name)
+            print(secret.enabled)
 
         # [END list_secrets]
         # [START list_secret_versions]
@@ -119,7 +123,8 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         async for secret in secret_versions:
             # the list doesn't include the versions' values
             print(secret.id)
-            print(secret.name)
+            print(secret.enabled)
+            print(secret.updated)
 
         # [END list_secret_versions]
         # [START list_deleted_secrets]
@@ -131,6 +136,9 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
             # the list doesn't include values or versions of the deleted secrets
             print(secret.id)
             print(secret.name)
+            print(secret.scheduled_purge_date)
+            print(secret.recovery_id)
+            print(secret.deleted_date)
 
         # [END list_deleted_secrets]
 


### PR DESCRIPTION
The list examples weren't testing anything because they ran list operations on empty vaults. This creates a few of the appropriate resources before listing them, and removes `key_material` access from the keys examples (it will always be `None`).