### PR TITLE
[devtools-cognitiveservices] temp fix to allow passing cog key in headers for azure-core

### DIFF
--- a/sdk/cognitiveservices/azure-cognitiveservices-language-textanalytics/tests/recordings/test_text_analytics.test_detect_language.yaml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-language-textanalytics/tests/recordings/test_text_analytics.test_detect_language.yaml
@@ -14,7 +14,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python/3.7.3 (Windows-10-10.0.18362-SP0) msrest/0.6.6 azure-cognitiveservices-language-textanalytics/0.2.0
+      - python/3.7.3 (Windows-10-10.0.18362-SP0) msrest/0.6.10 azure-cognitiveservices-language-textanalytics/0.2.0
       X-BingApis-SDK-Client:
       - Python-SDK
     method: POST
@@ -24,19 +24,19 @@ interactions:
       string: '{"documents":[{"id":"1","detectedLanguages":[{"name":"English","iso6391Name":"en","score":1.0}]}],"errors":[]}'
     headers:
       apim-request-id:
-      - 79422b97-439d-4042-b2ca-0053d00770d3
+      - 99652aa4-e000-4263-adf2-920d0e1f5d6f
       content-type:
       - application/json; charset=utf-8
       csp-billing-usage:
       - CognitiveServices.TextAnalytics.BatchScoring|1
       date:
-      - Mon, 09 Sep 2019 21:55:42 GMT
+      - Fri, 27 Sep 2019 20:56:30 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       transfer-encoding:
       - chunked
       x-aml-ta-request-id:
-      - f34d7b3c-5552-4b8e-89e0-164e129c66ac
+      - 97c455bd-bbb0-4b2b-bce2-1cdde2439e50
       x-content-type-options:
       - nosniff
       x-ms-transaction-count:

--- a/sdk/cognitiveservices/azure-cognitiveservices-language-textanalytics/tests/test_text_analytics.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-language-textanalytics/tests/test_text_analytics.py
@@ -18,7 +18,7 @@ from devtools_testutils.cognitiveservices_testcase import CognitiveServiceTest, 
 class TextAnalyticsTest(CognitiveServiceTest):
 
     @ResourceGroupPreparer()
-    @CognitiveServicesAccountPreparer(name_prefix="pycog")
+    @CognitiveServicesAccountPreparer(name_prefix="pycog", legacy=True)
     def test_detect_language(self, resource_group, location, cognitiveservices_account, cognitiveservices_account_key):
         text_analytics = TextAnalyticsClient(cognitiveservices_account, cognitiveservices_account_key)
 

--- a/tools/azure-sdk-tools/devtools_testutils/cognitiveservices_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/cognitiveservices_testcase.py
@@ -33,7 +33,7 @@ class CognitiveServicesAccountPreparer(AzureMgmtPreparer):
                  name_prefix='',
                  sku='S0', location='westus', kind='cognitiveservices',
                  parameter_name='cognitiveservices_account',
-                 use_core=False,
+                 legacy=False,
                  resource_group_parameter_name=RESOURCE_GROUP_PARAM,
                  disable_recording=True, playback_fake_resource=None,
                  client_kwargs=None):
@@ -47,7 +47,7 @@ class CognitiveServicesAccountPreparer(AzureMgmtPreparer):
         self.resource_group_parameter_name = resource_group_parameter_name
         self.parameter_name = parameter_name
         self.cogsci_key = ''
-        self.use_core = use_core
+        self.legacy = legacy
 
     def create_resource(self, name, **kwargs):
         if self.is_live:
@@ -72,15 +72,15 @@ class CognitiveServicesAccountPreparer(AzureMgmtPreparer):
             self.resource = FakeCognitiveServicesAccount("https://{}.api.cognitive.microsoft.com".format(self.location))
             self.cogsci_key = 'ZmFrZV9hY29jdW50X2tleQ=='
 
-        if self.use_core:
+        if self.legacy:
             return {
                 self.parameter_name: self.resource.endpoint,
-                '{}_key'.format(self.parameter_name): self.cogsci_key,
+                '{}_key'.format(self.parameter_name): CognitiveServicesCredentials(self.cogsci_key),
             }
         else:
             return {
                 self.parameter_name: self.resource.endpoint,
-                '{}_key'.format(self.parameter_name): CognitiveServicesCredentials(self.cogsci_key),
+                '{}_key'.format(self.parameter_name): self.cogsci_key,
             }
 
     def remove_resource(self, name, **kwargs):

--- a/tools/azure-sdk-tools/devtools_testutils/cognitiveservices_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/cognitiveservices_testcase.py
@@ -33,6 +33,7 @@ class CognitiveServicesAccountPreparer(AzureMgmtPreparer):
                  name_prefix='',
                  sku='S0', location='westus', kind='cognitiveservices',
                  parameter_name='cognitiveservices_account',
+                 use_core=False,
                  resource_group_parameter_name=RESOURCE_GROUP_PARAM,
                  disable_recording=True, playback_fake_resource=None,
                  client_kwargs=None):
@@ -46,6 +47,7 @@ class CognitiveServicesAccountPreparer(AzureMgmtPreparer):
         self.resource_group_parameter_name = resource_group_parameter_name
         self.parameter_name = parameter_name
         self.cogsci_key = ''
+        self.use_core = use_core
 
     def create_resource(self, name, **kwargs):
         if self.is_live:
@@ -62,17 +64,24 @@ class CognitiveServicesAccountPreparer(AzureMgmtPreparer):
                     'properties': {}
                 }
             )
-            time.sleep(5)  # it takes a few seconds to create a cognitive services account
+            time.sleep(10)  # it takes a few seconds to create a cognitive services account
             self.resource = cogsci_account
             self.cogsci_key = self.client.accounts.list_keys(group.name, name).key1
             # FIXME: LuisAuthoringClient and LuisRuntimeClient need authoring key from ARM API (coming soon-ish)
         else:
             self.resource = FakeCognitiveServicesAccount("https://{}.api.cognitive.microsoft.com".format(self.location))
             self.cogsci_key = 'ZmFrZV9hY29jdW50X2tleQ=='
-        return {
-            self.parameter_name: self.resource.endpoint,
-            '{}_key'.format(self.parameter_name): CognitiveServicesCredentials(self.cogsci_key),
-        }
+
+        if self.use_core:
+            return {
+                self.parameter_name: self.resource.endpoint,
+                '{}_key'.format(self.parameter_name): self.cogsci_key,
+            }
+        else:
+            return {
+                self.parameter_name: self.resource.endpoint,
+                '{}_key'.format(self.parameter_name): CognitiveServicesCredentials(self.cogsci_key),
+            }
 
     def remove_resource(self, name, **kwargs):
         if self.is_live:


### PR DESCRIPTION
Pass in `legacy=True` to the CognitiveServicesAccountPreparer for msrest. Otherwise will default to `cognitiveservices_account_key` returned as a string which can be added to the 'Ocp-Apim-Subscription-Key' header.

```
    @ResourceGroupPreparer()
    @CognitiveServicesAccountPreparer(name_prefix="pycog")
    def test_describe_image(self, resource_group, location, cognitiveservices_account, cognitiveservices_account_key):
        client = ComputerVisionClient(cognitiveservices_account, cognitiveservices_account_key)
```