### PR TITLE
creating custom sphinx sources that reflect the documentation that azure-cosmos wants to show

### DIFF
--- a/doc/sphinx/ref/azure.cosmos.auth.rst
+++ b/doc/sphinx/ref/azure.cosmos.auth.rst
@@ -1,0 +1,7 @@
+azure.cosmos.auth module
+========================
+
+.. automodule:: azure.cosmos.auth
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.base.rst
+++ b/doc/sphinx/ref/azure.cosmos.base.rst
@@ -1,0 +1,7 @@
+azure.cosmos.base module
+========================
+
+.. automodule:: azure.cosmos.base
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.consistent_hash_ring.rst
+++ b/doc/sphinx/ref/azure.cosmos.consistent_hash_ring.rst
@@ -1,0 +1,7 @@
+azure.cosmos.consistent\_hash\_ring module
+==========================================
+
+.. automodule:: azure.cosmos.consistent_hash_ring
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.constants.rst
+++ b/doc/sphinx/ref/azure.cosmos.constants.rst
@@ -1,0 +1,7 @@
+azure.cosmos.constants module
+=============================
+
+.. automodule:: azure.cosmos.constants
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.container.rst
+++ b/doc/sphinx/ref/azure.cosmos.container.rst
@@ -1,0 +1,7 @@
+azure.cosmos.container module
+=============================
+
+.. automodule:: azure.cosmos.container
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.cosmos_client.rst
+++ b/doc/sphinx/ref/azure.cosmos.cosmos_client.rst
@@ -1,0 +1,7 @@
+azure.cosmos.cosmos\_client module
+==================================
+
+.. automodule:: azure.cosmos.cosmos_client
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.cosmos_client_connection.rst
+++ b/doc/sphinx/ref/azure.cosmos.cosmos_client_connection.rst
@@ -1,0 +1,7 @@
+azure.cosmos.cosmos\_client\_connection module
+==============================================
+
+.. automodule:: azure.cosmos.cosmos_client_connection
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.database.rst
+++ b/doc/sphinx/ref/azure.cosmos.database.rst
@@ -1,0 +1,7 @@
+azure.cosmos.database module
+============================
+
+.. automodule:: azure.cosmos.database
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.default_retry_policy.rst
+++ b/doc/sphinx/ref/azure.cosmos.default_retry_policy.rst
@@ -1,0 +1,7 @@
+azure.cosmos.default\_retry\_policy module
+==========================================
+
+.. automodule:: azure.cosmos.default_retry_policy
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.diagnostics.rst
+++ b/doc/sphinx/ref/azure.cosmos.diagnostics.rst
@@ -1,0 +1,7 @@
+azure.cosmos.diagnostics module
+===============================
+
+.. automodule:: azure.cosmos.diagnostics
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.documents.rst
+++ b/doc/sphinx/ref/azure.cosmos.documents.rst
@@ -1,0 +1,7 @@
+azure.cosmos.documents module
+=============================
+
+.. automodule:: azure.cosmos.documents
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.endpoint_discovery_retry_policy.rst
+++ b/doc/sphinx/ref/azure.cosmos.endpoint_discovery_retry_policy.rst
@@ -1,0 +1,7 @@
+azure.cosmos.endpoint\_discovery\_retry\_policy module
+======================================================
+
+.. automodule:: azure.cosmos.endpoint_discovery_retry_policy
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.errors.rst
+++ b/doc/sphinx/ref/azure.cosmos.errors.rst
@@ -1,0 +1,7 @@
+azure.cosmos.errors module
+==========================
+
+.. automodule:: azure.cosmos.errors
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.execution_context.aggregators.rst
+++ b/doc/sphinx/ref/azure.cosmos.execution_context.aggregators.rst
@@ -1,0 +1,7 @@
+azure.cosmos.execution\_context.aggregators module
+==================================================
+
+.. automodule:: azure.cosmos.execution_context.aggregators
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.execution_context.base_execution_context.rst
+++ b/doc/sphinx/ref/azure.cosmos.execution_context.base_execution_context.rst
@@ -1,0 +1,7 @@
+azure.cosmos.execution\_context.base\_execution\_context module
+===============================================================
+
+.. automodule:: azure.cosmos.execution_context.base_execution_context
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.execution_context.document_producer.rst
+++ b/doc/sphinx/ref/azure.cosmos.execution_context.document_producer.rst
@@ -1,0 +1,7 @@
+azure.cosmos.execution\_context.document\_producer module
+=========================================================
+
+.. automodule:: azure.cosmos.execution_context.document_producer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.execution_context.endpoint_component.rst
+++ b/doc/sphinx/ref/azure.cosmos.execution_context.endpoint_component.rst
@@ -1,0 +1,7 @@
+azure.cosmos.execution\_context.endpoint\_component module
+==========================================================
+
+.. automodule:: azure.cosmos.execution_context.endpoint_component
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.execution_context.execution_dispatcher.rst
+++ b/doc/sphinx/ref/azure.cosmos.execution_context.execution_dispatcher.rst
@@ -1,0 +1,7 @@
+azure.cosmos.execution\_context.execution\_dispatcher module
+============================================================
+
+.. automodule:: azure.cosmos.execution_context.execution_dispatcher
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.execution_context.multi_execution_aggregator.rst
+++ b/doc/sphinx/ref/azure.cosmos.execution_context.multi_execution_aggregator.rst
@@ -1,0 +1,7 @@
+azure.cosmos.execution\_context.multi\_execution\_aggregator module
+===================================================================
+
+.. automodule:: azure.cosmos.execution_context.multi_execution_aggregator
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.execution_context.query_execution_info.rst
+++ b/doc/sphinx/ref/azure.cosmos.execution_context.query_execution_info.rst
@@ -1,0 +1,7 @@
+azure.cosmos.execution\_context.query\_execution\_info module
+=============================================================
+
+.. automodule:: azure.cosmos.execution_context.query_execution_info
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.execution_context.rst
+++ b/doc/sphinx/ref/azure.cosmos.execution_context.rst
@@ -4,62 +4,15 @@ azure.cosmos.execution\_context package
 Submodules
 ----------
 
-azure.cosmos.execution\_context.aggregators module
---------------------------------------------------
+.. toctree::
 
-.. automodule:: azure.cosmos.execution_context.aggregators
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.execution\_context.base\_execution\_context module
----------------------------------------------------------------
-
-.. automodule:: azure.cosmos.execution_context.base_execution_context
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.execution\_context.document\_producer module
----------------------------------------------------------
-
-.. automodule:: azure.cosmos.execution_context.document_producer
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.execution\_context.endpoint\_component module
-----------------------------------------------------------
-
-.. automodule:: azure.cosmos.execution_context.endpoint_component
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.execution\_context.execution\_dispatcher module
-------------------------------------------------------------
-
-.. automodule:: azure.cosmos.execution_context.execution_dispatcher
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.execution\_context.multi\_execution\_aggregator module
--------------------------------------------------------------------
-
-.. automodule:: azure.cosmos.execution_context.multi_execution_aggregator
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.execution\_context.query\_execution\_info module
--------------------------------------------------------------
-
-.. automodule:: azure.cosmos.execution_context.query_execution_info
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
+   azure.cosmos.execution_context.aggregators
+   azure.cosmos.execution_context.base_execution_context
+   azure.cosmos.execution_context.document_producer
+   azure.cosmos.execution_context.endpoint_component
+   azure.cosmos.execution_context.execution_dispatcher
+   azure.cosmos.execution_context.multi_execution_aggregator
+   azure.cosmos.execution_context.query_execution_info
 
 Module contents
 ---------------

--- a/doc/sphinx/ref/azure.cosmos.global_endpoint_manager.rst
+++ b/doc/sphinx/ref/azure.cosmos.global_endpoint_manager.rst
@@ -1,0 +1,7 @@
+azure.cosmos.global\_endpoint\_manager module
+=============================================
+
+.. automodule:: azure.cosmos.global_endpoint_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.hash_partition_resolver.rst
+++ b/doc/sphinx/ref/azure.cosmos.hash_partition_resolver.rst
@@ -1,0 +1,7 @@
+azure.cosmos.hash\_partition\_resolver module
+=============================================
+
+.. automodule:: azure.cosmos.hash_partition_resolver
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.http_constants.rst
+++ b/doc/sphinx/ref/azure.cosmos.http_constants.rst
@@ -1,0 +1,7 @@
+azure.cosmos.http\_constants module
+===================================
+
+.. automodule:: azure.cosmos.http_constants
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.location_cache.rst
+++ b/doc/sphinx/ref/azure.cosmos.location_cache.rst
@@ -1,0 +1,7 @@
+azure.cosmos.location\_cache module
+===================================
+
+.. automodule:: azure.cosmos.location_cache
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.murmur_hash.rst
+++ b/doc/sphinx/ref/azure.cosmos.murmur_hash.rst
@@ -1,0 +1,7 @@
+azure.cosmos.murmur\_hash module
+================================
+
+.. automodule:: azure.cosmos.murmur_hash
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.offer.rst
+++ b/doc/sphinx/ref/azure.cosmos.offer.rst
@@ -1,0 +1,7 @@
+azure.cosmos.offer module
+=========================
+
+.. automodule:: azure.cosmos.offer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.partition.rst
+++ b/doc/sphinx/ref/azure.cosmos.partition.rst
@@ -1,0 +1,7 @@
+azure.cosmos.partition module
+=============================
+
+.. automodule:: azure.cosmos.partition
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.partition_key.rst
+++ b/doc/sphinx/ref/azure.cosmos.partition_key.rst
@@ -1,0 +1,7 @@
+azure.cosmos.partition\_key module
+==================================
+
+.. automodule:: azure.cosmos.partition_key
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.permission.rst
+++ b/doc/sphinx/ref/azure.cosmos.permission.rst
@@ -1,0 +1,7 @@
+azure.cosmos.permission module
+==============================
+
+.. automodule:: azure.cosmos.permission
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.query_iterable.rst
+++ b/doc/sphinx/ref/azure.cosmos.query_iterable.rst
@@ -1,0 +1,7 @@
+azure.cosmos.query\_iterable module
+===================================
+
+.. automodule:: azure.cosmos.query_iterable
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.range.rst
+++ b/doc/sphinx/ref/azure.cosmos.range.rst
@@ -1,0 +1,7 @@
+azure.cosmos.range module
+=========================
+
+.. automodule:: azure.cosmos.range
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.range_partition_resolver.rst
+++ b/doc/sphinx/ref/azure.cosmos.range_partition_resolver.rst
@@ -1,0 +1,7 @@
+azure.cosmos.range\_partition\_resolver module
+==============================================
+
+.. automodule:: azure.cosmos.range_partition_resolver
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.request_object.rst
+++ b/doc/sphinx/ref/azure.cosmos.request_object.rst
@@ -1,0 +1,7 @@
+azure.cosmos.request\_object module
+===================================
+
+.. automodule:: azure.cosmos.request_object
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.resource_throttle_retry_policy.rst
+++ b/doc/sphinx/ref/azure.cosmos.resource_throttle_retry_policy.rst
@@ -1,0 +1,7 @@
+azure.cosmos.resource\_throttle\_retry\_policy module
+=====================================================
+
+.. automodule:: azure.cosmos.resource_throttle_retry_policy
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.retry_options.rst
+++ b/doc/sphinx/ref/azure.cosmos.retry_options.rst
@@ -1,0 +1,7 @@
+azure.cosmos.retry\_options module
+==================================
+
+.. automodule:: azure.cosmos.retry_options
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.retry_utility.rst
+++ b/doc/sphinx/ref/azure.cosmos.retry_utility.rst
@@ -1,0 +1,7 @@
+azure.cosmos.retry\_utility module
+==================================
+
+.. automodule:: azure.cosmos.retry_utility
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.routing.collection_routing_map.rst
+++ b/doc/sphinx/ref/azure.cosmos.routing.collection_routing_map.rst
@@ -1,0 +1,7 @@
+azure.cosmos.routing.collection\_routing\_map module
+====================================================
+
+.. automodule:: azure.cosmos.routing.collection_routing_map
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.routing.routing_map_provider.rst
+++ b/doc/sphinx/ref/azure.cosmos.routing.routing_map_provider.rst
@@ -1,0 +1,7 @@
+azure.cosmos.routing.routing\_map\_provider module
+==================================================
+
+.. automodule:: azure.cosmos.routing.routing_map_provider
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.routing.routing_range.rst
+++ b/doc/sphinx/ref/azure.cosmos.routing.routing_range.rst
@@ -1,0 +1,7 @@
+azure.cosmos.routing.routing\_range module
+==========================================
+
+.. automodule:: azure.cosmos.routing.routing_range
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.routing.rst
+++ b/doc/sphinx/ref/azure.cosmos.routing.rst
@@ -4,30 +4,11 @@ azure.cosmos.routing package
 Submodules
 ----------
 
-azure.cosmos.routing.collection\_routing\_map module
-----------------------------------------------------
+.. toctree::
 
-.. automodule:: azure.cosmos.routing.collection_routing_map
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.routing.routing\_map\_provider module
---------------------------------------------------
-
-.. automodule:: azure.cosmos.routing.routing_map_provider
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.routing.routing\_range module
-------------------------------------------
-
-.. automodule:: azure.cosmos.routing.routing_range
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
+   azure.cosmos.routing.collection_routing_map
+   azure.cosmos.routing.routing_map_provider
+   azure.cosmos.routing.routing_range
 
 Module contents
 ---------------

--- a/doc/sphinx/ref/azure.cosmos.rst
+++ b/doc/sphinx/ref/azure.cosmos.rst
@@ -12,230 +12,45 @@ Subpackages
 Submodules
 ----------
 
-azure.cosmos.auth module
-------------------------
+.. toctree::
 
-.. automodule:: azure.cosmos.auth
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.base module
-------------------------
-
-.. automodule:: azure.cosmos.base
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.consistent\_hash\_ring module
-------------------------------------------
-
-.. automodule:: azure.cosmos.consistent_hash_ring
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.constants module
------------------------------
-
-.. automodule:: azure.cosmos.constants
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.cosmos\_client module
-----------------------------------
-
-.. automodule:: azure.cosmos.cosmos_client
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.default\_retry\_policy module
-------------------------------------------
-
-.. automodule:: azure.cosmos.default_retry_policy
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.documents module
------------------------------
-
-.. automodule:: azure.cosmos.documents
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.endpoint\_discovery\_retry\_policy module
-------------------------------------------------------
-
-.. automodule:: azure.cosmos.endpoint_discovery_retry_policy
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.errors module
---------------------------
-
-.. automodule:: azure.cosmos.errors
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.global\_endpoint\_manager module
----------------------------------------------
-
-.. automodule:: azure.cosmos.global_endpoint_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.hash\_partition\_resolver module
----------------------------------------------
-
-.. automodule:: azure.cosmos.hash_partition_resolver
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.http\_constants module
------------------------------------
-
-.. automodule:: azure.cosmos.http_constants
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.location\_cache module
------------------------------------
-
-.. automodule:: azure.cosmos.location_cache
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.murmur\_hash module
---------------------------------
-
-.. automodule:: azure.cosmos.murmur_hash
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.partition module
------------------------------
-
-.. automodule:: azure.cosmos.partition
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.query\_iterable module
------------------------------------
-
-.. automodule:: azure.cosmos.query_iterable
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.range module
--------------------------
-
-.. automodule:: azure.cosmos.range
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.range\_partition\_resolver module
-----------------------------------------------
-
-.. automodule:: azure.cosmos.range_partition_resolver
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.request\_object module
------------------------------------
-
-.. automodule:: azure.cosmos.request_object
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.resource\_throttle\_retry\_policy module
------------------------------------------------------
-
-.. automodule:: azure.cosmos.resource_throttle_retry_policy
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.retry\_options module
-----------------------------------
-
-.. automodule:: azure.cosmos.retry_options
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.retry\_utility module
-----------------------------------
-
-.. automodule:: azure.cosmos.retry_utility
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.runtime\_constants module
---------------------------------------
-
-.. automodule:: azure.cosmos.runtime_constants
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.session module
----------------------------
-
-.. automodule:: azure.cosmos.session
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.session\_retry\_policy module
-------------------------------------------
-
-.. automodule:: azure.cosmos.session_retry_policy
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.synchronized\_request module
------------------------------------------
-
-.. automodule:: azure.cosmos.synchronized_request
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.utils module
--------------------------
-
-.. automodule:: azure.cosmos.utils
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.cosmos.vector\_session\_token module
-------------------------------------------
-
-.. automodule:: azure.cosmos.vector_session_token
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
+   azure.cosmos.auth
+   azure.cosmos.base
+   azure.cosmos.consistent_hash_ring
+   azure.cosmos.constants
+   azure.cosmos.container
+   azure.cosmos.cosmos_client
+   azure.cosmos.cosmos_client_connection
+   azure.cosmos.database
+   azure.cosmos.default_retry_policy
+   azure.cosmos.diagnostics
+   azure.cosmos.documents
+   azure.cosmos.endpoint_discovery_retry_policy
+   azure.cosmos.errors
+   azure.cosmos.global_endpoint_manager
+   azure.cosmos.hash_partition_resolver
+   azure.cosmos.http_constants
+   azure.cosmos.location_cache
+   azure.cosmos.murmur_hash
+   azure.cosmos.offer
+   azure.cosmos.partition
+   azure.cosmos.partition_key
+   azure.cosmos.permission
+   azure.cosmos.query_iterable
+   azure.cosmos.range
+   azure.cosmos.range_partition_resolver
+   azure.cosmos.request_object
+   azure.cosmos.resource_throttle_retry_policy
+   azure.cosmos.retry_options
+   azure.cosmos.retry_utility
+   azure.cosmos.runtime_constants
+   azure.cosmos.scripts
+   azure.cosmos.session
+   azure.cosmos.session_retry_policy
+   azure.cosmos.synchronized_request
+   azure.cosmos.user
+   azure.cosmos.utils
+   azure.cosmos.vector_session_token
 
 Module contents
 ---------------

--- a/doc/sphinx/ref/azure.cosmos.runtime_constants.rst
+++ b/doc/sphinx/ref/azure.cosmos.runtime_constants.rst
@@ -1,0 +1,7 @@
+azure.cosmos.runtime\_constants module
+======================================
+
+.. automodule:: azure.cosmos.runtime_constants
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.scripts.rst
+++ b/doc/sphinx/ref/azure.cosmos.scripts.rst
@@ -1,0 +1,7 @@
+azure.cosmos.scripts module
+===========================
+
+.. automodule:: azure.cosmos.scripts
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.session.rst
+++ b/doc/sphinx/ref/azure.cosmos.session.rst
@@ -1,0 +1,7 @@
+azure.cosmos.session module
+===========================
+
+.. automodule:: azure.cosmos.session
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.session_retry_policy.rst
+++ b/doc/sphinx/ref/azure.cosmos.session_retry_policy.rst
@@ -1,0 +1,7 @@
+azure.cosmos.session\_retry\_policy module
+==========================================
+
+.. automodule:: azure.cosmos.session_retry_policy
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.synchronized_request.rst
+++ b/doc/sphinx/ref/azure.cosmos.synchronized_request.rst
@@ -1,0 +1,7 @@
+azure.cosmos.synchronized\_request module
+=========================================
+
+.. automodule:: azure.cosmos.synchronized_request
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.user.rst
+++ b/doc/sphinx/ref/azure.cosmos.user.rst
@@ -1,0 +1,7 @@
+azure.cosmos.user module
+========================
+
+.. automodule:: azure.cosmos.user
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.utils.rst
+++ b/doc/sphinx/ref/azure.cosmos.utils.rst
@@ -1,0 +1,7 @@
+azure.cosmos.utils module
+=========================
+
+.. automodule:: azure.cosmos.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/ref/azure.cosmos.vector_session_token.rst
+++ b/doc/sphinx/ref/azure.cosmos.vector_session_token.rst
@@ -1,0 +1,7 @@
+azure.cosmos.vector\_session\_token module
+==========================================
+
+.. automodule:: azure.cosmos.vector_session_token
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
This should end up generating the same (different skin of course) content for our greater `all docs` build that the cosmos team has specified in their project specific doc/ folder.