### PR TITLE
Add sphinx extension for kwargs

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -53,7 +53,7 @@ for example_file in all_files:
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.doctest',
-              'sphinx.ext.viewcode', 'sphinx.ext.intersphinx']
+              'sphinx.ext.viewcode', 'sphinx.ext.intersphinx', 'sphinx.ext.napoleon']
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.5', None),


### PR DESCRIPTION
This extension will allow us to use :keyword: to document our kwargs in the docstrings and will show up in the documentation like this:
![kwarg](https://user-images.githubusercontent.com/31998003/62960332-4cfbaf00-bdaf-11e9-9eba-3e192f81ebae.PNG)
