### PR TITLE
adjusting where inconsistency is set. if we are inconsistent, but the…

### DIFF
--- a/scripts/analyze_deps.py
+++ b/scripts/analyze_deps.py
@@ -183,21 +183,24 @@ if __name__ == '__main__':
         packages, dependencies = get_lib_deps(base_dir)
 
     if args.verbose:
-        print('Packages analyzed:')
+        print('Packages analyzed')
+        print('=================')
         for package in sorted(packages.keys()):
             info = packages[package]
             print("%s %s" % (package, info['version']))
             print("  from %s" % (info['source']))
 
-        print('\n\nRequirements discovered:')
+        print('\n\nRequirements discovered')
+        print('=======================')
         for requirement in sorted(dependencies.keys()):
             specs = dependencies[requirement]
             libs = []
-            print('\n%s' % (requirement))
+            print('%s' % (requirement))
             for spec in specs.keys():
                 print('%s' % (spec if spec else '(empty)'))
                 for lib in specs[spec]:
                     print('  * %s' % (lib))
+            print('')
 
     inconsistent = []
     for requirement in sorted(dependencies.keys()):
@@ -206,16 +209,21 @@ if __name__ == '__main__':
         if num_specs == 1:
             continue
 
+        if not inconsistent and args.verbose:
+            print('\nInconsistencies detected')
+            print('========================')
+
         inconsistent.append(requirement)
         if args.verbose:
-            print("\n\nRequirement '%s' has %s unique specifiers:" % (requirement, num_specs))
+            print("Requirement '%s' has %s unique specifiers:" % (requirement, num_specs))
             for spec in sorted(specs.keys()):
                 libs = specs[spec]
                 friendly_spec = '(none)' if spec == '' else spec
-                print("\n  '%s'" % (friendly_spec))
+                print("  '%s'" % (friendly_spec))
                 print('  ' + ('-' * (len(friendly_spec) + 2)))
                 for lib in sorted(libs):
                     print('    * %s' % (lib))
+                print('')
 
     frozen_filename = os.path.join(base_dir, 'shared_requirements.txt')
     if args.freeze:
@@ -296,11 +304,9 @@ if __name__ == '__main__':
     elif inconsistent:
         exitcode = 1
         if not args.verbose:
-            print('\n\nIncompatible dependency versions detected in libraries, run this script with --verbose for details')
-        else:
-            print('\n')
+            print('\nIncompatible dependency versions detected in libraries, run this script with --verbose for details')
     else:
-        print('\n\nAll library dependencies verified, no incompatible versions detected')
+        print('\nAll library dependencies verified, no incompatible versions detected')
 
     if args.out:
         external = [k for k in dependencies if k not in packages and not should_skip_lib(k)]
@@ -329,6 +335,8 @@ if __name__ == '__main__':
         })
 
     if exitcode == 0:
+        if args.verbose:
+            print('')
         print('All library dependencies validated against frozen requirements')
     elif not args.verbose:
         print('Library dependencies do not match frozen requirements, run this script with --verbose for details')

--- a/scripts/analyze_deps.py
+++ b/scripts/analyze_deps.py
@@ -217,13 +217,11 @@ if __name__ == '__main__':
                 for lib in sorted(libs):
                     print('    * %s' % (lib))
 
-    exitcode = 0
-
     frozen_filename = os.path.join(base_dir, 'shared_requirements.txt')
     if args.freeze:
-        if exitcode != 0:
+        if inconsistent:
             print('Unable to freeze requirements due to incompatible dependency versions')
-            sys.exit(exitcode)
+            sys.exit(1)
         else:
             with io.open(frozen_filename, 'w', encoding='utf-8') as frozen_file:
                 for requirement in sorted(dependencies.keys()):
@@ -249,9 +247,10 @@ if __name__ == '__main__':
                     frozen[req_name] = [spec]
     except:
         print('Unable to open shared_requirements.txt, shared requirements have not been validated')
-        
+
     missing_reqs, new_reqs, changed_reqs = {}, {}, {}
     non_overridden_reqs_count = 0
+    exitcode = 0
     if frozen:
         flat_deps = {req: sorted(dependencies[req].keys()) for req in dependencies}
         missing_reqs, new_reqs, changed_reqs = dict_compare(frozen, flat_deps)

--- a/scripts/analyze_deps.py
+++ b/scripts/analyze_deps.py
@@ -223,7 +223,6 @@ if __name__ == '__main__':
             print('\n\nIncompatible dependency versions detected in libraries, run this script with --verbose for details')
         else:
             print('\n')
-        exitcode = 1
     else:
         print('\n\nAll library dependencies verified, no incompatible versions detected')
 
@@ -257,6 +256,8 @@ if __name__ == '__main__':
                     frozen[req_name] = [spec]
     except:
         print('Unable to open shared_requirements.txt, shared requirements have not been validated')
+        if inconsistent:
+            exitcode = 1
 
     missing_reqs, new_reqs, changed_reqs = {}, {}, {}
     non_overridden_reqs_count = 0

--- a/scripts/analyze_deps.py
+++ b/scripts/analyze_deps.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import argparse
 import ast
 from datetime import datetime

--- a/scripts/analyze_deps.py
+++ b/scripts/analyze_deps.py
@@ -301,8 +301,16 @@ if __name__ == '__main__':
                             print("\nThe following libraries declare requirement '%s' which does not match the frozen requirement '%s':" % (changed_req + spec, changed_req + frozen_specs[0]))
                             for lib in non_overridden_libs:
                                 print("  * %s" % (lib))
+        if exitcode == 0:
+            if args.verbose:
+                print('')
+            print('All library dependencies validated against frozen requirements')
+        elif not args.verbose:
+            print('Library dependencies do not match frozen requirements, run this script with --verbose for details')
     elif inconsistent:
         exitcode = 1
+    
+    if exitcode == 1:
         if not args.verbose:
             print('\nIncompatible dependency versions detected in libraries, run this script with --verbose for details')
     else:
@@ -333,12 +341,5 @@ if __name__ == '__main__':
             'packages': packages,
             'repo_name': 'azure-sdk-for-python'
         })
-
-    if exitcode == 0:
-        if args.verbose:
-            print('')
-        print('All library dependencies validated against frozen requirements')
-    elif not args.verbose:
-        print('Library dependencies do not match frozen requirements, run this script with --verbose for details')
 
     sys.exit(exitcode)

--- a/scripts/analyze_deps.py
+++ b/scripts/analyze_deps.py
@@ -218,13 +218,6 @@ if __name__ == '__main__':
                     print('    * %s' % (lib))
 
     exitcode = 0
-    if inconsistent:
-        if not args.verbose:
-            print('\n\nIncompatible dependency versions detected in libraries, run this script with --verbose for details')
-        else:
-            print('\n')
-    else:
-        print('\n\nAll library dependencies verified, no incompatible versions detected')
 
     frozen_filename = os.path.join(base_dir, 'shared_requirements.txt')
     if args.freeze:
@@ -256,9 +249,7 @@ if __name__ == '__main__':
                     frozen[req_name] = [spec]
     except:
         print('Unable to open shared_requirements.txt, shared requirements have not been validated')
-        if inconsistent:
-            exitcode = 1
-
+        
     missing_reqs, new_reqs, changed_reqs = {}, {}, {}
     non_overridden_reqs_count = 0
     if frozen:
@@ -303,6 +294,14 @@ if __name__ == '__main__':
                             print("\nThe following libraries declare requirement '%s' which does not match the frozen requirement '%s':" % (changed_req + spec, changed_req + frozen_specs[0]))
                             for lib in non_overridden_libs:
                                 print("  * %s" % (lib))
+    elif inconsistent:
+        exitcode = 1
+        if not args.verbose:
+            print('\n\nIncompatible dependency versions detected in libraries, run this script with --verbose for details')
+        else:
+            print('\n')
+    else:
+        print('\n\nAll library dependencies verified, no incompatible versions detected')
 
     if args.out:
         external = [k for k in dependencies if k not in packages and not should_skip_lib(k)]


### PR DESCRIPTION
…re is no lock file, we know that we have to exit with code 1

Sample: updated `azure-storage-blob` to azure-core b3, instead of b2.

![image](https://user-images.githubusercontent.com/45376673/64571771-c5f01700-d319-11e9-90bf-82028dec5e78.png)

![image](https://user-images.githubusercontent.com/45376673/64571799-daccaa80-d319-11e9-9548-f86d0fe88c52.png)

Confirmed that this still errors if I bump the dependency without adding the override to the lock file.
