### PR TITLE
Expand test coverage

### DIFF
--- a/sdk/identity/azure-identity/dev_requirements.txt
+++ b/sdk/identity/azure-identity/dev_requirements.txt
@@ -1,5 +1,4 @@
 -e ../../core/azure-core
 typing_extensions>=3.7.2
-httpretty
 pytest
 pytest-asyncio;python_full_version>="3.5.2"

--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -10,17 +10,10 @@ except ImportError:  # python < 3.3
     import mock  # type: ignore
 
 
-def mock_response(status_code=200, headers={}, payload=None):
-    response = mock.Mock(status_code=status_code, headers=headers)
-    if payload is not None:
-        response.text = lambda: json.dumps(payload)
-        response.headers["content-type"] = "application/json"
-        response.content_type = ["application/json"]
-    return response
-
-
 class Request:
-    def __init__(self, url=None, url_substring=None, method=None, required_headers={}, required_data={}, required_params={}):
+    def __init__(
+        self, url=None, url_substring=None, method=None, required_headers={}, required_data={}, required_params={}
+    ):
         self.method = method
         self.url = url
         self.url_substring = url_substring
@@ -41,6 +34,15 @@ class Request:
             assert request.headers.get(header) == expected_value
         for field, expected_value in self.required_data.items():
             assert request.body.get(field) == expected_value
+
+
+def mock_response(status_code=200, headers={}, json_payload=None):
+    response = mock.Mock(status_code=status_code, headers=headers)
+    if json_payload is not None:
+        response.text = lambda: json.dumps(json_payload)
+        response.headers["content-type"] = "application/json"
+        response.content_type = ["application/json"]
+    return response
 
 
 def validating_transport(requests, responses):

--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -44,9 +44,7 @@ def validating_transport(requests, responses):
         raise ValueError("each request must have one response")
 
     sessions = zip(requests, responses)
-    if isinstance(sessions, list):
-        # 2.7's zip returns a list
-        sessions = (s for s in sessions)
+    sessions = (s for s in sessions)  # 2.7's zip returns a list, and nesting a generator doesn't break it for 3.x
 
     def validate_request(request, **kwargs):
         expected_request, response = next(sessions)
@@ -54,3 +52,15 @@ def validating_transport(requests, responses):
         return response
 
     return mock.Mock(send=validate_request)
+
+
+try:
+    import asyncio
+
+    def async_validating_transport(requests, responses):
+        sync_transport = validating_transport(requests, responses)
+        return mock.Mock(send=asyncio.coroutine(sync_transport.send))
+
+
+except ImportError:
+    pass

--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -1,0 +1,56 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import json
+
+try:
+    from unittest import mock
+except ImportError:  # python < 3.3
+    import mock  # type: ignore
+
+
+def mock_response(status_code=200, headers={}, payload=None):
+    response = mock.Mock(status_code=status_code, headers=headers)
+    if payload is not None:
+        response.text = lambda: json.dumps(payload)
+        response.headers["content-type"] = "application/json"
+        response.content_type = ["application/json"]
+    return response
+
+
+class Request:
+    def __init__(self, url, method=None, required_headers={}, required_data={}, required_params={}):
+        self.method = method
+        self.url = url
+        self.required_headers = required_headers
+        self.required_data = required_data
+        self.required_params = required_params
+
+    def assert_matches(self, request):
+        assert request.url.split("?")[0] == self.url
+        if self.method:
+            assert request.method == self.method
+        for param, expected_value in self.required_params.items():
+            assert request.query.get(param) == expected_value
+        for header, expected_value in self.required_headers.items():
+            assert request.headers.get(header) == expected_value
+        for field, expected_value in self.required_data.items():
+            assert request.body.get(field) == expected_value
+
+
+def validating_transport(requests, responses):
+    if len(requests) != len(responses):
+        raise ValueError("each request must have one response")
+
+    sessions = zip(requests, responses)
+    if isinstance(sessions, list):
+        # 2.7's zip returns a list
+        sessions = (s for s in sessions)
+
+    def validate_request(request, **kwargs):
+        expected_request, response = next(sessions)
+        expected_request.assert_matches(request)
+        return response
+
+    return mock.Mock(send=validate_request)

--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -20,15 +20,19 @@ def mock_response(status_code=200, headers={}, payload=None):
 
 
 class Request:
-    def __init__(self, url, method=None, required_headers={}, required_data={}, required_params={}):
+    def __init__(self, url=None, url_substring=None, method=None, required_headers={}, required_data={}, required_params={}):
         self.method = method
         self.url = url
+        self.url_substring = url_substring
         self.required_headers = required_headers
         self.required_data = required_data
         self.required_params = required_params
 
     def assert_matches(self, request):
-        assert request.url.split("?")[0] == self.url
+        if self.url:
+            assert request.url.split("?")[0] == self.url
+        if self.url_substring:
+            assert self.url_substring in request.url
         if self.method:
             assert request.method == self.method
         for param, expected_value in self.required_params.items():

--- a/sdk/identity/azure-identity/tests/test_authn_client.py
+++ b/sdk/identity/azure-identity/tests/test_authn_client.py
@@ -176,7 +176,7 @@ def test_cache_scopes():
 
     def mock_send(request, **kwargs):
         token = expected_tokens[request.data["resource"]]
-        return mock_response(payload=token)
+        return mock_response(json_payload=token)
 
     client = AuthnClient("http://foo", transport=Mock(send=mock_send))
 

--- a/sdk/identity/azure-identity/tests/test_authn_client.py
+++ b/sdk/identity/azure-identity/tests/test_authn_client.py
@@ -2,6 +2,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+"""These tests use the synchronous AuthnClient as a driver to test functionality
+of the sans I/O AuthnClientBase shared with AsyncAuthnClient."""
+
 import json
 import time
 
@@ -13,10 +16,10 @@ except ImportError:  # python < 3.3
 from azure.core.credentials import AccessToken
 from azure.identity._authn_client import AuthnClient
 
+from helpers import mock_response
+
 
 def test_authn_client_deserialization():
-    # using the synchronous AuthnClient to drive this test but the functionality tested is
-    # in the sans I/O AuthnClientBase, shared with AsyncAuthnClient
     now = 6
     expires_in = 59 - now
     expires_on = now + expires_in
@@ -117,3 +120,77 @@ def test_expires_in_strings():
         token = AuthnClient("http://foo", transport=Mock(send=mock_send)).request_token("scope")
     assert token.token == expected_token
     assert token.expires_on == now + 42
+
+
+def test_cache_expiry():
+    access_token = "token"
+    now = 42
+    expires_in = 1800
+    expires_on = now + expires_in
+    expected_token = AccessToken(access_token, expires_on)
+    token_payload = {"access_token": access_token, "expires_in": expires_in, "token_type": "Bearer"}
+    mock_response = Mock(
+        text=lambda: json.dumps(token_payload),
+        headers={"content-type": "application/json"},
+        status_code=200,
+        content_type=["application/json"],
+    )
+    mock_send = Mock(return_value=mock_response)
+
+    client = AuthnClient("http://foo", transport=Mock(send=mock_send))
+    with patch("azure.identity._authn_client.time.time") as mock_time:
+        # populate the cache with a valid token
+        mock_time.return_value = now
+        token = client.request_token("scope")
+        assert token.token == expected_token.token
+        assert token.expires_on == expected_token.expires_on
+
+        cached_token = client.get_cached_token("scope")
+        assert cached_token == expected_token
+
+        # advance time past the cached token's expires_on
+        mock_time.return_value = expires_on + 3600
+        cached_token = client.get_cached_token("scope")
+        assert not cached_token
+
+        # request a new token
+        new_token = "new token"
+        token_payload["access_token"] = new_token
+        token = client.request_token("scope")
+        assert token.token == new_token
+
+        # it should be cached
+        cached_token = client.get_cached_token("scope")
+        assert cached_token.token == new_token
+
+
+def test_cache_scopes():
+    scope_a = "scope_a"
+    scope_b = "scope_b"
+    scope_ab = scope_a + " " + scope_b
+    expected_tokens = {
+        scope_a: {"access_token": scope_a, "expires_in": 1 << 31, "ext_expires_in": 1 << 31, "token_type": "Bearer"},
+        scope_b: {"access_token": scope_b, "expires_in": 1 << 31, "ext_expires_in": 1 << 31, "token_type": "Bearer"},
+        scope_ab: {"access_token": scope_ab, "expires_in": 1 << 31, "ext_expires_in": 1 << 31, "token_type": "Bearer"},
+    }
+
+    def mock_send(request, **kwargs):
+        token = expected_tokens[request.data["resource"]]
+        return mock_response(payload=token)
+
+    client = AuthnClient("http://foo", transport=Mock(send=mock_send))
+
+    # if the cache has a token for a & b, it should hit for a, b, a & b
+    token = client.request_token([scope_a, scope_b], form_data={"resource": scope_ab})
+    assert token.token == scope_ab
+    for scope in (scope_a, scope_b):
+        assert client.get_cached_token([scope]).token == scope_ab
+    assert client.get_cached_token([scope_a, scope_b]).token == scope_ab
+
+    # if the cache has only tokens for a and b alone, a & b should miss
+    client = AuthnClient("http://foo", transport=Mock(send=mock_send))
+    for scope in (scope_a, scope_b):
+        token = client.request_token([scope], form_data={"resource": scope})
+        assert token.token == scope
+        assert client.get_cached_token([scope]).token == scope
+    assert not client.get_cached_token([scope_a, scope_b])

--- a/sdk/identity/azure-identity/tests/test_identity.py
+++ b/sdk/identity/azure-identity/tests/test_identity.py
@@ -41,7 +41,7 @@ def test_client_secret_credential_cache():
         "not_before": now,
         "token_type": "Bearer",
     }
-    mock_send = Mock(return_value=mock_response(payload=token_payload))
+    mock_send = Mock(return_value=mock_response(json_payload=token_payload))
     scope = "scope"
 
     credential = ClientSecretCredential("client_id", "secret", tenant_id="some-guid", transport=Mock(send=mock_send))
@@ -72,7 +72,12 @@ def test_client_secret_credential():
         requests=[Request(url_substring=tenant_id, required_data={"client_id": client_id, "client_secret": secret})],
         responses=[
             mock_response(
-                payload={"token_type": "Bearer", "expires_in": 42, "ext_expires_in": 42, "access_token": access_token}
+                json_payload={
+                    "token_type": "Bearer",
+                    "expires_in": 42,
+                    "ext_expires_in": 42,
+                    "access_token": access_token,
+                }
             )
         ],
     )
@@ -95,7 +100,12 @@ def test_client_secret_environment_credential(monkeypatch):
         requests=[Request(url_substring=tenant_id, required_data={"client_id": client_id, "client_secret": secret})],
         responses=[
             mock_response(
-                payload={"token_type": "Bearer", "expires_in": 42, "ext_expires_in": 42, "access_token": access_token}
+                json_payload={
+                    "token_type": "Bearer",
+                    "expires_in": 42,
+                    "ext_expires_in": 42,
+                    "access_token": access_token,
+                }
             )
         ],
     )

--- a/sdk/identity/azure-identity/tests/test_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_identity_async.py
@@ -39,7 +39,7 @@ async def test_client_secret_credential_cache():
         "not_before": now,
         "token_type": "Bearer",
     }
-    mock_send = Mock(return_value=mock_response(payload=token_payload))
+    mock_send = Mock(return_value=mock_response(json_payload=token_payload))
     transport = Mock(send=asyncio.coroutine(mock_send))
     scope = "scope"
 
@@ -72,7 +72,12 @@ async def test_client_secret_credential():
         requests=[Request(url_substring=tenant_id, required_data={"client_id": client_id, "client_secret": secret})],
         responses=[
             mock_response(
-                payload={"token_type": "Bearer", "expires_in": 42, "ext_expires_in": 42, "access_token": access_token}
+                json_payload={
+                    "token_type": "Bearer",
+                    "expires_in": 42,
+                    "ext_expires_in": 42,
+                    "access_token": access_token,
+                }
             )
         ],
     )
@@ -96,7 +101,12 @@ async def test_client_secret_environment_credential(monkeypatch):
         requests=[Request(url_substring=tenant_id, required_data={"client_id": client_id, "client_secret": secret})],
         responses=[
             mock_response(
-                payload={"token_type": "Bearer", "expires_in": 42, "ext_expires_in": 42, "access_token": access_token}
+                json_payload={
+                    "token_type": "Bearer",
+                    "expires_in": 42,
+                    "ext_expires_in": 42,
+                    "access_token": access_token,
+                }
             )
         ],
     )

--- a/sdk/identity/azure-identity/tests/test_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_identity_async.py
@@ -28,8 +28,8 @@ from helpers import mock_response, Request, async_validating_transport
 @pytest.mark.asyncio
 async def test_client_secret_credential_cache():
     expired = "this token's expired"
-    now = time.time()
-    expired_on = int(now - 300)
+    now = int(time.time())
+    expired_on = now - 3600
     expired_token = AccessToken(expired, expired_on)
     token_payload = {
         "access_token": expired,
@@ -38,26 +38,26 @@ async def test_client_secret_credential_cache():
         "expires_on": expired_on,
         "not_before": now,
         "token_type": "Bearer",
-        "resource": str(uuid.uuid1()),
     }
+    mock_send = Mock(return_value=mock_response(payload=token_payload))
+    transport = Mock(send=asyncio.coroutine(mock_send))
+    scope = "scope"
 
-    mock_response = Mock(
-        text=lambda: json.dumps(token_payload),
-        headers={"content-type": "application/json"},
-        status_code=200,
-        content_type=["application/json"],
-    )
-    mock_send = Mock(return_value=mock_response)
+    credential = ClientSecretCredential("client_id", "secret", tenant_id="some-guid", transport=transport)
 
-    credential = ClientSecretCredential(
-        "client_id", "secret", tenant_id=str(uuid.uuid1()), transport=Mock(send=asyncio.coroutine(mock_send))
-    )
-    scopes = ("https://foo.bar/.default", "https://bar.qux/.default")
-    token = await credential.get_token(*scopes)
+    # get_token initially returns the expired token because the credential
+    # doesn't check whether tokens it receives from the service have expired
+    token = await credential.get_token(scope)
     assert token == expired_token
 
-    token = await credential.get_token(*scopes)
-    assert token == expired_token
+    access_token = "new token"
+    token_payload["access_token"] = access_token
+    token_payload["expires_on"] = now + 3600
+    valid_token = AccessToken(access_token, now + 3600)
+
+    # second call should observe the cached token has expired, and request another
+    token = await credential.get_token(scope)
+    assert token == valid_token
     assert mock_send.call_count == 2
 
 

--- a/sdk/identity/azure-identity/tests/test_managed_identity.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity.py
@@ -31,7 +31,7 @@ def test_cloud_shell():
         ],
         responses=[
             mock_response(
-                payload={
+                json_payload={
                     "access_token": access_token,
                     "expires_in": 0,
                     "expires_on": expires_on,
@@ -68,7 +68,7 @@ def test_cloud_shell_user_assigned_identity():
         ],
         responses=[
             mock_response(
-                payload={
+                json_payload={
                     "access_token": access_token,
                     "expires_in": 0,
                     "expires_on": expires_on,
@@ -105,7 +105,7 @@ def test_app_service():
         ],
         responses=[
             mock_response(
-                payload={
+                json_payload={
                     "access_token": access_token,
                     "expires_on": expires_on,
                     "resource": scope,
@@ -141,7 +141,7 @@ def test_app_service_user_assigned_identity():
         ],
         responses=[
             mock_response(
-                payload={
+                json_payload={
                     "access_token": access_token,
                     "expires_on": expires_on,
                     "resource": scope,
@@ -174,9 +174,9 @@ def test_imds():
         ],
         responses=[
             # probe receives error response
-            mock_response(status_code=400, payload={"error": "this is an error message"}),
+            mock_response(status_code=400, json_payload={"error": "this is an error message"}),
             mock_response(
-                payload={
+                json_payload={
                     "access_token": access_token,
                     "expires_in": 42,
                     "expires_on": expires_on,
@@ -212,9 +212,9 @@ def test_imds_user_assigned_identity():
         ],
         responses=[
             # probe receives error response
-            mock_response(status_code=400, payload={"error": "this is an error message"}),
+            mock_response(status_code=400, json_payload={"error": "this is an error message"}),
             mock_response(
-                payload={
+                json_payload={
                     "access_token": access_token,
                     "client_id": client_id,
                     "expires_in": 42,

--- a/sdk/identity/azure-identity/tests/test_managed_identity.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-import json
 import time
 
 try:
@@ -10,138 +9,224 @@ try:
 except ImportError:  # python < 3.3
     import mock  # type: ignore
 
-import httpretty
-
+from azure.core.credentials import AccessToken
 from azure.identity import ManagedIdentityCredential
 from azure.identity.constants import Endpoints, EnvironmentVariables
 
 
-@httpretty.activate
+from helpers import validating_transport, mock_response, Request
+
+
 def test_cloud_shell():
     """Cloud Shell environment: only MSI_ENDPOINT set"""
 
-    access_token = "AccessToken"
+    access_token = "****"
+    expires_on = 42
+    expected_token = AccessToken(access_token, expires_on)
     url = "http://localhost:42/token"
-
-    token_json = json.dumps({"access_token": access_token, "expires_on": int(time.time() + 3600)})
-    httpretty.register_uri(httpretty.POST, url, body=token_json, content_type="application/json")
+    scope = "scope"
+    transport = validating_transport(
+        requests=[
+            Request(url, method="POST", required_headers={"Metadata": "true"}, required_data={"resource": scope})
+        ],
+        responses=[
+            mock_response(
+                payload={
+                    "access_token": access_token,
+                    "expires_in": 0,
+                    "expires_on": expires_on,
+                    "not_before": int(time.time()),
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            )
+        ],
+    )
 
     with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url}):
-        token = ManagedIdentityCredential().get_token("scope")
-        assert token.token == access_token
-        last_request = httpretty.last_request()
-        assert last_request.headers["Metadata"] == "true"
-        assert b"resource=scope" in last_request.body
+        token = ManagedIdentityCredential(transport=transport).get_token(scope)
+        assert token == expected_token
 
 
-@httpretty.activate
 def test_cloud_shell_user_assigned_identity():
     """Cloud Shell environment: only MSI_ENDPOINT set"""
 
-    access_token = "AccessToken"
+    access_token = "****"
+    expires_on = 42
+    client_id = "some-guid"
+    expected_token = AccessToken(access_token, expires_on)
     url = "http://localhost:42/token"
-
-    token_json = json.dumps({"access_token": access_token, "expires_on": int(time.time() + 3600)})
-    httpretty.register_uri(httpretty.POST, url, body=token_json, content_type="application/json")
+    scope = "scope"
+    transport = validating_transport(
+        requests=[
+            Request(
+                url,
+                method="POST",
+                required_headers={"Metadata": "true"},
+                required_data={"client_id": client_id, "resource": scope},
+            )
+        ],
+        responses=[
+            mock_response(
+                payload={
+                    "access_token": access_token,
+                    "expires_in": 0,
+                    "expires_on": expires_on,
+                    "not_before": int(time.time()),
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            )
+        ],
+    )
 
     with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url}):
-        token = ManagedIdentityCredential(client_id="some-guid").get_token("scope")
-        assert token.token == access_token
-        assert httpretty.last_request().headers["Metadata"] == "true"
-        assert b"client_id=some-guid" in httpretty.last_request().body
-        assert b"resource=scope" in httpretty.last_request().body
+        token = ManagedIdentityCredential(client_id=client_id, transport=transport).get_token(scope)
+        assert token == expected_token
 
 
-@httpretty.activate
 def test_app_service():
     """App Service environment: MSI_ENDPOINT, MSI_SECRET set"""
 
-    expected_secret = "expected-secret"
-
-    access_token = "AccessToken"
+    access_token = "****"
+    expires_on = 42
+    expected_token = AccessToken(access_token, expires_on)
     url = "http://localhost:42/token"
+    secret = "expected-secret"
+    scope = "scope"
+    transport = validating_transport(
+        requests=[
+            Request(
+                url,
+                method="GET",
+                required_headers={"Metadata": "true", "secret": secret},
+                required_params={"api-version": "2017-09-01", "resource": scope},
+            )
+        ],
+        responses=[
+            mock_response(
+                payload={
+                    "access_token": access_token,
+                    "expires_on": expires_on,
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            )
+        ],
+    )
 
-    token_json = json.dumps({"access_token": access_token, "expires_on": int(time.time() + 3600)})
-    httpretty.register_uri(httpretty.GET, url, body=token_json, content_type="application/json")
-
-    with mock.patch(
-        "os.environ", {EnvironmentVariables.MSI_ENDPOINT: url, EnvironmentVariables.MSI_SECRET: expected_secret}
-    ):
-        token = ManagedIdentityCredential().get_token("scope")
-        assert token.token == access_token
-        assert httpretty.last_request().headers["secret"] == expected_secret
-        assert len(httpretty.httpretty.latest_requests) == 1
+    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url, EnvironmentVariables.MSI_SECRET: secret}):
+        token = ManagedIdentityCredential(transport=transport).get_token(scope)
+        assert token == expected_token
 
 
-@httpretty.activate
 def test_app_service_user_assigned_identity():
     """App Service environment: MSI_ENDPOINT, MSI_SECRET set"""
 
-    expected_secret = "expected-secret"
+    access_token = "****"
+    expires_on = 42
     client_id = "some-guid"
-    access_token = "AccessToken"
+    expected_token = AccessToken(access_token, expires_on)
     url = "http://localhost:42/token"
+    secret = "expected-secret"
+    scope = "scope"
+    transport = validating_transport(
+        requests=[
+            Request(
+                url,
+                method="GET",
+                required_headers={"Metadata": "true", "secret": secret},
+                required_params={"api-version": "2017-09-01", "client_id": client_id, "resource": scope},
+            )
+        ],
+        responses=[
+            mock_response(
+                payload={
+                    "access_token": access_token,
+                    "expires_on": expires_on,
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            )
+        ],
+    )
 
-    token_json = json.dumps({"access_token": access_token, "expires_on": int(time.time() + 3600)})
-    httpretty.register_uri(httpretty.GET, url, body=token_json, content_type="application/json")
-
-    with mock.patch(
-        "os.environ", {EnvironmentVariables.MSI_ENDPOINT: url, EnvironmentVariables.MSI_SECRET: expected_secret}
-    ):
-        token = ManagedIdentityCredential(client_id=client_id).get_token("scope")
-        assert token.token == access_token
-        assert len(httpretty.httpretty.latest_requests) == 1
-        last_request = httpretty.last_request()
-        assert last_request.headers["secret"] == expected_secret
-        assert last_request.querystring.get("client_id") == [client_id]  # pylint:disable=no-member
+    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url, EnvironmentVariables.MSI_SECRET: secret}):
+        token = ManagedIdentityCredential(client_id=client_id, transport=transport).get_token(scope)
+        assert token == expected_token
 
 
-@httpretty.activate
 def test_imds():
-    access_token = "AccessToken"
-    token_json = json.dumps({"access_token": access_token, "expires_on": int(time.time() + 3600)})
+    access_token = "****"
+    expires_on = 42
+    expected_token = AccessToken(access_token, expires_on)
+    url = Endpoints.IMDS
     scope = "scope"
+    transport = validating_transport(
+        requests=[
+            Request(url),  # first request should be availability probe => match only the URL
+            Request(
+                url,
+                method="GET",
+                required_headers={"Metadata": "true"},
+                required_params={"api-version": "2018-02-01", "resource": scope},
+            ),
+        ],
+        responses=[
+            # probe receives error response
+            mock_response(status_code=400, payload={"error": "this is an error message"}),
+            mock_response(
+                payload={
+                    "access_token": access_token,
+                    "expires_in": 42,
+                    "expires_on": expires_on,
+                    "ext_expires_in": 42,
+                    "not_before": int(time.time()),
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            ),
+        ],
+    )
 
-    class reqs:
-        count = 0
-
-    def request_callback(request, uri, response_headers):
-        reqs.count += 1
-        if reqs.count == 1:
-            # credential is probing to determine endpoint availability
-            return 400, response_headers, json.dumps({})
-        assert request.headers["Metadata"] == "true"
-        assert request.querystring.get("resource") == [scope]
-        return 200, response_headers, token_json
-
-    httpretty.register_uri(httpretty.GET, Endpoints.IMDS, body=request_callback, content_type="application/json")
-
-    token = ManagedIdentityCredential().get_token("scope")
-    assert token.token == access_token
+    token = ManagedIdentityCredential(transport=transport).get_token(scope)
+    assert token == expected_token
 
 
-@httpretty.activate
 def test_imds_user_assigned_identity():
-    access_token = "AccessToken"
-    token_json = json.dumps({"access_token": access_token, "expires_on": int(time.time() + 3600)})
+    access_token = "****"
+    expires_on = 42
+    expected_token = AccessToken(access_token, expires_on)
+    url = Endpoints.IMDS
     scope = "scope"
-    client_id = "client-id"
+    client_id = "some-guid"
+    transport = validating_transport(
+        requests=[
+            Request(url),  # first request should be availability probe => match only the URL
+            Request(
+                url,
+                method="GET",
+                required_headers={"Metadata": "true"},
+                required_params={"api-version": "2018-02-01", "client_id": client_id, "resource": scope},
+            ),
+        ],
+        responses=[
+            # probe receives error response
+            mock_response(status_code=400, payload={"error": "this is an error message"}),
+            mock_response(
+                payload={
+                    "access_token": access_token,
+                    "client_id": client_id,
+                    "expires_in": 42,
+                    "expires_on": expires_on,
+                    "ext_expires_in": 42,
+                    "not_before": int(time.time()),
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            ),
+        ],
+    )
 
-    class reqs:
-        count = 0
-
-    def request_callback(request, uri, response_headers):
-        reqs.count += 1
-        if reqs.count == 1:
-            # credential is probing to determine endpoint availability
-            return 400, response_headers, json.dumps({})
-        assert request.headers["Metadata"] == "true"
-        assert request.querystring.get("client_id") == [client_id]
-        assert request.querystring.get("resource") == [scope]
-        return 200, response_headers, token_json
-
-    httpretty.register_uri(httpretty.GET, Endpoints.IMDS, body=request_callback, content_type="application/json")
-
-    token = ManagedIdentityCredential(client_id=client_id).get_token(scope)
-    assert token.token == access_token
-    assert len(httpretty.httpretty.latest_requests) == 2
+    token = ManagedIdentityCredential(client_id=client_id, transport=transport).get_token(scope)
+    assert token == expected_token

--- a/sdk/identity/azure-identity/tests/test_managed_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity_async.py
@@ -28,7 +28,7 @@ async def test_cloud_shell():
         ],
         responses=[
             mock_response(
-                payload={
+                json_payload={
                     "access_token": access_token,
                     "expires_in": 0,
                     "expires_on": expires_on,
@@ -66,7 +66,7 @@ async def test_cloud_shell_user_assigned_identity():
         ],
         responses=[
             mock_response(
-                payload={
+                json_payload={
                     "access_token": access_token,
                     "expires_in": 0,
                     "expires_on": expires_on,
@@ -104,7 +104,7 @@ async def test_app_service():
         ],
         responses=[
             mock_response(
-                payload={
+                json_payload={
                     "access_token": access_token,
                     "expires_on": expires_on,
                     "resource": scope,
@@ -141,7 +141,7 @@ async def test_app_service_user_assigned_identity():
         ],
         responses=[
             mock_response(
-                payload={
+                json_payload={
                     "access_token": access_token,
                     "expires_on": expires_on,
                     "resource": scope,
@@ -175,9 +175,9 @@ async def test_imds():
         ],
         responses=[
             # probe receives error response
-            mock_response(status_code=400, payload={"error": "this is an error message"}),
+            mock_response(status_code=400, json_payload={"error": "this is an error message"}),
             mock_response(
-                payload={
+                json_payload={
                     "access_token": access_token,
                     "expires_in": 42,
                     "expires_on": expires_on,
@@ -214,9 +214,9 @@ async def test_imds_user_assigned_identity():
         ],
         responses=[
             # probe receives error response
-            mock_response(status_code=400, payload={"error": "this is an error message"}),
+            mock_response(status_code=400, json_payload={"error": "this is an error message"}),
             mock_response(
-                payload={
+                json_payload={
                     "access_token": access_token,
                     "client_id": client_id,
                     "expires_in": 42,

--- a/sdk/identity/azure-identity/tests/test_managed_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity_async.py
@@ -1,0 +1,234 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import time
+from unittest import mock
+
+from azure.core.credentials import AccessToken
+from azure.identity.aio import ManagedIdentityCredential
+from azure.identity.constants import Endpoints, EnvironmentVariables
+import pytest
+
+from helpers import async_validating_transport, mock_response, Request
+
+
+@pytest.mark.asyncio
+async def test_cloud_shell():
+    """Cloud Shell environment: only MSI_ENDPOINT set"""
+
+    access_token = "****"
+    expires_on = 42
+    expected_token = AccessToken(access_token, expires_on)
+    url = "http://localhost:42/token"
+    scope = "scope"
+    transport = async_validating_transport(
+        requests=[
+            Request(url, method="POST", required_headers={"Metadata": "true"}, required_data={"resource": scope})
+        ],
+        responses=[
+            mock_response(
+                payload={
+                    "access_token": access_token,
+                    "expires_in": 0,
+                    "expires_on": expires_on,
+                    "not_before": int(time.time()),
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            )
+        ],
+    )
+
+    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url}):
+        token = await ManagedIdentityCredential(transport=transport).get_token(scope)
+        assert token == expected_token
+
+
+@pytest.mark.asyncio
+async def test_cloud_shell_user_assigned_identity():
+    """Cloud Shell environment: only MSI_ENDPOINT set"""
+
+    access_token = "****"
+    expires_on = 42
+    client_id = "some-guid"
+    expected_token = AccessToken(access_token, expires_on)
+    url = "http://localhost:42/token"
+    scope = "scope"
+    transport = async_validating_transport(
+        requests=[
+            Request(
+                url,
+                method="POST",
+                required_headers={"Metadata": "true"},
+                required_data={"client_id": client_id, "resource": scope},
+            )
+        ],
+        responses=[
+            mock_response(
+                payload={
+                    "access_token": access_token,
+                    "expires_in": 0,
+                    "expires_on": expires_on,
+                    "not_before": int(time.time()),
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            )
+        ],
+    )
+
+    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url}):
+        token = await ManagedIdentityCredential(client_id=client_id, transport=transport).get_token(scope)
+        assert token == expected_token
+
+
+@pytest.mark.asyncio
+async def test_app_service():
+    """App Service environment: MSI_ENDPOINT, MSI_SECRET set"""
+
+    access_token = "****"
+    expires_on = 42
+    expected_token = AccessToken(access_token, expires_on)
+    url = "http://localhost:42/token"
+    secret = "expected-secret"
+    scope = "scope"
+    transport = async_validating_transport(
+        requests=[
+            Request(
+                url,
+                method="GET",
+                required_headers={"Metadata": "true", "secret": secret},
+                required_params={"api-version": "2017-09-01", "resource": scope},
+            )
+        ],
+        responses=[
+            mock_response(
+                payload={
+                    "access_token": access_token,
+                    "expires_on": expires_on,
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            )
+        ],
+    )
+
+    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url, EnvironmentVariables.MSI_SECRET: secret}):
+        token = await ManagedIdentityCredential(transport=transport).get_token(scope)
+        assert token == expected_token
+
+
+@pytest.mark.asyncio
+async def test_app_service_user_assigned_identity():
+    """App Service environment: MSI_ENDPOINT, MSI_SECRET set"""
+
+    access_token = "****"
+    expires_on = 42
+    client_id = "some-guid"
+    expected_token = AccessToken(access_token, expires_on)
+    url = "http://localhost:42/token"
+    secret = "expected-secret"
+    scope = "scope"
+    transport = async_validating_transport(
+        requests=[
+            Request(
+                url,
+                method="GET",
+                required_headers={"Metadata": "true", "secret": secret},
+                required_params={"api-version": "2017-09-01", "client_id": client_id, "resource": scope},
+            )
+        ],
+        responses=[
+            mock_response(
+                payload={
+                    "access_token": access_token,
+                    "expires_on": expires_on,
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            )
+        ],
+    )
+
+    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url, EnvironmentVariables.MSI_SECRET: secret}):
+        token = await ManagedIdentityCredential(client_id=client_id, transport=transport).get_token(scope)
+        assert token == expected_token
+
+
+@pytest.mark.asyncio
+async def test_imds():
+    access_token = "****"
+    expires_on = 42
+    expected_token = AccessToken(access_token, expires_on)
+    url = Endpoints.IMDS
+    scope = "scope"
+    transport = async_validating_transport(
+        requests=[
+            Request(url),  # first request should be availability probe => match only the URL
+            Request(
+                url,
+                method="GET",
+                required_headers={"Metadata": "true"},
+                required_params={"api-version": "2018-02-01", "resource": scope},
+            ),
+        ],
+        responses=[
+            # probe receives error response
+            mock_response(status_code=400, payload={"error": "this is an error message"}),
+            mock_response(
+                payload={
+                    "access_token": access_token,
+                    "expires_in": 42,
+                    "expires_on": expires_on,
+                    "ext_expires_in": 42,
+                    "not_before": int(time.time()),
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            ),
+        ],
+    )
+
+    token = await ManagedIdentityCredential(transport=transport).get_token(scope)
+    assert token == expected_token
+
+
+@pytest.mark.asyncio
+async def test_imds_user_assigned_identity():
+    access_token = "****"
+    expires_on = 42
+    expected_token = AccessToken(access_token, expires_on)
+    url = Endpoints.IMDS
+    scope = "scope"
+    client_id = "some-guid"
+    transport = async_validating_transport(
+        requests=[
+            Request(url),  # first request should be availability probe => match only the URL
+            Request(
+                url,
+                method="GET",
+                required_headers={"Metadata": "true"},
+                required_params={"api-version": "2018-02-01", "client_id": client_id, "resource": scope},
+            ),
+        ],
+        responses=[
+            # probe receives error response
+            mock_response(status_code=400, payload={"error": "this is an error message"}),
+            mock_response(
+                payload={
+                    "access_token": access_token,
+                    "client_id": client_id,
+                    "expires_in": 42,
+                    "expires_on": expires_on,
+                    "ext_expires_in": 42,
+                    "not_before": int(time.time()),
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            ),
+        ],
+    )
+
+    token = await ManagedIdentityCredential(client_id=client_id, transport=transport).get_token(scope)
+    assert token == expected_token


### PR DESCRIPTION
This closes #5899 with tests for async managed identity scenarios, removes the dependency on `httpretty`, and adds some additional coverage of token caching.