### PR TITLE
Un-use deprecated method in devtools

### DIFF
--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/utilities.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/utilities.py
@@ -70,7 +70,7 @@ def trim_kwargs_from_test_function(fn, kwargs):
     # the next function is the actual test function. the kwargs need to be trimmed so
     # that parameters which are not required will not be passed to it.
     if not is_preparer_func(fn):
-        args, _, kw, _ = inspect.getargspec(fn)  # pylint: disable=deprecated-method
+        args, _, kw, _, _, _, _ = inspect.getfullargspec(fn)
         if kw is None:
             args = set(args)
             for key in [k for k in kwargs if k not in args]:

--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/utilities.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/utilities.py
@@ -70,7 +70,10 @@ def trim_kwargs_from_test_function(fn, kwargs):
     # the next function is the actual test function. the kwargs need to be trimmed so
     # that parameters which are not required will not be passed to it.
     if not is_preparer_func(fn):
-        args, _, kw, _, _, _, _ = inspect.getfullargspec(fn)
+        try:
+            args, _, kw, _, _, _, _ = inspect.getfullargspec(fn)
+        except AttributeError:
+            args, _, kw, _ = inspect.getargspec(fn) # pylint: disable=deprecated-method
         if kw is None:
             args = set(args)
             for key in [k for k in kwargs if k not in args]:


### PR DESCRIPTION
Use of deprecated method is giving a lot of log warnings while running tests. 

`DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()`

Note: Warning is occurring everytime [this line ](https://github.com/Azure/azure-sdk-for-python/blob/824a5a24772296defe0cd284a0aa368f9475599d/tools/azure-devtools/src/azure_devtools/scenario_tests/preparers.py#L47) is executed
