### PR TITLE
[AutoPR eventhub/resource-manager] Eventhub: fixed typo in 2015 API version swagger

### DIFF
--- a/sdk/eventhub/azure-mgmt-eventhub/azure/mgmt/eventhub/v2015_08_01/operations/_event_hubs_operations.py
+++ b/sdk/eventhub/azure-mgmt-eventhub/azure/mgmt/eventhub/v2015_08_01/operations/_event_hubs_operations.py
@@ -532,7 +532,7 @@ class EventHubsOperations(object):
         return deserialized
     get_authorization_rule.metadata = {'url': '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/{authorizationRuleName}'}
 
-    def postt_authorization_rule(
+    def post_authorization_rule(
             self, resource_group_name, namespace_name, event_hub_name, authorization_rule_name, custom_headers=None, raw=False, **operation_config):
         """Gets an AuthorizationRule for an Event Hub by rule name.
 
@@ -558,7 +558,7 @@ class EventHubsOperations(object):
         :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
         """
         # Construct URL
-        url = self.postt_authorization_rule.metadata['url']
+        url = self.post_authorization_rule.metadata['url']
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str', max_length=90, min_length=1),
             'namespaceName': self._serialize.url("namespace_name", namespace_name, 'str', max_length=50, min_length=6),
@@ -600,7 +600,7 @@ class EventHubsOperations(object):
             return client_raw_response
 
         return deserialized
-    postt_authorization_rule.metadata = {'url': '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/{authorizationRuleName}'}
+    post_authorization_rule.metadata = {'url': '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/{authorizationRuleName}'}
 
     def delete_authorization_rule(
             self, resource_group_name, namespace_name, event_hub_name, authorization_rule_name, custom_headers=None, raw=False, **operation_config):


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/6407