### PR TITLE
[AutoPR monitor/resource-manager] BUG fix: Fixing type of MetricValue.Count to be double instead of the incorrect int64 it had before

### DIFF
--- a/sdk/monitor/azure-mgmt-monitor/README.rst
+++ b/sdk/monitor/azure-mgmt-monitor/README.rst
@@ -6,7 +6,7 @@ This is the Microsoft Azure Monitor Client Library.
 Azure Resource Manager (ARM) is the next generation of management APIs that
 replace the old Azure Service Management (ASM).
 
-This package has been tested with Python 2.7, 3.4, 3.5, 3.6 and 3.7.
+This package has been tested with Python 2.7, 3.5, 3.6 and 3.7.
 
 For the older Azure Service Management (ASM) libraries, see
 `azure-servicemanagement-legacy <https://pypi.python.org/pypi/azure-servicemanagement-legacy>`__ library.

--- a/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2015_04_01/operations/_activity_logs_operations.py
+++ b/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2015_04_01/operations/_activity_logs_operations.py
@@ -39,11 +39,12 @@ class ActivityLogsOperations(object):
         self.config = config
 
     def list(
-            self, filter=None, select=None, custom_headers=None, raw=False, **operation_config):
+            self, filter, select=None, custom_headers=None, raw=False, **operation_config):
         """Provides the list of records from the activity logs.
 
-        :param filter: Reduces the set of data collected.<br>The **$filter**
-         argument is very restricted and allows only the following
+        :param filter: Reduces the set of data collected.<br>This argument is
+         required and it also requires at least the start date/time.<br>The
+         **$filter** argument is very restricted and allows only the following
          patterns.<br>- *List events for a resource group*:
          $filter=eventTimestamp ge '2014-07-16T04:36:37.6407898Z' and
          eventTimestamp le '2014-07-20T04:36:37.6407898Z' and resourceGroupName
@@ -93,8 +94,7 @@ class ActivityLogsOperations(object):
                 # Construct parameters
                 query_parameters = {}
                 query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
-                if filter is not None:
-                    query_parameters['$filter'] = self._serialize.query("filter", filter, 'str')
+                query_parameters['$filter'] = self._serialize.query("filter", filter, 'str')
                 if select is not None:
                     query_parameters['$select'] = self._serialize.query("select", select, 'str')
 

--- a/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_01_01/models/_models.py
+++ b/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_01_01/models/_models.py
@@ -255,7 +255,7 @@ class MetricValue(Model):
     :type total: float
     :param count: the number of samples in the time range. Can be used to
      determine the number of values that contributed to the average value.
-    :type count: long
+    :type count: float
     """
 
     _validation = {
@@ -268,7 +268,7 @@ class MetricValue(Model):
         'minimum': {'key': 'minimum', 'type': 'float'},
         'maximum': {'key': 'maximum', 'type': 'float'},
         'total': {'key': 'total', 'type': 'float'},
-        'count': {'key': 'count', 'type': 'long'},
+        'count': {'key': 'count', 'type': 'float'},
     }
 
     def __init__(self, **kwargs):

--- a/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_01_01/models/_models_py3.py
+++ b/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_01_01/models/_models_py3.py
@@ -255,7 +255,7 @@ class MetricValue(Model):
     :type total: float
     :param count: the number of samples in the time range. Can be used to
      determine the number of values that contributed to the average value.
-    :type count: long
+    :type count: float
     """
 
     _validation = {
@@ -268,10 +268,10 @@ class MetricValue(Model):
         'minimum': {'key': 'minimum', 'type': 'float'},
         'maximum': {'key': 'maximum', 'type': 'float'},
         'total': {'key': 'total', 'type': 'float'},
-        'count': {'key': 'count', 'type': 'long'},
+        'count': {'key': 'count', 'type': 'float'},
     }
 
-    def __init__(self, *, time_stamp, average: float=None, minimum: float=None, maximum: float=None, total: float=None, count: int=None, **kwargs) -> None:
+    def __init__(self, *, time_stamp, average: float=None, minimum: float=None, maximum: float=None, total: float=None, count: float=None, **kwargs) -> None:
         super(MetricValue, self).__init__(**kwargs)
         self.time_stamp = time_stamp
         self.average = average

--- a/sdk/monitor/azure-mgmt-monitor/setup.py
+++ b/sdk/monitor/azure-mgmt-monitor/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/6485