### PR TITLE
Resolve cosmos emulator tests failures

### DIFF
--- a/sdk/cosmos/.azure-pipelines/cosmos.live.yml
+++ b/sdk/cosmos/.azure-pipelines/cosmos.live.yml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       maxParallel: 1
       matrix:
-        Windows_Python34:
+        Windows_Python35:
           OSVmImage: 'vs2017-win2016'
-          PythonVersion: '3.4'
+          PythonVersion: '3.5'
         Windows_Python27:
           OSVmImage: 'vs2017-win2016'
           PythonVersion: '2.7'

--- a/sdk/cosmos/.azure-pipelines/cosmos.live.yml
+++ b/sdk/cosmos/.azure-pipelines/cosmos.live.yml
@@ -79,6 +79,7 @@ jobs:
 
       - script: |
           python -m pip install --upgrade pip
+          pip install setuptools --upgrade
           python scripts/dev_setup.py --packageList azure-cosmos
         displayName: 'Set up Environment'
 

--- a/sdk/cosmos/.azure-pipelines/cosmos.test.yml
+++ b/sdk/cosmos/.azure-pipelines/cosmos.test.yml
@@ -78,6 +78,7 @@ jobs:
 
       - script: |
           python -m pip install --upgrade pip
+          pip install setuptools --upgrade
           python scripts/dev_setup.py --packageList azure-cosmos
         displayName: 'Set up Environment'
 

--- a/sdk/cosmos/.azure-pipelines/cosmos.test.yml
+++ b/sdk/cosmos/.azure-pipelines/cosmos.test.yml
@@ -15,9 +15,9 @@ jobs:
     continueOnError: false
     strategy:
       matrix:
-        Windows_Python34:
+        Windows_Python35:
           OSVmImage: 'vs2017-win2016'
-          PythonVersion: '3.4'
+          PythonVersion: '3.5'
         Windows_Python27:
           OSVmImage: 'vs2017-win2016'
           PythonVersion: '2.7'


### PR DESCRIPTION
1) Updated `setuptools` to 41 to allow for a better error message
2) Changed matrix from python 3.4 to python 3.5

@Azure/azure-sdk-eng 