### PR TITLE
handle 0 packages being passed to dev_setup from setup_execute_tests.py

### DIFF
--- a/scripts/devops_tasks/setup_execute_tests.py
+++ b/scripts/devops_tasks/setup_execute_tests.py
@@ -253,6 +253,9 @@ if __name__ == "__main__":
     targeted_packages = process_glob_string(args.glob_string, target_dir)
     extended_pytest_args = []
 
+    if len(targeted_packages) == 0:
+        exit(0) 
+
     # common argument handling
     if args.disablecov:
         extended_pytest_args.append("--no-cov")


### PR DESCRIPTION
When we target a specific release, we are getting multiple packages now. This is the incorrect behavior. We should correctly skip past this on py27.