### PR TITLE
Breaking Changes - Permission models

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/__init__.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/__init__.py
@@ -17,7 +17,7 @@ from ._shared.downloads import StorageStreamDownloader
 from ._shared.models import(
     LocationMode,
     ResourceTypes,
-    AccountPermissions,
+    AccountSasPermissions,
     StorageErrorCode
 )
 from .models import (
@@ -43,8 +43,8 @@ from .models import (
     BlobBlock,
     PageRange,
     AccessPolicy,
-    ContainerPermissions,
-    BlobPermissions,
+    ContainerSasPermissions,
+    BlobSasPermissions,
 )
 
 __version__ = VERSION
@@ -82,10 +82,10 @@ __all__ = [
     'BlobBlock',
     'PageRange',
     'AccessPolicy',
-    'ContainerPermissions',
-    'BlobPermissions',
+    'ContainerSasPermissions',
+    'BlobSasPermissions',
     'ResourceTypes',
-    'AccountPermissions',
+    'AccountSasPermissions',
     'StorageStreamDownloader',
 ]
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/models.py
@@ -306,8 +306,6 @@ class AccountSasPermissions(object):
         Valid for the following Object resource types only: queue messages.
     :param bool process:
         Valid for the following Object resource type only: queue messages.
-    :param str _str:
-        A string representing the permissions.
     """
     def __init__(self, read=False, write=False, delete=False, list=False,  # pylint: disable=redefined-builtin
                  add=False, create=False, update=False, process=False):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/models.py
@@ -328,20 +328,8 @@ class AccountSasPermissions(object):
     :param str _str:
         A string representing the permissions.
     """
-
-    READ = None  # type: AccountSasPermissions
-    WRITE = None  # type: AccountSasPermissions
-    DELETE = None  # type: AccountSasPermissions
-    LIST = None  # type: AccountSasPermissions
-    ADD = None  # type: AccountSasPermissions
-    CREATE = None  # type: AccountSasPermissions
-    UPDATE = None  # type: AccountSasPermissions
-    PROCESS = None  # type: AccountSasPermissions
-
     def __init__(self, read=False, write=False, delete=False, list=False,  # pylint: disable=redefined-builtin
-                 add=False, create=False, update=False, process=False, _str=None):
-        if not _str:
-            _str = ''
+                 add=False, create=False, update=False, process=False):
         self.read = read or ('r' in _str)
         self.write = write or ('w' in _str)
         self.delete = delete or ('d' in _str)
@@ -350,12 +338,6 @@ class AccountSasPermissions(object):
         self.create = create or ('c' in _str)
         self.update = update or ('u' in _str)
         self.process = process or ('p' in _str)
-
-    def __or__(self, other):
-        return AccountSasPermissions(_str=str(self) + str(other))
-
-    def __add__(self, other):
-        return AccountSasPermissions(_str=str(self) + str(other))
 
     def __str__(self):
         return (('r' if self.read else '') +
@@ -367,15 +349,32 @@ class AccountSasPermissions(object):
                 ('u' if self.update else '') +
                 ('p' if self.process else ''))
 
-
-AccountSasPermissions.READ = AccountSasPermissions(read=True)
-AccountSasPermissions.WRITE = AccountSasPermissions(write=True)
-AccountSasPermissions.DELETE = AccountSasPermissions(delete=True)
-AccountSasPermissions.LIST = AccountSasPermissions(list=True)
-AccountSasPermissions.ADD = AccountSasPermissions(add=True)
-AccountSasPermissions.CREATE = AccountSasPermissions(create=True)
-AccountSasPermissions.UPDATE = AccountSasPermissions(update=True)
-AccountSasPermissions.PROCESS = AccountSasPermissions(process=True)
+    @classmethod
+    def from_string(cls, permission):
+        read, write, delete, list = False, False, False, False
+        add, create, update, process = False, False, False, False
+        curr = 0
+        while curr < len(permission):
+            if permission[curr] =='r':
+                read = True
+            elif permission[curr] == 'w':
+                write = True
+            elif permission[curr] == 'd':
+                delete = True
+            elif permission[curr] == 'l':
+                list = True
+            elif permission[curr] =='a':
+                add = True
+            elif permission[curr] == 'c':
+                create = True
+            elif permission[curr] == 'u':
+                update = True
+            elif permission[curr] == 'p':
+                process = True
+            else:
+                raise ValueError("Invalid Permission String")
+            curr += 1
+        return cls(read, write, delete, list, add, create, update, process)
 
 
 class Services(object):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/models.py
@@ -333,9 +333,6 @@ class AccountSasPermissions(object):
 
     @classmethod
     def from_string(cls, permission):
-        if len(permission) > 8:
-            raise ValueError("Invalid Permission String")
-
         p_read = 'r' in permission
         p_write = 'w' in permission
         p_delete = 'd' in permission

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/models.py
@@ -341,7 +341,7 @@ class AccountSasPermissions(object):
         p_process = 'p' in permission
 
         parsed = cls(p_read, p_write, p_delete, p_list, p_add, p_create, p_update, p_process)
-        parsed._str = permission
+        parsed._str = permission # pylint: disable = protected-access
         return parsed
 
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/models.py
@@ -286,25 +286,6 @@ class AccountSasPermissions(object):
     entire service for a specific account and allow certain operations based on
     perms found here.
 
-    :cvar AccountSasPermissions AccountSasPermissions.ADD:
-        Valid for the following Object resource types only: queue messages and append blobs.
-    :cvar AccountSasPermissions AccountSasPermissions.CREATE:
-        Valid for the following Object resource types only: blobs and files. Users
-        can create new blobs or files, but may not overwrite existing blobs or files.
-    :cvar AccountSasPermissions AccountSasPermissions.DELETE:
-        Valid for Container and Object resource types, except for queue messages.
-    :cvar AccountSasPermissions AccountSasPermissions.LIST:
-        Valid for Service and Container resource types only.
-    :cvar AccountSasPermissions AccountSasPermissions.PROCESS:
-        Valid for the following Object resource type only: queue messages.
-    :cvar AccountSasPermissions AccountSasPermissions.READ:
-        Valid for all signed resources types (Service, Container, and Object).
-        Permits read permissions to the specified resource type.
-    :cvar AccountSasPermissions AccountSasPermissions.UPDATE:
-        Valid for the following Object resource types only: queue messages.
-    :cvar AccountSasPermissions AccountSasPermissions.WRITE:
-        Valid for all signed resources types (Service, Container, and Object).
-        Permits write permissions to the specified resource type.
     :param bool read:
         Valid for all signed resources types (Service, Container, and Object).
         Permits read permissions to the specified resource type.
@@ -351,6 +332,8 @@ class AccountSasPermissions(object):
 
     @classmethod
     def from_string(cls, permission):
+        if len(permission) > 8:
+            raise ValueError("Invalid Permission String")
         read, write, delete, list = False, False, False, False
         add, create, update, process = False, False, False, False
         curr = 0

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/models.py
@@ -27,7 +27,7 @@ class StorageErrorCode(str, Enum):
     condition_headers_not_supported = "ConditionHeadersNotSupported"
     condition_not_met = "ConditionNotMet"
     empty_metadata_key = "EmptyMetadataKey"
-    insufficient_account_permissions = "InsufficientAccountSasPermissions"
+    insufficient_account_permissions = "InsufficientAccountPermissions"
     internal_error = "InternalError"
     invalid_authentication_info = "InvalidAuthenticationInfo"
     invalid_header_value = "InvalidHeaderValue"
@@ -311,53 +311,43 @@ class AccountSasPermissions(object):
     """
     def __init__(self, read=False, write=False, delete=False, list=False,  # pylint: disable=redefined-builtin
                  add=False, create=False, update=False, process=False):
-        self.read = read or ('r' in _str)
-        self.write = write or ('w' in _str)
-        self.delete = delete or ('d' in _str)
-        self.list = list or ('l' in _str)
-        self.add = add or ('a' in _str)
-        self.create = create or ('c' in _str)
-        self.update = update or ('u' in _str)
-        self.process = process or ('p' in _str)
+        self.read = read
+        self.write = write
+        self.delete = delete
+        self.list = list
+        self.add = add
+        self.create = create
+        self.update = update
+        self.process = process
+        self._str = (('r' if self.read else '') +
+                     ('w' if  self.write else '') +
+                     ('d' if self.delete else '') +
+                     ('l' if self.list else '') +
+                     ('a' if self.add else '') +
+                     ('c' if self.create else '') +
+                     ('u' if self.update else '') +
+                     ('p' if self.process else ''))
 
     def __str__(self):
-        return (('r' if self.read else '') +
-                ('w' if self.write else '') +
-                ('d' if self.delete else '') +
-                ('l' if self.list else '') +
-                ('a' if self.add else '') +
-                ('c' if self.create else '') +
-                ('u' if self.update else '') +
-                ('p' if self.process else ''))
+        return self._str
 
     @classmethod
     def from_string(cls, permission):
         if len(permission) > 8:
             raise ValueError("Invalid Permission String")
-        read, write, delete, list = False, False, False, False
-        add, create, update, process = False, False, False, False
-        curr = 0
-        while curr < len(permission):
-            if permission[curr] =='r':
-                read = True
-            elif permission[curr] == 'w':
-                write = True
-            elif permission[curr] == 'd':
-                delete = True
-            elif permission[curr] == 'l':
-                list = True
-            elif permission[curr] =='a':
-                add = True
-            elif permission[curr] == 'c':
-                create = True
-            elif permission[curr] == 'u':
-                update = True
-            elif permission[curr] == 'p':
-                process = True
-            else:
-                raise ValueError("Invalid Permission String")
-            curr += 1
-        return cls(read, write, delete, list, add, create, update, process)
+
+        p_read = 'r' in permission
+        p_write = 'w' in permission
+        p_delete = 'd' in permission
+        p_list = 'l' in permission
+        p_add = 'a' in permission
+        p_create = 'c' in permission
+        p_update = 'u' in permission
+        p_process = 'p' in permission
+
+        parsed = cls(p_read, p_write, p_delete, p_list, p_add, p_create, p_update, p_process)
+        parsed._str = permission
+        return parsed
 
 
 class Services(object):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/models.py
@@ -27,7 +27,7 @@ class StorageErrorCode(str, Enum):
     condition_headers_not_supported = "ConditionHeadersNotSupported"
     condition_not_met = "ConditionNotMet"
     empty_metadata_key = "EmptyMetadataKey"
-    insufficient_account_permissions = "InsufficientAccountPermissions"
+    insufficient_account_permissions = "InsufficientAccountSasPermissions"
     internal_error = "InternalError"
     invalid_authentication_info = "InvalidAuthenticationInfo"
     invalid_header_value = "InvalidHeaderValue"
@@ -277,7 +277,7 @@ ResourceTypes.CONTAINER = ResourceTypes(container=True)
 ResourceTypes.OBJECT = ResourceTypes(object=True)
 
 
-class AccountPermissions(object):
+class AccountSasPermissions(object):
     """
     :class:`~ResourceTypes` class to be used with generate_shared_access_signature
     method and for the AccessPolicies used with set_*_acl. There are two types of
@@ -286,23 +286,23 @@ class AccountPermissions(object):
     entire service for a specific account and allow certain operations based on
     perms found here.
 
-    :cvar AccountPermissions AccountPermissions.ADD:
+    :cvar AccountSasPermissions AccountSasPermissions.ADD:
         Valid for the following Object resource types only: queue messages and append blobs.
-    :cvar AccountPermissions AccountPermissions.CREATE:
+    :cvar AccountSasPermissions AccountSasPermissions.CREATE:
         Valid for the following Object resource types only: blobs and files. Users
         can create new blobs or files, but may not overwrite existing blobs or files.
-    :cvar AccountPermissions AccountPermissions.DELETE:
+    :cvar AccountSasPermissions AccountSasPermissions.DELETE:
         Valid for Container and Object resource types, except for queue messages.
-    :cvar AccountPermissions AccountPermissions.LIST:
+    :cvar AccountSasPermissions AccountSasPermissions.LIST:
         Valid for Service and Container resource types only.
-    :cvar AccountPermissions AccountPermissions.PROCESS:
+    :cvar AccountSasPermissions AccountSasPermissions.PROCESS:
         Valid for the following Object resource type only: queue messages.
-    :cvar AccountPermissions AccountPermissions.READ:
+    :cvar AccountSasPermissions AccountSasPermissions.READ:
         Valid for all signed resources types (Service, Container, and Object).
         Permits read permissions to the specified resource type.
-    :cvar AccountPermissions AccountPermissions.UPDATE:
+    :cvar AccountSasPermissions AccountSasPermissions.UPDATE:
         Valid for the following Object resource types only: queue messages.
-    :cvar AccountPermissions AccountPermissions.WRITE:
+    :cvar AccountSasPermissions AccountSasPermissions.WRITE:
         Valid for all signed resources types (Service, Container, and Object).
         Permits write permissions to the specified resource type.
     :param bool read:
@@ -329,14 +329,14 @@ class AccountPermissions(object):
         A string representing the permissions.
     """
 
-    READ = None  # type: AccountPermissions
-    WRITE = None  # type: AccountPermissions
-    DELETE = None  # type: AccountPermissions
-    LIST = None  # type: AccountPermissions
-    ADD = None  # type: AccountPermissions
-    CREATE = None  # type: AccountPermissions
-    UPDATE = None  # type: AccountPermissions
-    PROCESS = None  # type: AccountPermissions
+    READ = None  # type: AccountSasPermissions
+    WRITE = None  # type: AccountSasPermissions
+    DELETE = None  # type: AccountSasPermissions
+    LIST = None  # type: AccountSasPermissions
+    ADD = None  # type: AccountSasPermissions
+    CREATE = None  # type: AccountSasPermissions
+    UPDATE = None  # type: AccountSasPermissions
+    PROCESS = None  # type: AccountSasPermissions
 
     def __init__(self, read=False, write=False, delete=False, list=False,  # pylint: disable=redefined-builtin
                  add=False, create=False, update=False, process=False, _str=None):
@@ -352,10 +352,10 @@ class AccountPermissions(object):
         self.process = process or ('p' in _str)
 
     def __or__(self, other):
-        return AccountPermissions(_str=str(self) + str(other))
+        return AccountSasPermissions(_str=str(self) + str(other))
 
     def __add__(self, other):
-        return AccountPermissions(_str=str(self) + str(other))
+        return AccountSasPermissions(_str=str(self) + str(other))
 
     def __str__(self):
         return (('r' if self.read else '') +
@@ -368,14 +368,14 @@ class AccountPermissions(object):
                 ('p' if self.process else ''))
 
 
-AccountPermissions.READ = AccountPermissions(read=True)
-AccountPermissions.WRITE = AccountPermissions(write=True)
-AccountPermissions.DELETE = AccountPermissions(delete=True)
-AccountPermissions.LIST = AccountPermissions(list=True)
-AccountPermissions.ADD = AccountPermissions(add=True)
-AccountPermissions.CREATE = AccountPermissions(create=True)
-AccountPermissions.UPDATE = AccountPermissions(update=True)
-AccountPermissions.PROCESS = AccountPermissions(process=True)
+AccountSasPermissions.READ = AccountSasPermissions(read=True)
+AccountSasPermissions.WRITE = AccountSasPermissions(write=True)
+AccountSasPermissions.DELETE = AccountSasPermissions(delete=True)
+AccountSasPermissions.LIST = AccountSasPermissions(list=True)
+AccountSasPermissions.ADD = AccountSasPermissions(add=True)
+AccountSasPermissions.CREATE = AccountSasPermissions(create=True)
+AccountSasPermissions.UPDATE = AccountSasPermissions(update=True)
+AccountSasPermissions.PROCESS = AccountSasPermissions(process=True)
 
 
 class Services(object):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/shared_access_signature.py
@@ -103,7 +103,7 @@ class SharedAccessSignature(object):
             Specifies the resource types that are accessible with the account
             SAS. You can combine values to provide access to more than one
             resource type.
-        :param AccountPermissions permission:
+        :param AccountSasPermissions permission:
             The permissions associated with the shared access signature. The
             user is restricted to operations allowed by the permissions.
             Required unless an id is given referencing a stored access policy

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
@@ -52,7 +52,7 @@ class BlobSharedAccessSignature(SharedAccessSignature):
         :param str snapshot:
             The snapshot parameter is an opaque DateTime value that,
             when present, specifies the blob snapshot to grant permission.
-        :param BlobPermissions permission:
+        :param BlobSasPermissions permission:
             The permissions associated with the shared access signature. The
             user is restricted to operations allowed by the permissions.
             Permissions must be ordered read, write, delete, list.
@@ -129,7 +129,7 @@ class BlobSharedAccessSignature(SharedAccessSignature):
 
         :param str container_name:
             Name of container.
-        :param ContainerPermissions permission:
+        :param ContainerSasPermissions permission:
             The permissions associated with the shared access signature. The
             user is restricted to operations allowed by the permissions.
             Permissions must be ordered read, write, delete, list.

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/__init__.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/__init__.py
@@ -9,7 +9,7 @@ from .._shared.downloads_async import StorageStreamDownloader
 from .._shared.models import(
     LocationMode,
     ResourceTypes,
-    AccountPermissions,
+    AccountSasPermissions,
     StorageErrorCode
 )
 from ..models import (
@@ -32,8 +32,8 @@ from ..models import (
     BlobBlock,
     PageRange,
     AccessPolicy,
-    ContainerPermissions,
-    BlobPermissions,
+    ContainerSasPermissions,
+    BlobSasPermissions,
 )
 from .models import (
     ContainerPropertiesPaged,
@@ -78,9 +78,9 @@ __all__ = [
     'BlobBlock',
     'PageRange',
     'AccessPolicy',
-    'ContainerPermissions',
-    'BlobPermissions',
+    'ContainerSasPermissions',
+    'BlobSasPermissions',
     'ResourceTypes',
-    'AccountPermissions',
+    'AccountSasPermissions',
     'StorageStreamDownloader',
 ]

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/blob_client_async.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from ..models import (  # pylint: disable=unused-import
         ContainerProperties,
         BlobProperties,
-        BlobPermissions,
+        BlobSasPermissions,
         ContentSettings,
         PremiumPageBlobTier,
         StandardBlobTier,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/blob_service_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/blob_service_client_async.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from datetime import datetime
     from azure.core.pipeline.transport import HttpTransport
     from azure.core.pipeline.policies import HTTPPolicy
-    from .._shared.models import AccountPermissions, ResourceTypes
+    from .._shared.models import AccountSasPermissions, ResourceTypes
     from .lease_async import LeaseClient
     from ..models import (
         BlobProperties,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/container_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/container_client_async.py
@@ -39,7 +39,7 @@ from .blob_client_async import BlobClient
 if TYPE_CHECKING:
     from azure.core.pipeline.transport import HttpTransport
     from azure.core.pipeline.policies import HTTPPolicy
-    from ..models import ContainerPermissions, PublicAccess
+    from ..models import ContainerSasPermissions, PublicAccess
     from datetime import datetime
     from ..models import ( # pylint: disable=unused-import
         AccessPolicy,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/blob_client.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
     from .models import (  # pylint: disable=unused-import
         ContainerProperties,
         BlobProperties,
-        BlobPermissions,
+        BlobSasPermissions,
         ContentSettings,
         PremiumPageBlobTier,
         StandardBlobTier,
@@ -225,7 +225,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             account_url, container=container, blob=blob, snapshot=snapshot, credential=credential, **kwargs)
 
     def generate_shared_access_signature(
-            self, permission=None,  # type: Optional[Union[BlobPermissions, str]]
+            self, permission=None,  # type: Optional[Union[BlobSasPermissions, str]]
             expiry=None,  # type: Optional[Union[datetime, str]]
             start=None,  # type: Optional[Union[datetime, str]]
             policy_id=None,  # type: Optional[str]
@@ -252,7 +252,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             Required unless an id is given referencing a stored access policy
             which contains this field. This field must be omitted if it has been
             specified in an associated stored access policy.
-        :type permission: str or ~azure.storage.blob.models.BlobPermissions
+        :type permission: str or ~azure.storage.blob.models.BlobSasPermissions
         :param expiry:
             The time at which the shared access signature becomes invalid.
             Required unless an id is given referencing a stored access policy

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/blob_service_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/blob_service_client.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from datetime import datetime
     from azure.core.pipeline.transport import HttpTransport
     from azure.core.pipeline.policies import HTTPPolicy
-    from ._shared.models import AccountPermissions, ResourceTypes
+    from ._shared.models import AccountSasPermissions, ResourceTypes
     from .lease import LeaseClient
     from .models import (
         BlobProperties,
@@ -157,7 +157,7 @@ class BlobServiceClient(StorageAccountHostsMixin):
 
     def generate_shared_access_signature(
             self, resource_types,  # type: Union[ResourceTypes, str]
-            permission,  # type: Union[AccountPermissions, str]
+            permission,  # type: Union[AccountSasPermissions, str]
             expiry,  # type: Optional[Union[datetime, str]]
             start=None,  # type: Optional[Union[datetime, str]]
             ip=None,  # type: Optional[str]
@@ -177,7 +177,7 @@ class BlobServiceClient(StorageAccountHostsMixin):
             Required unless an id is given referencing a stored access policy
             which contains this field. This field must be omitted if it has been
             specified in an associated stored access policy.
-        :type permission: str or ~azure.storage.blob.models.AccountPermissions
+        :type permission: str or ~azure.storage.blob.models.AccountSasPermissions
         :param expiry:
             The time at which the shared access signature becomes invalid.
             Required unless an id is given referencing a stored access policy

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/container_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/container_client.py
@@ -48,7 +48,7 @@ from ._shared_access_signature import BlobSharedAccessSignature
 if TYPE_CHECKING:
     from azure.core.pipeline.transport import HttpTransport  # pylint: disable=ungrouped-imports
     from azure.core.pipeline.policies import HTTPPolicy # pylint: disable=ungrouped-imports
-    from .models import ContainerPermissions, PublicAccess
+    from .models import ContainerSasPermissions, PublicAccess
     from datetime import datetime
     from .models import ( # pylint: disable=unused-import
         AccessPolicy,
@@ -185,7 +185,7 @@ class ContainerClient(StorageAccountHostsMixin):
             account_url, container=container, credential=credential, **kwargs)
 
     def generate_shared_access_signature(
-            self, permission=None,  # type: Optional[Union[ContainerPermissions, str]]
+            self, permission=None,  # type: Optional[Union[ContainerSasPermissions, str]]
             expiry=None,  # type: Optional[Union[datetime, str]]
             start=None,  # type: Optional[Union[datetime, str]]
             policy_id=None,  # type: Optional[str]
@@ -211,7 +211,7 @@ class ContainerClient(StorageAccountHostsMixin):
             Required unless an id is given referencing a stored access policy
             which contains this field. This field must be omitted if it has been
             specified in an associated stored access policy.
-        :type permission: str or ~azure.storage.blob.models.ContainerPermissions
+        :type permission: str or ~azure.storage.blob.models.ContainerSasPermissions
         :param expiry:
             The time at which the shared access signature becomes invalid.
             Required unless an id is given referencing a stored access policy

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
@@ -820,7 +820,7 @@ class AccessPolicy(GenAccessPolicy):
         Required unless an id is given referencing a stored access policy
         which contains this field. This field must be omitted if it has been
         specified in an associated stored access policy.
-    :type permission: str or ~azure.storage.blob.models.ContainerPermissions
+    :type permission: str or ~azure.storage.blob.models.ContainerSasPermissions
     :param expiry:
         The time at which the shared access signature becomes invalid.
         Required unless an id is given referencing a stored access policy
@@ -843,21 +843,21 @@ class AccessPolicy(GenAccessPolicy):
         self.permission = permission
 
 
-class ContainerPermissions(object):
-    """ContainerPermissions class to be used with
+class ContainerSasPermissions(object):
+    """ContainerSasPermissions class to be used with
     :func:`~azure.storage.blob.container_client.ContainerClient.generate_shared_access_signature` API and
     for the AccessPolicies used with
     :func:`~azure.storage.blob.container_client.ContainerClient.set_container_access_policy`.
 
-    :cvar ContainerPermissions ContainerPermissions.DELETE:
+    :cvar ContainerSasPermissions ContainerSasPermissions.DELETE:
         Delete any blob in the container. Note: You cannot grant permissions to
         delete a container with a container SAS. Use an account SAS instead.
-    :cvar ContainerPermissions ContainerPermissions.LIST:
+    :cvar ContainerSasPermissions ContainerSasPermissions.LIST:
         List blobs in the container.
-    :cvar ContainerPermissions ContainerPermissions.READ:
+    :cvar ContainerSasPermissions ContainerSasPermissions.READ:
         Read the content, properties, metadata or block list of any blob in the
         container. Use any blob in the container as the source of a copy operation.
-    :cvar ContainerPermissions ContainerPermissions.WRITE:
+    :cvar ContainerSasPermissions ContainerSasPermissions.WRITE:
         For any blob in the container, create or write content, properties,
         metadata, or block list. Snapshot or lease the blob. Resize the blob
         (page blob only). Use the blob as the destination of a copy operation
@@ -883,10 +883,10 @@ class ContainerPermissions(object):
         A string representing the permissions.
     """
 
-    DELETE = None  # type: ContainerPermissions
-    LIST = None  # type: ContainerPermissions
-    READ = None  # type: ContainerPermissions
-    WRITE = None  # type: ContainerPermissions
+    DELETE = None  # type: ContainerSasPermissions
+    LIST = None  # type: ContainerSasPermissions
+    READ = None  # type: ContainerSasPermissions
+    WRITE = None  # type: ContainerSasPermissions
 
     def __init__(self, read=False, write=False, delete=False, list=False, _str=None):  # pylint: disable=redefined-builtin
         if not _str:
@@ -897,10 +897,10 @@ class ContainerPermissions(object):
         self.list = list or ('l' in _str)
 
     def __or__(self, other):
-        return ContainerPermissions(_str=str(self) + str(other))
+        return ContainerSasPermissions(_str=str(self) + str(other))
 
     def __add__(self, other):
-        return ContainerPermissions(_str=str(self) + str(other))
+        return ContainerSasPermissions(_str=str(self) + str(other))
 
     def __str__(self):
         return (('r' if self.read else '') +
@@ -909,25 +909,25 @@ class ContainerPermissions(object):
                 ('l' if self.list else ''))
 
 
-ContainerPermissions.DELETE = ContainerPermissions(delete=True)
-ContainerPermissions.LIST = ContainerPermissions(list=True)
-ContainerPermissions.READ = ContainerPermissions(read=True)
-ContainerPermissions.WRITE = ContainerPermissions(write=True)
+ContainerSasPermissions.DELETE = ContainerSasPermissions(delete=True)
+ContainerSasPermissions.LIST = ContainerSasPermissions(list=True)
+ContainerSasPermissions.READ = ContainerSasPermissions(read=True)
+ContainerSasPermissions.WRITE = ContainerSasPermissions(write=True)
 
 
-class BlobPermissions(object):
-    """BlobPermissions class to be used with
+class BlobSasPermissions(object):
+    """BlobSasPermissions class to be used with
     :func:`~azure.storage.blob.blob_client.BlobClient.generate_shared_access_signature` API.
 
-    :cvar BlobPermissions BlobPermissions.ADD:
+    :cvar BlobSasPermissions BlobSasPermissions.ADD:
         Add a block to an append blob.
-    :cvar BlobPermissions BlobPermissions.CREATE:
+    :cvar BlobSasPermissions BlobSasPermissions.CREATE:
         Write a new blob, snapshot a blob, or copy a blob to a new blob.
-    :cvar BlobPermissions BlobPermissions.DELETE:
+    :cvar BlobSasPermissions BlobSasPermissions.DELETE:
         Delete the blob.
-    :cvar BlobPermissions BlobPermissions.READ:
+    :cvar BlobSasPermissions BlobSasPermissions.READ:
         Read the content, properties, metadata and block list. Use the blob as the source of a copy operation.
-    :cvar BlobPermissions BlobPermissions.WRITE:
+    :cvar BlobSasPermissions BlobSasPermissions.WRITE:
         Create or write content, properties, metadata, or block list. Snapshot or lease
         the blob. Resize the blob (page blob only). Use the blob as the destination of a
         copy operation within the same account.
@@ -947,11 +947,11 @@ class BlobPermissions(object):
     :param str _str:
         A string representing the permissions.
     """
-    ADD = None  # type: BlobPermissions
-    CREATE = None  # type: BlobPermissions
-    DELETE = None  # type: BlobPermissions
-    READ = None  # type: BlobPermissions
-    WRITE = None  # type: BlobPermissions
+    ADD = None  # type: BlobSasPermissions
+    CREATE = None  # type: BlobSasPermissions
+    DELETE = None  # type: BlobSasPermissions
+    READ = None  # type: BlobSasPermissions
+    WRITE = None  # type: BlobSasPermissions
 
 
     def __init__(self, read=False, add=False, create=False, write=False,
@@ -965,10 +965,10 @@ class BlobPermissions(object):
         self.delete = delete or ('d' in _str)
 
     def __or__(self, other):
-        return BlobPermissions(_str=str(self) + str(other))
+        return BlobSasPermissions(_str=str(self) + str(other))
 
     def __add__(self, other):
-        return BlobPermissions(_str=str(self) + str(other))
+        return BlobSasPermissions(_str=str(self) + str(other))
 
     def __str__(self):
         return (('r' if self.read else '') +
@@ -978,11 +978,11 @@ class BlobPermissions(object):
                 ('d' if self.delete else ''))
 
 
-BlobPermissions.ADD = BlobPermissions(add=True)
-BlobPermissions.CREATE = BlobPermissions(create=True)
-BlobPermissions.DELETE = BlobPermissions(delete=True)
-BlobPermissions.READ = BlobPermissions(read=True)
-BlobPermissions.WRITE = BlobPermissions(write=True)
+BlobSasPermissions.ADD = BlobSasPermissions(add=True)
+BlobSasPermissions.CREATE = BlobSasPermissions(create=True)
+BlobSasPermissions.DELETE = BlobSasPermissions(delete=True)
+BlobSasPermissions.READ = BlobSasPermissions(read=True)
+BlobSasPermissions.WRITE = BlobSasPermissions(write=True)
 
 
 class CustomerProvidedEncryptionKey(object):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
@@ -849,21 +849,6 @@ class ContainerSasPermissions(object):
     for the AccessPolicies used with
     :func:`~azure.storage.blob.container_client.ContainerClient.set_container_access_policy`.
 
-    :cvar ContainerSasPermissions ContainerSasPermissions.DELETE:
-        Delete any blob in the container. Note: You cannot grant permissions to
-        delete a container with a container SAS. Use an account SAS instead.
-    :cvar ContainerSasPermissions ContainerSasPermissions.LIST:
-        List blobs in the container.
-    :cvar ContainerSasPermissions ContainerSasPermissions.READ:
-        Read the content, properties, metadata or block list of any blob in the
-        container. Use any blob in the container as the source of a copy operation.
-    :cvar ContainerSasPermissions ContainerSasPermissions.WRITE:
-        For any blob in the container, create or write content, properties,
-        metadata, or block list. Snapshot or lease the blob. Resize the blob
-        (page blob only). Use the blob as the destination of a copy operation
-        within the same account. Note: You cannot grant permissions to read or
-        write container properties or metadata, nor to lease a container, with
-        a container SAS. Use an account SAS instead.
     :param bool read:
         Read the content, properties, metadata or block list of any blob in the
         container. Use any blob in the container as the source of a copy operation.
@@ -896,6 +881,8 @@ class ContainerSasPermissions(object):
 
     @classmethod
     def from_string(cls, permission):
+        if len(permission) > 4:
+            raise ValueError("Invalid Permission String")
         read, write, delete, list = False, False, False, False
         curr = 0
         while curr < len(permission):
@@ -917,18 +904,6 @@ class BlobSasPermissions(object):
     """BlobSasPermissions class to be used with
     :func:`~azure.storage.blob.blob_client.BlobClient.generate_shared_access_signature` API.
 
-    :cvar BlobSasPermissions BlobSasPermissions.ADD:
-        Add a block to an append blob.
-    :cvar BlobSasPermissions BlobSasPermissions.CREATE:
-        Write a new blob, snapshot a blob, or copy a blob to a new blob.
-    :cvar BlobSasPermissions BlobSasPermissions.DELETE:
-        Delete the blob.
-    :cvar BlobSasPermissions BlobSasPermissions.READ:
-        Read the content, properties, metadata and block list. Use the blob as the source of a copy operation.
-    :cvar BlobSasPermissions BlobSasPermissions.WRITE:
-        Create or write content, properties, metadata, or block list. Snapshot or lease
-        the blob. Resize the blob (page blob only). Use the blob as the destination of a
-        copy operation within the same account.
     :param bool read:
         Read the content, properties, metadata and block list. Use the blob as
         the source of a copy operation.
@@ -962,6 +937,8 @@ class BlobSasPermissions(object):
 
     @classmethod
     def from_string(cls, permission):
+        if len(permission) > 5:
+            raise ValueError("Invalid Permission String")
         read, add, create, write, delete = False, False, False, False, False
         curr = 0
         while curr < len(permission):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
@@ -882,25 +882,11 @@ class ContainerSasPermissions(object):
     :param str _str:
         A string representing the permissions.
     """
-
-    DELETE = None  # type: ContainerSasPermissions
-    LIST = None  # type: ContainerSasPermissions
-    READ = None  # type: ContainerSasPermissions
-    WRITE = None  # type: ContainerSasPermissions
-
-    def __init__(self, read=False, write=False, delete=False, list=False, _str=None):  # pylint: disable=redefined-builtin
-        if not _str:
-            _str = ''
-        self.read = read or ('r' in _str)
-        self.write = write or ('w' in _str)
-        self.delete = delete or ('d' in _str)
-        self.list = list or ('l' in _str)
-
-    def __or__(self, other):
-        return ContainerSasPermissions(_str=str(self) + str(other))
-
-    def __add__(self, other):
-        return ContainerSasPermissions(_str=str(self) + str(other))
+    def __init__(self, read=False, write=False, delete=False, list=False):  # pylint: disable=redefined-builtin
+        self.read = read
+        self.write = write
+        self.delete = delete
+        self.list = list
 
     def __str__(self):
         return (('r' if self.read else '') +
@@ -908,11 +894,23 @@ class ContainerSasPermissions(object):
                 ('d' if self.delete else '') +
                 ('l' if self.list else ''))
 
-
-ContainerSasPermissions.DELETE = ContainerSasPermissions(delete=True)
-ContainerSasPermissions.LIST = ContainerSasPermissions(list=True)
-ContainerSasPermissions.READ = ContainerSasPermissions(read=True)
-ContainerSasPermissions.WRITE = ContainerSasPermissions(write=True)
+    @classmethod
+    def from_string(cls, permission):
+        read, write, delete, list = False, False, False, False
+        curr = 0
+        while curr < len(permission):
+            if permission[curr] =='r':
+                read = True
+            elif permission[curr] == 'w':
+                write = True
+            elif permission[curr] == 'd':
+                delete = True
+            elif permission[curr] == 'l':
+                list = True
+            else:
+                raise ValueError("Invalid Permission String")
+            curr += 1
+        return cls(read, write, delete, list)
 
 
 class BlobSasPermissions(object):
@@ -947,28 +945,13 @@ class BlobSasPermissions(object):
     :param str _str:
         A string representing the permissions.
     """
-    ADD = None  # type: BlobSasPermissions
-    CREATE = None  # type: BlobSasPermissions
-    DELETE = None  # type: BlobSasPermissions
-    READ = None  # type: BlobSasPermissions
-    WRITE = None  # type: BlobSasPermissions
-
-
     def __init__(self, read=False, add=False, create=False, write=False,
-                 delete=False, _str=None):
-        if not _str:
-            _str = ''
-        self.read = read or ('r' in _str)
-        self.add = add or ('a' in _str)
-        self.create = create or ('c' in _str)
-        self.write = write or ('w' in _str)
-        self.delete = delete or ('d' in _str)
-
-    def __or__(self, other):
-        return BlobSasPermissions(_str=str(self) + str(other))
-
-    def __add__(self, other):
-        return BlobSasPermissions(_str=str(self) + str(other))
+                 delete=False):
+        self.read = read
+        self.add = add
+        self.create = create
+        self.write = write
+        self.delete = delete
 
     def __str__(self):
         return (('r' if self.read else '') +
@@ -977,12 +960,25 @@ class BlobSasPermissions(object):
                 ('w' if self.write else '') +
                 ('d' if self.delete else ''))
 
-
-BlobSasPermissions.ADD = BlobSasPermissions(add=True)
-BlobSasPermissions.CREATE = BlobSasPermissions(create=True)
-BlobSasPermissions.DELETE = BlobSasPermissions(delete=True)
-BlobSasPermissions.READ = BlobSasPermissions(read=True)
-BlobSasPermissions.WRITE = BlobSasPermissions(write=True)
+    @classmethod
+    def from_string(cls, permission):
+        read, add, create, write, delete = False, False, False, False, False
+        curr = 0
+        while curr < len(permission):
+            if permission[curr] =='r':
+                read = True
+            elif permission[curr] == 'a':
+                add = True
+            elif permission[curr] == 'c':
+                create = True
+            elif permission[curr] == 'w':
+                write = True
+            elif permission[curr] == 'd':
+                delete = True
+            else:
+                raise ValueError("Invalid Permission String")
+            curr += 1
+        return cls(read, add, create, write, delete)
 
 
 class CustomerProvidedEncryptionKey(object):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
@@ -864,8 +864,6 @@ class ContainerSasPermissions(object):
         delete a container with a container SAS. Use an account SAS instead.
     :param bool list:
         List blobs in the container.
-    :param str _str:
-        A string representing the permissions.
     """
     def __init__(self, read=False, write=False, delete=False, list=False):  # pylint: disable=redefined-builtin
         self.read = read
@@ -908,8 +906,6 @@ class BlobSasPermissions(object):
         destination of a copy operation within the same account.
     :param bool delete:
         Delete the blob.
-    :param str _str:
-        A string representing the permissions.
     """
     def __init__(self, read=False, add=False, create=False, write=False,
                  delete=False):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
@@ -872,32 +872,25 @@ class ContainerSasPermissions(object):
         self.write = write
         self.delete = delete
         self.list = list
+        self._str = (('r' if self.read else '') +
+                     ('w' if self.write else '') +
+                     ('d' if self.delete else '') +
+                     ('l' if self.list else ''))
 
     def __str__(self):
-        return (('r' if self.read else '') +
-                ('w' if self.write else '') +
-                ('d' if self.delete else '') +
-                ('l' if self.list else ''))
+        return self._str
 
     @classmethod
     def from_string(cls, permission):
         if len(permission) > 4:
             raise ValueError("Invalid Permission String")
-        read, write, delete, list = False, False, False, False
-        curr = 0
-        while curr < len(permission):
-            if permission[curr] =='r':
-                read = True
-            elif permission[curr] == 'w':
-                write = True
-            elif permission[curr] == 'd':
-                delete = True
-            elif permission[curr] == 'l':
-                list = True
-            else:
-                raise ValueError("Invalid Permission String")
-            curr += 1
-        return cls(read, write, delete, list)
+        p_read = 'r' in permission
+        p_write = 'w' in permission
+        p_delete = 'd' in permission
+        p_list = 'l' in permission
+        parsed = cls(p_read, p_write, p_delete, p_list)
+        parsed._str = permission
+        return parsed
 
 
 class BlobSasPermissions(object):
@@ -927,35 +920,28 @@ class BlobSasPermissions(object):
         self.create = create
         self.write = write
         self.delete = delete
+        self._str = (('r' if self.read else '') +
+                     ('a' if self.add else '') +
+                     ('c' if self.create else '') +
+                     ('w' if self.write else '') +
+                     ('d' if self.delete else ''))
 
     def __str__(self):
-        return (('r' if self.read else '') +
-                ('a' if self.add else '') +
-                ('c' if self.create else '') +
-                ('w' if self.write else '') +
-                ('d' if self.delete else ''))
+        return self._str
 
     @classmethod
     def from_string(cls, permission):
         if len(permission) > 5:
             raise ValueError("Invalid Permission String")
-        read, add, create, write, delete = False, False, False, False, False
-        curr = 0
-        while curr < len(permission):
-            if permission[curr] =='r':
-                read = True
-            elif permission[curr] == 'a':
-                add = True
-            elif permission[curr] == 'c':
-                create = True
-            elif permission[curr] == 'w':
-                write = True
-            elif permission[curr] == 'd':
-                delete = True
-            else:
-                raise ValueError("Invalid Permission String")
-            curr += 1
-        return cls(read, add, create, write, delete)
+        p_read = 'r' in permission
+        p_add = 'a' in permission
+        p_create = 'c' in permission
+        p_write = 'w' in permission
+        p_delete = 'd' in permission
+
+        parsed = cls(p_read, p_add, p_create, p_write, p_delete)
+        parsed._str = permission
+        return parsed
 
 
 class CustomerProvidedEncryptionKey(object):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
@@ -885,7 +885,7 @@ class ContainerSasPermissions(object):
         p_delete = 'd' in permission
         p_list = 'l' in permission
         parsed = cls(p_read, p_write, p_delete, p_list)
-        parsed._str = permission
+        parsed._str = permission # pylint: disable = protected-access
         return parsed
 
 
@@ -932,7 +932,7 @@ class BlobSasPermissions(object):
         p_delete = 'd' in permission
 
         parsed = cls(p_read, p_add, p_create, p_write, p_delete)
-        parsed._str = permission
+        parsed._str = permission # pylint: disable = protected-access
         return parsed
 
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
@@ -882,8 +882,6 @@ class ContainerSasPermissions(object):
 
     @classmethod
     def from_string(cls, permission):
-        if len(permission) > 4:
-            raise ValueError("Invalid Permission String")
         p_read = 'r' in permission
         p_write = 'w' in permission
         p_delete = 'd' in permission
@@ -931,8 +929,6 @@ class BlobSasPermissions(object):
 
     @classmethod
     def from_string(cls, permission):
-        if len(permission) > 5:
-            raise ValueError("Invalid Permission String")
         p_read = 'r' in permission
         p_add = 'a' in permission
         p_create = 'c' in permission

--- a/sdk/storage/azure-storage-blob/tests/test_append_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_append_blob.py
@@ -198,7 +198,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -238,7 +238,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         src_md5 = StorageContentValidation.get_content_md5(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -271,7 +271,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_blob_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -308,7 +308,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_blob_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -345,7 +345,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_blob_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -380,7 +380,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_blob_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -414,7 +414,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -452,7 +452,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -486,7 +486,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -520,7 +520,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -555,7 +555,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -591,7 +591,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_properties = source_blob_client.append_block(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 

--- a/sdk/storage/azure-storage-blob/tests/test_append_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_append_blob.py
@@ -17,7 +17,7 @@ from azure.storage.blob import (
     ContainerClient,
     BlobClient,
     BlobType,
-    BlobPermissions)
+    BlobSasPermissions)
 from azure.storage.blob._shared.policies import StorageContentValidation
 from testcase import (
     StorageTestCase,
@@ -198,7 +198,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -238,7 +238,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         src_md5 = StorageContentValidation.get_content_md5(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -271,7 +271,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_blob_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -308,7 +308,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_blob_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -345,7 +345,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_blob_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -380,7 +380,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_blob_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -414,7 +414,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -452,7 +452,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -486,7 +486,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -520,7 +520,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -555,7 +555,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -591,7 +591,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_properties = source_blob_client.append_block(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 

--- a/sdk/storage/azure-storage-blob/tests/test_append_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_append_blob.py
@@ -198,7 +198,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -238,7 +238,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         src_md5 = StorageContentValidation.get_content_md5(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -271,7 +271,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_blob_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -308,7 +308,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_blob_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -345,7 +345,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_blob_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -380,7 +380,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_blob_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -414,7 +414,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -452,7 +452,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -486,7 +486,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -520,7 +520,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -555,7 +555,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -591,7 +591,7 @@ class StorageAppendBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data)
         source_properties = source_blob_client.append_block(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 

--- a/sdk/storage/azure-storage-blob/tests/test_append_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_append_blob_async.py
@@ -255,7 +255,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -300,7 +300,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         src_md5 = StorageContentValidation.get_content_md5(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -338,7 +338,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_blob_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -381,7 +381,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_blob_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -424,7 +424,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -465,7 +465,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -505,7 +505,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -549,7 +549,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -589,7 +589,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -629,7 +629,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -670,7 +670,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -712,7 +712,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 

--- a/sdk/storage/azure-storage-blob/tests/test_append_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_append_blob_async.py
@@ -255,7 +255,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -300,7 +300,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         src_md5 = StorageContentValidation.get_content_md5(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -338,7 +338,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_blob_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -381,7 +381,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_blob_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -424,7 +424,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -465,7 +465,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -505,7 +505,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -549,7 +549,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -589,7 +589,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -629,7 +629,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -670,7 +670,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -712,7 +712,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 

--- a/sdk/storage/azure-storage-blob/tests/test_append_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_append_blob_async.py
@@ -18,7 +18,7 @@ from azure.core.exceptions import ResourceNotFoundError, ResourceModifiedError
 from azure.core.pipeline.transport import AioHttpTransport
 from multidict import CIMultiDict, CIMultiDictProxy
 
-from azure.storage.blob import BlobPermissions
+from azure.storage.blob import BlobSasPermissions
 from azure.storage.blob._shared.policies import StorageContentValidation
 from azure.storage.blob.aio import (
     BlobServiceClient,
@@ -255,7 +255,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -300,7 +300,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         src_md5 = StorageContentValidation.get_content_md5(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -338,7 +338,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_blob_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -381,7 +381,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_blob_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -424,7 +424,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -465,7 +465,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -505,7 +505,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -549,7 +549,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -589,7 +589,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -629,7 +629,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(LARGE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -670,7 +670,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -712,7 +712,7 @@ class StorageAppendBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 

--- a/sdk/storage/azure-storage-blob/tests/test_blob_samples_authentication.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_samples_authentication.py
@@ -119,7 +119,7 @@ class TestAuthSamples(StorageTestCase):
 
         sas_token = blob_service_client.generate_shared_access_signature(
             resource_types=ResourceTypes.OBJECT,
-            permission=AccountSasPermissions.READ,
+            permission=AccountSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
         # [END create_sas_token]

--- a/sdk/storage/azure-storage-blob/tests/test_blob_samples_authentication.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_samples_authentication.py
@@ -115,11 +115,11 @@ class TestAuthSamples(StorageTestCase):
         # [START create_sas_token]
         # Create a SAS token to use to authenticate a new client
         from datetime import datetime, timedelta
-        from azure.storage.blob import ResourceTypes, AccountPermissions
+        from azure.storage.blob import ResourceTypes, AccountSasPermissions
 
         sas_token = blob_service_client.generate_shared_access_signature(
             resource_types=ResourceTypes.OBJECT,
-            permission=AccountPermissions.READ,
+            permission=AccountSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
         # [END create_sas_token]

--- a/sdk/storage/azure-storage-blob/tests/test_blob_samples_authentication_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_samples_authentication_async.py
@@ -144,7 +144,7 @@ class TestAuthSamplesAsync(StorageTestCase):
 
         sas_token = blob_service_client.generate_shared_access_signature(
             resource_types=ResourceTypes.OBJECT,
-            permission=AccountSasPermissions.READ,
+            permission=AccountSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
         # [END create_sas_token]

--- a/sdk/storage/azure-storage-blob/tests/test_blob_samples_authentication_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_samples_authentication_async.py
@@ -140,11 +140,11 @@ class TestAuthSamplesAsync(StorageTestCase):
         # [START create_sas_token]
         # Create a SAS token to use to authenticate a new client
         from datetime import datetime, timedelta
-        from azure.storage.blob import ResourceTypes, AccountPermissions
+        from azure.storage.blob import ResourceTypes, AccountSasPermissions
 
         sas_token = blob_service_client.generate_shared_access_signature(
             resource_types=ResourceTypes.OBJECT,
-            permission=AccountPermissions.READ,
+            permission=AccountSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
         # [END create_sas_token]

--- a/sdk/storage/azure-storage-blob/tests/test_blob_samples_containers.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_samples_containers.py
@@ -149,8 +149,8 @@ class TestContainerSamples(StorageTestCase):
 
             # [START set_container_access_policy]
             # Create access policy
-            from azure.storage.blob import AccessPolicy, ContainerPermissions
-            access_policy = AccessPolicy(permission=ContainerPermissions(read=True),
+            from azure.storage.blob import AccessPolicy, ContainerSasPermissions
+            access_policy = AccessPolicy(permission=ContainerSasPermissions(read=True),
                                          expiry=datetime.utcnow() + timedelta(hours=1),
                                          start=datetime.utcnow() - timedelta(minutes=1))
 

--- a/sdk/storage/azure-storage-blob/tests/test_blob_samples_containers_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_samples_containers_async.py
@@ -166,8 +166,8 @@ class TestContainerSamplesAsync(StorageTestCase):
 
             # [START set_container_access_policy]
             # Create access policy
-            from azure.storage.blob import AccessPolicy, ContainerPermissions
-            access_policy = AccessPolicy(permission=ContainerPermissions(read=True),
+            from azure.storage.blob import AccessPolicy, ContainerSasPermissions
+            access_policy = AccessPolicy(permission=ContainerSasPermissions(read=True),
                                          expiry=datetime.utcnow() + timedelta(hours=1),
                                          start=datetime.utcnow() - timedelta(minutes=1))
 

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob_sync_copy.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob_sync_copy.py
@@ -55,7 +55,7 @@ class StorageBlockBlobTest(StorageTestCase):
 
         # generate a SAS so that it is accessible with a URL
         sas_token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         self.source_blob_url = BlobClient(blob.url, credential=sas_token).url

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob_sync_copy.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob_sync_copy.py
@@ -12,7 +12,7 @@ from azure.storage.blob import (
     ContainerClient,
     BlobClient,
     StorageErrorCode,
-    BlobPermissions
+    BlobSasPermissions
 )
 from azure.storage.blob._shared.policies import StorageContentValidation
 from testcase import (
@@ -55,7 +55,7 @@ class StorageBlockBlobTest(StorageTestCase):
 
         # generate a SAS so that it is accessible with a URL
         sas_token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         self.source_blob_url = BlobClient(blob.url, credential=sas_token).url

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob_sync_copy_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob_sync_copy_async.py
@@ -16,7 +16,7 @@ from azure.storage.blob.aio import (
     ContainerClient,
     BlobClient,
     StorageErrorCode,
-    BlobPermissions
+    BlobSasPermissions
 )
 from azure.storage.blob._shared.policies import StorageContentValidation
 from testcase import (
@@ -69,7 +69,7 @@ class StorageBlockBlobTestAsync(StorageTestCase):
 
         # generate a SAS so that it is accessible with a URL
         sas_token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         self.source_blob_url = BlobClient(blob.url, credential=sas_token).url
@@ -95,7 +95,7 @@ class StorageBlockBlobTestAsync(StorageTestCase):
 
         # generate a SAS so that it is accessible with a URL
         sas_token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         self.source_blob_url = BlobClient(blob.url, credential=sas_token).url

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob_sync_copy_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob_sync_copy_async.py
@@ -69,7 +69,7 @@ class StorageBlockBlobTestAsync(StorageTestCase):
 
         # generate a SAS so that it is accessible with a URL
         sas_token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         self.source_blob_url = BlobClient(blob.url, credential=sas_token).url
@@ -95,7 +95,7 @@ class StorageBlockBlobTestAsync(StorageTestCase):
 
         # generate a SAS so that it is accessible with a URL
         sas_token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         self.source_blob_url = BlobClient(blob.url, credential=sas_token).url

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -25,14 +25,14 @@ from azure.storage.blob import (
     BlobClient,
     BlobType,
     StorageErrorCode,
-    BlobPermissions,
-    ContainerPermissions,
+    BlobSasPermissions,
+    ContainerSasPermissions,
     ContentSettings,
     BlobProperties,
     RetentionPolicy,
     AccessPolicy,
     ResourceTypes,
-    AccountPermissions,
+    AccountSasPermissions,
     StandardBlobTier)
 from azure.storage.blob._generated.models import RehydratePriority
 from testcase import (
@@ -946,7 +946,7 @@ class StorageCommonBlobTest(StorageTestCase):
         self._create_remote_container()
         source_blob = self._create_remote_block_blob(blob_data=data)
         sas_token = source_blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         blob = BlobClient(source_blob.url, credential=sas_token)
@@ -1209,7 +1209,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         
         token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1233,7 +1233,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob_snapshot_client = self.bsc.get_blob_client(self.container_name, blob_name, snapshot=blob_snapshot)
 
         token = blob_snapshot_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1266,7 +1266,7 @@ class StorageCommonBlobTest(StorageTestCase):
         access_policy = AccessPolicy()
         access_policy.start = datetime.utcnow() - timedelta(hours=1)
         access_policy.expiry = datetime.utcnow() + timedelta(hours=1)
-        access_policy.permission = BlobPermissions.READ
+        access_policy.permission = BlobSasPermissions.READ
         identifiers = {'testid': access_policy}
 
         resp = container.set_container_access_policy(identifiers)
@@ -1292,7 +1292,7 @@ class StorageCommonBlobTest(StorageTestCase):
 
         token = self.bsc.generate_shared_access_signature(
             ResourceTypes(container=True, object=True),
-            AccountPermissions.READ,
+            AccountSasPermissions.READ,
             datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1358,7 +1358,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob_client.upload_blob(self.byte_data, length=len(self.byte_data))
 
         token = blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
             user_delegation_key=user_delegation_key,
             account_name='emilydevtest',
@@ -1404,7 +1404,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1428,7 +1428,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
             cache_control='no-cache',
             content_disposition='inline',
@@ -1462,7 +1462,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.WRITE,
+            permission=BlobSasPermissions.WRITE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(blob.url, credential=token)
@@ -1488,7 +1488,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.DELETE,
+            permission=BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(blob.url, credential=token)
@@ -1542,7 +1542,7 @@ class StorageCommonBlobTest(StorageTestCase):
         # Arrange
         container = self.bsc.get_container_client(self.container_name)
         token = container.generate_shared_access_signature(
-            permission=ContainerPermissions.READ,
+            permission=ContainerSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_container = ContainerClient(container.url, credential=token)
@@ -1565,7 +1565,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(blob.url, credential=token)
@@ -1586,7 +1586,7 @@ class StorageCommonBlobTest(StorageTestCase):
         self._create_remote_container()
         source_blob = self._create_remote_block_blob(blob_data=data)
         sas_token = source_blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         blob = BlobClient(source_blob.url, credential=sas_token)
@@ -1700,7 +1700,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.WRITE,
+            permission=BlobSasPermissions.WRITE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(blob.url, credential=token)

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -946,7 +946,7 @@ class StorageCommonBlobTest(StorageTestCase):
         self._create_remote_container()
         source_blob = self._create_remote_block_blob(blob_data=data)
         sas_token = source_blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         blob = BlobClient(source_blob.url, credential=sas_token)
@@ -1209,7 +1209,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         
         token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1233,7 +1233,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob_snapshot_client = self.bsc.get_blob_client(self.container_name, blob_name, snapshot=blob_snapshot)
 
         token = blob_snapshot_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1266,7 +1266,7 @@ class StorageCommonBlobTest(StorageTestCase):
         access_policy = AccessPolicy()
         access_policy.start = datetime.utcnow() - timedelta(hours=1)
         access_policy.expiry = datetime.utcnow() + timedelta(hours=1)
-        access_policy.permission = BlobSasPermissions.READ
+        access_policy.permission = BlobSasPermissions(read=True)
         identifiers = {'testid': access_policy}
 
         resp = container.set_container_access_policy(identifiers)
@@ -1292,7 +1292,7 @@ class StorageCommonBlobTest(StorageTestCase):
 
         token = self.bsc.generate_shared_access_signature(
             ResourceTypes(container=True, object=True),
-            AccountSasPermissions.READ,
+            AccountSasPermissions(read=True),
             datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1358,7 +1358,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob_client.upload_blob(self.byte_data, length=len(self.byte_data))
 
         token = blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
             user_delegation_key=user_delegation_key,
             account_name='emilydevtest',
@@ -1404,7 +1404,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1428,7 +1428,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
             cache_control='no-cache',
             content_disposition='inline',
@@ -1462,7 +1462,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.WRITE,
+            permission=BlobSasPermissions(write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(blob.url, credential=token)
@@ -1488,7 +1488,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(blob.url, credential=token)
@@ -1542,7 +1542,7 @@ class StorageCommonBlobTest(StorageTestCase):
         # Arrange
         container = self.bsc.get_container_client(self.container_name)
         token = container.generate_shared_access_signature(
-            permission=ContainerSasPermissions.READ,
+            permission=ContainerSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_container = ContainerClient(container.url, credential=token)
@@ -1565,7 +1565,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(blob.url, credential=token)
@@ -1586,7 +1586,7 @@ class StorageCommonBlobTest(StorageTestCase):
         self._create_remote_container()
         source_blob = self._create_remote_block_blob(blob_data=data)
         sas_token = source_blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         blob = BlobClient(source_blob.url, credential=sas_token)
@@ -1700,7 +1700,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.WRITE,
+            permission=BlobSasPermissions(write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(blob.url, credential=token)

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -1233,7 +1233,7 @@ class StorageCommonBlobTest(StorageTestCase):
         blob_snapshot_client = self.bsc.get_blob_client(self.container_name, blob_name, snapshot=blob_snapshot)
 
         token = blob_snapshot_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1827,10 +1827,13 @@ class StorageCommonBlobTest(StorageTestCase):
         self.assertEqual(permission1.read, permission2.read)
         self.assertEqual(permission1.write, permission2.write)
 
-    def test_set_blob_permission_from_string_fails(self):
+    def test_set_blob_permission(self):
         # Arrange
-        with self.assertRaises(ValueError):
-            permission = BlobSasPermissions.from_string('wrx')
+        permission = BlobSasPermissions.from_string('wrdx')
+        self.assertEqual(permission.read, True)
+        self.assertEqual(permission.delete, True)
+        self.assertEqual(permission.write, True)
+        self.assertEqual(permission._str, 'wrdx')
 
     def test_set_blob_permission_long_from_string_fails(self):
         # Arrange

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -1820,7 +1820,22 @@ class StorageCommonBlobTest(StorageTestCase):
         content = blob.download_blob().content_as_bytes()
         self.assertEqual(data, content)
 
+    def test_set_blob_permission_from_string(self):
+        # Arrange
+        permission1 = BlobSasPermissions(read=True, write=True)
+        permission2 = BlobSasPermissions.from_string('wr')
+        self.assertEqual(permission1.read, permission2.read)
+        self.assertEqual(permission1.write, permission2.write)
 
+    def test_set_blob_permission_from_string_fails(self):
+        # Arrange
+        with self.assertRaises(ValueError):
+            permission = BlobSasPermissions.from_string('wrx')
+
+    def test_set_blob_permission_long_from_string_fails(self):
+        # Arrange
+        with self.assertRaises(ValueError):
+            permission = BlobSasPermissions.from_string('wrrrrrwwwdd')
 #------------------------------------------------------------------------------
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -1835,10 +1835,6 @@ class StorageCommonBlobTest(StorageTestCase):
         self.assertEqual(permission.write, True)
         self.assertEqual(permission._str, 'wrdx')
 
-    def test_set_blob_permission_long_from_string_fails(self):
-        # Arrange
-        with self.assertRaises(ValueError):
-            permission = BlobSasPermissions.from_string('wrrrrrwwwdd')
 #------------------------------------------------------------------------------
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -34,14 +34,14 @@ from azure.storage.blob import (
     download_blob_from_url,
     BlobType,
     StorageErrorCode,
-    BlobPermissions,
-    ContainerPermissions,
+    BlobSasPermissions,
+    ContainerSasPermissions,
     ContentSettings,
     BlobProperties,
     RetentionPolicy,
     AccessPolicy,
     ResourceTypes,
-    AccountPermissions,
+    AccountSasPermissions,
     StandardBlobTier)
 
 from testcase import (
@@ -1249,7 +1249,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         await self._create_remote_container()
         source_blob = await self._create_remote_block_blob(blob_data=data)
         sas_token = source_blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         blob = BlobClient(source_blob.url, credential=sas_token)
@@ -1600,7 +1600,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1631,7 +1631,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         access_policy = AccessPolicy()
         access_policy.start = datetime.utcnow() - timedelta(hours=1)
         access_policy.expiry = datetime.utcnow() + timedelta(hours=1)
-        access_policy.permission = BlobPermissions.READ
+        access_policy.permission = BlobSasPermissions.READ
         identifiers = {'testid': access_policy}
 
         resp = await container.set_container_access_policy(identifiers)
@@ -1662,7 +1662,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
 
         token = self.bsc.generate_shared_access_signature(
             ResourceTypes(container=True, object=True),
-            AccountPermissions.READ,
+            AccountSasPermissions.READ,
             datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1764,7 +1764,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1793,7 +1793,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
             cache_control='no-cache',
             content_disposition='inline',
@@ -1832,7 +1832,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.WRITE,
+            permission=BlobSasPermissions.WRITE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(blob.url, credential=token)
@@ -1863,7 +1863,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.DELETE,
+            permission=BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(blob.url, credential=token)
@@ -1937,7 +1937,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         await self._setup()
         container = self.bsc.get_container_client(self.container_name)
         token = container.generate_shared_access_signature(
-            permission=ContainerPermissions.READ,
+            permission=ContainerSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_container = ContainerClient(container.url, credential=token)
@@ -1965,7 +1965,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(blob.url, credential=token)
@@ -1991,7 +1991,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         await self._create_remote_container()
         source_blob = await self._create_remote_block_blob(blob_data=data)
         sas_token = source_blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         blob = BlobClient(source_blob.url, credential=sas_token)
@@ -2129,7 +2129,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobPermissions.WRITE,
+            permission=BlobSasPermissions.WRITE,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(blob.url, credential=token)

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -1249,7 +1249,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         await self._create_remote_container()
         source_blob = await self._create_remote_block_blob(blob_data=data)
         sas_token = source_blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         blob = BlobClient(source_blob.url, credential=sas_token)
@@ -1600,7 +1600,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1631,7 +1631,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         access_policy = AccessPolicy()
         access_policy.start = datetime.utcnow() - timedelta(hours=1)
         access_policy.expiry = datetime.utcnow() + timedelta(hours=1)
-        access_policy.permission = BlobSasPermissions.READ
+        access_policy.permission = BlobSasPermissions(read=True)
         identifiers = {'testid': access_policy}
 
         resp = await container.set_container_access_policy(identifiers)
@@ -1662,7 +1662,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
 
         token = self.bsc.generate_shared_access_signature(
             ResourceTypes(container=True, object=True),
-            AccountSasPermissions.READ,
+            AccountSasPermissions(read=True),
             datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1764,7 +1764,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1793,7 +1793,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
             cache_control='no-cache',
             content_disposition='inline',
@@ -1832,7 +1832,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.WRITE,
+            permission=BlobSasPermissions(write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(blob.url, credential=token)
@@ -1863,7 +1863,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(blob.url, credential=token)
@@ -1937,7 +1937,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         await self._setup()
         container = self.bsc.get_container_client(self.container_name)
         token = container.generate_shared_access_signature(
-            permission=ContainerSasPermissions.READ,
+            permission=ContainerSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_container = ContainerClient(container.url, credential=token)
@@ -1965,7 +1965,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(blob.url, credential=token)
@@ -1991,7 +1991,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         await self._create_remote_container()
         source_blob = await self._create_remote_block_blob(blob_data=data)
         sas_token = source_blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         blob = BlobClient(source_blob.url, credential=sas_token)
@@ -2129,7 +2129,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         token = blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.WRITE,
+            permission=BlobSasPermissions(write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(blob.url, credential=token)

--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -22,7 +22,7 @@ from azure.storage.blob import (
     LeaseClient,
     ContainerSasPermissions,
     PublicAccess,
-    ContainerPermissions,
+    ContainerSasPermissions,
     AccessPolicy,
     StandardBlobTier,
     PremiumPageBlobTier

--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -1280,10 +1280,13 @@ class StorageContainerTest(StorageTestCase):
         self.assertEqual(permission1.read, permission2.read)
         self.assertEqual(permission1.write, permission2.write)
 
-    def test_set_container_permission_from_string_fails(self):
+    def test_set_container_permission(self):
         # Arrange
-        with self.assertRaises(ValueError):
-            permission = ContainerSasPermissions.from_string('wrx')
+        permission = ContainerSasPermissions.from_string('wrlx')
+        self.assertEqual(permission.read, True)
+        self.assertEqual(permission.list, True)
+        self.assertEqual(permission.write, True)
+        self.assertEqual(permission._str, 'wrlx')
 
     def test_set_container_permission_long_from_string_fails(self):
         # Arrange

--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -1273,6 +1273,23 @@ class StorageContainerTest(StorageTestCase):
         # Assert
         self.assertEqual(blob_content, b"".join(list(content)).decode('utf-8'))
 
+    def test_set_container_permission_from_string(self):
+        # Arrange
+        permission1 = ContainerSasPermissions(read=True, write=True)
+        permission2 = ContainerSasPermissions.from_string('wr')
+        self.assertEqual(permission1.read, permission2.read)
+        self.assertEqual(permission1.write, permission2.write)
+
+    def test_set_container_permission_from_string_fails(self):
+        # Arrange
+        with self.assertRaises(ValueError):
+            permission = ContainerSasPermissions.from_string('wrx')
+
+    def test_set_container_permission_long_from_string_fails(self):
+        # Arrange
+        with self.assertRaises(ValueError):
+            permission = ContainerSasPermissions.from_string('wrrrrrwwwdd')
+
 #------------------------------------------------------------------------------
 if __name__ == '__main__':
     import unittest

--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -434,7 +434,7 @@ class StorageContainerTest(StorageTestCase):
         container = self._create_container()
 
         # Act
-        access_policy = AccessPolicy(permission=ContainerSasPermissions.READ,
+        access_policy = AccessPolicy(permission=ContainerSasPermissions(read=True),
                                      expiry=datetime.utcnow() + timedelta(hours=1),
                                      start=datetime.utcnow())
         signed_identifier = {'testid': access_policy}
@@ -450,7 +450,7 @@ class StorageContainerTest(StorageTestCase):
         container = self._create_container()
 
         # Act
-        access_policy = AccessPolicy(permission=ContainerSasPermissions.READ,
+        access_policy = AccessPolicy(permission=ContainerSasPermissions(read=True),
                                      expiry=datetime.utcnow() + timedelta(hours=1),
                                      start=datetime.utcnow())
         signed_identifiers = {'testid': access_policy}
@@ -523,7 +523,7 @@ class StorageContainerTest(StorageTestCase):
         container = self._create_container()
 
         # Act
-        access_policy = AccessPolicy(permission=ContainerSasPermissions.READ,
+        access_policy = AccessPolicy(permission=ContainerSasPermissions(read=True),
                                      expiry=datetime.utcnow() + timedelta(hours=1),
                                      start=datetime.utcnow() - timedelta(minutes=1))
         identifiers = {'testid': access_policy}
@@ -556,7 +556,7 @@ class StorageContainerTest(StorageTestCase):
     def test_set_container_acl_with_three_identifiers(self):
         # Arrange
         container = self._create_container()
-        access_policy = AccessPolicy(permission=ContainerSasPermissions.READ,
+        access_policy = AccessPolicy(permission=ContainerSasPermissions(read=True),
                                      expiry=datetime.utcnow() + timedelta(hours=1),
                                      start=datetime.utcnow() - timedelta(minutes=1))
         identifiers = {str(i): access_policy for i in range(0, 3)}
@@ -1199,7 +1199,7 @@ class StorageContainerTest(StorageTestCase):
 
         token = container.generate_shared_access_signature(
             expiry=datetime.utcnow() + timedelta(hours=1),
-            permission=ContainerSasPermissions.READ,
+            permission=ContainerSasPermissions(read=True),
         )
         blob = BlobClient(blob.url, credential=token)
 
@@ -1257,7 +1257,7 @@ class StorageContainerTest(StorageTestCase):
         container_client = service_client.create_container(self.get_resource_name('oauthcontainer'))
         token = container_client.generate_shared_access_signature(
             expiry=datetime.utcnow() + timedelta(hours=1),
-            permission=ContainerSasPermissions.READ,
+            permission=ContainerSasPermissions(read=True),
             user_delegation_key=user_delegation_key,
             account_name='emilydevtest'
         )

--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -20,7 +20,7 @@ from azure.storage.blob import (
     ContainerClient,
     BlobClient,
     LeaseClient,
-    ContainerPermissions,
+    ContainerSasPermissions,
     PublicAccess,
     ContainerPermissions,
     AccessPolicy,
@@ -434,7 +434,7 @@ class StorageContainerTest(StorageTestCase):
         container = self._create_container()
 
         # Act
-        access_policy = AccessPolicy(permission=ContainerPermissions.READ,
+        access_policy = AccessPolicy(permission=ContainerSasPermissions.READ,
                                      expiry=datetime.utcnow() + timedelta(hours=1),
                                      start=datetime.utcnow())
         signed_identifier = {'testid': access_policy}
@@ -450,7 +450,7 @@ class StorageContainerTest(StorageTestCase):
         container = self._create_container()
 
         # Act
-        access_policy = AccessPolicy(permission=ContainerPermissions.READ,
+        access_policy = AccessPolicy(permission=ContainerSasPermissions.READ,
                                      expiry=datetime.utcnow() + timedelta(hours=1),
                                      start=datetime.utcnow())
         signed_identifiers = {'testid': access_policy}
@@ -523,7 +523,7 @@ class StorageContainerTest(StorageTestCase):
         container = self._create_container()
 
         # Act
-        access_policy = AccessPolicy(permission=ContainerPermissions.READ,
+        access_policy = AccessPolicy(permission=ContainerSasPermissions.READ,
                                      expiry=datetime.utcnow() + timedelta(hours=1),
                                      start=datetime.utcnow() - timedelta(minutes=1))
         identifiers = {'testid': access_policy}
@@ -556,7 +556,7 @@ class StorageContainerTest(StorageTestCase):
     def test_set_container_acl_with_three_identifiers(self):
         # Arrange
         container = self._create_container()
-        access_policy = AccessPolicy(permission=ContainerPermissions.READ,
+        access_policy = AccessPolicy(permission=ContainerSasPermissions.READ,
                                      expiry=datetime.utcnow() + timedelta(hours=1),
                                      start=datetime.utcnow() - timedelta(minutes=1))
         identifiers = {str(i): access_policy for i in range(0, 3)}
@@ -1199,7 +1199,7 @@ class StorageContainerTest(StorageTestCase):
 
         token = container.generate_shared_access_signature(
             expiry=datetime.utcnow() + timedelta(hours=1),
-            permission=ContainerPermissions.READ,
+            permission=ContainerSasPermissions.READ,
         )
         blob = BlobClient(blob.url, credential=token)
 
@@ -1257,7 +1257,7 @@ class StorageContainerTest(StorageTestCase):
         container_client = service_client.create_container(self.get_resource_name('oauthcontainer'))
         token = container_client.generate_shared_access_signature(
             expiry=datetime.utcnow() + timedelta(hours=1),
-            permission=ContainerPermissions.READ,
+            permission=ContainerSasPermissions.READ,
             user_delegation_key=user_delegation_key,
             account_name='emilydevtest'
         )

--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -1288,11 +1288,6 @@ class StorageContainerTest(StorageTestCase):
         self.assertEqual(permission.write, True)
         self.assertEqual(permission._str, 'wrlx')
 
-    def test_set_container_permission_long_from_string_fails(self):
-        # Arrange
-        with self.assertRaises(ValueError):
-            permission = ContainerSasPermissions.from_string('wrrrrrwwwdd')
-
 #------------------------------------------------------------------------------
 if __name__ == '__main__':
     import unittest

--- a/sdk/storage/azure-storage-blob/tests/test_container_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container_async.py
@@ -558,7 +558,7 @@ class StorageContainerTestAsync(StorageTestCase):
         container = await self._create_container()
 
         # Act
-        access_policy = AccessPolicy(permission=ContainerPermissions.READ,
+        access_policy = AccessPolicy(permission=ContainerSasPermissions.READ,
                                      expiry=datetime.utcnow() + timedelta(hours=1),
                                      start=datetime.utcnow())
         signed_identifier = {'testid': access_policy}
@@ -632,7 +632,7 @@ class StorageContainerTestAsync(StorageTestCase):
         container = await self._create_container()
 
         # Act
-        access_policy = AccessPolicy(permission=ContainerPermissions.READ,
+        access_policy = AccessPolicy(permission=ContainerSasPermissions.READ,
                                      expiry=datetime.utcnow() + timedelta(hours=1),
                                      start=datetime.utcnow() - timedelta(minutes=1))
         identifiers = {'testid': access_policy}
@@ -673,7 +673,7 @@ class StorageContainerTestAsync(StorageTestCase):
     async def _test_set_container_acl_with_three_identifiers(self):
         # Arrange
         container = await self._create_container()
-        access_policy = AccessPolicy(permission=ContainerPermissions.READ,
+        access_policy = AccessPolicy(permission=ContainerSasPermissions.READ,
                                      expiry=datetime.utcnow() + timedelta(hours=1),
                                      start=datetime.utcnow() - timedelta(minutes=1))
         identifiers = {i: access_policy for i in range(2)}
@@ -1460,7 +1460,7 @@ class StorageContainerTestAsync(StorageTestCase):
 
         token = container.generate_shared_access_signature(
             expiry=datetime.utcnow() + timedelta(hours=1),
-            permission=ContainerPermissions.READ,
+            permission=ContainerSasPermissions.READ,
         )
         blob = BlobClient(blob.url, credential=token)
 

--- a/sdk/storage/azure-storage-blob/tests/test_container_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container_async.py
@@ -558,7 +558,7 @@ class StorageContainerTestAsync(StorageTestCase):
         container = await self._create_container()
 
         # Act
-        access_policy = AccessPolicy(permission=ContainerSasPermissions.READ,
+        access_policy = AccessPolicy(permission=ContainerSasPermissions(read=True),
                                      expiry=datetime.utcnow() + timedelta(hours=1),
                                      start=datetime.utcnow())
         signed_identifier = {'testid': access_policy}
@@ -632,7 +632,7 @@ class StorageContainerTestAsync(StorageTestCase):
         container = await self._create_container()
 
         # Act
-        access_policy = AccessPolicy(permission=ContainerSasPermissions.READ,
+        access_policy = AccessPolicy(permission=ContainerSasPermissions(read=True),
                                      expiry=datetime.utcnow() + timedelta(hours=1),
                                      start=datetime.utcnow() - timedelta(minutes=1))
         identifiers = {'testid': access_policy}
@@ -673,7 +673,7 @@ class StorageContainerTestAsync(StorageTestCase):
     async def _test_set_container_acl_with_three_identifiers(self):
         # Arrange
         container = await self._create_container()
-        access_policy = AccessPolicy(permission=ContainerSasPermissions.READ,
+        access_policy = AccessPolicy(permission=ContainerSasPermissions(read=True),
                                      expiry=datetime.utcnow() + timedelta(hours=1),
                                      start=datetime.utcnow() - timedelta(minutes=1))
         identifiers = {i: access_policy for i in range(2)}
@@ -1460,7 +1460,7 @@ class StorageContainerTestAsync(StorageTestCase):
 
         token = container.generate_shared_access_signature(
             expiry=datetime.utcnow() + timedelta(hours=1),
-            permission=ContainerSasPermissions.READ,
+            permission=ContainerSasPermissions(read=True),
         )
         blob = BlobClient(blob.url, credential=token)
 

--- a/sdk/storage/azure-storage-blob/tests/test_container_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container_async.py
@@ -29,7 +29,7 @@ from azure.storage.blob.aio import (
     BlobType,
     ContentSettings,
     BlobProperties,
-    ContainerPermissions,
+    ContainerSasPermissions,
     StandardBlobTier,
     PremiumPageBlobTier
 )

--- a/sdk/storage/azure-storage-blob/tests/test_cpk.py
+++ b/sdk/storage/azure-storage-blob/tests/test_cpk.py
@@ -219,7 +219,7 @@ class StorageCPKTest(StorageTestCase):
         self.config.use_byte_buffer = True  # Make sure using chunk upload, then we can record the request
         source_blob_client, _ = self._create_block_blob(blob_name=source_blob_name, data=self.byte_data)
         source_blob_sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
         source_blob_url = source_blob_client.url + "?" + source_blob_sas
@@ -298,7 +298,7 @@ class StorageCPKTest(StorageTestCase):
         self.config.use_byte_buffer = True  # chunk upload
         source_blob_client, _ = self._create_block_blob(blob_name=source_blob_name, data=self.byte_data)
         source_blob_sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
         source_blob_url = source_blob_client.url + "?" + source_blob_sas
@@ -393,7 +393,7 @@ class StorageCPKTest(StorageTestCase):
         self.config.use_byte_buffer = True  # Make sure using chunk upload, then we can record the request
         source_blob_client, _ = self._create_block_blob(blob_name=source_blob_name, data=self.byte_data)
         source_blob_sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
         source_blob_url = source_blob_client.url + "?" + source_blob_sas

--- a/sdk/storage/azure-storage-blob/tests/test_cpk.py
+++ b/sdk/storage/azure-storage-blob/tests/test_cpk.py
@@ -14,7 +14,7 @@ from azure.storage.blob import (
     BlobType,
     BlobBlock,
 )
-from azure.storage.blob.models import CustomerProvidedEncryptionKey, BlobPermissions
+from azure.storage.blob.models import CustomerProvidedEncryptionKey, BlobSasPermissions
 from testcase import (
     StorageTestCase,
     TestMode,
@@ -219,7 +219,7 @@ class StorageCPKTest(StorageTestCase):
         self.config.use_byte_buffer = True  # Make sure using chunk upload, then we can record the request
         source_blob_client, _ = self._create_block_blob(blob_name=source_blob_name, data=self.byte_data)
         source_blob_sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
         source_blob_url = source_blob_client.url + "?" + source_blob_sas
@@ -298,7 +298,7 @@ class StorageCPKTest(StorageTestCase):
         self.config.use_byte_buffer = True  # chunk upload
         source_blob_client, _ = self._create_block_blob(blob_name=source_blob_name, data=self.byte_data)
         source_blob_sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
         source_blob_url = source_blob_client.url + "?" + source_blob_sas
@@ -393,7 +393,7 @@ class StorageCPKTest(StorageTestCase):
         self.config.use_byte_buffer = True  # Make sure using chunk upload, then we can record the request
         source_blob_client, _ = self._create_block_blob(blob_name=source_blob_name, data=self.byte_data)
         source_blob_sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
         source_blob_url = source_blob_client.url + "?" + source_blob_sas

--- a/sdk/storage/azure-storage-blob/tests/test_cpk_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_cpk_async.py
@@ -17,7 +17,7 @@ from azure.storage.blob.aio import (
     BlobType,
     BlobBlock,
 )
-from azure.storage.blob.models import CustomerProvidedEncryptionKey, BlobPermissions
+from azure.storage.blob.models import CustomerProvidedEncryptionKey, BlobSasPermissions
 from testcase import (
     StorageTestCase,
     TestMode,
@@ -254,7 +254,7 @@ class StorageCPKAsyncTest(StorageTestCase):
         self.config.use_byte_buffer = True  # Make sure using chunk upload, then we can record the request
         source_blob_client, _ = await self._create_block_blob(blob_name=source_blob_name, data=self.byte_data)
         source_blob_sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
         source_blob_url = source_blob_client.url + "?" + source_blob_sas
@@ -341,7 +341,7 @@ class StorageCPKAsyncTest(StorageTestCase):
         self.config.use_byte_buffer = True  # chunk upload
         source_blob_client, _ = await self._create_block_blob(blob_name=source_blob_name, data=self.byte_data)
         source_blob_sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
         source_blob_url = source_blob_client.url + "?" + source_blob_sas
@@ -448,7 +448,7 @@ class StorageCPKAsyncTest(StorageTestCase):
         self.config.use_byte_buffer = True  # Make sure using chunk upload, then we can record the request
         source_blob_client, _ = await self._create_block_blob(blob_name=source_blob_name, data=self.byte_data)
         source_blob_sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
         source_blob_url = source_blob_client.url + "?" + source_blob_sas

--- a/sdk/storage/azure-storage-blob/tests/test_cpk_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_cpk_async.py
@@ -254,7 +254,7 @@ class StorageCPKAsyncTest(StorageTestCase):
         self.config.use_byte_buffer = True  # Make sure using chunk upload, then we can record the request
         source_blob_client, _ = await self._create_block_blob(blob_name=source_blob_name, data=self.byte_data)
         source_blob_sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
         source_blob_url = source_blob_client.url + "?" + source_blob_sas
@@ -341,7 +341,7 @@ class StorageCPKAsyncTest(StorageTestCase):
         self.config.use_byte_buffer = True  # chunk upload
         source_blob_client, _ = await self._create_block_blob(blob_name=source_blob_name, data=self.byte_data)
         source_blob_sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
         source_blob_url = source_blob_client.url + "?" + source_blob_sas
@@ -448,7 +448,7 @@ class StorageCPKAsyncTest(StorageTestCase):
         self.config.use_byte_buffer = True  # Make sure using chunk upload, then we can record the request
         source_blob_client, _ = await self._create_block_blob(blob_name=source_blob_name, data=self.byte_data)
         source_blob_sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
         source_blob_url = source_blob_client.url + "?" + source_blob_sas

--- a/sdk/storage/azure-storage-blob/tests/test_logging.py
+++ b/sdk/storage/azure-storage-blob/tests/test_logging.py
@@ -14,8 +14,8 @@ from azure.storage.blob import (
     BlobServiceClient,
     ContainerClient,
     BlobClient,
-    ContainerPermissions,
-    BlobPermissions
+    ContainerSasPermissions,
+    BlobSasPermissions
 )
 from azure.storage.blob._shared.shared_access_signature import QueryStringConstants
 
@@ -56,7 +56,7 @@ class StorageLoggingTest(StorageTestCase):
 
         # generate a SAS so that it is accessible with a URL
         sas_token = source_blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_source = BlobClient(source_blob.url, credential=sas_token)
@@ -91,7 +91,7 @@ class StorageLoggingTest(StorageTestCase):
         # Arrange
         container = self.bsc.get_container_client(self.container_name)
         token = container.generate_shared_access_signature(
-            permission=ContainerPermissions.READ,
+            permission=ContainerSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         # parse out the signed signature

--- a/sdk/storage/azure-storage-blob/tests/test_logging.py
+++ b/sdk/storage/azure-storage-blob/tests/test_logging.py
@@ -56,7 +56,7 @@ class StorageLoggingTest(StorageTestCase):
 
         # generate a SAS so that it is accessible with a URL
         sas_token = source_blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_source = BlobClient(source_blob.url, credential=sas_token)
@@ -91,7 +91,7 @@ class StorageLoggingTest(StorageTestCase):
         # Arrange
         container = self.bsc.get_container_client(self.container_name)
         token = container.generate_shared_access_signature(
-            permission=ContainerSasPermissions.READ,
+            permission=ContainerSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         # parse out the signed signature

--- a/sdk/storage/azure-storage-blob/tests/test_logging_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_logging_async.py
@@ -21,8 +21,8 @@ from azure.storage.blob.aio import (
 )
 
 from azure.storage.blob import (
-    ContainerPermissions,
-    BlobPermissions,
+    ContainerSasPermissions,
+    BlobSasPermissions,
 )
 
 from azure.storage.blob._shared.shared_access_signature import QueryStringConstants
@@ -88,7 +88,7 @@ class StorageLoggingTestAsync(StorageTestCase):
 
                 # generate a SAS so that it is accessible with a URL
                 sas_token = source_blob.generate_shared_access_signature(
-                    permission=BlobPermissions.READ,
+                    permission=BlobSasPermissions.READ,
                     expiry=datetime.utcnow() + timedelta(hours=1),
                 )
                 sas_source = BlobClient(source_blob.url, credential=sas_token)
@@ -124,7 +124,7 @@ class StorageLoggingTestAsync(StorageTestCase):
         # Arrange
         container = self.bsc.get_container_client(self.container_name)
         token = container.generate_shared_access_signature(
-            permission=ContainerPermissions.READ,
+            permission=ContainerSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         # parse out the signed signature

--- a/sdk/storage/azure-storage-blob/tests/test_logging_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_logging_async.py
@@ -88,7 +88,7 @@ class StorageLoggingTestAsync(StorageTestCase):
 
                 # generate a SAS so that it is accessible with a URL
                 sas_token = source_blob.generate_shared_access_signature(
-                    permission=BlobSasPermissions.READ,
+                    permission=BlobSasPermissions(read=True),
                     expiry=datetime.utcnow() + timedelta(hours=1),
                 )
                 sas_source = BlobClient(source_blob.url, credential=sas_token)
@@ -124,7 +124,7 @@ class StorageLoggingTestAsync(StorageTestCase):
         # Arrange
         container = self.bsc.get_container_client(self.container_name)
         token = container.generate_shared_access_signature(
-            permission=ContainerSasPermissions.READ,
+            permission=ContainerSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         # parse out the signed signature

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob.py
@@ -367,7 +367,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -395,7 +395,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         src_md5 = StorageContentValidation.get_content_md5(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -430,7 +430,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -467,7 +467,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -504,7 +504,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -540,7 +540,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -576,7 +576,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -613,7 +613,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -650,7 +650,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -686,7 +686,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -723,7 +723,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)
@@ -759,7 +759,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)
@@ -795,7 +795,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)
@@ -1342,7 +1342,7 @@ class StoragePageBlobTest(StorageTestCase):
         snapshot_blob = BlobClient(
             source_blob.url, credential=source_blob.credential, snapshot=source_snapshot_blob)
         sas_token = snapshot_blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(snapshot_blob.url, credential=sas_token)

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob.py
@@ -18,7 +18,7 @@ from azure.storage.blob import (
     ContainerClient,
     BlobClient,
     BlobProperties,
-    BlobPermissions,
+    BlobSasPermissions,
     BlobType,
     PremiumPageBlobTier,
     SequenceNumberAction,
@@ -367,7 +367,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -395,7 +395,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         src_md5 = StorageContentValidation.get_content_md5(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -430,7 +430,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -467,7 +467,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -504,7 +504,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -540,7 +540,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -576,7 +576,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -613,7 +613,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -650,7 +650,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -686,7 +686,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -723,7 +723,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)
@@ -759,7 +759,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)
@@ -795,7 +795,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)
@@ -1342,7 +1342,7 @@ class StoragePageBlobTest(StorageTestCase):
         snapshot_blob = BlobClient(
             source_blob.url, credential=source_blob.credential, snapshot=source_snapshot_blob)
         sas_token = snapshot_blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(snapshot_blob.url, credential=sas_token)

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob.py
@@ -367,7 +367,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -395,7 +395,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         src_md5 = StorageContentValidation.get_content_md5(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -430,7 +430,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -467,7 +467,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -504,7 +504,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -540,7 +540,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -576,7 +576,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -613,7 +613,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -650,7 +650,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -686,7 +686,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE)
@@ -723,7 +723,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)
@@ -759,7 +759,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)
@@ -795,7 +795,7 @@ class StoragePageBlobTest(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
@@ -469,7 +469,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -503,7 +503,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         src_md5 = StorageContentValidation.get_content_md5(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -543,7 +543,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -585,7 +585,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -627,7 +627,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -666,7 +666,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -705,7 +705,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -747,7 +747,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -788,7 +788,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -827,7 +827,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -866,7 +866,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)
@@ -905,7 +905,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)
@@ -944,7 +944,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
+            permission=BlobSasPermissions(read=True, write=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)
@@ -1612,7 +1612,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         snapshot_blob = BlobClient(
             source_blob.url, credential=source_blob.credential, snapshot=source_snapshot_blob)
         sas_token = snapshot_blob.generate_shared_access_signature(
-            permission=BlobSasPermissions.READ,
+            permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(snapshot_blob.url, credential=sas_token)

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
@@ -22,7 +22,7 @@ from azure.storage.blob.aio import (
     ContainerClient,
     BlobClient,
     BlobProperties,
-    BlobPermissions,
+    BlobSasPermissions,
     BlobType,
     PremiumPageBlobTier,
     SequenceNumberAction,
@@ -469,7 +469,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -503,7 +503,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         src_md5 = StorageContentValidation.get_content_md5(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -543,7 +543,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -585,7 +585,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -627,7 +627,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -666,7 +666,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -705,7 +705,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -747,7 +747,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -788,7 +788,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -827,7 +827,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -866,7 +866,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)
@@ -905,7 +905,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)
@@ -944,7 +944,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobPermissions.READ + BlobPermissions.DELETE,
+            permission=BlobSasPermissions.READ + BlobSasPermissions.DELETE,
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)
@@ -1612,7 +1612,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         snapshot_blob = BlobClient(
             source_blob.url, credential=source_blob.credential, snapshot=source_snapshot_blob)
         sas_token = snapshot_blob.generate_shared_access_signature(
-            permission=BlobPermissions.READ,
+            permission=BlobSasPermissions.READ,
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         sas_blob = BlobClient(snapshot_blob.url, credential=sas_token)

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
@@ -469,7 +469,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -503,7 +503,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         src_md5 = StorageContentValidation.get_content_md5(source_blob_data)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -543,7 +543,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -585,7 +585,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -627,7 +627,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -666,7 +666,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -705,7 +705,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -747,7 +747,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         source_properties = await source_blob_client.get_blob_properties()
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -788,7 +788,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -827,7 +827,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE)
@@ -866,7 +866,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)
@@ -905,7 +905,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)
@@ -944,7 +944,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
         source_blob_data = self.get_random_bytes(SOURCE_BLOB_SIZE)
         source_blob_client = await self._create_source_blob(source_blob_data, 0, SOURCE_BLOB_SIZE - 1)
         sas = source_blob_client.generate_shared_access_signature(
-            permission=BlobSasPermissions(read=True, write=True),
+            permission=BlobSasPermissions(read=True, delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1))
 
         destination_blob_client = await self._create_blob(SOURCE_BLOB_SIZE, sequence_number=start_sequence)

--- a/sdk/storage/azure-storage-file/azure/storage/file/__init__.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/__init__.py
@@ -13,7 +13,7 @@ from ._shared.policies import ExponentialRetry, LinearRetry, NoRetry
 from ._shared.models import(
     LocationMode,
     ResourceTypes,
-    AccountPermissions,
+    AccountSasPermissions,
     StorageErrorCode)
 from .models import (
     ShareProperties,
@@ -27,8 +27,8 @@ from .models import (
     RetentionPolicy,
     CorsRule,
     AccessPolicy,
-    FilePermissions,
-    SharePermissions,
+    FileSasPermissions,
+    ShareSasPermissions,
     ContentSettings,
     NTFSAttributes)
 
@@ -46,14 +46,14 @@ __all__ = [
     'NoRetry',
     'LocationMode',
     'ResourceTypes',
-    'AccountPermissions',
+    'AccountSasPermissions',
     'StorageErrorCode',
     'Metrics',
     'RetentionPolicy',
     'CorsRule',
     'AccessPolicy',
-    'FilePermissions',
-    'SharePermissions',
+    'FileSasPermissions',
+    'ShareSasPermissions',
     'ShareProperties',
     'SharePropertiesPaged',
     'DirectoryProperties',

--- a/sdk/storage/azure-storage-file/azure/storage/file/_shared/models.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/_shared/models.py
@@ -340,7 +340,7 @@ class AccountSasPermissions(object):
         p_process = 'p' in permission
 
         parsed = cls(p_read, p_write, p_delete, p_list, p_add, p_create, p_update, p_process)
-        parsed._str = permission
+        parsed._str = permission # pylint: disable = protected-access
         return parsed
 
 class Services(object):

--- a/sdk/storage/azure-storage-file/azure/storage/file/_shared/models.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/_shared/models.py
@@ -277,7 +277,7 @@ ResourceTypes.CONTAINER = ResourceTypes(container=True)
 ResourceTypes.OBJECT = ResourceTypes(object=True)
 
 
-class AccountPermissions(object):
+class AccountSasPermissions(object):
     """
     :class:`~ResourceTypes` class to be used with generate_shared_access_signature
     method and for the AccessPolicies used with set_*_acl. There are two types of
@@ -285,26 +285,6 @@ class AccountPermissions(object):
     specific resource (resource-specific). Another is to grant access to the
     entire service for a specific account and allow certain operations based on
     perms found here.
-
-    :cvar AccountPermissions AccountPermissions.ADD:
-        Valid for the following Object resource types only: queue messages and append blobs.
-    :cvar AccountPermissions AccountPermissions.CREATE:
-        Valid for the following Object resource types only: blobs and files. Users
-        can create new blobs or files, but may not overwrite existing blobs or files.
-    :cvar AccountPermissions AccountPermissions.DELETE:
-        Valid for Container and Object resource types, except for queue messages.
-    :cvar AccountPermissions AccountPermissions.LIST:
-        Valid for Service and Container resource types only.
-    :cvar AccountPermissions AccountPermissions.PROCESS:
-        Valid for the following Object resource type only: queue messages.
-    :cvar AccountPermissions AccountPermissions.READ:
-        Valid for all signed resources types (Service, Container, and Object).
-        Permits read permissions to the specified resource type.
-    :cvar AccountPermissions AccountPermissions.UPDATE:
-        Valid for the following Object resource types only: queue messages.
-    :cvar AccountPermissions AccountPermissions.WRITE:
-        Valid for all signed resources types (Service, Container, and Object).
-        Permits write permissions to the specified resource type.
     :param bool read:
         Valid for all signed resources types (Service, Container, and Object).
         Permits read permissions to the specified resource type.
@@ -325,58 +305,43 @@ class AccountPermissions(object):
         Valid for the following Object resource types only: queue messages.
     :param bool process:
         Valid for the following Object resource type only: queue messages.
-    :param str _str:
-        A string representing the permissions.
     """
-
-    READ = None  # type: AccountPermissions
-    WRITE = None  # type: AccountPermissions
-    DELETE = None  # type: AccountPermissions
-    LIST = None  # type: AccountPermissions
-    ADD = None  # type: AccountPermissions
-    CREATE = None  # type: AccountPermissions
-    UPDATE = None  # type: AccountPermissions
-    PROCESS = None  # type: AccountPermissions
-
     def __init__(self, read=False, write=False, delete=False, list=False,  # pylint: disable=redefined-builtin
-                 add=False, create=False, update=False, process=False, _str=None):
-        if not _str:
-            _str = ''
-        self.read = read or ('r' in _str)
-        self.write = write or ('w' in _str)
-        self.delete = delete or ('d' in _str)
-        self.list = list or ('l' in _str)
-        self.add = add or ('a' in _str)
-        self.create = create or ('c' in _str)
-        self.update = update or ('u' in _str)
-        self.process = process or ('p' in _str)
-
-    def __or__(self, other):
-        return AccountPermissions(_str=str(self) + str(other))
-
-    def __add__(self, other):
-        return AccountPermissions(_str=str(self) + str(other))
+                 add=False, create=False, update=False, process=False):
+        self.read = read
+        self.write = write
+        self.delete = delete
+        self.list = list
+        self.add = add
+        self.create = create
+        self.update = update
+        self.process = process
+        self._str = (('r' if self.read else '') +
+                     ('w' if  self.write else '') +
+                     ('d' if self.delete else '') +
+                     ('l' if self.list else '') +
+                     ('a' if self.add else '') +
+                     ('c' if self.create else '') +
+                     ('u' if self.update else '') +
+                     ('p' if self.process else ''))
 
     def __str__(self):
-        return (('r' if self.read else '') +
-                ('w' if self.write else '') +
-                ('d' if self.delete else '') +
-                ('l' if self.list else '') +
-                ('a' if self.add else '') +
-                ('c' if self.create else '') +
-                ('u' if self.update else '') +
-                ('p' if self.process else ''))
+        return self._str
 
+    @classmethod
+    def from_string(cls, permission):
+        p_read = 'r' in permission
+        p_write = 'w' in permission
+        p_delete = 'd' in permission
+        p_list = 'l' in permission
+        p_add = 'a' in permission
+        p_create = 'c' in permission
+        p_update = 'u' in permission
+        p_process = 'p' in permission
 
-AccountPermissions.READ = AccountPermissions(read=True)
-AccountPermissions.WRITE = AccountPermissions(write=True)
-AccountPermissions.DELETE = AccountPermissions(delete=True)
-AccountPermissions.LIST = AccountPermissions(list=True)
-AccountPermissions.ADD = AccountPermissions(add=True)
-AccountPermissions.CREATE = AccountPermissions(create=True)
-AccountPermissions.UPDATE = AccountPermissions(update=True)
-AccountPermissions.PROCESS = AccountPermissions(process=True)
-
+        parsed = cls(p_read, p_write, p_delete, p_list, p_add, p_create, p_update, p_process)
+        parsed._str = permission
+        return parsed
 
 class Services(object):
     """Specifies the services accessible with the account SAS.

--- a/sdk/storage/azure-storage-file/azure/storage/file/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/_shared/shared_access_signature.py
@@ -103,7 +103,7 @@ class SharedAccessSignature(object):
             Specifies the resource types that are accessible with the account
             SAS. You can combine values to provide access to more than one
             resource type.
-        :param AccountPermissions permission:
+        :param AccountSasPermissions permission:
             The permissions associated with the shared access signature. The
             user is restricted to operations allowed by the permissions.
             Required unless an id is given referencing a stored access policy

--- a/sdk/storage/azure-storage-file/azure/storage/file/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/_shared_access_signature.py
@@ -43,7 +43,7 @@ class FileSharedAccessSignature(SharedAccessSignature):
             this parameter should only be present if file_name is provided.
         :param str file_name:
             Name of file.
-        :param FilePermissions permission:
+        :param FileSasPermissions permission:
             The permissions associated with the shared access signature. The
             user is restricted to operations allowed by the permissions.
             Permissions must be ordered read, create, write, delete, list.
@@ -121,7 +121,7 @@ class FileSharedAccessSignature(SharedAccessSignature):
 
         :param str share_name:
             Name of share.
-        :param SharePermissions permission:
+        :param ShareSasPermissions permission:
             The permissions associated with the shared access signature. The
             user is restricted to operations allowed by the permissions.
             Permissions must be ordered read, create, write, delete, list.

--- a/sdk/storage/azure-storage-file/azure/storage/file/aio/__init__.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/aio/__init__.py
@@ -12,7 +12,7 @@ from .._shared.policies_async import ExponentialRetry, LinearRetry, NoRetry
 from .._shared.models import (
     LocationMode,
     ResourceTypes,
-    AccountPermissions,
+    AccountSasPermissions,
     StorageErrorCode)
 from ..models import (
     Handle,
@@ -23,8 +23,8 @@ from ..models import (
     RetentionPolicy,
     CorsRule,
     AccessPolicy,
-    FilePermissions,
-    SharePermissions,
+    FileSasPermissions,
+    ShareSasPermissions,
     ContentSettings,
     NTFSAttributes)
 from .models import (
@@ -43,7 +43,7 @@ __all__ = [
     'NoRetry',
     'LocationMode',
     'ResourceTypes',
-    'AccountPermissions',
+    'AccountSasPermissions',
     'StorageErrorCode',
     'Metrics',
     'RetentionPolicy',
@@ -51,8 +51,8 @@ __all__ = [
     'Handle',
     'HandlesPaged',
     'AccessPolicy',
-    'FilePermissions',
-    'SharePermissions',
+    'FileSasPermissions',
+    'ShareSasPermissions',
     'ShareProperties',
     'SharePropertiesPaged',
     'DirectoryProperties',

--- a/sdk/storage/azure-storage-file/azure/storage/file/aio/file_service_client_async.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/aio/file_service_client_async.py
@@ -26,7 +26,7 @@ from .models import SharePropertiesPaged
 
 if TYPE_CHECKING:
     from datetime import datetime
-    from .._shared.models import ResourceTypes, AccountPermissions
+    from .._shared.models import ResourceTypes, AccountSasPermissions
     from ..models import Metrics, CorsRule, ShareProperties
 
 

--- a/sdk/storage/azure-storage-file/azure/storage/file/file_client.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/file_client.py
@@ -39,7 +39,7 @@ from ._shared_access_signature import FileSharedAccessSignature
 
 if TYPE_CHECKING:
     from datetime import datetime
-    from .models import ShareProperties, FilePermissions, ContentSettings, FileProperties
+    from .models import ShareProperties, FileSasPermissions, ContentSettings, FileProperties
     from ._generated.models import HandleItem
 
 
@@ -238,7 +238,7 @@ class FileClient(StorageAccountHostsMixin):
             account_url, share=share, file_path=file_path, snapshot=snapshot, credential=credential, **kwargs)
 
     def generate_shared_access_signature(
-            self, permission=None,  # type: Optional[Union[FilePermissions, str]]
+            self, permission=None,  # type: Optional[Union[FileSasPermissions, str]]
             expiry=None,  # type: Optional[Union[datetime, str]]
             start=None,  # type: Optional[Union[datetime, str]]
             policy_id=None,  # type: Optional[str]
@@ -256,7 +256,7 @@ class FileClient(StorageAccountHostsMixin):
         Use the returned signature with the credential parameter of any FileServiceClient,
         ShareClient, DirectoryClient, or FileClient.
 
-        :param ~azure.storage.file.models.FilePermissions permission:
+        :param ~azure.storage.file.models.FileSasPermissions permission:
             The permissions associated with the shared access signature. The
             user is restricted to operations allowed by the permissions.
             Permissions must be ordered read, write, delete, list.

--- a/sdk/storage/azure-storage-file/azure/storage/file/file_service_client.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/file_service_client.py
@@ -29,7 +29,7 @@ from .models import SharePropertiesPaged
 
 if TYPE_CHECKING:
     from datetime import datetime
-    from ._shared.models import ResourceTypes, AccountPermissions
+    from ._shared.models import ResourceTypes, AccountSasPermissions
     from .models import Metrics, CorsRule, ShareProperties
 
 
@@ -137,7 +137,7 @@ class FileServiceClient(StorageAccountHostsMixin):
 
     def generate_shared_access_signature(
             self, resource_types,  # type: Union[ResourceTypes, str]
-            permission,  # type: Union[AccountPermissions, str]
+            permission,  # type: Union[AccountSasPermissions, str]
             expiry,  # type: Optional[Union[datetime, str]]
             start=None,  # type: Optional[Union[datetime, str]]
             ip=None,  # type: Optional[str]
@@ -150,7 +150,7 @@ class FileServiceClient(StorageAccountHostsMixin):
 
         :param ~azure.storage.file._shared.models.ResourceTypes resource_types:
             Specifies the resource types that are accessible with the account SAS.
-        :param ~azure.storage.file._shared.models.AccountPermissions permission:
+        :param ~azure.storage.file._shared.models.AccountSasPermissions permission:
             The permissions associated with the shared access signature. The
             user is restricted to operations allowed by the permissions.
             Required unless an id is given referencing a stored access policy

--- a/sdk/storage/azure-storage-file/azure/storage/file/models.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/models.py
@@ -666,7 +666,7 @@ class FileSasPermissions(object):
         p_delete = 'd' in permission
 
         parsed = cls(p_read, p_create, p_write, p_delete)
-        parsed._str = permission
+        parsed._str = permission # pylint: disable = protected-access
         return parsed
 
 
@@ -712,7 +712,7 @@ class ShareSasPermissions(object):
         p_list = 'l' in permission
 
         parsed = cls(p_read, p_write, p_delete, p_list)
-        parsed._str = permission
+        parsed._str = permission # pylint: disable = protected-access
         return parsed
 
 class NTFSAttributes(object):

--- a/sdk/storage/azure-storage-file/azure/storage/file/models.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/models.py
@@ -630,20 +630,10 @@ class CopyProperties(DictMixin):
         return copy
 
 
-class FilePermissions(object):
-    """FilePermissions class to be used with
+class FileSasPermissions(object):
+    """FileSasPermissions class to be used with
     generating shared access signature operations.
 
-    :cvar FilePermissions FilePermissions.CREATE:
-        Create a new file or copy a file to a new file.
-    :cvar FilePermissions FilePermissions.DELETE:
-        Delete the file.
-    :cvar FilePermissions FilePermissions.READ:
-        Read the content, properties, metadata. Use the file as the source of a copy
-        operation.
-    :cvar FilePermissions FilePermissions.WRITE:
-        Create or write content, properties, metadata. Resize the file. Use the file
-        as the destination of a copy operation within the same account.
     :param bool read:
         Read the content, properties, metadata. Use the file as the source of a copy
         operation.
@@ -654,62 +644,36 @@ class FilePermissions(object):
         as the destination of a copy operation within the same account.
     :param bool delete:
         Delete the file.
-    :param str _str:
-        A string representing the permissions.
     """
-
-    CREATE = None  # type: FilePermissions
-    DELETE = None  # type: FilePermissions
-    READ = None  # type: FilePermissions
-    WRITE = None  # type: FilePermissions
-
-    def __init__(self, read=False, create=False, write=False, delete=False,
-                 _str=None):
-        if not _str:
-            _str = ''
-        self.read = read or ('r' in _str)
-        self.create = create or ('c' in _str)
-        self.write = write or ('w' in _str)
-        self.delete = delete or ('d' in _str)
-
-    def __or__(self, other):
-        return FilePermissions(_str=str(self) + str(other))
-
-    def __add__(self, other):
-        return FilePermissions(_str=str(self) + str(other))
+    def __init__(self, read=False, create=False, write=False, delete=False):
+        self.read = read
+        self.create = create
+        self.write = write
+        self.delete = delete
+        self._str = (('r' if self.read else '') +
+                     ('c' if self.create else '') +
+                     ('w' if self.write else '') +
+                     ('d' if self.delete else ''))
 
     def __str__(self):
-        return (('r' if self.read else '') +
-                ('c' if self.create else '') +
-                ('w' if self.write else '') +
-                ('d' if self.delete else ''))
+        return self._str
+
+    @classmethod
+    def from_string(cls, permission):
+        p_read = 'r' in permission
+        p_create = 'c' in permission
+        p_write = 'w' in permission
+        p_delete = 'd' in permission
+
+        parsed = cls(p_read, p_create, p_write, p_delete)
+        parsed._str = permission
+        return parsed
 
 
-FilePermissions.CREATE = FilePermissions(create=True) # type: ignore
-FilePermissions.DELETE = FilePermissions(delete=True) # type: ignore
-FilePermissions.READ = FilePermissions(read=True) # type: ignore
-FilePermissions.WRITE = FilePermissions(write=True) # type: ignore
-
-
-class SharePermissions(object):
-    """SharePermissions class to be used to be used with
+class ShareSasPermissions(object):
+    """ShareSasPermissions class to be used to be used with
     generating shared access signature and access policy operations.
 
-    :cvar SharePermissions SharePermissions.DELETE:
-        Delete any file in the share.
-        Note: You cannot grant permissions to delete a share with a service SAS. Use
-        an account SAS instead.
-    :cvar SharePermissions SharePermissions.LIST:
-        List files and directories in the share.
-    :cvar SharePermissions SharePermissions.READ:
-        Read the content, properties or metadata of any file in the share. Use any
-        file in the share as the source of a copy operation.
-    :cvar SharePermissions SharePermissions.WRITE:
-        For any file in the share, create or write content, properties or metadata.
-        Resize the file. Use the file as the destination of a copy operation within
-        the same account.
-        Note: You cannot grant permissions to read or write share properties or
-        metadata with a service SAS. Use an account SAS instead.
     :param bool read:
         Read the content, properties or metadata of any file in the share. Use any
         file in the share as the source of a copy operation.
@@ -725,42 +689,31 @@ class SharePermissions(object):
         an account SAS instead.
     :param bool list:
         List files and directories in the share.
-    :param str _str:
-        A string representing the permissions
     """
+    def __init__(self, read=False, write=False, delete=False, list=False):  # pylint: disable=redefined-builtin
+        self.read = read
+        self.write = write
+        self.delete = delete
+        self.list = list
+        self._str = (('r' if self.read else '') +
+                     ('w' if self.write else '') +
+                     ('d' if self.delete else '') +
+                     ('l' if self.list else ''))
 
-    LIST = None  # type: SharePermissions
-    DELETE = None  # type: SharePermissions
-    READ = None  # type: SharePermissions
-    WRITE = None  # type: SharePermissions
-
-    def __init__(self, read=False, write=False, delete=False, list=False,  # pylint: disable=redefined-builtin
-                 _str=None):
-        if not _str:
-            _str = ''
-        self.read = read or ('r' in _str)
-        self.write = write or ('w' in _str)
-        self.delete = delete or ('d' in _str)
-        self.list = list or ('l' in _str)
-
-    def __or__(self, other):
-        return SharePermissions(_str=str(self) + str(other))
-
-    def __add__(self, other):
-        return SharePermissions(_str=str(self) + str(other))
 
     def __str__(self):
-        return (('r' if self.read else '') +
-                ('w' if self.write else '') +
-                ('d' if self.delete else '') +
-                ('l' if self.list else ''))
+        return self._str
 
+    @classmethod
+    def from_string(cls, permission):
+        p_read = 'r' in permission
+        p_write = 'w' in permission
+        p_delete = 'd' in permission
+        p_list = 'l' in permission
 
-SharePermissions.DELETE = SharePermissions(delete=True) # type: ignore
-SharePermissions.LIST = SharePermissions(list=True) # type: ignore
-SharePermissions.READ = SharePermissions(read=True) # type: ignore
-SharePermissions.WRITE = SharePermissions(write=True) # type: ignore
-
+        parsed = cls(p_read, p_write, p_delete, p_list)
+        parsed._str = permission
+        return parsed
 
 class NTFSAttributes(object):
     """

--- a/sdk/storage/azure-storage-file/azure/storage/file/share_client.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/share_client.py
@@ -34,7 +34,7 @@ from .file_client import FileClient
 from ._shared_access_signature import FileSharedAccessSignature
 
 if TYPE_CHECKING:
-    from .models import ShareProperties, AccessPolicy, SharePermissions
+    from .models import ShareProperties, AccessPolicy, ShareSasPermissions
 
 
 class ShareClient(StorageAccountHostsMixin):
@@ -168,7 +168,7 @@ class ShareClient(StorageAccountHostsMixin):
             account_url, share=share, snapshot=snapshot, credential=credential, **kwargs)
 
     def generate_shared_access_signature(
-            self, permission=None,  # type: Optional[Union[SharePermissions, str]]
+            self, permission=None,  # type: Optional[Union[ShareSasPermissions, str]]
             expiry=None,  # type: Optional[Union[datetime, str]]
             start=None,  # type: Optional[Union[datetime, str]]
             policy_id=None,  # type: Optional[str]
@@ -184,7 +184,7 @@ class ShareClient(StorageAccountHostsMixin):
         Use the returned signature with the credential parameter of any FileServiceClient,
         ShareClient, DirectoryClient, or FileClient.
 
-        :param ~azure.storage.file.models.SharePermissions permission:
+        :param ~azure.storage.file.models.ShareSasPermissions permission:
             The permissions associated with the shared access signature. The
             user is restricted to operations allowed by the permissions.
             Permissions must be ordered read, create, write, delete, list.

--- a/sdk/storage/azure-storage-file/tests/test_file.py
+++ b/sdk/storage/azure-storage-file/tests/test_file.py
@@ -19,10 +19,10 @@ from azure.storage.file import (
     FileClient,
     FileServiceClient,
     ContentSettings,
-    FilePermissions,
+    FileSasPermissions,
     AccessPolicy,
     ResourceTypes,
-    AccountPermissions,
+    AccountSasPermissions,
     StorageErrorCode,
     NTFSAttributes)
 from filetestcase import (
@@ -620,7 +620,7 @@ class StorageFileTest(FileTestCase):
         # generate SAS for the source file
         sas_token_for_source_file = \
             source_file_client.generate_shared_access_signature(
-                                                          FilePermissions.READ,
+                                                          FileSasPermissions(read=True),
                                                           expiry=datetime.utcnow() + timedelta(hours=1))
 
         source_file_url = source_file_client.url + '?' + sas_token_for_source_file
@@ -652,7 +652,7 @@ class StorageFileTest(FileTestCase):
         # generate SAS for the source file
         sas_token_for_source_file = \
             source_file_client.generate_shared_access_signature(
-                                                          FilePermissions.READ,
+                                                          FileSasPermissions(read=True),
                                                           expiry=datetime.utcnow() + timedelta(hours=1))
 
         source_file_url = source_file_client.url + '?' + sas_token_for_source_file
@@ -858,7 +858,7 @@ class StorageFileTest(FileTestCase):
         self._create_remote_share()
         source_file = self._create_remote_file(file_data=data)
         sas_token = source_file.generate_shared_access_signature(
-            permission=FilePermissions.READ,
+            permission=FileSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         source_url = source_file.url + '?' + sas_token
@@ -886,7 +886,7 @@ class StorageFileTest(FileTestCase):
         self._create_remote_share()
         source_file = self._create_remote_file(file_data=data)
         sas_token = source_file.generate_shared_access_signature(
-            permission=FilePermissions.READ,
+            permission=FileSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         source_url = source_file.url + '?' + sas_token
@@ -1403,7 +1403,7 @@ class StorageFileTest(FileTestCase):
         # Arrange
         file_client = self._create_file()
         token = file_client.generate_shared_access_signature(
-            permission=FilePermissions.READ,
+            permission=FileSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1431,7 +1431,7 @@ class StorageFileTest(FileTestCase):
         access_policy = AccessPolicy()
         access_policy.start = datetime.utcnow() - timedelta(hours=1)
         access_policy.expiry = datetime.utcnow() + timedelta(hours=1)
-        access_policy.permission = FilePermissions.READ
+        access_policy.permission = FileSasPermissions(read=True)
         identifiers = {'testid': access_policy}
         share_client.set_share_access_policy(identifiers)
 
@@ -1457,7 +1457,7 @@ class StorageFileTest(FileTestCase):
         file_client = self._create_file()
         token = self.fsc.generate_shared_access_signature(
             ResourceTypes.OBJECT,
-            AccountPermissions.READ,
+            AccountSasPermissions(read=True),
             datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1483,7 +1483,7 @@ class StorageFileTest(FileTestCase):
         # Arrange
         file_client = self._create_file()
         token = file_client.generate_shared_access_signature(
-            permission=FilePermissions.READ,
+            permission=FileSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1508,7 +1508,7 @@ class StorageFileTest(FileTestCase):
         # Arrange
         file_client = self._create_file()
         token = file_client.generate_shared_access_signature(
-            permission=FilePermissions.READ,
+            permission=FileSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
             cache_control='no-cache',
             content_disposition='inline',
@@ -1543,7 +1543,7 @@ class StorageFileTest(FileTestCase):
         updated_data = b'updated file data'
         file_client_admin = self._create_file()
         token = file_client_admin.generate_shared_access_signature(
-            permission=FilePermissions.WRITE,
+            permission=FileSasPermissions(write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         file_client = FileClient(
@@ -1570,7 +1570,7 @@ class StorageFileTest(FileTestCase):
         # Arrange
         file_client_admin = self._create_file()
         token = file_client_admin.generate_shared_access_signature(
-            permission=FilePermissions.DELETE,
+            permission=FileSasPermissions(delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         file_client = FileClient(

--- a/sdk/storage/azure-storage-file/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file/tests/test_file_async.py
@@ -22,10 +22,10 @@ from azure.storage.file.aio import (
     FileClient,
     FileServiceClient,
     ContentSettings,
-    FilePermissions,
+    FileSasPermissions,
     AccessPolicy,
     ResourceTypes,
-    AccountPermissions,
+    AccountSasPermissions,
     StorageErrorCode
 )
 from filetestcase import (
@@ -768,7 +768,7 @@ class StorageFileAsyncTest(FileTestCase):
         # generate SAS for the source file
         sas_token_for_source_file = \
             source_file_client.generate_shared_access_signature(
-                                                          FilePermissions.READ,
+                                                          FileSasPermissions(read=True),
                                                           expiry=datetime.utcnow() + timedelta(hours=1))
 
         source_file_url = source_file_client.url + '?' + sas_token_for_source_file
@@ -805,7 +805,7 @@ class StorageFileAsyncTest(FileTestCase):
         # generate SAS for the source file
         sas_token_for_source_file = \
             source_file_client.generate_shared_access_signature(
-                                                          FilePermissions.READ,
+                                                          FileSasPermissions(read=True),
                                                           expiry=datetime.utcnow() + timedelta(hours=1))
 
         source_file_url = source_file_client.url + '?' + sas_token_for_source_file
@@ -1062,7 +1062,7 @@ class StorageFileAsyncTest(FileTestCase):
         await self._create_remote_share()
         source_file = await self._create_remote_file(file_data=data)
         sas_token = source_file.generate_shared_access_signature(
-            permission=FilePermissions.READ,
+            permission=FileSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         source_url = source_file.url + '?' + sas_token
@@ -1097,7 +1097,7 @@ class StorageFileAsyncTest(FileTestCase):
         await self._create_remote_share()
         source_file = await self._create_remote_file(file_data=data)
         sas_token = source_file.generate_shared_access_signature(
-            permission=FilePermissions.READ,
+            permission=FileSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         source_url = source_file.url + '?' + sas_token
@@ -1734,7 +1734,7 @@ class StorageFileAsyncTest(FileTestCase):
         # Arrange
         file_client = await self._create_file()
         token = file_client.generate_shared_access_signature(
-            permission=FilePermissions.READ,
+            permission=FileSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1767,7 +1767,7 @@ class StorageFileAsyncTest(FileTestCase):
         access_policy = AccessPolicy()
         access_policy.start = datetime.utcnow() - timedelta(hours=1)
         access_policy.expiry = datetime.utcnow() + timedelta(hours=1)
-        access_policy.permission = FilePermissions.READ
+        access_policy.permission = FileSasPermissions(read=True)
         identifiers = {'testid': access_policy}
         await share_client.set_share_access_policy(identifiers)
 
@@ -1798,7 +1798,7 @@ class StorageFileAsyncTest(FileTestCase):
         file_client = await self._create_file()
         token = self.fsc.generate_shared_access_signature(
             ResourceTypes.OBJECT,
-            AccountPermissions.READ,
+            AccountSasPermissions(read=True),
             datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1828,7 +1828,7 @@ class StorageFileAsyncTest(FileTestCase):
         # Arrange
         file_client = await self._create_file()
         token = file_client.generate_shared_access_signature(
-            permission=FilePermissions.READ,
+            permission=FileSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -1857,7 +1857,7 @@ class StorageFileAsyncTest(FileTestCase):
         # Arrange
         file_client = await self._create_file()
         token = file_client.generate_shared_access_signature(
-            permission=FilePermissions.READ,
+            permission=FileSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
             cache_control='no-cache',
             content_disposition='inline',
@@ -1896,7 +1896,7 @@ class StorageFileAsyncTest(FileTestCase):
         updated_data = b'updated file data'
         file_client_admin = await self._create_file()
         token = file_client_admin.generate_shared_access_signature(
-            permission=FilePermissions.WRITE,
+            permission=FileSasPermissions(write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         file_client = FileClient(
@@ -1928,7 +1928,7 @@ class StorageFileAsyncTest(FileTestCase):
         # Arrange
         file_client_admin = await self._create_file()
         token = file_client_admin.generate_shared_access_signature(
-            permission=FilePermissions.DELETE,
+            permission=FileSasPermissions(delete=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         file_client = FileClient(

--- a/sdk/storage/azure-storage-file/tests/test_share.py
+++ b/sdk/storage/azure-storage-file/tests/test_share.py
@@ -15,7 +15,7 @@ from azure.core.exceptions import (
     ResourceNotFoundError,
     ResourceExistsError)
 
-from azure.storage.file.models import AccessPolicy, SharePermissions
+from azure.storage.file.models import AccessPolicy, ShareSasPermissions
 from azure.storage.file.file_service_client import FileServiceClient
 from azure.storage.file.directory_client import DirectoryClient
 from azure.storage.file.file_client import FileClient
@@ -549,7 +549,7 @@ class StorageShareTest(FileTestCase):
         # Act
         identifiers = dict()
         identifiers['testid'] = AccessPolicy(
-            permission=SharePermissions.WRITE,
+            permission=ShareSasPermissions(write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
             start=datetime.utcnow() - timedelta(minutes=1),
         )
@@ -727,7 +727,7 @@ class StorageShareTest(FileTestCase):
 
         token = share.generate_shared_access_signature(
             expiry=datetime.utcnow() + timedelta(hours=1),
-            permission=SharePermissions.READ,
+            permission=ShareSasPermissions(read=True),
         )
         sas_client = FileClient(
             self.get_file_url(),

--- a/sdk/storage/azure-storage-file/tests/test_share_async.py
+++ b/sdk/storage/azure-storage-file/tests/test_share_async.py
@@ -19,7 +19,7 @@ from azure.core.exceptions import (
 
 from azure.storage.file.aio import (
     AccessPolicy,
-    SharePermissions,
+    ShareSasPermissions,
     FileServiceClient,
     DirectoryClient,
     FileClient,
@@ -662,7 +662,7 @@ class StorageShareTest(FileTestCase):
         # Act
         identifiers = dict()
         identifiers['testid'] = AccessPolicy(
-            permission=SharePermissions.WRITE,
+            permission=ShareSasPermissions(write=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
             start=datetime.utcnow() - timedelta(minutes=1),
         )
@@ -873,7 +873,7 @@ class StorageShareTest(FileTestCase):
 
         token = share.generate_shared_access_signature(
             expiry=datetime.utcnow() + timedelta(hours=1),
-            permission=SharePermissions.READ,
+            permission=ShareSasPermissions(read=True),
         )
         sas_client = FileClient(
             self.get_file_url(),

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/__init__.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/__init__.py
@@ -11,7 +11,7 @@ from ._shared.policies import ExponentialRetry, LinearRetry, NoRetry
 from ._shared.models import(
     LocationMode,
     ResourceTypes,
-    AccountPermissions,
+    AccountSasPermissions,
     StorageErrorCode
 )
 from ._message_encoding import (
@@ -28,7 +28,7 @@ from .models import (
     QueueMessage,
     QueueProperties,
     QueuePropertiesPaged,
-    QueuePermissions,
+    QueueSasPermissions,
     AccessPolicy,
     Logging,
     Metrics,
@@ -47,12 +47,12 @@ __all__ = [
     'NoRetry',
     'LocationMode',
     'ResourceTypes',
-    'AccountPermissions',
+    'AccountSasPermissions',
     'StorageErrorCode',
     'QueueMessage',
     'QueueProperties',
     'QueuePropertiesPaged',
-    'QueuePermissions',
+    'QueueSasPermissions',
     'AccessPolicy',
     'TextBase64EncodePolicy',
     'TextBase64DecodePolicy',

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/models.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/models.py
@@ -340,7 +340,7 @@ class AccountSasPermissions(object):
         p_process = 'p' in permission
 
         parsed = cls(p_read, p_write, p_delete, p_list, p_add, p_create, p_update, p_process)
-        parsed._str = permission
+        parsed._str = permission # pylint: disable = protected-access
         return parsed
 
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/models.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/models.py
@@ -277,7 +277,7 @@ ResourceTypes.CONTAINER = ResourceTypes(container=True)
 ResourceTypes.OBJECT = ResourceTypes(object=True)
 
 
-class AccountPermissions(object):
+class AccountSasPermissions(object):
     """
     :class:`~ResourceTypes` class to be used with generate_shared_access_signature
     method and for the AccessPolicies used with set_*_acl. There are two types of
@@ -285,26 +285,6 @@ class AccountPermissions(object):
     specific resource (resource-specific). Another is to grant access to the
     entire service for a specific account and allow certain operations based on
     perms found here.
-
-    :cvar AccountPermissions AccountPermissions.ADD:
-        Valid for the following Object resource types only: queue messages and append blobs.
-    :cvar AccountPermissions AccountPermissions.CREATE:
-        Valid for the following Object resource types only: blobs and files. Users
-        can create new blobs or files, but may not overwrite existing blobs or files.
-    :cvar AccountPermissions AccountPermissions.DELETE:
-        Valid for Container and Object resource types, except for queue messages.
-    :cvar AccountPermissions AccountPermissions.LIST:
-        Valid for Service and Container resource types only.
-    :cvar AccountPermissions AccountPermissions.PROCESS:
-        Valid for the following Object resource type only: queue messages.
-    :cvar AccountPermissions AccountPermissions.READ:
-        Valid for all signed resources types (Service, Container, and Object).
-        Permits read permissions to the specified resource type.
-    :cvar AccountPermissions AccountPermissions.UPDATE:
-        Valid for the following Object resource types only: queue messages.
-    :cvar AccountPermissions AccountPermissions.WRITE:
-        Valid for all signed resources types (Service, Container, and Object).
-        Permits write permissions to the specified resource type.
     :param bool read:
         Valid for all signed resources types (Service, Container, and Object).
         Permits read permissions to the specified resource type.
@@ -325,57 +305,43 @@ class AccountPermissions(object):
         Valid for the following Object resource types only: queue messages.
     :param bool process:
         Valid for the following Object resource type only: queue messages.
-    :param str _str:
-        A string representing the permissions.
     """
-
-    READ = None  # type: AccountPermissions
-    WRITE = None  # type: AccountPermissions
-    DELETE = None  # type: AccountPermissions
-    LIST = None  # type: AccountPermissions
-    ADD = None  # type: AccountPermissions
-    CREATE = None  # type: AccountPermissions
-    UPDATE = None  # type: AccountPermissions
-    PROCESS = None  # type: AccountPermissions
-
     def __init__(self, read=False, write=False, delete=False, list=False,  # pylint: disable=redefined-builtin
-                 add=False, create=False, update=False, process=False, _str=None):
-        if not _str:
-            _str = ''
-        self.read = read or ('r' in _str)
-        self.write = write or ('w' in _str)
-        self.delete = delete or ('d' in _str)
-        self.list = list or ('l' in _str)
-        self.add = add or ('a' in _str)
-        self.create = create or ('c' in _str)
-        self.update = update or ('u' in _str)
-        self.process = process or ('p' in _str)
-
-    def __or__(self, other):
-        return AccountPermissions(_str=str(self) + str(other))
-
-    def __add__(self, other):
-        return AccountPermissions(_str=str(self) + str(other))
+                 add=False, create=False, update=False, process=False):
+        self.read = read
+        self.write = write
+        self.delete = delete
+        self.list = list
+        self.add = add
+        self.create = create
+        self.update = update
+        self.process = process
+        self._str = (('r' if self.read else '') +
+                     ('w' if  self.write else '') +
+                     ('d' if self.delete else '') +
+                     ('l' if self.list else '') +
+                     ('a' if self.add else '') +
+                     ('c' if self.create else '') +
+                     ('u' if self.update else '') +
+                     ('p' if self.process else ''))
 
     def __str__(self):
-        return (('r' if self.read else '') +
-                ('w' if self.write else '') +
-                ('d' if self.delete else '') +
-                ('l' if self.list else '') +
-                ('a' if self.add else '') +
-                ('c' if self.create else '') +
-                ('u' if self.update else '') +
-                ('p' if self.process else ''))
+        return self._str
 
+    @classmethod
+    def from_string(cls, permission):
+        p_read = 'r' in permission
+        p_write = 'w' in permission
+        p_delete = 'd' in permission
+        p_list = 'l' in permission
+        p_add = 'a' in permission
+        p_create = 'c' in permission
+        p_update = 'u' in permission
+        p_process = 'p' in permission
 
-AccountPermissions.READ = AccountPermissions(read=True)
-AccountPermissions.WRITE = AccountPermissions(write=True)
-AccountPermissions.DELETE = AccountPermissions(delete=True)
-AccountPermissions.LIST = AccountPermissions(list=True)
-AccountPermissions.ADD = AccountPermissions(add=True)
-AccountPermissions.CREATE = AccountPermissions(create=True)
-AccountPermissions.UPDATE = AccountPermissions(update=True)
-AccountPermissions.PROCESS = AccountPermissions(process=True)
+        parsed = cls(p_read, p_write, p_delete, p_list, p_add, p_create, p_update, p_process)
+        parsed._str = permission
+        return parsed
 
 
 class Services(object):

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/shared_access_signature.py
@@ -103,7 +103,7 @@ class SharedAccessSignature(object):
             Specifies the resource types that are accessible with the account
             SAS. You can combine values to provide access to more than one
             resource type.
-        :param AccountPermissions permission:
+        :param AccountSasPermissions permission:
             The permissions associated with the shared access signature. The
             user is restricted to operations allowed by the permissions.
             Required unless an id is given referencing a stored access policy

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
@@ -35,7 +35,7 @@ class QueueSharedAccessSignature(SharedAccessSignature):
         Use the returned signature with the sas_token parameter of QueueService.
         :param str queue_name:
             Name of queue.
-        :param QueuePermissions permission:
+        :param QueueSasPermissions permission:
             The permissions associated with the shared access signature. The
             user is restricted to operations allowed by the permissions.
             Permissions must be ordered read, add, update, process.

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/__init__.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/__init__.py
@@ -10,7 +10,7 @@ from .queue_service_client_async import QueueServiceClient
 from .models import MessagesPaged, QueuePropertiesPaged
 from ..models import (
     Logging, Metrics, RetentionPolicy, CorsRule, AccessPolicy,
-    QueueMessage, QueuePermissions, QueueProperties)
+    QueueMessage, QueueSasPermissions, QueueProperties)
 
 __version__ = VERSION
 
@@ -24,7 +24,7 @@ __all__ = [
     'AccessPolicy',
     'QueueMessage',
     'MessagesPaged',
-    'QueuePermissions',
+    'QueueSasPermissions',
     'QueueProperties',
     'QueuePropertiesPaged'
 ]

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/queue_client_async.py
@@ -50,7 +50,7 @@ from ..queue_client import QueueClient as QueueClientBase
 if TYPE_CHECKING:
     from datetime import datetime
     from azure.core.pipeline.policies import HTTPPolicy
-    from azure.storage.queue.models import QueuePermissions, QueueProperties
+    from azure.storage.queue.models import QueueSasPermissions, QueueProperties
 
 
 class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase):

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/queue_service_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/queue_service_client_async.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from datetime import datetime
     from azure.core import Configuration
     from azure.core.pipeline.policies import HTTPPolicy
-    from azure.storage.queue._shared.models import AccountPermissions, ResourceTypes
+    from azure.storage.queue._shared.models import AccountSasPermissions, ResourceTypes
     from azure.storage.queue.aio.models import (
         QueueProperties
     )

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/models.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/models.py
@@ -368,5 +368,5 @@ class QueueSasPermissions(object):
         p_process = 'p' in permission
 
         parsed = cls(p_read, p_add, p_update, p_process)
-        parsed._str = permission
+        parsed._str = permission # pylint: disable = protected-access
         return parsed

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/models.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/models.py
@@ -331,21 +331,12 @@ class QueuePropertiesPaged(PageIterator):
         return self._response.next_marker or None, props_list
 
 
-class QueuePermissions(object):
-    """QueuePermissions class to be used with
+class QueueSasPermissions(object):
+    """QueueSasPermissions class to be used with
     :func:`~azure.storage.queue.queue_client.QueueClient.generate_shared_access_signature`
     method and for the AccessPolicies used with
     :func:`~azure.storage.queue.queue_client.QueueClient.set_queue_access_policy`.
 
-    :ivar QueuePermissions QueuePermissions.READ:
-        Read metadata and properties, including message count. Peek at messages.
-    :ivar QueuePermissions QueuePermissions.ADD:
-        Add messages to the queue.
-    :ivar QueuePermissions QueuePermissions.UPDATE:
-        Update messages in the queue. Note: Use the Process permission with
-        Update so you can first get the message you want to update.
-    :ivar QueuePermissions QueuePermissions.PROCESS: Delete entities.
-        Get and delete messages from the queue.
     :param bool read:
         Read metadata and properties, including message count. Peek at messages.
     :param bool add:
@@ -355,37 +346,27 @@ class QueuePermissions(object):
         Update so you can first get the message you want to update.
     :param bool process:
         Get and delete messages from the queue.
-    :param str _str:
-        A string representing the permissions.
     """
-
-    READ = None # type: QueuePermissions
-    ADD = None # type: QueuePermissions
-    UPDATE = None # type: QueuePermissions
-    PROCESS = None # type: QueuePermissions
-
-    def __init__(self, read=False, add=False, update=False, process=False, _str=None):
-        if not _str:
-            _str = ''
-        self.read = read or ('r' in _str)
-        self.add = add or ('a' in _str)
-        self.update = update or ('u' in _str)
-        self.process = process or ('p' in _str)
-
-    def __or__(self, other):
-        return QueuePermissions(_str=str(self) + str(other))
-
-    def __add__(self, other):
-        return QueuePermissions(_str=str(self) + str(other))
+    def __init__(self, read=False, add=False, update=False, process=False):
+        self.read = read
+        self.add = add
+        self.update = update
+        self.process = process
+        self._str = (('r' if self.read else '') +
+                     ('a' if self.add else '') +
+                     ('u' if self.update else '') +
+                     ('p' if self.process else ''))
 
     def __str__(self):
-        return (('r' if self.read else '') +
-                ('a' if self.add else '') +
-                ('u' if self.update else '') +
-                ('p' if self.process else ''))
+        return self._str
 
+    @classmethod
+    def from_string(cls, permission):
+        p_read = 'r' in permission
+        p_add = 'a' in permission
+        p_update = 'u' in permission
+        p_process = 'p' in permission
 
-QueuePermissions.READ = QueuePermissions(read=True)
-QueuePermissions.ADD = QueuePermissions(add=True)
-QueuePermissions.UPDATE = QueuePermissions(update=True)
-QueuePermissions.PROCESS = QueuePermissions(process=True)
+        parsed = cls(p_read, p_add, p_update, p_process)
+        parsed._str = permission
+        return parsed

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/queue_client.py
@@ -36,7 +36,7 @@ from .models import QueueMessage, AccessPolicy, MessagesPaged
 if TYPE_CHECKING:
     from datetime import datetime
     from azure.core.pipeline.policies import HTTPPolicy
-    from .models import QueuePermissions, QueueProperties
+    from .models import QueueSasPermissions, QueueProperties
 
 
 class QueueClient(StorageAccountHostsMixin):
@@ -162,7 +162,7 @@ class QueueClient(StorageAccountHostsMixin):
         return cls(account_url, queue=queue, credential=credential, **kwargs) # type: ignore
 
     def generate_shared_access_signature(
-            self, permission=None,  # type: Optional[Union[QueuePermissions, str]]
+            self, permission=None,  # type: Optional[Union[QueueSasPermissions, str]]
             expiry=None,  # type: Optional[Union[datetime, str]]
             start=None,  # type: Optional[Union[datetime, str]]
             policy_id=None,  # type: Optional[str]
@@ -173,7 +173,7 @@ class QueueClient(StorageAccountHostsMixin):
 
         Use the returned signature with the credential parameter of any Queue Service.
 
-        :param ~azure.storage.queue.models.QueuePermissions permission:
+        :param ~azure.storage.queue.models.QueueSasPermissions permission:
             The permissions associated with the shared access signature. The
             user is restricted to operations allowed by the permissions.
             Required unless a policy_id is given referencing a stored access policy

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/queue_service_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/queue_service_client.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from datetime import datetime
     from azure.core import Configuration
     from azure.core.pipeline.policies import HTTPPolicy
-    from ._shared.models import AccountPermissions, ResourceTypes
+    from ._shared.models import AccountSasPermissions, ResourceTypes
     from .models import (
         QueueProperties,
         Logging,
@@ -149,7 +149,7 @@ class QueueServiceClient(StorageAccountHostsMixin):
 
     def generate_shared_access_signature(
             self, resource_types,  # type: Union[ResourceTypes, str]
-            permission,  # type: Union[AccountPermissions, str]
+            permission,  # type: Union[AccountSasPermissions, str]
             expiry,  # type: Optional[Union[datetime, str]]
             start=None,  # type: Optional[Union[datetime, str]]
             ip=None,  # type: Optional[str]
@@ -161,7 +161,7 @@ class QueueServiceClient(StorageAccountHostsMixin):
 
         :param ~azure.storage.queue._shared.models.ResourceTypes resource_types:
             Specifies the resource types that are accessible with the account SAS.
-        :param ~azure.storage.queue._shared.models.AccountPermissions permission:
+        :param ~azure.storage.queue._shared.models.AccountSasPermissions permission:
             The permissions associated with the shared access signature. The
             user is restricted to operations allowed by the permissions.
         :param expiry:

--- a/sdk/storage/azure-storage-queue/tests/test_queue.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue.py
@@ -27,10 +27,10 @@ from azure.core.exceptions import (
 from azure.storage.queue import (
     QueueServiceClient,
     QueueClient,
-    QueuePermissions,
+    QueueSasPermissions,
     AccessPolicy,
     ResourceTypes,
-    AccountPermissions,
+    AccountSasPermissions,
 )
 
 from queuetestcase import (
@@ -543,7 +543,7 @@ class StorageQueueTest(QueueTestCase):
         queue_client.enqueue_message(u'message1')
         token = qsc.generate_shared_access_signature(
             ResourceTypes.OBJECT,
-            AccountPermissions.READ,
+            AccountSasPermissions(read=True),
             datetime.utcnow() + timedelta(hours=1),
             datetime.utcnow() - timedelta(minutes=5)
         )
@@ -600,7 +600,7 @@ class StorageQueueTest(QueueTestCase):
         queue_client.create_queue()
         queue_client.enqueue_message(u'message1')
         token = queue_client.generate_shared_access_signature(
-            QueuePermissions.READ,
+            QueueSasPermissions(read=True),
             datetime.utcnow() + timedelta(hours=1),
             datetime.utcnow() - timedelta(minutes=5)
         )
@@ -632,7 +632,7 @@ class StorageQueueTest(QueueTestCase):
         queue_client = self._get_queue_reference(qsc)         
         queue_client.create_queue()
         token = queue_client.generate_shared_access_signature(
-            QueuePermissions.ADD,
+            QueueSasPermissions(add=True),
             datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -660,7 +660,7 @@ class StorageQueueTest(QueueTestCase):
         queue_client.create_queue()
         queue_client.enqueue_message(u'message1')
         token = queue_client.generate_shared_access_signature(
-            QueuePermissions.UPDATE,
+            QueueSasPermissions(update=True),
             datetime.utcnow() + timedelta(hours=1),
         )
         messages = queue_client.receive_messages()
@@ -695,7 +695,7 @@ class StorageQueueTest(QueueTestCase):
         queue_client.create_queue()
         queue_client.enqueue_message(u'message1')
         token = queue_client.generate_shared_access_signature(
-            QueuePermissions.PROCESS,
+            QueueSasPermissions(process=True),
             datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -722,7 +722,7 @@ class StorageQueueTest(QueueTestCase):
         access_policy = AccessPolicy()
         access_policy.start = datetime.utcnow() - timedelta(hours=1)
         access_policy.expiry = datetime.utcnow() + timedelta(hours=1)
-        access_policy.permission = QueuePermissions.READ
+        access_policy.permission = QueueSasPermissions(read=True)
 
         identifiers = {'testid': access_policy}
 
@@ -858,7 +858,7 @@ class StorageQueueTest(QueueTestCase):
         queue_client.create_queue()
 
         # Act
-        access_policy = AccessPolicy(permission=QueuePermissions.READ,
+        access_policy = AccessPolicy(permission=QueueSasPermissions(read=True),
                                      expiry=datetime.utcnow() + timedelta(hours=1),
                                      start=datetime.utcnow() - timedelta(minutes=5))
         identifiers = {'testid': access_policy}

--- a/sdk/storage/azure-storage-queue/tests/test_queue_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_async.py
@@ -26,10 +26,10 @@ from azure.core.pipeline.transport import AioHttpTransport
 
 from azure.storage.queue.aio import QueueServiceClient, QueueClient
 from azure.storage.queue import (
-    QueuePermissions,
+    QueueSasPermissions,
     AccessPolicy,
     ResourceTypes,
-    AccountPermissions,
+    AccountSasPermissions,
 )
 
 from asyncqueuetestcase import (
@@ -585,7 +585,7 @@ class StorageQueueTestAsync(AsyncQueueTestCase):
         await queue_client.enqueue_message(u'message1')
         token = qsc.generate_shared_access_signature(
             ResourceTypes.OBJECT,
-            AccountPermissions.READ,
+            AccountSasPermissions(read=True),
             datetime.utcnow() + timedelta(hours=1),
             datetime.utcnow() - timedelta(minutes=5)
         )
@@ -647,7 +647,7 @@ class StorageQueueTestAsync(AsyncQueueTestCase):
         queue_client = await self._create_queue(qsc)
         await queue_client.enqueue_message(u'message1')
         token = queue_client.generate_shared_access_signature(
-            QueuePermissions.READ,
+            QueueSasPermissions(read=True),
             datetime.utcnow() + timedelta(hours=1),
             datetime.utcnow() - timedelta(minutes=5)
         )
@@ -679,7 +679,7 @@ class StorageQueueTestAsync(AsyncQueueTestCase):
         # Arrange
         queue_client = await self._create_queue(qsc)
         token = queue_client.generate_shared_access_signature(
-            QueuePermissions.ADD,
+            QueueSasPermissions(add=True),
             datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -710,7 +710,7 @@ class StorageQueueTestAsync(AsyncQueueTestCase):
         queue_client = await self._create_queue(qsc)
         await queue_client.enqueue_message(u'message1')
         token = queue_client.generate_shared_access_signature(
-            QueuePermissions.UPDATE,
+            QueueSasPermissions(update=True),
             datetime.utcnow() + timedelta(hours=1),
         )
         messages = []
@@ -750,7 +750,7 @@ class StorageQueueTestAsync(AsyncQueueTestCase):
         queue_client = await self._create_queue(qsc)
         await queue_client.enqueue_message(u'message1')
         token = queue_client.generate_shared_access_signature(
-            QueuePermissions.PROCESS,
+            QueueSasPermissions(process=True),
             datetime.utcnow() + timedelta(hours=1),
         )
 
@@ -782,7 +782,7 @@ class StorageQueueTestAsync(AsyncQueueTestCase):
         access_policy = AccessPolicy()
         access_policy.start = datetime.utcnow() - timedelta(hours=1)
         access_policy.expiry = datetime.utcnow() + timedelta(hours=1)
-        access_policy.permission = QueuePermissions.READ
+        access_policy.permission = QueueSasPermissions(read=True)
 
         identifiers = {'testid': access_policy}
 
@@ -917,7 +917,7 @@ class StorageQueueTestAsync(AsyncQueueTestCase):
         queue_client = await self._create_queue(qsc)
 
         # Act
-        access_policy = AccessPolicy(permission=QueuePermissions.READ,
+        access_policy = AccessPolicy(permission=QueueSasPermissions(read=True),
                                      expiry=datetime.utcnow() + timedelta(hours=1),
                                      start=datetime.utcnow() - timedelta(minutes=5))
         identifiers = {'testid': access_policy}

--- a/sdk/storage/azure-storage-queue/tests/test_queue_samples_message.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_samples_message.py
@@ -39,11 +39,11 @@ class TestMessageQueueSamples(QueueTestCase):
         try:
             # [START set_access_policy]
             # Create an access policy
-            from azure.storage.queue import AccessPolicy, QueuePermissions
+            from azure.storage.queue import AccessPolicy, QueueSasPermissions
             access_policy = AccessPolicy()
             access_policy.start = datetime.utcnow() - timedelta(hours=1)
             access_policy.expiry = datetime.utcnow() + timedelta(hours=1)
-            access_policy.permission = QueuePermissions.READ
+            access_policy.permission = QueueSasPermissions(read=True)
             identifiers = {'my-access-policy-id': access_policy}
 
             # Set the access policy

--- a/sdk/storage/azure-storage-queue/tests/test_queue_samples_message_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_samples_message_async.py
@@ -39,11 +39,11 @@ class TestMessageQueueSamples(AsyncQueueTestCase):
         try:
             # [START async_set_access_policy]
             # Create an access policy
-            from azure.storage.queue.aio import AccessPolicy, QueuePermissions
+            from azure.storage.queue.aio import AccessPolicy, QueueSasPermissions
             access_policy = AccessPolicy()
             access_policy.start = datetime.utcnow() - timedelta(hours=1)
             access_policy.expiry = datetime.utcnow() + timedelta(hours=1)
-            access_policy.permission = QueuePermissions.READ
+            access_policy.permission = QueueSasPermissions(read=True)
             identifiers = {'my-access-policy-id': access_policy}
 
             # Set the access policy


### PR DESCRIPTION
Resolves #7508 
Resolves #7510

Following changes are made to AccountPermissions, ContainerPermissions and BlobPermissions

- Rename models named `***Permissions` to `***SasPermissions`
- Remove enum-like list parameters
- Remove `__add__` and __or__` methods
- Add a class method `from_string`
