### PR TITLE
Update release histories

### DIFF
--- a/sdk/identity/azure-identity/HISTORY.md
+++ b/sdk/identity/azure-identity/HISTORY.md
@@ -1,12 +1,16 @@
 # Release History
 
-## 1.0.0b1
+## 1.0.0b1 (2019-06-28)
 Version 1.0.0b1 is the first preview of our efforts to create a user-friendly
 and Pythonic authentication API for Azure SDK client libraries. For more
-information, please visit https://aka.ms/azure-sdk-preview1-python.
+information about preview releases of other Azure SDK libraries, please visit
+https://aka.ms/azure-sdk-preview1-python.
 
 This release supports service principal and managed identity authentication.
 See the
 [documentation](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/identity/azure-identity/README.md)
 for more details. User authentication will be added in an upcoming preview
 release.
+
+This release supports only global Azure Active Directory tenants, i.e. those
+using the https://login.microsoftonline.com authentication endpoint.

--- a/sdk/identity/azure-identity/HISTORY.md
+++ b/sdk/identity/azure-identity/HISTORY.md
@@ -1,4 +1,12 @@
 # Release History
 
 ## 1.0.0b1
-First preview release of the library.
+Version 1.0.0b1 is the first preview of our efforts to create a user-friendly
+and Pythonic authentication API for Azure SDK client libraries. For more
+information, please visit https://aka.ms/azure-sdk-preview1-python.
+
+This release supports service principal and managed identity authentication.
+See the
+[documentation](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/identity/azure-identity/README.md)
+for more details. User authentication will be added in an upcoming preview
+release.

--- a/sdk/keyvault/azure-keyvault-keys/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-keys/HISTORY.md
@@ -8,6 +8,11 @@ https://aka.ms/azure-sdk-preview1-python.
 
 This library is not a direct replacement for `azure-keyvault`. Applications
 using that library would require code changes to use `azure-keyvault-keys`.
+This package's
+[documentation](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-keys/README.md)
+and
+[samples](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-keys/samples)
+demonstrate the new API.
 
 ### Major changes from `azure-keyvault`
 - Packages scoped by functionality

--- a/sdk/keyvault/azure-keyvault-keys/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-keys/HISTORY.md
@@ -1,5 +1,31 @@
 # Release History
 
 ## 4.0.0b1 (2019-06-28)
-For release notes and more information please visit
-https://aka.ms/azure-sdk-preview1-python
+Version 4.0.0b1 is the first preview of our efforts to create a user-friendly
+and Pythonic client library for Azure Key Vault. For more information, please
+visit https://aka.ms/azure-sdk-preview1-python.
+
+This library is not a direct replacement for `azure-keyvault`. Applications
+using that library would require code changes to use `azure-keyvault-keys`.
+
+### Major changes from `azure-keyvault`
+- Packages scoped by functionality
+    - `azure-keyvault-keys` contains a client for key operations,
+    `azure-keyvault-secrets` contains a client for secret operations
+- Client instances are scoped to vaults (an instance interacts with one vault
+only)
+- Asynchronous API supported on Python 3.5.3+
+    - the `azure.keyvault.keys.aio` namespace contains an async equivalent of
+    the synchronous client in `azure.keyvault.keys`
+- Authentication using `azure-identity` credentials
+  - see this package's
+  [documentation](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-keys/README.md)
+  , and the
+  [Azure Identity documentation](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/identity/azure-identity/README.md)
+  for more information
+
+### `azure-keyvault` features not implemented in this library
+This release doesn't include all features of `azure-keyvault`. In particular,
+APIs supporting cryptographic operations, e.g. sign, un/wrap, verify, en- and
+decrypt, are not part of this release. Also, certificate APIs are not included
+in this release.

--- a/sdk/keyvault/azure-keyvault-keys/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-keys/HISTORY.md
@@ -2,8 +2,9 @@
 
 ## 4.0.0b1 (2019-06-28)
 Version 4.0.0b1 is the first preview of our efforts to create a user-friendly
-and Pythonic client library for Azure Key Vault. For more information, please
-visit https://aka.ms/azure-sdk-preview1-python.
+and Pythonic client library for Azure Key Vault. For more information about
+preview releases of other Azure SDK libraries, please visit
+https://aka.ms/azure-sdk-preview1-python.
 
 This library is not a direct replacement for `azure-keyvault`. Applications
 using that library would require code changes to use `azure-keyvault-keys`.
@@ -24,8 +25,9 @@ only)
   [Azure Identity documentation](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/identity/azure-identity/README.md)
   for more information
 
-### `azure-keyvault` features not implemented in this library
-This release doesn't include all features of `azure-keyvault`. In particular,
-APIs supporting cryptographic operations, e.g. sign, un/wrap, verify, en- and
-decrypt, are not part of this release. Also, certificate APIs are not included
-in this release.
+### `azure-keyvault` features not implemented in this release
+- Certificate management APIs
+- Cryptographic operations, e.g. sign, un/wrap, verify, en- and
+decrypt
+- National cloud support. This release supports public global cloud vaults,
+    e.g. https://{vault-name}.vault.azure.net

--- a/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
@@ -1,5 +1,29 @@
 # Release History
 
 ## 4.0.0b1 (2019-06-28)
-For release notes and more information please visit
-https://aka.ms/azure-sdk-preview1-python
+Version 4.0.0b1 is the first preview of our efforts to create a user-friendly
+and Pythonic client library for Azure Key Vault. For more information, please
+visit https://aka.ms/azure-sdk-preview1-python.
+
+This library is not a direct replacement for `azure-keyvault`. Applications
+using that library would require code changes to use `azure-keyvault-secrets`.
+
+### Major changes from `azure-keyvault`
+- Packages scoped by functionality
+    - `azure-keyvault-secrets` contains a client for secret operations,
+    `azure-keyvault-keys` contains a client for key operations
+- Client instances are scoped to vaults (an instance interacts with one vault
+only)
+- Asynchronous API supported on Python 3.5.3+
+    - the `azure.keyvault.secrets.aio` namespace contains an async equivalent of
+    the synchronous client in `azure.keyvault.secrets`
+- Authentication using `azure-identity` credentials
+  - see this package's
+  [documentation](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-secrets/README.md)
+  , and the
+  [Azure Identity documentation](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/identity/azure-identity/README.md)
+  for more information
+
+### `azure-keyvault` features not implemented in this library
+This release doesn't include all features of `azure-keyvault`. In particular,
+certificate APIs are not included in this release.

--- a/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
@@ -2,8 +2,9 @@
 
 ## 4.0.0b1 (2019-06-28)
 Version 4.0.0b1 is the first preview of our efforts to create a user-friendly
-and Pythonic client library for Azure Key Vault. For more information, please
-visit https://aka.ms/azure-sdk-preview1-python.
+and Pythonic client library for Azure Key Vault. For more information about
+preview releases of other Azure SDK libraries, please visit
+https://aka.ms/azure-sdk-preview1-python.
 
 This library is not a direct replacement for `azure-keyvault`. Applications
 using that library would require code changes to use `azure-keyvault-secrets`.
@@ -25,5 +26,6 @@ only)
   for more information
 
 ### `azure-keyvault` features not implemented in this library
-This release doesn't include all features of `azure-keyvault`. In particular,
-certificate APIs are not included in this release.
+- Certificate management APIs
+- National cloud support. This release supports public global cloud vaults,
+    e.g. https://{vault-name}.vault.azure.net

--- a/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
@@ -8,6 +8,11 @@ https://aka.ms/azure-sdk-preview1-python.
 
 This library is not a direct replacement for `azure-keyvault`. Applications
 using that library would require code changes to use `azure-keyvault-secrets`.
+This package's
+[documentation](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-secrets/README.md)
+and
+[samples](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-secrets/samples)
+demonstrate the new API.
 
 ### Major changes from `azure-keyvault`
 - Packages scoped by functionality


### PR DESCRIPTION
This adds more information to the Key Vault and Identity release histories, focusing in particular on highlighting differences between `azure-keyvault` and the track 2 packages.

@Azure/adp-keyvault please comment on anything you think anything should be added or changed re Key Vault.