### PR TITLE
Pylint Now Fails Builds

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -10,7 +10,7 @@ parameters:
   BuildTargetingString: 'azure-*'
   ToxTestEnv: ""
   RunMyPy: and(ne(variables['PythonVersion'], '2.7'), ne(variables['PythonVersion'], 'pypy3'))
-  RunPylint: and(eq(variables['PythonVersion'], '3.7'))
+  RunPylint: eq(variables['PythonVersion'], '3.7')
 
 steps:
   - powershell: |

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -10,6 +10,7 @@ parameters:
   BuildTargetingString: 'azure-*'
   ToxTestEnv: ""
   RunMyPy: and(ne(variables['PythonVersion'], '2.7'), ne(variables['PythonVersion'], 'pypy3'))
+  RunPylint: and(eq(variables['PythonVersion'], '3.7'))
 
 steps:
   - powershell: |
@@ -67,6 +68,7 @@ steps:
         --toxenv="lint"
         --disablecov
     env: ${{ parameters.EnvVars }}
+    condition: and(succeededOrFailed(), ${{ parameters.RunPylint }})
 
   - task: PythonScript@0
     displayName: 'Run MyPy'

--- a/eng/tox/run_pylint.py
+++ b/eng/tox/run_pylint.py
@@ -24,14 +24,14 @@ lint_plugin_path = os.path.join(root_dir, "scripts/pylint_custom_plugin")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Run pylint against target folder. Add a local custom plugin to the path prior to execution."
+        description="Run pylint against target folder. Add a local custom plugin to the path prior to execution. "
     )
 
     parser.add_argument(
         "-t",
         "--target",
         dest="target_package",
-        help="The target module on disk.",
+        help="The target package directory on disk. The target module passed to pylint will be <target_package>/azure.",
         required=True,
     )
 
@@ -39,8 +39,8 @@ if __name__ == "__main__":
 
     package_name = os.path.basename(args.target_package)
 
-    try:
-        if "mgmt" not in package_name:
+    if package_name not in PYLINT_ACCEPTABLE_FAILURES:
+        try:
             check_call(
                 [
                     sys.executable,
@@ -51,15 +51,8 @@ if __name__ == "__main__":
                     os.path.join(args.target_package, "azure"),
                 ]
             )
-    except CalledProcessError as e:
-        logging.error(
-            "{} exited with linting error {}".format(package_name, e.returncode)
-        )
-        if package_name not in PYLINT_ACCEPTABLE_FAILURES:
-            exit(1)
-        else:
-            logging.info(
-                "Ignoring failure for pylint run against package {}".format(
-                    package_name
-                )
+        except CalledProcessError as e:
+            logging.error(
+                "{} exited with linting error {}".format(package_name, e.returncode)
             )
+            exit(1)

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -42,7 +42,7 @@ deps =
   pylint==1.8.4; python_version < '3.4'
   -e {toxinidir}/../../scripts/pylint_custom_plugin
 commands = 
-    - {envbindir}/python {toxinidir}/../../../eng/tox/run_pylint.py -t {toxinidir}
+    {envbindir}/python {toxinidir}/../../../eng/tox/run_pylint.py -t {toxinidir}
 
 [testenv:mypy]
 deps =


### PR DESCRIPTION
Adjustments:

1. `lint` tox errors are no longer ignored, so your build will turn red for failing pylint
2. We now only run `lint` for Python3.7
3. We only run pylint for packages that are NOT on the exception list

