### PR TITLE
use xdist in live tests (optional) and in nightly tests (default)

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-nightly.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-nightly.yml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
     - template: ../steps/build-artifacts.yml
-      parameters: 
+      parameters:
         ServiceDirectory: ${{ parameters.ServiceDirectory }}
         BuildTargetingString: ${{ parameters.BuildTargetingString }}
         BeforePublishSteps: ${{ parameters.BeforePublishSteps }}
-          
+
   - job: 'Analyze'
     variables:
     - template: ../variables/globals.yml
@@ -39,7 +39,7 @@ jobs:
     dependsOn:
        - 'Build'
 
-    timeoutInMinutes: 270
+    timeoutInMinutes: 240
 
     strategy:
       matrix:
@@ -83,17 +83,17 @@ jobs:
 
     steps:
     - template: ../steps/test-nightly.yml
-      parameters: 
+      parameters:
         ServiceDirectory: ${{ parameters.ServiceDirectory }}
         TestMarkArgument: ${{ parameters.TestMarkArgument }}
         OSName: $(OSName)
         PythonVersion: $(PythonVersion)
         BuildTargetingString: ${{ parameters.BuildTargetingString }}
-        AdditionalTestArgs: '--wheel_dir="$(Build.ArtifactStagingDirectory)"'
+        AdditionalTestArgs: '--wheel_dir="$(Build.ArtifactStagingDirectory)" -x'
         CoverageArg: $(CoverageArg)
-        BeforeTestSteps: 
+        BeforeTestSteps:
           - task: DownloadPipelineArtifact@0
             inputs:
-              artifactName: 'artifacts' 
+              artifactName: 'artifacts'
               targetPath: $(Build.ArtifactStagingDirectory)
         ToxTestEnv: "whl,sdist"

--- a/eng/pipelines/templates/jobs/archetype-sdk-nightly.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-nightly.yml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
     - template: ../steps/build-artifacts.yml
-      parameters:
+      parameters: 
         ServiceDirectory: ${{ parameters.ServiceDirectory }}
         BuildTargetingString: ${{ parameters.BuildTargetingString }}
         BeforePublishSteps: ${{ parameters.BeforePublishSteps }}
-
+          
   - job: 'Analyze'
     variables:
     - template: ../variables/globals.yml
@@ -39,7 +39,7 @@ jobs:
     dependsOn:
        - 'Build'
 
-    timeoutInMinutes: 240
+    timeoutInMinutes: 270
 
     strategy:
       matrix:
@@ -83,17 +83,17 @@ jobs:
 
     steps:
     - template: ../steps/test-nightly.yml
-      parameters:
+      parameters: 
         ServiceDirectory: ${{ parameters.ServiceDirectory }}
         TestMarkArgument: ${{ parameters.TestMarkArgument }}
         OSName: $(OSName)
         PythonVersion: $(PythonVersion)
         BuildTargetingString: ${{ parameters.BuildTargetingString }}
-        AdditionalTestArgs: '--wheel_dir="$(Build.ArtifactStagingDirectory)" -x'
+        AdditionalTestArgs: '--wheel_dir="$(Build.ArtifactStagingDirectory)"'
         CoverageArg: $(CoverageArg)
-        BeforeTestSteps:
+        BeforeTestSteps: 
           - task: DownloadPipelineArtifact@0
             inputs:
-              artifactName: 'artifacts'
+              artifactName: 'artifacts' 
               targetPath: $(Build.ArtifactStagingDirectory)
         ToxTestEnv: "whl,sdist"

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -4,6 +4,7 @@ parameters:
   MaxParallel: 0
   BeforeTestSteps: []
   BuildTargetingString: 'azure-*'
+  AdditionalTestArgs: ''
   TestMarkArgument: ''
   Matrix:
     Linux_Python35:
@@ -45,4 +46,5 @@ jobs:
           PythonVersion: $(PythonVersion)
           OSName: $(OSName)
           ToxTestEnv: "whl"
+          AdditionalTestArgs: ${{ parameters.AdditionalTestArgs }}
           TestMarkArgument: ${{ parameters.TestMarkArgument }}

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -3,10 +3,11 @@
 envlist = whl,sdist
 
 [base]
-deps = 
+deps =
   -rdev_requirements.txt
   pytest-custom_exit_code
   pytest-cov
+  pytest-xdist
   coverage
 
 [testenv]

--- a/scripts/devops_tasks/setup_execute_tests.py
+++ b/scripts/devops_tasks/setup_execute_tests.py
@@ -240,6 +240,14 @@ if __name__ == "__main__":
         help="Location for prebuilt artifacts (if any)",
     )
 
+    parser.add_argument(
+        "-x",
+        "--xdist",
+        default=False,
+        help=("Flag that enables xdist (requires pip install)"),
+        action="store_true"
+    )
+
     args = parser.parse_args()
 
     # We need to support both CI builds of everything and individual service
@@ -261,6 +269,9 @@ if __name__ == "__main__":
         extended_pytest_args.append("--no-cov")
     else:
         extended_pytest_args.extend(["--durations=10", "--cov", "--cov-report="])
+
+    if args.xdist:
+        extended_pytest_args.append(["-n", " auto"])
 
     if args.runtype != "none":
         execute_global_install_and_test(args, targeted_packages, extended_pytest_args)

--- a/scripts/devops_tasks/setup_execute_tests.py
+++ b/scripts/devops_tasks/setup_execute_tests.py
@@ -271,7 +271,7 @@ if __name__ == "__main__":
         extended_pytest_args.extend(["--durations=10", "--cov", "--cov-report="])
 
     if args.xdist:
-        extended_pytest_args.extend(["-n", "auto"])
+        extended_pytest_args.extend(["-n", "8"])
 
     if args.runtype != "none":
         execute_global_install_and_test(args, targeted_packages, extended_pytest_args)

--- a/scripts/devops_tasks/setup_execute_tests.py
+++ b/scripts/devops_tasks/setup_execute_tests.py
@@ -271,7 +271,7 @@ if __name__ == "__main__":
         extended_pytest_args.extend(["--durations=10", "--cov", "--cov-report="])
 
     if args.xdist:
-        extended_pytest_args.append(["-n", " auto"])
+        extended_pytest_args.extend(["-n", " auto"])
 
     if args.runtype != "none":
         execute_global_install_and_test(args, targeted_packages, extended_pytest_args)

--- a/scripts/devops_tasks/setup_execute_tests.py
+++ b/scripts/devops_tasks/setup_execute_tests.py
@@ -271,7 +271,7 @@ if __name__ == "__main__":
         extended_pytest_args.extend(["--durations=10", "--cov", "--cov-report="])
 
     if args.xdist:
-        extended_pytest_args.extend(["-n", " auto"])
+        extended_pytest_args.extend(["-n", "auto"])
 
     if args.runtype != "none":
         execute_global_install_and_test(args, targeted_packages, extended_pytest_args)


### PR DESCRIPTION
Add ability to use xdist into python live tests

I explored using this with the client build to improve performance. It cut our longest test time down by 50% (windows pypy), however there were some failures in that pipeline. To that end this change focuses entirely on providing the xdist capability to live tests for use in Key Vault today and others in the future. 