### PR TITLE
Resolve MyPy Issues

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -45,6 +45,10 @@ commands =
     {envbindir}/python {toxinidir}/../../../eng/tox/run_pylint.py -t {toxinidir}
 
 [testenv:mypy]
+skipsdist = false
+skip_install = false
+usedevelop = true
+changedir = {toxinidir}
 deps =
   {[base]deps}
   mypy; python_version >= '3.5'

--- a/sdk/cosmos/azure-cosmos/dev_requirements.txt
+++ b/sdk/cosmos/azure-cosmos/dev_requirements.txt
@@ -1,0 +1,1 @@
+-e ../../../tools/azure-sdk-tools


### PR DESCRIPTION
Errors like `azure-core` not being loadable etc.

Extending the python path is definitely an option. I proxied that action by simply making the `mypy` environment install the package in develop mode. If the package _references_ azure-core, then it will be available on the python path.