### PR TITLE
[AutoPR automation/resource-manager] fix: Double word "the" in automation

### DIFF
--- a/sdk/automation/azure-mgmt-automation/azure/mgmt/automation/operations/dsc_compilation_job_operations.py
+++ b/sdk/automation/azure-mgmt-automation/azure/mgmt/automation/operations/dsc_compilation_job_operations.py
@@ -95,7 +95,7 @@ class DscCompilationJobOperations(object):
         :type resource_group_name: str
         :param automation_account_name: The name of the automation account.
         :type automation_account_name: str
-        :param compilation_job_name: The the DSC configuration Id.
+        :param compilation_job_name: The DSC configuration Id.
         :type compilation_job_name: str
         :param parameters: The parameters supplied to the create compilation
          job operation.
@@ -151,7 +151,7 @@ class DscCompilationJobOperations(object):
         :type resource_group_name: str
         :param automation_account_name: The name of the automation account.
         :type automation_account_name: str
-        :param compilation_job_name: The the DSC configuration Id.
+        :param compilation_job_name: The DSC configuration Id.
         :type compilation_job_name: str
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the

--- a/sdk/automation/azure-mgmt-automation/azure/mgmt/automation/operations/dsc_configuration_operations.py
+++ b/sdk/automation/azure-mgmt-automation/azure/mgmt/automation/operations/dsc_configuration_operations.py
@@ -386,7 +386,7 @@ class DscConfigurationOperations(object):
         :type filter: str
         :param skip: The number of rows to skip.
         :type skip: int
-        :param top: The the number of rows to take.
+        :param top: The number of rows to take.
         :type top: int
         :param inlinecount: Return total rows.
         :type inlinecount: str

--- a/sdk/automation/azure-mgmt-automation/azure/mgmt/automation/operations/dsc_node_configuration_operations.py
+++ b/sdk/automation/azure-mgmt-automation/azure/mgmt/automation/operations/dsc_node_configuration_operations.py
@@ -273,7 +273,7 @@ class DscNodeConfigurationOperations(object):
         :type filter: str
         :param skip: The number of rows to skip.
         :type skip: int
-        :param top: The the number of rows to take.
+        :param top: The number of rows to take.
         :type top: int
         :param inlinecount: Return total rows.
         :type inlinecount: str

--- a/sdk/automation/azure-mgmt-automation/azure/mgmt/automation/operations/dsc_node_operations.py
+++ b/sdk/automation/azure-mgmt-automation/azure/mgmt/automation/operations/dsc_node_operations.py
@@ -251,7 +251,7 @@ class DscNodeOperations(object):
         :type filter: str
         :param skip: The number of rows to skip.
         :type skip: int
-        :param top: The the number of rows to take.
+        :param top: The number of rows to take.
         :type top: int
         :param inlinecount: Return total rows.
         :type inlinecount: str


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/7180