### PR TITLE
[Core] Fix aiohttp auto-headers

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/transport/aiohttp.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/aiohttp.py
@@ -90,7 +90,8 @@ class AioHttpTransport(AsyncHttpTransport):
         if not self.session and self._session_owner:
             self.session = aiohttp.ClientSession(
                 loop=self._loop,
-                trust_env=self._use_env_settings
+                trust_env=self._use_env_settings,
+                skip_auto_headers=['Content-Type']
             )
         if self.session is not None:
             await self.session.__aenter__()

--- a/sdk/core/azure-core/tests/azure_core_asynctests/test_universal_http.py
+++ b/sdk/core/azure-core/tests/azure_core_asynctests/test_universal_http.py
@@ -49,6 +49,15 @@ async def test_basic_aiohttp():
     assert response.status_code == 200
 
 @pytest.mark.asyncio
+async def test_aiohttp_auto_headers():
+
+    request = HttpRequest("POST", "https://www.bing.com/")
+    async with AioHttpTransport() as sender:
+        response = await sender.send(request)
+        auto_headers = response.internal_response.request_info.headers
+        assert 'Content-Type' not in auto_headers
+
+@pytest.mark.asyncio
 async def test_basic_async_requests():
 
     request = HttpRequest("GET", "https://www.bing.com/")

--- a/sdk/core/azure-core/tests/test_requests_universal.py
+++ b/sdk/core/azure-core/tests/test_requests_universal.py
@@ -46,3 +46,10 @@ def test_threading_basic_requests():
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
         future = executor.submit(thread_body, sender)
         assert future.result()
+
+def test_requests_auto_headers():
+    request = HttpRequest("POST", "https://www.bing.com/")
+    with RequestsTransport() as sender:
+        response = sender.send(request)
+        auto_headers = response.internal_response.request.headers
+        assert 'Content-Type' not in auto_headers


### PR DESCRIPTION
Currently aiohttp is automatically giving us a content-type header for Put/Post/Patch requests if one is not specified in the pipeline.
This behaviour is inconsistent with the requests transport.