### PR TITLE
Adding leading characters for the wildcard match - Servicebus CI

### DIFF
--- a/sdk/servicebus/ci.yml
+++ b/sdk/servicebus/ci.yml
@@ -16,7 +16,7 @@ pr:
     - feature/*
     - hotfix/*
     - release/*
-    - '*/resource-manager'
+    - 'restapi*/resource-manager'
   paths:
     include:
     - sdk/servicebus/


### PR DESCRIPTION
DevOps won't allow triggered builds properly for a leading `*` for some reason.