### PR TITLE
More useful exceptions for Key Vault errors

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/exceptions.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/exceptions.py
@@ -1,0 +1,37 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import functools
+from typing import TYPE_CHECKING
+
+from azure.core.exceptions import DecodeError, ResourceExistsError, ResourceNotFoundError
+from azure.core.pipeline.policies import ContentDecodePolicy
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import,ungrouped-imports
+    from typing import Type
+    from azure.core.exceptions import AzureError
+    from azure.core.pipeline.transport import HttpResponse
+
+
+def get_exception_for_key_vault_error(cls, response):
+    # type: (Type[AzureError], HttpResponse) -> AzureError
+    try:
+        body = ContentDecodePolicy.deserialize_from_http_generics(response)
+        message = "({}) {}".format(body["error"]["code"], body["error"]["message"])
+    except (DecodeError, KeyError):
+        # Key Vault error response bodies have the expected shape and should be deserializable.
+        # If we somehow land here, we'll take HttpResponse's default message.
+        message = None
+
+    return cls(message=message, response=response)
+
+
+_code_to_core_error = {404: ResourceNotFoundError, 409: ResourceExistsError}
+
+# map status codes to callables returning appropriate azure-core errors
+error_map = {
+    status_code: functools.partial(get_exception_for_key_vault_error, cls)
+    for status_code, cls in _code_to_core_error.items()
+}

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/client.py
@@ -29,6 +29,7 @@ from azure.keyvault.certificates.models import(
 )
 from ._polling_async import CreateCertificatePollerAsync
 from .._shared import AsyncKeyVaultClientBase
+from .._shared.exceptions import error_map
 
 
 class CertificateClient(AsyncKeyVaultClientBase):
@@ -148,7 +149,9 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :param str name: The name of the certificate in the given vault.
         :returns: An instance of Certificate
         :rtype: ~azure.keyvault.certificates.models.Certificate
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -162,6 +165,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
             vault_base_url=self.vault_url,
             certificate_name=name,
             certificate_version="",
+            error_map=error_map,
             **kwargs
         )
         return Certificate._from_certificate_bundle(certificate_bundle=bundle)
@@ -182,7 +186,9 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :param str version: The version of the certificate.
         :returns: An instance of Certificate
         :rtype: ~azure.keyvault.certificates.models.Certificate
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -196,6 +202,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
             vault_base_url=self.vault_url,
             certificate_name=name,
             certificate_version=version,
+            error_map=error_map,
             **kwargs
         )
         return Certificate._from_certificate_bundle(certificate_bundle=bundle)
@@ -212,7 +219,9 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :param str name: The name of the certificate.
         :returns: The deleted certificate
         :rtype: ~azure.keyvault.certificates.models.DeletedCertificate
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -225,6 +234,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         bundle = await self._client.delete_certificate(
             vault_base_url=self.vault_url,
             certificate_name=name,
+            error_map=error_map,
             **kwargs
         )
         return DeletedCertificate._from_deleted_certificate_bundle(deleted_certificate_bundle=bundle)
@@ -235,13 +245,15 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
         Retrieves the deleted certificate information plus its attributes,
         such as retention interval, scheduled permanent deletion, and the
-        current deletion recovery level. This operaiton requires the certificates/
+        current deletion recovery level. This operation requires the certificates/
         get permission.
 
         :param str name: The name of the certificate.
         :return: The deleted certificate
         :rtype: ~azure.keyvault.certificates.models.DeletedCertificate
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -254,6 +266,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         bundle = await self._client.get_deleted_certificate(
             vault_base_url=self.vault_url,
             certificate_name=name,
+            error_map=error_map,
             **kwargs
         )
         return DeletedCertificate._from_deleted_certificate_bundle(deleted_certificate_bundle=bundle)
@@ -467,7 +480,9 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :param str name: The name of the certificate.
         :return: the backup blob containing the backed up certificate.
         :rtype: bytes
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -480,6 +495,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         backup_result = await self._client.backup_certificate(
             vault_base_url=self.vault_url,
             certificate_name=name,
+            error_map=error_map,
             **kwargs
         )
         return backup_result.value
@@ -710,12 +726,15 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :param str name: The name of the certificate.
         :returns: The created CertificateOperation
         :rtype: ~azure.keyvault.certificates.models.CertificateOperation
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
         """
 
         bundle = await self._client.get_certificate_operation(
             vault_base_url=self.vault_url,
             certificate_name=name,
+            error_map=error_map,
             **kwargs
         )
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
@@ -731,11 +750,14 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :param str name: The name of the certificate.
         :return: The deleted CertificateOperation
         :rtype: ~azure.keyvault.certificates.models.CertificateOperation
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the operation doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
         """
         bundle = await self._client.delete_certificate_operation(
             vault_base_url=self.vault_url,
             certificate_name=name,
+            error_map=error_map,
             **kwargs
         )
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
@@ -775,7 +797,6 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: str
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
-        error_map = kwargs.pop("error_map", None)
         vault_base_url = self.vault_url
         # Construct URL
         url = '/certificates/{certificate-name}/pending'
@@ -874,7 +895,9 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :param str name: The name of the issuer.
         :return: The specified certificate issuer.
         :rtype: ~azure.keyvault.certificates.models.Issuer
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the issuer doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -887,6 +910,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         issuer_bundle = await self._client.get_certificate_issuer(
             vault_base_url=self.vault_url,
             issuer_name=name,
+            error_map=error_map,
             **kwargs
         )
         return Issuer._from_issuer_bundle(issuer_bundle=issuer_bundle)

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/client.py
@@ -11,6 +11,7 @@ from azure.core.polling import LROPoller
 from azure.core.tracing.decorator import distributed_trace
 
 from ._shared import KeyVaultClientBase
+from ._shared.exceptions import error_map
 from .models import (
     Certificate,
     CertificateBase,
@@ -58,7 +59,7 @@ class CertificateClient(KeyVaultClientBase):
             policy=None,  # type: Optional[CertificatePolicy]
             enabled=None,  # type: Optional[bool]
             tags=None,  # type: Optional[Dict[str, str]]
-            **kwargs  # type: **Any
+            **kwargs  # type: Any
     ):
         # type: (...) -> CertificateOperation
         """Creates a new certificate.
@@ -154,7 +155,9 @@ class CertificateClient(KeyVaultClientBase):
         :param str name: The name of the certificate in the given vault.
         :returns: An instance of Certificate
         :rtype: ~azure.keyvault.certificates.models.Certificate
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -168,6 +171,7 @@ class CertificateClient(KeyVaultClientBase):
             vault_base_url=self.vault_url,
             certificate_name=name,
             certificate_version="",
+            error_map=error_map,
             **kwargs
         )
         return Certificate._from_certificate_bundle(certificate_bundle=bundle)
@@ -184,7 +188,9 @@ class CertificateClient(KeyVaultClientBase):
         :param str version: The version of the certificate.
         :returns: An instance of Certificate
         :rtype: ~azure.keyvault.certificates.models.Certificate
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -198,6 +204,7 @@ class CertificateClient(KeyVaultClientBase):
             vault_base_url=self.vault_url,
             certificate_name=name,
             certificate_version=version,
+            error_map=error_map,
             **kwargs
         )
         return Certificate._from_certificate_bundle(certificate_bundle=bundle)
@@ -215,7 +222,9 @@ class CertificateClient(KeyVaultClientBase):
         :param str name: The name of the certificate.
         :returns: The deleted certificate
         :rtype: ~azure.keyvault.certificates.models.DeletedCertificate
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -228,6 +237,7 @@ class CertificateClient(KeyVaultClientBase):
         bundle = self._client.delete_certificate(
             vault_base_url=self.vault_url,
             certificate_name=name,
+            error_map=error_map,
             **kwargs
         )
         return DeletedCertificate._from_deleted_certificate_bundle(deleted_certificate_bundle=bundle)
@@ -239,13 +249,15 @@ class CertificateClient(KeyVaultClientBase):
 
         Retrieves the deleted certificate information plus its attributes,
         such as retention interval, scheduled permanent deletion, and the
-        current deletion recovery level. This operaiton requires the certificates/
+        current deletion recovery level. This operation requires the certificates/
         get permission.
 
         :param str name: The name of the certificate.
         :return: The deleted certificate
         :rtype: ~azure.keyvault.certificates.models.DeletedCertificate
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -258,6 +270,7 @@ class CertificateClient(KeyVaultClientBase):
         bundle = self._client.get_deleted_certificate(
             vault_base_url=self.vault_url,
             certificate_name=name,
+            error_map=error_map,
             **kwargs
         )
         return DeletedCertificate._from_deleted_certificate_bundle(deleted_certificate_bundle=bundle)
@@ -475,7 +488,9 @@ class CertificateClient(KeyVaultClientBase):
         :param str name: The name of the certificate.
         :return: the backup blob containing the backed up certificate.
         :rtype: bytes
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -488,6 +503,7 @@ class CertificateClient(KeyVaultClientBase):
         backup_result = self._client.backup_certificate(
             vault_base_url=self.vault_url,
             certificate_name=name,
+            error_map=error_map,
             **kwargs
         )
         return backup_result.value
@@ -709,12 +725,15 @@ class CertificateClient(KeyVaultClientBase):
         :param str name: The name of the certificate.
         :returns: The created CertificateOperation
         :rtype: ~azure.keyvault.certificates.models.CertificateOperation
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
         """
 
         bundle = self._client.get_certificate_operation(
             vault_base_url=self.vault_url,
             certificate_name=name,
+            error_map=error_map,
             **kwargs
         )
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
@@ -821,7 +840,6 @@ class CertificateClient(KeyVaultClientBase):
         :rtype: str
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
-        error_map = kwargs.pop("error_map", None)
         vault_base_url = self.vault_url
         # Construct URL
         url = '/certificates/{certificate-name}/pending'
@@ -876,7 +894,9 @@ class CertificateClient(KeyVaultClientBase):
         :param str name: The name of the issuer.
         :return: The specified certificate issuer.
         :rtype: ~azure.keyvault.certificates.models.Issuer
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the issuer doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -889,6 +909,7 @@ class CertificateClient(KeyVaultClientBase):
         issuer_bundle = self._client.get_certificate_issuer(
             vault_base_url=self.vault_url,
             issuer_name=name,
+            error_map=error_map,
             **kwargs
         )
         return Issuer._from_issuer_bundle(issuer_bundle=issuer_bundle)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/exceptions.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/exceptions.py
@@ -1,0 +1,37 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import functools
+from typing import TYPE_CHECKING
+
+from azure.core.exceptions import DecodeError, ResourceExistsError, ResourceNotFoundError
+from azure.core.pipeline.policies import ContentDecodePolicy
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import,ungrouped-imports
+    from typing import Type
+    from azure.core.exceptions import AzureError
+    from azure.core.pipeline.transport import HttpResponse
+
+
+def get_exception_for_key_vault_error(cls, response):
+    # type: (Type[AzureError], HttpResponse) -> AzureError
+    try:
+        body = ContentDecodePolicy.deserialize_from_http_generics(response)
+        message = "({}) {}".format(body["error"]["code"], body["error"]["message"])
+    except (DecodeError, KeyError):
+        # Key Vault error response bodies have the expected shape and should be deserializable.
+        # If we somehow land here, we'll take HttpResponse's default message.
+        message = None
+
+    return cls(message=message, response=response)
+
+
+_code_to_core_error = {404: ResourceNotFoundError, 409: ResourceExistsError}
+
+# map status codes to callables returning appropriate azure-core errors
+error_map = {
+    status_code: functools.partial(get_exception_for_key_vault_error, cls)
+    for status_code, cls in _code_to_core_error.items()
+}

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
@@ -17,9 +17,9 @@ from ..crypto.aio import CryptographyClient
 class KeyClient(AsyncKeyVaultClientBase):
     """A high-level asynchronous interface for managing a vault's keys.
 
+    :param str vault_url: URL of the vault the client will access
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity.aio`
-    :param str vault_url: URL of the vault the client will access
 
     Example:
         .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -33,6 +33,18 @@ class KeyClient(AsyncKeyVaultClientBase):
     # pylint:disable=protected-access
 
     def get_cryptography_client(self, key: Union[Key, str], **kwargs: Any) -> CryptographyClient:
+        """
+        Get a :class:`~azure.keyvault.keys.crypto.aio.CryptographyClient` capable of performing cryptographic operations
+        with a key.
+
+        :param key:
+            Either a :class:`~azure.keyvault.keys.Key` instance as returned by
+            :func:`~azure.keyvault.keys.aio.KeyClient.get_key`, or a string. If a string, the value must be the full
+            identifier of an Azure Key Vault key with a version.
+        :type key: str or :class:`~azure.keyvault.keys.Key`
+        :rtype: :class:`~azure.keyvault.keys.crypto.aio.CryptographyClient`
+        """
+
         # the initializer requires a credential but won't actually use it in this case because we pass in this
         # KeyClient's generated client, whose pipeline (and auth policy) is fully configured
         credential = object()
@@ -69,6 +81,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :type curve: ~azure.keyvault.keys.enums.KeyCurveName or str
         :returns: The created key
         :rtype: ~azure.keyvault.keys.models.Key
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -123,6 +136,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :param dict tags: (optional) Application specific metadata in the form of key-value pairs
         :returns: The created key
         :rtype: ~azure.keyvault.keys.models.Key
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -174,6 +188,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :param dict tags: (optional) Application specific metadata in the form of key-value pairs
         :returns: The created key
         :rtype: ~azure.keyvault.keys.models.Key
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -204,7 +219,9 @@ class KeyClient(AsyncKeyVaultClientBase):
         :param str name: The name of the key to delete.
         :returns: The deleted key
         :rtype: ~azure.keyvault.keys.models.DeletedKey
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -225,7 +242,9 @@ class KeyClient(AsyncKeyVaultClientBase):
         :param str version: (optional) A specific version of the key to get. If not specified, gets the latest version
             of the key.
         :rtype: ~azure.keyvault.keys.models.Key
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -251,6 +270,9 @@ class KeyClient(AsyncKeyVaultClientBase):
         :param str name: The name of the key
         :returns: The deleted key
         :rtype: ~azure.keyvault.keys.models.DeletedKey
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -346,6 +368,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :param str name: The name of the key
         :returns: None
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. code-block:: python
@@ -368,6 +391,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :param str name: The name of the deleted key
         :returns: The recovered key
         :rtype: ~azure.keyvault.keys.models.Key
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -405,7 +429,9 @@ class KeyClient(AsyncKeyVaultClientBase):
         :param dict tags: (optional) Application specific metadata in the form of key-value pairs
         :returns: The updated key
         :rtype: ~azure.keyvault.keys.models.Key
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -443,7 +469,9 @@ class KeyClient(AsyncKeyVaultClientBase):
         :param str name: The name of the key
         :returns: The raw bytes of the key backup
         :rtype: bytes
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -469,7 +497,9 @@ class KeyClient(AsyncKeyVaultClientBase):
         :param bytes backup: The raw bytes of the key backup
         :returns: The restored key
         :rtype: ~azure.keyvault.keys.models.Key
-        :raises: :class:`~azure.core.exceptions.ResourceExistsError` if the backed up key's name is already in use
+        :raises:
+            :class:`~azure.core.exceptions.ResourceExistsError` if the backed up key's name is already in use,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -507,6 +537,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :param dict tags: (optional) Application specific metadata in the form of key-value pairs
         :returns: The imported key
         :rtype: ~azure.keyvault.keys.models.Key
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         """
         if enabled is not None or not_before is not None or expires is not None:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
@@ -5,12 +5,12 @@
 from datetime import datetime
 from typing import Any, AsyncIterable, Optional, Dict, List, Union
 
-from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.keyvault.keys.models import DeletedKey, JsonWebKey, Key, KeyBase
 from azure.keyvault.keys._shared import AsyncKeyVaultClientBase
 
+from .._shared.exceptions import error_map
 from ..crypto.aio import CryptographyClient
 
 
@@ -62,7 +62,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         expires: Optional[datetime] = None,
         not_before: Optional[datetime] = None,
         tags: Optional[Dict[str, str]] = None,
-        **kwargs: "**Any"
+        **kwargs: "**Any",
     ) -> Key:
         """Create a key. If ``name`` is already in use, create a new version of the key. Requires the keys/create
         permission.
@@ -120,7 +120,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         expires: Optional[datetime] = None,
         not_before: Optional[datetime] = None,
         tags: Optional[Dict[str, str]] = None,
-        **kwargs: "**Any"
+        **kwargs: "**Any",
     ) -> Key:
         """Create a new RSA key. If ``name`` is already in use, create a new version of the key. Requires the
         keys/create permission.
@@ -171,7 +171,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         expires: Optional[datetime] = None,
         not_before: Optional[datetime] = None,
         tags: Optional[Dict[str, str]] = None,
-        **kwargs: "**Any"
+        **kwargs: "**Any",
     ) -> Key:
         """Create a new elliptic curve key. If ``name`` is already in use, create a new version of the key. Requires
         the keys/create permission.
@@ -231,7 +231,7 @@ class KeyClient(AsyncKeyVaultClientBase):
                 :caption: Delete a key
                 :dedent: 8
         """
-        bundle = await self._client.delete_key(self.vault_url, name, error_map={404: ResourceNotFoundError}, **kwargs)
+        bundle = await self._client.delete_key(self.vault_url, name, error_map=error_map, **kwargs)
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace_async
@@ -257,9 +257,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         if version is None:
             version = ""
 
-        bundle = await self._client.get_key(
-            self.vault_url, name, version, error_map={404: ResourceNotFoundError}, **kwargs
-        )
+        bundle = await self._client.get_key(self.vault_url, name, version, error_map=error_map, **kwargs)
         return Key._from_key_bundle(bundle)
 
     @distributed_trace_async
@@ -282,9 +280,7 @@ class KeyClient(AsyncKeyVaultClientBase):
                 :caption: Get a deleted key
                 :dedent: 8
         """
-        bundle = await self._client.get_deleted_key(
-            self.vault_url, name, error_map={404: ResourceNotFoundError}, **kwargs
-        )
+        bundle = await self._client.get_deleted_key(self.vault_url, name, error_map=error_map, **kwargs)
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace
@@ -308,7 +304,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             self.vault_url,
             maxresults=max_results,
             cls=lambda objs: [DeletedKey._from_deleted_key_item(x) for x in objs],
-            **kwargs
+            **kwargs,
         )
 
     @distributed_trace
@@ -328,10 +324,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         """
         max_results = kwargs.get("max_page_size")
         return self._client.get_keys(
-            self.vault_url,
-            maxresults=max_results,
-            cls=lambda objs: [KeyBase._from_key_item(x) for x in objs],
-            **kwargs
+            self.vault_url, maxresults=max_results, cls=lambda objs: [KeyBase._from_key_item(x) for x in objs], **kwargs
         )
 
     @distributed_trace
@@ -356,7 +349,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             name,
             maxresults=max_results,
             cls=lambda objs: [KeyBase._from_key_item(x) for x in objs],
-            **kwargs
+            **kwargs,
         )
 
     @distributed_trace_async
@@ -414,7 +407,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         not_before: Optional[datetime] = None,
         expires: Optional[datetime] = None,
         tags: Optional[Dict[str, str]] = None,
-        **kwargs: "**Any"
+        **kwargs: "**Any",
     ) -> Key:
         """Change attributes of a key. Cannot change a key's cryptographic material. Requires the keys/update
         permission.
@@ -453,7 +446,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             key_ops=key_operations,
             tags=tags,
             key_attributes=attributes,
-            error_map={404: ResourceNotFoundError},
+            error_map=error_map,
             **kwargs,
         )
         return Key._from_key_bundle(bundle)
@@ -481,9 +474,7 @@ class KeyClient(AsyncKeyVaultClientBase):
                 :caption: Get a key backup
                 :dedent: 8
         """
-        backup_result = await self._client.backup_key(
-            self.vault_url, name, error_map={404: ResourceNotFoundError}, **kwargs
-        )
+        backup_result = await self._client.backup_key(self.vault_url, name, error_map=error_map, **kwargs)
         return backup_result.value
 
     @distributed_trace_async
@@ -509,7 +500,7 @@ class KeyClient(AsyncKeyVaultClientBase):
                 :caption: Restore a key backup
                 :dedent: 8
         """
-        bundle = await self._client.restore_key(self.vault_url, backup, error_map={409: ResourceExistsError}, **kwargs)
+        bundle = await self._client.restore_key(self.vault_url, backup, error_map=error_map, **kwargs)
         return Key._from_key_bundle(bundle)
 
     @distributed_trace_async
@@ -522,7 +513,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         not_before: Optional[datetime] = None,
         expires: Optional[datetime] = None,
         tags: Optional[Dict[str, str]] = None,
-        **kwargs: "**Any"
+        **kwargs: "**Any",
     ) -> Key:
         """Import an externally created key. If ``name`` is already in use, import the key as a new version. Requires
         the keys/import permission.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
@@ -62,7 +62,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         expires: Optional[datetime] = None,
         not_before: Optional[datetime] = None,
         tags: Optional[Dict[str, str]] = None,
-        **kwargs: "**Any",
+        **kwargs: "**Any"
     ) -> Key:
         """Create a key. If ``name`` is already in use, create a new version of the key. Requires the keys/create
         permission.
@@ -120,7 +120,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         expires: Optional[datetime] = None,
         not_before: Optional[datetime] = None,
         tags: Optional[Dict[str, str]] = None,
-        **kwargs: "**Any",
+        **kwargs: "**Any"
     ) -> Key:
         """Create a new RSA key. If ``name`` is already in use, create a new version of the key. Requires the
         keys/create permission.
@@ -171,7 +171,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         expires: Optional[datetime] = None,
         not_before: Optional[datetime] = None,
         tags: Optional[Dict[str, str]] = None,
-        **kwargs: "**Any",
+        **kwargs: "**Any"
     ) -> Key:
         """Create a new elliptic curve key. If ``name`` is already in use, create a new version of the key. Requires
         the keys/create permission.
@@ -407,7 +407,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         not_before: Optional[datetime] = None,
         expires: Optional[datetime] = None,
         tags: Optional[Dict[str, str]] = None,
-        **kwargs: "**Any",
+        **kwargs: "**Any"
     ) -> Key:
         """Change attributes of a key. Cannot change a key's cryptographic material. Requires the keys/update
         permission.
@@ -513,7 +513,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         not_before: Optional[datetime] = None,
         expires: Optional[datetime] = None,
         tags: Optional[Dict[str, str]] = None,
-        **kwargs: "**Any",
+        **kwargs: "**Any"
     ) -> Key:
         """Import an externally created key. If ``name`` is already in use, import the key as a new version. Requires
         the keys/import permission.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
@@ -2,10 +2,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
 from azure.core.tracing.decorator import distributed_trace
 
 from ._shared import KeyVaultClientBase
+from ._shared.exceptions import error_map
 from .crypto import CryptographyClient
 from .models import Key, KeyBase, DeletedKey
 
@@ -244,7 +244,7 @@ class KeyClient(KeyVaultClientBase):
                 :caption: Delete a key
                 :dedent: 8
         """
-        bundle = self._client.delete_key(self.vault_url, name, error_map={404: ResourceNotFoundError}, **kwargs)
+        bundle = self._client.delete_key(self.vault_url, name, error_map=error_map, **kwargs)
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace
@@ -268,9 +268,7 @@ class KeyClient(KeyVaultClientBase):
                 :caption: Get a key
                 :dedent: 8
         """
-        bundle = self._client.get_key(
-            self.vault_url, name, key_version=version or "", error_map={404: ResourceNotFoundError}, **kwargs
-        )
+        bundle = self._client.get_key(self.vault_url, name, key_version=version or "", error_map=error_map, **kwargs)
         return Key._from_key_bundle(bundle)
 
     @distributed_trace
@@ -295,7 +293,7 @@ class KeyClient(KeyVaultClientBase):
                 :dedent: 8
         """
         # TODO: which exception is raised when soft-delete is not enabled
-        bundle = self._client.get_deleted_key(self.vault_url, name, error_map={404: ResourceNotFoundError}, **kwargs)
+        bundle = self._client.get_deleted_key(self.vault_url, name, error_map=error_map, **kwargs)
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace
@@ -393,11 +391,7 @@ class KeyClient(KeyVaultClientBase):
                 key_client.purge_deleted_key("key-name")
 
         """
-        self._client.purge_deleted_key(
-            vault_base_url=self.vault_url,
-            key_name=name,
-            **kwargs
-        )
+        self._client.purge_deleted_key(vault_base_url=self.vault_url, key_name=name, **kwargs)
 
     @distributed_trace
     def recover_deleted_key(self, name, **kwargs):
@@ -421,11 +415,7 @@ class KeyClient(KeyVaultClientBase):
                 :caption: Recover a deleted key
                 :dedent: 8
         """
-        bundle = self._client.recover_deleted_key(
-            vault_base_url=self.vault_url,
-            key_name=name,
-            **kwargs
-        )
+        bundle = self._client.recover_deleted_key(vault_base_url=self.vault_url, key_name=name, **kwargs)
         return Key._from_key_bundle(bundle)
 
     @distributed_trace
@@ -477,7 +467,7 @@ class KeyClient(KeyVaultClientBase):
             key_ops=key_operations,
             tags=tags,
             key_attributes=attributes,
-            error_map={404: ResourceNotFoundError},
+            error_map=error_map,
             **kwargs
         )
         return Key._from_key_bundle(bundle)
@@ -506,7 +496,7 @@ class KeyClient(KeyVaultClientBase):
                 :caption: Get a key backup
                 :dedent: 8
         """
-        backup_result = self._client.backup_key(self.vault_url, name, error_map={404: ResourceNotFoundError}, **kwargs)
+        backup_result = self._client.backup_key(self.vault_url, name, error_map=error_map, **kwargs)
         return backup_result.value
 
     @distributed_trace
@@ -533,7 +523,7 @@ class KeyClient(KeyVaultClientBase):
                 :caption: Restore a key backup
                 :dedent: 8
         """
-        bundle = self._client.restore_key(self.vault_url, backup, error_map={409: ResourceExistsError}, **kwargs)
+        bundle = self._client.restore_key(self.vault_url, backup, error_map=error_map, **kwargs)
         return Key._from_key_bundle(bundle)
 
     @distributed_trace

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
@@ -70,7 +70,7 @@ class KeyClient(KeyVaultClientBase):
         not_before=None,  # type: Optional[datetime]
         tags=None,  # type: Optional[Dict[str, str]]
         curve=None,  # type: Optional[str]
-        **kwargs  # type: **Any
+        **kwargs  # type: Any
     ):
         # type: (...) -> Key
         """Create a key. If ``name`` is already in use, create a new version of the key. Requires the keys/create
@@ -129,7 +129,7 @@ class KeyClient(KeyVaultClientBase):
         expires=None,  # type: Optional[datetime]
         not_before=None,  # type: Optional[datetime]
         tags=None,  # type: Optional[Dict[str, str]]
-        **kwargs  # type: **Any
+        **kwargs  # type: Any
     ):
         # type: (...) -> Key
         """Create a new RSA key. If ``name`` is already in use, create a new version of the key. Requires the
@@ -181,7 +181,7 @@ class KeyClient(KeyVaultClientBase):
         expires=None,  # type: Optional[datetime]
         not_before=None,  # type: Optional[datetime]
         tags=None,  # type: Optional[Dict[str, str]]
-        **kwargs  # type: **Any
+        **kwargs  # type: Any
     ):
         # type: (...) -> Key
         """Create a new elliptic curve key. If ``name`` is already in use, create a new version of the key. Requires
@@ -428,7 +428,7 @@ class KeyClient(KeyVaultClientBase):
         expires=None,  # type: Optional[datetime]
         not_before=None,  # type: Optional[datetime]
         tags=None,  # type: Optional[Dict[str, str]]
-        **kwargs  # type: **Any
+        **kwargs  # type: Any
     ):
         # type: (...) -> Key
         """Change attributes of a key. Cannot change a key's cryptographic material. Requires the keys/update
@@ -536,7 +536,7 @@ class KeyClient(KeyVaultClientBase):
         not_before=None,  # type: Optional[datetime]
         expires=None,  # type: Optional[datetime]
         tags=None,  # type: Optional[Dict[str, str]]
-        **kwargs  # type: **Any
+        **kwargs  # type: Any
     ):
         # type: (...) -> Key
         """Import an externally created key. If ``name`` is already in use, import the key as a new version. Requires

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
@@ -24,9 +24,9 @@ if TYPE_CHECKING:
 class KeyClient(KeyVaultClientBase):
     """A high-level interface for managing a vault's keys.
 
+    :param str vault_url: URL of the vault the client will access
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity`
-    :param str vault_url: URL of the vault the client will access
 
     Example:
         .. literalinclude:: ../tests/test_samples_keys.py
@@ -41,6 +41,17 @@ class KeyClient(KeyVaultClientBase):
 
     def get_cryptography_client(self, key, **kwargs):
         # type: (Union[Key, str], **Any) -> CryptographyClient
+        """
+        Get a :class:`~azure.keyvault.keys.crypto.CryptographyClient` capable of performing cryptographic operations
+        with a key.
+
+        :param key:
+            Either a :class:`~azure.keyvault.keys.Key` instance as returned by
+            :func:`~azure.keyvault.keys.KeyClient.get_key`, or a string. If a string, the value must be the full
+            identifier of an Azure Key Vault key with a version.
+        :type key: str or :class:`~azure.keyvault.keys.Key`
+        :rtype: :class:`~azure.keyvault.keys.crypto.CryptographyClient`
+        """
 
         # the initializer requires a credential but won't actually use it in this case because we pass in this
         # KeyClient's generated client, whose pipeline (and auth policy) is fully configured
@@ -79,6 +90,7 @@ class KeyClient(KeyVaultClientBase):
         :type curve: ~azure.keyvault.keys.enums.KeyCurveName or str
         :returns: The created key
         :rtype: ~azure.keyvault.keys.models.Key
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -134,6 +146,7 @@ class KeyClient(KeyVaultClientBase):
         :param dict tags: (optional) Application specific metadata in the form of key-value pairs
         :returns: The created key
         :rtype: ~azure.keyvault.keys.models.Key
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -186,6 +199,7 @@ class KeyClient(KeyVaultClientBase):
         :param dict tags: (optional) Application specific metadata in the form of key-value pairs
         :returns: The created key
         :rtype: ~azure.keyvault.keys.models.Key
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -218,7 +232,9 @@ class KeyClient(KeyVaultClientBase):
         :param str name: The name of the key to delete.
         :returns: The deleted key
         :rtype: ~azure.keyvault.keys.models.DeletedKey
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -240,7 +256,9 @@ class KeyClient(KeyVaultClientBase):
         :param str version: (optional) A specific version of the key to get. If not specified, gets the latest version
             of the key.
         :rtype: ~azure.keyvault.keys.models.Key
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -264,6 +282,9 @@ class KeyClient(KeyVaultClientBase):
         :param str name: The name of the key
         :returns: The deleted key
         :rtype: ~azure.keyvault.keys.models.DeletedKey
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -362,6 +383,7 @@ class KeyClient(KeyVaultClientBase):
 
         :param str name: The name of the key
         :returns: None
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. code-block:: python
@@ -389,6 +411,7 @@ class KeyClient(KeyVaultClientBase):
         :param str name: The name of the deleted key
         :returns: The recovered key
         :rtype: ~azure.keyvault.keys.models.Key
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -431,7 +454,9 @@ class KeyClient(KeyVaultClientBase):
         :param dict tags: (optional) Application specific metadata in the form of key-value pairs
         :returns: The updated key
         :rtype: ~azure.keyvault.keys.models.Key
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -469,7 +494,9 @@ class KeyClient(KeyVaultClientBase):
         :param str name: The name of the key
         :returns: The raw bytes of the key backup
         :rtype: bytes
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -494,7 +521,9 @@ class KeyClient(KeyVaultClientBase):
         :param bytes backup: The raw bytes of the key backup
         :returns: The restored key
         :rtype: ~azure.keyvault.keys.models.Key
-        :raises: :class:`~azure.core.exceptions.ResourceExistsError` if the backed up key's name is already in use
+        :raises:
+            :class:`~azure.core.exceptions.ResourceExistsError` if the backed up key's name is already in use,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -533,6 +562,7 @@ class KeyClient(KeyVaultClientBase):
         :param dict tags: (optional) Application specific metadata in the form of key-value pairs
         :returns: The imported key
         :rtype: ~azure.keyvault.keys.models.Key
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         """
         if enabled is not None or not_before is not None or expires is not None:

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/exceptions.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/exceptions.py
@@ -1,0 +1,37 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import functools
+from typing import TYPE_CHECKING
+
+from azure.core.exceptions import DecodeError, ResourceExistsError, ResourceNotFoundError
+from azure.core.pipeline.policies import ContentDecodePolicy
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import,ungrouped-imports
+    from typing import Type
+    from azure.core.exceptions import AzureError
+    from azure.core.pipeline.transport import HttpResponse
+
+
+def get_exception_for_key_vault_error(cls, response):
+    # type: (Type[AzureError], HttpResponse) -> AzureError
+    try:
+        body = ContentDecodePolicy.deserialize_from_http_generics(response)
+        message = "({}) {}".format(body["error"]["code"], body["error"]["message"])
+    except (DecodeError, KeyError):
+        # Key Vault error response bodies have the expected shape and should be deserializable.
+        # If we somehow land here, we'll take HttpResponse's default message.
+        message = None
+
+    return cls(message=message, response=response)
+
+
+_code_to_core_error = {404: ResourceNotFoundError, 409: ResourceExistsError}
+
+# map status codes to callables returning appropriate azure-core errors
+error_map = {
+    status_code: functools.partial(get_exception_for_key_vault_error, cls)
+    for status_code, cls in _code_to_core_error.items()
+}

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/client.py
@@ -16,9 +16,9 @@ from .._shared import AsyncKeyVaultClientBase
 class SecretClient(AsyncKeyVaultClientBase):
     """A high-level asynchronous interface for managing a vault's secrets.
 
+    :param str vault_url: URL of the vault the client will access
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity.aio`
-    :param str vault_url: URL of the vault the client will access
 
     Example:
         .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -38,7 +38,9 @@ class SecretClient(AsyncKeyVaultClientBase):
         :param str name: The name of the secret
         :param str version: (optional) Version of the secret to get. If unspecified, gets the latest version.
         :rtype: ~azure.keyvault.secrets.models.Secret
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -76,6 +78,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         :param datetime.datetime expires: (optional) Expiry date of the secret in UTC
         :param dict tags: (optional) Application specific metadata in the form of key-value pairs
         :rtype: ~azure.keyvault.secrets.models.Secret
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -118,7 +121,9 @@ class SecretClient(AsyncKeyVaultClientBase):
         :param datetime.datetime expires: (optional) Expiry date  of the secret in UTC.
         :param dict(str, str) tags: (optional) Application specific metadata in the form of key-value pairs.
         :rtype: ~azure.keyvault.secrets.models.SecretAttributes
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -201,7 +206,9 @@ class SecretClient(AsyncKeyVaultClientBase):
         :param str name: Name of the secret
         :returns: The raw bytes of the secret backup
         :rtype: bytes
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
          Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -223,7 +230,9 @@ class SecretClient(AsyncKeyVaultClientBase):
         :param bytes backup: The raw bytes of the secret backup
         :returns: The restored secret
         :rtype: ~azure.keyvault.secrets.models.SecretAttributes
-        :raises: :class:`~azure.core.exceptions.ResourceExistsError` if the secret's name is already in use
+        :raises:
+            :class:`~azure.core.exceptions.ResourceExistsError` if the secret's name is already in use,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -244,7 +253,9 @@ class SecretClient(AsyncKeyVaultClientBase):
 
         :param str name: Name of the secret
         :rtype: ~azure.keyvault.secrets.models.DeletedSecret
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -266,7 +277,9 @@ class SecretClient(AsyncKeyVaultClientBase):
 
         :param str name: Name of the secret
         :rtype: ~azure.keyvault.secrets.models.DeletedSecret
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the deleted secret doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the deleted secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -314,6 +327,7 @@ class SecretClient(AsyncKeyVaultClientBase):
 
         :param str name: Name of the secret
         :returns: None
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. code-block:: python
@@ -333,6 +347,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         :param str name: Name of the secret
         :returns: The recovered secret
         :rtype: ~azure.keyvault.secrets.models.SecretAttributes
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
@@ -23,9 +23,9 @@ if TYPE_CHECKING:
 class SecretClient(KeyVaultClientBase):
     """A high-level interface for managing a vault's secrets.
 
+    :param str vault_url: URL of the vault the client will access
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity`
-    :param str vault_url: URL of the vault the client will access
 
     Example:
         .. literalinclude:: ../tests/test_samples_secrets.py
@@ -46,7 +46,9 @@ class SecretClient(KeyVaultClientBase):
         :param str name: The name of the secret
         :param str version: (optional) Version of the secret to get. If unspecified, gets the latest version.
         :rtype: ~azure.keyvault.secrets.models.Secret
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -89,6 +91,7 @@ class SecretClient(KeyVaultClientBase):
         :param datetime.datetime expires: (optional) Expiry date of the secret in UTC
         :param dict tags: (optional) Application specific metadata in the form of key-value pairs
         :rtype: ~azure.keyvault.secrets.models.Secret
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -139,7 +142,9 @@ class SecretClient(KeyVaultClientBase):
         :param datetime.datetime expires: (optional) Expiry date  of the secret in UTC.
         :param dict tags: (optional) Application specific metadata in the form of key-value pairs
         :rtype: ~azure.keyvault.secrets.models.SecretAttributes
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -188,7 +193,7 @@ class SecretClient(KeyVaultClientBase):
         return self._client.get_secrets(
             self._vault_url,
             maxresults=max_page_size,
-            cls=lambda objs: [SecretAttributes._from_secret_item(x) for x in objs],
+            cls=lambda objs: [DeletedSecret._from_secret_item(x) for x in objs],
             **kwargs
         )
 
@@ -216,7 +221,7 @@ class SecretClient(KeyVaultClientBase):
             self._vault_url,
             name,
             maxresults=max_page_size,
-            cls=lambda objs: [SecretAttributes._from_secret_item(x) for x in objs],
+            cls=lambda objs: [DeletedSecret._from_secret_item(x) for x in objs],
             **kwargs
         )
 
@@ -228,7 +233,9 @@ class SecretClient(KeyVaultClientBase):
         :param str name: Name of the secret
         :returns: The raw bytes of the secret backup
         :rtype: bytes
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -252,7 +259,9 @@ class SecretClient(KeyVaultClientBase):
         :param bytes backup: The raw bytes of the secret backup
         :returns: The restored secret
         :rtype: ~azure.keyvault.secrets.models.SecretAttributes
-        :raises: :class:`~azure.core.exceptions.ResourceExistsError` if the secret's name is already in use
+        :raises:
+            :class:`~azure.core.exceptions.ResourceExistsError` if the secret's name is already in use,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -273,7 +282,9 @@ class SecretClient(KeyVaultClientBase):
 
         :param str name: Name of the secret
         :rtype: ~azure.keyvault.secrets.models.DeletedSecret
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -295,7 +306,9 @@ class SecretClient(KeyVaultClientBase):
 
         :param str name: Name of the secret
         :rtype: ~azure.keyvault.secrets.models.DeletedSecret
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the deleted secret doesn't exist
+        :raises:
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the deleted secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -345,6 +358,7 @@ class SecretClient(KeyVaultClientBase):
 
         :param str name: Name of the secret
         :returns: None
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. code-block:: python
@@ -365,6 +379,7 @@ class SecretClient(KeyVaultClientBase):
         :param str name: Name of the secret
         :returns: The recovered secret
         :rtype: ~azure.keyvault.secrets.models.SecretAttributes
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
@@ -193,7 +193,7 @@ class SecretClient(KeyVaultClientBase):
         return self._client.get_secrets(
             self._vault_url,
             maxresults=max_page_size,
-            cls=lambda objs: [DeletedSecret._from_secret_item(x) for x in objs],
+            cls=lambda objs: [SecretAttributes._from_secret_item(x) for x in objs],
             **kwargs
         )
 
@@ -221,7 +221,7 @@ class SecretClient(KeyVaultClientBase):
             self._vault_url,
             name,
             maxresults=max_page_size,
-            cls=lambda objs: [DeletedSecret._from_secret_item(x) for x in objs],
+            cls=lambda objs: [SecretAttributes._from_secret_item(x) for x in objs],
             **kwargs
         )
 


### PR DESCRIPTION
This ensures exceptions raised in lieu of the autorest-generated `KeyVaultErrorException` surface Key Vault's error text.

For example, given a 404 response, `ResourceNotFoundError` is more to the point than `KeyVaultErrorException`. We can use the `error_map` kwarg to raise `ResourceNotFoundError` instead, but without some extra code as in this PR, Key Vault's error text isn't surfaced:
- generated exception: `KeyVaultErrorException: (KeyNotFound) Key not found: imaginary-key`
- naively using `error_map`: `ResourceNotFoundError: Operation returned an invalid status 'Not Found'`
- with this change: `ResourceNotFoundError: (KeyNotFound) Key not found: imaginary-key`

Closes #7003