### PR TITLE
Resolve faulty package filter when building for release

### DIFF
--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -22,7 +22,7 @@ steps:
     displayName: 'Generate Python2 Applicable Namespace Packages'
     inputs:
       scriptPath: 'scripts/devops_tasks/build_packages.py'
-      arguments: '-d "$(Build.ArtifactStagingDirectory)" "*-nspkg" --service=${{parameters.ServiceDirectory}}'
+      arguments: '-d "$(Build.ArtifactStagingDirectory)" "${{ parameters.BuildTargetingString }}" --pkgfilter="nspkg" --service=${{parameters.ServiceDirectory}}'
 
   - task: UsePythonVersion@0
     displayName: 'Use Python $(PythonVersion)'

--- a/scripts/devops_tasks/build_packages.py
+++ b/scripts/devops_tasks/build_packages.py
@@ -64,6 +64,15 @@ if __name__ == "__main__":
         ),
     )
 
+    parser.add_argument(
+        "--pkgfilter",
+        default="",
+        dest="package_filter_string",
+        help=(
+            "An additional string used to filter the set of artifacts by a simple CONTAINS clause. This filters packages AFTER the set is built with compatibility and omission lists accounted."
+        ),
+    )
+
     args = parser.parse_args()
 
     # We need to support both CI builds of everything and individual service
@@ -74,5 +83,5 @@ if __name__ == "__main__":
     else:
         target_dir = root_dir
 
-    targeted_packages = process_glob_string(args.glob_string, target_dir)
+    targeted_packages = process_glob_string(args.glob_string, target_dir, args.package_filter_string)
     build_packages(targeted_packages, args.distribution_directory)

--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -131,7 +131,7 @@ def filter_for_compatibility(package_set):
 # this function is where a glob string gets translated to a list of packages
 # It is called by both BUILD (package) and TEST. In the future, this function will be the central location
 # for handling targeting of release packages
-def process_glob_string(glob_string, target_root_dir):
+def process_glob_string(glob_string, target_root_dir, additional_contains_filter=""):
     if glob_string:
         individual_globs = glob_string.split(",")
     else:
@@ -145,7 +145,7 @@ def process_glob_string(glob_string, target_root_dir):
         collected_top_level_directories.extend([os.path.dirname(p) for p in globbed])
 
     # dedup, in case we have double coverage from the glob strings. Example: "azure-mgmt-keyvault,azure-mgmt-*"
-    collected_directories = list(set(collected_top_level_directories))
+    collected_directories = list(set([p for p in collected_top_level_directories if additional_contains_filter in p]))
     
     # if we have individually queued this specific package, it's obvious that we want to build it specifically
     # in this case, do not honor the omission list

--- a/scripts/devops_tasks/setup_execute_tests.py
+++ b/scripts/devops_tasks/setup_execute_tests.py
@@ -186,15 +186,6 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--pkgfilter",
-        default="",
-        dest="package_filter_string",
-        help=(
-            "An additional string used to filter the set of artifacts by a simple CONTAINS clause. This filters packages AFTER the set is built with compatibility and omission lists accounted."
-        ),
-    )
-
-    parser.add_argument(
         "--junitxml",
         dest="test_results",
         help=(
@@ -259,7 +250,7 @@ if __name__ == "__main__":
     else:
         target_dir = root_dir
 
-    targeted_packages = process_glob_string(args.glob_string, target_dir, args.package_filter_string)
+    targeted_packages = process_glob_string(args.glob_string, target_dir)
     extended_pytest_args = []
 
     if len(targeted_packages) == 0:

--- a/scripts/devops_tasks/setup_execute_tests.py
+++ b/scripts/devops_tasks/setup_execute_tests.py
@@ -186,6 +186,15 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "--pkgfilter",
+        default="",
+        dest="package_filter_string",
+        help=(
+            "An additional string used to filter the set of artifacts by a simple CONTAINS clause. This filters packages AFTER the set is built with compatibility and omission lists accounted."
+        ),
+    )
+
+    parser.add_argument(
         "--junitxml",
         dest="test_results",
         help=(
@@ -250,7 +259,7 @@ if __name__ == "__main__":
     else:
         target_dir = root_dir
 
-    targeted_packages = process_glob_string(args.glob_string, target_dir)
+    targeted_packages = process_glob_string(args.glob_string, target_dir, args.package_filter_string)
     extended_pytest_args = []
 
     if len(targeted_packages) == 0:


### PR DESCRIPTION
Simply put, in a service dir context: the filter works appropriately:

`setup_execute_tests.py azure-* service==<servicedir>`

This worked properly. Building all nspkgs under the service dir wasn't wrong.

The issue was, when we targeted a _single package_ we still generated artifacts for all the nspkgs! This was due to the fact that the filter on `npskg` being built for py2 needs to be an AND clause, not an OR clause.

