### PR TITLE
ignoring root readme

### DIFF
--- a/.docsettings.yml
+++ b/.docsettings.yml
@@ -63,6 +63,9 @@ known_content_issues:
   - ['sdk/core/azure-mgmt-nspkg/README.rst', 'nspkg and common']
   - ['sdk/core/azure-core/README.md', 'nspkg and common']
 
+  # root readme
+  - ['README.md', 'root readme']
+
   # dev tools 
   - ['doc/dev/mgmt/swagger/single_api/readme.md', 'dev readme']
   - ['doc/dev/mgmt/swagger/multi_api/readme.md', 'dev readme']


### PR DESCRIPTION
It doesn't conform to the `X client library for Python` It's a root about an entire repo as a whole, not a specific package.