### PR TITLE
Remove Async credential name prefixes

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/__init__.py
@@ -5,10 +5,10 @@
 # -------------------------------------------------------------------------
 from .credentials import (
     CertificateCredential,
+    ChainedTokenCredential,
     ClientSecretCredential,
     EnvironmentCredential,
     ManagedIdentityCredential,
-    ChainedTokenCredential,
 )
 
 
@@ -31,32 +31,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
 
 __all__ = [
     "CertificateCredential",
+    "ChainedTokenCredential",
     "ClientSecretCredential",
     "DefaultAzureCredential",
     "EnvironmentCredential",
     "ManagedIdentityCredential",
-    "ChainedTokenCredential",
 ]
-
-try:
-    from .aio import (
-        AsyncCertificateCredential,
-        AsyncClientSecretCredential,
-        AsyncDefaultAzureCredential,
-        AsyncEnvironmentCredential,
-        AsyncManagedIdentityCredential,
-        AsyncChainedTokenCredential,
-    )
-
-    __all__.extend(
-        [
-            "AsyncCertificateCredential",
-            "AsyncClientSecretCredential",
-            "AsyncDefaultAzureCredential",
-            "AsyncEnvironmentCredential",
-            "AsyncManagedIdentityCredential",
-            "AsyncChainedTokenCredential",
-        ]
-    )
-except (ImportError, SyntaxError):
-    pass

--- a/sdk/identity/azure-identity/azure/identity/aio/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/__init__.py
@@ -4,34 +4,34 @@
 # license information.
 # ------------------------------------------------------------------------
 from .credentials import (
-    AsyncCertificateCredential,
-    AsyncClientSecretCredential,
-    AsyncEnvironmentCredential,
-    AsyncManagedIdentityCredential,
-    AsyncChainedTokenCredential,
+    CertificateCredential,
+    ChainedTokenCredential,
+    ClientSecretCredential,
+    EnvironmentCredential,
+    ManagedIdentityCredential,
 )
 
 
-class AsyncDefaultAzureCredential(AsyncChainedTokenCredential):
+class DefaultAzureCredential(ChainedTokenCredential):
     """
     A default credential capable of handling most Azure SDK authentication scenarios.
 
     When environment variable configuration is present, it authenticates as a service principal
-    using :class:`identity.aio.AsyncEnvironmentCredential`.
+    using :class:`identity.aio.EnvironmentCredential`.
 
     When environment configuration is not present, it authenticates with a managed identity
-    using :class:`identity.aio.AsyncManagedIdentityCredential`.
+    using :class:`identity.aio.ManagedIdentityCredential`.
     """
 
     def __init__(self, **kwargs):
-        super().__init__(AsyncEnvironmentCredential(**kwargs), AsyncManagedIdentityCredential(**kwargs))
+        super().__init__(EnvironmentCredential(**kwargs), ManagedIdentityCredential(**kwargs))
 
 
 __all__ = [
-    "AsyncCertificateCredential",
-    "AsyncClientSecretCredential",
-    "AsyncDefaultAzureCredential",
-    "AsyncEnvironmentCredential",
-    "AsyncManagedIdentityCredential",
-    "AsyncChainedTokenCredential",
+    "CertificateCredential",
+    "ClientSecretCredential",
+    "DefaultAzureCredential",
+    "EnvironmentCredential",
+    "ManagedIdentityCredential",
+    "ChainedTokenCredential",
 ]

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal.py
@@ -30,7 +30,7 @@ class _AsyncManagedIdentityBase(_ManagedIdentityBase):
         return _ManagedIdentityBase.create_config(retry_policy=AsyncRetryPolicy, **kwargs)
 
 
-class AsyncImdsCredential(_AsyncManagedIdentityBase):
+class ImdsCredential(_AsyncManagedIdentityBase):
     """
     Asynchronously authenticates with a managed identity via the IMDS endpoint.
 
@@ -83,7 +83,7 @@ class AsyncImdsCredential(_AsyncManagedIdentityBase):
         return token
 
 
-class AsyncMsiCredential(_AsyncManagedIdentityBase):
+class MsiCredential(_AsyncManagedIdentityBase):
     """
     Authenticates via the MSI endpoint in an App Service or Cloud Shell environment.
 

--- a/sdk/identity/azure-identity/tests/test_imds_async.py
+++ b/sdk/identity/azure-identity/tests/test_imds_async.py
@@ -5,11 +5,11 @@
 # -------------------------------------------------------------------------
 import pytest
 
-from azure.identity.aio._internal import AsyncImdsCredential
+from azure.identity.aio._internal import ImdsCredential
 
 
 @pytest.mark.asyncio
 async def test_imds_credential_async():
-    credential = AsyncImdsCredential()
+    credential = ImdsCredential()
     token = await credential.get_token("https://management.azure.com/.default")
     assert token

--- a/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/aio/keys/samples/backup_restore_operations_async.py
+++ b/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/aio/keys/samples/backup_restore_operations_async.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 from azure.security.keyvault.aio import KeyClient
-from azure.identity import AsyncDefaultAzureCredential
+from azure.identity.aio import DefaultAzureCredential
 from azure.core.exceptions import HttpResponseError
 
  # ----------------------------------------------------------------------------------------------------------
@@ -36,7 +36,7 @@ async def run_sample():
     # To make default credentials work, ensure that environment variables 'AZURE_CLIENT_ID',
     # 'AZURE_CLIENT_SECRET' and 'AZURE_TENANT_ID' are set with the service principal credentials.
     VAULT_URL = os.environ["VAULT_URL"]
-    credential = AsyncDefaultAzureCredential()
+    credential = DefaultAzureCredential()
     client = KeyClient(vault_url=VAULT_URL, credential=credential)
     try:
         # Let's create a Key of type RSA.

--- a/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/aio/keys/samples/hello_world_async.py
+++ b/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/aio/keys/samples/hello_world_async.py
@@ -2,7 +2,7 @@ import datetime
 import asyncio
 import os
 from azure.security.keyvault.aio import KeyClient
-from azure.identity import AsyncDefaultAzureCredential
+from azure.identity.aio import DefaultAzureCredential
 from azure.core.exceptions import HttpResponseError
 
 # ----------------------------------------------------------------------------------------------------------
@@ -38,7 +38,7 @@ async def run_sample():
     # To make default credentials work, ensure that environment variables 'AZURE_CLIENT_ID',
     # 'AZURE_CLIENT_SECRET' and 'AZURE_TENANT_ID' are set with the service principal credentials.
     VAULT_URL = os.environ["VAULT_URL"]
-    credential = AsyncDefaultAzureCredential()
+    credential = DefaultAzureCredential()
     client = KeyClient(vault_url=VAULT_URL, credential=credential)
     try:
         # Let's create an RSA key with size 2048, hsm disabled and optional key_operations of encrypt, decrypt.

--- a/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/aio/keys/samples/list_operations_async.py
+++ b/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/aio/keys/samples/list_operations_async.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 from azure.security.keyvault.aio import KeyClient
-from azure.identity import AsyncDefaultAzureCredential
+from azure.identity.aio import DefaultAzureCredential
 from azure.core.exceptions import HttpResponseError
 
  # ----------------------------------------------------------------------------------------------------------
@@ -37,7 +37,7 @@ async def run_sample():
     # To make default credentials work, ensure that environment variables 'AZURE_CLIENT_ID',
     # 'AZURE_CLIENT_SECRET' and 'AZURE_TENANT_ID' are set with the service principal credentials.
     VAULT_URL = os.environ["VAULT_URL"]
-    credential = AsyncDefaultAzureCredential()
+    credential = DefaultAzureCredential()
     client = KeyClient(vault_url=VAULT_URL, credential=credential)
     try:
         # Let's create keys with RSA and EC type. If the key

--- a/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/aio/keys/samples/recover_purge_operations_async.py
+++ b/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/aio/keys/samples/recover_purge_operations_async.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 from azure.security.keyvault.aio import KeyClient
-from azure.identity import AsyncDefaultAzureCredential
+from azure.identity.aio import DefaultAzureCredential
 from azure.core.exceptions import HttpResponseError
 
  # ----------------------------------------------------------------------------------------------------------
@@ -36,7 +36,7 @@ async def run_sample():
     # To make default credentials work, ensure that environment variables 'AZURE_CLIENT_ID',
     # 'AZURE_CLIENT_SECRET' and 'AZURE_TENANT_ID' are set with the service principal credentials.
     VAULT_URL = os.environ["VAULT_URL"]
-    credential = AsyncDefaultAzureCredential()
+    credential = DefaultAzureCredential()
     client = KeyClient(vault_url=VAULT_URL, credential=credential)
     try:
         # Let's create keys with RSA and EC type. If the key

--- a/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/aio/secrets/samples/backup_restore_operations_async.py
+++ b/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/aio/secrets/samples/backup_restore_operations_async.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 from azure.security.keyvault.aio import SecretClient
-from azure.identity import AsyncDefaultAzureCredential
+from azure.identity import DefaultAzureCredential
 from azure.core.exceptions import HttpResponseError
 
 # ----------------------------------------------------------------------------------------------------------
@@ -36,7 +36,7 @@ async def run_sample():
     # To make default credentials work, ensure that environment variables 'AZURE_CLIENT_ID',
     # 'AZURE_CLIENT_SECRET' and 'AZURE_TENANT_ID' are set with the service principal credentials.
     VAULT_URL = os.environ["VAULT_URL"]
-    credential = AsyncDefaultAzureCredential()
+    credential = DefaultAzureCredential()
     client = SecretClient(vault_url=VAULT_URL, credential=credential)
     try:
         # Let's create a secret holding storage account credentials.

--- a/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/aio/secrets/samples/hello_world_async.py
+++ b/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/aio/secrets/samples/hello_world_async.py
@@ -3,7 +3,7 @@ import os
 import pytz
 import asyncio
 from azure.security.keyvault.aio import SecretClient
-from azure.identity import AsyncDefaultAzureCredential
+from azure.identity import DefaultAzureCredential
 from azure.core.exceptions import HttpResponseError
 
 # ----------------------------------------------------------------------------------------------------------
@@ -39,7 +39,7 @@ async def run_sample():
     # To make default credentials work, ensure that environment variables 'AZURE_CLIENT_ID',
     # 'AZURE_CLIENT_SECRET' and 'AZURE_TENANT_ID' are set with the service principal credentials.
     VAULT_URL = os.environ["VAULT_URL"]
-    credential = AsyncDefaultAzureCredential()
+    credential = DefaultAzureCredential()
     client = SecretClient(vault_url=VAULT_URL, credential=credential)
     try:
         # Let's create a secret holding bank account credentials valid for 1 year.

--- a/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/aio/secrets/samples/list_operations_async.py
+++ b/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/aio/secrets/samples/list_operations_async.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 from azure.security.keyvault.aio import SecretClient
-from azure.identity import AsyncDefaultAzureCredential
+from azure.identity import DefaultAzureCredential
 from azure.core.exceptions import HttpResponseError
 
 # ----------------------------------------------------------------------------------------------------------
@@ -37,7 +37,7 @@ async def run_sample():
     # To make default credentials work, ensure that environment variables 'AZURE_CLIENT_ID',
     # 'AZURE_CLIENT_SECRET' and 'AZURE_TENANT_ID' are set with the service principal credentials.
     VAULT_URL = os.environ["VAULT_URL"]
-    credential = AsyncDefaultAzureCredential()
+    credential = DefaultAzureCredential()
     client = SecretClient(vault_url=VAULT_URL, credential=credential)
     try:
         # Let's create secrets holding storage and bank accounts credentials. If the secret

--- a/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/aio/secrets/samples/recover_purge_operations_async.py
+++ b/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/aio/secrets/samples/recover_purge_operations_async.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 from azure.security.keyvault.aio import SecretClient
-from azure.identity import AsyncDefaultAzureCredential
+from azure.identity import DefaultAzureCredential
 from azure.core.exceptions import HttpResponseError
 
 # ----------------------------------------------------------------------------------------------------------
@@ -36,7 +36,7 @@ async def run_sample():
     # To make default credentials work, ensure that environment variables 'AZURE_CLIENT_ID',
     # 'AZURE_CLIENT_SECRET' and 'AZURE_TENANT_ID' are set with the service principal credentials.
     VAULT_URL = os.environ["VAULT_URL"]
-    credential = AsyncDefaultAzureCredential()
+    credential = DefaultAzureCredential()
     client = SecretClient(vault_url=VAULT_URL, credential=credential)
     try:
         # Let's create secrets holding storage and bank accounts credentials. If the secret

--- a/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/keys/README.md
+++ b/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/keys/README.md
@@ -57,7 +57,7 @@ Use the [Azure Cloud Shell][azure_cloud_shell] snippet below to create/get clien
 
 * Use the above mentioned Key Vault name to retreive details of your Vault which also contains your Key Vault URL:
     ```Bash
-    az keyvault show --name <your-key-vault-name> 
+    az keyvault show --name <your-key-vault-name>
     ```
 
 #### Create Key client
@@ -169,12 +169,11 @@ The following examples provide code snippets for performing async operations in 
 ### Async create a Key
 This example creates a key in the Key Vault with the specified optional arguments.
 ```python
-from azure.identity import AsyncDefaultAzureCredential
+from azure.identity.aio import DefaultAzureCredential
 from azure.security.keyvault.aio import KeyClient
 
-# for async operations use AsyncDefaultAzureCredential
-credential = AsyncDefaultAzureCredential()
-
+# for async operations use DefaultAzureCredential
+credential = DefaultAzureCredential()
 # Create a new Key client using the default credential
 key_client = KeyClient(vault_url=vault_url, credential=credential)
 

--- a/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/secrets/README.md
+++ b/sdk/keyvault/azure-security-keyvault/azure/security/keyvault/secrets/README.md
@@ -55,7 +55,7 @@ Use the [Azure Cloud Shell][azure_cloud_shell] snippet below to create/get clien
 
 * Use the above mentioned Key Vault name to retreive details of your Vault which also contains your Key Vault URL:
     ```Bash
-    az keyvault show --name <your-key-vault-name> 
+    az keyvault show --name <your-key-vault-name>
     ```
 
 #### Create Secret client
@@ -150,19 +150,18 @@ This example lists all the secrets in the specified Key Vault.
 
 ### Async operations
 Python’s [asyncio package][asyncio_package] and its two keywords `async` and `await` serves to declare, build, execute, and manage asynchronous code.
-The package supports async API on Python 3.5+ and is identical to synchronous API. 
+The package supports async API on Python 3.5+ and is identical to synchronous API.
 
 The following examples provide code snippets for performing async operations in the Secret Client library:
 
 ### Async create a secret
 This example creates a secret in the Key Vault with the specified optional arguments.
 ```python
-    from azure.identity import AsyncDefaultAzureCredential
+    from azure.identity.aio import DefaultAzureCredential
     from azure.security.keyvault.aio import SecretClient
 
-    # for async operations use AsyncDefaultAzureCredential
-    credential = AsyncDefaultAzureCredential()
-    
+    # for async operations use DefaultAzureCredential
+    credential = DefaultAzureCredential()
     # Create a new secret client using the default credential
     secret_client = SecretClient(vault_url=vault_url, credential=credential)
 

--- a/sdk/keyvault/azure-security-keyvault/tests/async_preparer.py
+++ b/sdk/keyvault/azure-security-keyvault/tests/async_preparer.py
@@ -7,7 +7,7 @@ import asyncio
 from unittest.mock import Mock
 
 from azure.core.credentials import AccessToken
-from azure.identity.aio import AsyncEnvironmentCredential
+from azure.identity.aio import EnvironmentCredential
 from azure.security.keyvault.aio import VaultClient
 
 from preparer import VaultClientPreparer
@@ -16,7 +16,7 @@ from preparer import VaultClientPreparer
 class AsyncVaultClientPreparer(VaultClientPreparer):
     def create_vault_client(self, vault_uri):
         if self.is_live:
-            credential = AsyncEnvironmentCredential()
+            credential = EnvironmentCredential()
         else:
             credential = Mock(get_token=asyncio.coroutine(lambda _: AccessToken("fake-token", 0)))
         return VaultClient(vault_uri, credential)

--- a/sdk/keyvault/azure-security-keyvault/tests/test_examples_keys_async.py
+++ b/sdk/keyvault/azure-security-keyvault/tests/test_examples_keys_async.py
@@ -18,11 +18,11 @@ def test_create_key_client():
     # pylint:disable=unused-variable
     # [START create_key_client]
 
-    from azure.identity.aio import AsyncDefaultAzureCredential
+    from azure.identity.aio import DefaultAzureCredential
     from azure.security.keyvault.aio import KeyClient
 
     # Create a KeyClient using default Azure credentials
-    credential = AsyncDefaultAzureCredential()
+    credential = DefaultAzureCredential()
     key_client = KeyClient(vault_url, credential)
 
     # [END create_key_client]

--- a/sdk/keyvault/azure-security-keyvault/tests/test_examples_secrets_async.py
+++ b/sdk/keyvault/azure-security-keyvault/tests/test_examples_secrets_async.py
@@ -19,11 +19,11 @@ def test_create_secret_client():
     # pylint:disable=unused-variable
     # [START create_secret_client]
 
-    from azure.identity.aio import AsyncDefaultAzureCredential
+    from azure.identity.aio import DefaultAzureCredential
     from azure.security.keyvault.aio.secrets import SecretClient
 
-    # Create a SecretClient using Async default Azure credentials
-    credentials = AsyncDefaultAzureCredential()
+    # Create a SecretClient using default Azure credentials
+    credentials = DefaultAzureCredential()
     secret_client = SecretClient(vault_url, credentials)
 
     # [END create_secret_client]

--- a/sdk/keyvault/azure-security-keyvault/tests/test_examples_vault_client.py
+++ b/sdk/keyvault/azure-security-keyvault/tests/test_examples_vault_client.py
@@ -21,11 +21,11 @@ def test_create_vault_client():
     try:
         # [START create_async_vault_client]
 
-        from azure.identity.aio import AsyncDefaultAzureCredential
+        from azure.identity.aio import DefaultAzureCredential
         from azure.security.keyvault.aio import VaultClient
 
-        # Create a VaultClient using the Async default Azure credentials
-        credential = AsyncDefaultAzureCredential()
+        # Create a VaultClient using default Azure credentials
+        credential = DefaultAzureCredential()
         vault_client = VaultClient(vault_url, credential)
 
         # [END create_async_vault_client]


### PR DESCRIPTION
Renames async credentials as describe in the title and stops exposing them in `azure.identity`. That is to say,
```py
from azure.identity import AsyncEnvironmentCredential
```
becomes

```py
from azure.identity.aio import EnvironmentCredential
```