### PR TITLE
Remove create_config from READMEs

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/README.md
+++ b/sdk/keyvault/azure-keyvault-certificates/README.md
@@ -269,9 +269,8 @@ logger.addHandler(handler)
 file_handler = logging.FileHandler(filename)
 logger.addHandler(file_handler)
 
-# Enable network trace logging. This will be logged at DEBUG level.
-config = CertificateClient.create_config(credential=credential, logging_enable=True)
-client = CertificateClient(vault_url=url, credential=credential, config=config)
+# Enable network trace logging. Each HTTP request will be logged at DEBUG level.
+client = CertificateClient(vault_url=url, credential=credential, logging_enable=True))
 ```
 
 Network trace logging can also be enabled for any single operation:

--- a/sdk/keyvault/azure-keyvault-keys/README.md
+++ b/sdk/keyvault/azure-keyvault-keys/README.md
@@ -302,9 +302,8 @@ logger.addHandler(handler)
 file_handler = logging.FileHandler(filename)
 logger.addHandler(file_handler)
 
-# Enable network trace logging to log all HTTP requests at DEBUG level
-config = KeyClient.create_config(credential, logging_enable=True)
-client = KeyClient(vault_url, credential, config=config)
+# Enable network trace logging. Each HTTP request will be logged at DEBUG level.
+client = KeyClient(vault_url=url, credential=credential, logging_enable=True)
 ```
 
 Network trace logging can also be enabled for any single operation:

--- a/sdk/keyvault/azure-keyvault-secrets/README.md
+++ b/sdk/keyvault/azure-keyvault-secrets/README.md
@@ -274,9 +274,8 @@ logger.addHandler(handler)
 file_handler = logging.FileHandler(filename)
 logger.addHandler(file_handler)
 
-# Enable network trace logging to log all HTTP requests at DEBUG level
-config = SecretClient.create_config(credential, logging_enable=True)
-client = SecretClient(url, credential, config=config)
+# Enable network trace logging. Each HTTP request will be logged at DEBUG level.
+client = SecretClient(vault_url=url, credential=credential, logging_enable=True)
 ```
 
 Network trace logging can also be enabled for any single operation:


### PR DESCRIPTION
We removed `create_config` from the client API when switching to kwarg-based configuration.