### PR TITLE
Remove default development settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ app_creds_real.py
 *.user
 *.sln.docstates
 .vs/
-.vscode
+.vscode/
 
 # Windows image file caches
 Thumbs.db

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "git.ignoreLimitWarning": true,
-    "python.testing.pytestArgs": [],
-    "python.testing.pytestEnabled": true
-}

--- a/scripts/devops_tasks/setup_execute_tests.py
+++ b/scripts/devops_tasks/setup_execute_tests.py
@@ -95,9 +95,7 @@ if __name__ == '__main__':
     if args.disablecov:
         test_results_arg.append('--no-cov')
     else:
-        test_results_arg.append('--durations=10')
-        test_results_arg.append('--cov')
-        test_results_arg.append('--cov-report=')
+        test_results_arg.extend(['--durations=10', '--cov', '--cov-report='])
 
     if args.mark_arg:
         test_results_arg.extend(['-m', '"{}"'.format(args.mark_arg)])

--- a/scripts/devops_tasks/setup_execute_tests.py
+++ b/scripts/devops_tasks/setup_execute_tests.py
@@ -94,6 +94,10 @@ if __name__ == '__main__':
 
     if args.disablecov:
         test_results_arg.append('--no-cov')
+    else:
+        test_results_arg.append('--durations=10')
+        test_results_arg.append('--cov')
+        test_results_arg.append('--cov-report=')
 
     if args.mark_arg:
         test_results_arg.extend(['-m', '"{}"'.format(args.mark_arg)])

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,2 @@
 [tool:pytest]
-addopts = --durations=10 --cov --cov-report=
 norecursedirs = models


### PR DESCRIPTION
This addresses a couple annoyances in the dev experience:

1. The root `setup.cfg` adds coverage to all pytest runs across the repo. Coverage is typically unwanted in local development and somehow prevents attaching a debugger, so everyone on the team uses some workaround to debug tests (or doesn't debug tests 😉 ). This PR removes the additional pytest options. @scbedd we'll need to explicitly enable coverage when it's wanted.
1. The repo includes vscode settings. When a dev adjusts their workspace settings to accommodate their local environment, their settings become unstaged changes requiring eternal vigilance lest they be committed. Interestingly, it appears `.vscode` was intended to be ignored. This PR ensures it will be from now on, and removes the settings file.