### PR TITLE
Correct return type for list_secrets, _versions

### DIFF
--- a/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
@@ -1,4 +1,9 @@
 # Release History
+
+## 4.0.0b4
+### Fixes and improvements
+- `list_secrets` and `list_secret_versions` return the correct type
+
 ## 4.0.0b3 (2019-09-11)
 This release includes only internal changes.
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
@@ -188,7 +188,7 @@ class SecretClient(KeyVaultClientBase):
         return self._client.get_secrets(
             self._vault_url,
             maxresults=max_page_size,
-            cls=lambda objs: [DeletedSecret._from_secret_item(x) for x in objs],
+            cls=lambda objs: [SecretAttributes._from_secret_item(x) for x in objs],
             **kwargs
         )
 
@@ -216,7 +216,7 @@ class SecretClient(KeyVaultClientBase):
             self._vault_url,
             name,
             maxresults=max_page_size,
-            cls=lambda objs: [DeletedSecret._from_secret_item(x) for x in objs],
+            cls=lambda objs: [SecretAttributes._from_secret_item(x) for x in objs],
             **kwargs
         )
 


### PR DESCRIPTION
#6558 changed these to return `DeletedSecret` instead of `SecretAttributes`. Tests passed because `DeletedSecret` inherits `SecretAttributes`, and we don't validate return types.