### PR TITLE
Eventhubs conn

### DIFF
--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/_connection_manager.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/_connection_manager.py
@@ -74,4 +74,4 @@ class _SeparateConnectionManager(object):
 
 
 def get_connection_manager(**kwargs):
-    return _SharedConnectionManager(**kwargs)
+    return _SeparateConnectionManager(**kwargs)

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/_connection_manager.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/_connection_manager.py
@@ -7,7 +7,7 @@ import threading
 from uamqp import Connection, TransportType
 
 
-class _ConnectionManager(object):
+class _SharedConnectionManager(object):
     def __init__(self, **kwargs):
         self._lock = threading.Lock()
         self._conn = None
@@ -42,9 +42,23 @@ class _ConnectionManager(object):
                     encoding=self._encoding)
             return self._conn
 
-    def close_connection(self):
+    def close_connection(self, conn=None):
         with self._lock:
             if self._conn:
                 self._conn.destroy()
             self._conn = None
 
+
+class _SeparateConnectionManager(object):
+    def __init__(self, **kwargs):
+        pass
+
+    def get_connection(self, host, auth):
+        return None
+
+    def close_connection(self):
+        pass
+
+
+def get_connection_manager(**kwargs):
+    return _SeparateConnectionManager(**kwargs)

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/_consumer_producer_mixin.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/_consumer_producer_mixin.py
@@ -1,0 +1,109 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+from __future__ import unicode_literals
+
+import logging
+import time
+
+from uamqp import errors
+from azure.eventhub.error import EventHubError, _handle_exception
+
+log = logging.getLogger(__name__)
+
+
+class ConsumerProducerMixin(object):
+    def __init__(self):
+        self.client = None
+        self._handler = None
+        self.name = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close(exc_val)
+
+    def _check_closed(self):
+        if self.error:
+            raise EventHubError("{} has been closed. Please create a new consumer to receive event data.".format(self.name))
+
+    def _create_handler(self):
+        pass
+
+    def _redirect(self, redirect):
+        self.redirected = redirect
+        self.running = False
+        self._close_connection()
+
+    def _open(self, timeout_time=None):
+        """
+        Open the EventHubConsumer using the supplied connection.
+        If the handler has previously been redirected, the redirect
+        context will be used to create a new handler before opening it.
+
+        """
+        # pylint: disable=protected-access
+        if not self.running:
+            if self.redirected:
+                alt_creds = {
+                    "username": self.client._auth_config.get("iot_username"),
+                    "password": self.client._auth_config.get("iot_password")}
+            else:
+                alt_creds = {}
+            self._create_handler()
+            self._handler.open(connection=self.client._conn_manager.get_connection(
+                self.client.address.hostname,
+                self.client.get_auth(**alt_creds)
+            ))
+            while not self._handler.client_ready():
+                if timeout_time and time.time() >= timeout_time:
+                    return
+                time.sleep(0.05)
+            self.running = True
+
+    def _close_handler(self):
+        self._handler.close()  # close the link (sharing connection) or connection (not sharing)
+        self.running = False
+
+    def _close_connection(self):
+        self._close_handler()
+        self.client._conn_manager.reset_connection_if_broken()
+
+    def _handle_exception(self, exception, retry_count, max_retries, timeout_time):
+        _handle_exception(exception, retry_count, max_retries, self, timeout_time)
+
+    def close(self, exception=None):
+        # type:(Exception) -> None
+        """
+        Close down the handler. If the handler has already closed,
+        this will be a no op. An optional exception can be passed in to
+        indicate that the handler was shutdown due to error.
+
+        :param exception: An optional exception if the handler is closing
+         due to an error.
+        :type exception: Exception
+
+        Example:
+            .. literalinclude:: ../examples/test_examples_eventhub.py
+                :start-after: [START eventhub_client_receiver_close]
+                :end-before: [END eventhub_client_receiver_close]
+                :language: python
+                :dedent: 4
+                :caption: Close down the handler.
+
+        """
+        self.running = False
+        if self.error:
+            return
+        if isinstance(exception, errors.LinkRedirect):
+            self.redirected = exception
+        elif isinstance(exception, EventHubError):
+            self.error = exception
+        elif exception:
+            self.error = EventHubError(str(exception))
+        else:
+            self.error = EventHubError("{} handler is closed.".format(self.name))
+        if self._handler:
+            self._handler.close()  # this will close link if sharing connection. Otherwise close connection

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/_connection_manager_async.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/_connection_manager_async.py
@@ -49,8 +49,8 @@ class _SharedConnectionManager(object):
                 await self._conn.destroy_async()
             self._conn = None
 
-    def reset_connection_if_broken(self):
-        with self._lock:
+    async def reset_connection_if_broken(self):
+        async with self._lock:
             if self._conn and self._conn._state in (
                 c_uamqp.ConnectionState.CLOSE_RCVD,
                 c_uamqp.ConnectionState.CLOSE_SENT,
@@ -58,6 +58,7 @@ class _SharedConnectionManager(object):
                 c_uamqp.ConnectionState.END,
             ):
                 self._conn = None
+
 
 class _SeparateConnectionManager(object):
     def __init__(self, **kwargs):

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/_consumer_producer_mixin_async.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/_consumer_producer_mixin_async.py
@@ -1,0 +1,112 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+import asyncio
+import logging
+import time
+
+from uamqp import errors
+from azure.eventhub.error import EventHubError, ConnectError
+from ..aio.error_async import _handle_exception
+
+log = logging.getLogger(__name__)
+
+
+class ConsumerProducerMixin(object):
+
+    def __init__(self):
+        self.client = None
+        self._handler = None
+        self.name = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.close(exc_val)
+
+    def _check_closed(self):
+        if self.error:
+            raise EventHubError("{} has been closed. Please create a new consumer to receive event data.".format(self.name))
+
+    def _create_handler(self):
+        pass
+
+    async def _redirect(self, redirect):
+        self.redirected = redirect
+        self.running = False
+        await self._close_connection()
+
+    async def _open(self, timeout_time=None):
+        """
+        Open the EventHubConsumer using the supplied connection.
+        If the handler has previously been redirected, the redirect
+        context will be used to create a new handler before opening it.
+
+        """
+        # pylint: disable=protected-access
+        if not self.running:
+            if self.redirected:
+                alt_creds = {
+                    "username": self.client._auth_config.get("iot_username"),
+                    "password": self.client._auth_config.get("iot_password")}
+            else:
+                alt_creds = {}
+            self._create_handler()
+            await self._handler.open_async(connection=await self.client._conn_manager.get_connection(
+                self.client.address.hostname,
+                self.client.get_auth(**alt_creds)
+            ))
+            while not await self._handler.client_ready_async():
+                if timeout_time and time.time() >= timeout_time:
+                    return
+                await asyncio.sleep(0.05)
+            self.running = True
+
+    async def _close_handler(self):
+        await self._handler.close_async()  # close the link (sharing connection) or connection (not sharing)
+        self.running = False
+
+    async def _close_connection(self):
+        await self._close_handler()
+        await self.client._conn_manager.reset_connection_if_broken()
+
+    async def _handle_exception(self, exception, retry_count, max_retries, timeout_time):
+        await _handle_exception(exception, retry_count, max_retries, self, timeout_time)
+
+    async def close(self, exception=None):
+        # type: (Exception) -> None
+        """
+        Close down the handler. If the handler has already closed,
+        this will be a no op. An optional exception can be passed in to
+        indicate that the handler was shutdown due to error.
+
+        :param exception: An optional exception if the handler is closing
+         due to an error.
+        :type exception: Exception
+
+        Example:
+            .. literalinclude:: ../examples/async_examples/test_examples_eventhub_async.py
+                :start-after: [START eventhub_client_async_receiver_close]
+                :end-before: [END eventhub_client_async_receiver_close]
+                :language: python
+                :dedent: 4
+                :caption: Close down the handler.
+
+        """
+        self.running = False
+        if self.error:
+            return
+        if isinstance(exception, errors.LinkRedirect):
+            self.redirected = exception
+        elif isinstance(exception, EventHubError):
+            self.error = exception
+        elif isinstance(exception, (errors.LinkDetach, errors.ConnectionClose)):
+            self.error = ConnectError(str(exception), exception)
+        elif exception:
+            self.error = EventHubError(str(exception))
+        else:
+            self.error = EventHubError("This receive handler is now closed.")
+        if self._handler:
+            await self._handler.close_async()

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/client_async.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/client_async.py
@@ -98,7 +98,7 @@ class EventHubClient(EventHubClientAbstract):
                                                 transport_type=transport_type)
 
     async def _handle_exception(self, exception, retry_count, max_retries):
-        await _handle_exception(exception, retry_count, max_retries, self, log)
+        await _handle_exception(exception, retry_count, max_retries, self)
 
     async def _close_connection(self):
         await self._conn_manager.reset_connection_if_broken()

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/client_async.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/client_async.py
@@ -101,7 +101,7 @@ class EventHubClient(EventHubClientAbstract):
         await _handle_exception(exception, retry_count, max_retries, self, log)
 
     async def _close_connection(self):
-        self._conn_manager.reset_connection_if_broken()
+        await self._conn_manager.reset_connection_if_broken()
 
     async def _management_request(self, mgmt_msg, op_type):
         max_retries = self.config.max_retries

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/client_async.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/client_async.py
@@ -194,8 +194,7 @@ class EventHubClient(EventHubClientAbstract):
         return output
 
     def create_consumer(
-            self, consumer_group, partition_id, event_position, owner_level=None,
-            operation=None, prefetch=None, loop=None):
+            self, consumer_group, partition_id, event_position, **kwargs):
         # type: (str, str, EventPosition, int, str, int, asyncio.AbstractEventLoop) -> EventHubConsumer
         """
         Create an async consumer to the client for a particular consumer group and partition.
@@ -227,8 +226,12 @@ class EventHubClient(EventHubClientAbstract):
                 :caption: Add an async consumer to the client for a particular consumer group and partition.
 
         """
-        prefetch = self.config.prefetch if prefetch is None else prefetch
+        owner_level = kwargs.get("owner_level", None)
+        operation = kwargs.get("operation", None)
+        prefetch = kwargs.get("prefetch", None)
+        loop = kwargs.get("loop", None)
 
+        prefetch = prefetch or self.config.prefetch
         path = self.address.path + operation if operation else self.address.path
         source_url = "amqps://{}{}/ConsumerGroups/{}/Partitions/{}".format(
             self.address.hostname, path, consumer_group, partition_id)
@@ -238,7 +241,7 @@ class EventHubClient(EventHubClientAbstract):
         return handler
 
     def create_producer(
-            self, partition_id=None, operation=None, send_timeout=None, loop=None):
+            self, **kwargs):
         # type: (str, str, float, asyncio.AbstractEventLoop) -> EventHubProducer
         """
         Create an async producer to send EventData object to an EventHub.
@@ -265,6 +268,11 @@ class EventHubClient(EventHubClientAbstract):
                 :caption: Add an async producer to the client to send EventData.
 
         """
+        partition_id = kwargs.get("partition_id", None)
+        operation = kwargs.get("operation", None)
+        send_timeout = kwargs.get("send_timeout", None)
+        loop = kwargs.get("loop", None)
+
         target = "amqps://{}{}".format(self.address.hostname, self.address.path)
         if operation:
             target = target + operation

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/consumer_async.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/consumer_async.py
@@ -22,15 +22,15 @@ log = logging.getLogger(__name__)
 class EventHubConsumer(ConsumerProducerMixin):
     """
     A consumer responsible for reading EventData from a specific Event Hub
-     partition and as a member of a specific consumer group.
+    partition and as a member of a specific consumer group.
 
     A consumer may be exclusive, which asserts ownership over the partition for the consumer
-     group to ensure that only one consumer from that group is reading the from the partition.
-     These exclusive consumers are sometimes referred to as "Epoch Consumers."
+    group to ensure that only one consumer from that group is reading the from the partition.
+    These exclusive consumers are sometimes referred to as "Epoch Consumers."
 
     A consumer may also be non-exclusive, allowing multiple consumers from the same consumer
-     group to be actively reading events from the partition.  These non-exclusive consumers are
-     sometimes referred to as "Non-Epoch Consumers."
+    group to be actively reading events from the partition.  These non-exclusive consumers are
+    sometimes referred to as "Non-Epoch Consumers."
 
     """
     timeout = 0
@@ -38,8 +38,7 @@ class EventHubConsumer(ConsumerProducerMixin):
     _timeout = b'com.microsoft:timeout'
 
     def __init__(  # pylint: disable=super-init-not-called
-            self, client, source, event_position=None, prefetch=300, owner_level=None,
-            keep_alive=None, auto_reconnect=True, loop=None):
+            self, client, source, **kwargs):
         """
         Instantiate an async consumer. EventHubConsumer should be instantiated by calling the `create_consumer` method
          in EventHubClient.
@@ -58,6 +57,13 @@ class EventHubConsumer(ConsumerProducerMixin):
         :type owner_level: int
         :param loop: An event loop.
         """
+        event_position = kwargs.get("event_position", None)
+        prefetch = kwargs.get("prefetch", 300)
+        owner_level = kwargs.get("owner_level", None)
+        keep_alive = kwargs.get("keep_alive", None)
+        auto_reconnect = kwargs.get("auto_reconnect", True)
+        loop = kwargs.get("loop", None)
+
         super(EventHubConsumer, self).__init__()
         self.loop = loop or asyncio.get_event_loop()
         self.running = False
@@ -153,7 +159,7 @@ class EventHubConsumer(ConsumerProducerMixin):
             return self._handler._received_messages.qsize()
         return 0
 
-    async def receive(self, max_batch_size=None, timeout=None):
+    async def receive(self, **kwargs):
         # type: (int, float) -> List[EventData]
         """
         Receive events asynchronously from the EventHub.
@@ -180,6 +186,9 @@ class EventHubConsumer(ConsumerProducerMixin):
                 :caption: Receives events asynchronously
 
         """
+        max_batch_size = kwargs.get("max_batch_size", None)
+        timeout = kwargs.get("timeout", None)
+
         self._check_closed()
         max_batch_size = min(self.client.config.max_batch_size, self.prefetch) if max_batch_size is None else max_batch_size
         timeout = self.client.config.receive_timeout if timeout is None else timeout
@@ -217,7 +226,7 @@ class EventHubConsumer(ConsumerProducerMixin):
                 last_exception = await self._handle_exception(exception, retry_count, max_retries, timeout_time)
                 retry_count += 1
 
-    async def close(self, exception=None):
+    async def close(self, **kwargs):
         # type: (Exception) -> None
         """
         Close down the handler. If the handler has already closed,
@@ -237,6 +246,7 @@ class EventHubConsumer(ConsumerProducerMixin):
                 :caption: Close down the handler.
 
         """
+        exception = kwargs.get("exception", None)
         self.running = False
         if self.error:
             return

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/error_async.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/error_async.py
@@ -1,0 +1,79 @@
+from uamqp import errors, compat
+from ..error import EventHubError, EventDataSendError, \
+    EventDataError, ConnectError, ConnectionLostError, AuthenticationError
+
+
+async def _handle_exception(exception, retry_count, max_retries, closable, log):
+    type_name = type(closable).__name__
+    if isinstance(exception, KeyboardInterrupt):
+        log.info("{} stops due to keyboard interrupt".format(type_name))
+        await closable.close()
+        raise
+
+    elif isinstance(exception, (
+            errors.MessageAccepted,
+            errors.MessageAlreadySettled,
+            errors.MessageModified,
+            errors.MessageRejected,
+            errors.MessageReleased,
+            errors.MessageContentTooLarge)
+            ):
+        log.error("Event data error (%r)", exception)
+        error = EventDataError(str(exception), exception)
+        await closable.close(exception)
+        raise error
+    elif isinstance(exception, errors.MessageException):
+        log.error("Event data send error (%r)", exception)
+        error = EventDataSendError(str(exception), exception)
+        await closable.close(exception)
+        raise error
+    elif retry_count >= max_retries:
+        log.info("{} has an error and has exhausted retrying. (%r)".format(type_name), exception)
+        if isinstance(exception, errors.AuthenticationException):
+            log.info("{} authentication failed. Shutting down.".format(type_name))
+            error = AuthenticationError(str(exception), exception)
+        elif isinstance(exception, errors.VendorLinkDetach):
+            log.info("{} link detached. Shutting down.".format(type_name))
+            error = ConnectError(str(exception), exception)
+        elif isinstance(exception, errors.LinkDetach):
+            log.info("{} link detached. Shutting down.".format(type_name))
+            error = ConnectionLostError(str(exception), exception)
+        elif isinstance(exception, errors.ConnectionClose):
+            log.info("{} connection closed. Shutting down.".format(type_name))
+            error = ConnectionLostError(str(exception), exception)
+        elif isinstance(exception, errors.MessageHandlerError):
+            log.info("{} detached. Shutting down.".format(type_name))
+            error = ConnectionLostError(str(exception), exception)
+        elif isinstance(exception, errors.AMQPConnectionError):
+            log.info("{} connection lost. Shutting down.".format(type_name))
+            error_type = AuthenticationError if str(exception).startswith("Unable to open authentication session") \
+                else ConnectError
+            error = error_type(str(exception), exception)
+        elif isinstance(exception, compat.TimeoutException):
+            log.info("{} timed out. Shutting down.".format(type_name))
+            error = ConnectionLostError(str(exception), exception)
+        else:
+            log.error("Unexpected error occurred (%r). Shutting down.", exception)
+            error = EventHubError("Receive failed: {}".format(exception), exception)
+        await closable.close()
+        raise error
+    else:
+        log.info("{} has an exception (%r). Retrying...".format(type_name), exception)
+        if isinstance(exception, errors.AuthenticationException):
+            await closable._close_connection()
+        elif isinstance(exception, errors.LinkRedirect):
+            log.info("{} link redirected. Redirecting...".format(type_name))
+            redirect = exception
+            await closable._redirect(redirect)
+        elif isinstance(exception, errors.LinkDetach):
+            await closable._close_handler()
+        elif isinstance(exception, errors.ConnectionClose):
+            await closable._close_connection()
+        elif isinstance(exception, errors.MessageHandlerError):
+            await closable._close_handler()
+        elif isinstance(exception, errors.AMQPConnectionError):
+            await closable._close_connection()
+        elif isinstance(exception, compat.TimeoutException):
+            pass  # Timeout doesn't need to recreate link or connection to retry
+        else:
+            await closable._close_connection()

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/error_async.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/error_async.py
@@ -60,20 +60,27 @@ async def _handle_exception(exception, retry_count, max_retries, closable, log):
     else:
         log.info("{} has an exception (%r). Retrying...".format(type_name), exception)
         if isinstance(exception, errors.AuthenticationException):
-            await closable._close_connection()
+            if hasattr(closable, "_close_connection"):
+                await closable._close_connection()
         elif isinstance(exception, errors.LinkRedirect):
             log.info("{} link redirected. Redirecting...".format(type_name))
             redirect = exception
-            await closable._redirect(redirect)
+            if hasattr(closable, "_redirect"):
+                await closable._redirect(redirect)
         elif isinstance(exception, errors.LinkDetach):
-            await closable._close_handler()
+            if hasattr(closable, "_close_handler"):
+                await closable._close_handler()
         elif isinstance(exception, errors.ConnectionClose):
-            await closable._close_connection()
+            if hasattr(closable, "_close_connection"):
+                await closable._close_connection()
         elif isinstance(exception, errors.MessageHandlerError):
-            await closable._close_handler()
+            if hasattr(closable, "_close_handler"):
+                await closable._close_handler()
         elif isinstance(exception, errors.AMQPConnectionError):
-            await closable._close_connection()
+            if hasattr(closable, "_close_connection"):
+                await closable._close_connection()
         elif isinstance(exception, compat.TimeoutException):
             pass  # Timeout doesn't need to recreate link or connection to retry
         else:
-            await closable._close_connection()
+            if hasattr(closable, "_close_connection"):
+                await closable._close_connection()

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/error_async.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/error_async.py
@@ -1,15 +1,49 @@
+import asyncio
+import time
+import logging
+
 from uamqp import errors, compat
 from ..error import EventHubError, EventDataSendError, \
     EventDataError, ConnectError, ConnectionLostError, AuthenticationError
 
 
-async def _handle_exception(exception, retry_count, max_retries, closable, log):
-    type_name = type(closable).__name__
-    if isinstance(exception, KeyboardInterrupt):
-        log.info("{} stops due to keyboard interrupt".format(type_name))
-        await closable.close()
-        raise
+log = logging.getLogger(__name__)
 
+
+def _create_eventhub_exception(exception):
+    if isinstance(exception, errors.AuthenticationException):
+        error = AuthenticationError(str(exception), exception)
+    elif isinstance(exception, errors.VendorLinkDetach):
+        error = ConnectError(str(exception), exception)
+    elif isinstance(exception, errors.LinkDetach):
+        error = ConnectionLostError(str(exception), exception)
+    elif isinstance(exception, errors.ConnectionClose):
+        error = ConnectionLostError(str(exception), exception)
+    elif isinstance(exception, errors.MessageHandlerError):
+        error = ConnectionLostError(str(exception), exception)
+    elif isinstance(exception, errors.AMQPConnectionError):
+        error_type = AuthenticationError if str(exception).startswith("Unable to open authentication session") \
+            else ConnectError
+        error = error_type(str(exception), exception)
+    elif isinstance(exception, compat.TimeoutException):
+        error = ConnectionLostError(str(exception), exception)
+    else:
+        error = EventHubError(str(exception), exception)
+    return error
+
+
+async def _handle_exception(exception, retry_count, max_retries, closable, timeout_time):
+    try:
+        name = closable.name
+    except AttributeError:
+        name = closable.container_id
+    if isinstance(exception, KeyboardInterrupt):
+        log.info("%r stops due to keyboard interrupt", name)
+        closable.close()
+        raise
+    elif isinstance(exception, EventHubError):
+        closable.close()
+        raise
     elif isinstance(exception, (
             errors.MessageAccepted,
             errors.MessageAlreadySettled,
@@ -18,52 +52,23 @@ async def _handle_exception(exception, retry_count, max_retries, closable, log):
             errors.MessageReleased,
             errors.MessageContentTooLarge)
             ):
-        log.error("Event data error (%r)", exception)
+        log.info("%r Event data error (%r)", name, exception)
         error = EventDataError(str(exception), exception)
-        await closable.close(exception)
         raise error
     elif isinstance(exception, errors.MessageException):
-        log.error("Event data send error (%r)", exception)
+        log.info("%r Event data send error (%r)", name, exception)
         error = EventDataSendError(str(exception), exception)
-        await closable.close(exception)
         raise error
     elif retry_count >= max_retries:
-        log.info("{} has an error and has exhausted retrying. (%r)".format(type_name), exception)
-        if isinstance(exception, errors.AuthenticationException):
-            log.info("{} authentication failed. Shutting down.".format(type_name))
-            error = AuthenticationError(str(exception), exception)
-        elif isinstance(exception, errors.VendorLinkDetach):
-            log.info("{} link detached. Shutting down.".format(type_name))
-            error = ConnectError(str(exception), exception)
-        elif isinstance(exception, errors.LinkDetach):
-            log.info("{} link detached. Shutting down.".format(type_name))
-            error = ConnectionLostError(str(exception), exception)
-        elif isinstance(exception, errors.ConnectionClose):
-            log.info("{} connection closed. Shutting down.".format(type_name))
-            error = ConnectionLostError(str(exception), exception)
-        elif isinstance(exception, errors.MessageHandlerError):
-            log.info("{} detached. Shutting down.".format(type_name))
-            error = ConnectionLostError(str(exception), exception)
-        elif isinstance(exception, errors.AMQPConnectionError):
-            log.info("{} connection lost. Shutting down.".format(type_name))
-            error_type = AuthenticationError if str(exception).startswith("Unable to open authentication session") \
-                else ConnectError
-            error = error_type(str(exception), exception)
-        elif isinstance(exception, compat.TimeoutException):
-            log.info("{} timed out. Shutting down.".format(type_name))
-            error = ConnectionLostError(str(exception), exception)
-        else:
-            log.error("Unexpected error occurred (%r). Shutting down.", exception)
-            error = EventHubError("Receive failed: {}".format(exception), exception)
-        await closable.close()
+        error = _create_eventhub_exception(exception)
+        log.info("%r has exhausted retry. Exception still occurs (%r)", name, exception)
         raise error
     else:
-        log.info("{} has an exception (%r). Retrying...".format(type_name), exception)
         if isinstance(exception, errors.AuthenticationException):
             if hasattr(closable, "_close_connection"):
                 await closable._close_connection()
         elif isinstance(exception, errors.LinkRedirect):
-            log.info("{} link redirected. Redirecting...".format(type_name))
+            log.info("%r link redirect received. Redirecting...", name)
             redirect = exception
             if hasattr(closable, "_redirect"):
                 await closable._redirect(redirect)
@@ -84,3 +89,20 @@ async def _handle_exception(exception, retry_count, max_retries, closable, log):
         else:
             if hasattr(closable, "_close_connection"):
                 await closable._close_connection()
+        # start processing retry delay
+        try:
+            backoff_factor = closable.client.config.backoff_factor
+            backoff_max = closable.client.config.backoff_max
+        except AttributeError:
+            backoff_factor = closable.config.backoff_factor
+            backoff_max = closable.config.backoff_max
+        backoff = backoff_factor * 2 ** retry_count
+        if backoff <= backoff_max and time.time() + backoff <= timeout_time:
+            await asyncio.sleep(backoff)
+            log.info("%r has an exception (%r). Retrying...", format(name), exception)
+            return _create_eventhub_exception(exception)
+        else:
+            error = _create_eventhub_exception(exception)
+            log.info("%r operation has timed out. Last exception before timeout is (%r)", name, error)
+            raise error
+        # end of processing retry delay

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/error_async.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/error_async.py
@@ -32,7 +32,7 @@ def _create_eventhub_exception(exception):
     return error
 
 
-async def _handle_exception(exception, retry_count, max_retries, closable, timeout_time):
+async def _handle_exception(exception, retry_count, max_retries, closable, timeout_time=None):
     try:
         name = closable.name
     except AttributeError:
@@ -97,7 +97,7 @@ async def _handle_exception(exception, retry_count, max_retries, closable, timeo
             backoff_factor = closable.config.backoff_factor
             backoff_max = closable.config.backoff_max
         backoff = backoff_factor * 2 ** retry_count
-        if backoff <= backoff_max and time.time() + backoff <= timeout_time:
+        if backoff <= backoff_max and (timeout_time is None or time.time() + backoff <= timeout_time):
             await asyncio.sleep(backoff)
             log.info("%r has an exception (%r). Retrying...", format(name), exception)
             return _create_eventhub_exception(exception)

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/producer_async.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/aio/producer_async.py
@@ -8,7 +8,7 @@ import logging
 from typing import Iterable, Union
 import time
 
-from uamqp import constants, errors
+from uamqp import types, constants, errors
 from uamqp import SendClientAsync
 
 from azure.eventhub.common import EventData, _BatchSendEventData
@@ -28,6 +28,7 @@ class EventHubProducer(ConsumerProducerMixin):
      to a partition.
 
     """
+    _timeout = b'com.microsoft:timeout'
 
     def __init__(  # pylint: disable=super-init-not-called
             self, client, target, partition=None, send_timeout=60,
@@ -75,6 +76,7 @@ class EventHubProducer(ConsumerProducerMixin):
         self._handler = None
         self._outcome = None
         self._condition = None
+        self._link_properties = {types.AMQPSymbol(self._timeout): types.AMQPLong(int(self.timeout * 1000))}
 
     def _create_handler(self):
         self._handler = SendClientAsync(
@@ -85,6 +87,7 @@ class EventHubProducer(ConsumerProducerMixin):
             error_policy=self.retry_policy,
             keep_alive_interval=self.keep_alive,
             client_name=self.name,
+            link_properties=self._link_properties,
             properties=self.client._create_properties(
                 self.client.config.user_agent),  # pylint: disable=protected-access
             loop=self.loop)

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/client.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/client.py
@@ -200,8 +200,7 @@ class EventHubClient(EventHubClientAbstract):
         return output
 
     def create_consumer(
-            self, consumer_group, partition_id, event_position,
-            owner_level=None, operation=None, prefetch=None,
+            self, consumer_group, partition_id, event_position, **kwargs
     ):
         # type: (str, str, EventPosition, int, str, int) -> EventHubConsumer
         """
@@ -233,8 +232,11 @@ class EventHubClient(EventHubClientAbstract):
                 :caption: Add a consumer to the client for a particular consumer group and partition.
 
         """
-        prefetch = self.config.prefetch if prefetch is None else prefetch
+        owner_level = kwargs.get("owner_level", None)
+        operation = kwargs.get("operation", None)
+        prefetch = kwargs.get("prefetch", None)
 
+        prefetch = prefetch or self.config.prefetch
         path = self.address.path + operation if operation else self.address.path
         source_url = "amqps://{}{}/ConsumerGroups/{}/Partitions/{}".format(
             self.address.hostname, path, consumer_group, partition_id)
@@ -243,7 +245,7 @@ class EventHubClient(EventHubClientAbstract):
             prefetch=prefetch)
         return handler
 
-    def create_producer(self, partition_id=None, operation=None, send_timeout=None):
+    def create_producer(self, **kwargs):
         # type: (str, str, float) -> EventHubProducer
         """
         Create an producer to send EventData object to an EventHub.
@@ -269,6 +271,10 @@ class EventHubClient(EventHubClientAbstract):
                 :caption: Add a producer to the client to send EventData.
 
         """
+        partition_id = kwargs.get("partition_id", None)
+        operation = kwargs.get("operation", None)
+        send_timeout = kwargs.get("send_timeout", None)
+
         target = "amqps://{}{}".format(self.address.hostname, self.address.path)
         if operation:
             target = target + operation

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/client.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/client.py
@@ -52,9 +52,6 @@ class EventHubClient(EventHubClientAbstract):
         super(EventHubClient, self).__init__(host, event_hub_path, credential, **kwargs)
         self._conn_manager = get_connection_manager(**kwargs)
 
-    def __del__(self):
-        self._conn_manager.close_connection()
-
     def __enter__(self):
         return self
 

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/client.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/client.py
@@ -104,7 +104,7 @@ class EventHubClient(EventHubClientAbstract):
                                                transport_type=transport_type)
 
     def _handle_exception(self, exception, retry_count, max_retries):
-        _handle_exception(exception, retry_count, max_retries, self, log)
+        _handle_exception(exception, retry_count, max_retries, self)
 
     def _close_connection(self):
         self._conn_manager.reset_connection_if_broken()

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/client_abstract.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/client_abstract.py
@@ -219,7 +219,7 @@ class EventHubClientAbstract(object):
         self.mgmt_target = redirect_uri
 
     @classmethod
-    def from_connection_string(cls, conn_str, event_hub_path=None, **kwargs):
+    def from_connection_string(cls, conn_str, **kwargs):
         """Create an EventHubClient from an EventHub/IotHub connection string.
 
         :param conn_str: The connection string of an eventhub or IoT hub
@@ -266,6 +266,7 @@ class EventHubClientAbstract(object):
                 :caption: Create an EventHubClient from a connection string.
 
         """
+        event_hub_path = kwargs.get("event_hub_path", None)
         is_iot_conn_str = conn_str.lstrip().lower().startswith("hostname")
         if not is_iot_conn_str:
             address, policy, key, entity = _parse_conn_str(conn_str)
@@ -281,12 +282,10 @@ class EventHubClientAbstract(object):
 
     @abstractmethod
     def create_consumer(
-            self, consumer_group, partition_id, event_position, owner_level=None,
-            operation=None,
-            prefetch=None,
+            self, consumer_group, partition_id, event_position, **kwargs
     ):
         pass
 
     @abstractmethod
-    def create_producer(self, partition_id=None, operation=None, send_timeout=None):
+    def create_producer(self, **kwargs):
         pass

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/common.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/common.py
@@ -8,6 +8,7 @@ import datetime
 import calendar
 import json
 import six
+from enum import Enum
 
 from uamqp import BatchMessage, Message, types
 from uamqp.message import MessageHeader, MessageProperties

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/common.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/common.py
@@ -51,7 +51,7 @@ class EventData(object):
     PROP_TIMESTAMP = b"x-opt-enqueued-time"
     PROP_DEVICE_ID = b"iothub-connection-device-id"
 
-    def __init__(self, body=None, to_device=None, message=None):
+    def __init__(self, **kwargs):
         """
         Initialize EventData.
 
@@ -64,6 +64,10 @@ class EventData(object):
         :param message: The received message.
         :type message: ~uamqp.message.Message
         """
+        body = kwargs.get("body", None)
+        to_device = kwargs.get("to_device", None)
+        message = kwargs.get("message", None)
+
         self._partition_key = types.AMQPSymbol(EventData.PROP_PARTITION_KEY)
         self._annotations = {}
         self._app_properties = {}
@@ -206,7 +210,7 @@ class EventData(object):
         except TypeError:
             raise ValueError("Message data empty.")
 
-    def body_as_str(self, encoding='UTF-8'):
+    def body_as_str(self, **kwargs):
         """
         The body of the event data as a string if the data is of a
         compatible type.
@@ -215,6 +219,7 @@ class EventData(object):
          Default is 'UTF-8'
         :rtype: str or unicode
         """
+        encoding = kwargs.get("encoding", 'UTF-8')
         data = self.body
         try:
             return "".join(b.decode(encoding) for b in data)
@@ -227,7 +232,7 @@ class EventData(object):
         except Exception as e:
             raise TypeError("Message data is not compatible with string type: {}".format(e))
 
-    def body_as_json(self, encoding='UTF-8'):
+    def body_as_json(self, **kwargs):
         """
         The body of the event loaded as a JSON object is the data is compatible.
 
@@ -235,6 +240,7 @@ class EventData(object):
          Default is 'UTF-8'
         :rtype: dict
         """
+        encoding = kwargs.get("encoding", 'UTF-8')
         data_str = self.body_as_str(encoding=encoding)
         try:
             return json.loads(data_str)
@@ -280,7 +286,7 @@ class EventPosition(object):
       >>> event_pos = EventPosition(1506968696002)
     """
 
-    def __init__(self, value, inclusive=False):
+    def __init__(self, value, **kwargs):
         """
         Initialize EventPosition.
 
@@ -289,6 +295,7 @@ class EventPosition(object):
         :param inclusive: Whether to include the supplied value as the start point.
         :type inclusive: bool
         """
+        inclusive = kwargs.get("inclusive", False)
         self.value = value if value is not None else "-1"
         self.inclusive = inclusive
 

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/configuration.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/configuration.py
@@ -8,7 +8,11 @@ from uamqp.constants import TransportType
 class _Configuration(object):
     def __init__(self, **kwargs):
         self.user_agent = kwargs.get("user_agent")
-        self.max_retries = kwargs.get("max_retries", 3)
+        self.retry_total = kwargs.pop('retry_total', 3)
+        self.max_retries = self.retry_total or kwargs.get("max_retries", 3)
+        self.backoff_factor = kwargs.pop('retry_backoff_factor', 0.8)
+        self.backoff_max = kwargs.pop('retry_backoff_max', 120)
+
         self.network_tracing = kwargs.get("network_tracing", False)
         self.http_proxy = kwargs.get("http_proxy")
         self.transport_type = TransportType.AmqpOverWebsocket if self.http_proxy \

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/connection_manager.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/connection_manager.py
@@ -1,0 +1,50 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import threading
+from uamqp import Connection, TransportType
+
+
+class _ConnectionManager(object):
+    def __init__(self, **kwargs):
+        self._lock = threading.Lock()
+        self._conn = None
+
+        self._container_id = kwargs.get("container_id")
+        self._debug = kwargs.get("debug")
+        self._error_policy = kwargs.get("error_policy")
+        self._properties = kwargs.get("properties")
+        self._encoding = kwargs.get("encoding") or "UTF-8"
+        self._transport_type = kwargs.get('transport_type') or TransportType.Amqp
+        self._http_proxy = kwargs.get('http_proxy')
+        self._max_frame_size = kwargs.get("max_frame_size")
+        self._channel_max = kwargs.get("channel_max")
+        self._idle_timeout = kwargs.get("idle_timeout")
+        self._remote_idle_timeout_empty_frame_send_ratio = kwargs.get("remote_idle_timeout_empty_frame_send_ratio")
+
+    def get_connection(self, host, auth):
+        # type: (...) -> Connection
+        with self._lock:
+            if self._conn is None:
+                self._conn = Connection(
+                    host,
+                    auth,
+                    container_id=self._container_id,
+                    max_frame_size=self._max_frame_size,
+                    channel_max=self._channel_max,
+                    idle_timeout=self._idle_timeout,
+                    properties=self._properties,
+                    remote_idle_timeout_empty_frame_send_ratio=self._remote_idle_timeout_empty_frame_send_ratio,
+                    error_policy=self._error_policy,
+                    debug=self._debug,
+                    encoding=self._encoding)
+            return self._conn
+
+    def close_connection(self):
+        with self._lock:
+            if self._conn:
+                self._conn.destroy()
+            self._conn = None
+

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/consumer.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/consumer.py
@@ -102,8 +102,7 @@ class EventHubConsumer(object):
 
     def _check_closed(self):
         if self.error:
-            raise EventHubError("This consumer has been closed. Please create a new consumer to receive event data.",
-                                self.error)
+            raise EventHubError("This consumer has been closed. Please create a new consumer to receive event data.")
 
     def _create_handler(self):
         alt_creds = {
@@ -164,7 +163,7 @@ class EventHubConsumer(object):
 
     def _close_connection(self):
         self._close_handler()
-        self.client._conn_manager.close_connection()  # close the shared connection.
+        self.client._conn_manager.reset_connection_if_broken()
 
     def _handle_exception(self, exception, retry_count, max_retries):
         _handle_exception(exception, retry_count, max_retries, self, log)

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/error.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/error.py
@@ -19,6 +19,7 @@ _NO_RETRY_ERRORS = (
 
 log = logging.getLogger(__name__)
 
+
 def _error_handler(error):
     """
     Called internally when an event has failed to send so we
@@ -56,7 +57,8 @@ class EventHubError(Exception):
     :vartype details: dict[str, str]
     """
 
-    def __init__(self, message, details=None):
+    def __init__(self, message, **kwargs):
+        details = kwargs.get("details", None)
         self.error = None
         self.message = message
         self.details = details

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/error.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/error.py
@@ -162,7 +162,7 @@ def _create_eventhub_exception(exception):
     return error
 
 
-def _handle_exception(exception, retry_count, max_retries, closable, timeout_time):
+def _handle_exception(exception, retry_count, max_retries, closable, timeout_time=None):
     try:
         name = closable.name
     except AttributeError:
@@ -227,7 +227,7 @@ def _handle_exception(exception, retry_count, max_retries, closable, timeout_tim
             backoff_factor = closable.config.backoff_factor
             backoff_max = closable.config.backoff_max
         backoff = backoff_factor * 2 ** retry_count
-        if backoff <= backoff_max and time.time() + backoff <= timeout_time:
+        if backoff <= backoff_max and (timeout_time is None or time.time() + backoff <= timeout_time):
             time.sleep(backoff)
             log.info("%r has an exception (%r). Retrying...", format(name), exception)
             return _create_eventhub_exception(exception)

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/producer.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/producer.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 import uuid
 import logging
 import time
-from typing import Iterator, Generator, List, Union
+from typing import Iterable, Union
 
 from uamqp import constants, errors
 from uamqp import compat
@@ -85,6 +85,23 @@ class EventHubProducer(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close(exc_val)
 
+    def _create_handler(self):
+        self._handler = SendClient(
+            self.target,
+            auth=self.client.get_auth(),
+            debug=self.client.config.network_tracing,
+            msg_timeout=self.timeout,
+            error_policy=self.retry_policy,
+            keep_alive_interval=self.keep_alive,
+            client_name=self.name,
+            properties=self.client._create_properties(self.client.config.user_agent))  # pylint: disable=protected-access
+
+    def _redirect(self, redirect):
+        self.redirected = redirect
+        self.running = False
+        self.messages_iter = None
+        self._close_connection()
+
     def _open(self):
         """
         Open the EventHubProducer using the supplied connection.
@@ -93,182 +110,112 @@ class EventHubProducer(object):
 
         """
         # pylint: disable=protected-access
-        self._check_closed()
-        if self.redirected:
-            self.target = self.redirected.address
-            self._handler = SendClient(
-                self.target,
-                auth=self.client.get_auth(),
-                debug=self.client.config.network_tracing,
-                msg_timeout=self.timeout,
-                error_policy=self.retry_policy,
-                keep_alive_interval=self.keep_alive,
-                client_name=self.name,
-                properties=self.client._create_properties(self.client.config.user_agent))
         if not self.running:
-            self._connect()
-            self.running = True
-
-    def _connect(self):
-        connected = self._build_connection()
-        if not connected:
-            time.sleep(self.reconnect_backoff)
-            while not self._build_connection(is_reconnect=True):
-                time.sleep(self.reconnect_backoff)
-
-    def _build_connection(self, is_reconnect=False):
-        """
-
-        :param is_reconnect: True - trying to reconnect after fail to connect or a connection is lost.
-                             False - the 1st time to connect
-        :return: True - connected.  False - not connected
-        """
-        # pylint: disable=protected-access
-        if is_reconnect:
-            self._handler.close()
-            self._handler = SendClient(
-                self.target,
-                auth=self.client.get_auth(),
-                debug=self.client.config.network_tracing,
-                msg_timeout=self.timeout,
-                error_policy=self.retry_policy,
-                keep_alive_interval=self.keep_alive,
-                client_name=self.name,
-                properties=self.client._create_properties(self.client.config.user_agent))
-        try:
-            self._handler.open()
+            if self.redirected:
+                self.target = self.redirected.address
+            self._create_handler()
+            self._handler.open(connection=self.client._conn_manager.get_connection(
+                self.client.address.hostname,
+                self.client.get_auth()
+            ))
             while not self._handler.client_ready():
                 time.sleep(0.05)
-            return True
-        except errors.AuthenticationException as shutdown:
-            if is_reconnect:
-                log.info("EventHubProducer couldn't authenticate. Shutting down. (%r)", shutdown)
-                error = AuthenticationError(str(shutdown), shutdown)
-                self.close(exception=error)
-                raise error
+            self.running = True
+
+    def _close_handler(self):
+        self._handler.close()  # close the link (sharing connection) or connection (not sharing)
+        self.running = False
+
+    def _close_connection(self):
+        self._close_handler()
+        self.client._conn_manager.close_connection()  # close the shared connection.
+
+    def _handle_exception(self, exception, retry_count, max_retries):
+        if isinstance(exception, KeyboardInterrupt):
+            log.info("EventHubConsumer stops due to keyboard interrupt")
+            self.close()
+            raise
+        elif isinstance(exception, (
+                errors.MessageAccepted,
+                errors.MessageAlreadySettled,
+                errors.MessageModified,
+                errors.MessageRejected,
+                errors.MessageReleased,
+                errors.MessageContentTooLarge)
+                ):
+            log.error("Event data error (%r)", exception)
+            error = EventDataError(str(exception), exception)
+            self.close(exception)
+            raise error
+        elif isinstance(exception, errors.MessageException):
+            log.error("Event data send error (%r)", exception)
+            error = EventDataSendError(str(exception), exception)
+            self.close(exception)
+            raise error
+        elif retry_count >= max_retries:
+            log.info("EventHubConsumer has an error and has exhausted retrying. (%r)", exception)
+            if isinstance(exception, errors.AuthenticationException):
+                log.info("EventHubConsumer authentication failed. Shutting down.")
+                error = AuthenticationError(str(exception), exception)
+            elif isinstance(exception, errors.LinkDetach):
+                log.info("EventHubConsumer link detached. Shutting down.")
+                error = ConnectionLostError(str(exception), exception)
+            elif isinstance(exception, errors.ConnectionClose):
+                log.info("EventHubConsumer connection closed. Shutting down.")
+                error = ConnectionLostError(str(exception), exception)
+            elif isinstance(exception, errors.MessageHandlerError):
+                log.info("EventHubConsumer detached. Shutting down.")
+                error = ConnectionLostError(str(exception), exception)
+            elif isinstance(exception, errors.AMQPConnectionError):
+                log.info("EventHubConsumer connection lost. Shutting down.")
+                error_type = AuthenticationError if str(exception).startswith("Unable to open authentication session") \
+                    else ConnectError
+                error = error_type(str(exception), exception)
+            elif isinstance(exception, compat.TimeoutException):
+                log.info("EventHubConsumer timed out. Shutting down.")
+                error = ConnectionLostError(str(exception), exception)
             else:
-                log.info("EventHubProducer couldn't authenticate. Attempting reconnect.")
-                return False
-        except (errors.LinkDetach, errors.ConnectionClose) as shutdown:
-            if shutdown.action.retry:
-                log.info("EventHubProducer detached. Attempting reconnect.")
-                return False
-            else:
-                log.info("EventHubProducer detached. Shutting down.")
-                error = ConnectError(str(shutdown), shutdown)
-                self.close(exception=error)
-                raise error
-        except errors.MessageHandlerError as shutdown:
-            if is_reconnect:
-                log.info("EventHubProducer detached. Shutting down.")
-                error = ConnectError(str(shutdown), shutdown)
-                self.close(exception=error)
-                raise error
-            else:
-                log.info("EventHubProducer detached. Attempting reconnect.")
-                return False
-        except errors.AMQPConnectionError as shutdown:
-            if is_reconnect:
-                log.info("EventHubProducer connection error (%r). Shutting down.", shutdown)
-                error = AuthenticationError(str(shutdown), shutdown)
-                self.close(exception=error)
-                raise error
-            else:
-                log.info("EventHubProducer couldn't authenticate. Attempting reconnect.")
-                return False
-        except compat.TimeoutException as shutdown:
-            if is_reconnect:
-                log.info("EventHubProducer authentication timed out. Shutting down.")
-                error = AuthenticationError(str(shutdown), shutdown)
-                self.close(exception=error)
-                raise error
-            else:
-                log.info("EventHubProducer authentication timed out. Attempting reconnect.")
-                return False
-        except Exception as e:
-            log.info("Unexpected error occurred when building connection (%r). Shutting down.", e)
-            error = EventHubError("Unexpected error occurred when building connection", e)
+                log.error("Unexpected error occurred (%r). Shutting down.", exception)
+                error = EventHubError("Receive failed: {}".format(exception), exception)
             self.close(exception=error)
             raise error
-
-    def _reconnect(self):
-        return self._build_connection(is_reconnect=True)
+        else:
+            log.info("EventHubConsumer has an exception (%r). Retrying...", exception)
+            if isinstance(exception, errors.AuthenticationException):
+                self._close_connection()
+            elif isinstance(exception, errors.LinkRedirect):
+                log.info("EventHubConsumer link redirected. Redirecting...")
+                redirect = exception
+                self._redirect(redirect)
+            elif isinstance(exception, errors.LinkDetach):
+                self._close_handler()
+            elif isinstance(exception, errors.ConnectionClose):
+                self._close_connection()
+            elif isinstance(exception, errors.MessageHandlerError):
+                self._close_handler()
+            elif isinstance(exception, errors.AMQPConnectionError):
+                self._close_connection()
+            elif isinstance(exception, compat.TimeoutException):
+                pass  # Timeout doesn't need to recreate link or exception
+            else:
+                self._close_connection()
 
     def _send_event_data(self):
         self._open()
         max_retries = self.client.config.max_retries
-        connecting_count = 0
+        retry_count = 0
         while True:
-            connecting_count += 1
             try:
                 if self.unsent_events:
                     self._handler.queue_message(*self.unsent_events)
                     self._handler.wait()
                     self.unsent_events = self._handler.pending_messages
                 if self._outcome != constants.MessageSendResult.Ok:
-                    EventHubProducer._error(self._outcome, self._condition)
+                    _error(self._outcome, self._condition)
                 return
-            except (errors.MessageAccepted,
-                    errors.MessageAlreadySettled,
-                    errors.MessageModified,
-                    errors.MessageRejected,
-                    errors.MessageReleased,
-                    errors.MessageContentTooLarge) as msg_error:
-                raise EventDataError(str(msg_error), msg_error)
-            except errors.MessageException as failed:
-                log.error("Send event data error (%r)", failed)
-                error = EventDataSendError(str(failed), failed)
-                self.close(exception=error)
-                raise error
-            except errors.AuthenticationException as auth_error:
-                if connecting_count < max_retries:
-                    log.info("EventHubProducer disconnected due to token error. Attempting reconnect.")
-                    self._reconnect()
-                else:
-                    log.info("EventHubProducer authentication failed. Shutting down.")
-                    error = AuthenticationError(str(auth_error), auth_error)
-                    self.close(auth_error)
-                    raise error
-            except (errors.LinkDetach, errors.ConnectionClose) as shutdown:
-                if shutdown.action.retry:
-                    log.info("EventHubProducer detached. Attempting reconnect.")
-                    self._reconnect()
-                else:
-                    log.info("EventHubProducer detached. Shutting down.")
-                    error = ConnectionLostError(str(shutdown), shutdown)
-                    self.close(exception=error)
-                    raise error
-            except errors.MessageHandlerError as shutdown:
-                if connecting_count < max_retries:
-                    log.info("EventHubProducer detached. Attempting reconnect.")
-                    self._reconnect()
-                else:
-                    log.info("EventHubProducer detached. Shutting down.")
-                    error = ConnectionLostError(str(shutdown), shutdown)
-                    self.close(error)
-                    raise error
-            except errors.AMQPConnectionError as shutdown:
-                if connecting_count < max_retries:
-                    log.info("EventHubProducer connection lost. Attempting reconnect.")
-                    self._reconnect()
-                else:
-                    log.info("EventHubProducer connection lost. Shutting down.")
-                    error = ConnectionLostError(str(shutdown), shutdown)
-                    self.close(error)
-                    raise error
-            except compat.TimeoutException as shutdown:
-                if connecting_count < max_retries:
-                    log.info("EventHubProducer timed out sending event data. Attempting reconnect.")
-                    self._reconnect()
-                else:
-                    log.info("EventHubProducer timed out. Shutting down.")
-                    self.close(shutdown)
-                    raise ConnectionLostError(str(shutdown), shutdown)
-            except Exception as e:
-                log.info("Unexpected error occurred (%r). Shutting down.", e)
-                error = EventHubError("Send failed: {}".format(e), e)
-                self.close(exception=error)
-                raise error
+            except Exception as exception:
+                self._handle_exception(exception, retry_count, max_retries)
+                retry_count += 1
 
     def _check_closed(self):
         if self.error:
@@ -293,13 +240,8 @@ class EventHubProducer(object):
         self._outcome = outcome
         self._condition = condition
 
-    @staticmethod
-    def _error(outcome, condition):
-        if outcome != constants.MessageSendResult.Ok:
-            raise condition
-
     def send(self, event_data, partition_key=None):
-        # type:(Union[EventData, Union[List[EventData], Iterator[EventData], Generator[EventData]]], Union[str, bytes]) -> None
+        # type:(Union[EventData, Iterable[EventData]], Union[str, bytes]) -> None
         """
         Sends an event data and blocks until acknowledgement is
         received or operation times out.
@@ -370,3 +312,8 @@ class EventHubProducer(object):
         else:
             self.error = EventHubError("This send handler is now closed.")
         self._handler.close()
+
+
+def _error(outcome, condition):
+    if outcome != constants.MessageSendResult.Ok:
+        raise condition

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/producer.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/producer.py
@@ -129,10 +129,13 @@ class EventHubProducer(ConsumerProducerMixin):
                             error = OperationTimeoutError("send operation timed out")
                         log.info("%r send operation timed out. (%r)", self.name, error)
                         raise error
+                    self._handler._msg_timeout = remaining_time  # pylint: disable=protected-access
                     self._handler.queue_message(*self.unsent_events)
                     self._handler.wait()
                     self.unsent_events = self._handler.pending_messages
                     if self._outcome != constants.MessageSendResult.Ok:
+                        if self._outcome == constants.MessageSendResult.Timeout:
+                            self._condition = OperationTimeoutError("send operation timed out")
                         _error(self._outcome, self._condition)
                 return
             except Exception as exception:
@@ -162,6 +165,9 @@ class EventHubProducer(ConsumerProducerMixin):
         :param partition_key: With the given partition_key, event data will land to
          a particular partition of the Event Hub decided by the service.
         :type partition_key: str
+        :param timeout: The maximum wait time to send the event data.
+         If not specified, the default wait time specified when the producer was created will be used.
+        :type timeout:float
         :raises: ~azure.eventhub.AuthenticationError, ~azure.eventhub.ConnectError, ~azure.eventhub.ConnectionLostError,
                 ~azure.eventhub.EventDataError, ~azure.eventhub.EventDataSendError, ~azure.eventhub.EventHubError
 

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/producer.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/producer.py
@@ -9,7 +9,7 @@ import logging
 import time
 from typing import Iterable, Union
 
-from uamqp import constants, errors
+from uamqp import types, constants, errors
 from uamqp import compat
 from uamqp import SendClient
 
@@ -40,6 +40,7 @@ class EventHubProducer(ConsumerProducerMixin):
      to a partition.
 
     """
+    _timeout = b'com.microsoft:timeout'
 
     def __init__(self, client, target, partition=None, send_timeout=60, keep_alive=None, auto_reconnect=True):
         """
@@ -83,6 +84,7 @@ class EventHubProducer(ConsumerProducerMixin):
         self._handler = None
         self._outcome = None
         self._condition = None
+        self._link_properties = {types.AMQPSymbol(self._timeout): types.AMQPLong(int(self.timeout * 1000))}
 
     def _create_handler(self):
         self._handler = SendClient(
@@ -93,6 +95,7 @@ class EventHubProducer(ConsumerProducerMixin):
             error_policy=self.retry_policy,
             keep_alive_interval=self.keep_alive,
             client_name=self.name,
+            link_properties=self._link_properties,
             properties=self.client._create_properties(self.client.config.user_agent))  # pylint: disable=protected-access
 
     def _open(self, timeout_time=None):

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/producer.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/producer.py
@@ -35,14 +35,14 @@ def _set_partition_key(event_datas, partition_key):
 class EventHubProducer(ConsumerProducerMixin):
     """
     A producer responsible for transmitting EventData to a specific Event Hub,
-     grouped together in batches. Depending on the options specified at creation, the producer may
-     be created to allow event data to be automatically routed to an available partition or specific
-     to a partition.
+    grouped together in batches. Depending on the options specified at creation, the producer may
+    be created to allow event data to be automatically routed to an available partition or specific
+    to a partition.
 
     """
     _timeout = b'com.microsoft:timeout'
 
-    def __init__(self, client, target, partition=None, send_timeout=60, keep_alive=None, auto_reconnect=True):
+    def __init__(self, client, target, **kwargs):
         """
         Instantiate an EventHubProducer. EventHubProducer should be instantiated by calling the `create_producer` method
          in EventHubClient.
@@ -64,6 +64,11 @@ class EventHubProducer(ConsumerProducerMixin):
          Default value is `True`.
         :type auto_reconnect: bool
         """
+        partition = kwargs.get("partition", None)
+        send_timeout = kwargs.get("send_timeout", 60)
+        keep_alive = kwargs.get("keep_alive", None)
+        auto_reconnect = kwargs.get("auto_reconnect", True)
+
         super(EventHubProducer, self).__init__()
         self.running = False
         self.client = client
@@ -157,7 +162,7 @@ class EventHubProducer(ConsumerProducerMixin):
         self._outcome = outcome
         self._condition = condition
 
-    def send(self, event_data, partition_key=None, timeout=None):
+    def send(self, event_data, **kwargs):
         # type:(Union[EventData, Iterable[EventData]], Union[str, bytes], float) -> None
         """
         Sends an event data and blocks until acknowledgement is
@@ -186,6 +191,9 @@ class EventHubProducer(ConsumerProducerMixin):
                 :caption: Sends an event data and blocks until acknowledgement is received or operation times out.
 
         """
+        partition_key = kwargs.get("partition_key", None)
+        timeout = kwargs.get("timeout", None)
+
         self._check_closed()
         if isinstance(event_data, EventData):
             if partition_key:
@@ -200,7 +208,7 @@ class EventHubProducer(ConsumerProducerMixin):
         self.unsent_events = [wrapper_event_data.message]
         self._send_event_data(timeout=timeout)
 
-    def close(self, exception=None):
+    def close(self, **kwargs):
         # type:(Exception) -> None
         """
         Close down the handler. If the handler has already closed,
@@ -220,4 +228,5 @@ class EventHubProducer(ConsumerProducerMixin):
                 :caption: Close down the handler.
 
         """
+        exception = kwargs.get("exception", None)
         super(EventHubProducer, self).close(exception)

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/producer.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/producer.py
@@ -20,6 +20,18 @@ from ._consumer_producer_mixin import ConsumerProducerMixin
 log = logging.getLogger(__name__)
 
 
+def _error(outcome, condition):
+    if outcome != constants.MessageSendResult.Ok:
+        raise condition
+
+
+def _set_partition_key(event_datas, partition_key):
+    ed_iter = iter(event_datas)
+    for ed in ed_iter:
+        ed._set_partition_key(partition_key)
+        yield ed
+
+
 class EventHubProducer(ConsumerProducerMixin):
     """
     A producer responsible for transmitting EventData to a specific Event Hub,
@@ -200,15 +212,3 @@ class EventHubProducer(ConsumerProducerMixin):
 
         """
         super(EventHubProducer, self).close(exception)
-
-
-def _error(outcome, condition):
-    if outcome != constants.MessageSendResult.Ok:
-        raise condition
-
-
-def _set_partition_key(event_datas, partition_key):
-    ed_iter = iter(event_datas)
-    for ed in ed_iter:
-        ed._set_partition_key(partition_key)
-        yield ed

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/producer.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/producer.py
@@ -106,7 +106,7 @@ class EventHubProducer(ConsumerProducerMixin):
         if not self.running and self.redirected:
             self.client._process_redirect_uri(self.redirected)
             self.target = self.redirected.address
-        super(EventHubProducer, self)._open()
+        super(EventHubProducer, self)._open(timeout_time)
 
     def _send_event_data(self, timeout=None):
         timeout = self.client.config.send_timeout if timeout is None else timeout

--- a/sdk/eventhub/azure-eventhubs/tests/test_negative.py
+++ b/sdk/eventhub/azure-eventhubs/tests/test_negative.py
@@ -26,7 +26,7 @@ def test_send_with_invalid_hostname(invalid_hostname, connstr_receivers):
     client = EventHubClient.from_connection_string(invalid_hostname, network_tracing=False)
     sender = client.create_producer()
     with pytest.raises(AuthenticationError):
-        sender._open()
+        sender.send(EventData("test data"))
 
 
 @pytest.mark.liveTest
@@ -34,7 +34,7 @@ def test_receive_with_invalid_hostname_sync(invalid_hostname):
     client = EventHubClient.from_connection_string(invalid_hostname, network_tracing=False)
     receiver = client.create_consumer(consumer_group="$default", partition_id="0", event_position=EventPosition("-1"))
     with pytest.raises(AuthenticationError):
-        receiver._open()
+        receiver.receive(timeout=3)
 
 
 @pytest.mark.liveTest
@@ -43,7 +43,7 @@ def test_send_with_invalid_key(invalid_key, connstr_receivers):
     client = EventHubClient.from_connection_string(invalid_key, network_tracing=False)
     sender = client.create_producer()
     with pytest.raises(AuthenticationError):
-        sender._open()
+        sender.send(EventData("test data"))
 
 
 @pytest.mark.liveTest
@@ -51,7 +51,7 @@ def test_receive_with_invalid_key_sync(invalid_key):
     client = EventHubClient.from_connection_string(invalid_key, network_tracing=False)
     receiver = client.create_consumer(consumer_group="$default", partition_id="0", event_position=EventPosition("-1"))
     with pytest.raises(AuthenticationError):
-        receiver._open()
+        receiver.receive(timeout=3)
 
 
 @pytest.mark.liveTest
@@ -60,7 +60,7 @@ def test_send_with_invalid_policy(invalid_policy, connstr_receivers):
     client = EventHubClient.from_connection_string(invalid_policy, network_tracing=False)
     sender = client.create_producer()
     with pytest.raises(AuthenticationError):
-        sender._open()
+        sender.send(EventData("test data"))
 
 
 @pytest.mark.liveTest
@@ -68,7 +68,7 @@ def test_receive_with_invalid_policy_sync(invalid_policy):
     client = EventHubClient.from_connection_string(invalid_policy, network_tracing=False)
     receiver = client.create_consumer(consumer_group="$default", partition_id="0", event_position=EventPosition("-1"))
     with pytest.raises(AuthenticationError):
-        receiver._open()
+        receiver.receive(timeout=3)
 
 
 @pytest.mark.liveTest
@@ -90,7 +90,7 @@ def test_non_existing_entity_sender(connection_str):
     client = EventHubClient.from_connection_string(connection_str, event_hub_path="nemo", network_tracing=False)
     sender = client.create_producer(partition_id="1")
     with pytest.raises(AuthenticationError):
-        sender._open()
+        sender.send(EventData("test data"))
 
 
 @pytest.mark.liveTest
@@ -98,7 +98,7 @@ def test_non_existing_entity_receiver(connection_str):
     client = EventHubClient.from_connection_string(connection_str, event_hub_path="nemo", network_tracing=False)
     receiver = client.create_consumer(consumer_group="$default", partition_id="0", event_position=EventPosition("-1"))
     with pytest.raises(AuthenticationError):
-        receiver._open()
+        receiver.receive(timeout=3)
 
 
 @pytest.mark.liveTest
@@ -122,7 +122,7 @@ def test_send_to_invalid_partitions(connection_str):
         sender = client.create_producer(partition_id=p)
         try:
             with pytest.raises(ConnectError):
-                sender._open()
+                sender.send(EventData("test data"))
         finally:
             sender.close()
 


### PR DESCRIPTION
An EventHubClient has a connection manager, which creates a connection. All EventHubConsumer and EventHubProducer instances that are created by an EventHubClient share that connection.
EventHubClient.get_properties and .get_partition_properties use that shared connection too.
Exception handling code is also refactored as it's an important part of the connection / link management.
Both sync and async are updated.

There is a switch between shared connection and non-shared. Change get_connection_manager of _connection_manager.py to create a shared connection manager or separate connection manager. This switch isn't made into a parameter exposed to users. It is no longer needed after shared connection is stable.

There is a known bug possibly related to the underlying python-to-c binding.
