### PR TITLE
Expose Key Vault API crypto operations on KeyClient

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -52,32 +52,21 @@ class KeyClient(KeyVaultClientBase):
         Key Vault. If the named key already exists, Azure Key Vault creates a
         new version of the key. It requires the keys/create permission.
 
-        :param name: The name for the new key. The system will generate
-         the version name for the new key.
-        :type name: str
-        :param key_type: The type of key to create. For valid values, see
-         JsonWebKeyType. Possible values include: 'EC', 'EC-HSM', 'RSA',
-         'RSA-HSM', 'oct'
-        :type key_type: str or ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyType
-        :param size: The key size in bits. For example: 2048, 3072, or
-         4096 for RSA.
-        :type size: int
+        :param str name: The name for the new key. Key Vault will generate a version for the new key.
+        :param key_type: The type of key to create. For valid values, see ~azure.keyvault.keys.enums.JsonWebKeyType
+        :type key_type: str or ~azure.keyvault.keys.enums.JsonWebKeyType
+        :param int size: The key size in bits. For example: 2048, 3072, or 4096 for RSA.
         :param key_operations: Supported key operations.
-        :type key_operations: list[str or
-         ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyOperation]
-        :param enabled: Determines whether the object is enabled.
-        :type enabled: bool
-        :param expires: Expiry date of the key  in UTC.
+        :type key_operations: list[str or ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyOperation]
+        :param bool enabled: Determines whether the key is enabled.
+        :param expires: Expiry date of the key in UTC.
         :type expires: datetime.datetime
-        :param not_before: Not before date of the key in UTC
+        :param not_before: Not before date of the key in UTC.
         :type not_before: datetime.datetime
-        :param tags: Application specific metadata in the form of key-value
-         pairs.
+        :param tags: Application specific metadata in the form of key-value pairs.
         :type tags: Dict[str, str]
-        :param curve: Elliptic curve name. If none then defaults to 'P-256'. For valid values, see
-         JsonWebKeyCurveName. Possible values include: 'P-256', 'P-384',
-         'P-521', 'SECP256K1'
-        :type curve: str or ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyCurveName
+        :param curve: Elliptic curve name. If not provided, defaults to 'P-256'. See ~azure.keyvault.keys.enums.JsonWebKeyCurveName for valid values.
+        :type curve: str or ~azure.keyvault.keys.enums.JsonWebKeyCurveName
         :returns: The created key
         :rtype: ~azure.keyvault.keys._models.Key
 
@@ -126,20 +115,16 @@ class KeyClient(KeyVaultClientBase):
         Key Vault. If the named key already exists, Azure Key Vault creates a
         new version of the key. It requires the keys/create permission.
 
-        :param name: The name for the new key. The system will generate
-         the version name for the new key.
-        :type name: str
-        :param hsm: Whether to create as a hardware key (HSM) or software key.
-        :type hsm: bool
-        :param size: The key size in bits. For example: 2048, 3072, or
-         4096 for RSA.
+        :param str name: The name for the new key. Key Vault will generate a version for the new key.
+        :param bool hsm: Whether to create the key in a hardware security module.
+        :param size: The key size in bits. For example: 2048, 3072, or 4096 for RSA.
         :type size: int
         :param key_operations: Supported key operations.
         :type key_operations: list[str or
          ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyOperation]
-        :param enabled: Determines whether the object is enabled.
+        :param bool enabled: Determines whether the object is enabled.
         :type enabled: bool
-        :param expires: Expiry date of the key  in UTC.
+        :param expires: Expiry date of the key in UTC.
         :type expires: datetime.datetime
         :param not_before: Not before date of the key in UTC
         :type not_before: datetime.datetime
@@ -184,35 +169,24 @@ class KeyClient(KeyVaultClientBase):
         **kwargs
     ):
         # type: (str, bool, Optional[str],  Optional[List[str]], Optional[bool], Optional[datetime], Optional[datetime], Optional[Dict[str, str]], Mapping[str, Any]) -> Key
-        """Creates a new Elliptic curve type key, stores it, then returns key to the client.
+        """Creates a new elliptic curve key, stores it, then returns it to the client.
 
-        The create key operation can be used to create any key type in Azure
-        Key Vault. If the named key already exists, Azure Key Vault creates a
-        new version of the key. It requires the keys/create permission.
+        This requires the keys/create permission. If the named key already exists, Azure Key Vault creates a new version of the key.
 
-        :param name: The name for the new key. The system will generate
-         the version name for the new key.
-        :type name: str
-        :param hsm: Whether to create as a hardware key (HSM) or software key.
-        :type hsm: bool
-        :param curve: Elliptic curve name. If none then defaults to 'P-256'. For valid values, see
-         JsonWebKeyCurveName. Possible values include: 'P-256', 'P-384',
-         'P-521', 'SECP256K1'
-        :type curve: str or
-         ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyCurveName
+        :param str name: The name for the new key. Key Vault will generate a version for the new key.
+        :param bool hsm: Whether to create the key in a hardware security module.
+        :param curve: Elliptic curve name. If not provided, defaults to 'P-256'. See ~azure.keyvault.keys.enums.JsonWebKeyCurveName for valid values.
+        :type curve: str or ~azure.keyvault.keys.enums.JsonWebKeyCurveName
         :param key_operations: Supported key operations.
-        :type key_operations: list[str or
-         ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyOperation]
-        :param enabled: Determines whether the object is enabled.
-        :type enabled: bool
-        :param expires: Expiry date of the key  in UTC.
+        :type key_operations: list[str or ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyOperation]
+        :param bool enabled: Determines whether the object is enabled.
+        :param expires: Expiry date of the key in UTC.
         :type expires: datetime.datetime
         :param not_before: Not before date of the key in UTC
         :type not_before: datetime.datetime
-        :param tags: Application specific metadata in the form of key-value
-         pairs.
+        :param tags: Application specific metadata in the form of key-value pairs.
         :type tags: Dict[str, str]
-        :returns: The created EC key
+        :returns: The created key
         :rtype: ~azure.keyvault.keys._models.Key
 
         Example:
@@ -248,8 +222,7 @@ class KeyClient(KeyVaultClientBase):
         Wrap/Unwrap or Encrypt/Decrypt operations. This operation requires the
         keys/delete permission.
 
-        :param name: The name of the key to delete.
-        :type name: str
+        :param str name: The name of the key to delete.
         :returns: The deleted key
         :rtype: ~azure.keyvault.keys._models.DeletedKey
         :raises: ~azure.core.exceptions.ResourceNotFoundError if the client failed to retrieve the key
@@ -273,11 +246,8 @@ class KeyClient(KeyVaultClientBase):
         key is symmetric, then no key material is released in the response.
         This operation requires the keys/get permission.
 
-        :param name: The name of the key to get.
-        :type name: str
-        :param version: Retrieves a specific version of a key. If the version is None or an empty string,
-            the latest version of the key is returned
-        :type version: str
+        :param str name: The name of the key to get.
+        :param str version: Version of the key to get. If unspecified, the latest version of the key is returned.
         :returns: Key
         :rtype: ~azure.keyvault.keys._models.Key
         :raises: ~azure.core.exceptions.ResourceNotFoundError if the client failed to retrieve the key
@@ -304,8 +274,7 @@ class KeyClient(KeyVaultClientBase):
         an error if invoked on a non soft-delete enabled vault. This operation
         requires the keys/get permission.
 
-        :param name: The name of the key.
-        :type name: str
+        :param str name: The name of the key.
         :returns: The deleted key
         :rtype: ~azure.keyvault.keys._models.DeletedKey
 
@@ -333,8 +302,7 @@ class KeyClient(KeyVaultClientBase):
         keys/list permission.
 
         :returns: An iterator like instance of DeletedKey
-        :rtype:
-         Generator[~azure.keyvault.keys._models.DeletedKey]
+        :rtype: Generator[~azure.keyvault.keys._models.DeletedKey]
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -360,8 +328,7 @@ class KeyClient(KeyVaultClientBase):
         operation requires the keys/list permission.
 
         :returns: An iterator like instance of KeyBase
-        :rtype:
-         Generator[~azure.keyvault.keys._models.KeyBase]
+        :rtype: Generator[~azure.keyvault.keys._models.KeyBase]
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -382,11 +349,9 @@ class KeyClient(KeyVaultClientBase):
         The full key identifier, attributes, and tags are provided in the
         response. This operation requires the keys/list permission.
 
-        :param name: The name of the key.
-        :type name: str
+        :param str name: The name of the key.
         :returns: An iterator like instance of KeyBase
-        :rtype:
-         Generator[~azure.keyvault.keys._models.KeyBase]
+        :rtype: Generator[~azure.keyvault.keys._models.KeyBase]
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -409,10 +374,7 @@ class KeyClient(KeyVaultClientBase):
         an error if invoked on a non soft-delete enabled vault. This operation
         requires the keys/purge permission.
 
-        :param name: The name of the key
-        :type name: str
-        :returns: None
-        :rtype: None
+        :param str name: The name of the key
 
         Example:
             .. code-block:: python
@@ -435,9 +397,8 @@ class KeyClient(KeyVaultClientBase):
         on soft-delete enabled vaults. This operation requires the keys/recover
         permission.
 
-        :param name: The name of the deleted key.
-        :type name: str
-        :returns: The recovered deleted key
+        :param str name: The name of the deleted key.
+        :returns: The recovered key
         :rtype: ~azure.keyvault.keys._models.Key
 
         Example:
@@ -463,17 +424,14 @@ class KeyClient(KeyVaultClientBase):
         Key Vault. Note: The cryptographic material of a key itself cannot be
         changed. This operation requires the keys/update permission.
 
-        :param name: The name of key to update.
-        :type name: str
-        :param version: The version of the key to update.
-        :type version: str
+        :param str name: The name of key to update.
+        :param str version: The version of the key to update.
         :param key_operations: Json web key operations. For more information on
          possible key operations, see JsonWebKeyOperation.
-        :type key_operations: list[str or
-         ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyOperation]
-        :param enabled: Determines whether the object is enabled.
+        :type key_operations: list[str or ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyOperation]
+        :param bool enabled: Determines whether the object is enabled.
         :type enabled: bool
-        :param expires: Expiry date of the key  in UTC.
+        :param expires: Expiry date of the key in UTC.
         :type expires: datetime.datetime
         :param not_before: Not before date of the key in UTC
         :type not_before: datetime.datetime
@@ -528,8 +486,7 @@ class KeyClient(KeyVaultClientBase):
         geographical area cannot be restored in an EU geographical area. This
         operation requires the key/backup permission.
 
-        :param name: The name of the key.
-        :type name: str
+        :param str name: The name of the key.
         :returns: The raw bytes of the key backup.
         :rtype: bytes
         :raises: ~azure.core.exceptions.ResourceNotFoundError if the client failed to retrieve the key
@@ -590,15 +547,14 @@ class KeyClient(KeyVaultClientBase):
         creates a new version of the key. This operation requires the
         keys/import permission.
 
-        :param name: Name for the imported key.
-        :type name: str
+        :param str name: Name for the imported key.
         :param key: The Json web key
         :type key: ~azure.security.keyvault.v7_0.models.JsonWebKey
         :param hsm: Whether to import as a hardware key (HSM) or software key.
         :type hsm: bool
-        :param enabled: Determines whether the object is enabled.
+        :param bool enabled: Determines whether the object is enabled.
         :type enabled: bool
-        :param expires: Expiry date of the key  in UTC.
+        :param expires: Expiry date of the key in UTC.
         :type expires: datetime.datetime
         :param not_before: Not before date of the key in UTC
         :type not_before: datetime.datetime
@@ -631,25 +587,18 @@ class KeyClient(KeyVaultClientBase):
         key-reference but do not have access to the public key material. This
         operation requires the keys/wrapKey permission.
 
-        :param name: The name of the key.
-        :type name: str
-        :param version: The version of the key.
-        :type version: str
-        :param algorithm: algorithm identifier. Possible values include:
-         'RSA-OAEP', 'RSA-OAEP-256', 'RSA1_5'
-        :type algorithm: str or
-         ~azure.security.keyvault.v7_0.models.JsonWebKeyEncryptionAlgorithm
-        :param value:
+        :param str name: The name of the key.
+        :param str version: The version of the key to use. If unspecified, the latest version of the key is used.
+        :param algorithm: algorithm identifier to use
+        :type algorithm: str or ~azure.keyvault.keys.enums.JsonWebKeyEncryptionAlgorithm
+        :param value: The key to wrap.
         :type value: bytes
         :returns: The wrapped symmetric key.
         :rtype: ~azure.keyvault.keys._models.KeyOperationResult
 
         """
-        if version is None:
-            version = ""
-
         bundle = self._client.wrap_key(
-            self.vault_url, name, key_version=version, algorithm=algorithm, value=value, **kwargs
+            self.vault_url, name, key_version=version or "", algorithm=algorithm, value=value, **kwargs
         )
         return KeyOperationResult(id=bundle.kid, value=bundle.result)
 
@@ -664,24 +613,19 @@ class KeyClient(KeyVaultClientBase):
         keys stored in Azure Key Vault since it uses the private portion of the
         key. This operation requires the keys/unwrapKey permission.
 
-        :param name: The name of the key.
-        :type name: str
-        :param version: The version of the key.
-        :type version: str
+        :param str name: The name of the key.
+        :param str version: The version of the key to use. If unspecified, the latest version of the key is used.
         :param algorithm: algorithm identifier. Possible values include:
          'RSA-OAEP', 'RSA-OAEP-256', 'RSA1_5'
         :type algorithm: str or
-         ~azure.security.keyvault.v7_0.models.JsonWebKeyEncryptionAlgorithm
+         ~azure.keyvault.keys.enums.JsonWebKeyEncryptionAlgorithm
         :param value:
         :type value: bytes
         :returns: The unwrapped symmetric key.
         :rtype: ~azure.keyvault.keys._models.KeyOperationResult
 
         """
-        if version is None:
-            version = ""
-
         bundle = self._client.unwrap_key(
-            self.vault_url, name, key_version=version, algorithm=algorithm, value=value, **kwargs
+            self.vault_url, name, key_version=version or "", algorithm=algorithm, value=value, **kwargs
         )
         return KeyOperationResult(id=bundle.kid, value=bundle.result)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -629,3 +629,87 @@ class KeyClient(KeyVaultClientBase):
             self.vault_url, name, key_version=version or "", algorithm=algorithm, value=value, **kwargs
         )
         return KeyOperationResult(id=bundle.kid, value=bundle.result)
+
+    def decrypt(self, key_name, algorithm, encrypted_bytes, key_version=None, **kwargs):
+        """Decrypts a single block of encrypted data using the named key and specified
+        algorithm. Only a single block of data may be decrypted. The size of this block
+        depends on the key and algorithm to be used.
+
+        This operation requires the keys/decrypt permission.
+
+        :param str key_name: name of the key to use
+        :param str key_version: Version of the key to use. If unspecified, the latest version is used.
+        :param algorithm: algorithm to use
+        :type algorithm: str or ~azure.keyvault.keys.enums.JsonWebKeyEncryptionAlgorithm
+        :param bytes encrypted_bytes: bytes to decrypt
+        :returns: decrypted bytes
+        :rtype: bytes
+        """
+        result = self._client.decrypt(
+            self._vault_url, key_name, key_version or "", algorithm, encrypted_bytes, **kwargs
+        )
+        return result.result
+
+    def encrypt(self, key_name, algorithm, value, key_version=None, **kwargs):
+        """Encrypts an arbitrary sequence of bytes using an encryption key stored in the vault.
+
+        This method encrypts only a single block of data per call. The size of the block depends
+        on the key and algorithm used.
+
+        This is only strictly necessary for symmetric keys, because encryption with an
+        asymmetric key can be done with its public material. However, it is supported
+        by this method as a convenience for callers that have a reference to a key but not access to
+        its public material.
+
+        This operation requires the keys/encrypt permission.
+
+        :param str key_name: name of the key to use
+        :param str key_version: Version of the key to use. If unspecified, the latest version is used.
+        :param algorithm: algorithm to use
+        :type algorithm: str or ~azure.keyvault.keys.enums.JsonWebKeyEncryptionAlgorithm
+        :param bytes value: bytes to encrypt
+        :returns: encrypted bytes
+        :rtype: bytes
+        """
+        result = self._client.encrypt(self._vault_url, key_name, key_version or "", algorithm, value, **kwargs)
+        return result.result
+
+    def sign(self, key_name, algorithm, digest, key_version=None, **kwargs):
+        """Creates a signature from a digest using the specified key.
+
+        Signing is applicable to both symmetric and asymmetric keys because it uses the private portion of the key.
+
+        This operation requires the keys/sign permission.
+
+        :param str key_name: name of the key to use
+        :param str key_version: Version of the key to use. If unspecified, the latest version is used.
+        :param algorithm: signing/verification algorithm
+        :type algorithm: str or ~azure.keyvault.keys.enums.JsonWebKeySignatureAlgorithm
+        :param bytes digest: digest to sign
+        :rtype: str
+        """
+        result = self._client.sign(self._vault_url, key_name, key_version or "", algorithm, digest, **kwargs)
+        return result.result
+
+    def verify(self, key_name, algorithm, digest, signature, key_version=None, **kwargs):
+        """Verifies a signature using a specified key.
+
+        This isn't strictly necessary for asymmetric keys since signature verification can be performed using the
+        public portion of the key. However, this method supports asymmetric keys as a convenience for callers who
+        have a reference to a key but not its public material.
+
+        This operation requires the keys/verify permission.
+
+        :param str key_name: name of the key to use
+        :param str key_version: Version of the key to use. If unspecified, the latest version is used.
+        :param algorithm: signing/verification algorithm
+        :type algorithm: str or ~azure.keyvault.keys.enums.JsonWebKeySignatureAlgorithm
+        :param bytes digest: digest used for signing
+        :param bytes signature: signature to verify
+        :returns: ``True``, if the signature is valid; ``False``, if it isn't
+        :rtype: bool
+        """
+        result = self._client.verify(
+            self._vault_url, key_name, key_version or "", algorithm, digest, signature, **kwargs
+        )
+        return result.value

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -646,3 +646,88 @@ class KeyClient(AsyncKeyVaultClientBase):
             self.vault_url, name, key_version=version, algorithm=algorithm, value=value, **kwargs
         )
         return KeyOperationResult(id=bundle.kid, value=bundle.result)
+
+    async def decrypt(self, key_name, algorithm, encrypted_bytes, key_version=None, **kwargs):
+        """Decrypts a single block of encrypted data using the named key and specified
+        algorithm. Only a single block of data may be decrypted. The size of this block
+        depends on the key and algorithm to be used.
+
+        This operation requires the keys/decrypt permission.
+
+        :param str key_name: name of the key to use
+        :param str key_version: Version of the key to use. If unspecified, the latest version is used.
+        :param algorithm: algorithm to use
+        :type algorithm: str or ~azure.keyvault.keys.enums.JsonWebKeyEncryptionAlgorithm
+        :param bytes encrypted_bytes: bytes to decrypt
+        :returns: decrypted bytes
+        :rtype: bytes
+        """
+        result = await self._client.decrypt(
+            self._vault_url, key_name, key_version or "", algorithm, encrypted_bytes, **kwargs
+        )
+        return result.result
+
+    async def encrypt(self, key_name, algorithm, value, key_version=None, **kwargs):
+        """Encrypts an arbitrary sequence of bytes using an encryption key stored in the vault.
+
+        This method encrypts only a single block of data per call. The size of the block depends
+        on the key and algorithm used.
+
+        This is only strictly necessary for symmetric keys, because encryption with an
+        asymmetric key can be done with its public material. However, it is supported
+        by this method as a convenience for callers that have a reference to a key but not access to
+        its public material.
+
+        This operation requires the keys/encrypt permission.
+
+        :param str key_name: name of the key to use
+        :param str key_version: Version of the key to use. If unspecified, the latest version is used.
+        :param algorithm: algorithm to use
+        :type algorithm: str or ~azure.keyvault.keys.enums.JsonWebKeyEncryptionAlgorithm
+        :param bytes value: bytes to encrypt
+        :returns: encrypted bytes
+        :rtype: bytes
+        """
+        result = await self._client.encrypt(self._vault_url, key_name, key_version or "", algorithm, value, **kwargs)
+        return result.result
+
+    async def sign(self, key_name, algorithm, digest, key_version=None, **kwargs):
+        """Creates a signature from a digest using the specified key.
+
+        Signing is applicable to both symmetric and asymmetric keys because it uses the private portion of the key.
+
+        This operation requires the keys/sign permission.
+
+        :param str key_name: name of the key to use
+        :param str key_version: Version of the key to use. If unspecified, the latest version is used.
+        :param algorithm: signing/verification algorithm
+        :type algorithm: str or ~azure.keyvault.keys.enums.JsonWebKeySignatureAlgorithm
+        :param bytes digest: digest to sign
+        :returns:
+        :rtype: str
+        """
+        result = await self._client.sign(self._vault_url, key_name, key_version or "", algorithm, digest, **kwargs)
+        return result.result
+
+    async def verify(self, key_name, algorithm, digest, signature, key_version=None, **kwargs):
+        """Verifies a signature using a specified key.
+
+        This isn't strictly necessary for asymmetric keys since signature verification can be performed using
+        the public portion of a key. However, this method supports asymmetric keys as a convenience for callers who
+        have a reference to a key but not its public material.
+
+        This operation requires the keys/verify permission.
+
+        :param str key_name: name of the key to use
+        :param str key_version: Version of the key to use. If unspecified, the latest version is used.
+        :param algorithm: signing/verification algorithm
+        :type algorithm: str or ~azure.keyvault.keys.enums.JsonWebKeySignatureAlgorithm
+        :param bytes digest: digest used for signing
+        :param bytes signature: signature to verify
+        :returns: ``True``, if the signature is valid; ``False``, if it isn't
+        :rtype: bool
+        """
+        result = await self._client.verify(
+            self._vault_url, key_name, key_version or "", algorithm, digest, signature, **kwargs
+        )
+        return result.value

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -32,11 +32,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         key is symmetric, then no key material is released in the response.
         This operation requires the keys/get permission.
 
-        :param name: The name of the key to get.
-        :type name: str
-        :param version: Retrieves a specific version of a key. If the version is None or an empty string,
-         the latest version of the key is returned
-        :type version: str
+        :param str name: The name of the key to get.
+        :param str version: Version of the key to get. If unspecified, the latest version of the key is returned.
         :returns: Key
         :rtype: ~azure.keyvault.keys._models.Key
         :raises: ~azure.core.exceptions.ResourceNotFoundError if the client failed to retrieve the key
@@ -76,32 +73,21 @@ class KeyClient(AsyncKeyVaultClientBase):
         Key Vault. If the named key already exists, Azure Key Vault creates a
         new version of the key. It requires the keys/create permission.
 
-        :param name: The name for the new key. The system will generate
-         the version name for the new key.
-        :type name: str
-        :param key_type: The type of key to create. For valid values, see
-         JsonWebKeyType. Possible values include: 'EC', 'EC-HSM', 'RSA',
-         'RSA-HSM', 'oct'
-        :param size: The key size in bits. For example: 2048, 3072, or
-         4096 for RSA.
-        :type size: int
-        :param curve: Elliptic curve name. If none then defaults to 'P-256'. For valid values, see
-         JsonWebKeyCurveName. Possible values include: 'P-256', 'P-384',
-         'P-521', 'SECP256K1'
-        :type curve: str or
-        :type key_type: str or ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyType
+        :param str name: The name for the new key. Key Vault will generate a version for the new key.
+        :param key_type: The type of key to create. For valid values, see ~azure.keyvault.keys.enums.JsonWebKeyType
+        :type key_type: str or ~azure.keyvault.keys.enums.JsonWebKeyType
+        :param int size: The key size in bits. For example: 2048, 3072, or 4096 for RSA.
         :param key_operations: Supported key operations.
-        :type key_operations: list[str or
-         ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyOperation]
-        :param enabled: Determines whether the object is enabled.
-        :type enabled: bool
+        :type key_operations: list[str or ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyOperation]
+        :param bool enabled: Determines whether the key is enabled.
         :param expires: Expiry date of the key in UTC.
         :type expires: datetime.datetime
-        :param not_before: Not before date of the key in UTC
+        :param not_before: Not before date of the key in UTC.
         :type not_before: datetime.datetime
-        :param tags: Application specific metadata in the form of key-value
-         pairs.
+        :param tags: Application specific metadata in the form of key-value pairs.
         :type tags: Dict[str, str]
+        :param curve: Elliptic curve name. If not provided, defaults to 'P-256'. See ~azure.keyvault.keys.enums.JsonWebKeyCurveName for valid values.
+        :type curve: str or ~azure.keyvault.keys.enums.JsonWebKeyCurveName
         :returns: The created key
         :rtype: ~azure.keyvault.keys._models.Key
 
@@ -143,24 +129,20 @@ class KeyClient(AsyncKeyVaultClientBase):
         tags: Optional[Dict[str, str]] = None,
         **kwargs: Mapping[str, Any]
     ) -> Key:
-        """Creates a new RSA type key, stores it, then returns the key to the client.
+        """Creates a new RSA type key, stores it, then returns key to the client.
 
         The create key operation can be used to create any key type in Azure
         Key Vault. If the named key already exists, Azure Key Vault creates a
         new version of the key. It requires the keys/create permission.
 
-        :param name: The name for the new key. The system will generate
-         the version name for the new key.
-        :type name: str
-        :param hsm: Whether to import as a hardware key (HSM) or software key.
-        :type hsm: bool
-        :param size: The key size in bits. For example: 2048, 3072, or
-         4096 for RSA.
+        :param str name: The name for the new key. Key Vault will generate a version for the new key.
+        :param bool hsm: Whether to create the key in a hardware security module.
+        :param size: The key size in bits. For example: 2048, 3072, or 4096 for RSA.
         :type size: int
         :param key_operations: Supported key operations.
         :type key_operations: list[str or
          ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyOperation]
-        :param enabled: Determines whether the object is enabled.
+        :param bool enabled: Determines whether the object is enabled.
         :type enabled: bool
         :param expires: Expiry date of the key in UTC.
         :type expires: datetime.datetime
@@ -206,35 +188,24 @@ class KeyClient(AsyncKeyVaultClientBase):
         tags: Optional[Dict[str, str]] = None,
         **kwargs: Mapping[str, Any]
     ) -> Key:
-        """Creates a new Elliptic curve type key, stores it, then returns key attributes to the client.
+        """Creates a new elliptic curve key, stores it, then returns it to the client.
 
-        The create key operation can be used to create any key type in Azure
-        Key Vault. If the named key already exists, Azure Key Vault creates a
-        new version of the key. It requires the keys/create permission.
+        This requires the keys/create permission. If the named key already exists, Azure Key Vault creates a new version of the key.
 
-        :param name: The name for the new key. The system will generate
-         the version name for the new key.
-        :type name: str
-        :param hsm: Whether to import as a hardware key (HSM) or software key.
-        :type hsm: bool
-        :param curve: Elliptic curve name. If none then defaults to 'P-256'. For valid values, see
-         JsonWebKeyCurveName. Possible values include: 'P-256', 'P-384',
-         'P-521', 'SECP256K1'
-        :type curve: str or
-         ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyCurveName
+        :param str name: The name for the new key. Key Vault will generate a version for the new key.
+        :param bool hsm: Whether to create the key in a hardware security module.
+        :param curve: Elliptic curve name. If not provided, defaults to 'P-256'. See ~azure.keyvault.keys.enums.JsonWebKeyCurveName for valid values.
+        :type curve: str or ~azure.keyvault.keys.enums.JsonWebKeyCurveName
         :param key_operations: Supported key operations.
-        :type key_operations: list[str or
-         ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyOperation]
-        :param enabled: Determines whether the object is enabled.
-        :type enabled: bool
+        :type key_operations: list[str or ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyOperation]
+        :param bool enabled: Determines whether the object is enabled.
         :param expires: Expiry date of the key in UTC.
         :type expires: datetime.datetime
         :param not_before: Not before date of the key in UTC
         :type not_before: datetime.datetime
-        :param tags: Application specific metadata in the form of key-value
-         pairs.
+        :param tags: Application specific metadata in the form of key-value pairs.
         :type tags: Dict[str, str]
-        :returns: The created EC key
+        :returns: The created key
         :rtype: ~azure.keyvault.keys._models.Key
 
         Example:
@@ -278,15 +249,12 @@ class KeyClient(AsyncKeyVaultClientBase):
         Key Vault. Note: The cryptographic material of a key itself cannot be
         changed. This operation requires the keys/update permission.
 
-        :param name: The name of key to update.
-        :type name: str
-        :param version: The version of the key to update.
-        :type version: str
+        :param str name: The name of key to update.
+        :param str version: The version of the key to update.
         :param key_operations: Json web key operations. For more information on
          possible key operations, see JsonWebKeyOperation.
-        :type key_operations: list[str or
-         ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyOperation]
-        :param enabled: Determines whether the object is enabled.
+        :type key_operations: list[str or ~azure.keyvault.keys._generated.v7_0.models.JsonWebKeyOperation]
+        :param bool enabled: Determines whether the object is enabled.
         :type enabled: bool
         :param expires: Expiry date of the key in UTC.
         :type expires: datetime.datetime
@@ -296,7 +264,7 @@ class KeyClient(AsyncKeyVaultClientBase):
          pairs.
         :type tags: Dict[str, str]
         :returns: The updated key
-        :rtype: ~azure.security.keyvault.v7_0.models.Key
+        :rtype: ~azure.keyvault.keys._models.Key
         :raises: ~azure.core.exceptions.ResourceNotFoundError if the client failed to retrieve the key
 
         Example:
@@ -357,8 +325,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         The full key identifier, attributes, and tags are provided in the
         response. This operation requires the keys/list permission.
 
-        :param name: The name of the key.
-        :type name: str
+        :param str name: The name of the key.
         :returns: An iterator like instance of KeyBase
         :rtype:
          typing.AsyncIterable[~azure.keyvault.keys._models.KeyBase]
@@ -394,8 +361,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         geographical area cannot be restored in an EU geographical area. This
         operation requires the key/backup permission.
 
-        :param name: The name of the key.
-        :type name: str
+        :param str name: The name of the key.
         :return: The raw bytes of the key backup.
         :rtype: bytes
         :raises: ~azure.core.exceptions.ResourceNotFoundError if the client failed to retrieve the key
@@ -457,8 +423,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         Wrap/Unwrap or Encrypt/Decrypt operations. This operation requires the
         keys/delete permission.
 
-        :param name: The name of the key to delete.
-        :type name: str
+        :param str name: The name of the key to delete.
         :returns: The deleted key
         :rtype: ~azure.keyvault.keys._models.DeletedKey
         :raises: ~azure.core.exceptions.ResourceNotFoundError if the client failed to delete the key
@@ -482,8 +447,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         an error if invoked on a non soft-delete enabled vault. This operation
         requires the keys/get permission.
 
-        :param name: The name of the key.
-        :type name: str
+        :param str name: The name of the key.
         :returns: The deleted key
         :rtype: ~azure.keyvault.keys._models.DeletedKey
         :raises: ~azure.core.exceptions.ResourceNotFoundError if the client failed to retrieve the key
@@ -537,10 +501,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         an error if invoked on a non soft-delete enabled vault. This operation
         requires the keys/purge permission.
 
-        :param name: The name of the key
-        :type name: str
-        :returns: None
-        :rtype: None
+        :param str name: The name of the key
 
         Example:
             .. code-block:: python
@@ -562,9 +523,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         on soft-delete enabled vaults. This operation requires the keys/recover
         permission.
 
-        :param name: The name of the deleted key.
-        :type name: str
-        :returns: The recovered deleted key
+        :param str name: The name of the deleted key.
+        :returns: The recovered key
         :rtype: ~azure.keyvault.keys._models.Key
 
         Example:
@@ -596,15 +556,14 @@ class KeyClient(AsyncKeyVaultClientBase):
         creates a new version of the key. This operation requires the
         keys/import permission.
 
-        :param name: Name for the imported key.
-        :type name: str
+        :param str name: Name for the imported key.
         :param key: The Json web key
         :type key: ~azure.security.keyvault.v7_0.models.JsonWebKey
         :param hsm: Whether to import as a hardware key (HSM) or software key.
         :type hsm: bool
-        :param enabled: Determines whether the object is enabled.
+        :param bool enabled: Determines whether the object is enabled.
         :type enabled: bool
-        :param expires: Expiry date of the key  in UTC.
+        :param expires: Expiry date of the key in UTC.
         :type expires: datetime.datetime
         :param not_before: Not before date of the key in UTC
         :type not_before: datetime.datetime
@@ -638,15 +597,11 @@ class KeyClient(AsyncKeyVaultClientBase):
         key-reference but do not have access to the public key material. This
         operation requires the keys/wrapKey permission.
 
-        :param name: The name of the key.
-        :type name: str
-        :param version: The version of the key.
-        :type version: str
-        :param algorithm: algorithm identifier. Possible values include:
-         'RSA-OAEP', 'RSA-OAEP-256', 'RSA1_5'
-        :type algorithm: str or
-         ~azure.security.keyvault.v7_0.models.JsonWebKeyEncryptionAlgorithm
-        :param value:
+        :param str name: The name of the key.
+        :param str version: The version of the key to use. If unspecified, the latest version of the key is used.
+        :param algorithm: algorithm identifier to use
+        :type algorithm: str or ~azure.keyvault.keys.enums.JsonWebKeyEncryptionAlgorithm
+        :param value: The key to wrap.
         :type value: bytes
         :returns: The wrapped symmetric key.
         :rtype: ~azure.keyvault.keys._models.KeyOperationResult
@@ -672,14 +627,12 @@ class KeyClient(AsyncKeyVaultClientBase):
         keys stored in Azure Key Vault since it uses the private portion of the
         key. This operation requires the keys/unwrapKey permission.
 
-        :param name: The name of the key.
-        :type name: str
-        :param version: The version of the key.
-        :type version: str
+        :param str name: The name of the key.
+        :param str version: The version of the key to use. If unspecified, the latest version of the key is used.
         :param algorithm: algorithm identifier. Possible values include:
          'RSA-OAEP', 'RSA-OAEP-256', 'RSA1_5'
         :type algorithm: str or
-         ~azure.security.keyvault.v7_0.models.JsonWebKeyEncryptionAlgorithm
+         ~azure.keyvault.keys.enums.JsonWebKeyEncryptionAlgorithm
         :param value:
         :type value: bytes
         :returns: The unwrapped symmetric key.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/enums.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/enums.py
@@ -1,0 +1,115 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+"""Enums for use with JSON Web Key APIs"""
+
+from enum import Enum
+
+
+class JsonWebKeyCurveName:
+    """Elliptic curve algorithm names"""
+
+    class v7_0(str, Enum):
+        """Curves supported by Key Vault API version 7.0. This is the default version."""
+
+        p_256 = "P-256"  #: The NIST P-256 elliptic curve, AKA SECG curve SECP256R1.
+        p_384 = "P-384"  #: The NIST P-384 elliptic curve, AKA SECG curve SECP384R1.
+        p_521 = "P-521"  #: The NIST P-521 elliptic curve, AKA SECG curve SECP521R1.
+        p_256_k = "P-256K"  #: The SECG SECP256K1 elliptic curve.
+
+    default = v7_0
+
+    class v2016_10_01(str, Enum):
+        """Curves supported by Key Vault API version 2016-10-01"""
+
+        p_256 = "P-256"  #: The NIST P-256 elliptic curve, AKA SECG curve SECP256R1.
+        p_384 = "P-384"  #: The NIST P-384 elliptic curve, AKA SECG curve SECP384R1.
+        p_521 = "P-521"  #: The NIST P-521 elliptic curve, AKA SECG curve SECP521R1.
+        secp256_k1 = "SECP256K1"  #: The SECG SECP256K1 elliptic curve.
+
+
+class JsonWebKeyEncryptionAlgorithm:
+    """Encryption algorithm names"""
+
+    class v7_0(str, Enum):
+        """Algorithms supported by Key Vault API version 7.0. This is the default version."""
+
+        rsa_oaep = "RSA-OAEP"
+        rsa_oaep_256 = "RSA-OAEP-256"
+        rsa1_5 = "RSA1_5"
+
+    default = v7_0
+
+    class v2016_10_01(str, Enum):
+        """Algorithms supported by Key Vault API version 2016-10-01"""
+
+        rsa_oaep = "RSA-OAEP"
+        rsa_oaep_256 = "RSA-OAEP-256"
+        rsa1_5 = "RSA1_5"
+
+
+class JsonWebKeySignatureAlgorithm:
+    """Signature algorithm names"""
+
+    class v7_0(str, Enum):
+        """Algorithms supported by Key Vault API version 7.0. This is the default version."""
+
+        ps256 = (
+            "PS256"
+        )  #: RSASSA-PSS using SHA-256 and MGF1 with SHA-256, as described in https://tools.ietf.org/html/rfc7518
+        ps384 = (
+            "PS384"
+        )  #: RSASSA-PSS using SHA-384 and MGF1 with SHA-384, as described in https://tools.ietf.org/html/rfc7518
+        ps512 = (
+            "PS512"
+        )  #: RSASSA-PSS using SHA-512 and MGF1 with SHA-512, as described in https://tools.ietf.org/html/rfc7518
+        rs256 = "RS256"  #: RSASSA-PKCS1-v1_5 using SHA-256, as described in https://tools.ietf.org/html/rfc7518
+        rs384 = "RS384"  #: RSASSA-PKCS1-v1_5 using SHA-384, as described in https://tools.ietf.org/html/rfc7518
+        rs512 = "RS512"  #: RSASSA-PKCS1-v1_5 using SHA-512, as described in https://tools.ietf.org/html/rfc7518
+        rsnull = "RSNULL"  #: Reserved
+        es256 = "ES256"  #: ECDSA using P-256 and SHA-256, as described in https://tools.ietf.org/html/rfc7518.
+        es384 = "ES384"  #: ECDSA using P-384 and SHA-384, as described in https://tools.ietf.org/html/rfc7518
+        es512 = "ES512"  #: ECDSA using P-521 and SHA-512, as described in https://tools.ietf.org/html/rfc7518
+        es256_k = "ES256K"  #: ECDSA using P-256K and SHA-256, as described in https://tools.ietf.org/html/rfc7518
+
+    default = v7_0
+
+    class v2016_10_01(str, Enum):
+        """Algorithms supported by Key Vault API version 2016-10-01"""
+
+        ps256 = "PS256"
+        ps384 = "PS384"
+        ps512 = "PS512"
+        rs256 = "RS256"
+        rs384 = "RS384"
+        rs512 = "RS512"
+        rsnull = "RSNULL"
+        es256 = "ES256"
+        es384 = "ES384"
+        es512 = "ES512"
+        ecdsa256 = "ECDSA256"
+
+
+class JsonWebKeyType:
+    """JSON Web Key types"""
+
+    class v7_0(str, Enum):
+        """Algorithms supported by Key Vault API version 7.0. This is the default version."""
+
+        ec = "EC"  #: Elliptic Curve.
+        ec_hsm = "EC-HSM"  #: Elliptic Curve with a private key which is not exportable from the HSM.
+        rsa = "RSA"  #: RSA (https://tools.ietf.org/html/rfc3447)
+        rsa_hsm = "RSA-HSM"  #: RSA with a private key which is not exportable from the HSM.
+        oct = "oct"  #: Octet sequence (used to represent symmetric keys)
+
+    default = v7_0
+
+    class v2016_10_01(str, Enum):
+        """Key types supported by Key Vault API version 2016-10-01"""
+
+        ec = "EC"
+        ec_hsm = "EC-HSM"
+        rsa = "RSA"
+        rsa_hsm = "RSA-HSM"
+        oct = "oct"

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_encrypt_and_decrypt.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_encrypt_and_decrypt.yaml
@@ -1,0 +1,326 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vault979f122d.vault.azure.net/keys/keycrypt979f122d?api-version=7.0
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"key": {"d": "Ynx9JGaBSP4iUsf6ZJ6opantRNdcdmzaQrKbZg6ZQE8Ohi1FYabJWvaoPSE-CiJEsDzShXZHMhUHN4X7Bn8BXaGQhK3p9HXgiwQKmix7oAJTu4ElUIyd8UC3UWHSZr40el4PaQD-HYu_eMzCXus34MnRiNbh_BUWm6T-Eidhk9d3kNIyaSi9YNDQHW6tjWrEhhq63O7JU1j9ZonFChZxpKk20jdkQKQURVAdpOdL-5j4I70ZxFuU6wHZj8DS8oRQfwGOvZKbgYDb5jgf3UNL_7eACqq92XPVX56vm7iKbqeyjCqAIx5y3hrSRIJtZlWCwjYnYQGd4unxDLi8wmJWSQ",
+      "qi": "AJ_nrkLpK8BPzVeARkvSHQyKwMWZ-a8CD95qsKfn0dOZAvXY-2xhQYTEwbED-0bpTNEKbIpA-ZkaHygmnzJkNbbFAnb9pkkzU8ZQqDP3JNgMfVIroWx58Oth9nJza2j7i-MkPRCUPEq3Ao0J52z7WJIiLji8TTVYW_NaiM1oxzsH",
+      "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU",
+      "key_ops": ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"],
+      "p": "ANHerI1o3dLB_VLVmZZVss8VZSYN5SaeQ_0qhfOSgOFwj__waCFmy2EG7l6l6f_Z-Y0L7Mn_LNov68lyWSFa2EuQUeVj4UoFHc5Di8ZUGiSsTwFM-XMtNuv8HmGgDYLL5BIJD3eTz71LdgW-Ez38OZH34b7VeG8zfeUDb8Hi30zz",
+      "q": "AMPcZrZBqbc82DO8Q5zTT8ZXRGWrW36KktMllaIk1W2RHnRiQiW0jBWmcCgqUcQNHa1LwumjyNqwx28QBS37BTvG7ULGUoio6LrOeoiBGEMj-U19sX6m37plEhj5Mak7j3OPPY_T9rohjTW5aGGg9YSwq4jdz0RrmBX00ofYOjI3",
+      "e": "AQAB", "kty": "RSA", "dq": "AKC9TAo9n2RDaggjdLXK8kiLrBVoaWFTpqXkzYXRhtsx4vWPAkxhfSnze05rVMl6HiXv7FnE0f0wYawzUJzoyuXBH0zS6D9BqCZPeF543AmWB27iPf38Q9Z8Rjr6oBgMSnGDV_mm8nDVQkeaDyE4cOZh-5UKvKShTKKQVwunmDNH",
+      "dp": "AMmhWb5yZcu6vJr8xJZ-t0_likxJRUMZAtEULaWZt2DgODj4y9JrZDJP6mvckzhQP0WXk2NuWbU2HR5pUeCN2wieG1B76VKoH76vfnaJDqT1NuJVBcP2SLHog3ffwZtMME5zjfygchG3kihqOSpwTQ9ETAqAJTkRC38fEhwAz_Cp"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1724'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vault979f122d.vault.azure.net/keys/keycrypt979f122d?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vault979f122d.vault.azure.net/keys/keycrypt979f122d/5296335953f94b56a762a8a752088a86","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU","e":"AQAB"},"attributes":{"enabled":true,"created":1563478095,"updated":1563478095,"recoveryLevel":"Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '653'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ",
+      "alg": "RSA-OAEP"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '299'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault979f122d.vault.azure.net/keys/keycrypt979f122d/encrypt?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vault979f122d.vault.azure.net/keys/keycrypt979f122d/5296335953f94b56a762a8a752088a86","value":"bQcvKF-j_5N3ax-DSntX0qjzYcoJDDGOixmrIoRb5OJ_6540ZT1oyGhxbkMfSeh0QJxG6Wd6v8WtDJ7viUeJ_qQnTM-wISsxSjLpBZTvsW9siOShNGUYoagsOYW_61W4JbGzk4lQOaqkRks0sLbLXUbZCpNLKvC88RfS3u6ugz_Xav0obvixh3Kl-rE8n_BvITjj9rw1Y9IoM6csh6VrZkrPE_FLjZE6kStZ2-hGQ5NqaKDdp5ArnMmC9TpTjj5J9Dx6KUegUdSBrRJeYjkHLGBUYQtPpIz3EpCShkS4nqmQm2m6FiBfikMBNsmHhnDTIRIIP7pDXg1kJAuiT5rHwQ"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '455'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "bQcvKF-j_5N3ax-DSntX0qjzYcoJDDGOixmrIoRb5OJ_6540ZT1oyGhxbkMfSeh0QJxG6Wd6v8WtDJ7viUeJ_qQnTM-wISsxSjLpBZTvsW9siOShNGUYoagsOYW_61W4JbGzk4lQOaqkRks0sLbLXUbZCpNLKvC88RfS3u6ugz_Xav0obvixh3Kl-rE8n_BvITjj9rw1Y9IoM6csh6VrZkrPE_FLjZE6kStZ2-hGQ5NqaKDdp5ArnMmC9TpTjj5J9Dx6KUegUdSBrRJeYjkHLGBUYQtPpIz3EpCShkS4nqmQm2m6FiBfikMBNsmHhnDTIRIIP7pDXg1kJAuiT5rHwQ",
+      "alg": "RSA-OAEP"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault979f122d.vault.azure.net/keys/keycrypt979f122d/decrypt?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vault979f122d.vault.azure.net/keys/keycrypt979f122d/5296335953f94b56a762a8a752088a86","value":"NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '380'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ",
+      "alg": "RSA-OAEP"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '299'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault979f122d.vault.azure.net/keys/keycrypt979f122d/encrypt?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vault979f122d.vault.azure.net/keys/keycrypt979f122d/5296335953f94b56a762a8a752088a86","value":"KxyOSibw7QEO5wu9nlQQJCHrfZvnIyPDtlBGlTl_vjUKpSSVpGWQZrt7p-hvm-x0OmzB-ylJBkj30u6IZMLY_99vH1_NHTOGtsLIjXGpx_03p1P_IOWDYSfg1i4IKArmsG5nJIc13QvxC7U6cNCCn17m-IN4hBMdOchJ13Is8eqUs5YX8m3HYw7Yx8zmOlxKF4g372mKypchbyT9pbnjylYNQneVnXRW19ujm_TrpnITpZXDg0mVTM07DR92TWSxGuAoD15C0fc65G8XDBG7CM_KK5t0Qt7YA5-55HZCTKvnQBOOGpt2rhP6hlXGtSPJS-JeYm-7j_hbSPqov_cBUA"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '455'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "KxyOSibw7QEO5wu9nlQQJCHrfZvnIyPDtlBGlTl_vjUKpSSVpGWQZrt7p-hvm-x0OmzB-ylJBkj30u6IZMLY_99vH1_NHTOGtsLIjXGpx_03p1P_IOWDYSfg1i4IKArmsG5nJIc13QvxC7U6cNCCn17m-IN4hBMdOchJ13Is8eqUs5YX8m3HYw7Yx8zmOlxKF4g372mKypchbyT9pbnjylYNQneVnXRW19ujm_TrpnITpZXDg0mVTM07DR92TWSxGuAoD15C0fc65G8XDBG7CM_KK5t0Qt7YA5-55HZCTKvnQBOOGpt2rhP6hlXGtSPJS-JeYm-7j_hbSPqov_cBUA",
+      "alg": "RSA-OAEP"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault979f122d.vault.azure.net/keys/keycrypt979f122d/5296335953f94b56a762a8a752088a86/decrypt?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vault979f122d.vault.azure.net/keys/keycrypt979f122d/5296335953f94b56a762a8a752088a86","value":"NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '380'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_sign_and_verify.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_key_sign_and_verify.yaml
@@ -1,0 +1,324 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vault51081073.vault.azure.net/keys/keysign51081073?api-version=7.0
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 18 Jul 2019 19:28:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"key": {"e": "AQAB", "dq": "AKC9TAo9n2RDaggjdLXK8kiLrBVoaWFTpqXkzYXRhtsx4vWPAkxhfSnze05rVMl6HiXv7FnE0f0wYawzUJzoyuXBH0zS6D9BqCZPeF543AmWB27iPf38Q9Z8Rjr6oBgMSnGDV_mm8nDVQkeaDyE4cOZh-5UKvKShTKKQVwunmDNH",
+      "kty": "RSA", "key_ops": ["encrypt", "decrypt", "sign", "verify", "wrapKey",
+      "unwrapKey"], "d": "Ynx9JGaBSP4iUsf6ZJ6opantRNdcdmzaQrKbZg6ZQE8Ohi1FYabJWvaoPSE-CiJEsDzShXZHMhUHN4X7Bn8BXaGQhK3p9HXgiwQKmix7oAJTu4ElUIyd8UC3UWHSZr40el4PaQD-HYu_eMzCXus34MnRiNbh_BUWm6T-Eidhk9d3kNIyaSi9YNDQHW6tjWrEhhq63O7JU1j9ZonFChZxpKk20jdkQKQURVAdpOdL-5j4I70ZxFuU6wHZj8DS8oRQfwGOvZKbgYDb5jgf3UNL_7eACqq92XPVX56vm7iKbqeyjCqAIx5y3hrSRIJtZlWCwjYnYQGd4unxDLi8wmJWSQ",
+      "p": "ANHerI1o3dLB_VLVmZZVss8VZSYN5SaeQ_0qhfOSgOFwj__waCFmy2EG7l6l6f_Z-Y0L7Mn_LNov68lyWSFa2EuQUeVj4UoFHc5Di8ZUGiSsTwFM-XMtNuv8HmGgDYLL5BIJD3eTz71LdgW-Ez38OZH34b7VeG8zfeUDb8Hi30zz",
+      "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU",
+      "q": "AMPcZrZBqbc82DO8Q5zTT8ZXRGWrW36KktMllaIk1W2RHnRiQiW0jBWmcCgqUcQNHa1LwumjyNqwx28QBS37BTvG7ULGUoio6LrOeoiBGEMj-U19sX6m37plEhj5Mak7j3OPPY_T9rohjTW5aGGg9YSwq4jdz0RrmBX00ofYOjI3",
+      "qi": "AJ_nrkLpK8BPzVeARkvSHQyKwMWZ-a8CD95qsKfn0dOZAvXY-2xhQYTEwbED-0bpTNEKbIpA-ZkaHygmnzJkNbbFAnb9pkkzU8ZQqDP3JNgMfVIroWx58Oth9nJza2j7i-MkPRCUPEq3Ao0J52z7WJIiLji8TTVYW_NaiM1oxzsH",
+      "dp": "AMmhWb5yZcu6vJr8xJZ-t0_likxJRUMZAtEULaWZt2DgODj4y9JrZDJP6mvckzhQP0WXk2NuWbU2HR5pUeCN2wieG1B76VKoH76vfnaJDqT1NuJVBcP2SLHog3ffwZtMME5zjfygchG3kihqOSpwTQ9ETAqAJTkRC38fEhwAz_Cp"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1724'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vault51081073.vault.azure.net/keys/keysign51081073?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vault51081073.vault.azure.net/keys/keysign51081073/9b36fd2608204e89843b5efa023a1e8a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU","e":"AQAB"},"attributes":{"enabled":true,"created":1563478095,"updated":1563478095,"recoveryLevel":"Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '652'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RS256", "value": "vgZc0NQUb6WMKX___V2JntcFRO_vszKwSAj7R2rL1zg"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '72'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault51081073.vault.azure.net/keys/keysign51081073/sign?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vault51081073.vault.azure.net/keys/keysign51081073/9b36fd2608204e89843b5efa023a1e8a","value":"YX0IOuHlYW7IEVboW0c8M_geUfp2pKoCw7ujVZfXZOy0890603_QcjCSzuw_qUWehJ8IYVlfaXeF3Ebu36oB6cD8oG8OfI6rLM9BKQUR2KE5VoCBKAGit7FxhAnLRFGP69dF6gyO_wv_-zCJnXLIOg1Pu0K80WVSYkj6Wzczj35OQHEptDqRmxdwQoDYoEk5iYcb3JOeWC1frcGVEf9qs0yzwx1AbgkAOPElweovZZlleS6MALP0HTt7L5zJg7kjnCsuksVsEfM2R0_Mzt8nT24LczCNyZac50hHVkCepaZDRs26KodYnSs3doFlYOUJpCu8sxil7VBTEtFY38dENg"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '454'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RS256", "digest": "vgZc0NQUb6WMKX___V2JntcFRO_vszKwSAj7R2rL1zg",
+      "value": "YX0IOuHlYW7IEVboW0c8M_geUfp2pKoCw7ujVZfXZOy0890603_QcjCSzuw_qUWehJ8IYVlfaXeF3Ebu36oB6cD8oG8OfI6rLM9BKQUR2KE5VoCBKAGit7FxhAnLRFGP69dF6gyO_wv_-zCJnXLIOg1Pu0K80WVSYkj6Wzczj35OQHEptDqRmxdwQoDYoEk5iYcb3JOeWC1frcGVEf9qs0yzwx1AbgkAOPElweovZZlleS6MALP0HTt7L5zJg7kjnCsuksVsEfM2R0_Mzt8nT24LczCNyZac50hHVkCepaZDRs26KodYnSs3doFlYOUJpCu8sxil7VBTEtFY38dENg"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '428'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault51081073.vault.azure.net/keys/keysign51081073/verify?api-version=7.0
+  response:
+    body:
+      string: '{"value":true}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '14'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RS256", "value": "vgZc0NQUb6WMKX___V2JntcFRO_vszKwSAj7R2rL1zg"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '72'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault51081073.vault.azure.net/keys/keysign51081073/sign?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vault51081073.vault.azure.net/keys/keysign51081073/9b36fd2608204e89843b5efa023a1e8a","value":"YX0IOuHlYW7IEVboW0c8M_geUfp2pKoCw7ujVZfXZOy0890603_QcjCSzuw_qUWehJ8IYVlfaXeF3Ebu36oB6cD8oG8OfI6rLM9BKQUR2KE5VoCBKAGit7FxhAnLRFGP69dF6gyO_wv_-zCJnXLIOg1Pu0K80WVSYkj6Wzczj35OQHEptDqRmxdwQoDYoEk5iYcb3JOeWC1frcGVEf9qs0yzwx1AbgkAOPElweovZZlleS6MALP0HTt7L5zJg7kjnCsuksVsEfM2R0_Mzt8nT24LczCNyZac50hHVkCepaZDRs26KodYnSs3doFlYOUJpCu8sxil7VBTEtFY38dENg"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '454'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RS256", "digest": "vgZc0NQUb6WMKX___V2JntcFRO_vszKwSAj7R2rL1zg",
+      "value": "YX0IOuHlYW7IEVboW0c8M_geUfp2pKoCw7ujVZfXZOy0890603_QcjCSzuw_qUWehJ8IYVlfaXeF3Ebu36oB6cD8oG8OfI6rLM9BKQUR2KE5VoCBKAGit7FxhAnLRFGP69dF6gyO_wv_-zCJnXLIOg1Pu0K80WVSYkj6Wzczj35OQHEptDqRmxdwQoDYoEk5iYcb3JOeWC1frcGVEf9qs0yzwx1AbgkAOPElweovZZlleS6MALP0HTt7L5zJg7kjnCsuksVsEfM2R0_Mzt8nT24LczCNyZac50hHVkCepaZDRs26KodYnSs3doFlYOUJpCu8sxil7VBTEtFY38dENg"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '428'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault51081073.vault.azure.net/keys/keysign51081073/9b36fd2608204e89843b5efa023a1e8a/verify?api-version=7.0
+  response:
+    body:
+      string: '{"value":true}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '14'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_encrypt_and_decrypt.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_encrypt_and_decrypt.yaml
@@ -1,0 +1,326 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vault9a39123f.vault.azure.net/keys/keycrypt9a39123f?api-version=7.0
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"key": {"d": "Ynx9JGaBSP4iUsf6ZJ6opantRNdcdmzaQrKbZg6ZQE8Ohi1FYabJWvaoPSE-CiJEsDzShXZHMhUHN4X7Bn8BXaGQhK3p9HXgiwQKmix7oAJTu4ElUIyd8UC3UWHSZr40el4PaQD-HYu_eMzCXus34MnRiNbh_BUWm6T-Eidhk9d3kNIyaSi9YNDQHW6tjWrEhhq63O7JU1j9ZonFChZxpKk20jdkQKQURVAdpOdL-5j4I70ZxFuU6wHZj8DS8oRQfwGOvZKbgYDb5jgf3UNL_7eACqq92XPVX56vm7iKbqeyjCqAIx5y3hrSRIJtZlWCwjYnYQGd4unxDLi8wmJWSQ",
+      "dp": "AMmhWb5yZcu6vJr8xJZ-t0_likxJRUMZAtEULaWZt2DgODj4y9JrZDJP6mvckzhQP0WXk2NuWbU2HR5pUeCN2wieG1B76VKoH76vfnaJDqT1NuJVBcP2SLHog3ffwZtMME5zjfygchG3kihqOSpwTQ9ETAqAJTkRC38fEhwAz_Cp",
+      "key_ops": ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"],
+      "kty": "RSA", "q": "AMPcZrZBqbc82DO8Q5zTT8ZXRGWrW36KktMllaIk1W2RHnRiQiW0jBWmcCgqUcQNHa1LwumjyNqwx28QBS37BTvG7ULGUoio6LrOeoiBGEMj-U19sX6m37plEhj5Mak7j3OPPY_T9rohjTW5aGGg9YSwq4jdz0RrmBX00ofYOjI3",
+      "e": "AQAB", "p": "ANHerI1o3dLB_VLVmZZVss8VZSYN5SaeQ_0qhfOSgOFwj__waCFmy2EG7l6l6f_Z-Y0L7Mn_LNov68lyWSFa2EuQUeVj4UoFHc5Di8ZUGiSsTwFM-XMtNuv8HmGgDYLL5BIJD3eTz71LdgW-Ez38OZH34b7VeG8zfeUDb8Hi30zz",
+      "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU",
+      "qi": "AJ_nrkLpK8BPzVeARkvSHQyKwMWZ-a8CD95qsKfn0dOZAvXY-2xhQYTEwbED-0bpTNEKbIpA-ZkaHygmnzJkNbbFAnb9pkkzU8ZQqDP3JNgMfVIroWx58Oth9nJza2j7i-MkPRCUPEq3Ao0J52z7WJIiLji8TTVYW_NaiM1oxzsH",
+      "dq": "AKC9TAo9n2RDaggjdLXK8kiLrBVoaWFTpqXkzYXRhtsx4vWPAkxhfSnze05rVMl6HiXv7FnE0f0wYawzUJzoyuXBH0zS6D9BqCZPeF543AmWB27iPf38Q9Z8Rjr6oBgMSnGDV_mm8nDVQkeaDyE4cOZh-5UKvKShTKKQVwunmDNH"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1724'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vault9a39123f.vault.azure.net/keys/keycrypt9a39123f?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vault9a39123f.vault.azure.net/keys/keycrypt9a39123f/7691c97ba4464f70bb8313f7de08d847","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU","e":"AQAB"},"attributes":{"enabled":true,"created":1563478095,"updated":1563478095,"recoveryLevel":"Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '653'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ",
+      "alg": "RSA-OAEP"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '299'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault9a39123f.vault.azure.net/keys/keycrypt9a39123f/encrypt?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vault9a39123f.vault.azure.net/keys/keycrypt9a39123f/7691c97ba4464f70bb8313f7de08d847","value":"YlPiIru6dvNmn8rQPbkI-Q6dqzsu-RCrBHySFqKBex5dJDG4E1_tXTp79y0a6Jmtx9yEKhgO8JuafLlQXUnt1eQiCmicyOBjbd-t6taDXEZxmPJtYAuuvCiOwEuBNLOuCo6mCTkMu0apgwwLO-2Y5xUHQR3nWyJCvNAGy8xo6Szpfnf2wL7e_Yr7H1eiulpZA7EVP9QfO3z2zGTNoP1KPGV4grnXD3_v5pkWWrkenxy7I6LhzB_pEKABMGGJ62oNGbl-DTO7IynTj-y7vaUt0DlgsFtDCnzTQR2OTuhZxLvZa2TaDJO1AXB2XRZXFwIb8M_Dhf-Y_WEoPemT5VC64g"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '455'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "YlPiIru6dvNmn8rQPbkI-Q6dqzsu-RCrBHySFqKBex5dJDG4E1_tXTp79y0a6Jmtx9yEKhgO8JuafLlQXUnt1eQiCmicyOBjbd-t6taDXEZxmPJtYAuuvCiOwEuBNLOuCo6mCTkMu0apgwwLO-2Y5xUHQR3nWyJCvNAGy8xo6Szpfnf2wL7e_Yr7H1eiulpZA7EVP9QfO3z2zGTNoP1KPGV4grnXD3_v5pkWWrkenxy7I6LhzB_pEKABMGGJ62oNGbl-DTO7IynTj-y7vaUt0DlgsFtDCnzTQR2OTuhZxLvZa2TaDJO1AXB2XRZXFwIb8M_Dhf-Y_WEoPemT5VC64g",
+      "alg": "RSA-OAEP"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault9a39123f.vault.azure.net/keys/keycrypt9a39123f/decrypt?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vault9a39123f.vault.azure.net/keys/keycrypt9a39123f/7691c97ba4464f70bb8313f7de08d847","value":"NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '380'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ",
+      "alg": "RSA-OAEP"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '299'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault9a39123f.vault.azure.net/keys/keycrypt9a39123f/encrypt?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vault9a39123f.vault.azure.net/keys/keycrypt9a39123f/7691c97ba4464f70bb8313f7de08d847","value":"DCxIkL5TRcNhDJIttmKcgLkux8kaU-BQZyBPiMOyS6RiefcbrBpO6dcL6_GkWuu-1g9xyrGvo9hPFrs44Ny1wSLrlc_NGdGlZbQXf2x7Mes0C5GTnoe086MbFz4kBX-KNXovd0vgrwmqjQouBxoR2dK-VDxho_waympacoa2rrTQxgxsAvhlXb774G5I2fBABaLVhxwlKBCVwhPlkoy-tWqkY7MZkNqmkeEgSmcUPNvfXvfMA7Rxa4CIbtXYXIw35v-oB1NTVDAprrTcDLC9IZZ4UPf5pvltc5gt30LJpQjztdn9Oea7rupcbk7aw2dkFRJtbrpC70Y8UO0zKf0OcA"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '455'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "DCxIkL5TRcNhDJIttmKcgLkux8kaU-BQZyBPiMOyS6RiefcbrBpO6dcL6_GkWuu-1g9xyrGvo9hPFrs44Ny1wSLrlc_NGdGlZbQXf2x7Mes0C5GTnoe086MbFz4kBX-KNXovd0vgrwmqjQouBxoR2dK-VDxho_waympacoa2rrTQxgxsAvhlXb774G5I2fBABaLVhxwlKBCVwhPlkoy-tWqkY7MZkNqmkeEgSmcUPNvfXvfMA7Rxa4CIbtXYXIw35v-oB1NTVDAprrTcDLC9IZZ4UPf5pvltc5gt30LJpQjztdn9Oea7rupcbk7aw2dkFRJtbrpC70Y8UO0zKf0OcA",
+      "alg": "RSA-OAEP"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault9a39123f.vault.azure.net/keys/keycrypt9a39123f/7691c97ba4464f70bb8313f7de08d847/decrypt?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vault9a39123f.vault.azure.net/keys/keycrypt9a39123f/7691c97ba4464f70bb8313f7de08d847","value":"NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '380'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_sign_and_verify.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_key_sign_and_verify.yaml
@@ -1,0 +1,325 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vault535a1085.vault.azure.net/keys/keysign535a1085?api-version=7.0
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"key": {"e": "AQAB", "d": "Ynx9JGaBSP4iUsf6ZJ6opantRNdcdmzaQrKbZg6ZQE8Ohi1FYabJWvaoPSE-CiJEsDzShXZHMhUHN4X7Bn8BXaGQhK3p9HXgiwQKmix7oAJTu4ElUIyd8UC3UWHSZr40el4PaQD-HYu_eMzCXus34MnRiNbh_BUWm6T-Eidhk9d3kNIyaSi9YNDQHW6tjWrEhhq63O7JU1j9ZonFChZxpKk20jdkQKQURVAdpOdL-5j4I70ZxFuU6wHZj8DS8oRQfwGOvZKbgYDb5jgf3UNL_7eACqq92XPVX56vm7iKbqeyjCqAIx5y3hrSRIJtZlWCwjYnYQGd4unxDLi8wmJWSQ",
+      "dp": "AMmhWb5yZcu6vJr8xJZ-t0_likxJRUMZAtEULaWZt2DgODj4y9JrZDJP6mvckzhQP0WXk2NuWbU2HR5pUeCN2wieG1B76VKoH76vfnaJDqT1NuJVBcP2SLHog3ffwZtMME5zjfygchG3kihqOSpwTQ9ETAqAJTkRC38fEhwAz_Cp",
+      "qi": "AJ_nrkLpK8BPzVeARkvSHQyKwMWZ-a8CD95qsKfn0dOZAvXY-2xhQYTEwbED-0bpTNEKbIpA-ZkaHygmnzJkNbbFAnb9pkkzU8ZQqDP3JNgMfVIroWx58Oth9nJza2j7i-MkPRCUPEq3Ao0J52z7WJIiLji8TTVYW_NaiM1oxzsH",
+      "n": "AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU",
+      "p": "ANHerI1o3dLB_VLVmZZVss8VZSYN5SaeQ_0qhfOSgOFwj__waCFmy2EG7l6l6f_Z-Y0L7Mn_LNov68lyWSFa2EuQUeVj4UoFHc5Di8ZUGiSsTwFM-XMtNuv8HmGgDYLL5BIJD3eTz71LdgW-Ez38OZH34b7VeG8zfeUDb8Hi30zz",
+      "key_ops": ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"],
+      "q": "AMPcZrZBqbc82DO8Q5zTT8ZXRGWrW36KktMllaIk1W2RHnRiQiW0jBWmcCgqUcQNHa1LwumjyNqwx28QBS37BTvG7ULGUoio6LrOeoiBGEMj-U19sX6m37plEhj5Mak7j3OPPY_T9rohjTW5aGGg9YSwq4jdz0RrmBX00ofYOjI3",
+      "dq": "AKC9TAo9n2RDaggjdLXK8kiLrBVoaWFTpqXkzYXRhtsx4vWPAkxhfSnze05rVMl6HiXv7FnE0f0wYawzUJzoyuXBH0zS6D9BqCZPeF543AmWB27iPf38Q9Z8Rjr6oBgMSnGDV_mm8nDVQkeaDyE4cOZh-5UKvKShTKKQVwunmDNH",
+      "kty": "RSA"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1724'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: PUT
+    uri: https://vault535a1085.vault.azure.net/keys/keysign535a1085?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vault535a1085.vault.azure.net/keys/keysign535a1085/3c184ac077414ca0afab65b95acc3e30","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AKCRTQAjSsaDshtMFdW-2Ie9yVnC5Xr1Suc06PAHINd10nXkVSB-N4TO62ClCkZV3XKnqU0nHo7o95WaZpym53W_DiO62umRtFKdl4UotL2QUh0y3SZWeWuoK2u_x2aMj17rUFN0f9GZMZ0pqEQNCPRBLVJ_-TEe2nGCWSC0exxGsRqz6R1zFkB-icfzQPe4WjQELOUXQ7J9RxhAPTTHtDivYYG-BeTRHrmF04JT1_6b9T_C8bAC0i0teT-nmlBLarQtBJKATXBx1yegbPOoiTqlQrFQP4MrKWNxtnB9Tcbjcvj-Z9je0ckI_eRc4DvAhqcUh_p15Dqg4GeaoNIO_jU","e":"AQAB"},"attributes":{"enabled":true,"created":1563478096,"updated":1563478096,"recoveryLevel":"Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '652'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RS256", "value": "vgZc0NQUb6WMKX___V2JntcFRO_vszKwSAj7R2rL1zg"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '72'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault535a1085.vault.azure.net/keys/keysign535a1085/sign?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vault535a1085.vault.azure.net/keys/keysign535a1085/3c184ac077414ca0afab65b95acc3e30","value":"YX0IOuHlYW7IEVboW0c8M_geUfp2pKoCw7ujVZfXZOy0890603_QcjCSzuw_qUWehJ8IYVlfaXeF3Ebu36oB6cD8oG8OfI6rLM9BKQUR2KE5VoCBKAGit7FxhAnLRFGP69dF6gyO_wv_-zCJnXLIOg1Pu0K80WVSYkj6Wzczj35OQHEptDqRmxdwQoDYoEk5iYcb3JOeWC1frcGVEf9qs0yzwx1AbgkAOPElweovZZlleS6MALP0HTt7L5zJg7kjnCsuksVsEfM2R0_Mzt8nT24LczCNyZac50hHVkCepaZDRs26KodYnSs3doFlYOUJpCu8sxil7VBTEtFY38dENg"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '454'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RS256", "digest": "vgZc0NQUb6WMKX___V2JntcFRO_vszKwSAj7R2rL1zg",
+      "value": "YX0IOuHlYW7IEVboW0c8M_geUfp2pKoCw7ujVZfXZOy0890603_QcjCSzuw_qUWehJ8IYVlfaXeF3Ebu36oB6cD8oG8OfI6rLM9BKQUR2KE5VoCBKAGit7FxhAnLRFGP69dF6gyO_wv_-zCJnXLIOg1Pu0K80WVSYkj6Wzczj35OQHEptDqRmxdwQoDYoEk5iYcb3JOeWC1frcGVEf9qs0yzwx1AbgkAOPElweovZZlleS6MALP0HTt7L5zJg7kjnCsuksVsEfM2R0_Mzt8nT24LczCNyZac50hHVkCepaZDRs26KodYnSs3doFlYOUJpCu8sxil7VBTEtFY38dENg"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '428'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault535a1085.vault.azure.net/keys/keysign535a1085/verify?api-version=7.0
+  response:
+    body:
+      string: '{"value":true}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '14'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RS256", "value": "vgZc0NQUb6WMKX___V2JntcFRO_vszKwSAj7R2rL1zg"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '72'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault535a1085.vault.azure.net/keys/keysign535a1085/sign?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vault535a1085.vault.azure.net/keys/keysign535a1085/3c184ac077414ca0afab65b95acc3e30","value":"YX0IOuHlYW7IEVboW0c8M_geUfp2pKoCw7ujVZfXZOy0890603_QcjCSzuw_qUWehJ8IYVlfaXeF3Ebu36oB6cD8oG8OfI6rLM9BKQUR2KE5VoCBKAGit7FxhAnLRFGP69dF6gyO_wv_-zCJnXLIOg1Pu0K80WVSYkj6Wzczj35OQHEptDqRmxdwQoDYoEk5iYcb3JOeWC1frcGVEf9qs0yzwx1AbgkAOPElweovZZlleS6MALP0HTt7L5zJg7kjnCsuksVsEfM2R0_Mzt8nT24LczCNyZac50hHVkCepaZDRs26KodYnSs3doFlYOUJpCu8sxil7VBTEtFY38dENg"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '454'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "RS256", "digest": "vgZc0NQUb6WMKX___V2JntcFRO_vszKwSAj7R2rL1zg",
+      "value": "YX0IOuHlYW7IEVboW0c8M_geUfp2pKoCw7ujVZfXZOy0890603_QcjCSzuw_qUWehJ8IYVlfaXeF3Ebu36oB6cD8oG8OfI6rLM9BKQUR2KE5VoCBKAGit7FxhAnLRFGP69dF6gyO_wv_-zCJnXLIOg1Pu0K80WVSYkj6Wzczj35OQHEptDqRmxdwQoDYoEk5iYcb3JOeWC1frcGVEf9qs0yzwx1AbgkAOPElweovZZlleS6MALP0HTt7L5zJg7kjnCsuksVsEfM2R0_Mzt8nT24LczCNyZac50hHVkCepaZDRs26KodYnSs3doFlYOUJpCu8sxil7VBTEtFY38dENg"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '428'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.18362-SP0) azure-core/1.0.0b2 azsdk-python-azure-keyvault/7.0
+    method: POST
+    uri: https://vault535a1085.vault.azure.net/keys/keysign535a1085/3c184ac077414ca0afab65b95acc3e30/verify?api-version=7.0
+  response:
+    body:
+      string: '{"value":true}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '14'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jul 2019 19:28:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.135;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.872
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -5,6 +5,7 @@
 import codecs
 from dateutil import parser as date_parse
 import functools
+import hashlib
 import time
 
 from azure.core.exceptions import ResourceNotFoundError
@@ -15,6 +16,8 @@ from devtools_testutils import ResourceGroupPreparer
 
 
 class KeyClientTests(KeyVaultTestCase):
+    test_plain_text = b"5063e6aaa845f150200547944fd199679c98ed6f99da0a0b2dafeaf1f4684496fd532c1c229968cb9dee44957fcef7ccef59ceda0b362e56bcd78fd3faee5781c623c0bb22b35beabde0664fd30e0e824aba3dd1b0afffc4a3d955ede20cf6a854d52cfd"
+
     def _assert_key_attributes_equal(self, k1, k2):
         self.assertEqual(k1.name, k2.name)
         self.assertEqual(k1.vault_url, k2.vault_url)
@@ -351,21 +354,56 @@ class KeyClientTests(KeyVaultTestCase):
         # create key
         created_bundle = client.create_key(key_name, "RSA")
         self.assertIsNotNone(created_bundle)
-        plain_text = b"5063e6aaa845f150200547944fd199679c98ed6f99da0a0b2dafeaf1f4684496fd532c1c229968cb9dee44957fcef7ccef59ceda0b362e56bcd78fd3faee5781c623c0bb22b35beabde0664fd30e0e824aba3dd1b0afffc4a3d955ede20cf6a854d52cfd"
 
         # wrap without version
-        result = client.wrap_key(created_bundle.name, "RSA-OAEP", plain_text)
+        result = client.wrap_key(created_bundle.name, "RSA-OAEP", self.test_plain_text)
         cipher_text = result.value
 
         # unwrap without version
         result = client.unwrap_key(created_bundle.name, "RSA-OAEP", cipher_text)
-        self.assertEqual(plain_text, result.value)
+        self.assertEqual(self.test_plain_text, result.value)
 
         # wrap with version
-        result = client.wrap_key(created_bundle.name, "RSA-OAEP", plain_text, version=created_bundle.version)
+        result = client.wrap_key(created_bundle.name, "RSA-OAEP", self.test_plain_text, version=created_bundle.version)
         cipher_text = result.value
         self.assertIsNotNone(cipher_text)
 
         # unwrap with version
         result = client.unwrap_key(created_bundle.name, "RSA-OAEP", cipher_text, version=created_bundle.version)
-        self.assertEqual(plain_text, result.value)
+        self.assertEqual(self.test_plain_text, result.value)
+
+    @ResourceGroupPreparer()
+    @VaultClientPreparer()
+    def test_key_encrypt_and_decrypt(self, vault_client, **kwargs):
+        client = vault_client.keys
+        key_name = self.get_resource_name("keycrypt")
+        key = self._import_test_key(client, key_name)
+
+        # en/decrypt should round-trip
+        cipher_text = client.encrypt(key.name, "RSA-OAEP", self.test_plain_text)
+        plain_text = client.decrypt(key.name, "RSA-OAEP", cipher_text)
+        self.assertEqual(self.test_plain_text, plain_text)
+
+        cipher_text = client.encrypt(key.name, "RSA-OAEP", plain_text)
+        plain_text = client.decrypt(key.name, "RSA-OAEP", cipher_text, key_version=key.version)
+        self.assertEqual(self.test_plain_text, plain_text)
+
+    @ResourceGroupPreparer()
+    @VaultClientPreparer()
+    def test_key_sign_and_verify(self, vault_client, **kwargs):
+        client = vault_client.keys
+        key_name = self.get_resource_name("keysign")
+        key = self._import_test_key(client, key_name)
+
+        md = hashlib.sha256()
+        md.update(self.test_plain_text)
+        digest = md.digest()
+
+
+        signature = client.sign(key.name, "RS256", digest)
+        result = client.verify(key.name, "RS256", digest, signature)
+        self.assertTrue(result)
+
+        signature = client.sign(key.name, "RS256", digest)
+        result = client.verify(key.name, "RS256", digest, signature, key_version=key.version)
+        self.assertTrue(result)


### PR DESCRIPTION
This closes #6407 by exposing Key Vault crypto operations encrypt, decrypt, sign and verify on `KeyClient`, and closes #6408 by migrating tests for them from `azure-keyvault`.

I also added enums for algorithm names and the like to expose them in generated docs, and updated existing docstrings to reference them. I did a little tidying of `KeyClient` docstrings in general while I was at it.