### PR TITLE
Policy bug

### DIFF
--- a/sdk/core/azure-core/tests/test_tracing_policy.py
+++ b/sdk/core/azure-core/tests/test_tracing_policy.py
@@ -29,6 +29,7 @@ def test_distributed_tracing_policy_solo(should_set_sdk_context):
             policy = DistributedTracingPolicy()
 
             request = HttpRequest("GET", "http://127.0.0.1/temp?query=query")
+            request.headers["x-ms-client-request-id"] = "some client request id"
 
             pipeline_request = PipelineRequest(request, PipelineContext(None))
             policy.on_request(pipeline_request)
@@ -57,6 +58,7 @@ def test_distributed_tracing_policy_solo(should_set_sdk_context):
         assert network_span.span_data.attributes.get("http.url") == "http://127.0.0.1/temp?query=query"
         assert network_span.span_data.attributes.get("http.user_agent") is None
         assert network_span.span_data.attributes.get("x-ms-request-id") == "some request id"
+        assert network_span.span_data.attributes.get("x-ms-client-request-id") == "some client request id"
         assert network_span.span_data.attributes.get("http.status_code") == 202
 
         network_span = parent.children[1]
@@ -64,6 +66,7 @@ def test_distributed_tracing_policy_solo(should_set_sdk_context):
         assert network_span.span_data.attributes.get("http.method") == "GET"
         assert network_span.span_data.attributes.get("component") == "http"
         assert network_span.span_data.attributes.get("http.url") == "http://127.0.0.1/temp?query=query"
+        assert network_span.span_data.attributes.get("x-ms-client-request-id") == "some client request id"
         assert network_span.span_data.attributes.get("http.user_agent") is None
         assert network_span.span_data.attributes.get("x-ms-request-id") == None
         assert network_span.span_data.attributes.get("http.status_code") == 504
@@ -79,6 +82,7 @@ def test_distributed_tracing_policy_with_user_agent():
             policy = DistributedTracingPolicy()
 
             request = HttpRequest("GET", "http://127.0.0.1")
+            request.headers["x-ms-client-request-id"] = "some client request id"
 
             pipeline_request = PipelineRequest(request, PipelineContext(None))
 
@@ -114,6 +118,7 @@ def test_distributed_tracing_policy_with_user_agent():
         assert network_span.span_data.attributes.get("http.url") == "http://127.0.0.1"
         assert network_span.span_data.attributes.get("http.user_agent").endswith("mytools")
         assert network_span.span_data.attributes.get("x-ms-request-id") == "some request id"
+        assert network_span.span_data.attributes.get("x-ms-client-request-id") == "some client request id"
         assert network_span.span_data.attributes.get("http.status_code") == 202
 
         network_span = parent.children[1]
@@ -122,5 +127,6 @@ def test_distributed_tracing_policy_with_user_agent():
         assert network_span.span_data.attributes.get("component") == "http"
         assert network_span.span_data.attributes.get("http.url") == "http://127.0.0.1"
         assert network_span.span_data.attributes.get("http.user_agent").endswith("mytools")
+        assert network_span.span_data.attributes.get("x-ms-client-request-id") == "some client request id"
         assert network_span.span_data.attributes.get("x-ms-request-id") is None
         assert network_span.span_data.attributes.get("http.status_code") == 504

--- a/sdk/core/azure-core/tests/test_tracing_policy.py
+++ b/sdk/core/azure-core/tests/test_tracing_policy.py
@@ -64,6 +64,54 @@ def test_distributed_tracing_policy_solo():
         assert network_span.span_data.attributes.get("x-ms-request-id") == None
         assert network_span.span_data.attributes.get("http.status_code") == 504
 
+def test_distributed_tracing_policy_without_setting_sdk_context():
+    """Test policy with no other policy and happy path"""
+    with ContextHelper():
+        exporter = MockExporter()
+        trace = tracer_module.Tracer(sampler=AlwaysOnSampler(), exporter=exporter)
+        with trace.span("parent"):
+            policy = DistributedTracingPolicy()
+
+            request = HttpRequest("GET", "http://127.0.0.1/temp?query=query")
+
+            pipeline_request = PipelineRequest(request, PipelineContext(None))
+            policy.on_request(pipeline_request)
+
+            response = HttpResponse(request, None)
+            response.headers = request.headers
+            response.status_code = 202
+            response.headers["x-ms-request-id"] = "some request id"
+
+            ctx = trace.span_context
+            header = trace.propagator.to_headers(ctx)
+            assert request.headers.get("traceparent") == header.get("traceparent")
+
+            policy.on_response(pipeline_request, PipelineResponse(request, response, PipelineContext(None)))
+            time.sleep(0.001)
+            policy.on_request(pipeline_request)
+            policy.on_exception(pipeline_request)
+
+        trace.finish()
+        exporter.build_tree()
+        parent = exporter.root
+        network_span = parent.children[0]
+        assert network_span.span_data.name == "/temp"
+        assert network_span.span_data.attributes.get("http.method") == "GET"
+        assert network_span.span_data.attributes.get("component") == "http"
+        assert network_span.span_data.attributes.get("http.url") == "http://127.0.0.1/temp?query=query"
+        assert network_span.span_data.attributes.get("http.user_agent") is None
+        assert network_span.span_data.attributes.get("x-ms-request-id") == "some request id"
+        assert network_span.span_data.attributes.get("http.status_code") == 202
+
+        network_span = parent.children[1]
+        assert network_span.span_data.name == "/temp"
+        assert network_span.span_data.attributes.get("http.method") == "GET"
+        assert network_span.span_data.attributes.get("component") == "http"
+        assert network_span.span_data.attributes.get("http.url") == "http://127.0.0.1/temp?query=query"
+        assert network_span.span_data.attributes.get("http.user_agent") is None
+        assert network_span.span_data.attributes.get("x-ms-request-id") == None
+        assert network_span.span_data.attributes.get("http.status_code") == 504
+
 
 def test_distributed_tracing_policy_with_user_agent():
     """Test policy working with user agent."""

--- a/sdk/core/azure-core/tests/test_tracing_policy.py
+++ b/sdk/core/azure-core/tests/test_tracing_policy.py
@@ -14,62 +14,18 @@ from opencensus.trace.samplers import AlwaysOnSampler
 from azure.core.tracing.ext.opencensus_span import OpenCensusSpan
 from tracing_common import ContextHelper, MockExporter
 import time
+import pytest
 
-def test_distributed_tracing_policy_solo():
+
+@pytest.mark.parametrize("should_set_sdk_context", [True, False])
+def test_distributed_tracing_policy_solo(should_set_sdk_context):
     """Test policy with no other policy and happy path"""
     with ContextHelper():
         exporter = MockExporter()
         trace = tracer_module.Tracer(sampler=AlwaysOnSampler(), exporter=exporter)
         with trace.span("parent"):
-            tracing_context.current_span.set(OpenCensusSpan(trace.current_span()))
-            policy = DistributedTracingPolicy()
-
-            request = HttpRequest("GET", "http://127.0.0.1/temp?query=query")
-
-            pipeline_request = PipelineRequest(request, PipelineContext(None))
-            policy.on_request(pipeline_request)
-
-            response = HttpResponse(request, None)
-            response.headers = request.headers
-            response.status_code = 202
-            response.headers["x-ms-request-id"] = "some request id"
-
-            ctx = trace.span_context
-            header = trace.propagator.to_headers(ctx)
-            assert request.headers.get("traceparent") == header.get("traceparent")
-
-            policy.on_response(pipeline_request, PipelineResponse(request, response, PipelineContext(None)))
-            time.sleep(0.001)
-            policy.on_request(pipeline_request)
-            policy.on_exception(pipeline_request)
-
-        trace.finish()
-        exporter.build_tree()
-        parent = exporter.root
-        network_span = parent.children[0]
-        assert network_span.span_data.name == "/temp"
-        assert network_span.span_data.attributes.get("http.method") == "GET"
-        assert network_span.span_data.attributes.get("component") == "http"
-        assert network_span.span_data.attributes.get("http.url") == "http://127.0.0.1/temp?query=query"
-        assert network_span.span_data.attributes.get("http.user_agent") is None
-        assert network_span.span_data.attributes.get("x-ms-request-id") == "some request id"
-        assert network_span.span_data.attributes.get("http.status_code") == 202
-
-        network_span = parent.children[1]
-        assert network_span.span_data.name == "/temp"
-        assert network_span.span_data.attributes.get("http.method") == "GET"
-        assert network_span.span_data.attributes.get("component") == "http"
-        assert network_span.span_data.attributes.get("http.url") == "http://127.0.0.1/temp?query=query"
-        assert network_span.span_data.attributes.get("http.user_agent") is None
-        assert network_span.span_data.attributes.get("x-ms-request-id") == None
-        assert network_span.span_data.attributes.get("http.status_code") == 504
-
-def test_distributed_tracing_policy_without_setting_sdk_context():
-    """Test policy with no other policy and happy path"""
-    with ContextHelper():
-        exporter = MockExporter()
-        trace = tracer_module.Tracer(sampler=AlwaysOnSampler(), exporter=exporter)
-        with trace.span("parent"):
+            if should_set_sdk_context:
+                tracing_context.current_span.set(OpenCensusSpan(trace.current_span()))
             policy = DistributedTracingPolicy()
 
             request = HttpRequest("GET", "http://127.0.0.1/temp?query=query")


### PR DESCRIPTION
so the policy would not use the correct span context if it was not being called inside of a decorated function. I fixed that and added a tests for it. When I parameterize the first test it checks for the bug,