### PR TITLE
Update MSAL dependency

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -58,15 +58,8 @@ class AuthnClientBase(object):
 
         token = payload["access_token"]
 
-        # these values are strings in some responses but msal.TokenCache requires they be integers
-        # https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/55
-        if "expires_in" in payload:
-            payload["expires_in"] = int(payload["expires_in"])
-        if "ext_expires_in" in payload:
-            payload["ext_expires_in"] = int(payload["ext_expires_in"])
-
         # AccessToken wants expires_on as an int
-        expires_on = payload.get("expires_on") or payload["expires_in"] + request_time
+        expires_on = payload.get("expires_on") or int(payload["expires_in"]) + request_time
         try:
             expires_on = int(expires_on)
         except ValueError:

--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -69,6 +69,6 @@ setup(
             "azure",
         ]
     ),
-    install_requires=["azure-core<2.0.0,>=1.0.0b1", "cryptography>=2.1.4", "msal~=0.3.1"],
+    install_requires=["azure-core<2.0.0,>=1.0.0b1", "cryptography>=2.1.4", "msal~=0.4.1"],
     extras_require={":python_version<'3.0'": ["azure-nspkg"], ":python_version<'3.5'": ["typing"]},
 )

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -87,7 +87,7 @@ azure-storage-queue~=1.3
 cryptography>=2.1.4
 futures
 typing
-msal~=0.3.1
+msal~=0.4.1
 msrest>=0.5.0
 msrestazure<2.0.0,>=0.4.32
 requests>=2.18.4


### PR DESCRIPTION
AzureAD/microsoft-authentication-library-for-python#55 was merged and released in MSAL 0.4.1, so updating to that version allows removing a workaround.