### PR TITLE
document container properties name

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
@@ -259,6 +259,10 @@ class ContainerProperties(DictMixin):
         Represents whether the container has a legal hold.
     :param dict metadata: A dict with name-value pairs to associate with the
         container as metadata.
+
+    Returned ``ContainerProperties`` instances expose these values through a 
+    dictionary interface, for example: ``container_props["last_modified"]``. 
+    Additionally, the container name is available as ``container_props["name"]``.
     """
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
Describe how to access the container name in a returned `ContainerProperties`