### PR TITLE
Added Logging to python v3 sdk

### DIFF
--- a/sdk/cosmos/azure-cosmos/.gitignore
+++ b/sdk/cosmos/azure-cosmos/.gitignore
@@ -17,6 +17,7 @@ local.properties
 .classpath
 .settings/
 .loadpath
+.pytest_cache
 
 # External tool builders
 .externalToolBuilders/

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/base.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/base.py
@@ -28,6 +28,8 @@ import json
 import uuid
 import urllib
 import binascii
+import logging
+import logging.config
 
 from . import auth
 from . import documents
@@ -40,6 +42,7 @@ import six
 from six.moves.urllib.parse import quote as urllib_quote
 from six.moves import xrange
 
+logger = logging.getLogger(__name__)
 def GetHeaders(cosmos_client_connection,
                default_headers,
                verb,
@@ -544,6 +547,7 @@ def IsValidBase64String(string_to_validate):
         if type(e) == binascii.Error:
             return False
         else:
+            logger.exception(e)
             raise e
     return True
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/constants.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/constants.py
@@ -36,3 +36,9 @@ class _Constants(object):
 
     #ServiceDocument Resource
     EnableMultipleWritableLocations = "enableMultipleWriteLocations"
+
+    # Environment variable for custom logging config file path
+    LogConfigurationFilePath = 'LOG_CONFIGURATION_FILE_PATH'
+
+    # Name of default logging config file
+    DefaultLogConfigurationFilePath = 'logging.json'

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -23,6 +23,8 @@
 """
 
 import six
+import logging
+import logging.config
 from .cosmos_client_connection import CosmosClientConnection
 from .errors import HTTPFailure
 from .http_constants import StatusCodes
@@ -66,6 +68,7 @@ class Container:
         self.container_link = u"{}/colls/{}".format(database_link, self.id)
         self._is_system_key = None
         self._scripts = None
+        self.logger = logging.getLogger(__name__)
 
     def _get_properties(self):
         # type: () -> Dict[str, Any]

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -124,6 +124,7 @@ class Container:
         :returns: :class:`Container` instance representing the retrieved container.
 
         """
+        self.logger.debug("Reading a Container. container_link: [%s]" % self.container_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
         if session_token:
@@ -183,7 +184,7 @@ class Container:
 
         """
         doc_link = self._get_document_link(item)
-
+        self.logger.debug("Reading an item. item_link: [%s]" % doc_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
         if partition_key:
@@ -224,6 +225,7 @@ class Container:
         :param response_hook: a callable invoked with the response metadata
         :returns: A :class:`QueryIterable` instance representing an iterable of items (dicts).
         """
+        self.logger.debug("Reading Items. container_link: [%s]" % self.container_link)
         if not feed_options:
             feed_options = {} # type: Dict[str, Any]
         if max_item_count is not None:
@@ -267,6 +269,7 @@ class Container:
         :returns: A :class:`QueryIterable` instance representing an iterable of items (dicts).
 
         """
+        self.logger.debug("Querying items change feed. container_link: [%s]" % self.container_link)
         if not feed_options:
             feed_options = {} # type: Dict[str, Any]
         if partition_key_range_id is not None:
@@ -340,6 +343,7 @@ class Container:
             :name: query_items_param
 
         """
+        self.logger.debug("Querying Items. container_link: [%s], query [%s]" % (self.container_link, query))
         if not feed_options:
             feed_options = {} # type: Dict[str, Any]
         if enable_cross_partition_query is not None:
@@ -404,6 +408,7 @@ class Container:
 
         """
         item_link = self._get_document_link(item)
+        self.logger.debug("Replacing an item. item_link: [%s], item id: [%s]" % (item_link, body['id']))
         if not request_options:
             request_options = {} # type: Dict[str, Any]
         request_options["disableIdGeneration"] = True
@@ -459,6 +464,7 @@ class Container:
         If the item already exists in the container, it is replaced. If it does not, it is inserted.
 
         """
+        self.logger.debug("Upserting an item. container_link: [%s]" % self.container_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
         request_options["disableIdGeneration"] = True
@@ -515,6 +521,7 @@ class Container:
         To update or replace an existing item, use the :func:`Container.upsert_item` method.
 
         """
+        self.logger.debug("Creating an item. container_link: [%s]" % self.container_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
@@ -572,6 +579,8 @@ class Container:
         :raises `HTTPFailure`: The item wasn't deleted successfully. If the item does not exist in the container, a `404` error is returned.
 
         """
+        item_link = self._get_document_link(item)
+        self.logger.debug("Deleting an item. item_link: [%s]", item_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
         if partition_key:
@@ -589,9 +598,8 @@ class Container:
         if post_trigger_include:
             request_options["postTriggerInclude"] = post_trigger_include
 
-        document_link = self._get_document_link(item)
         result = self.client_connection.DeleteItem(
-            document_link=document_link, options=request_options
+            document_link=item_link, options=request_options
         )
         if response_hook:
             response_hook(self.client_connection.last_response_headers, result) 
@@ -605,6 +613,7 @@ class Container:
         :raise HTTPFailure: If no offer exists for the container or if the offer could not be retrieved.
 
         """
+        self.logger.debug("Reading container's offer. container_link [%s]", self.container_link)
         properties = self._get_properties()
         link = properties['_self']
         query_spec = {
@@ -638,6 +647,7 @@ class Container:
         :raise HTTPFailure: If no offer exists for the container or if the offer could not be updated.
 
         """
+        self.logger.debug("Replacing container's throughput. container_link [%s], new throughput [%s]" % (self.container_link, throughput))
         properties = self._get_properties()
         link = properties['_self']
         query_spec = {
@@ -678,6 +688,7 @@ class Container:
         :returns: A :class:`QueryIterable` instance representing an iterable of conflicts (dicts).
 
         """
+        self.logger.debug("Reading Conflicts. container_link [%s]" % self.container_link)
         if not feed_options:
             feed_options = {} # type: Dict[str, Any]
         if max_item_count is not None:
@@ -715,6 +726,7 @@ class Container:
         :returns: A :class:`QueryIterable` instance representing an iterable of conflicts (dicts).
 
         """
+        self.logger.debug("Querying Conflicts. container_link [%s], query [%s]" % (self.container_link, query))
         if not feed_options:
             feed_options = {} # type: Dict[str, Any]
         if max_item_count is not None:
@@ -753,13 +765,15 @@ class Container:
         :raise `HTTPFailure`: If the given conflict couldn't be retrieved.
 
         """
+        conflict_link = self._get_conflict_link(conflict)
+        self.logger.debug("Reading a Conflict. conflict_link [%s]" % conflict_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
         if partition_key:
             request_options["partitionKey"] = self._set_partition_key(partition_key)
 
         result = self.client_connection.ReadConflict(
-            conflict_link=self._get_conflict_link(conflict),
+            conflict_link=conflict_link,
             options=request_options
         )
         if response_hook:
@@ -783,13 +797,15 @@ class Container:
         :raises `HTTPFailure`: The conflict wasn't deleted successfully. If the conflict does not exist in the container, a `404` error is returned.
 
         """
+        conflict_link = self._get_conflict_link(conflict)
+        self.logger.debug("Deleting a Conflict. conflict_link [%s]" % conflict_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
         if partition_key:
             request_options["partitionKey"] = self._set_partition_key(partition_key)
 
         result = self.client_connection.DeleteConflict(
-            conflict_link=self._get_conflict_link(conflict),
+            conflict_link=conflict_link,
             options=request_options
         )
         if response_hook:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client_connection.py
@@ -2764,6 +2764,7 @@ class CosmosClientConnection(object):
         :raises SystemError: If the query compatibility mode is undefined.
 
         """
+        self.logger.debug('partition_key_range_id being queried [%s]' % partition_key_range_id)
         if options is None:
             options = {}
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client_connection.py
@@ -24,6 +24,8 @@
 import requests
 
 import six
+import logging
+import logging.config
 from typing import cast
 from . import base
 from . import documents
@@ -154,6 +156,7 @@ class CosmosClientConnection(object):
 
         database_account = self._global_endpoint_manager._GetDatabaseAccount()
         self._global_endpoint_manager.force_refresh(database_account)
+        self.logger = logging.getLogger(__name__)
 
     @property
     def Session(self):

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
@@ -23,6 +23,8 @@
 """
 
 import six
+import logging
+import logging.config
 from .cosmos_client_connection import CosmosClientConnection
 from .container import Container
 from .offer import Offer
@@ -77,6 +79,8 @@ class Database(object):
         self.id = id
         self.database_link = u"dbs/{}".format(self.id)
         self._properties = properties
+        self.logger = logging.getLogger(__name__)
+
 
     @staticmethod
     def _get_container_id(container_or_id):
@@ -211,7 +215,7 @@ class Database(object):
         """
 
         self.logger.debug(
-            "Creating a Container. database_link: [%s], container id: [%s], partition_key" % (self.database_link, id, partition_key))
+            "Creating a Container. database_link: [%s], container id: [%s], partition_key: [%s]" % (self.database_link, id, partition_key))
         definition = dict(id=id)  # type: Dict[str, Any]
         if partition_key:
             definition["partitionKey"] = partition_key

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/default_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/default_retry_policy.py
@@ -21,6 +21,9 @@
 
 """Internal class for connection reset retry policy implementation in the Azure Cosmos database service.
 """
+import logging
+import logging.config
+
 from . import http_constants
 
 class _DefaultRetryPolicy(object):
@@ -50,6 +53,7 @@ class _DefaultRetryPolicy(object):
         self.current_retry_attempt_count = 0
         self.retry_after_in_milliseconds = 1000
         self.args = args
+        self.logger = logging.getLogger(__name__)
 
     def needsRetry(self, error_code):
         if error_code in _DefaultRetryPolicy.CONNECTION_ERROR_CODES:
@@ -70,5 +74,8 @@ class _DefaultRetryPolicy(object):
         """
         if (self.current_retry_attempt_count < self._max_retry_attempt_count) and self.needsRetry(exception.status_code):
             self.current_retry_attempt_count += 1
+            self.logger.debug('Retrying again.')
             return True
+
+        self.logger.debug('Not retrying again.')
         return False

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/endpoint_discovery_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/endpoint_discovery_retry_policy.py
@@ -23,15 +23,8 @@
 """
 
 import logging
+import logging.config
 from azure.cosmos.documents import _OperationType
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-log_formatter = logging.Formatter('%(levelname)s:%(message)s')
-log_handler = logging.StreamHandler()
-log_handler.setFormatter(log_formatter)
-logger.addHandler(log_handler)
-
 
 class _EndpointDiscoveryRetryPolicy(object):
     """The endpoint discovery retry policy class used for geo-replicated database accounts
@@ -57,6 +50,7 @@ class _EndpointDiscoveryRetryPolicy(object):
             # This enables marking the endpoint unavailability on endpoint failover/unreachability
             self.location_endpoint = self.global_endpoint_manager.resolve_service_endpoint(self.request)
             self.request.route_to_location(self.location_endpoint)
+        self.logger = logging.getLogger(__name__)
 
     def ShouldRetry(self, exception):
         """Returns true if should retry based on the passed-in exception.
@@ -68,9 +62,11 @@ class _EndpointDiscoveryRetryPolicy(object):
 
         """
         if not self.connection_policy.EnableEndpointDiscovery:
+            self.logger.debug('Not retrying again.')
             return False
 
         if self.failover_retry_count >= self.Max_retry_attempt_count:
+            self.logger.debug('Not retrying again.')
             return False
 
         self.failover_retry_count += 1
@@ -98,4 +94,5 @@ class _EndpointDiscoveryRetryPolicy(object):
         # This enables marking the endpoint unavailability on endpoint failover/unreachability
         self.location_endpoint = self.global_endpoint_manager.resolve_service_endpoint(self.request)
         self.request.route_to_location(self.location_endpoint)
+        self.logger.debug('Retrying again.')
         return True

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/execution_context/execution_dispatcher.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/execution_context/execution_dispatcher.py
@@ -23,6 +23,9 @@
 """
 
 import json
+import logging
+import logging.config
+import six
 from six.moves import xrange
 from azure.cosmos.errors import HTTPFailure
 from azure.cosmos.execution_context.base_execution_context import _QueryExecutionContextBase
@@ -50,6 +53,7 @@ class _ProxyQueryExecutionContext(_QueryExecutionContextBase):
         self._resource_link = resource_link
         self._query = query
         self._fetch_function = fetch_function
+        self.logger = logging.getLogger(__name__)
         
     def next(self):
         """Returns the next query result.
@@ -67,6 +71,10 @@ class _ProxyQueryExecutionContext(_QueryExecutionContextBase):
                 query_execution_info = self._get_partitioned_execution_info(e)
                 self._execution_context = self._create_pipelined_execution_context(query_execution_info)
             else:
+                if six.PY2:
+                    self.logger.exception(e.message)
+                else:
+                    self.logger(e)
                 raise e
         
         return next(self._execution_context)
@@ -88,6 +96,10 @@ class _ProxyQueryExecutionContext(_QueryExecutionContextBase):
                 query_execution_info = self._get_partitioned_execution_info(e)
                 self._execution_context = self._create_pipelined_execution_context(query_execution_info)
             else:
+                if six.PY2:
+                    self.logger.exception(e.message)
+                else:
+                    self.logger(e)
                 raise e
              
         return self._execution_context.fetch_next_block()        

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/logging.json
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/logging.json
@@ -1,0 +1,40 @@
+{
+    "version": 1,
+    "formatters": {
+        "simple": {
+            "format": "%(asctime)s,%(levelname)s,%(name)s %(funcName)s: %(message)s",
+            "datefmt": "%Y-%m-%dT%H:%M:%SZ"
+        }
+    },
+
+     "handlers": {
+        "console_handler": {
+            "class": "logging.StreamHandler",
+            "level": "DEBUG",
+            "formatter": "simple",
+            "stream": "ext://sys.stdout"
+        },
+
+         "file_handler": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "level": "DEBUG",
+            "filename": "info.log",
+            "formatter": "simple",
+            "maxBytes": 10485760,
+            "backupCount": 20,
+            "encoding": "utf8"
+        }
+    },
+    "loggers": {
+        "azure.cosmos": {
+            "level": "DEBUG",
+            "handlers": ["console_handler", "file_handler"],
+            "propagate": false
+        }
+    },
+
+     "root": {
+        "level": "DEBUG",
+        "handlers": ["console_handler", "file_handler"]
+    }
+}

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/resource_throttle_retry_policy.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/resource_throttle_retry_policy.py
@@ -22,6 +22,8 @@
 """Internal class for resource throttle retry policy implementation in the Azure Cosmos database service.
 """
 
+import logging
+import logging.config
 from . import http_constants
 
 class _ResourceThrottleRetryPolicy(object):
@@ -32,6 +34,7 @@ class _ResourceThrottleRetryPolicy(object):
         self._max_wait_time_in_milliseconds = max_wait_time_in_seconds * 1000
         self.current_retry_attempt_count = 0
         self.cummulative_wait_time_in_milliseconds = 0
+        self.logger = logging.getLogger(__name__)
 
     def ShouldRetry(self, exception):
         """Returns true if should retry based on the passed-in exception.
@@ -53,7 +56,9 @@ class _ResourceThrottleRetryPolicy(object):
                 
             if self.cummulative_wait_time_in_milliseconds < self._max_wait_time_in_milliseconds:
                 self.cummulative_wait_time_in_milliseconds += self.retry_after_in_milliseconds
+                self.logger.debug('Retrying again.')
                 return True
-            
+
+        self.logger.debug('Not retrying again.')
         return False
     

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/scripts.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/scripts.py
@@ -67,6 +67,7 @@ class Scripts:
         :returns: A :class:`QueryIterable` instance representing an iterable of stored procedures (dicts).
 
         """
+        self.logger.debug("Reading UserDefinedFunctions. container_link [%s]" % self.container_link)
         if not feed_options:
             feed_options = {} # type: Dict[str, Any]
         if max_item_count is not None:
@@ -94,6 +95,7 @@ class Scripts:
         :returns: A :class:`QueryIterable` instance representing an iterable of stored procedures (dicts).
 
         """
+        self.logger.debug("Querying StoredProcedures. container_link [%s], query [%s]" % (self.container_link, query))
         if not feed_options:
             feed_options = {} # type: Dict[str, Any]
         if max_item_count is not None:
@@ -122,11 +124,13 @@ class Scripts:
         :raise `HTTPFailure`: If the given stored procedure couldn't be retrieved.
 
         """
+        sproc_link = self._get_resource_link(sproc, ScriptType.StoredProcedure)
+        self.logger.debug("Reading a StoredProcedure. sproc_link [%s]" % sproc_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
         return self.client_connection.ReadStoredProcedure(
-            sproc_link=self._get_resource_link(sproc, ScriptType.StoredProcedure),
+            sproc_link=sproc_link,
             options=request_options
         )
 
@@ -146,6 +150,8 @@ class Scripts:
         To replace an existing sproc, use the :func:`Container.scripts.replace_stored_procedure` method.
 
         """
+        self.logger.debug(
+            "Creating a StoredProcedure. container_link: [%s], storedProcedure id [%s]" % (self.container_link, body['id']))
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
@@ -171,11 +177,14 @@ class Scripts:
         :raise `HTTPFailure`: If the replace failed or the stored procedure with given id does not exist.
 
         """
+        sproc_link = self._get_resource_link(sproc, ScriptType.StoredProcedure),
+        self.logger.debug(
+            "Replacing a StoredProcedure. sproc_link [%s], storedProcedure id [%s]" % (sproc_link, sproc['id']))
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
         return self.client_connection.ReplaceStoredProcedure(
-            sproc_link=self._get_resource_link(sproc, ScriptType.StoredProcedure),
+            sproc_link=sproc_link,
             sproc=body,
             options=request_options
         )
@@ -193,11 +202,13 @@ class Scripts:
         :raises `HTTPFailure`: The sproc wasn't deleted successfully. If the sproc does not exist in the container, a `404` error is returned.
 
         """
+        sproc_link = self._get_resource_link(sproc, ScriptType.StoredProcedure)
+        self.logger.debug("Deleting a StoredProcedure. sproc_link [%s]" % sproc_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
         self.client_connection.DeleteStoredProcedure(
-            sproc_link=self._get_resource_link(sproc, ScriptType.StoredProcedure),
+            sproc_link=sproc_link,
             options=request_options
         )
 
@@ -221,7 +232,8 @@ class Scripts:
         :raise `HTTPFailure`: If the stored procedure execution failed or if the stored procedure with given id does not exists in the container.
 
         """
-
+        sproc_link = self._get_resource_link(sproc, ScriptType.StoredProcedure)
+        self.logger.debug("Executing a StoredProcedure. sproc_link [%s]" % sproc_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
         if partition_key is not None:
@@ -231,7 +243,7 @@ class Scripts:
             request_options["enableScriptLogging"] = enable_script_logging
 
         return self.client_connection.ExecuteStoredProcedure(
-            sproc_link=self._get_resource_link(sproc, ScriptType.StoredProcedure),
+            sproc_link=sproc_link,
             params=params,
             options=request_options
         )
@@ -249,6 +261,7 @@ class Scripts:
         :returns: A :class:`QueryIterable` instance representing an iterable of triggers (dicts).
 
         """
+        self.logger.debug("Reading Triggers. collectionLink [%s]" % self.container_link)
         if not feed_options:
             feed_options = {} # type: Dict[str, Any]
         if max_item_count is not None:
@@ -276,6 +289,7 @@ class Scripts:
         :returns: A :class:`QueryIterable` instance representing an iterable of triggers (dicts).
 
         """
+        self.logger.debug("Querying Triggers. container_link [%s], query [%s]" % (self.container_link, query))
         if not feed_options:
             feed_options = {} # type: Dict[str, Any]
         if max_item_count is not None:
@@ -304,11 +318,13 @@ class Scripts:
         :raise `HTTPFailure`: If the given trigger couldn't be retrieved.
 
         """
+        trigger_link = self._get_resource_link(trigger, ScriptType.Trigger)
+        self.logger.debug("Reading a Trigger. trigger_link [%s]" % trigger_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
         return self.client_connection.ReadTrigger(
-            trigger_link=self._get_resource_link(trigger, ScriptType.Trigger),
+            trigger_link=trigger_link,
             options=request_options
         )
 
@@ -328,6 +344,7 @@ class Scripts:
         To replace an existing trigger, use the :func:`Container.scripts.replace_trigger` method.
 
         """
+        self.logger.debug("Creating a Trigger. container_link [%s], trigger id [%s]" % (self.container_link, body['id']))
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
@@ -353,11 +370,13 @@ class Scripts:
         :raise `HTTPFailure`: If the replace failed or the trigger with given id does not exist.
 
         """
+        trigger_link = self._get_resource_link(trigger, ScriptType.Trigger)
+        self.logger.debug("Replacing a Trigger. trigger_link [%s], trigger id [%s]" % (trigger_link, trigger['id']))
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
         return self.client_connection.ReplaceTrigger(
-            trigger_link=self._get_resource_link(trigger, ScriptType.Trigger),
+            trigger_link=trigger_link,
             trigger=body,
             options=request_options
         )
@@ -375,11 +394,13 @@ class Scripts:
         :raises `HTTPFailure`: The trigger wasn't deleted successfully. If the trigger does not exist in the container, a `404` error is returned.
 
         """
+        trigger_link = self._get_resource_link(trigger, ScriptType.Trigger)
+        self.logger.debug("Deleting a Trigger. trigger_link [%s]" % trigger_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
         self.client_connection.DeleteTrigger(
-            trigger_link=self._get_resource_link(trigger, ScriptType.Trigger),
+            trigger_link,
             options=request_options
         )
 
@@ -397,6 +418,7 @@ class Scripts:
         :returns: A :class:`QueryIterable` instance representing an iterable of user defined functions (dicts).
 
         """
+        self.logger.debug("Reading UserDefinedFunctions. container_link [%s]" % self.container_link)
         if not feed_options:
             feed_options = {} # type: Dict[str, Any]
         if max_item_count is not None:
@@ -424,6 +446,7 @@ class Scripts:
         :returns: A :class:`QueryIterable` instance representing an iterable of user defined functions (dicts).
 
         """
+        self.logger.debug("Querying UserDefinedFunctions. container_link [%s], query [%s]" % (self.container_link, query))
         if not feed_options:
             feed_options = {} # type: Dict[str, Any]
         if max_item_count is not None:
@@ -452,11 +475,14 @@ class Scripts:
         :raise `HTTPFailure`: If the given user defined function couldn't be retrieved.
 
         """
+        udf_link = self._get_resource_link(udf, ScriptType.UserDefinedFunction),
+
+        self.logger.debug("Reading a UserDefinedFunction. udf_link [%s]" % udf_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
         return self.client_connection.ReadUserDefinedFunction(
-            udf_link=self._get_resource_link(udf, ScriptType.UserDefinedFunction),
+            udf_link=udf_link,
             options=request_options
         )
 
@@ -476,6 +502,8 @@ class Scripts:
         To replace an existing udf, use the :func:`Container.scripts.replace_user_defined_function` method.
 
         """
+        self.logger.debug(
+            "Creating a UserDefinedFunction. container_link [%s], udf id [%s]" % (self.container_link, body['id']))
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
@@ -501,11 +529,13 @@ class Scripts:
         :raise `HTTPFailure`: If the replace failed or the user defined function with given id does not exist.
 
         """
+        udf_link = self._get_resource_link(udf, ScriptType.UserDefinedFunction)
+        self.logger.debug("Replacing a UserDefinedFunction. udf_link [%s], udf id [%s]" % (udf_link, udf['id']))
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
         return self.client_connection.ReplaceUserDefinedFunction(
-            udf_link=self._get_resource_link(udf, ScriptType.UserDefinedFunction),
+            udf_link=udf_link,
             udf=body,
             options=request_options
         )
@@ -523,10 +553,12 @@ class Scripts:
         :raises `HTTPFailure`: The udf wasn't deleted successfully. If the udf does not exist in the container, a `404` error is returned.
 
         """
+        udf_link = self._get_resource_link(udf, ScriptType.UserDefinedFunction)
+        self.logger.debug("Deleting a UserDefinedFunction. udf_link [%s]" % udf_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
         self.client_connection.DeleteUserDefinedFunction(
-            udf_link=self._get_resource_link(udf, ScriptType.UserDefinedFunction),
+            udf_link=udf_link,
             options=request_options
         )

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/scripts.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/scripts.py
@@ -23,6 +23,8 @@
 """
 
 import six
+import logging
+import logging.config
 from azure.cosmos.cosmos_client_connection import CosmosClientConnection
 from .partition_key import NonePartitionKeyValue
 from.query_iterable import QueryIterable
@@ -47,6 +49,7 @@ class Scripts:
         self.client_connection = client_connection
         self.container_link = container_link
         self.is_system_key = is_system_key
+        self.logger = logging.getLogger(__name__)
 
     def _get_resource_link(self, script_or_id, type):
         # type: (Union[Dict[str, Any], str], str) -> str

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/session.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/session.py
@@ -24,6 +24,9 @@
 
 import sys, traceback
 import threading
+import logging
+import logging.config
+import six
 
 from . import base
 from . import http_constants
@@ -36,6 +39,7 @@ class SessionContainer(object):
         self.collection_name_to_rid = {}
         self.rid_to_session_token = {}
         self.session_lock = threading.RLock()
+        self.logger = logging.getLogger(__name__)
 
     def get_session_token(self, resource_path):
         """
@@ -114,12 +118,13 @@ class SessionContainer(object):
                     return
                 collection_rid, collection_name = base.GetItemContainerInfo(self_link, alt_content_path, response_result_id)
          
-            except ValueError:
+            except ValueError as e:
+                if six.PY2:
+                    e = e.message
+                self.logger.exception(e)
                 return
             except:
-                exc_type, exc_value, exc_traceback = sys.exc_info()
-                traceback.print_exception(exc_type, exc_value, exc_traceback,
-                                  limit=2, file=sys.stdout)
+                self.logger.exception('')
                 return
 
             if collection_name in self.collection_name_to_rid:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/user.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/user.py
@@ -74,6 +74,7 @@ class User:
         :raise `HTTPFailure`: If the given user couldn't be retrieved.
 
         """
+        self.logger.debug("Reading a User. user_link [%s]" % self.user_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
@@ -102,6 +103,7 @@ class User:
         :returns: A :class:`QueryIterable` instance representing an iterable of permissions (dicts).
 
         """
+        self.logger.debug("Reading Permissions. user_link [%s]" % self.user_link)
         if not feed_options:
             feed_options = {} # type: Dict[str, Any]
         if max_item_count is not None:
@@ -136,6 +138,7 @@ class User:
         :returns: A :class:`QueryIterable` instance representing an iterable of permissions (dicts).
 
         """
+        self.logger.debug("Querying Permissions. user_link [%s], query [%s]" % (self.user_link, query))
         if not feed_options:
             feed_options = {} # type: Dict[str, Any]
         if max_item_count is not None:
@@ -171,11 +174,13 @@ class User:
         :raise `HTTPFailure`: If the given permission couldn't be retrieved.
 
         """
+        permission_link = self._get_permission_link(permission)
+        self.logger.debug("Reading a Permission. permission_link [%s]" % permission_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
         permission = self.client_connection.ReadPermission(
-            permission_link=self._get_permission_link(permission),
+            permission_link=permission_link,
             options=request_options
         )
 
@@ -208,6 +213,7 @@ class User:
         To update or replace an existing permision, use the :func:`User.upsert_permission` method.
 
         """
+        self.logger.debug("Creating a Permission. user_link [%s], permission id [%s]" % (self.user_link, body['id']))
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
@@ -246,6 +252,7 @@ class User:
         If the permission already exists in the container, it is replaced. If it does not, it is inserted.
         """
 
+        self.logger.debug("Upserting a Permission. user_link [%s], permission id [%s]", self.user_link, body['id'])
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
@@ -284,11 +291,14 @@ class User:
         :raise `HTTPFailure`: If the replace failed or the permission with given id does not exist.
 
         """
+        permission_link = self._get_permission_link(permission)
+        self.logger.debug(
+            "Replacing a Permission. permission_link [%s], permission id [%s]" % (permission_link, permission['id']))
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
         permission = self.client_connection.ReplacePermission(
-            permission_link=self._get_permission_link(permission),
+            permission_link=permission_link,
             permission=body,
             options=request_options
         )
@@ -319,12 +329,13 @@ class User:
         :raises `HTTPFailure`: The permission wasn't deleted successfully. If the permission does not exist for the user, a `404` error is returned.
 
         """
-
+        permission_link = self._get_permission_link(permission)
+        self.logger.debug("Deleting a Permission. permission_link [%s]" % permission_link)
         if not request_options:
             request_options = {} # type: Dict[str, Any]
 
         result = self.client_connection.DeletePermission(
-            permission_link=self._get_permission_link(permission),
+            permission_link=permission_link,
             options=request_options
         )
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/user.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/user.py
@@ -23,6 +23,8 @@
 """
 
 import six
+import logging
+import logging.config
 from .cosmos_client_connection import CosmosClientConnection
 from typing import (
     Any,
@@ -42,6 +44,7 @@ class User:
         self.id = id
         self.user_link = u"{}/users/{}".format(database_link, id)
         self._properties = properties
+        self.logger = logging.getLogger(__name__)
 
     def _get_permission_link(self, permission_or_id):
         # type: (Union[Permission, str, Dict[str, Any]]) -> str

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/vector_session_token.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/vector_session_token.py
@@ -22,6 +22,9 @@
 """Session Consistency Tracking in the Azure Cosmos database service.
 """
 
+import logging
+import logging.config
+import six
 from . import errors
 from . import base
 from .http_constants import StatusCodes
@@ -29,6 +32,7 @@ from .http_constants import StatusCodes
 class VectorSessionToken(object):
     segment_separator = '#'
     region_progress_separator = "="
+    logger = logging.getLogger(__name__)
 
     def __init__(self, version, global_lsn, local_lsn_by_region, session_token=None):
 
@@ -74,12 +78,20 @@ class VectorSessionToken(object):
 
         try:
             version = int(segments[0])
-        except ValueError as _:
+        except ValueError as e:
+            if six.PY2:
+                cls.logger.exception(e.message)
+            else:
+                cls.logger(e)
             return None
 
         try:
             global_lsn = int(segments[1])
-        except ValueError as _:
+        except ValueError as e:
+            if six.PY2:
+                cls.logger.exception(e.message)
+            else:
+                cls.logger(e)
             return None
 
         for i in range(2, len(segments)):
@@ -92,7 +104,11 @@ class VectorSessionToken(object):
             try:
                 region_id = int(region_id_with_lsn[0])
                 local_lsn = int(region_id_with_lsn[1])
-            except ValueError as _:
+            except ValueError as e:
+                if six.PY2:
+                    cls.logger.exception(e.message)
+                else:
+                    cls.logger(e)
                 return None
             local_lsn_by_region[region_id] = local_lsn
 


### PR DESCRIPTION
Added logging mesages to the SDK

- Logger config file can be passed in through an environment varaible
- Default config file added as well
- Writing to console and file is present as default.
- Logging currently present for
    - Beginning of all operations
    - latency logger per request
    - Logs for cross partition queries indicating which partition id is being hit
    - Error logs on all error paths in the SDK
    - Logging on retries