### PR TITLE
update CODEOWNERS links to point to sync documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
-# See for instructions on this file https://help.github.com/articles/about-codeowners/
-
 # Instructions for CODEOWNERS file format and automatic build failure notifications:
 # https://github.com/Azure/azure-sdk/blob/master/docs/engineering-system/codeowners.md
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,28 @@
 # See for instructions on this file https://help.github.com/articles/about-codeowners/
 
-# Instructions for subscribing to scheduled build failure notifications:
-# https://github.com/Azure/azure-sdk/blob/master/docs/engineering-system/codeowners-notifications.md
+# Instructions for CODEOWNERS file format and automatic build failure notifications:
+# https://github.com/Azure/azure-sdk/blob/master/docs/engineering-system/codeowners.md
 
+###########
+# Eng Sys
+###########
+/eng/   @weshaggard @scbedd
+
+/eng/pipelines/ @weshaggard @scbedd @mitchdenny @danieljurek
+
+/eng/pipelines/client.yml   @mitchdenny @danieljurek
+/**/tests.yml   @danieljurek
+/**/ci.yml      @mitchdenny
+
+
+###########
+# SDK
+###########
+
+# Catch all
+# /sdk/ @mayurid
+
+# Core
 /sdk/core/ @lmazuel
 /sdk/core/azure-core/ @xiangyan99 @bryevdv
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,8 @@
 # See for instructions on this file https://help.github.com/articles/about-codeowners/
 
+# Instructions for subscribing to scheduled build failure notifications:
+# https://github.com/Azure/azure-sdk/blob/master/docs/engineering-system/codeowners-notifications.md
+
 /sdk/core/ @lmazuel
 /sdk/core/azure-core/ @xiangyan99 @bryevdv
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,9 @@
 /sdk/core/azure-core/ @xiangyan99 @bryevdv
 
 # Service team
+# /sdk/identity/
+# /sdk/eventhub/
+# /sdk/storage/
 /sdk/applicationinsights/ @alexeldeib
 /sdk/batch/ @bgklein @matthchr @xingwu1
 /sdk/cognitiveservices/azure-cognitiveservices-vision-customvision/ @areddish
@@ -22,7 +25,7 @@
 /sdk/loganalytics/ @alexeldeib
 /sdk/consumption/ @sandeepnl
 /sdk/containerinstance/ @samkreter @xizhamsft
-/sdk/containerregistry/ @djyou 
+/sdk/containerregistry/ @djyou
 /sdk/containerservice/ @samkreter @zqingqing1 @GaneshaThirumurthi
 /sdk/cosmos/ @dmakwana
 /sdk/datafactory/ @hvermis

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,14 +4,6 @@
 # https://github.com/Azure/azure-sdk/blob/master/docs/engineering-system/codeowners.md
 
 ###########
-# Eng Sys
-###########
-/eng/   @weshaggard @scbedd @mitchdenny @danieljurek
-/**/tests.yml   @danieljurek
-/**/ci.yml      @mitchdenny
-
-
-###########
 # SDK
 ###########
 
@@ -43,3 +35,10 @@
 /sdk/servicefabric/ @QingChenmsft @samedder
 /sql/sql/ @jaredmoo
 /sdk/servicebus/azure-servicebus/ @annatisch
+
+###########
+# Eng Sys
+###########
+/eng/   @weshaggard @scbedd @mitchdenny @danieljurek
+/**/tests.yml   @danieljurek
+/**/ci.yml      @mitchdenny

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,11 +6,7 @@
 ###########
 # Eng Sys
 ###########
-/eng/   @weshaggard @scbedd
-
-/eng/pipelines/ @weshaggard @scbedd @mitchdenny @danieljurek
-
-/eng/pipelines/client.yml   @mitchdenny @danieljurek
+/eng/   @weshaggard @scbedd @mitchdenny @danieljurek
 /**/tests.yml   @danieljurek
 /**/ci.yml      @mitchdenny
 


### PR DESCRIPTION
Adding link to documentation in the azure-sdk repo

@Azure/azure-sdk-eng 