### PR TITLE
Comment to clarify how BrokenSender is broken

### DIFF
--- a/sdk/core/azure-core/tests/azure_core_asynctests/test_pipeline.py
+++ b/sdk/core/azure-core/tests/azure_core_asynctests/test_pipeline.py
@@ -48,6 +48,7 @@ async def test_sans_io_exception():
             raise ValueError("Broken")
 
         async def open(self):
+            # NameError will be raised because requests is not imported
             self.session = requests.Session()
 
         async def close(self):


### PR DESCRIPTION
__requests__ is an _undefined name_ in this context because it has never been imported or defined.