### PR TITLE
Refactor max_connections to max_concurrency

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/__init__.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/__init__.py
@@ -94,7 +94,7 @@ def upload_blob_to_url(
         blob_url,  # type: str
         data,  # type: Union[Iterable[AnyStr], IO[AnyStr]]
         overwrite=False,  # type: bool
-        max_connections=1,  # type: int
+        max_concurrency=1,  # type: int
         encoding='UTF-8', # type: str
         credential=None,  # type: Any
         **kwargs):
@@ -125,22 +125,22 @@ def upload_blob_to_url(
             data=data,
             blob_type=BlobType.BlockBlob,
             overwrite=overwrite,
-            max_connections=max_connections,
+            max_concurrency=max_concurrency,
             encoding=encoding,
             **kwargs)
 
 
-def _download_to_stream(client, handle, max_connections, **kwargs):
+def _download_to_stream(client, handle, max_concurrency, **kwargs):
     """Download data to specified open file-handle."""
     stream = client.download_blob(**kwargs)
-    stream.download_to_stream(handle, max_connections=max_connections)
+    stream.download_to_stream(handle, max_concurrency=max_concurrency)
 
 
 def download_blob_from_url(
         blob_url,  # type: str
         output,  # type: str
         overwrite=False,  # type: bool
-        max_connections=1,  # type: int
+        max_concurrency=1,  # type: int
         credential=None,  # type: Any
         **kwargs):
     # type: (...) -> None
@@ -166,9 +166,9 @@ def download_blob_from_url(
     """
     with BlobClient(blob_url, credential=credential) as client:
         if hasattr(output, 'write'):
-            _download_to_stream(client, output, max_connections, **kwargs)
+            _download_to_stream(client, output, max_concurrency, **kwargs)
         else:
             if not overwrite and os.path.isfile(output):
                 raise ValueError("The file '{}' already exists.".format(output))
             with open(output, 'wb') as file_handle:
-                _download_to_stream(client, file_handle, max_connections, **kwargs)
+                _download_to_stream(client, file_handle, max_concurrency, **kwargs)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/downloads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/downloads.py
@@ -383,32 +383,32 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
 
         return response
 
-    def content_as_bytes(self, max_connections=1):
+    def content_as_bytes(self, max_concurrency=1):
         """Download the contents of this file.
 
         This operation is blocking until all data is downloaded.
 
-        :param int max_connections:
+        :param int max_concurrency:
             The number of parallel connections with which to download.
         :rtype: bytes
         """
         stream = BytesIO()
-        self.download_to_stream(stream, max_connections=max_connections)
+        self.download_to_stream(stream, max_concurrency=max_concurrency)
         return stream.getvalue()
 
-    def content_as_text(self, max_connections=1, encoding="UTF-8"):
+    def content_as_text(self, max_concurrency=1, encoding="UTF-8"):
         """Download the contents of this file, and decode as text.
 
         This operation is blocking until all data is downloaded.
 
-        :param int max_connections:
+        :param int max_concurrency:
             The number of parallel connections with which to download.
         :rtype: str
         """
-        content = self.content_as_bytes(max_connections=max_connections)
+        content = self.content_as_bytes(max_concurrency=max_concurrency)
         return content.decode(encoding)
 
-    def download_to_stream(self, stream, max_connections=1):
+    def download_to_stream(self, stream, max_concurrency=1):
         """Download the contents of this file to a stream.
 
         :param stream:
@@ -419,7 +419,7 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
         :rtype: Any
         """
         # the stream must be seekable if parallel download is required
-        if max_connections > 1:
+        if max_concurrency > 1:
             error_message = "Target stream handle must be seekable."
             if sys.version_info >= (3,) and not stream.seekable():
                 raise ValueError(error_message)
@@ -447,7 +447,7 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
             # Use the length unless it is over the end of the file
             data_end = min(self.file_size, self.length + 1)
 
-        downloader_class = ParallelChunkDownloader if max_connections > 1 else SequentialChunkDownloader
+        downloader_class = ParallelChunkDownloader if max_concurrency > 1 else SequentialChunkDownloader
         downloader = downloader_class(
             service=self.service,
             total_size=self.download_size,
@@ -462,9 +462,9 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
             **self.request_options
         )
 
-        if max_connections > 1:
+        if max_concurrency > 1:
             import concurrent.futures
-            executor = concurrent.futures.ThreadPoolExecutor(max_connections)
+            executor = concurrent.futures.ThreadPoolExecutor(max_concurrency)
             list(executor.map(
                     with_current_context(downloader.process_chunk),
                     downloader.get_chunk_offsets()

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
@@ -50,7 +50,7 @@ async def upload_data_chunks(
         uploader_class=None,
         total_size=None,
         chunk_size=None,
-        max_connections=None,
+        max_concurrency=None,
         stream=None,
         encryption_options=None,
         **kwargs):
@@ -63,7 +63,7 @@ async def upload_data_chunks(
         kwargs['encryptor'] = encryptor
         kwargs['padder'] = padder
 
-    parallel = max_connections > 1
+    parallel = max_concurrency > 1
     if parallel and 'modified_access_conditions' in kwargs:
         # Access conditions do not work with parallelism
         kwargs['modified_access_conditions'] = None
@@ -80,7 +80,7 @@ async def upload_data_chunks(
         upload_tasks = uploader.get_chunk_streams()
         running_futures = [
             asyncio.ensure_future(uploader.process_chunk(u))
-            for u in islice(upload_tasks, 0, max_connections)
+            for u in islice(upload_tasks, 0, max_concurrency)
         ]
         range_ids = await _parallel_uploads(uploader.process_chunk, upload_tasks, running_futures)
     else:
@@ -98,10 +98,10 @@ async def upload_substream_blocks(
         uploader_class=None,
         total_size=None,
         chunk_size=None,
-        max_connections=None,
+        max_concurrency=None,
         stream=None,
         **kwargs):
-    parallel = max_connections > 1
+    parallel = max_concurrency > 1
     if parallel and 'modified_access_conditions' in kwargs:
         # Access conditions do not work with parallelism
         kwargs['modified_access_conditions'] = None
@@ -117,7 +117,7 @@ async def upload_substream_blocks(
         upload_tasks = uploader.get_substream_blocks()
         running_futures = [
             asyncio.ensure_future(uploader.process_substream_block(u))
-            for u in islice(upload_tasks, 0, max_connections)
+            for u in islice(upload_tasks, 0, max_concurrency)
         ]
         range_ids = await _parallel_uploads(uploader.process_substream_block, upload_tasks, running_futures)
     else:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_upload_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_upload_helpers.py
@@ -68,7 +68,7 @@ def upload_block_blob(  # pylint: disable=too-many-locals
         overwrite=None,
         headers=None,
         validate_content=None,
-        max_connections=None,
+        max_concurrency=None,
         blob_settings=None,
         encryption_options=None,
         **kwargs):
@@ -121,7 +121,7 @@ def upload_block_blob(  # pylint: disable=too-many-locals
                 uploader_class=BlockBlobChunkUploader,
                 total_size=length,
                 chunk_size=blob_settings.max_block_size,
-                max_connections=max_connections,
+                max_concurrency=max_concurrency,
                 stream=stream,
                 validate_content=validate_content,
                 encryption_options=encryption_options,
@@ -133,7 +133,7 @@ def upload_block_blob(  # pylint: disable=too-many-locals
                 uploader_class=BlockBlobChunkUploader,
                 total_size=length,
                 chunk_size=blob_settings.max_block_size,
-                max_connections=max_connections,
+                max_concurrency=max_concurrency,
                 stream=stream,
                 validate_content=validate_content,
                 **kwargs
@@ -165,7 +165,7 @@ def upload_page_blob(
         overwrite=None,
         headers=None,
         validate_content=None,
-        max_connections=None,
+        max_concurrency=None,
         blob_settings=None,
         encryption_options=None,
         **kwargs):
@@ -203,7 +203,7 @@ def upload_page_blob(
             total_size=length,
             chunk_size=blob_settings.max_page_size,
             stream=stream,
-            max_connections=max_connections,
+            max_concurrency=max_concurrency,
             validate_content=validate_content,
             encryption_options=encryption_options,
             **kwargs)
@@ -224,7 +224,7 @@ def upload_append_blob(  # pylint: disable=unused-argument
         overwrite=None,
         headers=None,
         validate_content=None,
-        max_connections=None,
+        max_concurrency=None,
         blob_settings=None,
         encryption_options=None,
         **kwargs):
@@ -248,7 +248,7 @@ def upload_append_blob(  # pylint: disable=unused-argument
                 total_size=length,
                 chunk_size=blob_settings.max_block_size,
                 stream=stream,
-                max_connections=max_connections,
+                max_concurrency=max_concurrency,
                 validate_content=validate_content,
                 append_position_access_conditions=append_conditions,
                 **kwargs)
@@ -274,7 +274,7 @@ def upload_append_blob(  # pylint: disable=unused-argument
                 total_size=length,
                 chunk_size=blob_settings.max_block_size,
                 stream=stream,
-                max_connections=max_connections,
+                max_concurrency=max_concurrency,
                 validate_content=validate_content,
                 append_position_access_conditions=append_conditions,
                 **kwargs)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_upload_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_upload_helpers.py
@@ -42,7 +42,7 @@ async def upload_block_blob(  # pylint: disable=too-many-locals
         overwrite=None,
         headers=None,
         validate_content=None,
-        max_connections=None,
+        max_concurrency=None,
         blob_settings=None,
         encryption_options=None,
         **kwargs):
@@ -95,7 +95,7 @@ async def upload_block_blob(  # pylint: disable=too-many-locals
                 uploader_class=BlockBlobChunkUploader,
                 total_size=length,
                 chunk_size=blob_settings.max_block_size,
-                max_connections=max_connections,
+                max_concurrency=max_concurrency,
                 stream=stream,
                 validate_content=validate_content,
                 encryption_options=encryption_options,
@@ -107,7 +107,7 @@ async def upload_block_blob(  # pylint: disable=too-many-locals
                 uploader_class=BlockBlobChunkUploader,
                 total_size=length,
                 chunk_size=blob_settings.max_block_size,
-                max_connections=max_connections,
+                max_concurrency=max_concurrency,
                 stream=stream,
                 validate_content=validate_content,
                 **kwargs
@@ -139,7 +139,7 @@ async def upload_page_blob(
         overwrite=None,
         headers=None,
         validate_content=None,
-        max_connections=None,
+        max_concurrency=None,
         blob_settings=None,
         encryption_options=None,
         **kwargs):
@@ -177,7 +177,7 @@ async def upload_page_blob(
             total_size=length,
             chunk_size=blob_settings.max_page_size,
             stream=stream,
-            max_connections=max_connections,
+            max_concurrency=max_concurrency,
             validate_content=validate_content,
             encryption_options=encryption_options,
             **kwargs)
@@ -198,7 +198,7 @@ async def upload_append_blob(  # pylint: disable=unused-argument
         overwrite=None,
         headers=None,
         validate_content=None,
-        max_connections=None,
+        max_concurrency=None,
         blob_settings=None,
         encryption_options=None,
         **kwargs):
@@ -222,7 +222,7 @@ async def upload_append_blob(  # pylint: disable=unused-argument
                 total_size=length,
                 chunk_size=blob_settings.max_block_size,
                 stream=stream,
-                max_connections=max_connections,
+                max_concurrency=max_concurrency,
                 validate_content=validate_content,
                 append_position_access_conditions=append_conditions,
                 **kwargs)
@@ -248,7 +248,7 @@ async def upload_append_blob(  # pylint: disable=unused-argument
                 total_size=length,
                 chunk_size=blob_settings.max_block_size,
                 stream=stream,
-                max_connections=max_connections,
+                max_concurrency=max_concurrency,
                 validate_content=validate_content,
                 append_position_access_conditions=append_conditions,
                 **kwargs)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/blob_client_async.py
@@ -142,7 +142,7 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase):  # pylint: disa
             metadata=None,  # type: Optional[Dict[str, str]]
             content_settings=None,  # type: Optional[ContentSettings]
             validate_content=False,  # type: Optional[bool]
-            max_connections=1,  # type: int
+            max_concurrency=1,  # type: int
             **kwargs
         ):
         # type: (...) -> Any
@@ -212,7 +212,7 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase):  # pylint: disa
             to exceed that limit or if the blob size is already greater than the
             value specified in this header, the request will fail with
             MaxBlobSizeConditionNotMet error (HTTP status code 412 - Precondition Failed).
-        :param int max_connections:
+        :param int max_concurrency:
             Maximum number of parallel connections to use when the blob size exceeds
             64MB.
         :param ~azure.storage.blob.models.CustomerProvidedEncryptionKey cpk:
@@ -245,7 +245,7 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase):  # pylint: disa
             metadata=metadata,
             content_settings=content_settings,
             validate_content=validate_content,
-            max_connections=max_connections,
+            max_concurrency=max_concurrency,
             **kwargs)
         if blob_type == BlobType.BlockBlob:
             return await upload_block_blob(**options)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/blob_client_async.py
@@ -945,7 +945,7 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase):  # pylint: disa
 
     @distributed_trace_async
     async def abort_copy(self, copy_id, **kwargs):
-        # type: (Union[str, BlobProperties], Any) -> None
+        # type: (Union[str, Dict[str, Any], BlobProperties], Any) -> None
         """Abort an ongoing copy operation.
 
         This will leave a destination blob with zero length and full metadata.
@@ -1744,7 +1744,7 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase):  # pylint: disa
 
     @distributed_trace_async
     async def append_block( # type: ignore
-            self, data,  # type: Union[Iterable[AnyStr], IO[AnyStr]]
+            self, data,  # type: Union[AnyStr, Iterable[AnyStr], IO[AnyStr]]
             length=None,  # type: Optional[int]
             validate_content=False,  # type: Optional[bool]
             maxsize_condition=None,  # type: Optional[int]

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/container_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/container_client_async.py
@@ -589,7 +589,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase):
             validate_content=False,  # type: Optional[bool]
             lease=None,  # type: Optional[Union[LeaseClient, str]]
             timeout=None,  # type: Optional[int]
-            max_connections=1,  # type: int
+            max_concurrency=1,  # type: int
             encoding='UTF-8', # type: str
             **kwargs
         ):
@@ -666,7 +666,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase):
             to exceed that limit or if the blob size is already greater than the
             value specified in this header, the request will fail with
             MaxBlobSizeConditionNotMet error (HTTP status code 412 - Precondition Failed).
-        :param int max_connections:
+        :param int max_concurrency:
             Maximum number of parallel connections to use when the blob size exceeds
             64MB.
         :param ~azure.storage.blob.models.CustomerProvidedEncryptionKey cpk:
@@ -699,7 +699,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase):
             validate_content=validate_content,
             lease=lease,
             timeout=timeout,
-            max_connections=max_connections,
+            max_concurrency=max_concurrency,
             encoding=encoding,
             **kwargs
         )

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/blob_client.py
@@ -356,7 +356,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             metadata=None,  # type: Optional[Dict[str, str]]
             content_settings=None,  # type: Optional[ContentSettings]
             validate_content=False,  # type: Optional[bool]
-            max_connections=1,  # type: int
+            max_concurrency=1,  # type: int
             **kwargs
         ):
         # type: (...) -> Dict[str, Any]
@@ -422,7 +422,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
         kwargs['headers'] = headers
         kwargs['validate_content'] = validate_content
         kwargs['blob_settings'] = self._config
-        kwargs['max_connections'] = max_connections
+        kwargs['max_concurrency'] = max_concurrency
         kwargs['encryption_options'] = encryption_options
         if blob_type == BlobType.BlockBlob:
             kwargs['client'] = self._client.block_blob
@@ -446,7 +446,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             metadata=None,  # type: Optional[Dict[str, str]]
             content_settings=None,  # type: Optional[ContentSettings]
             validate_content=False,  # type: Optional[bool]
-            max_connections=1,  # type: int
+            max_concurrency=1,  # type: int
             **kwargs
         ):
         # type: (...) -> Any
@@ -516,7 +516,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             to exceed that limit or if the blob size is already greater than the
             value specified in this header, the request will fail with
             MaxBlobSizeConditionNotMet error (HTTP status code 412 - Precondition Failed).
-        :param int max_connections:
+        :param int max_concurrency:
             Maximum number of parallel connections to use when the blob size exceeds
             64MB.
         :param ~azure.storage.blob.models.CustomerProvidedEncryptionKey cpk:
@@ -549,7 +549,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             metadata=metadata,
             content_settings=content_settings,
             validate_content=validate_content,
-            max_connections=max_connections,
+            max_concurrency=max_concurrency,
             **kwargs)
         if blob_type == BlobType.BlockBlob:
             return upload_block_blob(**options)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/blob_client.py
@@ -1534,7 +1534,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             process_storage_error(error)
 
     def _abort_copy_options(self, copy_id, **kwargs):
-        # type: (Union[str, FileProperties], **Any) -> Dict[str, Any]
+        # type: (Union[str, Dict[str, Any], BlobProperties], **Any) -> Dict[str, Any]
         access_conditions = get_access_conditions(kwargs.pop('lease', None))
         try:
             copy_id = copy_id.copy.id
@@ -1552,7 +1552,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
 
     @distributed_trace
     def abort_copy(self, copy_id, **kwargs):
-        # type: (Union[str, BlobProperties], **Any) -> None
+        # type: (Union[str, Dict[str, Any], BlobProperties], **Any) -> None
         """Abort an ongoing copy operation.
 
         This will leave a destination blob with zero length and full metadata.
@@ -2758,7 +2758,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             process_storage_error(error)
 
     def _append_block_options( # type: ignore
-            self, data,  # type: Union[Iterable[AnyStr], IO[AnyStr]]
+            self, data,  # type: Union[AnyStr, Iterable[AnyStr], IO[AnyStr]]
             length=None,  # type: Optional[int]
             validate_content=False,  # type: Optional[bool]
             maxsize_condition=None,  # type: Optional[int]
@@ -2816,7 +2816,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
 
     @distributed_trace
     def append_block( # type: ignore
-            self, data,  # type: Union[Iterable[AnyStr], IO[AnyStr]]
+            self, data,  # type: Union[AnyStr, Iterable[AnyStr], IO[AnyStr]]
             length=None,  # type: Optional[int]
             validate_content=False,  # type: Optional[bool]
             maxsize_condition=None,  # type: Optional[int]

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/container_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/container_client.py
@@ -765,7 +765,7 @@ class ContainerClient(StorageAccountHostsMixin):
             validate_content=False,  # type: Optional[bool]
             lease=None,  # type: Optional[Union[LeaseClient, str]]
             timeout=None,  # type: Optional[int]
-            max_connections=1,  # type: int
+            max_concurrency=1,  # type: int
             encoding='UTF-8', # type: str
             **kwargs
         ):
@@ -842,7 +842,7 @@ class ContainerClient(StorageAccountHostsMixin):
             to exceed that limit or if the blob size is already greater than the
             value specified in this header, the request will fail with
             MaxBlobSizeConditionNotMet error (HTTP status code 412 - Precondition Failed).
-        :param int max_connections:
+        :param int max_concurrency:
             Maximum number of parallel connections to use when the blob size exceeds
             64MB.
         :param ~azure.storage.blob.models.CustomerProvidedEncryptionKey cpk:
@@ -875,7 +875,7 @@ class ContainerClient(StorageAccountHostsMixin):
             validate_content=validate_content,
             lease=lease,
             timeout=timeout,
-            max_connections=max_connections,
+            max_concurrency=max_concurrency,
             encoding=encoding,
             **kwargs
         )

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
@@ -768,7 +768,7 @@ class BlobBlock(DictMixin):
         Block size in bytes.
     """
 
-    def __init__(self, block_id=None, state=BlockState.Latest):
+    def __init__(self, block_id, state=BlockState.Latest):
         self.id = block_id
         self.state = state
         self.size = None

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/models.py
@@ -775,8 +775,7 @@ class BlobBlock(DictMixin):
 
     @classmethod
     def _from_generated(cls, generated):
-        block = cls()
-        block.id = decode_base64_to_text(generated.name)
+        block = cls(decode_base64_to_text(generated.name))
         block.size = generated.size
         return block
 

--- a/sdk/storage/azure-storage-blob/tests/blob_performance.py
+++ b/sdk/storage/azure-storage-blob/tests/blob_performance.py
@@ -69,16 +69,16 @@ def upload_blob(service, name, connections):
     start_time = datetime.datetime.now()
     if isinstance(service, BlockBlobService):
         service.create_blob_from_path(
-            CONTAINER_NAME, blob_name, file_name, max_connections=connections)
+            CONTAINER_NAME, blob_name, file_name, max_concurrency=connections)
     elif isinstance(service, PageBlobService):
         service.create_blob_from_path(
-            CONTAINER_NAME, blob_name, file_name, max_connections=connections)
+            CONTAINER_NAME, blob_name, file_name, max_concurrency=connections)
     elif isinstance(service, AppendBlobService):
         service.append_blob_from_path(
-            CONTAINER_NAME, blob_name, file_name, max_connections=connections)
+            CONTAINER_NAME, blob_name, file_name, max_concurrency=connections)
     else:
         service.create_blob_from_path(
-            CONTAINER_NAME, blob_name, file_name, max_connections=connections)
+            CONTAINER_NAME, blob_name, file_name, max_concurrency=connections)
     elapsed_time = datetime.datetime.now() - start_time
     sys.stdout.write('{0}s'.format(elapsed_time.total_seconds()))
 
@@ -90,7 +90,7 @@ def download_blob(service, name, connections):
     sys.stdout.write('\tDn:')
     start_time = datetime.datetime.now()
     service.get_blob_to_path(
-        CONTAINER_NAME, blob_name, target_file_name, max_connections=connections)
+        CONTAINER_NAME, blob_name, target_file_name, max_concurrency=connections)
     elapsed_time = datetime.datetime.now() - start_time
     sys.stdout.write('{0}s'.format(elapsed_time.total_seconds()))
 

--- a/sdk/storage/azure-storage-blob/tests/test_blob_encryption.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_encryption.py
@@ -311,8 +311,8 @@ class StorageBlobEncryptionTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         # Act
-        blob.upload_blob(content, max_connections=3)
-        blob_content = blob.download_blob().content_as_bytes(max_connections=3)
+        blob.upload_blob(content, max_concurrency=3)
+        blob_content = blob.download_blob().content_as_bytes(max_concurrency=3)
 
         # Assert
         self.assertEqual(content, blob_content)
@@ -330,8 +330,8 @@ class StorageBlobEncryptionTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         # Act
-        blob.upload_blob(content, max_connections=3)
-        blob_content = blob.download_blob().content_as_bytes(max_connections=3)
+        blob.upload_blob(content, max_concurrency=3)
+        blob_content = blob.download_blob().content_as_bytes(max_concurrency=3)
 
         # Assert
         self.assertEqual(content, blob_content)
@@ -352,8 +352,8 @@ class StorageBlobEncryptionTest(StorageTestCase):
         blob.upload_blob(
             content,
             length=self.config.max_single_put_size + 53,
-            max_connections=3)
-        blob_content = blob.download_blob().content_as_bytes(max_connections=3)
+            max_concurrency=3)
+        blob_content = blob.download_blob().content_as_bytes(max_concurrency=3)
 
         # Assert
         self.assertEqual(content[:self.config.max_single_put_size+53], blob_content)
@@ -390,8 +390,8 @@ class StorageBlobEncryptionTest(StorageTestCase):
         blob.upload_blob(
             content[2:],
             length=self.config.max_single_put_size + 5,
-            max_connections=1)
-        blob_content = blob.download_blob().content_as_bytes(max_connections=1)
+            max_concurrency=1)
+        blob_content = blob.download_blob().content_as_bytes(max_concurrency=1)
 
         # Assert
         self.assertEqual(content[2:2 + self.config.max_single_put_size + 5], blob_content)
@@ -407,7 +407,7 @@ class StorageBlobEncryptionTest(StorageTestCase):
 
         # Act
         blob.upload_blob(content)
-        blob_content = blob.download_blob().content_as_bytes(max_connections=2)
+        blob_content = blob.download_blob().content_as_bytes(max_concurrency=2)
 
         # Assert
         self.assertEqual(content, blob_content)
@@ -422,8 +422,8 @@ class StorageBlobEncryptionTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         # Act
-        blob.upload_blob(content, max_connections=1)
-        blob_content = blob.download_blob().content_as_bytes(max_connections=1)
+        blob.upload_blob(content, max_concurrency=1)
+        blob_content = blob.download_blob().content_as_bytes(max_concurrency=1)
 
         # Assert
         self.assertEqual(content, blob_content)
@@ -438,8 +438,8 @@ class StorageBlobEncryptionTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         # Act
-        blob.upload_blob(content, max_connections=1)
-        blob_content = blob.download_blob(offset=0, length=50).content_as_bytes(max_connections=1)
+        blob.upload_blob(content, max_concurrency=1)
+        blob_content = blob.download_blob(offset=0, length=50).content_as_bytes(max_concurrency=1)
 
         # Assert
         self.assertEqual(content[:51], blob_content)
@@ -454,7 +454,7 @@ class StorageBlobEncryptionTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         # Act
-        blob.upload_blob(content, max_connections=1)
+        blob.upload_blob(content, max_concurrency=1)
         blob_content = blob.download_blob(offset=50, length=127).content_as_bytes()
         blob_content2 = blob.download_blob(offset=50).content_as_bytes()
 

--- a/sdk/storage/azure-storage-blob/tests/test_blob_encryption_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_encryption_async.py
@@ -383,8 +383,8 @@ class StorageBlobEncryptionTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         # Act
-        await blob.upload_blob(content, max_connections=3)
-        blob_content = await (await blob.download_blob()).content_as_bytes(max_connections=3)
+        await blob.upload_blob(content, max_concurrency=3)
+        blob_content = await (await blob.download_blob()).content_as_bytes(max_concurrency=3)
 
         # Assert
         self.assertEqual(content, blob_content)
@@ -408,8 +408,8 @@ class StorageBlobEncryptionTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         # Act
-        await blob.upload_blob(content, max_connections=3)
-        blob_content = await (await blob.download_blob()).content_as_bytes(max_connections=3)
+        await blob.upload_blob(content, max_concurrency=3)
+        blob_content = await (await blob.download_blob()).content_as_bytes(max_concurrency=3)
 
         # Assert
         self.assertEqual(content, blob_content)
@@ -436,8 +436,8 @@ class StorageBlobEncryptionTestAsync(StorageTestCase):
         await blob.upload_blob(
             content,
             length=self.config.max_single_put_size + 53,
-            max_connections=3)
-        blob_content = await (await blob.download_blob()).content_as_bytes(max_connections=3)
+            max_concurrency=3)
+        blob_content = await (await blob.download_blob()).content_as_bytes(max_concurrency=3)
 
         # Assert
         self.assertEqual(content[:self.config.max_single_put_size+53], blob_content)
@@ -484,8 +484,8 @@ class StorageBlobEncryptionTestAsync(StorageTestCase):
         await blob.upload_blob(
             content[2:],
             length=self.config.max_single_put_size + 5,
-            max_connections=1)
-        blob_content = await (await blob.download_blob()).content_as_bytes(max_connections=1)
+            max_concurrency=1)
+        blob_content = await (await blob.download_blob()).content_as_bytes(max_concurrency=1)
 
         # Assert
         self.assertEqual(content[2:2 + self.config.max_single_put_size + 5], blob_content)
@@ -506,7 +506,7 @@ class StorageBlobEncryptionTestAsync(StorageTestCase):
 
         # Act
         await blob.upload_blob(content)
-        blob_content = await (await blob.download_blob()).content_as_bytes(max_connections=2)
+        blob_content = await (await blob.download_blob()).content_as_bytes(max_concurrency=2)
 
         # Assert
         self.assertEqual(content, blob_content)
@@ -526,8 +526,8 @@ class StorageBlobEncryptionTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         # Act
-        await blob.upload_blob(content, max_connections=1)
-        blob_content = await (await blob.download_blob()).content_as_bytes(max_connections=1)
+        await blob.upload_blob(content, max_concurrency=1)
+        blob_content = await (await blob.download_blob()).content_as_bytes(max_concurrency=1)
 
         # Assert
         self.assertEqual(content, blob_content)
@@ -547,8 +547,8 @@ class StorageBlobEncryptionTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         # Act
-        await blob.upload_blob(content, max_connections=1)
-        blob_content = await (await blob.download_blob(offset=0, length=50)).content_as_bytes(max_connections=1)
+        await blob.upload_blob(content, max_concurrency=1)
+        blob_content = await (await blob.download_blob(offset=0, length=50)).content_as_bytes(max_concurrency=1)
 
         # Assert
         self.assertEqual(content[:51], blob_content)
@@ -568,7 +568,7 @@ class StorageBlobEncryptionTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
 
         # Act
-        await blob.upload_blob(content, max_connections=1)
+        await blob.upload_blob(content, max_concurrency=1)
         blob_content = await (await blob.download_blob(offset=50, length=127)).content_as_bytes()
         blob_content2 = await (await blob.download_blob(offset=50)).content_as_bytes()
 

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob.py
@@ -559,7 +559,7 @@ class StorageBlockBlobTest(StorageTestCase):
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
 
         # Act
-        blob.upload_blob(data, length=LARGE_BLOB_SIZE, max_connections=1)
+        blob.upload_blob(data, length=LARGE_BLOB_SIZE, max_concurrency=1)
 
         # Assert
         self.assertBlobEqual(self.container_name, blob.blob_name, data)
@@ -612,7 +612,7 @@ class StorageBlockBlobTest(StorageTestCase):
 
         # Act
         with open(FILE_PATH, 'rb') as stream:
-            create_resp = blob.upload_blob(stream, length=100, max_connections=1)
+            create_resp = blob.upload_blob(stream, length=100, max_concurrency=1)
         props = blob.get_blob_properties()
 
         # Assert
@@ -631,7 +631,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_tier = StandardBlobTier.Cool
         # Act
         with open(FILE_PATH, 'rb') as stream:
-            blob.upload_blob(stream, length=100, max_connections=1, standard_blob_tier=blob_tier)
+            blob.upload_blob(stream, length=100, max_concurrency=1, standard_blob_tier=blob_tier)
         props = blob.get_blob_properties()
 
         # Assert
@@ -727,7 +727,7 @@ class StorageBlockBlobTest(StorageTestCase):
         # Act
         with open(FILE_PATH, 'rb') as stream:
             non_seekable_file = StorageBlockBlobTest.NonSeekableFile(stream)
-            blob.upload_blob(non_seekable_file, length=blob_size, max_connections=1)
+            blob.upload_blob(non_seekable_file, length=blob_size, max_concurrency=1)
 
         # Assert
         self.assertBlobEqual(self.container_name, blob_name, data[:blob_size])
@@ -747,7 +747,7 @@ class StorageBlockBlobTest(StorageTestCase):
         # Act
         with open(FILE_PATH, 'rb') as stream:
             non_seekable_file = StorageBlockBlobTest.NonSeekableFile(stream)
-            blob.upload_blob(non_seekable_file, max_connections=1)
+            blob.upload_blob(non_seekable_file, max_concurrency=1)
 
         # Assert
         self.assertBlobEqual(self.container_name, blob_name, data)
@@ -868,7 +868,7 @@ class StorageBlockBlobTest(StorageTestCase):
             content_type='image/png',
             content_language='spanish')
         with open(FILE_PATH, 'rb') as stream:
-            blob.upload_blob(stream, content_settings=content_settings, max_connections=2, standard_blob_tier=blob_tier)
+            blob.upload_blob(stream, content_settings=content_settings, max_concurrency=2, standard_blob_tier=blob_tier)
 
         properties = blob.get_blob_properties()
 

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob_async.py
@@ -699,7 +699,7 @@ class StorageBlockBlobTestAsync(StorageTestCase):
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
 
         # Act
-        await blob.upload_blob(data, length=LARGE_BLOB_SIZE, max_connections=1)
+        await blob.upload_blob(data, length=LARGE_BLOB_SIZE, max_concurrency=1)
 
         # Assert
         await self.assertBlobEqual(self.container_name, blob.blob_name, data)
@@ -768,7 +768,7 @@ class StorageBlockBlobTestAsync(StorageTestCase):
 
         # Act
         with open(FILE_PATH, 'rb') as stream:
-            create_resp = await blob.upload_blob(stream, length=100, max_connections=1)
+            create_resp = await blob.upload_blob(stream, length=100, max_concurrency=1)
         props = await blob.get_blob_properties()
 
         # Assert
@@ -792,7 +792,7 @@ class StorageBlockBlobTestAsync(StorageTestCase):
         blob_tier = StandardBlobTier.Cool
         # Act
         with open(FILE_PATH, 'rb') as stream:
-            await blob.upload_blob(stream, length=100, max_connections=1, standard_blob_tier=blob_tier)
+            await blob.upload_blob(stream, length=100, max_concurrency=1, standard_blob_tier=blob_tier)
         props = await blob.get_blob_properties()
 
         # Assert
@@ -912,7 +912,7 @@ class StorageBlockBlobTestAsync(StorageTestCase):
         # Act
         with open(FILE_PATH, 'rb') as stream:
             non_seekable_file = StorageBlockBlobTestAsync.NonSeekableFile(stream)
-            await blob.upload_blob(non_seekable_file, length=blob_size, max_connections=1)
+            await blob.upload_blob(non_seekable_file, length=blob_size, max_concurrency=1)
 
         # Assert
         await self.assertBlobEqual(self.container_name, blob_name, data[:blob_size])
@@ -938,7 +938,7 @@ class StorageBlockBlobTestAsync(StorageTestCase):
         # Act
         with open(FILE_PATH, 'rb') as stream:
             non_seekable_file = StorageBlockBlobTestAsync.NonSeekableFile(stream)
-            await blob.upload_blob(non_seekable_file, max_connections=1)
+            await blob.upload_blob(non_seekable_file, max_concurrency=1)
 
         # Assert
         await self.assertBlobEqual(self.container_name, blob_name, data)
@@ -1089,7 +1089,7 @@ class StorageBlockBlobTestAsync(StorageTestCase):
             content_type='image/png',
             content_language='spanish')
         with open(FILE_PATH, 'rb') as stream:
-            await blob.upload_blob(stream, content_settings=content_settings, max_connections=2,
+            await blob.upload_blob(stream, content_settings=content_settings, max_concurrency=2,
                                    standard_blob_tier=blob_tier)
 
         properties = await blob.get_blob_properties()

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -1612,7 +1612,7 @@ class StorageCommonBlobTest(StorageTestCase):
         # Act
         download_blob_from_url(
             source_blob.url, FILE_PATH,
-            max_connections=2,
+            max_concurrency=2,
             credential=self.settings.REMOTE_STORAGE_ACCOUNT_KEY)
 
         # Assert
@@ -1633,7 +1633,7 @@ class StorageCommonBlobTest(StorageTestCase):
         with open(FILE_PATH, 'wb') as stream:
             download_blob_from_url(
                 source_blob.url, stream,
-                max_connections=2,
+                max_concurrency=2,
                 credential=self.settings.REMOTE_STORAGE_ACCOUNT_KEY)
 
         # Assert

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -2021,7 +2021,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         # Act
         download_blob_from_url(
             source_blob.url, FILE_PATH,
-            max_connections=2,
+            max_concurrency=2,
             credential=self.settings.REMOTE_STORAGE_ACCOUNT_KEY)
 
         # Assert
@@ -2047,7 +2047,7 @@ class StorageCommonBlobTestAsync(StorageTestCase):
         with open(FILE_PATH, 'wb') as stream:
             download_blob_from_url(
                 source_blob.url, stream,
-                max_connections=2,
+                max_concurrency=2,
                 credential=self.settings.REMOTE_STORAGE_ACCOUNT_KEY)
 
         # Assert

--- a/sdk/storage/azure-storage-blob/tests/test_cpk.py
+++ b/sdk/storage/azure-storage-blob/tests/test_cpk.py
@@ -67,11 +67,11 @@ class StorageCPKTest(StorageTestCase):
     def _get_blob_reference(self):
         return self.get_resource_name("cpk")
 
-    def _create_block_blob(self, blob_name=None, data=None, cpk=None, max_connections=1):
+    def _create_block_blob(self, blob_name=None, data=None, cpk=None, max_concurrency=1):
         blob_name = blob_name if blob_name else self._get_blob_reference()
         blob_client = self.bsc.get_blob_client(self.container_name, blob_name)
         data = data if data else b''
-        resp = blob_client.upload_blob(data, cpk=cpk, max_connections=max_connections)
+        resp = blob_client.upload_blob(data, cpk=cpk, max_concurrency=max_concurrency)
         return blob_client, resp
 
     def _create_append_blob(self, cpk=None):
@@ -135,7 +135,7 @@ class StorageCPKTest(StorageTestCase):
         # Act
         # create_blob_from_bytes forces the in-memory chunks to be used
         blob_client, upload_response = self._create_block_blob(data=self.byte_data, cpk=TEST_ENCRYPTION_KEY,
-                                                               max_connections=2)
+                                                               max_concurrency=2)
 
         # Assert
         self.assertIsNotNone(upload_response['etag'])
@@ -164,7 +164,7 @@ class StorageCPKTest(StorageTestCase):
         # Act
         # create_blob_from_bytes forces the in-memory chunks to be used
         blob_client, upload_response = self._create_block_blob(data=self.byte_data, cpk=TEST_ENCRYPTION_KEY,
-                                                               max_connections=2)
+                                                               max_concurrency=2)
 
         # Assert
         self.assertIsNotNone(upload_response['etag'])
@@ -436,7 +436,7 @@ class StorageCPKTest(StorageTestCase):
         blob_client = self.bsc.get_blob_client(self.container_name, self._get_blob_reference())
         page_blob_prop = blob_client.upload_blob(self.byte_data,
                                                  blob_type=BlobType.PageBlob,
-                                                 max_connections=2,
+                                                 max_concurrency=2,
                                                  cpk=TEST_ENCRYPTION_KEY)
 
         # Assert

--- a/sdk/storage/azure-storage-blob/tests/test_cpk_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_cpk_async.py
@@ -87,11 +87,11 @@ class StorageCPKAsyncTest(StorageTestCase):
     def _get_blob_reference(self):
         return self.get_resource_name("cpk")
 
-    async def _create_block_blob(self, blob_name=None, data=None, cpk=None, max_connections=1):
+    async def _create_block_blob(self, blob_name=None, data=None, cpk=None, max_concurrency=1):
         blob_name = blob_name if blob_name else self._get_blob_reference()
         blob_client = self.bsc.get_blob_client(self.container_name, blob_name)
         data = data if data else b''
-        resp = await blob_client.upload_blob(data, cpk=cpk, max_connections=max_connections)
+        resp = await blob_client.upload_blob(data, cpk=cpk, max_concurrency=max_concurrency)
         return blob_client, resp
 
     async def _create_append_blob(self, cpk=None):
@@ -159,7 +159,7 @@ class StorageCPKAsyncTest(StorageTestCase):
         # Act
         # create_blob_from_bytes forces the in-memory chunks to be used
         blob_client, upload_response = await self._create_block_blob(data=self.byte_data, cpk=TEST_ENCRYPTION_KEY,
-                                                                     max_connections=2)
+                                                                     max_concurrency=2)
 
         # Assert
         self.assertIsNotNone(upload_response['etag'])
@@ -192,7 +192,7 @@ class StorageCPKAsyncTest(StorageTestCase):
         # Act
         # create_blob_from_bytes forces the in-memory chunks to be used
         blob_client, upload_response = await self._create_block_blob(data=self.byte_data, cpk=TEST_ENCRYPTION_KEY,
-                                                                     max_connections=2)
+                                                                     max_concurrency=2)
 
         # Assert
         self.assertIsNotNone(upload_response['etag'])
@@ -496,7 +496,7 @@ class StorageCPKAsyncTest(StorageTestCase):
         blob_client = self.bsc.get_blob_client(self.container_name, self._get_blob_reference())
         page_blob_prop = await blob_client.upload_blob(self.byte_data,
                                                        blob_type=BlobType.PageBlob,
-                                                       max_connections=2,
+                                                       max_concurrency=2,
                                                        cpk=TEST_ENCRYPTION_KEY)
 
         # Assert

--- a/sdk/storage/azure-storage-blob/tests/test_get_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_get_blob.py
@@ -152,7 +152,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        content = blob.download_blob().content_as_bytes(max_connections=2)
+        content = blob.download_blob().content_as_bytes(max_concurrency=2)
 
         # Assert
         self.assertEqual(self.byte_data, content)
@@ -221,7 +221,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob.upload_blob(self.byte_data, overwrite=True) # Modify the blob so the Etag no longer matches
 
         # Act
-        content = snapshot.download_blob().content_as_bytes(max_connections=2)
+        content = snapshot.download_blob().content_as_bytes(max_concurrency=2)
 
         # Assert
         self.assertEqual(self.byte_data, content)
@@ -241,7 +241,7 @@ class StorageGetBlobTest(StorageTestCase):
             progress.append((current, total))
 
         # Act
-        content = blob.download_blob(raw_response_hook=callback).content_as_bytes(max_connections=2)
+        content = blob.download_blob(raw_response_hook=callback).content_as_bytes(max_concurrency=2)
 
         # Assert
         self.assertEqual(self.byte_data, content)
@@ -263,7 +263,7 @@ class StorageGetBlobTest(StorageTestCase):
             progress.append((current, total))
 
         # Act
-        content = blob.download_blob(raw_response_hook=callback).content_as_bytes(max_connections=1)
+        content = blob.download_blob(raw_response_hook=callback).content_as_bytes(max_concurrency=1)
 
         # Assert
         self.assertEqual(self.byte_data, content)
@@ -310,7 +310,7 @@ class StorageGetBlobTest(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob()
-            properties = downloader.download_to_stream(stream, max_connections=2)
+            properties = downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -335,7 +335,7 @@ class StorageGetBlobTest(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(raw_response_hook=callback)
-            properties = downloader.download_to_stream(stream, max_connections=2)
+            properties = downloader.download_to_stream(stream, max_concurrency=2)
         # Assert
         self.assertIsInstance(properties, BlobProperties)
         with open(FILE_PATH, 'rb') as stream:
@@ -361,7 +361,7 @@ class StorageGetBlobTest(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(raw_response_hook=callback)
-            properties = downloader.download_to_stream(stream, max_connections=1)
+            properties = downloader.download_to_stream(stream, max_concurrency=1)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -393,7 +393,7 @@ class StorageGetBlobTest(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(raw_response_hook=callback)
-            properties = downloader.download_to_stream(stream, max_connections=2)
+            properties = downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -418,7 +418,7 @@ class StorageGetBlobTest(StorageTestCase):
         end_range = self.config.max_single_get_size
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=1, length=end_range)
-            properties = downloader.download_to_stream(stream, max_connections=2)
+            properties = downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -445,7 +445,7 @@ class StorageGetBlobTest(StorageTestCase):
         end_range = self.config.max_single_get_size + 1024
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=start_range, length=end_range, raw_response_hook=callback)
-            properties = downloader.download_to_stream(stream, max_connections=2)
+            properties = downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -466,7 +466,7 @@ class StorageGetBlobTest(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=1, length=4)
-            properties = downloader.download_to_stream(stream, max_connections=2)
+            properties = downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -482,7 +482,7 @@ class StorageGetBlobTest(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=1, length=3)
-            properties = downloader.download_to_stream(stream, max_connections=1)
+            properties = downloader.download_to_stream(stream, max_concurrency=1)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -507,7 +507,7 @@ class StorageGetBlobTest(StorageTestCase):
         end_range = 2 * self.config.max_single_get_size
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=1, length=end_range)
-            properties = downloader.download_to_stream(stream, max_connections=2)
+            properties = downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -532,7 +532,7 @@ class StorageGetBlobTest(StorageTestCase):
         end_range = 2 * self.config.max_single_get_size
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=1, length=end_range)
-            properties = downloader.download_to_stream(stream, max_connections=2)
+            properties = downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -554,7 +554,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob.upload_blob(text_data)
 
         # Act
-        content = blob.download_blob().content_as_text(max_connections=2)
+        content = blob.download_blob().content_as_text(max_concurrency=2)
 
         # Assert
         self.assertEqual(text_data, content)
@@ -578,7 +578,7 @@ class StorageGetBlobTest(StorageTestCase):
             progress.append((current, total))
 
         # Act
-        content = blob.download_blob(raw_response_hook=callback).content_as_text(max_connections=2)
+        content = blob.download_blob(raw_response_hook=callback).content_as_text(max_concurrency=2)
 
         # Assert
         self.assertEqual(text_data, content)
@@ -604,7 +604,7 @@ class StorageGetBlobTest(StorageTestCase):
             progress.append((current, total))
 
         # Act
-        content = blob.download_blob(raw_response_hook=callback).content_as_text(max_connections=1)
+        content = blob.download_blob(raw_response_hook=callback).content_as_text(max_concurrency=1)
 
         # Assert
         self.assertEqual(text_data, content)
@@ -689,7 +689,7 @@ class StorageGetBlobTest(StorageTestCase):
         with open(FILE_PATH, 'wb') as stream:
             non_seekable_stream = StorageGetBlobTest.NonSeekableFile(stream)
             downloader = blob.download_blob()
-            properties = downloader.download_to_stream(non_seekable_stream, max_connections=1)
+            properties = downloader.download_to_stream(non_seekable_stream, max_concurrency=1)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -711,7 +711,7 @@ class StorageGetBlobTest(StorageTestCase):
 
             with self.assertRaises(ValueError):
                 downloader = blob.download_blob()
-                properties = downloader.download_to_stream(non_seekable_stream, max_connections=2)
+                properties = downloader.download_to_stream(non_seekable_stream, max_concurrency=2)
 
     @record
     def test_get_blob_to_stream_exact_get_size(self):
@@ -731,7 +731,7 @@ class StorageGetBlobTest(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(raw_response_hook=callback)
-            properties = downloader.download_to_stream(stream, max_connections=2)
+            properties = downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         with open(FILE_PATH, 'rb') as stream:
@@ -811,7 +811,7 @@ class StorageGetBlobTest(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(validate_content=True)
-            properties = downloader.download_to_stream(stream, max_connections=2)
+            properties = downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -828,7 +828,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        content = blob.download_blob(validate_content=True).content_as_bytes(max_connections=2)
+        content = blob.download_blob(validate_content=True).content_as_bytes(max_concurrency=2)
 
         # Assert
         self.assertEqual(self.byte_data, content)
@@ -847,7 +847,7 @@ class StorageGetBlobTest(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=0, length=1024, validate_content=True)
-            properties = downloader.download_to_stream(stream, max_connections=2)
+            properties = downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)

--- a/sdk/storage/azure-storage-blob/tests/test_get_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_get_blob_async.py
@@ -184,7 +184,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        content = await (await blob.download_blob()).content_as_bytes(max_connections=2)
+        content = await (await blob.download_blob()).content_as_bytes(max_concurrency=2)
 
         # Assert
         self.assertEqual(self.byte_data, content)
@@ -275,7 +275,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         await blob.upload_blob(self.byte_data, overwrite=True) # Modify the blob so the Etag no longer matches
 
         # Act
-        content = await (await snapshot.download_blob()).content_as_bytes(max_connections=2)
+        content = await (await snapshot.download_blob()).content_as_bytes(max_concurrency=2)
 
         # Assert
         self.assertEqual(self.byte_data, content)
@@ -301,7 +301,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
             progress.append((current, total))
 
         # Act
-        content = await (await blob.download_blob(raw_response_hook=callback)).content_as_bytes(max_connections=2)
+        content = await (await blob.download_blob(raw_response_hook=callback)).content_as_bytes(max_concurrency=2)
 
         # Assert
         self.assertEqual(self.byte_data, content)
@@ -328,7 +328,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
             progress.append((current, total))
 
         # Act
-        content = await (await blob.download_blob(raw_response_hook=callback)).content_as_bytes(max_connections=1)
+        content = await (await blob.download_blob(raw_response_hook=callback)).content_as_bytes(max_concurrency=1)
 
         # Assert
         self.assertEqual(self.byte_data, content)
@@ -386,7 +386,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob()
-            properties = await downloader.download_to_stream(stream, max_connections=2)
+            properties = await downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -417,7 +417,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(raw_response_hook=callback)
-            properties = await downloader.download_to_stream(stream, max_connections=2)
+            properties = await downloader.download_to_stream(stream, max_concurrency=2)
         # Assert
         self.assertIsInstance(properties, BlobProperties)
         with open(FILE_PATH, 'rb') as stream:
@@ -448,7 +448,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(raw_response_hook=callback)
-            properties = await downloader.download_to_stream(stream, max_connections=1)
+            properties = await downloader.download_to_stream(stream, max_concurrency=1)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -485,7 +485,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(raw_response_hook=callback)
-            properties = await downloader.download_to_stream(stream, max_connections=2)
+            properties = await downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -516,7 +516,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         end_range = self.config.max_single_get_size
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=1, length=end_range)
-            properties = await downloader.download_to_stream(stream, max_connections=2)
+            properties = await downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -549,7 +549,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         end_range = self.config.max_single_get_size + 1024
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=start_range, length=end_range, raw_response_hook=callback)
-            properties = await downloader.download_to_stream(stream, max_connections=2)
+            properties = await downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -575,7 +575,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=1, length=4)
-            properties = await downloader.download_to_stream(stream, max_connections=2)
+            properties = await downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -596,7 +596,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=1, length=3)
-            properties = await downloader.download_to_stream(stream, max_connections=1)
+            properties = await downloader.download_to_stream(stream, max_concurrency=1)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -626,7 +626,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         end_range = 2 * self.config.max_single_get_size
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=1, length=end_range)
-            properties = await downloader.download_to_stream(stream, max_connections=2)
+            properties = await downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -656,7 +656,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         end_range = 2 * self.config.max_single_get_size
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=1, length=end_range)
-            properties = await downloader.download_to_stream(stream, max_connections=2)
+            properties = await downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -684,7 +684,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         await blob.upload_blob(text_data)
 
         # Act
-        content = await (await blob.download_blob()).content_as_text(max_connections=2)
+        content = await (await blob.download_blob()).content_as_text(max_concurrency=2)
 
         # Assert
         self.assertEqual(text_data, content)
@@ -714,7 +714,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
             progress.append((current, total))
 
         # Act
-        content = await (await blob.download_blob(raw_response_hook=callback)).content_as_text(max_connections=2)
+        content = await (await blob.download_blob(raw_response_hook=callback)).content_as_text(max_concurrency=2)
 
         # Assert
         self.assertEqual(text_data, content)
@@ -745,7 +745,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
             progress.append((current, total))
 
         # Act
-        content = await (await blob.download_blob(raw_response_hook=callback)).content_as_text(max_connections=1)
+        content = await (await blob.download_blob(raw_response_hook=callback)).content_as_text(max_concurrency=1)
 
         # Assert
         self.assertEqual(text_data, content)
@@ -850,7 +850,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         with open(FILE_PATH, 'wb') as stream:
             non_seekable_stream = StorageGetBlobTestAsync.NonSeekableFile(stream)
             downloader = await blob.download_blob()
-            properties = await downloader.download_to_stream(non_seekable_stream, max_connections=1)
+            properties = await downloader.download_to_stream(non_seekable_stream, max_concurrency=1)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -878,7 +878,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
 
             with self.assertRaises(ValueError):
                 downloader = await blob.download_blob()
-                properties = await downloader.download_to_stream(non_seekable_stream, max_connections=2)
+                properties = await downloader.download_to_stream(non_seekable_stream, max_concurrency=2)
 
     @record
     def test_get_blob_non_seekable_parallel_async(self):
@@ -903,7 +903,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(raw_response_hook=callback)
-            properties = await downloader.download_to_stream(stream, max_connections=2)
+            properties = await downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         with open(FILE_PATH, 'rb') as stream:
@@ -1000,7 +1000,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(validate_content=True)
-            properties = await downloader.download_to_stream(stream, max_connections=2)
+            properties = await downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)
@@ -1023,7 +1023,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        content = await (await blob.download_blob(validate_content=True)).content_as_bytes(max_connections=2)
+        content = await (await blob.download_blob(validate_content=True)).content_as_bytes(max_concurrency=2)
 
         # Assert
         self.assertEqual(self.byte_data, content)
@@ -1048,7 +1048,7 @@ class StorageGetBlobTestAsync(StorageTestCase):
         # Act
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=0, length=1024, validate_content=True)
-            properties = await downloader.download_to_stream(stream, max_connections=2)
+            properties = await downloader.download_to_stream(stream, max_concurrency=2)
 
         # Assert
         self.assertIsInstance(properties, BlobProperties)

--- a/sdk/storage/azure-storage-blob/tests/test_large_block_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_large_block_blob.py
@@ -176,7 +176,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
 
         # Act
         with open(FILE_PATH, 'rb') as stream:
-            blob.upload_blob(stream, max_connections=2)
+            blob.upload_blob(stream, max_concurrency=2)
 
         # Assert
         self.assertBlobEqual(self.container_name, blob_name, data)
@@ -195,7 +195,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
 
         # Act
         with open(FILE_PATH, 'rb') as stream:
-            blob.upload_blob(stream, validate_content=True, max_connections=2)
+            blob.upload_blob(stream, validate_content=True, max_concurrency=2)
 
         # Assert
         self.assertBlobEqual(self.container_name, blob_name, data)
@@ -213,7 +213,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
 
         # Act
         with open(FILE_PATH, 'rb') as stream:
-            blob.upload_blob(stream, max_connections=1)
+            blob.upload_blob(stream, max_concurrency=1)
 
         # Assert
         self.assertBlobEqual(self.container_name, blob_name, data)
@@ -239,7 +239,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
                 progress.append((current, total))
 
         with open(FILE_PATH, 'rb') as stream:
-            blob.upload_blob(stream, max_connections=2, raw_response_hook=callback)
+            blob.upload_blob(stream, max_concurrency=2, raw_response_hook=callback)
 
         # Assert
         self.assertBlobEqual(self.container_name, blob_name, data)
@@ -262,7 +262,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
             content_type='image/png',
             content_language='spanish')
         with open(FILE_PATH, 'rb') as stream:
-            blob.upload_blob(stream, content_settings=content_settings, max_connections=2)
+            blob.upload_blob(stream, content_settings=content_settings, max_concurrency=2)
 
         # Assert
         self.assertBlobEqual(self.container_name, blob_name, data)
@@ -284,7 +284,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
 
         # Act
         with open(FILE_PATH, 'rb') as stream:
-            blob.upload_blob(stream, max_connections=2)
+            blob.upload_blob(stream, max_concurrency=2)
 
         # Assert
         self.assertBlobEqual(self.container_name, blob_name, data)
@@ -310,7 +310,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
                 progress.append((current, total))
 
         with open(FILE_PATH, 'rb') as stream:
-            blob.upload_blob(stream, max_connections=2, raw_response_hook=callback)
+            blob.upload_blob(stream, max_concurrency=2, raw_response_hook=callback)
 
         # Assert
         self.assertBlobEqual(self.container_name, blob_name, data)
@@ -331,7 +331,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
         # Act
         blob_size = len(data) - 301
         with open(FILE_PATH, 'rb') as stream:
-            blob.upload_blob(stream, length=blob_size, max_connections=2)
+            blob.upload_blob(stream, length=blob_size, max_concurrency=2)
 
         # Assert
         self.assertBlobEqual(self.container_name, blob_name, data[:blob_size])
@@ -355,7 +355,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
         blob_size = len(data) - 301
         with open(FILE_PATH, 'rb') as stream:
             blob.upload_blob(
-                stream, length=blob_size, content_settings=content_settings, max_connections=2)
+                stream, length=blob_size, content_settings=content_settings, max_concurrency=2)
 
         # Assert
         self.assertBlobEqual(self.container_name, blob_name, data[:blob_size])
@@ -380,7 +380,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
             content_type='image/png',
             content_language='spanish')
         with open(FILE_PATH, 'rb') as stream:
-            blob.upload_blob(stream, content_settings=content_settings, max_connections=2)
+            blob.upload_blob(stream, content_settings=content_settings, max_concurrency=2)
 
         # Assert
         self.assertBlobEqual(self.container_name, blob_name, data)

--- a/sdk/storage/azure-storage-blob/tests/test_large_block_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_large_block_blob_async.py
@@ -224,7 +224,7 @@ class StorageLargeBlockBlobTestAsync(StorageTestCase):
 
         # Act
         with open(FILE_PATH, 'rb') as stream:
-            await blob.upload_blob(stream, max_connections=2)
+            await blob.upload_blob(stream, max_concurrency=2)
 
         # Assert
         await self.assertBlobEqual(self.container_name, blob_name, data)
@@ -249,7 +249,7 @@ class StorageLargeBlockBlobTestAsync(StorageTestCase):
 
         # Act
         with open(FILE_PATH, 'rb') as stream:
-            await blob.upload_blob(stream, validate_content=True, max_connections=2)
+            await blob.upload_blob(stream, validate_content=True, max_concurrency=2)
 
         # Assert
         await self.assertBlobEqual(self.container_name, blob_name, data)
@@ -273,7 +273,7 @@ class StorageLargeBlockBlobTestAsync(StorageTestCase):
 
         # Act
         with open(FILE_PATH, 'rb') as stream:
-            await blob.upload_blob(stream, max_connections=1)
+            await blob.upload_blob(stream, max_concurrency=1)
 
         # Assert
         await self.assertBlobEqual(self.container_name, blob_name, data)
@@ -305,7 +305,7 @@ class StorageLargeBlockBlobTestAsync(StorageTestCase):
                 progress.append((current, total))
 
         with open(FILE_PATH, 'rb') as stream:
-            await blob.upload_blob(stream, max_connections=2, raw_response_hook=callback)
+            await blob.upload_blob(stream, max_concurrency=2, raw_response_hook=callback)
 
         # Assert
         await self.assertBlobEqual(self.container_name, blob_name, data)
@@ -334,7 +334,7 @@ class StorageLargeBlockBlobTestAsync(StorageTestCase):
             content_type='image/png',
             content_language='spanish')
         with open(FILE_PATH, 'rb') as stream:
-            await blob.upload_blob(stream, content_settings=content_settings, max_connections=2)
+            await blob.upload_blob(stream, content_settings=content_settings, max_concurrency=2)
 
         # Assert
         await self.assertBlobEqual(self.container_name, blob_name, data)
@@ -362,7 +362,7 @@ class StorageLargeBlockBlobTestAsync(StorageTestCase):
 
         # Act
         with open(FILE_PATH, 'rb') as stream:
-            await blob.upload_blob(stream, max_connections=2)
+            await blob.upload_blob(stream, max_concurrency=2)
 
         # Assert
         await self.assertBlobEqual(self.container_name, blob_name, data)
@@ -394,7 +394,7 @@ class StorageLargeBlockBlobTestAsync(StorageTestCase):
                 progress.append((current, total))
 
         with open(FILE_PATH, 'rb') as stream:
-            await blob.upload_blob(stream, max_connections=2, raw_response_hook=callback)
+            await blob.upload_blob(stream, max_concurrency=2, raw_response_hook=callback)
 
         # Assert
         await self.assertBlobEqual(self.container_name, blob_name, data)
@@ -421,7 +421,7 @@ class StorageLargeBlockBlobTestAsync(StorageTestCase):
         # Act
         blob_size = len(data) - 301
         with open(FILE_PATH, 'rb') as stream:
-            await blob.upload_blob(stream, length=blob_size, max_connections=2)
+            await blob.upload_blob(stream, length=blob_size, max_concurrency=2)
 
         # Assert
         await self.assertBlobEqual(self.container_name, blob_name, data[:blob_size])
@@ -451,7 +451,7 @@ class StorageLargeBlockBlobTestAsync(StorageTestCase):
         blob_size = len(data) - 301
         with open(FILE_PATH, 'rb') as stream:
             await blob.upload_blob(
-                stream, length=blob_size, content_settings=content_settings, max_connections=2)
+                stream, length=blob_size, content_settings=content_settings, max_concurrency=2)
 
         # Assert
         await self.assertBlobEqual(self.container_name, blob_name, data[:blob_size])
@@ -482,7 +482,7 @@ class StorageLargeBlockBlobTestAsync(StorageTestCase):
             content_type='image/png',
             content_language='spanish')
         with open(FILE_PATH, 'rb') as stream:
-            await blob.upload_blob(stream, content_settings=content_settings, max_connections=2)
+            await blob.upload_blob(stream, content_settings=content_settings, max_concurrency=2)
 
         # Assert
         await self.assertBlobEqual(self.container_name, blob_name, data)

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob.py
@@ -1219,7 +1219,7 @@ class StoragePageBlobTest(StorageTestCase):
             blob.upload_blob(
                 non_seekable_file,
                 length=blob_size,
-                max_connections=1,
+                max_concurrency=1,
                 blob_type=BlobType.PageBlob)
 
         # Assert

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
@@ -1454,7 +1454,7 @@ class StoragePageBlobTestAsync(StorageTestCase):
             await blob.upload_blob(
                 non_seekable_file,
                 length=blob_size,
-                max_connections=1,
+                max_concurrency=1,
                 blob_type=BlobType.PageBlob)
 
         # Assert


### PR DESCRIPTION
...and some other minor changes
- `BlobBlock` shouldn't have block_id as optional
- mypy error in abort_copy
- mypy error in append_block

Resolves #7512 
Resolves #7507 