### PR TITLE
Patch os.environ in Identity mock tests

### DIFF
--- a/sdk/identity/azure-identity/tests/test_identity.py
+++ b/sdk/identity/azure-identity/tests/test_identity.py
@@ -94,7 +94,7 @@ def test_client_secret_credential():
     assert token.token == access_token
 
 
-def test_client_secret_environment_credential(monkeypatch):
+def test_client_secret_environment_credential():
     client_id = "fake-client-id"
     secret = "fake-client-secret"
     tenant_id = "fake-tenant-id"
@@ -114,11 +114,13 @@ def test_client_secret_environment_credential(monkeypatch):
         ],
     )
 
-    monkeypatch.setenv(EnvironmentVariables.AZURE_CLIENT_ID, client_id)
-    monkeypatch.setenv(EnvironmentVariables.AZURE_CLIENT_SECRET, secret)
-    monkeypatch.setenv(EnvironmentVariables.AZURE_TENANT_ID, tenant_id)
-
-    token = EnvironmentCredential(transport=transport).get_token("scope")
+    environment = {
+        EnvironmentVariables.AZURE_CLIENT_ID: client_id,
+        EnvironmentVariables.AZURE_CLIENT_SECRET: secret,
+        EnvironmentVariables.AZURE_TENANT_ID: tenant_id,
+    }
+    with patch("os.environ", environment):
+        token = EnvironmentCredential(transport=transport).get_token("scope")
 
     # not validating expires_on because doing so requires monkeypatching time, and this is tested elsewhere
     assert token.token == access_token
@@ -341,7 +343,9 @@ def test_device_code_credential_timeout():
     assert "timed out" in ex.value.message.lower()
 
 
-@patch("azure.identity._credentials.browser.webbrowser.open", lambda _: None)  # prevent the credential opening a browser
+@patch(
+    "azure.identity._credentials.browser.webbrowser.open", lambda _: None
+)  # prevent the credential opening a browser
 def test_interactive_credential():
     oauth_state = "state"
     expected_token = "access-token"
@@ -380,7 +384,9 @@ def test_interactive_credential():
     assert token.token == expected_token
 
 
-@patch("azure.identity._credentials.browser.webbrowser.open", lambda _: None)  # prevent the credential opening a browser
+@patch(
+    "azure.identity._credentials.browser.webbrowser.open", lambda _: None
+)  # prevent the credential opening a browser
 def test_interactive_credential_timeout():
     # mock transport handles MSAL's tenant discovery
     transport = Mock(
@@ -441,7 +447,7 @@ def test_username_password_credential():
     assert token.token == expected_token
 
 
-def test_username_password_environment_credential(monkeypatch):
+def test_username_password_environment_credential():
     client_id = "fake-client-id"
     username = "foo@bar.com"
     password = "password"
@@ -467,18 +473,25 @@ def test_username_password_environment_credential(monkeypatch):
         ],
     )
 
-    monkeypatch.setenv(EnvironmentVariables.AZURE_CLIENT_ID, client_id)
-    monkeypatch.setenv(EnvironmentVariables.AZURE_USERNAME, username)
-    monkeypatch.setenv(EnvironmentVariables.AZURE_PASSWORD, password)
-
-    token = EnvironmentCredential(transport=create_transport()).get_token("scope")
+    environment = {
+        EnvironmentVariables.AZURE_CLIENT_ID: client_id,
+        EnvironmentVariables.AZURE_USERNAME: username,
+        EnvironmentVariables.AZURE_PASSWORD: password,
+    }
+    with patch("os.environ", environment):
+        token = EnvironmentCredential(transport=create_transport()).get_token("scope")
 
     # not validating expires_on because doing so requires monkeypatching time, and this is tested elsewhere
     assert token.token == expected_token
 
     # now with a tenant id
-    monkeypatch.setenv(EnvironmentVariables.AZURE_TENANT_ID, "tenant_id")
-
-    token = EnvironmentCredential(transport=create_transport()).get_token("scope")
+    environment = {
+        EnvironmentVariables.AZURE_CLIENT_ID: client_id,
+        EnvironmentVariables.AZURE_USERNAME: username,
+        EnvironmentVariables.AZURE_PASSWORD: password,
+        EnvironmentVariables.AZURE_TENANT_ID: "tenant_id",
+    }
+    with patch("os.environ", environment):
+        token = EnvironmentCredential(transport=create_transport()).get_token("scope")
 
     assert token.token == expected_token


### PR DESCRIPTION
Live testing azure-identity entails setting environment variables to configure `EnvironmentCredential`. These variables are then set during mock tests as well, potentially breaking those tests. With this change, mock tests patch `os.environ` to ensure the environment under test contains only the values they set.