### PR TITLE
Enable SSO on Windows

### DIFF
--- a/sdk/identity/azure-identity/HISTORY.md
+++ b/sdk/identity/azure-identity/HISTORY.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b3 (2019-09-09)
+## 1.0.0b3 (2019-09-10)
 ### New features:
 - `SharedTokenCacheCredential` authenticates with tokens stored in a local
 cache shared by Microsoft applications. This enables Azure SDK clients to

--- a/sdk/identity/azure-identity/HISTORY.md
+++ b/sdk/identity/azure-identity/HISTORY.md
@@ -1,5 +1,20 @@
 # Release History
 
+## 1.0.0b3 (2019-09-09)
+### New features:
+- `SharedTokenCacheCredential` authenticates with tokens stored in a local
+cache shared by Microsoft applications. This enables Azure SDK clients to
+authenticate silently after you've signed in to Visual Studio 2019, for
+example. `DefaultAzureCredential` includes `SharedTokenCacheCredential` when
+the shared cache is available, and environment variable `AZURE_USERNAME`
+is set. See the
+[README](https://github.com/Azure/azure-sdk-for-python/blob/tree/master/sdk/identity/azure-identity/README.md#single-sign-on)
+for more information.
+
+### Dependency changes:
+- New dependency: [`msal-extensions`](https://pypi.org/project/msal-extensions/)
+0.1.1
+
 ## 1.0.0b2 (2019-08-05)
 ### Breaking changes:
 - Removed `azure.core.Configuration` from the public API in preparation for a

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -62,7 +62,7 @@ configuration:
 
 |credential class|identity|configuration
 |-|-|-
-|`DefaultAzureCredential`|service principal, managed identity or user|none for managed identity; [environment variables](#environment-variables) for service principal or user authentication
+|`DefaultAzureCredential`|service principal, managed identity, user|none for managed identity or [single sign-on](#single-sign-on); [environment variables](#environment-variables) for service principal or user authentication
 |`ManagedIdentityCredential`|managed identity|none
 |`EnvironmentCredential`|service principal|[environment variables](#environment-variables)
 |`ClientSecretCredential`|service principal|constructor parameters
@@ -92,6 +92,13 @@ Authenticating as a managed identity requires no configuration, but does
 require platform support. See the
 [managed identity documentation](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/services-support-managed-identities)
 for more information.
+
+### Single sign-on
+During local development on Windows, `DefaultAzureCredential` can authenticate
+without configuration using a single sign-on shared with Microsoft applications,
+for example Visual Studio 2019. To authenticate this way, sign in with the
+application and use `DefaultAzureCredential` without setting configuration
+environment variables.
 
 ## Environment variables
 

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -62,7 +62,7 @@ configuration:
 
 |credential class|identity|configuration
 |-|-|-
-|`DefaultAzureCredential`|service principal, managed identity, user|none for managed identity or [single sign-on](#single-sign-on); [environment variables](#environment-variables) for service principal or user authentication
+|`DefaultAzureCredential`|service principal, managed identity, user|none for managed identity, [environment variables](#environment-variables) for service principal or user authentication
 |`ManagedIdentityCredential`|managed identity|none
 |`EnvironmentCredential`|service principal|[environment variables](#environment-variables)
 |`ClientSecretCredential`|service principal|constructor parameters

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -95,10 +95,10 @@ for more information.
 
 ### Single sign-on
 During local development on Windows, `DefaultAzureCredential` can authenticate
-without configuration using a single sign-on shared with Microsoft applications,
-for example Visual Studio 2019. To authenticate this way, sign in with the
-application and use `DefaultAzureCredential` without setting configuration
-environment variables.
+using a single sign-on shared with Microsoft applications, for example Visual
+Studio 2019. Because you may have multiple signed in identities, to
+authenticate this way you must set the environment variable `AZURE_USERNAME`
+with your desired identity's username (typically an email address).
 
 ## Environment variables
 

--- a/sdk/identity/azure-identity/azure/identity/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/__init__.py
@@ -19,15 +19,14 @@ class DefaultAzureCredential(ChainedTokenCredential):
     """
     A default credential capable of handling most Azure SDK authentication scenarios.
 
-    When environment variable configuration is present, it authenticates as a service principal using
-    :class:`azure.identity.EnvironmentCredential`.
+    The identity it uses depends on the environment. When an access token is needed, it requests one using these
+    identities in turn, stopping when one provides a token:
 
-    When environment configuration is not present, it authenticates with a managed identity using
-    :class:`azure.identity.ManagedIdentityCredential`.
-
-    On Windows, when environment variable configuration and managed identity are unavailable, it finally
-    attempts to authenticate with a token from the cache shared by Microsoft applications using
-    :class:`azure.identity.SharedTokenCacheCredential`.
+    1. A service principal configured by environment variables. See :class:`~azure.identity.EnvironmentCredential` for
+       more details.
+    2. An Azure managed identity. See :class:`~azure.identity.ManagedIdentityCredential` for more details.
+    3. On Windows only, the current user, using a token from the local cache shared by Microsoft applications. See
+       :class:`~azure.identity.SharedTokenCacheCredential` for more details.
     """
 
     def __init__(self, **kwargs):

--- a/sdk/identity/azure-identity/azure/identity/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/__init__.py
@@ -19,11 +19,15 @@ class DefaultAzureCredential(ChainedTokenCredential):
     """
     A default credential capable of handling most Azure SDK authentication scenarios.
 
-    When environment variable configuration is present, it authenticates as a service principal
-    using :class:`azure.identity.EnvironmentCredential`.
+    When environment variable configuration is present, it authenticates as a service principal using
+    :class:`azure.identity.EnvironmentCredential`.
 
-    When environment configuration is not present, it authenticates with a managed identity
-    using :class:`azure.identity.ManagedIdentityCredential`.
+    When environment configuration is not present, it authenticates with a managed identity using
+    :class:`azure.identity.ManagedIdentityCredential`.
+
+    On Windows, when environment variable configuration and managed identity are unavailable, it finally
+    attempts to authenticate with a token from the cache shared by Microsoft applications using
+    :class:`azure.identity.SharedTokenCacheCredential`.
     """
 
     def __init__(self, **kwargs):

--- a/sdk/identity/azure-identity/azure/identity/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/__init__.py
@@ -10,6 +10,7 @@ from .credentials import (
     DeviceCodeCredential,
     EnvironmentCredential,
     ManagedIdentityCredential,
+    SharedTokenCacheCredential,
     UsernamePasswordCredential,
 )
 
@@ -26,9 +27,11 @@ class DefaultAzureCredential(ChainedTokenCredential):
     """
 
     def __init__(self, **kwargs):
-        super(DefaultAzureCredential, self).__init__(
-            EnvironmentCredential(**kwargs), ManagedIdentityCredential(**kwargs)
-        )
+        credentials = [EnvironmentCredential(**kwargs), ManagedIdentityCredential(**kwargs)]
+        if SharedTokenCacheCredential.supported():
+            credentials.append(SharedTokenCacheCredential(**kwargs))
+
+        super(DefaultAzureCredential, self).__init__(*credentials)
 
 
 __all__ = [
@@ -40,5 +43,6 @@ __all__ = [
     "EnvironmentCredential",
     "InteractiveBrowserCredential",
     "ManagedIdentityCredential",
+    "SharedTokenCacheCredential",
     "UsernamePasswordCredential",
 ]

--- a/sdk/identity/azure-identity/azure/identity/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/__init__.py
@@ -2,7 +2,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import os
+
 from ._browser_auth import InteractiveBrowserCredential
+from ._constants import EnvironmentVariables
 from .credentials import (
     CertificateCredential,
     ChainedTokenCredential,
@@ -25,14 +28,26 @@ class DefaultAzureCredential(ChainedTokenCredential):
     1. A service principal configured by environment variables. See :class:`~azure.identity.EnvironmentCredential` for
        more details.
     2. An Azure managed identity. See :class:`~azure.identity.ManagedIdentityCredential` for more details.
-    3. On Windows only, the current user, using a token from the local cache shared by Microsoft applications. See
-       :class:`~azure.identity.SharedTokenCacheCredential` for more details.
+    3. On Windows only: a user who has signed in with a Microsoft application, such as Visual Studio. This requires a
+       value for the environment variable ``AZURE_USERNAME``. See :class:`~azure.identity.SharedTokenCacheCredential`
+       for more details.
     """
 
     def __init__(self, **kwargs):
         credentials = [EnvironmentCredential(**kwargs), ManagedIdentityCredential(**kwargs)]
-        if SharedTokenCacheCredential.supported():
-            credentials.append(SharedTokenCacheCredential(**kwargs))
+
+        # SharedTokenCacheCredential is part of the default only on supported platforms, when $AZURE_USERNAME has a
+        # value (because the cache may contain tokens for multiple identities and we can only choose one arbitrarily
+        # without more information from the user), and when $AZURE_PASSWORD has no value (because when $AZURE_USERNAME
+        # and $AZURE_PASSWORD are set, EnvironmentCredential will be used instead)
+        if (
+            SharedTokenCacheCredential.supported()
+            and EnvironmentVariables.AZURE_USERNAME in os.environ
+            and EnvironmentVariables.AZURE_PASSWORD not in os.environ
+        ):
+            credentials.append(
+                SharedTokenCacheCredential(username=os.environ.get(EnvironmentVariables.AZURE_USERNAME), **kwargs)
+            )
 
         super(DefaultAzureCredential, self).__init__(*credentials)
 

--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -38,11 +38,11 @@ class AuthnClientBase(object):
             raise ValueError("auth_url should be the URL of an OAuth endpoint")
         super(AuthnClientBase, self).__init__()
         self._auth_url = auth_url
-        self._cache = TokenCache()
+        self._cache = kwargs.pop("cache", None) or TokenCache()  # type: TokenCache
 
     def get_cached_token(self, scopes):
         # type: (Iterable[str]) -> Optional[AccessToken]
-        tokens = self._cache.find(TokenCache.CredentialType.ACCESS_TOKEN, list(scopes))
+        tokens = self._cache.find(TokenCache.CredentialType.ACCESS_TOKEN, target=list(scopes))
         for token in tokens:
             if all((scope in token["target"] for scope in scopes)):
                 expires_on = int(token["expires_on"])

--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -44,10 +44,9 @@ class AuthnClientBase(object):
         # type: (Iterable[str]) -> Optional[AccessToken]
         tokens = self._cache.find(TokenCache.CredentialType.ACCESS_TOKEN, target=list(scopes))
         for token in tokens:
-            if all((scope in token["target"] for scope in scopes)):
-                expires_on = int(token["expires_on"])
-                if expires_on - 300 > int(time.time()):
-                    return AccessToken(token["secret"], expires_on)
+            expires_on = int(token["expires_on"])
+            if expires_on - 300 > int(time.time()):
+                return AccessToken(token["secret"], expires_on)
         return None
 
     def _deserialize_and_cache_token(self, response, scopes, request_time):

--- a/sdk/identity/azure-identity/azure/identity/_constants.py
+++ b/sdk/identity/azure-identity/azure/identity/_constants.py
@@ -4,6 +4,9 @@
 # ------------------------------------
 
 
+AZURE_CLI_CLIENT_ID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
+
+
 class EnvironmentVariables:
     AZURE_CLIENT_ID = "AZURE_CLIENT_ID"
     AZURE_CLIENT_SECRET = "AZURE_CLIENT_SECRET"

--- a/sdk/identity/azure-identity/azure/identity/_version.py
+++ b/sdk/identity/azure-identity/azure/identity/_version.py
@@ -2,4 +2,4 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-VERSION = "1.0.0b2"
+VERSION = "1.0.0b3"

--- a/sdk/identity/azure-identity/azure/identity/aio/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/__init__.py
@@ -8,6 +8,7 @@ from .credentials import (
     ClientSecretCredential,
     EnvironmentCredential,
     ManagedIdentityCredential,
+    SharedTokenCacheCredential,
 )
 
 
@@ -23,7 +24,11 @@ class DefaultAzureCredential(ChainedTokenCredential):
     """
 
     def __init__(self, **kwargs):
-        super().__init__(EnvironmentCredential(**kwargs), ManagedIdentityCredential(**kwargs))
+        credentials = [EnvironmentCredential(**kwargs), ManagedIdentityCredential(**kwargs)]
+        if SharedTokenCacheCredential.supported():
+            credentials.append(SharedTokenCacheCredential(**kwargs))
+
+        super().__init__(*credentials)
 
 
 __all__ = [
@@ -33,4 +38,5 @@ __all__ = [
     "EnvironmentCredential",
     "ManagedIdentityCredential",
     "ChainedTokenCredential",
+    "SharedTokenCacheCredential",
 ]

--- a/sdk/identity/azure-identity/azure/identity/aio/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/__init__.py
@@ -16,15 +16,14 @@ class DefaultAzureCredential(ChainedTokenCredential):
     """
     A default credential capable of handling most Azure SDK authentication scenarios.
 
-    When environment variable configuration is present, it authenticates as a service principal using
-    :class:`azure.identity.EnvironmentCredential`.
+    The identity it uses depends on the environment. When an access token is needed, it requests one using these
+    identities in turn, stopping when one provides a token:
 
-    When environment configuration is not present, it authenticates with a managed identity using
-    :class:`azure.identity.ManagedIdentityCredential`.
-
-    On Windows, when environment variable configuration and managed identity are unavailable, it finally
-    attempts to authenticate with a token from the cache shared by Microsoft applications using
-    :class:`azure.identity.SharedTokenCacheCredential`.
+    1. A service principal configured by environment variables. See :class:`~azure.identity.aio.EnvironmentCredential`
+       for more details.
+    2. An Azure managed identity. See :class:`~azure.identity.aio.ManagedIdentityCredential` for more details.
+    3. On Windows only, the current user, using a token from the local cache shared by Microsoft applications. See
+       :class:`~azure.identity.aio.SharedTokenCacheCredential` for more details.
     """
 
     def __init__(self, **kwargs):

--- a/sdk/identity/azure-identity/azure/identity/aio/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/__init__.py
@@ -2,6 +2,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import os
+
+from .._constants import EnvironmentVariables
 from .credentials import (
     CertificateCredential,
     ChainedTokenCredential,
@@ -22,14 +25,26 @@ class DefaultAzureCredential(ChainedTokenCredential):
     1. A service principal configured by environment variables. See :class:`~azure.identity.aio.EnvironmentCredential`
        for more details.
     2. An Azure managed identity. See :class:`~azure.identity.aio.ManagedIdentityCredential` for more details.
-    3. On Windows only, the current user, using a token from the local cache shared by Microsoft applications. See
+    3. On Windows only: a user who has signed in with a Microsoft application, such as Visual Studio. This requires a
+       value for the environment variable ``AZURE_USERNAME``. See
        :class:`~azure.identity.aio.SharedTokenCacheCredential` for more details.
     """
 
     def __init__(self, **kwargs):
         credentials = [EnvironmentCredential(**kwargs), ManagedIdentityCredential(**kwargs)]
-        if SharedTokenCacheCredential.supported():
-            credentials.append(SharedTokenCacheCredential(**kwargs))
+
+        # SharedTokenCacheCredential is part of the default only on supported platforms, when $AZURE_USERNAME has a
+        # value (because the cache may contain tokens for multiple identities and we can only choose one arbitrarily
+        # without more information from the user), and when $AZURE_PASSWORD has no value (because when $AZURE_USERNAME
+        # and $AZURE_PASSWORD are set, EnvironmentCredential will be used instead)
+        if (
+            SharedTokenCacheCredential.supported()
+            and EnvironmentVariables.AZURE_USERNAME in os.environ
+            and EnvironmentVariables.AZURE_PASSWORD not in os.environ
+        ):
+            credentials.append(
+                SharedTokenCacheCredential(username=os.environ.get(EnvironmentVariables.AZURE_USERNAME), **kwargs)
+            )
 
         super().__init__(*credentials)
 

--- a/sdk/identity/azure-identity/azure/identity/aio/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/__init__.py
@@ -16,11 +16,15 @@ class DefaultAzureCredential(ChainedTokenCredential):
     """
     A default credential capable of handling most Azure SDK authentication scenarios.
 
-    When environment variable configuration is present, it authenticates as a service principal
-    using :class:`azure.identity.aio.EnvironmentCredential`.
+    When environment variable configuration is present, it authenticates as a service principal using
+    :class:`azure.identity.EnvironmentCredential`.
 
-    When environment configuration is not present, it authenticates with a managed identity
-    using :class:`azure.identity.aio.ManagedIdentityCredential`.
+    When environment configuration is not present, it authenticates with a managed identity using
+    :class:`azure.identity.ManagedIdentityCredential`.
+
+    On Windows, when environment variable configuration and managed identity are unavailable, it finally
+    attempts to authenticate with a token from the cache shared by Microsoft applications using
+    :class:`azure.identity.SharedTokenCacheCredential`.
     """
 
     def __init__(self, **kwargs):

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/__init__.py
@@ -1,0 +1,7 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from .exception_wrapper import wrap_exceptions
+
+__all__ = ["wrap_exceptions"]

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/exception_wrapper.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/exception_wrapper.py
@@ -1,0 +1,24 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import functools
+
+from azure.core.exceptions import ClientAuthenticationError
+
+
+def wrap_exceptions(fn):
+    """Prevents leaking exceptions defined outside azure-core by raising ClientAuthenticationError from them."""
+
+    @functools.wraps(fn)
+    async def wrapper(*args, **kwargs):
+        try:
+            result = await fn(*args, **kwargs)
+            return result
+        except ClientAuthenticationError:
+            raise
+        except Exception as ex:  # pylint:disable=broad-except
+            auth_error = ClientAuthenticationError(message="Authentication failed: {}".format(ex))
+            raise auth_error from ex
+
+    return wrapper

--- a/sdk/identity/azure-identity/azure/identity/aio/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/credentials.py
@@ -6,16 +6,25 @@
 Credentials for asynchronous Azure SDK authentication.
 """
 import os
-from typing import Any, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Union
 
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
 
 from ._authn_client import AsyncAuthnClient
+from ._internal import wrap_exceptions
 from ._managed_identity import ImdsCredential, MsiCredential
 from .._base import ClientSecretCredentialBase, CertificateCredentialBase
 from .._constants import Endpoints, EnvironmentVariables
-from ..credentials import ChainedTokenCredential as SyncChainedTokenCredential
+from ..credentials import (
+    ChainedTokenCredential as SyncChainedTokenCredential,
+    SharedTokenCacheCredential as SyncSharedTokenCacheCredential,
+)
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import,ungrouped-imports
+    import msal_extensions
+    from ._authn_client import AuthnClientBase
 
 # pylint:disable=too-few-public-methods
 
@@ -186,3 +195,33 @@ class ChainedTokenCredential(SyncChainedTokenCredential):
                 history.append((credential, str(ex)))
         error_message = self._get_error_message(history)
         raise ClientAuthenticationError(message=error_message)
+
+
+class SharedTokenCacheCredential(SyncSharedTokenCacheCredential):
+    """Authenticates using tokens in the local cache shared between Microsoft applications."""
+
+    @wrap_exceptions
+    async def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+        """
+        Get an access token for `scopes` from the shared cache. If no access token is cached, attempt to acquire one
+        using a cached refresh token.
+
+        :param str scopes: desired scopes for the token
+        :rtype: :class:`azure.core.credentials.AccessToken`
+        :raises:
+            :class:`azure.core.exceptions.ClientAuthenticationError` when the cache is unavailable or no access token
+            can be acquired from it
+        """
+
+        if not self._client:
+            raise ClientAuthenticationError(message="Shared token cache unavailable")
+
+        token = self._client.get_cached_token(scopes) or await self._client.obtain_token_by_refresh_token(scopes)
+        if not token:
+            raise ClientAuthenticationError(message="No cached token found for '{}'".format(scopes))
+
+        return token
+
+    @staticmethod
+    def _get_auth_client(cache: "Optional[msal_extensions.FileTokenCache]") -> "Optional[AuthnClientBase]":
+        return AsyncAuthnClient(Endpoints.AAD_OAUTH2_V2_FORMAT.format("common"), cache=cache) if cache else None

--- a/sdk/identity/azure-identity/azure/identity/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/credentials.py
@@ -266,7 +266,7 @@ class DeviceCodeCredential(PublicClientCredential):
     """
 
     def __init__(self, client_id, prompt_callback=None, **kwargs):
-        # type: (str, Optional[Callable[[str, str], None]], Any) -> None
+        # type: (str, Optional[Callable[[str, str, str], None]], Any) -> None
         self._timeout = kwargs.pop("timeout", None)  # type: Optional[int]
         self._prompt_callback = prompt_callback
         super(DeviceCodeCredential, self).__init__(client_id=client_id, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/credentials.py
@@ -328,6 +328,10 @@ class SharedTokenCacheCredential(object):
 
             cache = WindowsTokenCache(cache_location=os.environ["LOCALAPPDATA"] + "/.IdentityService/msal.cache")
 
+            # prevent writing to the shared cache
+            # TODO: seperating deserializing access tokens from caching them would make this cleaner
+            cache.add = lambda *_: None
+
         self._client = self._get_auth_client(cache)
 
     @wrap_exceptions

--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -69,7 +69,13 @@ setup(
             "azure",
         ]
     ),
-    install_requires=["azure-core<2.0.0,>=1.0.0b2", "cryptography>=2.1.4", "msal~=0.4.1", "six>=1.6"],
+    install_requires=[
+        "azure-core<2.0.0,>=1.0.0b2",
+        "cryptography>=2.1.4",
+        "msal~=0.4.1",
+        "msal_extensions~=0.1.1",
+        "six>=1.6",
+    ],
     extras_require={
         ":python_version<'3.0'": ["azure-nspkg"],
         ":python_version<'3.3'": ["mock"],

--- a/sdk/identity/azure-identity/tests/test_identity.py
+++ b/sdk/identity/azure-identity/tests/test_identity.py
@@ -291,7 +291,7 @@ def test_device_code_credential_timeout():
     )
 
     credential = DeviceCodeCredential(
-        client_id="_", prompt_callback=Mock(), transport=transport, timeout=0.1, instance_discovery=False
+        client_id="_", prompt_callback=Mock(), transport=transport, timeout=0.01, instance_discovery=False
     )
 
     with pytest.raises(ClientAuthenticationError) as ex:
@@ -348,8 +348,8 @@ def test_interactive_credential_timeout():
     )
 
     # mock local server blocks long enough to exceed the timeout
-    timeout = 1
-    server_instance = Mock(wait_for_redirect=functools.partial(time.sleep, timeout + 1))
+    timeout = 0.01
+    server_instance = Mock(wait_for_redirect=functools.partial(time.sleep, timeout + 0.01))
     server_class = Mock(return_value=server_instance)
 
     credential = InteractiveBrowserCredential(

--- a/sdk/identity/azure-identity/tests/test_identity.py
+++ b/sdk/identity/azure-identity/tests/test_identity.py
@@ -11,7 +11,7 @@ import uuid
 try:
     from unittest.mock import Mock, patch
 except ImportError:  # python < 3.3
-    from mock import Mock, patch
+    from mock import Mock, patch  # type: ignore
 
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
@@ -236,8 +236,45 @@ def test_imds_credential_retries():
         assert mock_send.call_count == 2 + total_retries
 
 
-def test_default_credential():
-    DefaultAzureCredential()
+@patch("azure.identity.SharedTokenCacheCredential")
+def test_default_credential_shared_cache_use(mock_credential):
+    mock_credential.supported = Mock(return_value=False)
+
+    # unsupported platform -> default credential shouldn't use shared cache
+    credential = DefaultAzureCredential()
+    assert mock_credential.call_count == 0
+    assert mock_credential.supported.call_count == 1
+    mock_credential.supported.reset_mock()
+
+    # unsupported platform, $AZURE_USERNAME set, $AZURE_PASSWORD not set -> default credential shouldn't use shared cache
+    credential = DefaultAzureCredential()
+    assert mock_credential.call_count == 0
+    assert mock_credential.supported.call_count == 1
+
+    mock_credential.supported = Mock(return_value=True)
+
+    # supported platform, $AZURE_USERNAME not set -> default credential shouldn't use shared cache
+    credential = DefaultAzureCredential()
+    assert mock_credential.call_count == 0
+    assert mock_credential.supported.call_count == 1
+    mock_credential.supported.reset_mock()
+
+    # supported platform, $AZURE_USERNAME and $AZURE_PASSWORD set -> default credential shouldn't use shared cache
+    # (EnvironmentCredential should be used when both variables are set)
+    with patch.dict("os.environ", {"AZURE_USERNAME": "foo@bar.com", "AZURE_PASSWORD": "***"}):
+        credential = DefaultAzureCredential()
+        assert mock_credential.call_count == 0
+
+    # supported platform, $AZURE_USERNAME set, $AZURE_PASSWORD not set -> default credential should use shared cache
+    with patch.dict("os.environ", {"AZURE_USERNAME": "foo@bar.com"}):
+        expected_token = AccessToken("***", 42)
+        mock_credential.return_value = Mock(get_token=lambda *_: expected_token)
+
+        credential = DefaultAzureCredential()
+        assert mock_credential.call_count == 1
+
+        token = credential.get_token("scope")
+        assert token == expected_token
 
 
 def test_device_code_credential():
@@ -252,7 +289,12 @@ def test_device_code_credential():
             # expected requests: discover tenant, start device code flow, poll for completion
             mock_response(json_payload={"authorization_endpoint": "https://a/b", "token_endpoint": "https://a/b"}),
             mock_response(
-                json_payload={"device_code": "_", "user_code": user_code, "verification_uri": verification_uri, "expires_in": expires_in}
+                json_payload={
+                    "device_code": "_",
+                    "user_code": user_code,
+                    "verification_uri": verification_uri,
+                    "expires_in": expires_in,
+                }
             ),
             mock_response(
                 json_payload={

--- a/sdk/identity/azure-identity/tests/test_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_identity_async.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import os
 import time
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 import uuid
 
 import pytest
@@ -280,5 +280,43 @@ async def test_managed_identity_cloud_shell(monkeypatch):
     assert ex.value.message is success_message
 
 
-def test_default_credential():
-    DefaultAzureCredential()
+@pytest.mark.asyncio
+async def test_default_credential_shared_cache_use():
+    with patch("azure.identity.aio.SharedTokenCacheCredential") as mock_credential:
+        mock_credential.supported = Mock(return_value=False)
+
+        # unsupported platform -> default credential shouldn't use shared cache
+        credential = DefaultAzureCredential()
+        assert mock_credential.call_count == 0
+        assert mock_credential.supported.call_count == 1
+        mock_credential.supported.reset_mock()
+
+        # unsupported platform, $AZURE_USERNAME set, $AZURE_PASSWORD not set -> default credential shouldn't use shared cache
+        credential = DefaultAzureCredential()
+        assert mock_credential.call_count == 0
+        assert mock_credential.supported.call_count == 1
+
+        mock_credential.supported = Mock(return_value=True)
+
+        # supported platform, $AZURE_USERNAME not set -> default credential shouldn't use shared cache
+        credential = DefaultAzureCredential()
+        assert mock_credential.call_count == 0
+        assert mock_credential.supported.call_count == 1
+        mock_credential.supported.reset_mock()
+
+        # supported platform, $AZURE_USERNAME and $AZURE_PASSWORD set -> default credential shouldn't use shared cache
+        # (EnvironmentCredential should be used when both variables are set)
+        with patch.dict("os.environ", {"AZURE_USERNAME": "foo@bar.com", "AZURE_PASSWORD": "***"}):
+            credential = DefaultAzureCredential()
+            assert mock_credential.call_count == 0
+
+        # supported platform, $AZURE_USERNAME set, $AZURE_PASSWORD not set -> default credential should use shared cache
+        with patch.dict("os.environ", {"AZURE_USERNAME": "foo@bar.com"}):
+            expected_token = AccessToken("***", 42)
+            mock_credential.return_value=Mock(get_token=asyncio.coroutine(lambda *_: expected_token))
+
+            credential = DefaultAzureCredential()
+            assert mock_credential.call_count == 1
+
+            token = await credential.get_token("scope")
+            assert token == expected_token

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -90,6 +90,7 @@ futures
 mock
 typing
 msal~=0.4.1
+msal_extensions~=0.1.1
 msrest>=0.5.0
 msrestazure<2.0.0,>=0.4.32
 requests>=2.18.4


### PR DESCRIPTION
Closes #6948 with `SharedTokenCacheCredential`, enabling SSO for developers on Windows. Only this new credential uses the shared cache.