### PR TITLE
we don't need thread locks for SDK tracing context

### DIFF
--- a/sdk/core/azure-core/tests/test_tracing_context.py
+++ b/sdk/core/azure-core/tests/test_tracing_context.py
@@ -34,19 +34,14 @@ class ContextHelper(object):
 
 
 class TestContext(unittest.TestCase):
-    def test_get_context_class(self):
-        with ContextHelper():
-            slot = tracing_context._get_context_class("temp", 1)
-            assert slot.get() == 1
-            slot.set(2)
-            assert slot.get() == 2
-
     def test_current_span(self):
         with ContextHelper():
-            assert tracing_context.current_span.get() is None
+            assert not tracing_context.current_span.get()
             val = mock.Mock(spec=AbstractSpan)
             tracing_context.current_span.set(val)
             assert tracing_context.current_span.get() == val
+            tracing_context.current_span.clear()
+            assert not tracing_context.current_span.get()
 
     def test_with_current_context(self):
         with ContextHelper(tracer_to_use=mock.Mock(AbstractSpan)):


### PR DESCRIPTION
The locks are an artifact of trying to simplify OpenCensus's code.

https://github.com/census-instrumentation/opencensus-python/blob/edad023aa4f565bf88e4fcd6a6a5dda544a81592/context/opencensus-context/opencensus/common/runtime_context/__init__.py#L134-L173

They try to make it so that anything can be in the context. My simplification is that only current_span can at this point. This makes it so that I do not need the thread lock as I do not have the _slots which keeps track of the set of variables in the context.