### PR TITLE
[azure-core] Small fixes for aiohttp

### DIFF
--- a/sdk/core/azure-core/azure/core/exceptions.py
+++ b/sdk/core/azure-core/azure/core/exceptions.py
@@ -36,6 +36,14 @@ if TYPE_CHECKING:
     from azure.core.pipeline.transport.base import _HttpResponseBase
 
 
+def _get_status_code(resonse):
+    # type: (_HttpResponseBase) -> int
+    try:
+        return response.status_code  # Requests
+    except AttributeError:
+        return response.status  # Aiohttp
+
+
 def raise_with_traceback(exception, *args, **kwargs):
     # type: (Callable, Any, Any) -> None
     """Raise exception with a specified traceback.
@@ -113,10 +121,8 @@ class HttpResponseError(AzureError):
         self.response = response
         if response:
             self.reason = response.reason
-            try:
-                self.status_code = response.status_code  # Requests
-            except AttributeError:
-                self.status_code = response.status  # Aiohttp
+            self.status_code = _get_status_code(response)
+
         message = message or "Operation returned an invalid status '{}'".format(self.reason)
         try:
             try:

--- a/sdk/core/azure-core/azure/core/exceptions.py
+++ b/sdk/core/azure-core/azure/core/exceptions.py
@@ -36,14 +36,6 @@ if TYPE_CHECKING:
     from azure.core.pipeline.transport.base import _HttpResponseBase
 
 
-def _get_status_code(response):
-    # type: (_HttpResponseBase) -> int
-    try:
-        return response.status_code  # Requests
-    except AttributeError:
-        return response.status  # Aiohttp
-
-
 def raise_with_traceback(exception, *args, **kwargs):
     # type: (Callable, Any, Any) -> None
     """Raise exception with a specified traceback.
@@ -121,7 +113,7 @@ class HttpResponseError(AzureError):
         self.response = response
         if response:
             self.reason = response.reason
-            self.status_code = _get_status_code(response)
+            self.status_code = response.status_code
 
         message = message or "Operation returned an invalid status '{}'".format(self.reason)
         try:

--- a/sdk/core/azure-core/azure/core/exceptions.py
+++ b/sdk/core/azure-core/azure/core/exceptions.py
@@ -113,7 +113,10 @@ class HttpResponseError(AzureError):
         self.response = response
         if response:
             self.reason = response.reason
-            self.status_code = response.status_code
+            try:
+                self.status_code = response.status_code  # Requests
+            except AttributeError:
+                self.status_code = response.status  # Aiohttp
         message = message or "Operation returned an invalid status '{}'".format(self.reason)
         try:
             try:

--- a/sdk/core/azure-core/azure/core/exceptions.py
+++ b/sdk/core/azure-core/azure/core/exceptions.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from azure.core.pipeline.transport.base import _HttpResponseBase
 
 
-def _get_status_code(resonse):
+def _get_status_code(response):
     # type: (_HttpResponseBase) -> int
     try:
         return response.status_code  # Requests

--- a/sdk/core/azure-core/azure/core/pipeline/policies/universal.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/universal.py
@@ -51,14 +51,6 @@ _LOGGER = logging.getLogger(__name__)
 ContentDecodePolicyType = TypeVar('ContentDecodePolicyType', bound='ContentDecodePolicy')
 
 
-def _get_content_type(response):
-    # type: (PipelineResponse) -> str
-    try:
-        return response.content_type.strip().lower()
-    except AttributeError:
-        return response.content_type[0].strip().lower()
-
-
 class HeadersPolicy(SansIOHTTPPolicy):
     """A simple policy that sends the given headers with the request.
 
@@ -358,7 +350,7 @@ class ContentDecodePolicy(SansIOHTTPPolicy):
         # Try to use content-type from headers if available
         content_type = None
         if response.content_type: # type: ignore
-            content_type = _get_content_type(response)
+            content_type = response.content_type.split(";")[0].strip().lower() # type: ignore
 
         # Ouch, this server did not declare what it sent...
         # Let's guess it's JSON...

--- a/sdk/core/azure-core/azure/core/pipeline/policies/universal.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/universal.py
@@ -350,7 +350,10 @@ class ContentDecodePolicy(SansIOHTTPPolicy):
         # Try to use content-type from headers if available
         content_type = None
         if response.content_type: # type: ignore
-            content_type = response.content_type[0].strip().lower() # type: ignore
+            try:
+                content_type = response.content_type.strip().lower() # type: ignore
+            except AttributeError:
+                content_type = response.content_type[0].strip().lower() # type: ignore
 
         # Ouch, this server did not declare what it sent...
         # Let's guess it's JSON...

--- a/sdk/core/azure-core/azure/core/pipeline/policies/universal.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/universal.py
@@ -51,6 +51,14 @@ _LOGGER = logging.getLogger(__name__)
 ContentDecodePolicyType = TypeVar('ContentDecodePolicyType', bound='ContentDecodePolicy')
 
 
+def _get_content_type(response):
+    # type: (PipelineResponse) -> str
+    try:
+        return response.content_type.strip().lower()
+    except AttributeError:
+        return response.content_type[0].strip().lower()
+
+
 class HeadersPolicy(SansIOHTTPPolicy):
     """A simple policy that sends the given headers with the request.
 
@@ -350,10 +358,7 @@ class ContentDecodePolicy(SansIOHTTPPolicy):
         # Try to use content-type from headers if available
         content_type = None
         if response.content_type: # type: ignore
-            try:
-                content_type = response.content_type.strip().lower() # type: ignore
-            except AttributeError:
-                content_type = response.content_type[0].strip().lower() # type: ignore
+            content_type = _get_content_type(response)
 
         # Ouch, this server did not declare what it sent...
         # Let's guess it's JSON...

--- a/sdk/core/azure-core/azure/core/pipeline/transport/aiohttp.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/aiohttp.py
@@ -31,7 +31,7 @@ import asyncio
 import aiohttp
 
 from azure.core.configuration import ConnectionConfiguration
-from azure.core.exceptions import ServiceRequestError
+from azure.core.exceptions import ServiceRequestError, ServiceResponseError
 from azure.core.pipeline import Pipeline
 
 from requests.exceptions import (
@@ -181,7 +181,8 @@ class AioHttpTransport(AsyncHttpTransport):
                 await response.load_body()
         except aiohttp.client_exceptions.ClientConnectorError as err:
             error = ServiceRequestError(err, error=err)
-
+        except asyncio.TimeoutError as err:
+            error = ServiceResponseError(err, error=err)
         if error:
             raise error
         return response

--- a/sdk/core/azure-core/azure/core/pipeline/transport/aiohttp.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/aiohttp.py
@@ -192,19 +192,16 @@ class AioHttpStreamDownloadGenerator(AsyncIterator):
     """Streams the response body data.
 
     :param pipeline: The pipeline object
-    :param request: The request object
     :param response: The client response object.
-    :type response: aiohttp.ClientResponse
     :param block_size: block size of data sent over connection.
     :type block_size: int
     """
-    def __init__(self, pipeline: Pipeline, request: HttpRequest,
-                 response: aiohttp.ClientResponse, block_size: int) -> None:
+    def __init__(self, pipeline: Pipeline, response: AsyncHttpResponse) -> None:
         self.pipeline = pipeline
-        self.request = request
+        self.request = response.request
         self.response = response
-        self.block_size = block_size
-        self.content_length = int(response.headers.get('Content-Length', 0))
+        self.block_size = response.block_size
+        self.content_length = int(response.internal_response.headers.get('Content-Length', 0))
         self.downloaded = 0
 
     def __len__(self):
@@ -216,13 +213,13 @@ class AioHttpStreamDownloadGenerator(AsyncIterator):
         retry_interval = 1000
         while retry_active:
             try:
-                chunk = await self.response.content.read(self.block_size)
+                chunk = await self.response.internal_response.content.read(self.block_size)
                 if not chunk:
                     raise _ResponseStopIteration()
                 self.downloaded += self.block_size
                 return chunk
             except _ResponseStopIteration:
-                self.response.close()
+                self.response.internal_response.close()
                 raise StopAsyncIteration()
             except (ChunkedEncodingError, ConnectionError):
                 retry_total -= 1
@@ -234,7 +231,7 @@ class AioHttpStreamDownloadGenerator(AsyncIterator):
                     resp = self.pipeline.run(self.request, stream=True, headers=headers)
                     if resp.status_code == 416:
                         raise
-                    chunk = await self.response.content.read(self.block_size)
+                    chunk = await self.response.internal_response.content.read(self.block_size)
                     if not chunk:
                         raise StopIteration()
                     self.downloaded += chunk
@@ -244,7 +241,7 @@ class AioHttpStreamDownloadGenerator(AsyncIterator):
                 raise
             except Exception as err:
                 _LOGGER.warning("Unable to stream download: %s", err)
-                self.response.close()
+                self.response.internal_response.close()
                 raise
 
 class AioHttpTransportResponse(AsyncHttpResponse):
@@ -283,4 +280,4 @@ class AioHttpTransportResponse(AsyncHttpResponse):
         :param pipeline: The pipeline object
         :type pipeline: azure.core.pipeline
         """
-        return AioHttpStreamDownloadGenerator(pipeline, self.request, self.internal_response, self.block_size)
+        return AioHttpStreamDownloadGenerator(pipeline, self)

--- a/sdk/core/azure-core/azure/core/pipeline/transport/requests_asyncio.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/requests_asyncio.py
@@ -78,6 +78,9 @@ class AsyncioRequestsTransport(RequestsTransport, AsyncHttpTransport):  # type: 
     async def __aexit__(self, *exc_details):  # pylint: disable=arguments-differ
         return super(AsyncioRequestsTransport, self).__exit__()
 
+    async def sleep(self, duration):
+        await asyncio.sleep(duration)
+
     async def send(self, request: HttpRequest, **kwargs: Any) -> AsyncHttpResponse:  # type: ignore
         """Send the request using this HTTP sender.
 

--- a/sdk/core/azure-core/azure/core/pipeline/transport/requests_asyncio.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/requests_asyncio.py
@@ -138,18 +138,16 @@ class AsyncioStreamDownloadGenerator(AsyncIterator):
     """Streams the response body data.
 
     :param pipeline: The pipeline object
-    :param request: The request object
     :param response: The response object.
-    :param int block_size: block size of data sent over connection.
     :param generator iter_content_func: Iterator for response data.
     :param int content_length: size of body in bytes.
     """
-    def __init__(self, pipeline: Pipeline, request: HttpRequest, response: requests.Response, block_size: int) -> None:
+    def __init__(self, pipeline: Pipeline, response: AsyncHttpResponse) -> None:
         self.pipeline = pipeline
-        self.request = request
+        self.request = response.request
         self.response = response
-        self.block_size = block_size
-        self.iter_content_func = self.response.iter_content(self.block_size)
+        self.block_size = response.block_size
+        self.iter_content_func = self.response.internal_response.iter_content(self.block_size)
         self.content_length = int(response.headers.get('Content-Length', 0))
         self.downloaded = 0
 
@@ -173,7 +171,7 @@ class AsyncioStreamDownloadGenerator(AsyncIterator):
                 self.downloaded += self.block_size
                 return chunk
             except _ResponseStopIteration:
-                self.response.close()
+                self.response.internal_response.close()
                 raise StopAsyncIteration()
             except (requests.exceptions.ChunkedEncodingError,
                     requests.exceptions.ConnectionError):
@@ -200,7 +198,7 @@ class AsyncioStreamDownloadGenerator(AsyncIterator):
                 raise
             except Exception as err:
                 _LOGGER.warning("Unable to stream download: %s", err)
-                self.response.close()
+                self.response.internal_response.close()
                 raise
 
 
@@ -209,5 +207,4 @@ class AsyncioRequestsTransportResponse(AsyncHttpResponse, RequestsTransportRespo
     """
     def stream_download(self, pipeline) -> AsyncIteratorType[bytes]: # type: ignore
         """Generator for streaming request body data."""
-        return AsyncioStreamDownloadGenerator(pipeline, self.request,
-                                              self.internal_response, self.block_size) # type: ignore
+        return AsyncioStreamDownloadGenerator(pipeline, self) # type: ignore

--- a/sdk/core/azure-core/azure/core/pipeline/transport/requests_trio.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/requests_trio.py
@@ -53,18 +53,16 @@ class TrioStreamDownloadGenerator(AsyncIterator):
     """Generator for streaming response data.
 
     :param pipeline: The pipeline object
-    :param request: The request object
     :param response: The response object.
-    :param int block_size: Number of bytes to read into memory.
     :param generator iter_content_func: Iterator for response data.
     :param int content_length: size of body in bytes.
     """
-    def __init__(self, pipeline: Pipeline, request: HttpRequest, response: requests.Response, block_size: int) -> None:
+    def __init__(self, pipeline: Pipeline, response: AsyncHttpResponse) -> None:
         self.pipeline = pipeline
-        self.request = request
+        self.request = response.request
         self.response = response
-        self.block_size = block_size
-        self.iter_content_func = self.response.iter_content(self.block_size)
+        self.block_size = response.block_size
+        self.iter_content_func = self.response.internal_response.iter_content(self.block_size)
         self.content_length = int(response.headers.get('Content-Length', 0))
         self.downloaded = 0
 
@@ -85,7 +83,7 @@ class TrioStreamDownloadGenerator(AsyncIterator):
                 self.downloaded += self.block_size
                 return chunk
             except _ResponseStopIteration:
-                self.response.close()
+                self.response.internal_response.close()
                 raise StopAsyncIteration()
             except (requests.exceptions.ChunkedEncodingError,
                     requests.exceptions.ConnectionError):
@@ -111,7 +109,7 @@ class TrioStreamDownloadGenerator(AsyncIterator):
                 raise
             except Exception as err:
                 _LOGGER.warning("Unable to stream download: %s", err)
-                self.response.close()
+                self.response.internal_response.close()
                 raise
 
 class TrioRequestsTransportResponse(AsyncHttpResponse, RequestsTransportResponse):  # type: ignore
@@ -120,8 +118,7 @@ class TrioRequestsTransportResponse(AsyncHttpResponse, RequestsTransportResponse
     def stream_download(self, pipeline) -> AsyncIteratorType[bytes]:  # type: ignore
         """Generator for streaming response data.
         """
-        return TrioStreamDownloadGenerator(pipeline, self.request,
-                                           self.internal_response, self.block_size) # type: ignore
+        return TrioStreamDownloadGenerator(pipeline, self) # type: ignore
 
 
 class TrioRequestsTransport(RequestsTransport, AsyncHttpTransport):  # type: ignore

--- a/sdk/core/azure-core/azure/core/pipeline/transport/requests_trio.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/requests_trio.py
@@ -143,7 +143,7 @@ class TrioRequestsTransport(RequestsTransport, AsyncHttpTransport):  # type: ign
         return super(TrioRequestsTransport, self).__exit__()
 
     async def sleep(self, duration):
-        await trio.sleep(duration)
+        return super(TrioRequestsTransport, self).sleep(duration)
 
     async def send(self, request: HttpRequest, **kwargs: Any) -> AsyncHttpResponse:  # type: ignore
         """Send the request using this HTTP sender.

--- a/sdk/core/azure-core/azure/core/pipeline/transport/requests_trio.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/requests_trio.py
@@ -140,7 +140,7 @@ class TrioRequestsTransport(RequestsTransport, AsyncHttpTransport):  # type: ign
         return super(TrioRequestsTransport, self).__exit__()
 
     async def sleep(self, duration):
-        return super(TrioRequestsTransport, self).sleep(duration)
+        await trio.sleep(duration)
 
     async def send(self, request: HttpRequest, **kwargs: Any) -> AsyncHttpResponse:  # type: ignore
         """Send the request using this HTTP sender.

--- a/sdk/core/azure-core/tests/azure_core_asynctests/test_pipeline.py
+++ b/sdk/core/azure-core/tests/azure_core_asynctests/test_pipeline.py
@@ -120,6 +120,18 @@ async def test_basic_async_requests():
     assert response.http_response.status_code == 200
 
 @pytest.mark.asyncio
+async def test_async_transport_sleep():
+
+    async with AsyncioRequestsTransport() as transport:
+        await transport.sleep(1)
+
+    async with AioHttpTransport() as transport:
+        await transport.sleep(1)
+
+    async with TrioRequestsTransport() as transport:
+        await transport.sleep(1)
+
+@pytest.mark.asyncio
 async def test_conf_async_requests():
 
     request = HttpRequest("GET", "https://bing.com/")

--- a/sdk/core/azure-core/tests/azure_core_asynctests/test_pipeline.py
+++ b/sdk/core/azure-core/tests/azure_core_asynctests/test_pipeline.py
@@ -128,8 +128,13 @@ async def test_async_transport_sleep():
     async with AioHttpTransport() as transport:
         await transport.sleep(1)
 
-    async with TrioRequestsTransport() as transport:
-        await transport.sleep(1)
+def test_async_trio_transport_sleep():
+
+    async def do():
+        async with TrioRequestsTransport() as transport:
+            await transport.sleep(1)
+
+    response = trio.run(do)
 
 @pytest.mark.asyncio
 async def test_conf_async_requests():

--- a/sdk/core/azure-core/tests/test_universal_pipeline.py
+++ b/sdk/core/azure-core/tests/test_universal_pipeline.py
@@ -123,9 +123,7 @@ def test_raw_deserializer():
             def __init__(self, body, content_type):
                 super(MockResponse, self).__init__(None, None)
                 self._body = body
-                self.content_type = None
-                if content_type:
-                    self.content_type = [content_type]
+                self.content_type = content_type
 
             def body(self):
                 return self._body

--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -41,7 +41,7 @@ def mock_response(status_code=200, headers={}, json_payload=None):
     if json_payload is not None:
         response.text = lambda: json.dumps(json_payload)
         response.headers["content-type"] = "application/json"
-        response.content_type = ["application/json"]
+        response.content_type = "application/json"
     return response
 
 

--- a/sdk/identity/azure-identity/tests/test_authn_client.py
+++ b/sdk/identity/azure-identity/tests/test_authn_client.py
@@ -28,7 +28,7 @@ def test_authn_client_deserialization():
     scope = "scope"
 
     mock_response = Mock(
-        headers={"content-type": "application/json"}, status_code=200, content_type=["application/json"]
+        headers={"content-type": "application/json"}, status_code=200, content_type="application/json"
     )
     mock_send = Mock(return_value=mock_response)
 
@@ -87,7 +87,7 @@ def test_caching_when_only_expires_in_set():
         text=lambda: json.dumps({"access_token": access_token, "expires_in": expires_in, "token_type": "Bearer"}),
         headers={"content-type": "application/json"},
         status_code=200,
-        content_type=["application/json"],
+        content_type="application/json",
     )
     mock_send = Mock(return_value=mock_response)
 
@@ -106,7 +106,7 @@ def test_expires_in_strings():
     expected_token = "token"
 
     mock_response = Mock(
-        headers={"content-type": "application/json"}, status_code=200, content_type=["application/json"]
+        headers={"content-type": "application/json"}, status_code=200, content_type="application/json"
     )
     mock_send = Mock(return_value=mock_response)
 
@@ -133,7 +133,7 @@ def test_cache_expiry():
         text=lambda: json.dumps(token_payload),
         headers={"content-type": "application/json"},
         status_code=200,
-        content_type=["application/json"],
+        content_type="application/json",
     )
     mock_send = Mock(return_value=mock_response)
 

--- a/sdk/identity/azure-identity/tests/test_identity.py
+++ b/sdk/identity/azure-identity/tests/test_identity.py
@@ -191,7 +191,7 @@ def test_imds_credential_cache():
         text=lambda: json.dumps(token_payload),
         headers={"content-type": "application/json"},
         status_code=200,
-        content_type=["application/json"],
+        content_type="application/json",
     )
     mock_send = Mock(return_value=mock_response)
 
@@ -219,7 +219,7 @@ def test_imds_credential_retries():
     mock_response = Mock(
         text=lambda: b"{}",
         headers={"content-type": "application/json", "Retry-After": "0"},
-        content_type=["application/json"],
+        content_type="application/json",
     )
     mock_send = Mock(return_value=mock_response)
 

--- a/sdk/identity/azure-identity/tests/test_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_identity_async.py
@@ -196,7 +196,7 @@ async def test_imds_credential_cache():
         text=lambda: json.dumps(token_payload),
         headers={"content-type": "application/json"},
         status_code=200,
-        content_type=["application/json"],
+        content_type="application/json",
     )
     mock_send = Mock(return_value=mock_response)
 
@@ -225,7 +225,7 @@ async def test_imds_credential_retries():
     mock_response = Mock(
         text=lambda: b"{}",
         headers={"content-type": "application/json", "Retry-After": "0"},
-        content_type=["application/json"],
+        content_type="application/json",
     )
     mock_send = Mock(return_value=mock_response)
 


### PR DESCRIPTION
There are 3 fixes in this PR:
- Aiohttp does not define an error for request read timeouts - instead it relies on the async future to timeout. The patch I have here catches the asyncio.TimeoutError and raises the ServiceResponseError - however I'm not entirely sure this correct - given that there may be other reasons the future times-out. Either way, whichever is raised here, the retry policy must be updated to work with it.
- Aiohttp ClientResponse object has a "status" attribute rather than the "status_code" used by Requests.
- Aiohttp uses a single string for the content-type headers rather than the list used by Requests.