### PR TITLE
Renaming Azure.Identity classes for cross-language consistency

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/__init__.py
@@ -9,11 +9,11 @@ from .credentials import (
     ClientSecretCredential,
     EnvironmentCredential,
     ManagedIdentityCredential,
-    TokenCredentialChain,
+    ChainedTokenCredential,
 )
 
 
-class DefaultAzureCredential(TokenCredentialChain):
+class DefaultAzureCredential(ChainedTokenCredential):
     """default credential is environment followed by MSI/IMDS"""
 
     def __init__(self, **kwargs):
@@ -29,7 +29,7 @@ __all__ = [
     "DefaultAzureCredential",
     "EnvironmentCredential",
     "ManagedIdentityCredential",
-    "TokenCredentialChain",
+    "ChainedTokenCredential",
 ]
 
 try:
@@ -39,7 +39,7 @@ try:
         AsyncDefaultAzureCredential,
         AsyncEnvironmentCredential,
         AsyncManagedIdentityCredential,
-        AsyncTokenCredentialChain,
+        AsyncChainedTokenCredential,
     )
 
     __all__.extend(
@@ -49,7 +49,7 @@ try:
             "AsyncDefaultAzureCredential",
             "AsyncEnvironmentCredential",
             "AsyncManagedIdentityCredential",
-            "AsyncTokenCredentialChain",
+            "AsyncChainedTokenCredential",
         ]
     )
 except (ImportError, SyntaxError):

--- a/sdk/identity/azure-identity/azure/identity/aio/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/__init__.py
@@ -8,11 +8,11 @@ from .credentials import (
     AsyncClientSecretCredential,
     AsyncEnvironmentCredential,
     AsyncManagedIdentityCredential,
-    AsyncTokenCredentialChain,
+    AsyncChainedTokenCredential,
 )
 
 
-class AsyncDefaultAzureCredential(AsyncTokenCredentialChain):
+class AsyncDefaultAzureCredential(AsyncChainedTokenCredential):
     """default credential is environment followed by MSI/IMDS"""
 
     def __init__(self, **kwargs):
@@ -25,5 +25,5 @@ __all__ = [
     "AsyncDefaultAzureCredential",
     "AsyncEnvironmentCredential",
     "AsyncManagedIdentityCredential",
-    "AsyncTokenCredentialChain",
+    "AsyncChainedTokenCredential",
 ]

--- a/sdk/identity/azure-identity/azure/identity/aio/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/credentials.py
@@ -14,7 +14,7 @@ from ._authn_client import AsyncAuthnClient
 from ._internal import AsyncImdsCredential, AsyncMsiCredential
 from .._base import ClientSecretCredentialBase, CertificateCredentialBase
 from ..constants import Endpoints, EnvironmentVariables
-from ..credentials import TokenCredentialChain
+from ..credentials import ChainedTokenCredential
 from ..exceptions import AuthenticationError
 
 # pylint:disable=too-few-public-methods
@@ -109,7 +109,7 @@ class AsyncManagedIdentityCredential(object):
         return AccessToken()
 
 
-class AsyncTokenCredentialChain(TokenCredentialChain):
+class AsyncChainedTokenCredential(ChainedTokenCredential):
     """A sequence of token credentials"""
 
     async def get_token(self, *scopes: str) -> AccessToken:  # type: ignore

--- a/sdk/identity/azure-identity/azure/identity/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/credentials.py
@@ -118,7 +118,7 @@ class ManagedIdentityCredential(object):
         return AccessToken()
 
 
-class TokenCredentialChain(object):
+class ChainedTokenCredential(object):
     """A sequence of token credentials"""
 
     def __init__(self, *credentials):

--- a/sdk/identity/azure-identity/tests/test_identity.py
+++ b/sdk/identity/azure-identity/tests/test_identity.py
@@ -21,7 +21,7 @@ from azure.identity import (
     DefaultAzureCredential,
     EnvironmentCredential,
     ManagedIdentityCredential,
-    TokenCredentialChain,
+    ChainedTokenCredential,
 )
 from azure.identity._internal import ImdsCredential
 from azure.identity.constants import EnvironmentVariables
@@ -101,7 +101,7 @@ def test_credential_chain_error_message():
     second_credential = Mock(name="second_credential", get_token=lambda _: raise_authn_error(second_error))
 
     with pytest.raises(AuthenticationError) as ex:
-        TokenCredentialChain(first_credential, second_credential).get_token("scope")
+        ChainedTokenCredential(first_credential, second_credential).get_token("scope")
 
     assert "ClientSecretCredential" in ex.value.message
     assert first_error in ex.value.message
@@ -120,7 +120,7 @@ def test_chain_attempts_all_credentials():
         Mock(get_token=Mock(return_value=expected_token)),
     ]
 
-    token = TokenCredentialChain(*credentials).get_token("scope")
+    token = ChainedTokenCredential(*credentials).get_token("scope")
     assert token is expected_token
 
     for credential in credentials:
@@ -132,7 +132,7 @@ def test_chain_returns_first_token():
     first_credential = Mock(get_token=lambda _: expected_token)
     second_credential = Mock(get_token=Mock())
 
-    aggregate = TokenCredentialChain(first_credential, second_credential)
+    aggregate = ChainedTokenCredential(first_credential, second_credential)
     credential = aggregate.get_token("scope")
 
     assert credential is expected_token

--- a/sdk/identity/azure-identity/tests/test_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_identity_async.py
@@ -18,7 +18,7 @@ from azure.identity import (
     AsyncDefaultAzureCredential,
     AsyncEnvironmentCredential,
     AsyncManagedIdentityCredential,
-    AsyncTokenCredentialChain,
+    AsyncChainedTokenCredential,
 )
 from azure.identity.aio._internal import AsyncImdsCredential
 from azure.identity.constants import EnvironmentVariables
@@ -102,7 +102,7 @@ async def test_credential_chain_error_message():
     second_credential = Mock(name="second_credential", get_token=lambda _: raise_authn_error(second_error))
 
     with pytest.raises(AuthenticationError) as ex:
-        await AsyncTokenCredentialChain(first_credential, second_credential).get_token("scope")
+        await AsyncChainedTokenCredential(first_credential, second_credential).get_token("scope")
 
     assert "ClientSecretCredential" in ex.value.message
     assert first_error in ex.value.message
@@ -121,7 +121,7 @@ async def test_chain_attempts_all_credentials():
         Mock(get_token=asyncio.coroutine(lambda _: expected_token)),
     ]
 
-    token = await AsyncTokenCredentialChain(*credentials).get_token("scope")
+    token = await AsyncChainedTokenCredential(*credentials).get_token("scope")
     assert token is expected_token
 
     for credential in credentials[:-1]:
@@ -134,7 +134,7 @@ async def test_chain_returns_first_token():
     first_credential = Mock(get_token=asyncio.coroutine(lambda _: expected_token))
     second_credential = Mock(get_token=Mock())
 
-    aggregate = AsyncTokenCredentialChain(first_credential, second_credential)
+    aggregate = AsyncChainedTokenCredential(first_credential, second_credential)
     credential = await aggregate.get_token("scope")
 
     assert credential is expected_token


### PR DESCRIPTION
Renaming the following so identity classes / concepts are consistent across all languages:

TokenCredentialChain -> ChainedTokenCredential

Updated the classes as well as the tests referencing them.