### PR TITLE
Fix error creating EnvironmentCredential with username/password

### DIFF
--- a/sdk/identity/azure-identity/HISTORY.md
+++ b/sdk/identity/azure-identity/HISTORY.md
@@ -1,5 +1,12 @@
 # Release History
 
+## 1.0.0b4
+### Fixes and improvements:
+- `UsernamePasswordCredential` correctly handles environment configuration with
+no tenant information (#7260)
+- MSAL's user realm discovery requests are sent through credential
+pipelines (#7260)
+
 ## 1.0.0b3 (2019-09-10)
 ### New features:
 - `SharedTokenCacheCredential` authenticates with tokens stored in a local

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
@@ -21,11 +21,6 @@ except AttributeError:  # Python 2.7, abc exists, but not ABC
     ABC = abc.ABCMeta("ABC", (object,), {"__slots__": ()})  # type: ignore
 
 try:
-    from unittest import mock
-except ImportError:  # python < 3.3
-    import mock  # type: ignore
-
-try:
     from typing import TYPE_CHECKING
 except ImportError:
     TYPE_CHECKING = False

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
@@ -68,6 +68,7 @@ class MsalCredential(ABC):
             app = cls(client_id=self._client_id, client_credential=self._client_credential, authority=self._authority)
 
         # monkeypatch the app to replace requests.Session with MsalTransportAdapter
+        app.client.session.close()
         app.client.session = self._adapter
 
         return app

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
@@ -106,8 +106,9 @@ class PublicClientCredential(MsalCredential):
 
     def __init__(self, **kwargs):
         # type: (Any) -> None
+        tenant = kwargs.pop("tenant", None) or "organizations"
         super(PublicClientCredential, self).__init__(
-            authority="https://login.microsoftonline.com/" + kwargs.pop("tenant", "organizations"), **kwargs
+            authority="https://login.microsoftonline.com/" + tenant, **kwargs
         )
 
     @abc.abstractmethod

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
@@ -64,7 +64,7 @@ class MsalCredential(ABC):
         """Creates an MSAL application, patching msal.authority to use an azure-core pipeline during tenant discovery"""
 
         # MSAL application initializers use msal.authority to send AAD tenant discovery requests
-        with mock.patch("msal.authority.requests", self._adapter):
+        with self._adapter:
             app = cls(client_id=self._client_id, client_credential=self._client_credential, authority=self._authority)
 
         # monkeypatch the app to replace requests.Session with MsalTransportAdapter

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
@@ -61,7 +61,8 @@ class MsalTransportAdapter(object):
         self._pipeline = self._build_pipeline(**kwargs)
 
     def __enter__(self):
-        return self._patch.__enter__()
+        self._patch.__enter__()
+        return self
 
     def __exit__(self, *args):
         self._patch.__exit__(*args)

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
@@ -23,7 +23,7 @@ except ImportError:
     TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    # pylint:disable=unused-import
+    # pylint:disable=unused-import,ungrouped-imports
     from typing import Any, Dict, Mapping, Optional
     from azure.core.pipeline import PipelineResponse
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
@@ -38,7 +38,8 @@ class MsalTransportResponse:
 
     def raise_for_status(self):
         # type: () -> None
-        raise ClientAuthenticationError("authentication failed", self._response)
+        if self.status_code >= 400:
+            raise ClientAuthenticationError("authentication failed", self._response)
 
 
 class MsalTransportAdapter(object):

--- a/sdk/identity/azure-identity/azure/identity/credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/credentials.py
@@ -433,9 +433,10 @@ class UsernamePasswordCredential(PublicClientCredential):
 
         if not result:
             # cache miss -> request a new token
-            result = app.acquire_token_by_username_password(
-                username=self._username, password=self._password, scopes=scopes
-            )
+            with self._adapter:
+                result = app.acquire_token_by_username_password(
+                    username=self._username, password=self._password, scopes=scopes
+                )
 
         if "access_token" not in result:
             raise ClientAuthenticationError(message="authentication failed: {}".format(result.get("error_description")))

--- a/sdk/identity/azure-identity/tests/test_identity.py
+++ b/sdk/identity/azure-identity/tests/test_identity.py
@@ -411,10 +411,13 @@ def test_interactive_credential_timeout():
 def test_username_password_credential():
     expected_token = "access-token"
     transport = validating_transport(
-        requests=[Request()] * 2,  # not validating requests because they're formed by MSAL
+        requests=[Request()] * 3,  # not validating requests because they're formed by MSAL
         responses=[
-            # expecting tenant discovery then a token request
+            # tenant discovery
             mock_response(json_payload={"authorization_endpoint": "https://a/b", "token_endpoint": "https://a/b"}),
+            # user realm discovery, interests MSAL only when the response body contains account_type == "Federated"
+            mock_response(json_payload={}),
+            # token request
             mock_response(
                 json_payload={
                     "access_token": expected_token,


### PR DESCRIPTION
When `UsernamePasswordCredential` is instantiated by `EnvironmentCredential` and `$AZURE_TENANT_ID` has no value, a base class initializer raises because it gets `None` where it expects a string. This ensures it gets a string and adds a test covering the case.

This PR also makes `MsalTransportAdapter` a context manager `UsernamePasswordCredential` uses to apply a patch before each token request. This is to ensure the discovery request MSAL sends before its token request is sent through the credential's pipeline rather than `requests` directly.

One existing limitation of the adapter design not addressed here is that in a multi-threaded application using MSAL directly, MSAL may send requests originating outside `azure-identity` through a credential's pipeline.