### PR TITLE
Cosmos DB v3 packaging

### DIFF
--- a/sdk/cosmos/azure-cosmos/MANIFEST.in
+++ b/sdk/cosmos/azure-cosmos/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.md
 include LICENSE.txt
+include azure/__init__.py
 recursive-include doc *.bat
 recursive-include doc *.py
 recursive-include doc *.rst

--- a/sdk/cosmos/azure-cosmos/MANIFEST.in
+++ b/sdk/cosmos/azure-cosmos/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.md
+include changelog.md
 include LICENSE.txt
 include azure/__init__.py
 recursive-include doc *.bat

--- a/sdk/cosmos/azure-cosmos/azure/__init__.py
+++ b/sdk/cosmos/azure-cosmos/azure/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/sdk/cosmos/azure-cosmos/changelog.md
+++ b/sdk/cosmos/azure-cosmos/changelog.md
@@ -21,8 +21,8 @@
   - DocumentClient to CosmosClient
   - Collection to Container
   - Document to Item
-  - Package name updated to “azure-cosmos”
-  - Namespace updated to “azure.cosmos”
+  - Package name updated to "azure-cosmos"
+  - Namespace updated to "azure.cosmos"
 
 ## Changes in 2.3.3 : ##
 
@@ -78,17 +78,17 @@
 
 ## Changes in 1.9.0 : ##
 
-- Added retry policy support for throttled requests. (Throttled requests receive a request rate too large exception, error code 429.) 
-  By default, DocumentDB retries nine times for each request when error code 429 is encountered, honoring the retryAfter time in the response header. 
-  A fixed retry interval time can now be set as part of the RetryOptions property on the ConnectionPolicy object if you want to ignore the retryAfter time returned by server between the retries. 
+- Added retry policy support for throttled requests. (Throttled requests receive a request rate too large exception, error code 429.)
+  By default, DocumentDB retries nine times for each request when error code 429 is encountered, honoring the retryAfter time in the response header.
+  A fixed retry interval time can now be set as part of the RetryOptions property on the ConnectionPolicy object if you want to ignore the retryAfter time returned by server between the retries.
   DocumentDB now waits for a maximum of 30 seconds for each request that is being throttled (irrespective of retry count) and returns the response with error code 429.
   This time can also be overriden in the RetryOptions property on ConnectionPolicy object.
 
-- DocumentDB now returns x-ms-throttle-retry-count and x-ms-throttle-retry-wait-time-ms as the response headers in every request to denote the throttle retry count 
+- DocumentDB now returns x-ms-throttle-retry-count and x-ms-throttle-retry-wait-time-ms as the response headers in every request to denote the throttle retry count
   and the cummulative time the request waited between the retries.
 
-- Removed the RetryPolicy class and the corresponding property (retry_policy) exposed on the document_client class and instead introduced a RetryOptions class 
-  exposing the RetryOptions property on ConnectionPolicy class that can be used to override some of the default retry options. 
+- Removed the RetryPolicy class and the corresponding property (retry_policy) exposed on the document_client class and instead introduced a RetryOptions class
+  exposing the RetryOptions property on ConnectionPolicy class that can be used to override some of the default retry options.
 
 ## Changes in 1.8.0 : ##
 

--- a/sdk/cosmos/azure-cosmos/setup.cfg
+++ b/sdk/cosmos/azure-cosmos/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/sdk/cosmos/azure-cosmos/setup.py
+++ b/sdk/cosmos/azure-cosmos/setup.py
@@ -1,32 +1,75 @@
-﻿#!/usr/bin/env python
+#!/usr/bin/env python
 
-from distutils.core import setup
-import setuptools
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+# pylint:disable=missing-docstring
 
-setup(name='azure-cosmos',
-      version='4.0.0a1',
-      description='Azure Cosmos Python SDK',
-      author="Microsoft",
-      author_email="askdocdb@microsoft.com",
-      maintainer="Microsoft",
-      maintainer_email="askdocdb@microsoft.com",
-      url="https://github.com/Azure/azure-documentdb-python",
-      license='MIT',
-      install_requires=['six >=1.6', 'requests>=2.18.4'],
-      extras_require={
-        ":python_version<'3.5'": ['typing', ],
-      },
-      classifiers=[
-        'License :: OSI Approved :: MIT License',
-        'Intended Audience :: Developers',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Topic :: Software Development :: Libraries :: Python Modules'
-      ],
-      packages=setuptools.find_packages(exclude=['test', 'test.*']))
+import re
+import os.path
+from io import open
+from setuptools import find_packages, setup
+
+# Change the PACKAGE_NAME only to change folder and different name
+PACKAGE_NAME = "azure-cosmos"
+PACKAGE_PPRINT_NAME = "Cosmos"
+
+# a-b-c => a/b/c
+PACKAGE_FOLDER_PATH = PACKAGE_NAME.replace("-", "/")
+# a-b-c => a.b.c
+NAMESPACE_NAME = PACKAGE_NAME.replace("-", ".")
+
+
+with open("README.md", encoding="utf-8") as f:
+    README = f.read()
+with open("changelog.md", encoding="utf-8") as f:
+    HISTORY = f.read()
+
+setup(
+    name=PACKAGE_NAME,
+    version='4.0.0a1',
+    description="Microsoft Azure {} Client Library for Python".format(PACKAGE_PPRINT_NAME),
+    long_description=README + "\n\n" + HISTORY,
+    long_description_content_type="text/markdown",
+    license="MIT License",
+    author="Microsoft Corporation",
+    author_email="askdocdb@microsoft.com",
+    maintainer="Microsoft",
+    maintainer_email="askdocdb@microsoft.com",
+    url="https://github.com/Azure/azure-sdk-for-python",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "License :: OSI Approved :: MIT License",
+    ],
+    zip_safe=False,
+    packages=find_packages(
+        exclude=[
+            "samples",
+            "samples.Shared",
+            "samples.Shared.config",
+            "test",
+            "doc",
+            # Exclude packages that will be covered by PEP420 or nspkg
+            "azure",
+        ]
+    ),
+    install_requires=[
+      'six >=1.6',
+      'requests>=2.18.4'
+    ],
+    extras_require={
+      ":python_version<'3.0'": ["azure-nspkg"],
+      ":python_version<'3.5'": ["typing"]
+    },
+)


### PR DESCRIPTION
Fix packaging according to https://github.com/Azure/azure-sdk-for-python/blob/master/doc/dev/packaging.md:

- MANIFEST should include azure/init.py, and setup.py should exclude it
- Use pkgutil and not pkg_resources
- azure-nspkg is a dep on 2.7 only
- excludes samples, doc and test from the wheel
- universal wheel

I also fixed utf-8 trouble in the changelog in order to include it in the long_description. I used KV secrets setup.py as my model, to be closer to what you are used to use in data-plane nowadays.

I opened manually the wheel and the sdist and found what I expect to see, I will try to install them in a venv to double check everything import as expected and do another comment