### PR TITLE
Run pylint, mypy and black as "unit tests"

### DIFF
--- a/sdk/core/azure-core/tests/test_static_analysis.py
+++ b/sdk/core/azure-core/tests/test_static_analysis.py
@@ -1,0 +1,21 @@
+import subprocess
+
+def test_run_pylint():
+    argv = [
+        'pylint', '--rcfile', '../../../pylintrc', 'azure.core'
+    ]
+
+    result = subprocess.check_call(argv)
+
+def test_run_black():
+    argv = [
+        'black', 'azure', '--check'
+    ]
+
+    result = subprocess.check_call(argv)
+
+def test_mypy():
+    argv = [
+        'mypy', 'azure/core'
+    ]
+    result = subprocess.check_call(argv)


### PR DESCRIPTION
Adding "unit tests" to the azure-core package that will run pylint, black and mypy on the package.