### PR TITLE
forcing earlier version of vcrpy in azure_devtools dependencies

### DIFF
--- a/tools/azure-devtools/setup.py
+++ b/tools/azure-devtools/setup.py
@@ -29,7 +29,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'ConfigArgParse>=0.12.0',
     'six>=1.10.0',
-    'vcrpy>=1.11.0',
+    'vcrpy>=1.11.0,<2.1.0',
 ]
 
 with io.open('README.rst', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
The new version is breaking a lot of our tests.