### PR TITLE
Fix Python 2.7 response with unicode characters

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/universal.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/universal.py
@@ -308,6 +308,12 @@ class ContentDecodePolicy(SansIOHTTPPolicy):
                 raise DecodeError(message="JSON is invalid: {}".format(err), response=response, error=err)
         elif "xml" in (content_type or []):
             try:
+                try:
+                    if isinstance(data, unicode):  # type: ignore
+                        # If I'm Python 2.7 and unicode XML will scream if I try a "fromstring" on unicode string
+                        data_as_str = data_as_str.encode(encoding="utf-8")  # type: ignore
+                except NameError:
+                    pass
                 return ET.fromstring(data_as_str)
             except ET.ParseError:
                 # It might be because the server has an issue, and returned JSON with

--- a/sdk/core/azure-core/tests/test_universal_pipeline.py
+++ b/sdk/core/azure-core/tests/test_universal_pipeline.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #--------------------------------------------------------------------------
 #
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -134,6 +135,12 @@ def test_raw_deserializer():
     raw_deserializer.on_response(None, response)
     result = response.context["deserialized_data"]
     assert result.tag == "groot"
+
+    # The basic deserializer works with unicode XML
+    response = build_response(u'<groot language="français"/>'.encode('utf-8'), content_type="application/xml")
+    raw_deserializer.on_response(None, response)
+    result = response.context["deserialized_data"]
+    assert result.attrib["language"] == u"français"
 
     # Catch some weird situation where content_type is XML, but content is JSON
     response = build_response(b'{"ugly": true}', content_type="application/xml")


### PR DESCRIPTION
If response contains UTF8 characters, and the current Python is 2.7, XML ElementTree expects to receive a "string" (and not a "unicode"). Without this patch, this ends with:
```
sdk\storage\azure-storage-queue\tests\queues\test_queue.py:824: in test_unicode_get_messages_unicode_data
    result = next(queue_client.dequeue_messages())
sdk\storage\azure-storage-queue\azure\storage\queue\_queue_utils.py:62: in __next__
    messages = self._command()
sdk\storage\azure-storage-queue\azure\storage\queue\_generated\operations\_messages_operations.py:96: in dequeue
    pipeline_response = self._client._pipeline.run(request, stream=False, **kwargs)
sdk\core\azure-core\azure\core\pipeline\base.py:145: in run
    return first_node.send(pipeline_request)  # type: ignore
sdk\core\azure-core\azure\core\pipeline\base.py:65: in send
    response = self.next.send(request)
sdk\core\azure-core\azure\core\pipeline\base.py:65: in send
    response = self.next.send(request)
sdk\core\azure-core\azure\core\pipeline\base.py:65: in send
    response = self.next.send(request)
sdk\core\azure-core\azure\core\pipeline\base.py:65: in send
    response = self.next.send(request)
sdk\core\azure-core\azure\core\pipeline\base.py:65: in send
    response = self.next.send(request)
sdk\core\azure-core\azure\core\pipeline\base.py:65: in send
    response = self.next.send(request)
sdk\core\azure-core\azure\core\pipeline\base.py:70: in send
    self._policy.on_response(request, response)
sdk\core\azure-core\azure\core\pipeline\policies\universal.py:380: in on_response
    response.context[self.CONTEXT_NAME] = self.deserialize_from_http_generics(response.http_response) # type: ignore
sdk\core\azure-core\azure\core\pipeline\policies\universal.py:357: in deserialize_from_http_generics
    return cls.deserialize_from_text(response, content_type)
sdk\core\azure-core\azure\core\pipeline\policies\universal.py:312: in deserialize_from_text
    return ET.fromstring(data_as_str)
C:\Python27\Lib\xml\etree\ElementTree.py:1311: in XML
    parser.feed(text)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <xml.etree.ElementTree.XMLParser object at 0x0468A490>
data = '<?xml version="1.0" encoding="utf-8"?><QueueMessagesList><QueueMessage><MessageId>42cd8c38-9c3d-477e-bf38-f9481282464.../TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message1πÜê</MessageText></QueueMessage></QueueMessagesList>'

    def feed(self, data):
        try:
>           self._parser.Parse(data, 0)
E           UnicodeEncodeError: 'ascii' codec can't encode character u'\u3688' in position 420: ordinal not in range(128)
```

Tested on https://github.com/Azure/azure-sdk-for-python/pull/6039