### PR TITLE
Forcing Storage LiveTests to Run in Serial

### DIFF
--- a/sdk/storage/tests.yml
+++ b/sdk/storage/tests.yml
@@ -3,6 +3,7 @@ trigger: none
 jobs:
   - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
     parameters:
+      MaxParallel: 1
       Matrix:
         Linux_Python35:
           OSName: 'Linux'


### PR DESCRIPTION
setting a maxparallel parameter for the storage livetests. we need to run them in serial for now.

