### PR TITLE
SansIOHttpPolicy can return awaitable objects

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/base.py
@@ -37,6 +37,14 @@ _LOGGER = logging.getLogger(__name__)
 PoliciesType = List[Union[HTTPPolicy, SansIOHTTPPolicy]]
 
 
+def _await_result(func, *args, **kwargs):
+    """If func returns an awaitable, raise that this runner can't handle it."""
+    result = func(*args, **kwargs)
+    if hasattr(result, '__await__'):
+        raise TypeError("Policy {} returned awaitable object in non-async pipeline.".format(func))
+    return result
+
+
 class _SansIOHTTPPolicyRunner(HTTPPolicy, Generic[HTTPRequestType, HTTPResponseType]):
     """Sync implementation of the SansIO policy.
 
@@ -60,14 +68,14 @@ class _SansIOHTTPPolicyRunner(HTTPPolicy, Generic[HTTPRequestType, HTTPResponseT
         :return: The PipelineResponse object.
         :rtype: ~azure.core.pipeline.PipelineResponse
         """
-        self._policy.on_request(request)
+        _await_result(self._policy.on_request, request)
         try:
             response = self.next.send(request)
         except Exception: #pylint: disable=broad-except
-            if not self._policy.on_exception(request):
+            if not _await_result(self._policy.on_exception, request):
                 raise
         else:
-            self._policy.on_response(request, response)
+            _await_result(self._policy.on_response, request, response)
         return response
 
 

--- a/sdk/core/azure-core/azure/core/pipeline/policies/authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/authentication_async.py
@@ -5,12 +5,12 @@
 # -------------------------------------------------------------------------
 import threading
 
-from azure.core.pipeline import PipelineRequest, PipelineResponse
-from azure.core.pipeline.policies import AsyncHTTPPolicy
+from azure.core.pipeline import PipelineRequest
+from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.core.pipeline.policies.authentication import _BearerTokenCredentialPolicyBase
 
 
-class AsyncBearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, AsyncHTTPPolicy):
+class AsyncBearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, SansIOHTTPPolicy):
     # pylint:disable=too-few-public-methods
     """Adds a bearer token Authorization header to requests.
 
@@ -23,16 +23,13 @@ class AsyncBearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, AsyncHT
         super().__init__(credential, *scopes, **kwargs)
         self._lock = threading.Lock()
 
-    async def send(self, request: PipelineRequest) -> PipelineResponse:
+    async def on_request(self, request: PipelineRequest):
         """Adds a bearer token Authorization header to request and sends request to next policy.
 
         :param request: The pipeline request object to be modified.
         :type request: ~azure.core.pipeline.PipelineRequest
-        :return: The pipeline response object
-        :rtype: ~azure.core.pipeline.PipelineResponse
         """
         with self._lock:
             if self._need_new_token:
                 self._token = await self._credential.get_token(*self._scopes)  # type: ignore
         self._update_headers(request.http_request.headers, self._token.token)  # type: ignore
-        return await self.next.send(request)  # type: ignore

--- a/sdk/core/azure-core/azure/core/pipeline/policies/base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/base.py
@@ -31,21 +31,19 @@ import logging
 from azure.core.pipeline import ABC, PipelineRequest, PipelineResponse
 
 try:
-    from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING, Awaitable
 except ImportError:
     TYPE_CHECKING = False
 
-if TYPE_CHECKING:
-    from typing import (
-        Generic,
-        TypeVar,
-        Union,
-        Any,
-        Dict,
-        Optional,
-        Callable,
-        Awaitable,
-    )  # pylint: disable=unused-import
+from typing import (
+    Generic,
+    TypeVar,
+    Union,
+    Any,
+    Dict,
+    Optional,
+    Callable,
+)  # pylint: disable=unused-import
 
 HTTPResponseType = TypeVar("HTTPResponseType")
 HTTPRequestType = TypeVar("HTTPRequestType")

--- a/sdk/core/azure-core/azure/core/pipeline/policies/base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/base.py
@@ -29,7 +29,7 @@ import copy
 import logging
 
 from typing import (TYPE_CHECKING, Generic, TypeVar, cast, IO, List, Union, Any, Mapping, Dict, Optional,  # pylint: disable=unused-import
-                    Tuple, Callable, Iterator)
+                    Tuple, Callable, Iterator, Awaitable)
 
 from azure.core.pipeline import ABC, PipelineRequest, PipelineResponse
 
@@ -72,10 +72,12 @@ class SansIOHTTPPolicy(Generic[HTTPRequestType, HTTPResponseType]):
     on the specifics of any particular transport. SansIOHTTPPolicy
     subclasses will function in either a Pipeline or an AsyncPipeline,
     and can act either before the request is done, or after.
+    You can optionally make these methods coroutines (or returns awaitable objects)
+    but they will then be tight to AsyncPipeline usage.
     """
 
     def on_request(self, request):
-        # type: (PipelineRequest) -> None
+        # type: (PipelineRequest) -> Union[None, Awaitable[None]]
         """Is executed before sending the request from next policy.
 
         :param request: Request to be modified before sent from next policy.
@@ -83,7 +85,7 @@ class SansIOHTTPPolicy(Generic[HTTPRequestType, HTTPResponseType]):
         """
 
     def on_response(self, request, response):
-        # type: (PipelineRequest, PipelineResponse) -> None
+        # type: (PipelineRequest, PipelineResponse) -> Union[None, Awaitable[None]]
         """Is executed after the request comes back from the policy.
 
         :param request: Request to be modified after returning from the policy.
@@ -94,7 +96,7 @@ class SansIOHTTPPolicy(Generic[HTTPRequestType, HTTPResponseType]):
 
     #pylint: disable=no-self-use
     def on_exception(self, _request):  #pylint: disable=unused-argument
-        # type: (PipelineRequest) -> bool
+        # type: (PipelineRequest) -> Union[bool, Awaitable[bool]]
         """Is executed if an exception is raised while executing the next policy.
 
         Developer can optionally implement this method to return True

--- a/sdk/core/azure-core/azure/core/pipeline/policies/base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/base.py
@@ -28,13 +28,6 @@ import abc
 import copy
 import logging
 
-from azure.core.pipeline import ABC, PipelineRequest, PipelineResponse
-
-try:
-    from typing import TYPE_CHECKING, Awaitable
-except ImportError:
-    TYPE_CHECKING = False
-
 from typing import (
     Generic,
     TypeVar,
@@ -42,8 +35,15 @@ from typing import (
     Any,
     Dict,
     Optional,
-    Callable,
 )  # pylint: disable=unused-import
+
+try:
+    from typing import Awaitable   # pylint: disable=unused-import
+except ImportError:
+    pass
+
+from azure.core.pipeline import ABC, PipelineRequest, PipelineResponse
+
 
 HTTPResponseType = TypeVar("HTTPResponseType")
 HTTPRequestType = TypeVar("HTTPRequestType")

--- a/sdk/core/azure-core/azure/core/pipeline/policies/base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/base.py
@@ -72,8 +72,8 @@ class SansIOHTTPPolicy(Generic[HTTPRequestType, HTTPResponseType]):
     on the specifics of any particular transport. SansIOHTTPPolicy
     subclasses will function in either a Pipeline or an AsyncPipeline,
     and can act either before the request is done, or after.
-    You can optionally make these methods coroutines (or returns awaitable objects)
-    but they will then be tight to AsyncPipeline usage.
+    You can optionally make these methods coroutines (or return awaitable objects)
+    but they will then be tied to AsyncPipeline usage.
     """
 
     def on_request(self, request):

--- a/sdk/core/azure-core/azure/core/pipeline/policies/base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/base.py
@@ -28,10 +28,24 @@ import abc
 import copy
 import logging
 
-from typing import (TYPE_CHECKING, Generic, TypeVar, cast, IO, List, Union, Any, Mapping, Dict, Optional,  # pylint: disable=unused-import
-                    Tuple, Callable, Iterator, Awaitable)
-
 from azure.core.pipeline import ABC, PipelineRequest, PipelineResponse
+
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from typing import (
+        Generic,
+        TypeVar,
+        Union,
+        Any,
+        Dict,
+        Optional,
+        Callable,
+        Awaitable,
+    )  # pylint: disable=unused-import
 
 HTTPResponseType = TypeVar("HTTPResponseType")
 HTTPRequestType = TypeVar("HTTPRequestType")
@@ -39,7 +53,7 @@ HTTPRequestType = TypeVar("HTTPRequestType")
 _LOGGER = logging.getLogger(__name__)
 
 
-class HTTPPolicy(ABC, Generic[HTTPRequestType, HTTPResponseType]): # type: ignore
+class HTTPPolicy(ABC, Generic[HTTPRequestType, HTTPResponseType]):  # type: ignore
     """An HTTP policy ABC.
 
     Use with a synchronous pipeline.
@@ -48,6 +62,7 @@ class HTTPPolicy(ABC, Generic[HTTPRequestType, HTTPResponseType]): # type: ignor
      instantiated and all policies chained.
     :type next: ~azure.core.pipeline.policies.HTTPPolicy or ~azure.core.pipeline.transport.HTTPTransport
     """
+
     def __init__(self):
         self.next = None
 
@@ -63,6 +78,7 @@ class HTTPPolicy(ABC, Generic[HTTPRequestType, HTTPResponseType]): # type: ignor
         :return: The pipeline response object.
         :rtype: ~azure.core.pipeline.PipelineResponse
         """
+
 
 class SansIOHTTPPolicy(Generic[HTTPRequestType, HTTPResponseType]):
     """Represents a sans I/O policy.
@@ -94,8 +110,8 @@ class SansIOHTTPPolicy(Generic[HTTPRequestType, HTTPResponseType]):
         :type response: ~azure.core.pipeline.PipelineResponse
         """
 
-    #pylint: disable=no-self-use
-    def on_exception(self, _request):  #pylint: disable=unused-argument
+    # pylint: disable=no-self-use
+    def on_exception(self, _request):  # pylint: disable=unused-argument
         # type: (PipelineRequest) -> Union[bool, Awaitable[bool]]
         """Is executed if an exception is raised while executing the next policy.
 
@@ -131,6 +147,7 @@ class RequestHistory(object):
     :param Exception error: An error encountered during the request, or None if the response was received successfully.
     :param dict context: The pipeline context.
     """
+
     def __init__(self, http_request, http_response=None, error=None, context=None):
         # type: (PipelineRequest, Optional[PipelineResponse], Exception, Optional[Dict[str, Any]]) -> None
         self.http_request = copy.deepcopy(http_request)


### PR DESCRIPTION
Coroutine being awaitable objects, this means we can define on_request/on_response/on_exception as coroutine (corollary).