### PR TITLE
Bryanv/cosmos api followup

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client.py
@@ -141,7 +141,7 @@ class CosmosClient:
             response_hook(self.client_connection.last_response_headers)
         return Database(self.client_connection, id=result["id"], properties=result)
 
-    def get_database(
+    def get_database_client(
         self,
         database
     ):

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
@@ -283,7 +283,7 @@ class Database(object):
         if response_hook:
             response_hook(self.client_connection.last_response_headers, result)
 
-    def get_container(
+    def get_container_client(
         self,
         container,
     ):

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
@@ -556,7 +556,7 @@ class Database(object):
         return result
 
 
-    def get_user(
+    def get_user_client(
             self,
             user,
     ):

--- a/sdk/cosmos/azure-cosmos/samples/CollectionManagement/Program.py
+++ b/sdk/cosmos/azure-cosmos/samples/CollectionManagement/Program.py
@@ -204,7 +204,7 @@ class ContainerManagement:
         
         try:
             # read the container, so we can get its _self
-            container = db.get_container(container=id)
+            container = db.get_container_client(container=id)
 
             # now use its _self to query for Offers
             offer = container.read_offer()
@@ -230,7 +230,7 @@ class ContainerManagement:
         print("\n4. Get a Container by id")
 
         try:
-            container = db.get_container(id)
+            container = db.get_container_client(id)
             print('Container with id \'{0}\' was found, it\'s link is {1}'.format(container.id, container.container_link))
 
         except errors.HTTPFailure as e:

--- a/sdk/cosmos/azure-cosmos/samples/DatabaseManagement/Program.py
+++ b/sdk/cosmos/azure-cosmos/samples/DatabaseManagement/Program.py
@@ -79,7 +79,7 @@ class DatabaseManagement:
         print("\n3. Get a Database by id")
 
         try:
-            database = client.get_database(id)
+            database = client.get_database_client(id)
             print('Database with id \'{0}\' was found, it\'s link is {1}'.format(id, database.database_link))
 
         except errors.HTTPFailure as e:

--- a/sdk/cosmos/azure-cosmos/samples/IndexManagement/Program.py
+++ b/sdk/cosmos/azure-cosmos/samples/IndexManagement/Program.py
@@ -86,7 +86,7 @@ def CreateDatabaseIfNotExists(client, database_id):
         database = Query_Entities(client, 'database', id = database_id)
         if database == None:
             database = client.create_database(id=database_id)
-        return client.get_database(database['id'])
+        return client.get_database_client(database['id'])
     except errors.HTTPFailure as e:
         if e.status_code == 409: # Move these constants to an enum
             pass

--- a/sdk/cosmos/azure-cosmos/samples/NonPartitionedCollectionOperations/Program.py
+++ b/sdk/cosmos/azure-cosmos/samples/NonPartitionedCollectionOperations/Program.py
@@ -97,7 +97,7 @@ class ItemManagement:
             # python 3 compatible: convert data from byte to unicode string
             data = data.decode('utf-8')
         data = json.loads(data)
-        created_collection = db.get_container(data['id'])
+        created_collection = db.get_container_client(data['id'])
 
         # Create a document in the non partitioned collection using the rest API and older version
         resource_url = base_url_split[0] + ":" + base_url_split[1] + ":" + base_url_split[2].split("/")[0] \

--- a/sdk/cosmos/azure-cosmos/test/crud_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/crud_tests.py
@@ -124,12 +124,12 @@ class CRUDTests(unittest.TestCase):
                      'number of results for the query should be > 0')
 
         # read database.
-        self.client.get_database(created_db.id)
+        self.client.get_database_client(created_db.id)
 
         # delete database.
         self.client.delete_database(created_db.id)
         # read database after deletion
-        read_db = self.client.get_database(created_db.id)
+        read_db = self.client.get_database_client(created_db.id)
         self.__AssertHTTPFailureWithStatus(StatusCodes.NOT_FOUND,
                                            read_db.read)
 
@@ -2380,15 +2380,15 @@ class CRUDTests(unittest.TestCase):
         created_db = self.databaseForTest
 
         # read database with id
-        read_db = self.client.get_database(created_db.id)
+        read_db = self.client.get_database_client(created_db.id)
         self.assertEquals(read_db.id, created_db.id)
 
         # read database with instance
-        read_db = self.client.get_database(created_db)
+        read_db = self.client.get_database_client(created_db)
         self.assertEquals(read_db.id, created_db.id)
 
         # read database with properties
-        read_db = self.client.get_database(created_db.read())
+        read_db = self.client.get_database_client(created_db.read())
         self.assertEquals(read_db.id, created_db.id)
 
         created_container = self.configs.create_multi_partition_collection_if_not_exist(self.client)

--- a/sdk/cosmos/azure-cosmos/test/crud_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/crud_tests.py
@@ -228,7 +228,7 @@ class CRUDTests(unittest.TestCase):
         # delete collection
         created_db.delete_container(created_collection.id)
         # read collection after deletion
-        created_container = created_db.get_container(created_collection.id)
+        created_container = created_db.get_container_client(created_collection.id)
         self.__AssertHTTPFailureWithStatus(StatusCodes.NOT_FOUND,
                                            created_container.read)
 
@@ -269,7 +269,7 @@ class CRUDTests(unittest.TestCase):
 
         created_collection = self.configs.create_multi_partition_collection_if_not_exist(self.client)
 
-        retrieved_collection = created_db.get_container(
+        retrieved_collection = created_db.get_container_client(
             container=created_collection.id
         )
 
@@ -1370,7 +1370,7 @@ class CRUDTests(unittest.TestCase):
         old_client_connection = db.client_connection
         db.client_connection = col1_client.client_connection
         # 1. Success-- Use Col1 Permission to Read
-        success_coll1 = db.get_container(container=entities['coll1'])
+        success_coll1 = db.get_container_client(container=entities['coll1'])
         # 2. Failure-- Use Col1 Permission to delete
         self.__AssertHTTPFailureWithStatus(StatusCodes.FORBIDDEN,
                                            db.delete_container,
@@ -2234,7 +2234,7 @@ class CRUDTests(unittest.TestCase):
             id='test_index_progress_headers consistent_coll ' + str(uuid.uuid4()),
             partition_key=PartitionKey(path="/id", kind='Hash'),
         )
-        created_container = created_db.get_container(container=consistent_coll)
+        created_container = created_db.get_container_client(container=consistent_coll)
         created_container.read(populate_quota_info=True)
         self.assertFalse(HttpHeaders.LazyIndexingProgress in created_db.client_connection.last_response_headers)
         self.assertTrue(HttpHeaders.IndexTransformationProgress in created_db.client_connection.last_response_headers)
@@ -2244,7 +2244,7 @@ class CRUDTests(unittest.TestCase):
             indexing_policy={'indexingMode': documents.IndexingMode.Lazy},
             partition_key=PartitionKey(path="/id", kind='Hash')
         )
-        created_container = created_db.get_container(container=lazy_coll)
+        created_container = created_db.get_container_client(container=lazy_coll)
         created_container.read(populate_quota_info=True)
         self.assertTrue(HttpHeaders.LazyIndexingProgress in created_db.client_connection.last_response_headers)
         self.assertTrue(HttpHeaders.IndexTransformationProgress in created_db.client_connection.last_response_headers)
@@ -2257,7 +2257,7 @@ class CRUDTests(unittest.TestCase):
             },
             partition_key=PartitionKey(path="/id", kind='Hash')
         )
-        created_container = created_db.get_container(container=none_coll)
+        created_container = created_db.get_container_client(container=none_coll)
         created_container.read(populate_quota_info=True)
         self.assertFalse(HttpHeaders.LazyIndexingProgress in created_db.client_connection.last_response_headers)
         self.assertTrue(HttpHeaders.IndexTransformationProgress in created_db.client_connection.last_response_headers)
@@ -2394,16 +2394,16 @@ class CRUDTests(unittest.TestCase):
         created_container = self.configs.create_multi_partition_collection_if_not_exist(self.client)
 
         # read container with id
-        read_container = created_db.get_container(created_container.id)
+        read_container = created_db.get_container_client(created_container.id)
         self.assertEquals(read_container.id, created_container.id)
 
         # read container with instance
-        read_container = created_db.get_container(created_container)
+        read_container = created_db.get_container_client(created_container)
         self.assertEquals(read_container.id, created_container.id)
 
         # read container with properties
         created_properties = created_container.read()
-        read_container = created_db.get_container(created_properties)
+        read_container = created_db.get_container_client(created_properties)
         self.assertEquals(read_container.id, created_container.id)
 
         created_item = created_container.create_item({'id':'1' + str(uuid.uuid4())})

--- a/sdk/cosmos/azure-cosmos/test/crud_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/crud_tests.py
@@ -1070,12 +1070,12 @@ class CRUDTests(unittest.TestCase):
                          replaced_user.id,
                          'user id should stay the same')
         # read user
-        user = db.get_user(replaced_user.id)
+        user = db.get_user_client(replaced_user.id)
         self.assertEqual(replaced_user.id, user.id)
         # delete user
         db.delete_user(user.id)
         # read user after deletion
-        deleted_user = db.get_user(user.id)
+        deleted_user = db.get_user_client(user.id)
         self.__AssertHTTPFailureWithStatus(StatusCodes.NOT_FOUND,
                                            deleted_user.read)
 
@@ -2462,16 +2462,16 @@ class CRUDTests(unittest.TestCase):
         })
 
         # read user with id
-        read_user = created_db.get_user(created_user.id)
+        read_user = created_db.get_user_client(created_user.id)
         self.assertEquals(read_user.id, created_user.id)
 
         # read user with instance
-        read_user = created_db.get_user(created_user)
+        read_user = created_db.get_user_client(created_user)
         self.assertEquals(read_user.id, created_user.id)
 
         # read user with properties
         created_user_properties = created_user.read()
-        read_user = created_db.get_user(created_user_properties)
+        read_user = created_db.get_user_client(created_user_properties)
         self.assertEquals(read_user.id, created_user.id)
 
         created_permission = created_user.create_permission({

--- a/sdk/cosmos/azure-cosmos/test/diagnostics_unit_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/diagnostics_unit_tests.py
@@ -4,7 +4,6 @@ import azure.cosmos.diagnostics as m
 
 _common = {
     'x-ms-activity-id',
-    'x-ms-request-charge',
     'x-ms-session-token',
 
     'x-ms-item-count',

--- a/sdk/cosmos/azure-cosmos/test/partition_key_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/partition_key_tests.py
@@ -122,7 +122,7 @@ class PartitionKeyTests(unittest.TestCase):
         return authorization
 
     def test_non_partitioned_collection_operations(self):
-        created_container = self.created_db.get_container(self.created_collection_id)
+        created_container = self.created_db.get_container_client(self.created_collection_id)
 
         # Pass partitionKey.Empty as partition key to access documents from a single partition collection with v 2018-12-31 SDK
         read_item = created_container.read_item(self.created_document['id'], partition_key=partition_key.NonePartitionKeyValue)

--- a/sdk/cosmos/azure-cosmos/test/session_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/session_tests.py
@@ -36,7 +36,7 @@ class SessionTests(unittest.TestCase):
         created_document = self.created_collection.create_item(body={'id': '1' + str(uuid.uuid4()), 'pk': 'mypk'})
         self.created_collection.read_item(item=created_document['id'], partition_key='mypk')
         self.assertNotEqual(self.last_session_token_sent, None)
-        self.created_db.get_container(container=self.created_collection).read()
+        self.created_db.get_container_client(container=self.created_collection).read()
         self.assertEqual(self.last_session_token_sent, None)
         self.created_collection.read_item(item=created_document['id'], partition_key='mypk')
         self.assertNotEqual(self.last_session_token_sent, None)


### PR DESCRIPTION
This PR makes the following renames:

* `get_database` -> `get_database_client`
* `get_container` -> `get_container_client`
* `get_user `-> `get_user_client`

As discussed after the UX study results. 

Additionally, an issue with the diagnostic test is fixed (change was dropped somewhere, somehow)