### PR TITLE
msal_extensions -> msal-extensions

### DIFF
--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -73,7 +73,7 @@ setup(
         "azure-core<2.0.0,>=1.0.0b2",
         "cryptography>=2.1.4",
         "msal~=0.4.1",
-        "msal_extensions~=0.1.1",
+        "msal-extensions~=0.1.1",
         "six>=1.6",
     ],
     extras_require={

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -90,7 +90,7 @@ futures
 mock
 typing
 msal~=0.4.1
-msal_extensions~=0.1.1
+msal-extensions~=0.1.1
 msrest>=0.5.0
 msrestazure<2.0.0,>=0.4.32
 requests>=2.18.4


### PR DESCRIPTION
@scbedd interesting this passed dependency validation up until the release pipeline. The error there (Release-116) was:

> libraries declare requirement 'msal-extensions~=0.1.1' which does not match the frozen requirement 'msal-extensionsmsal_extensions~=0.1.1'