### PR TITLE
Fix tracing if method raise exception

### DIFF
--- a/sdk/core/azure-core/azure/core/tracing/decorator.py
+++ b/sdk/core/azure-core/azure/core/tracing/decorator.py
@@ -62,12 +62,14 @@ def distributed_trace(func=None, name_of_span=None):
             child = parent_span.span(name=name)
             child.start()
             common.set_span_contexts(child)
-            ans = func(*args, **kwargs) # type: ignore
-            child.finish()
-            common.set_span_contexts(parent_span)
-            if orig_wrapped_span is None and passed_in_parent is None and original_span_instance is None:
-                parent_span.finish()
-            common.set_span_contexts(orig_wrapped_span, span_instance=original_span_instance)
+            try:
+                ans = func(*args, **kwargs) # type: ignore
+            finally:
+                child.finish()
+                common.set_span_contexts(parent_span)
+                if orig_wrapped_span is None and passed_in_parent is None and original_span_instance is None:
+                    parent_span.finish()
+                common.set_span_contexts(orig_wrapped_span, span_instance=original_span_instance)
         else:
             ans = func(*args, **kwargs) # type: ignore
         return ans

--- a/sdk/core/azure-core/azure/core/tracing/decorator_async.py
+++ b/sdk/core/azure-core/azure/core/tracing/decorator_async.py
@@ -62,12 +62,14 @@ def distributed_trace_async(func=None, name_of_span=None):
             child = parent_span.span(name=name)
             child.start()
             common.set_span_contexts(child)
-            ans = await func(*args, **kwargs)   # type: ignore
-            child.finish()
-            common.set_span_contexts(parent_span)
-            if orig_wrapped_span is None and passed_in_parent is None and original_span_instance is None:
-                parent_span.finish()
-            common.set_span_contexts(orig_wrapped_span, span_instance=original_span_instance)
+            try:
+                ans = await func(*args, **kwargs)   # type: ignore
+            finally:
+                child.finish()
+                common.set_span_contexts(parent_span)
+                if orig_wrapped_span is None and passed_in_parent is None and original_span_instance is None:
+                    parent_span.finish()
+                common.set_span_contexts(orig_wrapped_span, span_instance=original_span_instance)
         else:
             ans = await func(*args, **kwargs)   # type: ignore
         return ans


### PR DESCRIPTION
If one of the decorated method was raising an exception, the next span was added under the span of the method that raised the exception, and the global span from customer was lost.

Without fix:
![image](https://user-images.githubusercontent.com/1050156/64560767-05a90580-d2fe-11e9-8b03-9dfbb5c5101f.png)

With fix:
![image](https://user-images.githubusercontent.com/1050156/64560743-f1fd9f00-d2fd-11e9-8353-c1850dd08397.png)
