### PR TITLE
Fix failure to parse UTF8 files with BOM

### DIFF
--- a/scripts/analyze_deps.py
+++ b/scripts/analyze_deps.py
@@ -101,7 +101,7 @@ def parse_setup(setup_filename):
         __setup_calls__.append((args, kwargs))
     ''')
     parsed_mock_setup = ast.parse(mock_setup, filename=setup_filename)
-    with open(setup_filename, 'rt') as setup_file:
+    with io.open(setup_filename, 'r', encoding='utf-8-sig') as setup_file:
         parsed = ast.parse(setup_file.read())
         for index, node in enumerate(parsed.body[:]):
             if (
@@ -232,7 +232,7 @@ if __name__ == '__main__':
             print('Unable to freeze requirements due to incompatible dependency versions')
             sys.exit(exitcode)
         else:
-            with open(frozen_filename, 'w') as frozen_file:
+            with io.open(frozen_filename, 'w', encoding='utf-8') as frozen_file:
                 for requirement in sorted(dependencies.keys()):
                     spec = list(dependencies[requirement].keys())[0]
                     if spec == '':
@@ -243,7 +243,7 @@ if __name__ == '__main__':
 
     frozen = {}
     try:
-        with open(frozen_filename, 'r') as frozen_file:
+        with io.open(frozen_filename, 'r', encoding='utf-8-sig') as frozen_file:
             for line in frozen_file:
                 req_name, spec = parse_req(line)
                 frozen[req_name] = [spec]

--- a/sdk/cosmos/azure-cosmos/setup.py
+++ b/sdk/cosmos/azure-cosmos/setup.py
@@ -12,7 +12,7 @@ setup(name='azure-cosmos',
       maintainer_email="askdocdb@microsoft.com",
       url="https://github.com/Azure/azure-documentdb-python",
       license='MIT',
-      install_requires=['six >=1.6', 'requests>=2.10.0'],
+      install_requires=['six >=1.6', 'requests>=2.18.4'],
       classifiers=[
         'License :: OSI Approved :: MIT License',
         'Intended Audience :: Developers',

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -97,3 +97,4 @@ certifi>=2017.4.17
 aiohttp>=3.0
 aiodns>=2.0
 python-dateutil>=2.8.0
+six>=1.6


### PR DESCRIPTION
The setup.py for azure-cosmos contains a BOM which was causing our parser to bail out. Unfortunately some dependency inconsistencies were introduced in azure-cosmos which we never caught because of this bug. This fixes the bug but builds will fail due to the broken dependencies in azure-cosmos.