### PR TITLE
Adds pylint docparams extension

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,6 +1,7 @@
 [MASTER]
 ignore-patterns=test_*
 reports=no
+load-plugins=pylint.extensions.docparams
 
 [MESSAGES CONTROL]
 # For all codes, run 'pylint --list-msgs' or go to 'https://pylint.readthedocs.io/en/latest/reference_guide/features.html'


### PR DESCRIPTION
Pylint will be enabled in the CI in the near future and this extension will be included. The extension checks that all params, exceptions, and return types are documented in the docstrings. Previously pylint-clean libraries are likely to become "unclean" with this extension enabled so I want to get this in the repo ASAP. 