### PR TITLE
Support A256KW locally

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -220,7 +220,7 @@ class KeyVaultKey(object):
     """
 
     def __init__(self, key_id, jwk=None, **kwargs):
-        # type: (str, Optional[JsonWebKey], **Any) -> None
+        # type: (str, Optional[dict], **Any) -> None
         self._properties = kwargs.pop("properties", None) or KeyProperties(key_id, **kwargs)
         if isinstance(jwk, dict):
             if any(field in kwargs for field in JsonWebKey.FIELDS):

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -200,22 +200,22 @@ class KeyVaultKey(object):
 
     .. code-block:: python
 
-        from azure.keyvault.keys.models import Key
+        from azure.keyvault.keys.models import KeyVaultKey
 
         key_id = 'https://myvault.vault.azure.net/keys/my-key/my-key-version'
         key_bytes = os.urandom(32)
-        key = Key(key_id, k=key_bytes, kty='oct', key_ops=['unwrapKey', 'wrapKey'])
+        key = KeyVaultKey(key_id, k=key_bytes, kty='oct', key_ops=['unwrapKey', 'wrapKey'])
 
     Providing cryptographic material as a dictionary:
 
     .. code-block:: python
 
-        from azure.keyvault.keys.models import Key
+        from azure.keyvault.keys.models import KeyVaultKey
 
         key_id = 'https://myvault.vault.azure.net/keys/my-key/my-key-version'
         key_bytes = os.urandom(32)
         jwk = {'k': key_bytes, 'kty': 'oct', 'key_ops': ['unwrapKey', 'wrapKey']}
-        key = Key(key_id, jwk=jwk)
+        key = KeyVaultKey(key_id, jwk=jwk)
 
     """
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -282,7 +282,7 @@ class KeyVaultKey(object):
 
         :rtype: ~azure.keyvault.keys.KeyType or str
         """
-        return self._key_material.kty
+        return self._key_material.kty  # pylint:disable=no-member
 
     @property
     def key_operations(self):
@@ -291,7 +291,7 @@ class KeyVaultKey(object):
 
         :rtype: list[~azure.keyvault.keys.KeyOperation or str]
         """
-        return self._key_material.key_ops
+        return self._key_material.key_ops  # pylint:disable=no-member
 
 
 class DeletedKey(KeyVaultKey):

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
@@ -149,6 +149,7 @@ class CryptographyClient(KeyVaultClientBase):
 
         return self._internal_key
 
+    @distributed_trace
     def encrypt(self, algorithm, plaintext, **kwargs):
         # type: (EncryptionAlgorithm, bytes, **Any) -> EncryptResult
         # pylint:disable=line-too-long

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
@@ -6,8 +6,8 @@ import six
 from azure.core.exceptions import AzureError, HttpResponseError
 from azure.core.tracing.decorator import distributed_trace
 
-from . import DecryptResult, EncryptResult, SignResult, VerifyResult, WrapResult, UnwrapResult
-from ._internal import EllipticCurveKey, RsaKey
+from . import DecryptResult, EncryptResult, SignResult, VerifyResult, UnwrapResult, WrapResult
+from ._internal import EllipticCurveKey, RsaKey, SymmetricKey
 from .._models import KeyVaultKey
 from .._shared import KeyVaultClientBase, parse_vault_id
 
@@ -137,14 +137,18 @@ class CryptographyClient(KeyVaultClientBase):
             if not key:
                 return None
 
-            if key.key_type.lower().startswith("ec"):
+            kty = key.key_type.lower()
+            if kty.startswith("ec"):
                 self._internal_key = EllipticCurveKey.from_jwk(key.key)
-            else:
+            elif kty.startswith("rsa"):
                 self._internal_key = RsaKey.from_jwk(key.key)
+            elif kty == "oct":
+                self._internal_key = SymmetricKey.from_jwk(key.key)
+            else:
+                raise ValueError("Unsupported key type '{}'".format(key.key_type))
 
         return self._internal_key
 
-    @distributed_trace
     def encrypt(self, algorithm, plaintext, **kwargs):
         # type: (EncryptionAlgorithm, bytes, **Any) -> EncryptResult
         # pylint:disable=line-too-long
@@ -284,16 +288,21 @@ class CryptographyClient(KeyVaultClientBase):
             key = result.key
 
         """
-
-        result = self._client.unwrap_key(
-            vault_base_url=self._key_id.vault_endpoint,
-            key_name=self._key_id.name,
-            key_version=self._key_id.version,
-            algorithm=algorithm,
-            value=encrypted_key,
-            **kwargs
-        )
-        return UnwrapResult(key_id=self.key_id, algorithm=algorithm, key=result.result)
+        local_key = self._get_local_key(**kwargs)
+        if local_key and local_key.is_private_key():
+            if "unwrapKey" not in self._allowed_ops:
+                raise AzureError("This client doesn't have 'keys/unwrapKey' permission")
+            result = local_key.unwrap_key(encrypted_key, **kwargs)
+        else:
+            result = self._client.unwrap_key(
+                vault_base_url=self._key_id.vault_endpoint,
+                key_name=self._key_id.name,
+                key_version=self._key_id.version,
+                algorithm=algorithm,
+                value=encrypted_key,
+                **kwargs
+            ).result
+        return UnwrapResult(key_id=self._key_id, algorithm=algorithm, key=result)
 
     @distributed_trace
     def sign(self, algorithm, digest, **kwargs):
@@ -357,6 +366,7 @@ class CryptographyClient(KeyVaultClientBase):
             assert verified.is_valid
 
         """
+
         local_key = self._get_local_key(**kwargs)
         if local_key:
             if "verify" not in self._allowed_ops:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_enums.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_enums.py
@@ -8,6 +8,7 @@ from enum import Enum
 class KeyWrapAlgorithm(str, Enum):
     """Key wrapping algorithms"""
 
+    aes_256 = "A256KW"
     rsa_oaep = "RSA-OAEP"
     rsa_oaep_256 = "RSA-OAEP-256"
     rsa1_5 = "RSA1_5"

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/__init__.py
@@ -12,6 +12,7 @@ from .algorithm import (
 from .ec_key import EllipticCurveKey
 from .key import Key
 from .rsa_key import RsaKey
+from .symmetric_key import SymmetricKey
 from .transform import CryptoTransform, BlockCryptoTransform, AuthenticatedCryptoTransform, SignatureTransform
 
 __all__ = {
@@ -27,4 +28,5 @@ __all__ = {
     "BlockCryptoTransform",
     "AuthenticatedSymmetricEncryptionAlgorithm",
     "SignatureTransform",
+    "SymmetricKey",
 }

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/ec_key.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/ec_key.py
@@ -56,6 +56,9 @@ class EllipticCurveKey(Key):
 
         return cls(_bytes_to_int(jwk.x), _bytes_to_int(jwk.y), kid=jwk.kid, curve=jwk.crv)
 
+    def is_private_key(self):
+        return False
+
     def decrypt(self, cipher_text, **kwargs):
         raise NotImplementedError()
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/key.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/key.py
@@ -45,6 +45,10 @@ class Key(with_metaclass(ABCMeta, object)):
         return self._kid
 
     @abstractmethod
+    def is_private_key(self):
+        pass
+
+    @abstractmethod
     def decrypt(self, cipher_text, **kwargs):
         raise NotImplementedError()
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/rsa_key.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/rsa_key.py
@@ -14,7 +14,6 @@ from cryptography.hazmat.primitives.asymmetric.rsa import (
     rsa_crt_dmp1,
     rsa_crt_dmq1,
     rsa_crt_iqmp,
-    RSAPrivateKey,
 )
 
 from azure.keyvault.keys._models import JsonWebKey
@@ -214,7 +213,10 @@ class RsaKey(Key):  # pylint:disable=too-many-public-methods
         return decryptor.transform(encrypted_key)
 
     def is_private_key(self):
-        return isinstance(self._rsa_impl, RSAPrivateKey)
+        # return isinstance(self._rsa_impl, RSAPrivateKey)
+        # TODO returning False here even if someone sneaked in private key material because
+        # currently we don't want to perform decrypt/unwrap/sign locally
+        return False
 
     def _public_key_material(self):
         return self.public_key.public_numbers()

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/symmetric_key.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/symmetric_key.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-
 import uuid
 import os
 from .key import Key
@@ -55,6 +54,13 @@ class SymmetricKey(Key):
             raise ValueError("The key size must be 128, 192, 256, 384 or 512 bits of data")
 
         self._key = key_bytes
+
+    def is_private_key(self):
+        return True
+
+    @classmethod
+    def from_jwk(cls, jwk):
+        return cls(kid=jwk.kid, key_bytes=jwk.k)
 
     @property
     def kid(self):
@@ -114,12 +120,12 @@ class SymmetricKey(Key):
     def wrap_key(self, key, **kwargs):
         algorithm = self._get_algorithm("wrapKey", **kwargs)
         encryptor = algorithm.create_encryptor(key=self._key)
-        return encryptor.transform(key, **kwargs)
+        return encryptor.transform(key)
 
     def unwrap_key(self, encrypted_key, **kwargs):
-        algorithm = self._get_algorithm("decrypt", **kwargs)
+        algorithm = self._get_algorithm("unwrapKey", **kwargs)
         decryptor = algorithm.create_decryptor(key=self._key)
-        return decryptor.transform(encrypted_key, **kwargs)
+        return decryptor.transform(encrypted_key)
 
     def sign(self, digest, **kwargs):
         raise NotImplementedError()

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
@@ -182,6 +182,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             result = operation.result
         return EncryptResult(key_id=self.key_id, algorithm=algorithm, ciphertext=result)
 
+    @distributed_trace_async
     async def decrypt(self, algorithm: "EncryptionAlgorithm", ciphertext: bytes, **kwargs: "Any") -> DecryptResult:
         """
         Decrypt a single block of encrypted data using the client's key. Requires the keys/decrypt permission.
@@ -254,6 +255,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             result = operation.result
         return WrapResult(key_id=self.key_id, algorithm=algorithm, encrypted_key=result)
 
+    @distributed_trace_async
     async def unwrap_key(self, algorithm: "KeyWrapAlgorithm", encrypted_key: bytes, **kwargs: "Any") -> UnwrapResult:
         """
         Unwrap a key previously wrapped with the client's key. Requires the keys/unwrapKey permission.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
@@ -6,8 +6,8 @@ from azure.core.exceptions import AzureError, HttpResponseError
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.keyvault.keys._shared import AsyncKeyVaultClientBase, parse_vault_id
 
-from .. import DecryptResult, EncryptResult, SignResult, VerifyResult, WrapResult, UnwrapResult
-from .._internal import EllipticCurveKey, RsaKey
+from .. import DecryptResult, EncryptResult, SignResult, VerifyResult, UnwrapResult, WrapResult
+from .._internal import EllipticCurveKey, RsaKey, SymmetricKey
 from ..._models import KeyVaultKey
 
 try:
@@ -68,7 +68,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
 
     """
 
-    def __init__(self, key: "Union[KeyVaultKey, str]", credential: "TokenCredential", **kwargs: "**Any") -> None:
+    def __init__(self, key: "Union[KeyVaultKey, str]", credential: "TokenCredential", **kwargs: "Any") -> None:
         if isinstance(key, KeyVaultKey):
             self._key = key
             self._key_id = parse_vault_id(key.id)
@@ -131,10 +131,15 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             if not key:
                 return None
 
-            if key.key_type.lower().startswith("ec"):
+            kty = key.key_type.lower()
+            if kty.startswith("ec"):
                 self._internal_key = EllipticCurveKey.from_jwk(key.key)
-            else:
+            elif kty.startswith("rsa"):
                 self._internal_key = RsaKey.from_jwk(key.key)
+            elif kty == "oct":
+                self._internal_key = SymmetricKey.from_jwk(key.key)
+            else:
+                raise ValueError("Unsupported key type '{}'".format(key.key_type))
 
         return self._internal_key
 
@@ -171,13 +176,13 @@ class CryptographyClient(AsyncKeyVaultClientBase):
                 raise AzureError("This client doesn't have 'keys/encrypt' permission")
             result = local_key.encrypt(plaintext, algorithm=algorithm.value)
         else:
-            result = await self._client.encrypt(
+            operation = await self._client.encrypt(
                 self._key_id.vault_endpoint, self._key_id.name, self._key_id.version, algorithm, plaintext, **kwargs
-            ).result
+            )
+            result = operation.result
         return EncryptResult(key_id=self.key_id, algorithm=algorithm, ciphertext=result)
 
-    @distributed_trace_async
-    async def decrypt(self, algorithm: "EncryptionAlgorithm", ciphertext: bytes, **kwargs: "**Any") -> DecryptResult:
+    async def decrypt(self, algorithm: "EncryptionAlgorithm", ciphertext: bytes, **kwargs: "Any") -> DecryptResult:
         """
         Decrypt a single block of encrypted data using the client's key. Requires the keys/decrypt permission.
 
@@ -238,17 +243,17 @@ class CryptographyClient(AsyncKeyVaultClientBase):
                 raise AzureError("This client doesn't have 'keys/wrapKey' permission")
             result = local_key.wrap_key(key, algorithm=algorithm.value)
         else:
-            result = await self._client.wrap_key(
+            operation = await self._client.wrap_key(
                 self._key_id.vault_endpoint,
                 self._key_id.name,
                 self._key_id.version,
                 algorithm=algorithm,
                 value=key,
                 **kwargs
-            ).result
+            )
+            result = operation.result
         return WrapResult(key_id=self.key_id, algorithm=algorithm, encrypted_key=result)
 
-    @distributed_trace_async
     async def unwrap_key(self, algorithm: "KeyWrapAlgorithm", encrypted_key: bytes, **kwargs: "Any") -> UnwrapResult:
         """
         Unwrap a key previously wrapped with the client's key. Requires the keys/unwrapKey permission.
@@ -268,16 +273,22 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             key = result.key
 
         """
-
-        result = await self._client.unwrap_key(
-            self._key_id.vault_endpoint,
-            self._key_id.name,
-            self._key_id.version,
-            algorithm=algorithm,
-            value=encrypted_key,
-            **kwargs
-        )
-        return UnwrapResult(key_id=self.key_id, algorithm=algorithm, key=result.result)
+        local_key = await self._get_local_key(**kwargs)
+        if local_key and local_key.is_private_key():
+            if "unwrapKey" not in self._allowed_ops:
+                raise AzureError("This client doesn't have 'keys/unwrapKey' permission")
+            result = local_key.unwrap_key(encrypted_key, **kwargs)
+        else:
+            operation = await self._client.unwrap_key(
+                self._key_id.vault_endpoint,
+                self._key_id.name,
+                self._key_id.version,
+                algorithm=algorithm,
+                value=encrypted_key,
+                **kwargs
+            )
+            result = operation.result
+        return UnwrapResult(key_id=self._key_id, algorithm=algorithm, key=result)
 
     @distributed_trace_async
     async def sign(self, algorithm: "SignatureAlgorithm", digest: bytes, **kwargs: "**Any") -> SignResult:
@@ -320,7 +331,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def verify(
-        self, algorithm: "SignatureAlgorithm", digest: bytes, signature: bytes, **kwargs: "**Any"
+        self, algorithm: "SignatureAlgorithm", digest: bytes, signature: bytes, **kwargs: "Any"
     ) -> VerifyResult:
         """
         Verify a signature using the client's key. Requires the keys/verify permission.

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -6,8 +6,8 @@ import codecs
 import hashlib
 import os
 
-from azure.keyvault.keys import JsonWebKey, KeyCurveName
-from azure.keyvault.keys.crypto import EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
+from azure.keyvault.keys import JsonWebKey, KeyCurveName, KeyVaultKey
+from azure.keyvault.keys.crypto import CryptographyClient, EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
 from azure.mgmt.keyvault.models import KeyPermissions, Permissions
 from devtools_testutils import ResourceGroupPreparer
 from keys_preparer import VaultClientPreparer
@@ -130,7 +130,19 @@ class CryptoClientTests(KeyVaultTestCase):
         result = crypto_client.unwrap_key(result.algorithm, result.encrypted_key)
         self.assertEqual(key_bytes, result.key)
 
-    @ResourceGroupPreparer(name_prefix=name_prefix)
+    def test_symmetric_wrap_and_unwrap_local(self, **kwargs):
+        jwk = {"k": os.urandom(32), "kty": "oct", "key_ops": ("unwrapKey", "wrapKey")}
+        key = KeyVaultKey(key_id="http://fake.test.vault/keys/key/version", jwk=jwk)
+
+        crypto_client = CryptographyClient(key, credential=lambda *_: None)
+
+        # Wrap a key with the created key, then unwrap it. The wrapped key's bytes should round-trip.
+        key_bytes = os.urandom(32)
+        wrap_result = crypto_client.wrap_key(KeyWrapAlgorithm.aes_256, key_bytes)
+        unwrap_result = crypto_client.unwrap_key(wrap_result.algorithm, wrap_result.encrypted_key)
+        self.assertEqual(unwrap_result.key, key_bytes)
+
+    @ResourceGroupPreparer()
     @VaultClientPreparer()
     def test_encrypt_local(self, vault_client, **kwargs):
         """Encrypt locally, decrypt with Key Vault"""
@@ -155,7 +167,7 @@ class CryptoClientTests(KeyVaultTestCase):
         key = key_client.create_rsa_key("wrap-local", size=4096)
         crypto_client = vault_client.get_cryptography_client(key)
 
-        for wrap_algorithm in KeyWrapAlgorithm:
+        for wrap_algorithm in (algo for algo in KeyWrapAlgorithm if algo.value.startswith("RSA")):
             result = crypto_client.wrap_key(wrap_algorithm, self.plaintext)
             self.assertEqual(result.key_id, key.id)
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -23,6 +23,24 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
     # incorporate md5 hashing of run identifier into resource group name for uniqueness
     name_prefix = "kv-test-" + hashlib.md5(os.environ['RUN_IDENTIFIER'].encode()).hexdigest()[-3:]
 
+    def _assert_jwks_equal(self, jwk1, jwk2):
+        assert jwk1.kid == jwk2.kid
+        assert jwk1.kty == jwk2.kty
+        assert jwk1.key_ops == jwk2.key_ops
+        assert jwk1.n == jwk2.n
+        assert jwk1.e == jwk2.e
+        assert jwk1.d == jwk2.d
+        assert jwk1.dp == jwk2.dp
+        assert jwk1.dq == jwk2.dq
+        assert jwk1.qi == jwk2.qi
+        assert jwk1.p == jwk2.p
+        assert jwk1.q == jwk2.q
+        assert jwk1.k == jwk2.k
+        assert jwk1.t == jwk2.t
+        assert jwk1.crv == jwk2.crv
+        assert jwk1.x == jwk2.x
+        assert jwk1.y == jwk2.y
+
     def _assert_key_attributes_equal(self, k1, k2):
         self.assertEqual(k1.name, k2.name)
         self.assertEqual(k1.vault_endpoint, k2.vault_endpoint)
@@ -180,7 +198,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
             polling_interval = None
         deleted_key = await client.delete_key(created_rsa_key.name, _polling_interval=polling_interval)
         self.assertIsNotNone(deleted_key)
-        self.assertEqual(created_rsa_key.key, deleted_key.key)
+        self._assert_jwks_equal(created_rsa_key.key, deleted_key.key)
         self.assertEqual(deleted_key.id, created_rsa_key.id)
         self.assertTrue(
             deleted_key.recovery_id and deleted_key.deleted_date and deleted_key.scheduled_purge_date,


### PR DESCRIPTION
Closes #7437 with support for local un/wrapping with A256KW. For example, with this one can un/wrap with a symmetric key stored as a Key Vault secret:
```py
import base64
from os import urandom
from azure.keyvault.keys.crypto import CryptographyClient
from azure.keyvault.keys.models import Key
from azure.keyvault.secrets import SecretClient
from azure.identity import ClientSecretCredential

credential = ClientSecretCredential(CLIENT_ID, CLIENT_SECRET, TENANT_ID)
secret_client = SecretClient(VAULT_URL, credential)

# the secret is url-safe base64 encoded bytes, content type 'application/octet-stream'
secret = secret_client.get_secret("symmetric-key")
key_bytes = base64.urlsafe_b64decode(secret.value)

# kty 'oct' is per RFC 7517. This will be awkward if the service wants something else.
kek = Key(key_id=secret.id, key_ops=["unwrapKey", "wrapKey"], k=key_bytes, kty="oct")
crypto_client = CryptographyClient(kek, credential)

inner_key = urandom(32)
kid, algorithm, encrypted_key = crypto_client.wrap_key(KeyWrapAlgorithm.aes_256, inner_key)
result = crypto_client.unwrap_key(algorithm, encrypted_key)

assert result.unwrapped_bytes == inner_key
```

`Key` was previously only a return type, not a class users would instantiate, so a large part of this is refactoring to improve its ergonomics.