### PR TITLE
remove Python :: 3.4 classifiers

### DIFF
--- a/sdk/advisor/azure-mgmt-advisor/setup.py
+++ b/sdk/advisor/azure-mgmt-advisor/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/aks/azure-mgmt-devspaces/setup.py
+++ b/sdk/aks/azure-mgmt-devspaces/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/alertsmanagement/azure-mgmt-alertsmanagement/setup.py
+++ b/sdk/alertsmanagement/azure-mgmt-alertsmanagement/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/apimanagement/azure-mgmt-apimanagement/setup.py
+++ b/sdk/apimanagement/azure-mgmt-apimanagement/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/appconfiguration/azure-mgmt-appconfiguration/setup.py
+++ b/sdk/appconfiguration/azure-mgmt-appconfiguration/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/applicationinsights/azure-applicationinsights/setup.py
+++ b/sdk/applicationinsights/azure-applicationinsights/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/applicationinsights/azure-mgmt-applicationinsights/setup.py
+++ b/sdk/applicationinsights/azure-mgmt-applicationinsights/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/appservice/azure-mgmt-web/setup.py
+++ b/sdk/appservice/azure-mgmt-web/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/authorization/azure-mgmt-authorization/setup.py
+++ b/sdk/authorization/azure-mgmt-authorization/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/automation/azure-mgmt-automation/setup.py
+++ b/sdk/automation/azure-mgmt-automation/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/batch/azure-batch/setup.py
+++ b/sdk/batch/azure-batch/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/batch/azure-mgmt-batch/setup.py
+++ b/sdk/batch/azure-mgmt-batch/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/billing/azure-mgmt-billing/setup.py
+++ b/sdk/billing/azure-mgmt-billing/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/botservice/azure-mgmt-botservice/setup.py
+++ b/sdk/botservice/azure-mgmt-botservice/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cdn/azure-mgmt-cdn/setup.py
+++ b/sdk/cdn/azure-mgmt-cdn/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-anomalydetector/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-anomalydetector/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-formrecognizer/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-formrecognizer/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-knowledge-nspkg/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-knowledge-nspkg/setup.py
@@ -45,7 +45,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-knowledge-qnamaker/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-knowledge-qnamaker/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-language-luis/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-language-luis/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-language-nspkg/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-language-nspkg/setup.py
@@ -45,7 +45,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-language-spellcheck/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-language-spellcheck/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-language-textanalytics/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-language-textanalytics/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-nspkg/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-nspkg/setup.py
@@ -45,7 +45,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-personalizer/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-personalizer/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-autosuggest/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-autosuggest/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-customimagesearch/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-customimagesearch/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-customsearch/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-customsearch/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-entitysearch/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-entitysearch/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-imagesearch/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-imagesearch/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-newssearch/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-newssearch/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-nspkg/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-nspkg/setup.py
@@ -45,7 +45,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-videosearch/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-videosearch/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-visualsearch/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-visualsearch/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-websearch/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-websearch/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-vision-computervision/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-vision-computervision/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-vision-contentmoderator/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-vision-contentmoderator/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-vision-customvision/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-vision-customvision/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-vision-face/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-vision-face/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-cognitiveservices-vision-nspkg/setup.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-vision-nspkg/setup.py
@@ -45,7 +45,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cognitiveservices/azure-mgmt-cognitiveservices/setup.py
+++ b/sdk/cognitiveservices/azure-mgmt-cognitiveservices/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/commerce/azure-mgmt-commerce/setup.py
+++ b/sdk/commerce/azure-mgmt-commerce/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/compute/azure-mgmt-compute/setup.py
+++ b/sdk/compute/azure-mgmt-compute/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/compute/azure-mgmt-imagebuilder/setup.py
+++ b/sdk/compute/azure-mgmt-imagebuilder/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/consumption/azure-mgmt-consumption/setup.py
+++ b/sdk/consumption/azure-mgmt-consumption/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/containerinstance/azure-mgmt-containerinstance/setup.py
+++ b/sdk/containerinstance/azure-mgmt-containerinstance/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/containerregistry/azure-mgmt-containerregistry/setup.py
+++ b/sdk/containerregistry/azure-mgmt-containerregistry/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/containerservice/azure-mgmt-containerservice/setup.py
+++ b/sdk/containerservice/azure-mgmt-containerservice/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/core/azure-common/setup.py
+++ b/sdk/core/azure-common/setup.py
@@ -62,7 +62,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/core/azure-mgmt-datalake-nspkg/setup.py
+++ b/sdk/core/azure-mgmt-datalake-nspkg/setup.py
@@ -44,7 +44,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/core/azure-mgmt-nspkg/setup.py
+++ b/sdk/core/azure-mgmt-nspkg/setup.py
@@ -45,7 +45,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/core/azure-mgmt/setup.py
+++ b/sdk/core/azure-mgmt/setup.py
@@ -23,7 +23,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/core/azure-nspkg/setup.py
+++ b/sdk/core/azure-nspkg/setup.py
@@ -45,7 +45,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/core/azure-servicemanagement-legacy/setup.py
+++ b/sdk/core/azure-servicemanagement-legacy/setup.py
@@ -54,7 +54,6 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'License :: OSI Approved :: Apache Software License',

--- a/sdk/core/azure/setup.py
+++ b/sdk/core/azure/setup.py
@@ -24,7 +24,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cosmos/azure-cosmos/setup.py
+++ b/sdk/cosmos/azure-cosmos/setup.py
@@ -21,7 +21,6 @@ setup(name='azure-cosmos',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Software Development :: Libraries :: Python Modules'

--- a/sdk/cosmos/azure-mgmt-cosmosdb/setup.py
+++ b/sdk/cosmos/azure-mgmt-cosmosdb/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/cosmos/azure-mgmt-documentdb/setup.py
+++ b/sdk/cosmos/azure-mgmt-documentdb/setup.py
@@ -70,7 +70,6 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'License :: OSI Approved :: MIT License',

--- a/sdk/costmanagement/azure-mgmt-costmanagement/setup.py
+++ b/sdk/costmanagement/azure-mgmt-costmanagement/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/databricks/azure-mgmt-databricks/setup.py
+++ b/sdk/databricks/azure-mgmt-databricks/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/datafactory/azure-mgmt-datafactory/setup.py
+++ b/sdk/datafactory/azure-mgmt-datafactory/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/datalake/azure-mgmt-datalake-analytics/setup.py
+++ b/sdk/datalake/azure-mgmt-datalake-analytics/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/datalake/azure-mgmt-datalake-store/setup.py
+++ b/sdk/datalake/azure-mgmt-datalake-store/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/datamigration/azure-mgmt-datamigration/setup.py
+++ b/sdk/datamigration/azure-mgmt-datamigration/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/deploymentmanager/azure-mgmt-deploymentmanager/setup.py
+++ b/sdk/deploymentmanager/azure-mgmt-deploymentmanager/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/devtestlabs/azure-mgmt-devtestlabs/setup.py
+++ b/sdk/devtestlabs/azure-mgmt-devtestlabs/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/edgegateway/azure-mgmt-edgegateway/setup.py
+++ b/sdk/edgegateway/azure-mgmt-edgegateway/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/eventgrid/azure-eventgrid/setup.py
+++ b/sdk/eventgrid/azure-eventgrid/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/eventgrid/azure-mgmt-eventgrid/setup.py
+++ b/sdk/eventgrid/azure-mgmt-eventgrid/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/eventhub/azure-mgmt-eventhub/setup.py
+++ b/sdk/eventhub/azure-mgmt-eventhub/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/graphrbac/azure-graphrbac/setup.py
+++ b/sdk/graphrbac/azure-graphrbac/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/hanaonazure/azure-mgmt-hanaonazure/setup.py
+++ b/sdk/hanaonazure/azure-mgmt-hanaonazure/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/hdinsight/azure-mgmt-hdinsight/setup.py
+++ b/sdk/hdinsight/azure-mgmt-hdinsight/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -62,7 +62,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/sdk/iothub/azure-mgmt-iotcentral/setup.py
+++ b/sdk/iothub/azure-mgmt-iotcentral/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/iothub/azure-mgmt-iothub/setup.py
+++ b/sdk/iothub/azure-mgmt-iothub/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/iothub/azure-mgmt-iothubprovisioningservices/setup.py
+++ b/sdk/iothub/azure-mgmt-iothubprovisioningservices/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/keyvault/azure-keyvault/setup.py
+++ b/sdk/keyvault/azure-keyvault/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/keyvault/azure-mgmt-keyvault/setup.py
+++ b/sdk/keyvault/azure-mgmt-keyvault/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/keyvault/azure-security-keyvault/setup.py
+++ b/sdk/keyvault/azure-security-keyvault/setup.py
@@ -64,7 +64,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/sdk/keyvault/azure-security-nspkg/setup.py
+++ b/sdk/keyvault/azure-security-nspkg/setup.py
@@ -40,7 +40,6 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/sdk/kusto/azure-mgmt-kusto/setup.py
+++ b/sdk/kusto/azure-mgmt-kusto/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/labservices/azure-mgmt-labservices/setup.py
+++ b/sdk/labservices/azure-mgmt-labservices/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/loganalytics/azure-loganalytics/setup.py
+++ b/sdk/loganalytics/azure-loganalytics/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/loganalytics/azure-mgmt-loganalytics/setup.py
+++ b/sdk/loganalytics/azure-mgmt-loganalytics/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/logic/azure-mgmt-logic/setup.py
+++ b/sdk/logic/azure-mgmt-logic/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/machinelearning/azure-mgmt-machinelearningcompute/setup.py
+++ b/sdk/machinelearning/azure-mgmt-machinelearningcompute/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/managedservices/azure-mgmt-managedservices/setup.py
+++ b/sdk/managedservices/azure-mgmt-managedservices/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/managementgroups/azure-mgmt-managementgroups/setup.py
+++ b/sdk/managementgroups/azure-mgmt-managementgroups/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/managementpartner/azure-mgmt-managementpartner/setup.py
+++ b/sdk/managementpartner/azure-mgmt-managementpartner/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/maps/azure-mgmt-maps/setup.py
+++ b/sdk/maps/azure-mgmt-maps/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/marketplaceordering/azure-mgmt-marketplaceordering/setup.py
+++ b/sdk/marketplaceordering/azure-mgmt-marketplaceordering/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/media/azure-mgmt-media/setup.py
+++ b/sdk/media/azure-mgmt-media/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/mixedreality/azure-mgmt-mixedreality/setup.py
+++ b/sdk/mixedreality/azure-mgmt-mixedreality/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/monitor/azure-mgmt-monitor/setup.py
+++ b/sdk/monitor/azure-mgmt-monitor/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/netapp/azure-mgmt-netapp/setup.py
+++ b/sdk/netapp/azure-mgmt-netapp/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/network/azure-mgmt-dns/setup.py
+++ b/sdk/network/azure-mgmt-dns/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/network/azure-mgmt-frontdoor/setup.py
+++ b/sdk/network/azure-mgmt-frontdoor/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/network/azure-mgmt-network/setup.py
+++ b/sdk/network/azure-mgmt-network/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/network/azure-mgmt-privatedns/setup.py
+++ b/sdk/network/azure-mgmt-privatedns/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/notificationhubs/azure-mgmt-notificationhubs/setup.py
+++ b/sdk/notificationhubs/azure-mgmt-notificationhubs/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/policyinsights/azure-mgmt-policyinsights/setup.py
+++ b/sdk/policyinsights/azure-mgmt-policyinsights/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/powerbiembedded/azure-mgmt-powerbiembedded/setup.py
+++ b/sdk/powerbiembedded/azure-mgmt-powerbiembedded/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/rdbms/azure-mgmt-rdbms/setup.py
+++ b/sdk/rdbms/azure-mgmt-rdbms/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/recoveryservices/azure-mgmt-recoveryservices/setup.py
+++ b/sdk/recoveryservices/azure-mgmt-recoveryservices/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/recoveryservices/azure-mgmt-recoveryservicesbackup/setup.py
+++ b/sdk/recoveryservices/azure-mgmt-recoveryservicesbackup/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/redis/azure-mgmt-redis/setup.py
+++ b/sdk/redis/azure-mgmt-redis/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/relay/azure-mgmt-relay/setup.py
+++ b/sdk/relay/azure-mgmt-relay/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/reservations/azure-mgmt-reservations/setup.py
+++ b/sdk/reservations/azure-mgmt-reservations/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/resources/azure-mgmt-msi/setup.py
+++ b/sdk/resources/azure-mgmt-msi/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/resources/azure-mgmt-resource/setup.py
+++ b/sdk/resources/azure-mgmt-resource/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/resources/azure-mgmt-resourcegraph/setup.py
+++ b/sdk/resources/azure-mgmt-resourcegraph/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/scheduler/azure-mgmt-scheduler/setup.py
+++ b/sdk/scheduler/azure-mgmt-scheduler/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/search/azure-mgmt-search/setup.py
+++ b/sdk/search/azure-mgmt-search/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/security/azure-mgmt-security/setup.py
+++ b/sdk/security/azure-mgmt-security/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/serialconsole/azure-mgmt-serialconsole/setup.py
+++ b/sdk/serialconsole/azure-mgmt-serialconsole/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/servermanager/azure-mgmt-servermanager/setup.py
+++ b/sdk/servermanager/azure-mgmt-servermanager/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/servicebus/azure-mgmt-servicebus/setup.py
+++ b/sdk/servicebus/azure-mgmt-servicebus/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/servicebus/azure-servicebus/setup.py
+++ b/sdk/servicebus/azure-servicebus/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/servicefabric/azure-mgmt-servicefabric/setup.py
+++ b/sdk/servicefabric/azure-mgmt-servicefabric/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/servicefabric/azure-servicefabric/setup.py
+++ b/sdk/servicefabric/azure-servicefabric/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/signalr/azure-mgmt-signalr/setup.py
+++ b/sdk/signalr/azure-mgmt-signalr/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/sql/azure-mgmt-sql/setup.py
+++ b/sdk/sql/azure-mgmt-sql/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/sql/azure-mgmt-sqlvirtualmachine/setup.py
+++ b/sdk/sql/azure-mgmt-sqlvirtualmachine/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/storage/azure-mgmt-storage/setup.py
+++ b/sdk/storage/azure-mgmt-storage/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/storage/azure-mgmt-storagesync/setup.py
+++ b/sdk/storage/azure-mgmt-storagesync/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/subscription/azure-mgmt-subscription/setup.py
+++ b/sdk/subscription/azure-mgmt-subscription/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/template/azure-template/setup.py
+++ b/sdk/template/azure-template/setup.py
@@ -48,7 +48,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/trafficmanager/azure-mgmt-trafficmanager/setup.py
+++ b/sdk/trafficmanager/azure-mgmt-trafficmanager/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Executed via
```
~/work/azure-sdk-for-python/sdk bryanv/classifiers
base ❯ perl -p -i -e 's/^.* "Programming Language :: Python :: 3.4",\n//g' `find ./ -name setup.py`

~/work/azure-sdk-for-python/sdk bryanv/classifiers*
base ❯ perl -p -i -e "s/^.* 'Programming Language :: Python :: 3.4',\n//g" `find ./ -name setup.py`

~/work/azure-sdk-for-python/sdk bryanv/classifiers*
base ❯ grip "Python :: 3\.4"

~/work/azure-sdk-for-python/sdk
```

@lmazuel I'm not sure what the best tags for this would be