### PR TITLE
[AutoPR iothub/resource-manager] fix: Double word "the" in iothub

### DIFF
--- a/sdk/iothub/azure-mgmt-iothub/azure/mgmt/iothub/models/_models.py
+++ b/sdk/iothub/azure-mgmt-iothub/azure/mgmt/iothub/models/_models.py
@@ -781,7 +781,7 @@ class IotHubLocationDescription(Model):
     :type location: str
     :param role: The role of the region, can be either primary or secondary.
      The primary region is where the IoT hub is currently provisioned. The
-     secondary region is the the Azure disaster recovery (DR) paired region and
+     secondary region is the Azure disaster recovery (DR) paired region and
      also the region where the IoT hub can failover to. Possible values
      include: 'primary', 'secondary'
     :type role: str or ~azure.mgmt.iothub.models.IotHubReplicaRoleType

--- a/sdk/iothub/azure-mgmt-iothub/azure/mgmt/iothub/models/_models_py3.py
+++ b/sdk/iothub/azure-mgmt-iothub/azure/mgmt/iothub/models/_models_py3.py
@@ -781,7 +781,7 @@ class IotHubLocationDescription(Model):
     :type location: str
     :param role: The role of the region, can be either primary or secondary.
      The primary region is where the IoT hub is currently provisioned. The
-     secondary region is the the Azure disaster recovery (DR) paired region and
+     secondary region is the Azure disaster recovery (DR) paired region and
      also the region where the IoT hub can failover to. Possible values
      include: 'primary', 'secondary'
     :type role: str or ~azure.mgmt.iothub.models.IotHubReplicaRoleType


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/7183