### PR TITLE
Update documented modules

### DIFF
--- a/doc/sphinx/ref/azure.identity.rst
+++ b/doc/sphinx/ref/azure.identity.rst
@@ -11,26 +11,10 @@ Subpackages
 Submodules
 ----------
 
-azure.identity.constants module
--------------------------------
-
-.. automodule:: azure.identity.constants
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 azure.identity.credentials module
 ---------------------------------
 
 .. automodule:: azure.identity.credentials
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-azure.identity.version module
------------------------------
-
-.. automodule:: azure.identity.version
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/sphinx/ref/azure.keyvault.secrets.aio.rst
+++ b/doc/sphinx/ref/azure.keyvault.secrets.aio.rst
@@ -1,6 +1,18 @@
 azure.keyvault.secrets.aio package
 ==================================
 
+Submodules
+----------
+
+azure.keyvault.secrets.aio.client module
+----------------------------------------
+
+.. automodule:: azure.keyvault.secrets.aio.client
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 Module contents
 ---------------
 

--- a/doc/sphinx/ref/azure.keyvault.secrets.rst
+++ b/doc/sphinx/ref/azure.keyvault.secrets.rst
@@ -11,10 +11,18 @@ Subpackages
 Submodules
 ----------
 
-azure.keyvault.secrets.version module
--------------------------------------
+azure.keyvault.secrets.client module
+------------------------------------
 
-.. automodule:: azure.keyvault.secrets.version
+.. automodule:: azure.keyvault.secrets.client
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+azure.keyvault.secrets.models module
+------------------------------------
+
+.. automodule:: azure.keyvault.secrets.models
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
Public modules have changed since preview 1. This ensures docs for `azure-identity` and `azure-keyvault-secrets` cover preview 2's public API. (`azure-keyvault-keys` docs are updated by #6537)