### PR TITLE
[AutoPR monitor/resource-manager] Adding flag to support non-dynamic destination types while exporting to LogAnalytics. Adding new metric units. Fixing some documentation issues.

### DIFF
--- a/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2017_05_01_preview/models/_models.py
+++ b/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2017_05_01_preview/models/_models.py
@@ -131,17 +131,22 @@ class DiagnosticSettingsResource(ProxyOnlyResource):
     :param event_hub_name: The name of the event hub. If none is specified,
      the default event hub will be selected.
     :type event_hub_name: str
-    :param metrics: the list of metric settings.
+    :param metrics: The list of metric settings.
     :type metrics:
      list[~azure.mgmt.monitor.v2017_05_01_preview.models.MetricSettings]
-    :param logs: the list of logs settings.
+    :param logs: The list of logs settings.
     :type logs:
      list[~azure.mgmt.monitor.v2017_05_01_preview.models.LogSettings]
-    :param workspace_id: The workspace ID (resource ID of a Log Analytics
-     workspace) for a Log Analytics workspace to which you would like to send
-     Diagnostic Logs. Example:
+    :param workspace_id: The full ARM resource ID of the Log Analytics
+     workspace to which you would like to send Diagnostic Logs. Example:
      /subscriptions/4b9e8510-67ab-4e9a-95a9-e2f1e570ea9c/resourceGroups/insights-integration/providers/Microsoft.OperationalInsights/workspaces/viruela2
     :type workspace_id: str
+    :param log_analytics_destination_type: A string indicating whether the
+     export to Log Analytics should use the default destination type, i.e.
+     AzureDiagnostics, or use a destinatin type constructed as follows:
+     <normalized service identity>_<normalized category name>. Possible values
+     are: Dedicated and null (null is default.)
+    :type log_analytics_destination_type: str
     """
 
     _validation = {
@@ -161,6 +166,7 @@ class DiagnosticSettingsResource(ProxyOnlyResource):
         'metrics': {'key': 'properties.metrics', 'type': '[MetricSettings]'},
         'logs': {'key': 'properties.logs', 'type': '[LogSettings]'},
         'workspace_id': {'key': 'properties.workspaceId', 'type': 'str'},
+        'log_analytics_destination_type': {'key': 'properties.logAnalyticsDestinationType', 'type': 'str'},
     }
 
     def __init__(self, **kwargs):
@@ -172,6 +178,7 @@ class DiagnosticSettingsResource(ProxyOnlyResource):
         self.metrics = kwargs.get('metrics', None)
         self.logs = kwargs.get('logs', None)
         self.workspace_id = kwargs.get('workspace_id', None)
+        self.log_analytics_destination_type = kwargs.get('log_analytics_destination_type', None)
 
 
 class DiagnosticSettingsResourceCollection(Model):

--- a/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2017_05_01_preview/models/_models.py
+++ b/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2017_05_01_preview/models/_models.py
@@ -143,7 +143,7 @@ class DiagnosticSettingsResource(ProxyOnlyResource):
     :type workspace_id: str
     :param log_analytics_destination_type: A string indicating whether the
      export to Log Analytics should use the default destination type, i.e.
-     AzureDiagnostics, or use a destinatin type constructed as follows:
+     AzureDiagnostics, or use a destination type constructed as follows:
      <normalized service identity>_<normalized category name>. Possible values
      are: Dedicated and null (null is default.)
     :type log_analytics_destination_type: str

--- a/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2017_05_01_preview/models/_models_py3.py
+++ b/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2017_05_01_preview/models/_models_py3.py
@@ -131,17 +131,22 @@ class DiagnosticSettingsResource(ProxyOnlyResource):
     :param event_hub_name: The name of the event hub. If none is specified,
      the default event hub will be selected.
     :type event_hub_name: str
-    :param metrics: the list of metric settings.
+    :param metrics: The list of metric settings.
     :type metrics:
      list[~azure.mgmt.monitor.v2017_05_01_preview.models.MetricSettings]
-    :param logs: the list of logs settings.
+    :param logs: The list of logs settings.
     :type logs:
      list[~azure.mgmt.monitor.v2017_05_01_preview.models.LogSettings]
-    :param workspace_id: The workspace ID (resource ID of a Log Analytics
-     workspace) for a Log Analytics workspace to which you would like to send
-     Diagnostic Logs. Example:
+    :param workspace_id: The full ARM resource ID of the Log Analytics
+     workspace to which you would like to send Diagnostic Logs. Example:
      /subscriptions/4b9e8510-67ab-4e9a-95a9-e2f1e570ea9c/resourceGroups/insights-integration/providers/Microsoft.OperationalInsights/workspaces/viruela2
     :type workspace_id: str
+    :param log_analytics_destination_type: A string indicating whether the
+     export to Log Analytics should use the default destination type, i.e.
+     AzureDiagnostics, or use a destinatin type constructed as follows:
+     <normalized service identity>_<normalized category name>. Possible values
+     are: Dedicated and null (null is default.)
+    :type log_analytics_destination_type: str
     """
 
     _validation = {
@@ -161,9 +166,10 @@ class DiagnosticSettingsResource(ProxyOnlyResource):
         'metrics': {'key': 'properties.metrics', 'type': '[MetricSettings]'},
         'logs': {'key': 'properties.logs', 'type': '[LogSettings]'},
         'workspace_id': {'key': 'properties.workspaceId', 'type': 'str'},
+        'log_analytics_destination_type': {'key': 'properties.logAnalyticsDestinationType', 'type': 'str'},
     }
 
-    def __init__(self, *, storage_account_id: str=None, service_bus_rule_id: str=None, event_hub_authorization_rule_id: str=None, event_hub_name: str=None, metrics=None, logs=None, workspace_id: str=None, **kwargs) -> None:
+    def __init__(self, *, storage_account_id: str=None, service_bus_rule_id: str=None, event_hub_authorization_rule_id: str=None, event_hub_name: str=None, metrics=None, logs=None, workspace_id: str=None, log_analytics_destination_type: str=None, **kwargs) -> None:
         super(DiagnosticSettingsResource, self).__init__(**kwargs)
         self.storage_account_id = storage_account_id
         self.service_bus_rule_id = service_bus_rule_id
@@ -172,6 +178,7 @@ class DiagnosticSettingsResource(ProxyOnlyResource):
         self.metrics = metrics
         self.logs = logs
         self.workspace_id = workspace_id
+        self.log_analytics_destination_type = log_analytics_destination_type
 
 
 class DiagnosticSettingsResourceCollection(Model):

--- a/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2017_05_01_preview/models/_models_py3.py
+++ b/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2017_05_01_preview/models/_models_py3.py
@@ -143,7 +143,7 @@ class DiagnosticSettingsResource(ProxyOnlyResource):
     :type workspace_id: str
     :param log_analytics_destination_type: A string indicating whether the
      export to Log Analytics should use the default destination type, i.e.
-     AzureDiagnostics, or use a destinatin type constructed as follows:
+     AzureDiagnostics, or use a destination type constructed as follows:
      <normalized service identity>_<normalized category name>. Possible values
      are: Dedicated and null (null is default.)
     :type log_analytics_destination_type: str

--- a/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_01_01/models/_models.py
+++ b/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_01_01/models/_models.py
@@ -113,7 +113,8 @@ class Metric(Model):
     :type name: ~azure.mgmt.monitor.v2018_01_01.models.LocalizableString
     :param unit: Required. the unit of the metric. Possible values include:
      'Count', 'Bytes', 'Seconds', 'CountPerSecond', 'BytesPerSecond',
-     'Percent', 'MilliSeconds', 'ByteSeconds', 'Unspecified'
+     'Percent', 'MilliSeconds', 'ByteSeconds', 'Unspecified', 'Cores',
+     'MilliCores', 'NanoCores', 'BitsPerSecond'
     :type unit: str or ~azure.mgmt.monitor.v2018_01_01.models.Unit
     :param timeseries: Required. the time series returned when a data query is
      performed.
@@ -185,7 +186,8 @@ class MetricDefinition(Model):
     :type name: ~azure.mgmt.monitor.v2018_01_01.models.LocalizableString
     :param unit: the unit of the metric. Possible values include: 'Count',
      'Bytes', 'Seconds', 'CountPerSecond', 'BytesPerSecond', 'Percent',
-     'MilliSeconds', 'ByteSeconds', 'Unspecified'
+     'MilliSeconds', 'ByteSeconds', 'Unspecified', 'Cores', 'MilliCores',
+     'NanoCores', 'BitsPerSecond'
     :type unit: str or ~azure.mgmt.monitor.v2018_01_01.models.Unit
     :param primary_aggregation_type: the primary aggregation type value
      defining how to use the values for display. Possible values include:

--- a/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_01_01/models/_models_py3.py
+++ b/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_01_01/models/_models_py3.py
@@ -113,7 +113,8 @@ class Metric(Model):
     :type name: ~azure.mgmt.monitor.v2018_01_01.models.LocalizableString
     :param unit: Required. the unit of the metric. Possible values include:
      'Count', 'Bytes', 'Seconds', 'CountPerSecond', 'BytesPerSecond',
-     'Percent', 'MilliSeconds', 'ByteSeconds', 'Unspecified'
+     'Percent', 'MilliSeconds', 'ByteSeconds', 'Unspecified', 'Cores',
+     'MilliCores', 'NanoCores', 'BitsPerSecond'
     :type unit: str or ~azure.mgmt.monitor.v2018_01_01.models.Unit
     :param timeseries: Required. the time series returned when a data query is
      performed.
@@ -185,7 +186,8 @@ class MetricDefinition(Model):
     :type name: ~azure.mgmt.monitor.v2018_01_01.models.LocalizableString
     :param unit: the unit of the metric. Possible values include: 'Count',
      'Bytes', 'Seconds', 'CountPerSecond', 'BytesPerSecond', 'Percent',
-     'MilliSeconds', 'ByteSeconds', 'Unspecified'
+     'MilliSeconds', 'ByteSeconds', 'Unspecified', 'Cores', 'MilliCores',
+     'NanoCores', 'BitsPerSecond'
     :type unit: str or ~azure.mgmt.monitor.v2018_01_01.models.Unit
     :param primary_aggregation_type: the primary aggregation type value
      defining how to use the values for display. Possible values include:

--- a/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_01_01/models/_monitor_management_client_enums.py
+++ b/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_01_01/models/_monitor_management_client_enums.py
@@ -23,6 +23,10 @@ class Unit(str, Enum):
     milli_seconds = "MilliSeconds"
     byte_seconds = "ByteSeconds"
     unspecified = "Unspecified"
+    cores = "Cores"
+    milli_cores = "MilliCores"
+    nano_cores = "NanoCores"
+    bits_per_second = "BitsPerSecond"
 
 
 class AggregationType(str, Enum):


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/6454