### PR TITLE
class links with extra text need :class:

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
@@ -204,7 +204,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :param str name: The name of the key to delete.
         :returns: The deleted key
         :rtype: ~azure.keyvault.keys.models.DeletedKey
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the key doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -225,7 +225,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :param str version: (optional) A specific version of the key to get. If not specified, gets the latest version
             of the key.
         :rtype: ~azure.keyvault.keys.models.Key
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the key doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -405,7 +405,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :param dict tags: (optional) Application specific metadata in the form of key-value pairs
         :returns: The updated key
         :rtype: ~azure.keyvault.keys.models.Key
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the key doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -443,7 +443,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :param str name: The name of the key
         :returns: The raw bytes of the key backup
         :rtype: bytes
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the key doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -469,7 +469,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :param bytes backup: The raw bytes of the key backup
         :returns: The restored key
         :rtype: ~azure.keyvault.keys.models.Key
-        :raises: ~azure.core.exceptions.ResourceExistsError if the backed up key's name is already in use
+        :raises: :class:`~azure.core.exceptions.ResourceExistsError` if the backed up key's name is already in use
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
@@ -218,7 +218,7 @@ class KeyClient(KeyVaultClientBase):
         :param str name: The name of the key to delete.
         :returns: The deleted key
         :rtype: ~azure.keyvault.keys.models.DeletedKey
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the key doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -240,7 +240,7 @@ class KeyClient(KeyVaultClientBase):
         :param str version: (optional) A specific version of the key to get. If not specified, gets the latest version
             of the key.
         :rtype: ~azure.keyvault.keys.models.Key
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the key doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -431,7 +431,7 @@ class KeyClient(KeyVaultClientBase):
         :param dict tags: (optional) Application specific metadata in the form of key-value pairs
         :returns: The updated key
         :rtype: ~azure.keyvault.keys.models.Key
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the key doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -469,7 +469,7 @@ class KeyClient(KeyVaultClientBase):
         :param str name: The name of the key
         :returns: The raw bytes of the key backup
         :rtype: bytes
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the key doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -494,7 +494,7 @@ class KeyClient(KeyVaultClientBase):
         :param bytes backup: The raw bytes of the key backup
         :returns: The restored key
         :rtype: ~azure.keyvault.keys.models.Key
-        :raises: ~azure.core.exceptions.ResourceExistsError if the backed up key's name is already in use
+        :raises: :class:`~azure.core.exceptions.ResourceExistsError` if the backed up key's name is already in use
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/client.py
@@ -38,7 +38,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         :param str name: The name of the secret
         :param str version: (optional) Version of the secret to get. If unspecified, gets the latest version.
         :rtype: ~azure.keyvault.secrets.models.Secret
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -118,7 +118,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         :param datetime.datetime expires: (optional) Expiry date  of the secret in UTC.
         :param dict(str, str) tags: (optional) Application specific metadata in the form of key-value pairs.
         :rtype: ~azure.keyvault.secrets.models.SecretAttributes
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -201,7 +201,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         :param str name: Name of the secret
         :returns: The raw bytes of the secret backup
         :rtype: bytes
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist
 
          Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -223,7 +223,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         :param bytes backup: The raw bytes of the secret backup
         :returns: The restored secret
         :rtype: ~azure.keyvault.secrets.models.SecretAttributes
-        :raises: ~azure.core.exceptions.ResourceExistsError if the secret's name is already in use
+        :raises: :class:`~azure.core.exceptions.ResourceExistsError` if the secret's name is already in use
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -244,7 +244,7 @@ class SecretClient(AsyncKeyVaultClientBase):
 
         :param str name: Name of the secret
         :rtype: ~azure.keyvault.secrets.models.DeletedSecret
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -266,7 +266,7 @@ class SecretClient(AsyncKeyVaultClientBase):
 
         :param str name: Name of the secret
         :rtype: ~azure.keyvault.secrets.models.DeletedSecret
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the deleted secret doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the deleted secret doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
@@ -46,7 +46,7 @@ class SecretClient(KeyVaultClientBase):
         :param str name: The name of the secret
         :param str version: (optional) Version of the secret to get. If unspecified, gets the latest version.
         :rtype: ~azure.keyvault.secrets.models.Secret
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -139,7 +139,7 @@ class SecretClient(KeyVaultClientBase):
         :param datetime.datetime expires: (optional) Expiry date  of the secret in UTC.
         :param dict tags: (optional) Application specific metadata in the form of key-value pairs
         :rtype: ~azure.keyvault.secrets.models.SecretAttributes
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -228,7 +228,7 @@ class SecretClient(KeyVaultClientBase):
         :param str name: Name of the secret
         :returns: The raw bytes of the secret backup
         :rtype: bytes
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -252,7 +252,7 @@ class SecretClient(KeyVaultClientBase):
         :param bytes backup: The raw bytes of the secret backup
         :returns: The restored secret
         :rtype: ~azure.keyvault.secrets.models.SecretAttributes
-        :raises: ~azure.core.exceptions.ResourceExistsError if the secret's name is already in use
+        :raises: :class:`~azure.core.exceptions.ResourceExistsError` if the secret's name is already in use
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -273,7 +273,7 @@ class SecretClient(KeyVaultClientBase):
 
         :param str name: Name of the secret
         :rtype: ~azure.keyvault.secrets.models.DeletedSecret
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -295,7 +295,7 @@ class SecretClient(KeyVaultClientBase):
 
         :param str name: Name of the secret
         :rtype: ~azure.keyvault.secrets.models.DeletedSecret
-        :raises: ~azure.core.exceptions.ResourceNotFoundError if the deleted secret doesn't exist
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError` if the deleted secret doesn't exist
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py


### PR DESCRIPTION
If there is additional text after the `~foo.bar.Baz` then the implicit syntax [fails to render properly](https://azure.github.io/azure-sdk-for-python/ref/azure.keyvault.secrets.html#azure.keyvault.secrets.client.SecretClient.update_secret):

<img width="400" alt="Screen Shot 2019-09-11 at 1 19 35 PM" src="https://user-images.githubusercontent.com/1078448/64733201-23f73880-d499-11e9-93a6-15b0ecbf91b9.png">

After this change:

<img width="400" alt="Screen Shot 2019-09-11 at 1 33 11 PM" src="https://user-images.githubusercontent.com/1078448/64733235-340f1800-d499-11e9-8a18-b4ce8f11800f.png">

( I only built the KV docs locally, so there is no link for the external class, but it renders correctly)