### PR TITLE
properly ignoring all of cognitive services missing tests

### DIFF
--- a/scripts/devops_tasks/setup_execute_tests.py
+++ b/scripts/devops_tasks/setup_execute_tests.py
@@ -22,7 +22,7 @@ dev_setup_script_location = os.path.join(root_dir, 'scripts/dev_setup.py')
 # evaluating whether we want this or not.
 ALLOWED_RETURN_CODES = []
 
-MANAGEMENT_PACKAGE_IDENTIFIERS = ['mgmt', 'azure-cognitiveservices-personalizer', 'azure-servicefabric']
+MANAGEMENT_PACKAGE_IDENTIFIERS = ['mgmt', 'azure-cognitiveservices', 'azure-servicefabric']
 
 def prep_and_run_tests(targeted_packages, python_version, test_res):
     print('running test setup for {}'.format(targeted_packages))


### PR DESCRIPTION
azure-cognitiveservices-* shouldn't _demand_ tests. They are all management generated right now.