### PR TITLE
Omit documentdb from CI builds. 

### DIFF
--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -15,6 +15,7 @@ import os
 import sys
 
 DEFAULT_BUILD_PACKAGES = ['azure-keyvault', 'azure-servicebus']
+OMITTED_CI_PACKAGES = ['azure-mgmt-documentdb']
 
 # this function is where a glob string gets translated to a list of packages
 # It is called by both BUILD (package) and TEST. In the future, this function will be the central location
@@ -31,7 +32,20 @@ def process_glob_string(glob_string, target_root_dir):
         collected_top_level_directories.extend([os.path.dirname(p) for p in globbed])
 
     # dedup, in case we have double coverage from the glob strings. Example: "azure-mgmt-keyvault,azure-mgmt-*"
-    return list(set(collected_top_level_directories))
+    collected_directories = list(set(collected_top_level_directories))
+
+    # if we have individually queued this specific package, it's obvious that we want to build it specifically
+    # in this case, do not honor the omission list
+    if len(collected_directories) == 1:
+        return collected_directories
+    # however, if there are multiple packages being built, we should honor the omission list and NOT build the omitted
+    # packages
+    else :
+        return remove_omitted_packages(collected_directories)
+
+def remove_omitted_packages(collected_directories):
+    return [package_dir for package_dir in collected_directories if os.path.basename(package_dir) not in OMITTED_CI_PACKAGES]
+    
 
 def run_check_call(command_array, working_directory, acceptable_return_codes = [], run_as_shell = False):
     try:

--- a/scripts/devops_tasks/setup_execute_tests.py
+++ b/scripts/devops_tasks/setup_execute_tests.py
@@ -95,8 +95,6 @@ if __name__ == '__main__':
     else:
         target_dir = root_dir
 
-    print(args.glob_string);
-
     targeted_packages = process_glob_string(args.glob_string, target_dir)
     test_results_arg = []
     if args.test_results:


### PR DESCRIPTION
If we individually queue this package, we will still be able to build and test.

However, if it's part of the regular triggered builds, we don't build omitted packages.