### PR TITLE
Allow dependency overrides to be specified in shared_requirements

### DIFF
--- a/scripts/analyze_deps.py
+++ b/scripts/analyze_deps.py
@@ -89,7 +89,8 @@ def get_wheel_deps(wheel_dir):
 
                 requires = pkg_info.get_all('Requires-Dist')
                 for req in requires:
-                    req = re.sub(r'[\s\(\)]', '', req)
+                    req = req.split(';')[0] # Extras conditions appear after a semicolon
+                    req = re.sub(r'[\s\(\)]', '', req) # Version specifiers appear in parentheses
                     record_dep(dependencies, req, lib_name)
         except:
             print('Failed to parse METADATA from %s' % (whl_path))

--- a/scripts/analyze_deps.py
+++ b/scripts/analyze_deps.py
@@ -290,7 +290,6 @@ if __name__ == '__main__':
                 override_specs = overrides.get(changed_req, [])
 
                 for spec in unmatched_specs:
-                    non_overridden_libs = []
                     if spec in override_specs:
                         non_overridden_libs = set(dependencies[changed_req][spec]) - set(override_specs[spec])
                     else:

--- a/scripts/analyze_deps.py
+++ b/scripts/analyze_deps.py
@@ -242,18 +242,32 @@ if __name__ == '__main__':
             sys.exit(0)
 
     frozen = {}
+    overrides = {}
+    override_count = 0
     try:
         with io.open(frozen_filename, 'r', encoding='utf-8-sig') as frozen_file:
             for line in frozen_file:
-                req_name, spec = parse_req(line)
-                frozen[req_name] = [spec]
+                if line.startswith('#override'):
+                    _, lib_name, req_override = line.split(' ', 2)
+                    record_dep(overrides, req_override, lib_name)
+                    override_count += 1
+                elif not line.startswith('#'):
+                    req_name, spec = parse_req(line)
+                    frozen[req_name] = [spec]
     except:
         print('Unable to open shared_requirements.txt, shared requirements have not been validated')
 
     missing_reqs, new_reqs, changed_reqs = {}, {}, {}
+    non_overridden_reqs_count = 0
     if frozen:
         flat_deps = {req: sorted(dependencies[req].keys()) for req in dependencies}
         missing_reqs, new_reqs, changed_reqs = dict_compare(frozen, flat_deps)
+        if args.verbose and len(overrides) > 0:
+            print('\nThe following requirement overrides are in place:')
+            for overridden_req in overrides:
+                for spec in overrides[overridden_req]:
+                    libs = ', '.join(sorted(overrides[overridden_req][spec]))
+                    print('  * %s is allowed for %s' % (overridden_req + spec, libs))
         if args.verbose and len(missing_reqs) > 0:
             print('\nThe following requirements are frozen but do not exist in any current library:')
             for missing_req in missing_reqs:
@@ -269,17 +283,25 @@ if __name__ == '__main__':
                         for lib in libs:
                             print("  * %s" % (lib))
         if len(changed_reqs) > 0:
-            exitcode = 1
-            if args.verbose:
-                for changed_req in changed_reqs:
-                    [frozen_spec] = frozen[changed_req]
-                    for current_spec in dependencies[changed_req]:
-                        if frozen_spec == current_spec:
-                            continue
-                        libs = dependencies[changed_req][current_spec]
-                        print("\nThe following libraries declare requirement '%s' which does not match the frozen requirement '%s':" % (changed_req + current_spec, changed_req + frozen_spec))
-                        for lib in libs:
-                            print("  * %s" % (lib))
+            for changed_req in changed_reqs:
+                frozen_specs, current_specs = changed_reqs[changed_req]
+                unmatched_specs = set(current_specs) - set(frozen_specs)
+                override_specs = overrides.get(changed_req, [])
+
+                for spec in unmatched_specs:
+                    non_overridden_libs = []
+                    if spec in override_specs:
+                        non_overridden_libs = set(dependencies[changed_req][spec]) - set(override_specs[spec])
+                    else:
+                        non_overridden_libs = dependencies[changed_req][spec]
+
+                    if len(non_overridden_libs) > 0:
+                        exitcode = 1
+                        non_overridden_reqs_count += 1
+                        if args.verbose:
+                            print("\nThe following libraries declare requirement '%s' which does not match the frozen requirement '%s':" % (changed_req + spec, changed_req + frozen_specs[0]))
+                            for lib in non_overridden_libs:
+                                print("  * %s" % (lib))
 
     if args.out:
         external = [k for k in dependencies if k not in packages and not should_skip_lib(k)]
@@ -299,7 +321,10 @@ if __name__ == '__main__':
             'inconsistent': inconsistent,
             'missing_reqs': missing_reqs,
             'new_reqs': new_reqs,
+            'non_overridden_reqs_count': non_overridden_reqs_count,
             'ordered_deps': sorted(dependencies.keys(), key=display_order),
+            'override_count': override_count,
+            'overrides': overrides,
             'packages': packages,
             'repo_name': 'azure-sdk-for-python'
         })

--- a/scripts/deps.html.j2
+++ b/scripts/deps.html.j2
@@ -91,6 +91,14 @@
           color: #CC0000;
       }
 
+      .dep_type {
+          border: 1px solid gray;
+          border-radius: 2px;
+          background: lightgray;
+          font-size: 10px;
+          padding: 1px 2px;
+      }
+
       @media only screen and (max-width: 1350px) {
           body, table {
               font-size: 25px;
@@ -133,13 +141,16 @@
         {% endif %}
         {% if frozen %}
         {{ frozen|length }} dependency {{ pluralize(frozen|length,'version was','versions were') }} discovered in the <a href="#lockfile">lockfile</a>.<br/>
+        {% if override_count %}
+        <strong>{{ override_count }} dependency version {{ pluralize(override_count,'override is','overrides are') }} present, causing dependency versions to differ from the version in the lockfile.</strong><br/>
+        {% endif %}
         {% if new_reqs %}
         <strong>{{ new_reqs|length }} {{ pluralize(new_reqs|length,'dependency is','dependencies are') }} missing from the lockfile.</strong><br/>
         {% endif %}
-        {% if changed_reqs %}
-        <strong>{{ changed_reqs|length }} dependency {{ pluralize(changed_reqs|length,'version does','versions do') }} not match the version in the lockfile.</strong><br/>
+        {% if non_overridden_reqs_count %}
+        <strong>{{ non_overridden_reqs_count }} dependency {{ pluralize(non_overridden_reqs_count,'version does','versions do') }} not match the version in the lockfile.</strong><br/>
         {% endif %}
-        {% if not new_reqs and not changed_reqs %}
+        {% if not new_reqs and not non_overridden_reqs_count %}
         All declared dependency versions were validated against those in the lockfile.<br/>
         {% endif %}
         {% else %}
@@ -172,7 +183,11 @@
           <td class="version">{{ requirement if requirement else '(empty)' }}</td>
           <td>
             {% for package_name in packages|sort %}
-            {{ package_name }}<br/>
+            {{ package_name }}
+            {% if dep_name in overrides and requirement in overrides[dep_name] and package_name in overrides[dep_name][requirement] %}
+            <span class="dep_type">override</span>
+            {% endif %}
+            <br/>
             {% endfor %}
           </td>
         </tr>


### PR DESCRIPTION
Dependency overrides can be specified with the syntax:

`#override <libraryname> <requirement>`

e.g. `#override azure-identity azure-core<2.0.0,>=1.0.0b1`

Multiple override lines for any given library or requirement are permitted. Additionally, other lines starting with `#` are treated as comments and are ignored by the script.

The report now calls out when an inconsistent dependency is due to an override.