### PR TITLE
Eventhubs fix typing

### DIFF
--- a/sdk/eventhub/azure-eventhubs/README.md
+++ b/sdk/eventhub/azure-eventhubs/README.md
@@ -9,7 +9,7 @@ The Azure Event Hubs client library allows for publishing and consuming of Azure
 - Observe interesting operations and interactions happening within your business or other ecosystem, allowing loosely coupled systems to interact without the need to bind them together.
 - Receive events from one or more publishers, transform them to better meet the needs of your ecosystem, then publish the transformed events to a new stream for consumers to observe.
 
-[Source code](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/eventhub/azure-eventhubs) | [Package (PyPi)](https://pypi.org/project/azure-eventhub/) | [API reference documentation](http://azure.github.io/azure-sdk-for-python/ref/azure.eventhub) | [Product documentation](https://docs.microsoft.com/en-ca/azure/event-hubs/)
+[Source code](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/eventhub/azure-eventhubs) | [Package (PyPi)](https://pypi.org/project/azure-eventhub/) | [API reference documentation](https://azure.github.io/azure-sdk-for-python/ref/azure.eventhub) | [Product documentation](https://docs.microsoft.com/en-ca/azure/event-hubs/)
 
 ## Getting started
 
@@ -289,7 +289,7 @@ These are the samples in our repo demonstraing the usage of the library.
 
 ### Documentation
 
-Reference documentation is available at http://azure.github.io/azure-sdk-for-python/ref/azure.eventhub.
+Reference documentation is available at https://azure.github.io/azure-sdk-for-python/ref/azure.eventhub.
 
 ### Logging
 

--- a/sdk/eventhub/azure-eventhubs/README.md
+++ b/sdk/eventhub/azure-eventhubs/README.md
@@ -9,7 +9,7 @@ The Azure Event Hubs client library allows for publishing and consuming of Azure
 - Observe interesting operations and interactions happening within your business or other ecosystem, allowing loosely coupled systems to interact without the need to bind them together.
 - Receive events from one or more publishers, transform them to better meet the needs of your ecosystem, then publish the transformed events to a new stream for consumers to observe.
 
-[Source code](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/eventhub/azure-eventhubs) | [Package (PyPi)](https://pypi.org/project/azure-eventhub/) | [API reference documentation](https://azure.github.io/azure-sdk-for-python) | [Product documentation](https://docs.microsoft.com/en-ca/azure/event-hubs/)
+[Source code](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/eventhub/azure-eventhubs) | [Package (PyPi)](https://pypi.org/project/azure-eventhub/) | [API reference documentation](http://azure.github.io/azure-sdk-for-python/ref/azure.eventhub) | [Product documentation](https://docs.microsoft.com/en-ca/azure/event-hubs/)
 
 ## Getting started
 
@@ -19,6 +19,10 @@ Install the Azure Event Hubs client library for Python with pip:
 
 ```
 $ pip install --pre azure-eventhub
+```
+For Python2.7, please install package "typing". This is a workaround for [issue 6767](https://github.com/Azure/azure-sdk-for-python/issues/6767).
+```
+$ pip install typing
 ```
 
 **Prerequisites**
@@ -285,7 +289,7 @@ These are the samples in our repo demonstraing the usage of the library.
 
 ### Documentation
 
-Reference documentation is available at https://azure.github.io/azure-sdk-for-python.
+Reference documentation is available at http://azure.github.io/azure-sdk-for-python/ref/azure.eventhub.
 
 ### Logging
 


### PR DESCRIPTION
1. Updated Readme to tell users to install typing for Python 2.7 with reference to issue #6767 
2. Docs reference updated to eventhubs specific url instead of azure-sdk-for-python url in readme
