### PR TITLE
Resolve CheckpointStore Doc Gen

### DIFF
--- a/.azure-pipelines/docs.yml
+++ b/.azure-pipelines/docs.yml
@@ -22,7 +22,7 @@ jobs:
         displayName: 'Install All Packages'
         inputs:
           scriptPath: 'scripts/dev_setup.py'
-          arguments: '--exceptionlist=azure-eventhubs-checkpointstoreblob-aio'
+          arguments: '--exceptionlist=azure-eventhubs,azure-eventhubs-checkpointstoreblob-aio'
 
       - powershell: |
           cd $(Build.SourcesDirectory)/doc/sphinx


### PR DESCRIPTION
Both eventhubs and checkpointstore must be installed in non-dev mode.

This bugfix should work unless someone else installs `azure-eventhub ` in dev mode as a dev requirement.

I'm getting this ball rolling for checkin just in case I'm correct.