### PR TITLE
Disable network tracing in ServiceBus livetest and sample codes

### DIFF
--- a/sdk/servicebus/azure-servicebus/examples/async_examples/example_queue_send_receive_batch_async.py
+++ b/sdk/servicebus/azure-servicebus/examples/async_examples/example_queue_send_receive_batch_async.py
@@ -17,7 +17,7 @@ async def sample_queue_send_receive_batch_async(sb_config, queue):
         service_namespace=sb_config['hostname'],
         shared_access_key_name=sb_config['key_name'],
         shared_access_key_value=sb_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(queue)
     async with queue_client.get_sender() as sender:

--- a/sdk/servicebus/azure-servicebus/examples/async_examples/topic_send_async.py
+++ b/sdk/servicebus/azure-servicebus/examples/async_examples/topic_send_async.py
@@ -33,7 +33,7 @@ connection_str = os.environ['SERVICE_BUS_CONNECTION_STR']
 
 
 async def main():
-    topic_client = TopicClient.from_connection_string(connection_str, name="pytopic", debug=True)
+    topic_client = TopicClient.from_connection_string(connection_str, name="pytopic", debug=False)
     message = Message(b"sample topic message")
     await topic_client.send(message)
 

--- a/sdk/servicebus/azure-servicebus/examples/example_queue_send_receive_batch.py
+++ b/sdk/servicebus/azure-servicebus/examples/example_queue_send_receive_batch.py
@@ -17,7 +17,7 @@ def sample_queue_send_receive_batch(sb_config, queue):
         service_namespace=sb_config['hostname'],
         shared_access_key_name=sb_config['key_name'],
         shared_access_key_value=sb_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(queue)
     with queue_client.get_sender() as sender:

--- a/sdk/servicebus/azure-servicebus/examples/example_session_send_receive_batch.py
+++ b/sdk/servicebus/azure-servicebus/examples/example_session_send_receive_batch.py
@@ -18,7 +18,7 @@ def sample_session_send_receive_batch(sb_config, queue):
         service_namespace=sb_config['hostname'],
         shared_access_key_name=sb_config['key_name'],
         shared_access_key_value=sb_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(queue)
     with queue_client.get_sender(session=session_id) as sender:

--- a/sdk/servicebus/azure-servicebus/examples/example_session_send_receive_with_pool.py
+++ b/sdk/servicebus/azure-servicebus/examples/example_session_send_receive_with_pool.py
@@ -45,7 +45,7 @@ def sample_session_send_receive_with_pool(sb_config, queue):
         service_namespace=sb_config['hostname'],
         shared_access_key_name=sb_config['key_name'],
         shared_access_key_value=sb_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(queue)
     for session_id in sessions:

--- a/sdk/servicebus/azure-servicebus/examples/subscription_receive.py
+++ b/sdk/servicebus/azure-servicebus/examples/subscription_receive.py
@@ -32,7 +32,7 @@ connection_str = os.environ['SERVICE_BUS_CONNECTION_STR']
 if __name__ == '__main__':
 
     sub_client = SubscriptionClient.from_connection_string(
-        connection_str, name="pytopic/Subscriptions/pysub", debug=True)
+        connection_str, name="pytopic/Subscriptions/pysub", debug=False)
 
     with sub_client.get_receiver() as receiver:
         batch = receiver.fetch_next(timeout=10)

--- a/sdk/servicebus/azure-servicebus/examples/topic_send.py
+++ b/sdk/servicebus/azure-servicebus/examples/topic_send.py
@@ -33,7 +33,7 @@ connection_str = os.environ['SERVICE_BUS_CONNECTION_STR']
 
 if __name__ == '__main__':
 
-    topic_client = TopicClient.from_connection_string(connection_str, name="pytopic", debug=True)
+    topic_client = TopicClient.from_connection_string(connection_str, name="pytopic", debug=False)
     with topic_client.get_sender() as sender:
         message = Message(b"sample topic message")
         sender.send(message)

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -71,7 +71,7 @@ async def test_async_queue_by_queue_client_conn_str_receive_handler_peeklock(liv
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=standard_queue,
-        debug=True)
+        debug=False)
     queue_client.get_properties()
 
     async with queue_client.get_sender() as sender:
@@ -98,7 +98,7 @@ async def test_async_queue_by_queue_client_conn_str_receive_handler_receiveandde
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=standard_queue,
-        debug=True)
+        debug=False)
     queue_client.get_properties()
 
     async with queue_client.get_sender() as sender:
@@ -130,7 +130,7 @@ async def test_async_queue_by_queue_client_conn_str_receive_handler_with_stop(li
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=standard_queue,
-        debug=True)
+        debug=False)
 
     async with queue_client.get_sender() as sender:
         for i in range(10):
@@ -165,7 +165,7 @@ async def test_async_queue_by_servicebus_client_iter_messages_simple(live_servic
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     async with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock) as receiver:
@@ -193,7 +193,7 @@ async def test_async_queue_by_servicebus_client_iter_messages_simple(live_servic
 @pytest.mark.liveTest
 @pytest.mark.asyncio
 async def test_async_queue_by_servicebus_conn_str_client_iter_messages_with_abandon(live_servicebus_config, standard_queue):
-    client = ServiceBusClient.from_connection_string(live_servicebus_config['conn_str'], debug=True)
+    client = ServiceBusClient.from_connection_string(live_servicebus_config['conn_str'], debug=False)
 
     queue_client = client.get_queue(standard_queue)
     async with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock) as receiver:
@@ -230,7 +230,7 @@ async def test_async_queue_by_servicebus_client_iter_messages_with_defer(live_se
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     deferred_messages = []
@@ -264,7 +264,7 @@ async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_defe
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     deferred_messages = []
@@ -304,7 +304,7 @@ async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_defe
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     deferred_messages = []
@@ -339,7 +339,7 @@ async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_defe
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     deferred_messages = []
@@ -381,7 +381,7 @@ async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_defe
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     deferred_messages = []
@@ -415,7 +415,7 @@ async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_defe
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     deferred_messages = []
@@ -448,7 +448,7 @@ async def test_async_queue_by_servicebus_client_receive_batch_with_deadletter(li
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     async with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock, prefetch=10) as receiver:
@@ -484,7 +484,7 @@ async def test_async_queue_by_servicebus_client_receive_batch_with_retrieve_dead
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     async with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock, prefetch=10) as receiver:
@@ -523,7 +523,7 @@ async def test_async_queue_by_servicebus_client_session_fail(live_servicebus_con
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     with pytest.raises(ValueError):
@@ -539,7 +539,7 @@ async def test_async_queue_by_servicebus_client_browse_messages_client(live_serv
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     async with queue_client.get_sender() as sender:
@@ -562,7 +562,7 @@ async def test_async_queue_by_servicebus_client_browse_messages_with_receiver(li
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     async with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock) as receiver:
@@ -586,7 +586,7 @@ async def test_async_queue_by_servicebus_client_browse_empty_messages(live_servi
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     async with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock, prefetch=10) as receiver:
@@ -600,7 +600,7 @@ async def test_async_queue_by_servicebus_client_renew_message_locks(live_service
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     messages = []
@@ -637,7 +637,7 @@ async def test_async_queue_by_queue_client_conn_str_receive_handler_with_autoloc
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=standard_queue,
-        debug=True)
+        debug=False)
 
     async with queue_client.get_sender() as sender:
         for i in range(10):
@@ -685,7 +685,7 @@ async def test_async_queue_by_servicebus_client_fail_send_messages(live_serviceb
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     try:
         queue_client = client.get_queue(standard_queue)
@@ -721,7 +721,7 @@ async def test_async_queue_by_servicebus_client_fail_send_batch_messages(live_se
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     results = await queue_client.send(BatchMessage(batch_data()))
@@ -747,7 +747,7 @@ async def test_async_queue_message_time_to_live(live_servicebus_config, standard
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(standard_queue)
     
@@ -778,7 +778,7 @@ async def test_async_queue_message_duplicate_detection(live_servicebus_config, d
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     message_id = uuid.uuid4()
     queue_client = client.get_queue(duplicate_queue)
@@ -805,7 +805,7 @@ async def test_async_queue_message_connection_closed(live_servicebus_config, sta
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(standard_queue)
     
@@ -828,7 +828,7 @@ async def test_async_queue_message_expiry(live_servicebus_config, standard_queue
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(standard_queue)
     
@@ -861,7 +861,7 @@ async def test_async_queue_message_lock_renew(live_servicebus_config, standard_q
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(standard_queue)
     
@@ -892,7 +892,7 @@ async def test_async_queue_message_receive_and_delete(live_servicebus_config, st
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     queue_client = client.get_queue(standard_queue)
     
     async with queue_client.get_sender() as sender:
@@ -929,7 +929,7 @@ async def test_async_queue_message_batch(live_servicebus_config, standard_queue)
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     queue_client = client.get_queue(standard_queue)
     
     def message_content():
@@ -960,7 +960,7 @@ async def test_async_queue_schedule_message(live_servicebus_config, standard_que
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(standard_queue)
     enqueue_time = (datetime.utcnow() + timedelta(minutes=2)).replace(microsecond=0)
@@ -995,7 +995,7 @@ async def test_async_queue_schedule_multiple_messages(live_servicebus_config, st
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(standard_queue)
     enqueue_time = (datetime.utcnow() + timedelta(minutes=2)).replace(microsecond=0)
@@ -1037,7 +1037,7 @@ async def test_async_queue_cancel_scheduled_messages(live_servicebus_config, sta
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     enqueue_time = (datetime.utcnow() + timedelta(minutes=2)).replace(microsecond=0)

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
@@ -67,7 +67,7 @@ async def test_async_session_by_session_client_conn_str_receive_handler_peeklock
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=session_queue,
-        debug=True)
+        debug=False)
     queue_client.get_properties()
 
     session_id = str(uuid.uuid4())
@@ -95,7 +95,7 @@ async def test_async_session_by_queue_client_conn_str_receive_handler_receiveand
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=session_queue,
-        debug=True)
+        debug=False)
     queue_client.get_properties()
 
     session_id = str(uuid.uuid4())
@@ -129,7 +129,7 @@ async def test_async_session_by_session_client_conn_str_receive_handler_with_sto
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=session_queue,
-        debug=True)
+        debug=False)
 
     session_id = str(uuid.uuid4())
     async with queue_client.get_sender(session=session_id) as sender:
@@ -168,7 +168,7 @@ async def test_async_session_by_session_client_conn_str_receive_handler_with_no_
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=session_queue,
-        debug=True)
+        debug=False)
 
     session = queue_client.get_receiver(session=NEXT_AVAILABLE, idle_timeout=5)
     with pytest.raises(NoActiveSession):
@@ -180,7 +180,7 @@ async def test_async_session_by_session_client_conn_str_receive_handler_with_ina
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=session_queue,
-        debug=True)
+        debug=False)
 
     session_id = str(uuid.uuid4())
     messages = []
@@ -198,7 +198,7 @@ async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_de
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     deferred_messages = []
@@ -236,7 +236,7 @@ async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_de
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     deferred_messages = []
@@ -279,7 +279,7 @@ async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_de
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     deferred_messages = []
@@ -314,7 +314,7 @@ async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_de
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     deferred_messages = []
@@ -347,7 +347,7 @@ async def test_async_session_by_servicebus_client_fetch_next_with_retrieve_deadl
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     session_id = str(uuid.uuid4())
@@ -385,7 +385,7 @@ async def test_async_session_by_servicebus_client_browse_messages_client(live_se
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     session_id = str(uuid.uuid4())
@@ -412,7 +412,7 @@ async def test_async_session_by_servicebus_client_browse_messages_with_receiver(
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     session_id = str(uuid.uuid4())
@@ -437,7 +437,7 @@ async def test_async_session_by_servicebus_client_renew_client_locks(live_servic
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     session_id = str(uuid.uuid4())
@@ -479,7 +479,7 @@ async def test_async_session_by_conn_str_receive_handler_with_autolockrenew(live
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=session_queue,
-        debug=True)
+        debug=False)
 
     async with queue_client.get_sender(session=session_id) as sender:
         for i in range(10):
@@ -528,7 +528,7 @@ async def test_async_session_message_connection_closed(live_servicebus_config, s
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     session_id = str(uuid.uuid4())
     queue_client = client.get_queue(session_queue)
@@ -552,7 +552,7 @@ async def test_async_session_message_expiry(live_servicebus_config, session_queu
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     session_id = str(uuid.uuid4())
     queue_client = client.get_queue(session_queue)
     
@@ -590,7 +590,7 @@ async def test_async_session_schedule_message(live_servicebus_config, session_qu
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     session_id = str(uuid.uuid4())
     queue_client = client.get_queue(session_queue)
@@ -627,7 +627,7 @@ async def test_async_session_schedule_multiple_messages(live_servicebus_config, 
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     session_id = str(uuid.uuid4())
     queue_client = client.get_queue(session_queue)
@@ -667,7 +667,7 @@ async def test_async_session_cancel_scheduled_messages(live_servicebus_config, s
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     session_id = str(uuid.uuid4())
     queue_client = client.get_queue(session_queue)
@@ -700,7 +700,7 @@ async def test_async_session_get_set_state_with_receiver(live_servicebus_config,
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=session_queue,
-        debug=True)
+        debug=False)
 
     session_id = str(uuid.uuid4())
     queue_client.get_properties()
@@ -727,7 +727,7 @@ async def test_async_session_by_servicebus_client_list_sessions_with_receiver(li
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     sessions = []
@@ -756,7 +756,7 @@ async def test_async_session_by_servicebus_client_list_sessions_with_client(live
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     sessions = []
@@ -802,7 +802,7 @@ async def test_async_session_by_servicebus_client_session_pool(live_servicebus_c
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     for session_id in sessions:

--- a/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_queue_peeklock_send_receive_batch.py
+++ b/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_queue_peeklock_send_receive_batch.py
@@ -24,7 +24,7 @@ def message_send_process(sb_config, queue, endtime):
         service_namespace=sb_config['hostname'],
         shared_access_key_name=sb_config['key_name'],
         shared_access_key_value=sb_config['access_key'],
-        debug=True)
+        debug=False)
 
     total = 0
     queue_client = client.get_queue(queue)
@@ -42,7 +42,7 @@ def message_receive_process(sb_config, queue, endtime):
         service_namespace=sb_config['hostname'],
         shared_access_key_name=sb_config['key_name'],
         shared_access_key_value=sb_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(queue)
     with queue_client.get_receiver(idle_timeout=10, mode=ReceiveSettleMode.PeekLock, prefetch=10) as receiver:

--- a/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_queue_receivedelete_send_receive.py
+++ b/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_queue_receivedelete_send_receive.py
@@ -24,7 +24,7 @@ def message_send_process(sb_config, queue, endtime):
         service_namespace=sb_config['hostname'],
         shared_access_key_name=sb_config['key_name'],
         shared_access_key_value=sb_config['access_key'],
-        debug=True)
+        debug=False)
 
     total = 0
     queue_client = client.get_queue(queue)
@@ -42,7 +42,7 @@ def message_receive_process(sb_config, queue, endtime):
         service_namespace=sb_config['hostname'],
         shared_access_key_name=sb_config['key_name'],
         shared_access_key_value=sb_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(queue)
     with queue_client.get_receiver(idle_timeout=10, mode=ReceiveSettleMode.ReceiveAndDelete, prefetch=10) as receiver:

--- a/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_queue_receivedelete_send_receive_batch.py
+++ b/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_queue_receivedelete_send_receive_batch.py
@@ -24,7 +24,7 @@ def message_send_process(sb_config, queue, endtime):
         service_namespace=sb_config['hostname'],
         shared_access_key_name=sb_config['key_name'],
         shared_access_key_value=sb_config['access_key'],
-        debug=True)
+        debug=False)
 
     total = 0
     queue_client = client.get_queue(queue)
@@ -42,7 +42,7 @@ def message_receive_process(sb_config, queue, endtime):
         service_namespace=sb_config['hostname'],
         shared_access_key_name=sb_config['key_name'],
         shared_access_key_value=sb_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(queue)
     with queue_client.get_receiver(idle_timeout=10, mode=ReceiveSettleMode.ReceiveAndDelete, prefetch=10) as receiver:

--- a/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_queue_reconnect_send_receive.py
+++ b/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_queue_reconnect_send_receive.py
@@ -17,7 +17,7 @@ def message_send_process(sb_config, queue, endtime):
         service_namespace=sb_config['hostname'],
         shared_access_key_name=sb_config['key_name'],
         shared_access_key_value=sb_config['access_key'],
-        debug=True)
+        debug=False)
 
     total = 0
     queue_client = client.get_queue(queue)
@@ -33,7 +33,7 @@ def message_receive_process(sb_config, queue, endtime):
         service_namespace=sb_config['hostname'],
         shared_access_key_name=sb_config['key_name'],
         shared_access_key_value=sb_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(queue)
     total = 0

--- a/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_queue_slow_send_receive.py
+++ b/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_queue_slow_send_receive.py
@@ -18,7 +18,7 @@ def message_send_process(sb_config, queue, endtime):
         service_namespace=sb_config['hostname'],
         shared_access_key_name=sb_config['key_name'],
         shared_access_key_value=sb_config['access_key'],
-        debug=True)
+        debug=False)
 
     total = 0
     queue_client = client.get_queue(queue)
@@ -35,7 +35,7 @@ def message_receive_process(sb_config, queue, endtime):
         service_namespace=sb_config['hostname'],
         shared_access_key_name=sb_config['key_name'],
         shared_access_key_value=sb_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(queue)
     with queue_client.get_receiver(mode=ReceiveSettleMode.PeekLock) as receiver:

--- a/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_queue_slow_send_receive_batch.py
+++ b/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_queue_slow_send_receive_batch.py
@@ -18,7 +18,7 @@ def message_send_process(sb_config, queue, endtime):
         service_namespace=sb_config['hostname'],
         shared_access_key_name=sb_config['key_name'],
         shared_access_key_value=sb_config['access_key'],
-        debug=True)
+        debug=False)
 
     total = 0
     queue_client = client.get_queue(queue)
@@ -35,7 +35,7 @@ def message_receive_process(sb_config, queue, endtime):
         service_namespace=sb_config['hostname'],
         shared_access_key_name=sb_config['key_name'],
         shared_access_key_value=sb_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(queue)
     with queue_client.get_receiver(mode=ReceiveSettleMode.PeekLock) as receiver:

--- a/sdk/servicebus/azure-servicebus/tests/test_partitioned_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_partitioned_queues.py
@@ -63,7 +63,7 @@ def test_pqueue_by_queue_client_conn_str_receive_handler_peeklock(live_servicebu
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=partitioned_queue,
-        debug=True)
+        debug=False)
 
     with queue_client.get_sender() as sender:
         for i in range(10):
@@ -85,7 +85,7 @@ def test_pqueue_by_queue_client_conn_str_receive_handler_receiveanddelete(live_s
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=partitioned_queue,
-        debug=True)
+        debug=False)
 
     with queue_client.get_sender() as sender:
         for i in range(10):
@@ -115,7 +115,7 @@ def test_pqueue_by_queue_client_conn_str_receive_handler_with_stop(live_serviceb
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=partitioned_queue,
-        debug=True)
+        debug=False)
 
     with queue_client.get_sender() as sender:
         for i in range(10):
@@ -149,7 +149,7 @@ def test_pqueue_by_servicebus_client_iter_messages_simple(live_servicebus_config
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock) as receiver:
@@ -175,7 +175,7 @@ def test_pqueue_by_servicebus_client_iter_messages_simple(live_servicebus_config
 
 @pytest.mark.liveTest
 def test_pqueue_by_servicebus_conn_str_client_iter_messages_with_abandon(live_servicebus_config, partitioned_queue):
-    client = ServiceBusClient.from_connection_string(live_servicebus_config['conn_str'], debug=True)
+    client = ServiceBusClient.from_connection_string(live_servicebus_config['conn_str'], debug=False)
     queue_client = client.get_queue(partitioned_queue)
     with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock) as receiver:
 
@@ -210,7 +210,7 @@ def test_pqueue_by_servicebus_client_iter_messages_with_defer(live_servicebus_co
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     deferred_messages = []
@@ -244,7 +244,7 @@ def test_pqueue_by_servicebus_client_iter_messages_with_retrieve_deferred_client
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     deferred_messages = []
@@ -287,7 +287,7 @@ def test_pqueue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiv
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     deferred_messages = []
@@ -324,7 +324,7 @@ def test_pqueue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiv
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     deferred_messages = []
@@ -367,7 +367,7 @@ def test_pqueue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiv
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     deferred_messages = []
@@ -402,7 +402,7 @@ def test_pqueue_by_servicebus_client_iter_messages_with_retrieve_deferred_not_fo
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     deferred_messages = []
@@ -436,7 +436,7 @@ def test_pqueue_by_servicebus_client_receive_batch_with_deadletter(live_serviceb
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock, prefetch=10) as receiver:
@@ -472,7 +472,7 @@ def test_pqueue_by_servicebus_client_receive_batch_with_retrieve_deadletter(live
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock, prefetch=10) as receiver:
@@ -511,7 +511,7 @@ def test_pqueue_by_servicebus_client_session_fail(live_servicebus_config, partit
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     with pytest.raises(ValueError):
@@ -527,7 +527,7 @@ def test_pqueue_by_servicebus_client_browse_messages_client(live_servicebus_conf
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     with queue_client.get_sender() as sender:
@@ -551,7 +551,7 @@ def test_pqueue_by_servicebus_client_browse_messages_with_receiver(live_serviceb
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock) as receiver:
@@ -576,7 +576,7 @@ def test_pqueue_by_servicebus_client_browse_empty_messages(live_servicebus_confi
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock, prefetch=10) as receiver:
@@ -589,7 +589,7 @@ def test_pqueue_by_servicebus_client_fail_send_messages(live_servicebus_config, 
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     too_large = "A" * 1024 * 512
@@ -624,7 +624,7 @@ def test_pqueue_by_servicebus_client_fail_send_batch_messages(live_servicebus_co
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     results = queue_client.send(BatchMessage(batch_data()))
@@ -650,7 +650,7 @@ def test_pqueue_by_servicebus_client_renew_message_locks(live_servicebus_config,
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     messages = []
@@ -687,7 +687,7 @@ def test_pqueue_by_queue_client_conn_str_receive_handler_with_autolockrenew(live
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=partitioned_queue,
-        debug=True)
+        debug=False)
 
     with queue_client.get_sender() as sender:
         for i in range(10):
@@ -734,7 +734,7 @@ def test_pqueue_message_time_to_live(live_servicebus_config, partitioned_queue):
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(partitioned_queue)
     
@@ -764,7 +764,7 @@ def test_pqueue_message_connection_closed(live_servicebus_config, partitioned_qu
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(partitioned_queue)
     
@@ -787,7 +787,7 @@ def test_pqueue_message_expiry(live_servicebus_config, partitioned_queue):
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(partitioned_queue)
     
@@ -819,7 +819,7 @@ def test_pqueue_message_lock_renew(live_servicebus_config, partitioned_queue):
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(partitioned_queue)
     
@@ -849,7 +849,7 @@ def test_pqueue_message_receive_and_delete(live_servicebus_config, partitioned_q
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     queue_client = client.get_queue(partitioned_queue)
     
     with queue_client.get_sender() as sender:
@@ -886,7 +886,7 @@ def test_pqueue_message_batch(live_servicebus_config, partitioned_queue):
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     queue_client = client.get_queue(partitioned_queue)
     
     def message_content():
@@ -916,7 +916,7 @@ def test_pqueue_schedule_message(live_servicebus_config, partitioned_queue):
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(partitioned_queue)
     enqueue_time = (datetime.utcnow() + timedelta(minutes=2)).replace(microsecond=0)
@@ -950,7 +950,7 @@ def test_pqueue_schedule_multiple_messages(live_servicebus_config, partitioned_q
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(partitioned_queue)
     enqueue_time = (datetime.utcnow() + timedelta(minutes=2)).replace(microsecond=0)
@@ -988,7 +988,7 @@ def test_pqueue_cancel_scheduled_messages(live_servicebus_config, partitioned_qu
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_queue)
     enqueue_time = (datetime.utcnow() + timedelta(minutes=2)).replace(microsecond=0)

--- a/sdk/servicebus/azure-servicebus/tests/test_partitioned_sessions.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_partitioned_sessions.py
@@ -58,7 +58,7 @@ def test_qsession_by_session_client_conn_str_receive_handler_peeklock(live_servi
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=partitioned_session_queue,
-        debug=True)
+        debug=False)
     queue_client.get_properties()
 
     session_id = str(uuid.uuid4())
@@ -85,7 +85,7 @@ def test_qsession_by_queue_client_conn_str_receive_handler_receiveanddelete(live
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=partitioned_session_queue,
-        debug=True)
+        debug=False)
     queue_client.get_properties()
 
     session_id = str(uuid.uuid4())
@@ -118,7 +118,7 @@ def test_qsession_by_session_client_conn_str_receive_handler_with_stop(live_serv
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=partitioned_session_queue,
-        debug=True)
+        debug=False)
 
     session_id = str(uuid.uuid4())
     with queue_client.get_sender(session=session_id) as sender:
@@ -156,7 +156,7 @@ def test_qsession_by_session_client_conn_str_receive_handler_with_no_session(liv
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=partitioned_session_queue,
-        debug=True)
+        debug=False)
 
     session = queue_client.get_receiver(session=NEXT_AVAILABLE, idle_timeout=5)
     with pytest.raises(NoActiveSession):
@@ -167,7 +167,7 @@ def test_qsession_by_session_client_conn_str_receive_handler_with_inactive_sessi
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=partitioned_session_queue,
-        debug=True)
+        debug=False)
 
     session_id = str(uuid.uuid4())
     messages = []
@@ -184,7 +184,7 @@ def test_qsession_by_servicebus_client_iter_messages_with_retrieve_deferred_rece
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_session_queue)
     deferred_messages = []
@@ -223,7 +223,7 @@ def test_qsession_by_servicebus_client_iter_messages_with_retrieve_deferred_rece
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_session_queue)
     deferred_messages = []
@@ -267,7 +267,7 @@ def test_qsession_by_servicebus_client_iter_messages_with_retrieve_deferred_rece
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_session_queue)
     deferred_messages = []
@@ -303,7 +303,7 @@ def test_qsession_by_servicebus_client_iter_messages_with_retrieve_deferred_clie
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_session_queue)
     deferred_messages = []
@@ -336,7 +336,7 @@ def test_qsession_by_servicebus_client_fetch_next_with_retrieve_deadletter(live_
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_session_queue)
     session_id = str(uuid.uuid4())
@@ -373,7 +373,7 @@ def test_qsession_by_servicebus_client_browse_messages_client(live_servicebus_co
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_session_queue)
     session_id = str(uuid.uuid4())
@@ -401,7 +401,7 @@ def test_qsession_by_servicebus_client_browse_messages_with_receiver(live_servic
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_session_queue)
     session_id = str(uuid.uuid4())
@@ -426,7 +426,7 @@ def test_qsession_by_servicebus_client_renew_client_locks(live_servicebus_config
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_session_queue)
     session_id = str(uuid.uuid4())
@@ -467,7 +467,7 @@ def test_qsession_by_conn_str_receive_handler_with_autolockrenew(live_servicebus
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=partitioned_session_queue,
-        debug=True)
+        debug=False)
 
     with queue_client.get_sender(session=session_id) as sender:
         for i in range(10):
@@ -517,7 +517,7 @@ def test_qsession_message_connection_closed(live_servicebus_config, partitioned_
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     session_id = str(uuid.uuid4())
     queue_client = client.get_queue(partitioned_session_queue)
@@ -540,7 +540,7 @@ def test_qsession_message_expiry(live_servicebus_config, partitioned_session_que
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     session_id = str(uuid.uuid4())
     queue_client = client.get_queue(partitioned_session_queue)
     
@@ -577,7 +577,7 @@ def test_qsession_schedule_message(live_servicebus_config, partitioned_session_q
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     session_id = str(uuid.uuid4())
     queue_client = client.get_queue(partitioned_session_queue)
@@ -611,7 +611,7 @@ def test_qsession_schedule_multiple_messages(live_servicebus_config, partitioned
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     session_id = str(uuid.uuid4())
     queue_client = client.get_queue(partitioned_session_queue)
@@ -647,7 +647,7 @@ def test_qsession_cancel_scheduled_messages(live_servicebus_config, partitioned_
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     session_id = str(uuid.uuid4())
     queue_client = client.get_queue(partitioned_session_queue)
@@ -677,7 +677,7 @@ def test_qsession_get_set_state_with_receiver(live_servicebus_config, partitione
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=partitioned_session_queue,
-        debug=True)
+        debug=False)
     queue_client.get_properties()
     session_id = str(uuid.uuid4())
     with queue_client.get_sender(session=session_id) as sender:
@@ -702,7 +702,7 @@ def test_qsession_by_servicebus_client_list_sessions_with_receiver(live_serviceb
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_session_queue)
     sessions = []
@@ -731,7 +731,7 @@ def test_qsession_by_servicebus_client_list_sessions_with_client(live_servicebus
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_session_queue)
     sessions = []
@@ -776,7 +776,7 @@ def test_qsession_by_servicebus_client_session_pool(live_servicebus_config, part
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(partitioned_session_queue)
     sessions = [str(uuid.uuid4()) for i in range(concurrent_receivers)]

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -62,7 +62,7 @@ def test_queue_by_queue_client_conn_str_receive_handler_peeklock(live_servicebus
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=standard_queue,
-        debug=True)
+        debug=False)
 
     with queue_client.get_sender() as sender:
         for i in range(10):
@@ -84,7 +84,7 @@ def test_queue_by_queue_client_conn_str_receive_handler_receiveanddelete(live_se
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=standard_queue,
-        debug=True)
+        debug=False)
 
     with queue_client.get_sender() as sender:
         for i in range(10):
@@ -114,7 +114,7 @@ def test_queue_by_queue_client_conn_str_receive_handler_with_stop(live_servicebu
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=standard_queue,
-        debug=True)
+        debug=False)
 
     with queue_client.get_sender() as sender:
         for i in range(10):
@@ -148,7 +148,7 @@ def test_queue_by_servicebus_client_iter_messages_simple(live_servicebus_config,
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock) as receiver:
@@ -174,7 +174,7 @@ def test_queue_by_servicebus_client_iter_messages_simple(live_servicebus_config,
 
 @pytest.mark.liveTest
 def test_queue_by_servicebus_conn_str_client_iter_messages_with_abandon(live_servicebus_config, standard_queue):
-    client = ServiceBusClient.from_connection_string(live_servicebus_config['conn_str'], debug=True)
+    client = ServiceBusClient.from_connection_string(live_servicebus_config['conn_str'], debug=False)
     queue_client = client.get_queue(standard_queue)
     with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock) as receiver:
 
@@ -209,7 +209,7 @@ def test_queue_by_servicebus_client_iter_messages_with_defer(live_servicebus_con
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     deferred_messages = []
@@ -243,7 +243,7 @@ def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_client(
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     deferred_messages = []
@@ -283,7 +283,7 @@ def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receive
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     deferred_messages = []
@@ -318,7 +318,7 @@ def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receive
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     deferred_messages = []
@@ -359,7 +359,7 @@ def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receive
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     deferred_messages = []
@@ -392,7 +392,7 @@ def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_not_fou
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     deferred_messages = []
@@ -425,7 +425,7 @@ def test_queue_by_servicebus_client_receive_batch_with_deadletter(live_servicebu
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock, prefetch=10) as receiver:
@@ -461,7 +461,7 @@ def test_queue_by_servicebus_client_receive_batch_with_retrieve_deadletter(live_
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock, prefetch=10) as receiver:
@@ -500,7 +500,7 @@ def test_queue_by_servicebus_client_session_fail(live_servicebus_config, standar
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     with pytest.raises(ValueError):
@@ -516,7 +516,7 @@ def test_queue_by_servicebus_client_browse_messages_client(live_servicebus_confi
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     with queue_client.get_sender() as sender:
@@ -539,7 +539,7 @@ def test_queue_by_servicebus_client_browse_messages_with_receiver(live_servicebu
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock) as receiver:
@@ -563,7 +563,7 @@ def test_queue_by_servicebus_client_browse_empty_messages(live_servicebus_config
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     with queue_client.get_receiver(idle_timeout=5, mode=ReceiveSettleMode.PeekLock, prefetch=10) as receiver:
@@ -576,7 +576,7 @@ def test_queue_by_servicebus_client_fail_send_messages(live_servicebus_config, s
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     too_large = "A" * 1024 * 512
@@ -611,7 +611,7 @@ def test_queue_by_servicebus_client_fail_send_batch_messages(live_servicebus_con
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     results = queue_client.send(BatchMessage(batch_data()))
@@ -636,7 +636,7 @@ def test_queue_by_servicebus_client_renew_message_locks(live_servicebus_config, 
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     messages = []
@@ -672,7 +672,7 @@ def test_queue_by_queue_client_conn_str_receive_handler_with_autolockrenew(live_
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=standard_queue,
-        debug=True)
+        debug=False)
 
     with queue_client.get_sender() as sender:
         for i in range(10):
@@ -719,7 +719,7 @@ def test_queue_message_time_to_live(live_servicebus_config, standard_queue):
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(standard_queue)
     
@@ -749,7 +749,7 @@ def test_queue_message_duplicate_detection(live_servicebus_config, duplicate_que
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     message_id = uuid.uuid4()
     queue_client = client.get_queue(duplicate_queue)
@@ -775,7 +775,7 @@ def test_queue_message_connection_closed(live_servicebus_config, standard_queue)
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(standard_queue)
     
@@ -797,7 +797,7 @@ def test_queue_message_expiry(live_servicebus_config, standard_queue):
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(standard_queue)
     
@@ -829,7 +829,7 @@ def test_queue_message_lock_renew(live_servicebus_config, standard_queue):
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(standard_queue)
     
@@ -859,7 +859,7 @@ def test_queue_message_receive_and_delete(live_servicebus_config, standard_queue
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     queue_client = client.get_queue(standard_queue)
     
     with queue_client.get_sender() as sender:
@@ -896,7 +896,7 @@ def test_queue_message_batch(live_servicebus_config, standard_queue):
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     queue_client = client.get_queue(standard_queue)
     
     def message_content():
@@ -926,7 +926,7 @@ def test_queue_schedule_message(live_servicebus_config, standard_queue):
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(standard_queue)
     enqueue_time = (datetime.utcnow() + timedelta(minutes=2)).replace(microsecond=0)
@@ -960,7 +960,7 @@ def test_queue_schedule_multiple_messages(live_servicebus_config, standard_queue
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     queue_client = client.get_queue(standard_queue)
     enqueue_time = (datetime.utcnow() + timedelta(minutes=2)).replace(microsecond=0)
@@ -998,7 +998,7 @@ def test_queue_cancel_scheduled_messages(live_servicebus_config, standard_queue)
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(standard_queue)
     enqueue_time = (datetime.utcnow() + timedelta(minutes=2)).replace(microsecond=0)

--- a/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
@@ -28,7 +28,7 @@ def test_sb_client_bad_credentials(live_servicebus_config, standard_queue):
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name="invalid",
         shared_access_key_value="invalid",
-        debug=True)
+        debug=False)
 
     with pytest.raises(AzureHttpError):
         client.get_queue(standard_queue)
@@ -41,7 +41,7 @@ def test_sb_client_bad_namespace(live_servicebus_config):
         service_namespace="invalid",
         shared_access_key_name="invalid",
         shared_access_key_value="invalid",
-        debug=True)
+        debug=False)
 
     with pytest.raises(ServiceBusConnectionError):
         client.get_queue("testq")
@@ -53,7 +53,7 @@ def test_sb_client_bad_entity(live_servicebus_config):
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     with pytest.raises(ServiceBusResourceNotFound):
         client.get_queue("invalid")
@@ -68,7 +68,7 @@ def test_sb_client_entity_conflict(live_servicebus_config, standard_queue):
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     with pytest.raises(AzureConflictHttpError):
         client.create_queue(standard_queue)
@@ -83,7 +83,7 @@ def test_sb_client_entity_delete(live_servicebus_config, standard_queue):
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     with pytest.raises(ServiceBusResourceNotFound):
         client.delete_queue("invalid", fail_not_exist=True)
@@ -93,7 +93,7 @@ def test_sb_client_entity_delete(live_servicebus_config, standard_queue):
 
 @pytest.mark.liveTest
 def test_sb_client_readonly_credentials(servicebus_conn_str_readonly, standard_queue):
-    client = ServiceBusClient.from_connection_string(servicebus_conn_str_readonly, debug=True)
+    client = ServiceBusClient.from_connection_string(servicebus_conn_str_readonly, debug=False)
     with pytest.raises(AzureHttpError):
         client.get_queue(standard_queue)
 
@@ -110,7 +110,7 @@ def test_sb_client_writeonly_credentials(servicebus_conn_str_writeonly, standard
     with pytest.raises(AzureHttpError):
         client.get_queue(standard_queue)
 
-    client = QueueClient.from_connection_string(servicebus_conn_str_writeonly, name=standard_queue, debug=True)
+    client = QueueClient.from_connection_string(servicebus_conn_str_writeonly, name=standard_queue, debug=False)
     with pytest.raises(ServiceBusAuthorizationError):
         with client.get_receiver(idle_timeout=5) as receiver:
             messages = receiver.fetch_next()

--- a/sdk/servicebus/azure-servicebus/tests/test_sessions.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sessions.py
@@ -58,7 +58,7 @@ def test_session_by_session_client_conn_str_receive_handler_peeklock(live_servic
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=session_queue,
-        debug=True)
+        debug=False)
     queue_client.get_properties()
 
     session_id = str(uuid.uuid4())
@@ -85,7 +85,7 @@ def test_session_by_queue_client_conn_str_receive_handler_receiveanddelete(live_
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=session_queue,
-        debug=True)
+        debug=False)
     queue_client.get_properties()
 
     session_id = str(uuid.uuid4())
@@ -118,7 +118,7 @@ def test_session_by_session_client_conn_str_receive_handler_with_stop(live_servi
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=session_queue,
-        debug=True)
+        debug=False)
 
     session_id = str(uuid.uuid4())
     with queue_client.get_sender(session=session_id) as sender:
@@ -156,7 +156,7 @@ def test_session_by_session_client_conn_str_receive_handler_with_no_session(live
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=session_queue,
-        debug=True)
+        debug=False)
 
     session = queue_client.get_receiver(session=NEXT_AVAILABLE, idle_timeout=5)
     with pytest.raises(NoActiveSession):
@@ -167,7 +167,7 @@ def test_session_by_session_client_conn_str_receive_handler_with_inactive_sessio
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=session_queue,
-        debug=True)
+        debug=False)
 
     session_id = str(uuid.uuid4())
     messages = []
@@ -184,7 +184,7 @@ def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_recei
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     deferred_messages = []
@@ -221,7 +221,7 @@ def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_recei
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     deferred_messages = []
@@ -263,7 +263,7 @@ def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_recei
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     deferred_messages = []
@@ -297,7 +297,7 @@ def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_clien
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     deferred_messages = []
@@ -330,7 +330,7 @@ def test_session_by_servicebus_client_fetch_next_with_retrieve_deadletter(live_s
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     session_id = str(uuid.uuid4())
@@ -367,7 +367,7 @@ def test_session_by_servicebus_client_browse_messages_client(live_servicebus_con
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     session_id = str(uuid.uuid4())
@@ -394,7 +394,7 @@ def test_session_by_servicebus_client_browse_messages_with_receiver(live_service
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     session_id = str(uuid.uuid4())
@@ -418,7 +418,7 @@ def test_session_by_servicebus_client_renew_client_locks(live_servicebus_config,
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     session_id = str(uuid.uuid4())
@@ -459,7 +459,7 @@ def test_session_by_conn_str_receive_handler_with_autolockrenew(live_servicebus_
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=session_queue,
-        debug=True)
+        debug=False)
 
     with queue_client.get_sender(session=session_id) as sender:
         for i in range(10):
@@ -509,7 +509,7 @@ def test_session_message_connection_closed(live_servicebus_config, session_queue
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     session_id = str(uuid.uuid4())
     queue_client = client.get_queue(session_queue)
@@ -532,7 +532,7 @@ def test_session_message_expiry(live_servicebus_config, session_queue):
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     session_id = str(uuid.uuid4())
     queue_client = client.get_queue(session_queue)
     
@@ -569,7 +569,7 @@ def test_session_schedule_message(live_servicebus_config, session_queue):
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     session_id = str(uuid.uuid4())
     queue_client = client.get_queue(session_queue)
@@ -603,7 +603,7 @@ def test_session_schedule_multiple_messages(live_servicebus_config, session_queu
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
     import uuid
     session_id = str(uuid.uuid4())
     queue_client = client.get_queue(session_queue)
@@ -642,7 +642,7 @@ def test_session_cancel_scheduled_messages(live_servicebus_config, session_queue
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     session_id = str(uuid.uuid4())
     queue_client = client.get_queue(session_queue)
@@ -669,7 +669,7 @@ def test_session_get_set_state_with_receiver(live_servicebus_config, session_que
     queue_client = QueueClient.from_connection_string(
         live_servicebus_config['conn_str'],
         name=session_queue,
-        debug=True)
+        debug=False)
     queue_client.get_properties()
     session_id = str(uuid.uuid4())
     with queue_client.get_sender(session=session_id) as sender:
@@ -694,7 +694,7 @@ def test_session_by_servicebus_client_list_sessions_with_receiver(live_servicebu
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     sessions = []
@@ -723,7 +723,7 @@ def test_session_by_servicebus_client_list_sessions_with_client(live_servicebus_
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     sessions = []
@@ -768,7 +768,7 @@ def test_session_by_servicebus_client_session_pool(live_servicebus_config, sessi
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     queue_client = client.get_queue(session_queue)
     sessions = [str(uuid.uuid4()) for i in range(concurrent_receivers)]

--- a/sdk/servicebus/azure-servicebus/tests/test_subscriptions.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_subscriptions.py
@@ -36,12 +36,12 @@ _logger = get_logger(logging.DEBUG)
 @pytest.mark.liveTest
 def test_subscription_by_subscription_client_conn_str_receive_basic(live_servicebus_config, standard_subscription):
     topic_name, subscription_name = standard_subscription
-    topic_client = TopicClient.from_connection_string(live_servicebus_config['conn_str'], name=topic_name, debug=True)
+    topic_client = TopicClient.from_connection_string(live_servicebus_config['conn_str'], name=topic_name, debug=False)
     with topic_client.get_sender() as sender:
         message = Message(b"Sample topic message")
         sender.send(message)
 
-    sub_client = SubscriptionClient.from_connection_string(live_servicebus_config['conn_str'], subscription_name, topic=topic_name, debug=True)
+    sub_client = SubscriptionClient.from_connection_string(live_servicebus_config['conn_str'], subscription_name, topic=topic_name, debug=False)
     with sub_client.get_receiver(idle_timeout=5) as receiver:
         count = 0
         for message in receiver:
@@ -56,7 +56,7 @@ def test_subscription_by_servicebus_client_conn_str_send_basic(live_servicebus_c
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     topic_client = client.get_topic(topic_name)
     sub_client = client.get_subscription(topic_name, subscription_name)
@@ -79,7 +79,7 @@ def test_subscription_by_servicebus_client_list_subscriptions(live_servicebus_co
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     subs = client.list_subscriptions(topic_name)
     assert len(subs) >= 1
@@ -91,6 +91,6 @@ def test_subscription_by_servicebus_client_list_subscriptions(live_servicebus_co
 def test_subscription_by_subscription_client_conn_str_send_fail(live_servicebus_config, standard_subscription):
     topic_name, subscription_name = standard_subscription
 
-    sub_client = SubscriptionClient.from_connection_string(live_servicebus_config['conn_str'], subscription_name, topic=topic_name, debug=True)
+    sub_client = SubscriptionClient.from_connection_string(live_servicebus_config['conn_str'], subscription_name, topic=topic_name, debug=False)
     with pytest.raises(AttributeError):
         sub_client.get_sender()

--- a/sdk/servicebus/azure-servicebus/tests/test_topics.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_topics.py
@@ -36,7 +36,7 @@ _logger = get_logger(logging.DEBUG)
 @pytest.mark.liveTest
 def test_topic_by_topic_client_conn_str_send_basic(live_servicebus_config, standard_topic):
 
-    topic_client = TopicClient.from_connection_string(live_servicebus_config['conn_str'], name=standard_topic, debug=True)
+    topic_client = TopicClient.from_connection_string(live_servicebus_config['conn_str'], name=standard_topic, debug=False)
     with topic_client.get_sender() as sender:
         message = Message(b"Sample topic message")
         sender.send(message)
@@ -50,7 +50,7 @@ def test_topic_by_servicebus_client_conn_str_send_basic(live_servicebus_config, 
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     topic_client = client.get_topic(standard_topic)
     with topic_client.get_sender() as sender:
@@ -66,7 +66,7 @@ def test_topic_by_servicebus_client_list_topics(live_servicebus_config, standard
         service_namespace=live_servicebus_config['hostname'],
         shared_access_key_name=live_servicebus_config['key_name'],
         shared_access_key_value=live_servicebus_config['access_key'],
-        debug=True)
+        debug=False)
 
     topics = client.list_topics()
     assert len(topics) >= 1
@@ -74,6 +74,6 @@ def test_topic_by_servicebus_client_list_topics(live_servicebus_config, standard
 
 @pytest.mark.liveTest
 def test_topic_by_topic_client_conn_str_receive_fail(live_servicebus_config, standard_topic):
-    topic_client = TopicClient.from_connection_string(live_servicebus_config['conn_str'], name=standard_topic, debug=True)
+    topic_client = TopicClient.from_connection_string(live_servicebus_config['conn_str'], name=standard_topic, debug=False)
     with pytest.raises(AttributeError):
         topic_client.get_receiver()


### PR DESCRIPTION
Disable debug in livetest and sample codes as it would causes segmentation fault in macos.