### PR TITLE
Remove get_pending_certificate_signing_request

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-certificates/HISTORY.md
@@ -1,7 +1,8 @@
 # Release History
 
 ## 4.0.0b5
-
+### Breaking changes
+- Removed redundant method `get_pending_certificate_signing_request()`. A pending CSR can be retrieved via `get_certificate_operation()`.
 
 ## 4.0.0b4 (2019-10-08)
 ### Breaking changes
@@ -16,6 +17,7 @@ for details.
 - `update_certificate` has been renamed to `update_certificate_properties`
 - The `vault_url` parameter of `CertificateClient` has been renamed to `vault_endpoint`
 - The property `vault_url` has been renamed to `vault_endpoint` in all models
+
 
 ## 4.0.0b3 (2019-09-11)
 Version 4.0.0b3 is the first preview of our efforts to create a user-friendly and Pythonic client library for Azure Key Vault's certificates.

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/client.py
@@ -4,7 +4,6 @@
 # ------------------------------------
 # pylint:disable=too-many-lines,too-many-public-methods
 import base64
-import uuid
 from typing import Any, AsyncIterable, Optional, Iterable, List, Dict, Coroutine
 from functools import partial
 
@@ -704,58 +703,6 @@ class CertificateClient(AsyncKeyVaultClientBase):
             vault_base_url=self.vault_endpoint, certificate_name=name, cancellation_requested=True, **kwargs
         )
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
-
-    @distributed_trace_async
-    async def get_pending_certificate_signing_request(
-        self, name: str, custom_headers: Optional[Dict[str, str]] = None, **kwargs: "**Any"
-    ) -> str:
-        """Gets the Base64 pending certificate signing request (PKCS-10).
-
-        :param str name: The name of the certificate
-        :param custom_headers: headers that will be added to the request
-        :type custom_headers: dict[str, str]
-        :return: Base64 encoded pending certificate signing request (PKCS-10).
-        :rtype: str
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
-        """
-        vault_base_url = self.vault_endpoint
-        # Construct URL
-        url = "/certificates/{certificate-name}/pending"
-        path_format_arguments = {
-            "vaultBaseUrl": self._client._serialize.url("vault_base_url", vault_base_url, "str", skip_quote=True),
-            "certificate-name": self._client._serialize.url("certificate_name", name, "str"),
-        }
-        url = self._client._client.format_url(url, **path_format_arguments)
-
-        # Construct parameters
-        query_parameters = {}
-        query_parameters["api-version"] = self._client._serialize.query(
-            name="self.api_version", data=self._client.api_version, data_type="str"
-        )
-
-        # Construct headers
-        header_parameters = {}
-        header_parameters["Accept"] = "application/pkcs10"
-        if self._client._config.generate_client_request_id:
-            header_parameters["x-ms-client-request-id"] = str(uuid.uuid1())
-        if custom_headers:
-            header_parameters.update(custom_headers)
-
-        # Construct and send request
-        request = self._client._client.get(url=url, params=query_parameters, headers=header_parameters)
-        pipeline_response = await self._client._client._pipeline.run(request, stream=False, **kwargs)
-        response = pipeline_response.http_response
-
-        if response.status_code not in [200]:
-            self._client.map_error(status_code=response.status_code, response=response, error_map=_error_map)
-            raise self._client.models.KeyVaultErrorException(response, self._client._deserialize)
-
-        deserialized = None
-
-        if response.status_code == 200:
-            deserialized = response.body() if hasattr(response, "body") else response.content
-
-        return deserialized
 
     @distributed_trace_async
     async def merge_certificate(self, name: str, x509_certificates: List[bytearray], **kwargs: "**Any") -> Certificate:

--- a/sdk/keyvault/azure-keyvault-certificates/tests/recordings/test_certificates_client.test_get_pending_certificate_signing_request.yaml
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/recordings/test_certificates_client.test_get_pending_certificate_signing_request.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: POST
     uri: https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/create?api-version=7.0
   response:
@@ -28,7 +28,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Sep 2019 20:47:32 GMT
+      - Wed, 02 Oct 2019 19:05:17 GMT
       expires:
       - '-1'
       pragma:
@@ -45,7 +45,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.174.72;act_addr_fam=InterNetwork;
+      - addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
@@ -56,10 +56,10 @@ interactions:
       code: 401
       message: Unauthorized
 - request:
-    body: '{"policy": {"key_props": {"exportable": true, "kty": "RSA", "key_size":
-      2048, "reuse_key": false}, "secret_props": {"contentType": "application/x-pkcs12"},
-      "x509_props": {"subject": "CN=*.microsoft.com", "sans": {"dns_names": ["sdk.azure-int.net"]},
-      "validity_months": 24}, "issuer": {"name": "Self"}}}'
+    body: '{"policy": {"issuer": {"name": "Self"}, "x509_props": {"validity_months":
+      24, "sans": {"dns_names": ["sdk.azure-int.net"]}, "subject": "CN=*.microsoft.com"},
+      "key_props": {"exportable": true, "kty": "RSA", "key_size": 2048, "reuse_key":
+      false}, "secret_props": {"contentType": "application/x-pkcs12"}}}'
     headers:
       Accept:
       - application/json
@@ -72,14 +72,14 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: POST
     uri: https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/create?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt/ONPj8hXRz9PVMfHNC/+M3wTF6fkqq/kmUwJaBK7ywNXv7i4LXSfMF18rM3Lzetdp4jhCjy7zyHRGYP6xxwOL42F4daAdwgBTZqbVzieBfVTpw7sEKscuQFLlFzEcKOWjLeHFkQ9XVs9IzJWhjIdfcQAlaM0NdFSmtqYsVvzMSUPtqxxrM3NA9rr9fcKYJes72qr/dZch1eax3+jYL3Fko4f34fg+VkUuiL96DVBapErwvmtL1mFuM4dxSIIElTchipqDxO3Dgn9sU5RRdydINWtfpLF3HUj2anGzR/tIEK/A37mgGDYZsJxDvyxR3hv9GZnOARFrI1cp6lVIfzXwIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAKTLGwqvtXIPDBQaQLcFut6yzfdyG90Ie7qryP8w0S//DxNZ2QxFj8DCwF0nyFZvxTDLE+PWsSUeAdN+uQRFlT0M9i6/C6SzFGLN7Qzlk7Pyg8vgqsOeqR54pQ42mTb8FJzMFGsvOaSlR79PUXzRNS+DZFj4y0NdEYfvwQ49D88iiXBy29UtNFQT+0Kqymqjo0eDuH7CoOFqW0Al8BRSyGl7oH+9ZM+zQlhtcfPu6+sFADRmB9VtN2cxxaeQ3pvhX+GIMXf0J+z8/FbvQTzWQcCKnPjDTQGPHvTOLEBikRxOykvus43PAqozCzSAprw2MhPXzDX1YRYbyIXTLAI9/D4=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmmPGY3xBR+g1mgKQemztUmwJyCi9X0cBBa7VTzBFNKyPbBbSRlS0v2M5mTG6eB+xWKpn5sMrRDIJT2uEtsKFVRwBqGQqsaBbIFkgoVYJ2DL2pXceUZ9p0bnOjS9PERZ/MNg9jLXCb3AwoEFZKkr3nGxL3weCFOXPlX4EIQWZ9ET2H0cTIRyOKmXICIh+/lezZL3p8ZvKlWxPuyBVQY9l4O16ui9qlrtdpsEFq++40m4kP2YWBG4gRdbnzyUjhjlCFgPZKQ1A2hZUw5Usyh1XVTJxFPMIlMtvYzNcvZyKE3Qxynb19nGi3jG5to3lGfKGx6P2ich5kCemo5RyQmgwzQIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAIM7cWxg6KZJi5UPokLZa65NZmWX7YKyajHabqwudjMVydPXJpbpJiSi4Wt6a/+y74NRyEQvHu+8yNMi+ZKo7Plug6vJgQFVKeGdEHA/tLdsJOF0zCSBjwy95RsiAaKiNYC1AtJnyugvU7FAWOn46ZvBlfB0anNp8ERKvFjBO9f8CHzlzaskJydCSCibBFtLCNEcYrcffA8vGPP/sbm2+3oDIfnP3TcQ8jRpUhli9phgDV9xN8H5u8nmaZ1x5SQCtY5dCVDXc2HHt9tVj1YZ6r3R7S3IxBDkckeF0YCSWo9RDi1Qu3h4aBk3r7RjoTynRahUXvus2hRMLZDrRMyyh3I=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"5e1f4346a50f444a96b78f380473280d"}'
+        time based on the issuer provider. Please check again later.","request_id":"c87f693df850407ba663c14bd18c6dbb"}'
     headers:
       cache-control:
       - no-cache
@@ -88,11 +88,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Sep 2019 20:47:33 GMT
+      - Wed, 02 Oct 2019 19:05:19 GMT
       expires:
       - '-1'
       location:
-      - https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0&request_id=5e1f4346a50f444a96b78f380473280d
+      - https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0&request_id=c87f693df850407ba663c14bd18c6dbb
       pragma:
       - no-cache
       retry-after:
@@ -106,7 +106,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.174.72;act_addr_fam=InterNetwork;
+      - addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
@@ -126,14 +126,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: GET
     uri: https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt/ONPj8hXRz9PVMfHNC/+M3wTF6fkqq/kmUwJaBK7ywNXv7i4LXSfMF18rM3Lzetdp4jhCjy7zyHRGYP6xxwOL42F4daAdwgBTZqbVzieBfVTpw7sEKscuQFLlFzEcKOWjLeHFkQ9XVs9IzJWhjIdfcQAlaM0NdFSmtqYsVvzMSUPtqxxrM3NA9rr9fcKYJes72qr/dZch1eax3+jYL3Fko4f34fg+VkUuiL96DVBapErwvmtL1mFuM4dxSIIElTchipqDxO3Dgn9sU5RRdydINWtfpLF3HUj2anGzR/tIEK/A37mgGDYZsJxDvyxR3hv9GZnOARFrI1cp6lVIfzXwIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAKTLGwqvtXIPDBQaQLcFut6yzfdyG90Ie7qryP8w0S//DxNZ2QxFj8DCwF0nyFZvxTDLE+PWsSUeAdN+uQRFlT0M9i6/C6SzFGLN7Qzlk7Pyg8vgqsOeqR54pQ42mTb8FJzMFGsvOaSlR79PUXzRNS+DZFj4y0NdEYfvwQ49D88iiXBy29UtNFQT+0Kqymqjo0eDuH7CoOFqW0Al8BRSyGl7oH+9ZM+zQlhtcfPu6+sFADRmB9VtN2cxxaeQ3pvhX+GIMXf0J+z8/FbvQTzWQcCKnPjDTQGPHvTOLEBikRxOykvus43PAqozCzSAprw2MhPXzDX1YRYbyIXTLAI9/D4=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmmPGY3xBR+g1mgKQemztUmwJyCi9X0cBBa7VTzBFNKyPbBbSRlS0v2M5mTG6eB+xWKpn5sMrRDIJT2uEtsKFVRwBqGQqsaBbIFkgoVYJ2DL2pXceUZ9p0bnOjS9PERZ/MNg9jLXCb3AwoEFZKkr3nGxL3weCFOXPlX4EIQWZ9ET2H0cTIRyOKmXICIh+/lezZL3p8ZvKlWxPuyBVQY9l4O16ui9qlrtdpsEFq++40m4kP2YWBG4gRdbnzyUjhjlCFgPZKQ1A2hZUw5Usyh1XVTJxFPMIlMtvYzNcvZyKE3Qxynb19nGi3jG5to3lGfKGx6P2ich5kCemo5RyQmgwzQIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAIM7cWxg6KZJi5UPokLZa65NZmWX7YKyajHabqwudjMVydPXJpbpJiSi4Wt6a/+y74NRyEQvHu+8yNMi+ZKo7Plug6vJgQFVKeGdEHA/tLdsJOF0zCSBjwy95RsiAaKiNYC1AtJnyugvU7FAWOn46ZvBlfB0anNp8ERKvFjBO9f8CHzlzaskJydCSCibBFtLCNEcYrcffA8vGPP/sbm2+3oDIfnP3TcQ8jRpUhli9phgDV9xN8H5u8nmaZ1x5SQCtY5dCVDXc2HHt9tVj1YZ6r3R7S3IxBDkckeF0YCSWo9RDi1Qu3h4aBk3r7RjoTynRahUXvus2hRMLZDrRMyyh3I=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"5e1f4346a50f444a96b78f380473280d"}'
+        time based on the issuer provider. Please check again later.","request_id":"c87f693df850407ba663c14bd18c6dbb"}'
     headers:
       cache-control:
       - no-cache
@@ -142,7 +142,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Sep 2019 20:47:33 GMT
+      - Wed, 02 Oct 2019 19:05:19 GMT
       expires:
       - '-1'
       pragma:
@@ -158,7 +158,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.174.72;act_addr_fam=InterNetwork;
+      - addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
@@ -178,14 +178,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: GET
     uri: https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt/ONPj8hXRz9PVMfHNC/+M3wTF6fkqq/kmUwJaBK7ywNXv7i4LXSfMF18rM3Lzetdp4jhCjy7zyHRGYP6xxwOL42F4daAdwgBTZqbVzieBfVTpw7sEKscuQFLlFzEcKOWjLeHFkQ9XVs9IzJWhjIdfcQAlaM0NdFSmtqYsVvzMSUPtqxxrM3NA9rr9fcKYJes72qr/dZch1eax3+jYL3Fko4f34fg+VkUuiL96DVBapErwvmtL1mFuM4dxSIIElTchipqDxO3Dgn9sU5RRdydINWtfpLF3HUj2anGzR/tIEK/A37mgGDYZsJxDvyxR3hv9GZnOARFrI1cp6lVIfzXwIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAKTLGwqvtXIPDBQaQLcFut6yzfdyG90Ie7qryP8w0S//DxNZ2QxFj8DCwF0nyFZvxTDLE+PWsSUeAdN+uQRFlT0M9i6/C6SzFGLN7Qzlk7Pyg8vgqsOeqR54pQ42mTb8FJzMFGsvOaSlR79PUXzRNS+DZFj4y0NdEYfvwQ49D88iiXBy29UtNFQT+0Kqymqjo0eDuH7CoOFqW0Al8BRSyGl7oH+9ZM+zQlhtcfPu6+sFADRmB9VtN2cxxaeQ3pvhX+GIMXf0J+z8/FbvQTzWQcCKnPjDTQGPHvTOLEBikRxOykvus43PAqozCzSAprw2MhPXzDX1YRYbyIXTLAI9/D4=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmmPGY3xBR+g1mgKQemztUmwJyCi9X0cBBa7VTzBFNKyPbBbSRlS0v2M5mTG6eB+xWKpn5sMrRDIJT2uEtsKFVRwBqGQqsaBbIFkgoVYJ2DL2pXceUZ9p0bnOjS9PERZ/MNg9jLXCb3AwoEFZKkr3nGxL3weCFOXPlX4EIQWZ9ET2H0cTIRyOKmXICIh+/lezZL3p8ZvKlWxPuyBVQY9l4O16ui9qlrtdpsEFq++40m4kP2YWBG4gRdbnzyUjhjlCFgPZKQ1A2hZUw5Usyh1XVTJxFPMIlMtvYzNcvZyKE3Qxynb19nGi3jG5to3lGfKGx6P2ich5kCemo5RyQmgwzQIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAIM7cWxg6KZJi5UPokLZa65NZmWX7YKyajHabqwudjMVydPXJpbpJiSi4Wt6a/+y74NRyEQvHu+8yNMi+ZKo7Plug6vJgQFVKeGdEHA/tLdsJOF0zCSBjwy95RsiAaKiNYC1AtJnyugvU7FAWOn46ZvBlfB0anNp8ERKvFjBO9f8CHzlzaskJydCSCibBFtLCNEcYrcffA8vGPP/sbm2+3oDIfnP3TcQ8jRpUhli9phgDV9xN8H5u8nmaZ1x5SQCtY5dCVDXc2HHt9tVj1YZ6r3R7S3IxBDkckeF0YCSWo9RDi1Qu3h4aBk3r7RjoTynRahUXvus2hRMLZDrRMyyh3I=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"5e1f4346a50f444a96b78f380473280d"}'
+        time based on the issuer provider. Please check again later.","request_id":"c87f693df850407ba663c14bd18c6dbb"}'
     headers:
       cache-control:
       - no-cache
@@ -194,7 +194,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Sep 2019 20:47:44 GMT
+      - Wed, 02 Oct 2019 19:05:29 GMT
       expires:
       - '-1'
       pragma:
@@ -210,7 +210,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.174.72;act_addr_fam=InterNetwork;
+      - addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
@@ -230,14 +230,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: GET
     uri: https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt/ONPj8hXRz9PVMfHNC/+M3wTF6fkqq/kmUwJaBK7ywNXv7i4LXSfMF18rM3Lzetdp4jhCjy7zyHRGYP6xxwOL42F4daAdwgBTZqbVzieBfVTpw7sEKscuQFLlFzEcKOWjLeHFkQ9XVs9IzJWhjIdfcQAlaM0NdFSmtqYsVvzMSUPtqxxrM3NA9rr9fcKYJes72qr/dZch1eax3+jYL3Fko4f34fg+VkUuiL96DVBapErwvmtL1mFuM4dxSIIElTchipqDxO3Dgn9sU5RRdydINWtfpLF3HUj2anGzR/tIEK/A37mgGDYZsJxDvyxR3hv9GZnOARFrI1cp6lVIfzXwIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAKTLGwqvtXIPDBQaQLcFut6yzfdyG90Ie7qryP8w0S//DxNZ2QxFj8DCwF0nyFZvxTDLE+PWsSUeAdN+uQRFlT0M9i6/C6SzFGLN7Qzlk7Pyg8vgqsOeqR54pQ42mTb8FJzMFGsvOaSlR79PUXzRNS+DZFj4y0NdEYfvwQ49D88iiXBy29UtNFQT+0Kqymqjo0eDuH7CoOFqW0Al8BRSyGl7oH+9ZM+zQlhtcfPu6+sFADRmB9VtN2cxxaeQ3pvhX+GIMXf0J+z8/FbvQTzWQcCKnPjDTQGPHvTOLEBikRxOykvus43PAqozCzSAprw2MhPXzDX1YRYbyIXTLAI9/D4=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmmPGY3xBR+g1mgKQemztUmwJyCi9X0cBBa7VTzBFNKyPbBbSRlS0v2M5mTG6eB+xWKpn5sMrRDIJT2uEtsKFVRwBqGQqsaBbIFkgoVYJ2DL2pXceUZ9p0bnOjS9PERZ/MNg9jLXCb3AwoEFZKkr3nGxL3weCFOXPlX4EIQWZ9ET2H0cTIRyOKmXICIh+/lezZL3p8ZvKlWxPuyBVQY9l4O16ui9qlrtdpsEFq++40m4kP2YWBG4gRdbnzyUjhjlCFgPZKQ1A2hZUw5Usyh1XVTJxFPMIlMtvYzNcvZyKE3Qxynb19nGi3jG5to3lGfKGx6P2ich5kCemo5RyQmgwzQIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAIM7cWxg6KZJi5UPokLZa65NZmWX7YKyajHabqwudjMVydPXJpbpJiSi4Wt6a/+y74NRyEQvHu+8yNMi+ZKo7Plug6vJgQFVKeGdEHA/tLdsJOF0zCSBjwy95RsiAaKiNYC1AtJnyugvU7FAWOn46ZvBlfB0anNp8ERKvFjBO9f8CHzlzaskJydCSCibBFtLCNEcYrcffA8vGPP/sbm2+3oDIfnP3TcQ8jRpUhli9phgDV9xN8H5u8nmaZ1x5SQCtY5dCVDXc2HHt9tVj1YZ6r3R7S3IxBDkckeF0YCSWo9RDi1Qu3h4aBk3r7RjoTynRahUXvus2hRMLZDrRMyyh3I=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"5e1f4346a50f444a96b78f380473280d"}'
+        time based on the issuer provider. Please check again later.","request_id":"c87f693df850407ba663c14bd18c6dbb"}'
     headers:
       cache-control:
       - no-cache
@@ -246,7 +246,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Sep 2019 20:47:54 GMT
+      - Wed, 02 Oct 2019 19:05:39 GMT
       expires:
       - '-1'
       pragma:
@@ -262,7 +262,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.174.72;act_addr_fam=InterNetwork;
+      - addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
@@ -282,12 +282,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: GET
     uri: https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt/ONPj8hXRz9PVMfHNC/+M3wTF6fkqq/kmUwJaBK7ywNXv7i4LXSfMF18rM3Lzetdp4jhCjy7zyHRGYP6xxwOL42F4daAdwgBTZqbVzieBfVTpw7sEKscuQFLlFzEcKOWjLeHFkQ9XVs9IzJWhjIdfcQAlaM0NdFSmtqYsVvzMSUPtqxxrM3NA9rr9fcKYJes72qr/dZch1eax3+jYL3Fko4f34fg+VkUuiL96DVBapErwvmtL1mFuM4dxSIIElTchipqDxO3Dgn9sU5RRdydINWtfpLF3HUj2anGzR/tIEK/A37mgGDYZsJxDvyxR3hv9GZnOARFrI1cp6lVIfzXwIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAKTLGwqvtXIPDBQaQLcFut6yzfdyG90Ie7qryP8w0S//DxNZ2QxFj8DCwF0nyFZvxTDLE+PWsSUeAdN+uQRFlT0M9i6/C6SzFGLN7Qzlk7Pyg8vgqsOeqR54pQ42mTb8FJzMFGsvOaSlR79PUXzRNS+DZFj4y0NdEYfvwQ49D88iiXBy29UtNFQT+0Kqymqjo0eDuH7CoOFqW0Al8BRSyGl7oH+9ZM+zQlhtcfPu6+sFADRmB9VtN2cxxaeQ3pvhX+GIMXf0J+z8/FbvQTzWQcCKnPjDTQGPHvTOLEBikRxOykvus43PAqozCzSAprw2MhPXzDX1YRYbyIXTLAI9/D4=","cancellation_requested":false,"status":"completed","target":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert","request_id":"5e1f4346a50f444a96b78f380473280d"}'
+      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmmPGY3xBR+g1mgKQemztUmwJyCi9X0cBBa7VTzBFNKyPbBbSRlS0v2M5mTG6eB+xWKpn5sMrRDIJT2uEtsKFVRwBqGQqsaBbIFkgoVYJ2DL2pXceUZ9p0bnOjS9PERZ/MNg9jLXCb3AwoEFZKkr3nGxL3weCFOXPlX4EIQWZ9ET2H0cTIRyOKmXICIh+/lezZL3p8ZvKlWxPuyBVQY9l4O16ui9qlrtdpsEFq++40m4kP2YWBG4gRdbnzyUjhjlCFgPZKQ1A2hZUw5Usyh1XVTJxFPMIlMtvYzNcvZyKE3Qxynb19nGi3jG5to3lGfKGx6P2ich5kCemo5RyQmgwzQIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAIM7cWxg6KZJi5UPokLZa65NZmWX7YKyajHabqwudjMVydPXJpbpJiSi4Wt6a/+y74NRyEQvHu+8yNMi+ZKo7Plug6vJgQFVKeGdEHA/tLdsJOF0zCSBjwy95RsiAaKiNYC1AtJnyugvU7FAWOn46ZvBlfB0anNp8ERKvFjBO9f8CHzlzaskJydCSCibBFtLCNEcYrcffA8vGPP/sbm2+3oDIfnP3TcQ8jRpUhli9phgDV9xN8H5u8nmaZ1x5SQCtY5dCVDXc2HHt9tVj1YZ6r3R7S3IxBDkckeF0YCSWo9RDi1Qu3h4aBk3r7RjoTynRahUXvus2hRMLZDrRMyyh3I=","cancellation_requested":false,"status":"completed","target":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert","request_id":"c87f693df850407ba663c14bd18c6dbb"}'
     headers:
       cache-control:
       - no-cache
@@ -296,7 +296,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Sep 2019 20:48:04 GMT
+      - Wed, 02 Oct 2019 19:05:49 GMT
       expires:
       - '-1'
       pragma:
@@ -310,7 +310,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.174.72;act_addr_fam=InterNetwork;
+      - addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
@@ -330,12 +330,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: GET
     uri: https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/c270665afd194c7ebcb51039a8572e87","kid":"https://vaultdda41c5d.vault.azure.net/keys/unknownIssuerCert/c270665afd194c7ebcb51039a8572e87","sid":"https://vaultdda41c5d.vault.azure.net/secrets/unknownIssuerCert/c270665afd194c7ebcb51039a8572e87","x5t":"HW271xe3p2PaikZi8eoGJ4dhDHU","cer":"MIIDWjCCAkKgAwIBAgIQDGo7vTrrS+megtLlsuxHgzANBgkqhkiG9w0BAQsFADAaMRgwFgYDVQQDDA8qLm1pY3Jvc29mdC5jb20wHhcNMTkwOTE4MjAzODAyWhcNMjEwOTE4MjA0ODAyWjAaMRgwFgYDVQQDDA8qLm1pY3Jvc29mdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3840+PyFdHP09Ux8c0L/4zfBMXp+Sqr+SZTAloErvLA1e/uLgtdJ8wXXyszcvN612niOEKPLvPIdEZg/rHHA4vjYXh1oB3CAFNmptXOJ4F9VOnDuwQqxy5AUuUXMRwo5aMt4cWRD1dWz0jMlaGMh19xACVozQ10VKa2pixW/MxJQ+2rHGszc0D2uv19wpgl6zvaqv91lyHV5rHf6NgvcWSjh/fh+D5WRS6Iv3oNUFqkSvC+a0vWYW4zh3FIggSVNyGKmoPE7cOCf2xTlFF3J0g1a1+ksXcdSPZqcbNH+0gQr8DfuaAYNhmwnEO/LFHeG/0Zmc4BEWsjVynqVUh/NfAgMBAAGjgZswgZgwDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFCBJjUBUdIkR3bGgNsLZIAoTQQDrMB0GA1UdDgQWBBQgSY1AVHSJEd2xoDbC2SAKE0EA6zANBgkqhkiG9w0BAQsFAAOCAQEAqO6fKTw2CAy2RjjaYJXE3L9JC8NpSXvcyYqrUpnJ2Il0yUCAufaEV2Ouoss0+7tsJg2DekPYSWbYk439fSzOfxciG8GcoQuZZVbD+SoLzV6D9NaQgAltnshq/h+eqQp3k+662czUNJRSBXx/t/J7+CrRN9jtgF9ecq+BP3kcWVVvaLrCgivNlcaQ5RFCtcJ+0n6eeK95UICuHwCtc0NxanO3eJabdGu5S5UMhPl30evRSQyK3yHXkhMo3CGLxs8QVvgA8fF2Ofez43SDxJX3oMT5EJJTeQsQhmuhGB7UeLZktZT1AFpM/3ySs2R586dsUNv+IQEARIEr4YUzJ/ksiw==","attributes":{"enabled":true,"nbf":1568839082,"exp":1631998082,"created":1568839682,"updated":1568839682,"recoveryLevel":"Purgeable"},"policy":{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.microsoft.com","sans":{"dns_names":["sdk.azure-int.net"]},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":24,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1568839654,"updated":1568839654}},"pending":{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending"}}'
+      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/2527ca18b40b42a8a0f07b65d01a0373","kid":"https://vaultdda41c5d.vault.azure.net/keys/unknownIssuerCert/2527ca18b40b42a8a0f07b65d01a0373","sid":"https://vaultdda41c5d.vault.azure.net/secrets/unknownIssuerCert/2527ca18b40b42a8a0f07b65d01a0373","x5t":"O58S7jwqOVpZIdcOI2NYzjAZ_Mo","cer":"MIIDWjCCAkKgAwIBAgIQctUpPxSzQfCs7x3XFX4e0zANBgkqhkiG9w0BAQsFADAaMRgwFgYDVQQDDA8qLm1pY3Jvc29mdC5jb20wHhcNMTkxMDAyMTg1NTQ1WhcNMjExMDAyMTkwNTQ1WjAaMRgwFgYDVQQDDA8qLm1pY3Jvc29mdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCaY8ZjfEFH6DWaApB6bO1SbAnIKL1fRwEFrtVPMEU0rI9sFtJGVLS/YzmZMbp4H7FYqmfmwytEMglPa4S2woVVHAGoZCqxoFsgWSChVgnYMvaldx5Rn2nRuc6NL08RFn8w2D2MtcJvcDCgQVkqSvecbEvfB4IU5c+VfgQhBZn0RPYfRxMhHI4qZcgIiH7+V7Nkvenxm8qVbE+7IFVBj2Xg7Xq6L2qWu12mwQWr77jSbiQ/ZhYEbiBF1ufPJSOGOUIWA9kpDUDaFlTDlSzKHVdVMnEU8wiUy29jM1y9nIoTdDHKdvX2caLeMbm2jeUZ8obHo/aJyHmQJ6ajlHJCaDDNAgMBAAGjgZswgZgwDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFENETx79TigEX9P0TH3I6v1UWYXjMB0GA1UdDgQWBBRDRE8e/U4oBF/T9Ex9yOr9VFmF4zANBgkqhkiG9w0BAQsFAAOCAQEARkHvQ8aQ0tfNFITomhhSdV4cP/bmu4pUln8Y8dMMMGlsGTQ3vylnjThFueBLyMkxBiQ05ceOezts45rgcg6bGCglBlI4OAqKRhFQwrvrk5LZWDP7voF+lyljz74Mp7VBX9YrEp+AlaRTi/RgcACSvizGqUASNJtNPWtVgaaBTw0LbLJmidsQU+yK4Wn2pXPZoIzD7L+CSZYAMOa+SPcwqP/SxdCrqY1GT1by6pBY/EjPNKsjn3ZXI/nB/guYMCSttBOLaZ7WuhuclC5wzqC1aHcMr5JWxtJ4EIPhd3rQWP9qI34/SnoEdJkUaSTtagpeRXqP0tgH6OWPlgUhGesEaA==","attributes":{"enabled":true,"nbf":1570042545,"exp":1633201545,"created":1570043145,"updated":1570043145,"recoveryLevel":"Purgeable"},"policy":{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.microsoft.com","sans":{"dns_names":["sdk.azure-int.net"]},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":24,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1570043118,"updated":1570043118}},"pending":{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending"}}'
     headers:
       cache-control:
       - no-cache
@@ -344,7 +344,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Sep 2019 20:48:10 GMT
+      - Wed, 02 Oct 2019 19:05:54 GMT
       expires:
       - '-1'
       pragma:
@@ -358,55 +358,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.174.72;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - westus
-      x-ms-keyvault-service-version:
-      - 1.1.0.878
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/pkcs10
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
-    method: GET
-    uri: https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0
-  response:
-    body:
-      string: MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt/ONPj8hXRz9PVMfHNC/+M3wTF6fkqq/kmUwJaBK7ywNXv7i4LXSfMF18rM3Lzetdp4jhCjy7zyHRGYP6xxwOL42F4daAdwgBTZqbVzieBfVTpw7sEKscuQFLlFzEcKOWjLeHFkQ9XVs9IzJWhjIdfcQAlaM0NdFSmtqYsVvzMSUPtqxxrM3NA9rr9fcKYJes72qr/dZch1eax3+jYL3Fko4f34fg+VkUuiL96DVBapErwvmtL1mFuM4dxSIIElTchipqDxO3Dgn9sU5RRdydINWtfpLF3HUj2anGzR/tIEK/A37mgGDYZsJxDvyxR3hv9GZnOARFrI1cp6lVIfzXwIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAKTLGwqvtXIPDBQaQLcFut6yzfdyG90Ie7qryP8w0S//DxNZ2QxFj8DCwF0nyFZvxTDLE+PWsSUeAdN+uQRFlT0M9i6/C6SzFGLN7Qzlk7Pyg8vgqsOeqR54pQ42mTb8FJzMFGsvOaSlR79PUXzRNS+DZFj4y0NdEYfvwQ49D88iiXBy29UtNFQT+0Kqymqjo0eDuH7CoOFqW0Al8BRSyGl7oH+9ZM+zQlhtcfPu6+sFADRmB9VtN2cxxaeQ3pvhX+GIMXf0J+z8/FbvQTzWQcCKnPjDTQGPHvTOLEBikRxOykvus43PAqozCzSAprw2MhPXzDX1YRYbyIXTLAI9/D4=
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '956'
-      content-type:
-      - application/pkcs10; charset=utf-8
-      date:
-      - Wed, 18 Sep 2019 20:48:10 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - addr=131.107.174.72;act_addr_fam=InterNetwork;
+      - addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
@@ -426,12 +378,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: GET
     uri: https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt/ONPj8hXRz9PVMfHNC/+M3wTF6fkqq/kmUwJaBK7ywNXv7i4LXSfMF18rM3Lzetdp4jhCjy7zyHRGYP6xxwOL42F4daAdwgBTZqbVzieBfVTpw7sEKscuQFLlFzEcKOWjLeHFkQ9XVs9IzJWhjIdfcQAlaM0NdFSmtqYsVvzMSUPtqxxrM3NA9rr9fcKYJes72qr/dZch1eax3+jYL3Fko4f34fg+VkUuiL96DVBapErwvmtL1mFuM4dxSIIElTchipqDxO3Dgn9sU5RRdydINWtfpLF3HUj2anGzR/tIEK/A37mgGDYZsJxDvyxR3hv9GZnOARFrI1cp6lVIfzXwIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAKTLGwqvtXIPDBQaQLcFut6yzfdyG90Ie7qryP8w0S//DxNZ2QxFj8DCwF0nyFZvxTDLE+PWsSUeAdN+uQRFlT0M9i6/C6SzFGLN7Qzlk7Pyg8vgqsOeqR54pQ42mTb8FJzMFGsvOaSlR79PUXzRNS+DZFj4y0NdEYfvwQ49D88iiXBy29UtNFQT+0Kqymqjo0eDuH7CoOFqW0Al8BRSyGl7oH+9ZM+zQlhtcfPu6+sFADRmB9VtN2cxxaeQ3pvhX+GIMXf0J+z8/FbvQTzWQcCKnPjDTQGPHvTOLEBikRxOykvus43PAqozCzSAprw2MhPXzDX1YRYbyIXTLAI9/D4=","cancellation_requested":false,"status":"completed","target":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert","request_id":"5e1f4346a50f444a96b78f380473280d"}'
+      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmmPGY3xBR+g1mgKQemztUmwJyCi9X0cBBa7VTzBFNKyPbBbSRlS0v2M5mTG6eB+xWKpn5sMrRDIJT2uEtsKFVRwBqGQqsaBbIFkgoVYJ2DL2pXceUZ9p0bnOjS9PERZ/MNg9jLXCb3AwoEFZKkr3nGxL3weCFOXPlX4EIQWZ9ET2H0cTIRyOKmXICIh+/lezZL3p8ZvKlWxPuyBVQY9l4O16ui9qlrtdpsEFq++40m4kP2YWBG4gRdbnzyUjhjlCFgPZKQ1A2hZUw5Usyh1XVTJxFPMIlMtvYzNcvZyKE3Qxynb19nGi3jG5to3lGfKGx6P2ich5kCemo5RyQmgwzQIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAIM7cWxg6KZJi5UPokLZa65NZmWX7YKyajHabqwudjMVydPXJpbpJiSi4Wt6a/+y74NRyEQvHu+8yNMi+ZKo7Plug6vJgQFVKeGdEHA/tLdsJOF0zCSBjwy95RsiAaKiNYC1AtJnyugvU7FAWOn46ZvBlfB0anNp8ERKvFjBO9f8CHzlzaskJydCSCibBFtLCNEcYrcffA8vGPP/sbm2+3oDIfnP3TcQ8jRpUhli9phgDV9xN8H5u8nmaZ1x5SQCtY5dCVDXc2HHt9tVj1YZ6r3R7S3IxBDkckeF0YCSWo9RDi1Qu3h4aBk3r7RjoTynRahUXvus2hRMLZDrRMyyh3I=","cancellation_requested":false,"status":"completed","target":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert","request_id":"c87f693df850407ba663c14bd18c6dbb"}'
     headers:
       cache-control:
       - no-cache
@@ -440,7 +392,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Sep 2019 20:48:10 GMT
+      - Wed, 02 Oct 2019 19:05:54 GMT
       expires:
       - '-1'
       pragma:
@@ -454,7 +406,55 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.174.72;act_addr_fam=InterNetwork;
+      - addr=167.220.2.94;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.878
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
+    method: GET
+    uri: https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0
+  response:
+    body:
+      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmmPGY3xBR+g1mgKQemztUmwJyCi9X0cBBa7VTzBFNKyPbBbSRlS0v2M5mTG6eB+xWKpn5sMrRDIJT2uEtsKFVRwBqGQqsaBbIFkgoVYJ2DL2pXceUZ9p0bnOjS9PERZ/MNg9jLXCb3AwoEFZKkr3nGxL3weCFOXPlX4EIQWZ9ET2H0cTIRyOKmXICIh+/lezZL3p8ZvKlWxPuyBVQY9l4O16ui9qlrtdpsEFq++40m4kP2YWBG4gRdbnzyUjhjlCFgPZKQ1A2hZUw5Usyh1XVTJxFPMIlMtvYzNcvZyKE3Qxynb19nGi3jG5to3lGfKGx6P2ich5kCemo5RyQmgwzQIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAIM7cWxg6KZJi5UPokLZa65NZmWX7YKyajHabqwudjMVydPXJpbpJiSi4Wt6a/+y74NRyEQvHu+8yNMi+ZKo7Plug6vJgQFVKeGdEHA/tLdsJOF0zCSBjwy95RsiAaKiNYC1AtJnyugvU7FAWOn46ZvBlfB0anNp8ERKvFjBO9f8CHzlzaskJydCSCibBFtLCNEcYrcffA8vGPP/sbm2+3oDIfnP3TcQ8jRpUhli9phgDV9xN8H5u8nmaZ1x5SQCtY5dCVDXc2HHt9tVj1YZ6r3R7S3IxBDkckeF0YCSWo9RDi1Qu3h4aBk3r7RjoTynRahUXvus2hRMLZDrRMyyh3I=","cancellation_requested":false,"status":"completed","target":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert","request_id":"c87f693df850407ba663c14bd18c6dbb"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1255'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 02 Oct 2019 19:05:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
@@ -476,12 +476,12 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: DELETE
     uri: https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/c270665afd194c7ebcb51039a8572e87","kid":"https://vaultdda41c5d.vault.azure.net/keys/unknownIssuerCert/c270665afd194c7ebcb51039a8572e87","sid":"https://vaultdda41c5d.vault.azure.net/secrets/unknownIssuerCert/c270665afd194c7ebcb51039a8572e87","x5t":"HW271xe3p2PaikZi8eoGJ4dhDHU","cer":"MIIDWjCCAkKgAwIBAgIQDGo7vTrrS+megtLlsuxHgzANBgkqhkiG9w0BAQsFADAaMRgwFgYDVQQDDA8qLm1pY3Jvc29mdC5jb20wHhcNMTkwOTE4MjAzODAyWhcNMjEwOTE4MjA0ODAyWjAaMRgwFgYDVQQDDA8qLm1pY3Jvc29mdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3840+PyFdHP09Ux8c0L/4zfBMXp+Sqr+SZTAloErvLA1e/uLgtdJ8wXXyszcvN612niOEKPLvPIdEZg/rHHA4vjYXh1oB3CAFNmptXOJ4F9VOnDuwQqxy5AUuUXMRwo5aMt4cWRD1dWz0jMlaGMh19xACVozQ10VKa2pixW/MxJQ+2rHGszc0D2uv19wpgl6zvaqv91lyHV5rHf6NgvcWSjh/fh+D5WRS6Iv3oNUFqkSvC+a0vWYW4zh3FIggSVNyGKmoPE7cOCf2xTlFF3J0g1a1+ksXcdSPZqcbNH+0gQr8DfuaAYNhmwnEO/LFHeG/0Zmc4BEWsjVynqVUh/NfAgMBAAGjgZswgZgwDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFCBJjUBUdIkR3bGgNsLZIAoTQQDrMB0GA1UdDgQWBBQgSY1AVHSJEd2xoDbC2SAKE0EA6zANBgkqhkiG9w0BAQsFAAOCAQEAqO6fKTw2CAy2RjjaYJXE3L9JC8NpSXvcyYqrUpnJ2Il0yUCAufaEV2Ouoss0+7tsJg2DekPYSWbYk439fSzOfxciG8GcoQuZZVbD+SoLzV6D9NaQgAltnshq/h+eqQp3k+662czUNJRSBXx/t/J7+CrRN9jtgF9ecq+BP3kcWVVvaLrCgivNlcaQ5RFCtcJ+0n6eeK95UICuHwCtc0NxanO3eJabdGu5S5UMhPl30evRSQyK3yHXkhMo3CGLxs8QVvgA8fF2Ofez43SDxJX3oMT5EJJTeQsQhmuhGB7UeLZktZT1AFpM/3ySs2R586dsUNv+IQEARIEr4YUzJ/ksiw==","attributes":{"enabled":true,"nbf":1568839082,"exp":1631998082,"created":1568839682,"updated":1568839682,"recoveryLevel":"Purgeable"},"policy":{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.microsoft.com","sans":{"dns_names":["sdk.azure-int.net"]},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":24,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1568839654,"updated":1568839654}},"pending":{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending"}}'
+      string: '{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/2527ca18b40b42a8a0f07b65d01a0373","kid":"https://vaultdda41c5d.vault.azure.net/keys/unknownIssuerCert/2527ca18b40b42a8a0f07b65d01a0373","sid":"https://vaultdda41c5d.vault.azure.net/secrets/unknownIssuerCert/2527ca18b40b42a8a0f07b65d01a0373","x5t":"O58S7jwqOVpZIdcOI2NYzjAZ_Mo","cer":"MIIDWjCCAkKgAwIBAgIQctUpPxSzQfCs7x3XFX4e0zANBgkqhkiG9w0BAQsFADAaMRgwFgYDVQQDDA8qLm1pY3Jvc29mdC5jb20wHhcNMTkxMDAyMTg1NTQ1WhcNMjExMDAyMTkwNTQ1WjAaMRgwFgYDVQQDDA8qLm1pY3Jvc29mdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCaY8ZjfEFH6DWaApB6bO1SbAnIKL1fRwEFrtVPMEU0rI9sFtJGVLS/YzmZMbp4H7FYqmfmwytEMglPa4S2woVVHAGoZCqxoFsgWSChVgnYMvaldx5Rn2nRuc6NL08RFn8w2D2MtcJvcDCgQVkqSvecbEvfB4IU5c+VfgQhBZn0RPYfRxMhHI4qZcgIiH7+V7Nkvenxm8qVbE+7IFVBj2Xg7Xq6L2qWu12mwQWr77jSbiQ/ZhYEbiBF1ufPJSOGOUIWA9kpDUDaFlTDlSzKHVdVMnEU8wiUy29jM1y9nIoTdDHKdvX2caLeMbm2jeUZ8obHo/aJyHmQJ6ajlHJCaDDNAgMBAAGjgZswgZgwDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFENETx79TigEX9P0TH3I6v1UWYXjMB0GA1UdDgQWBBRDRE8e/U4oBF/T9Ex9yOr9VFmF4zANBgkqhkiG9w0BAQsFAAOCAQEARkHvQ8aQ0tfNFITomhhSdV4cP/bmu4pUln8Y8dMMMGlsGTQ3vylnjThFueBLyMkxBiQ05ceOezts45rgcg6bGCglBlI4OAqKRhFQwrvrk5LZWDP7voF+lyljz74Mp7VBX9YrEp+AlaRTi/RgcACSvizGqUASNJtNPWtVgaaBTw0LbLJmidsQU+yK4Wn2pXPZoIzD7L+CSZYAMOa+SPcwqP/SxdCrqY1GT1by6pBY/EjPNKsjn3ZXI/nB/guYMCSttBOLaZ7WuhuclC5wzqC1aHcMr5JWxtJ4EIPhd3rQWP9qI34/SnoEdJkUaSTtagpeRXqP0tgH6OWPlgUhGesEaA==","attributes":{"enabled":true,"nbf":1570042545,"exp":1633201545,"created":1570043145,"updated":1570043145,"recoveryLevel":"Purgeable"},"policy":{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.microsoft.com","sans":{"dns_names":["sdk.azure-int.net"]},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":24,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1570043118,"updated":1570043118}},"pending":{"id":"https://vaultdda41c5d.vault.azure.net/certificates/unknownIssuerCert/pending"}}'
     headers:
       cache-control:
       - no-cache
@@ -490,7 +490,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Sep 2019 20:48:10 GMT
+      - Wed, 02 Oct 2019 19:05:55 GMT
       expires:
       - '-1'
       pragma:
@@ -504,7 +504,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.174.72;act_addr_fam=InterNetwork;
+      - addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:

--- a/sdk/keyvault/azure-keyvault-certificates/tests/recordings/test_certificates_client_async.test_get_pending_certificate_signing_request.yaml
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/recordings/test_certificates_client_async.test_get_pending_certificate_signing_request.yaml
@@ -9,7 +9,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: POST
     uri: https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/create?api-version=7.0
   response:
@@ -20,7 +20,7 @@ interactions:
       cache-control: no-cache
       content-length: '87'
       content-type: application/json; charset=utf-8
-      date: Wed, 18 Sep 2019 20:48:14 GMT
+      date: Wed, 02 Oct 2019 19:08:05 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-IIS/10.0
@@ -29,7 +29,7 @@ interactions:
         resource="https://vault.azure.net"
       x-aspnet-version: 4.0.30319
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.174.72;act_addr_fam=InterNetwork;
+      x-ms-keyvault-network-info: addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.1.0.878
       x-powered-by: ASP.NET
@@ -45,10 +45,10 @@ interactions:
         - api-version=7.0
         - ''
 - request:
-    body: '{"policy": {"key_props": {"exportable": true, "kty": "RSA", "key_size":
-      2048, "reuse_key": false}, "secret_props": {"contentType": "application/x-pkcs12"},
-      "x509_props": {"subject": "CN=*.microsoft.com", "sans": {"dns_names": ["sdk.azure-int.net"]},
-      "validity_months": 24}, "issuer": {"name": "Self"}}}'
+    body: '{"policy": {"key_props": {"kty": "RSA", "key_size": 2048, "exportable":
+      true, "reuse_key": false}, "issuer": {"name": "Self"}, "x509_props": {"sans":
+      {"dns_names": ["sdk.azure-int.net"]}, "subject": "CN=*.microsoft.com", "validity_months":
+      24}, "secret_props": {"contentType": "application/x-pkcs12"}}}'
     headers:
       Accept:
       - application/json
@@ -57,28 +57,28 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: POST
     uri: https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/create?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqels3Z9HdB7hEBOglj0tvPHfb5RUp64BLg0eejsQBzpODvd7+sMfgQJNYUbkY15/5B1sOVnrspbVL4UzTKnCdAZ3DpzMkemMGlq+vp1g0dSwdwa08JnOnSyifuWu5fmknYKR50pUoMnNzls0n+TI9XPR6Il4sqSRQavsV1povy5NaHNeZv90Ud9e8+D+pc0lm35vi2oeslrPyIOCliSXLYA1mLiFbxrWUjM0tW1Y/8Mz2Fzy6rHe+sujNweef8bTH7RV/7+Srrl3hqVvl7uv0kTHmyz9BbGHQjDCAKUxwgncS8geOkYUwbFEtFfUxtCQxOrzBhxmUoiSnT++siBG6wIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBADqSLli62pOgpQtsNEt60xrDWf4GafdMf4v+O2p3/Z6Opas4chpb+MXAxPMW6DWa1S/iqmtQQk+C7jF8114hximsUVSo25Vzks+Oz8vR2Dkl+YwCdUpv/hFr62WWl/MSJ2D6svPTlRZDcBBn2f1JcucUJWDWs5lt8tXr/GqFW0AuuTyqwFqA5Hnkhny1FBMAZK8VFro0UiaKvRJ5UceTVU3uKQTNcjqHH4VbvKCY1NCpS2H33vTEcoFk1FtVU4wpll/5KUpykpxc2yGaQZ1X4kluyc4UmL+6aiM4LgZCsrnd27KvdJDtZjcDOgB0PfWVbA6xZghFy50XUJbrZMSe7K0=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwsAcpXkyGyexDh98HG3tUQyQhWYFIhjZRBivCUa4597f0eLZDPOHjHmKOXJJnVKdaH6jMJpYZrQtQhmseztK0bjEJ4gv6EHbPhy/jY0iSAUuMUtBuyjgxx6/sLDKIYA0mGFEVqvue6SAJ3UjYBMHxE7Gtkv+sOjL2+anALtuN56mm+OJ3QinHJQWtGW3g7yEiKPVm5LcKLvT4V4QOL8LjgpN+zy3ljDcyrBkdTS898rcooSxH8z0jgvPeYy4NVwFv24W1C5mHTrsaHvrDGINDgzqiObOMQ3n6C5iLO+0fm5bZTz2rSBgB7GURvwHZTs+ssM5mIDY5lW+FET5rGvIpQIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAAXYTq4Q1C+c/CAqigVeHK6iG8WNsYrbZO4CII8AJS0/dQe9TK/IPPFNW4QzO0xxshAdmb2ac4phnag5WIIb7Ce0Nv1UsBQOD/h2CoLtNx7/hR0Qh7cyWG30RlBBeoVF2aOlJy7pDEm0qhgIBSoR2mY4kKGrPNt373GL5AwvFmIy3WgwM/uZvAHSPjuLK5GN+RT6parbpWIUMMsJ8Qi705rChe1NMcjdvjz0cRyyzWT+O/UB7dM7PGpsZniyBb3yoBlsJDxhbIV2wkKAxKm2fCHWnG0hGosIOlSwGxSWzCfKUdPoQzD170iuKnSI4lkQiDbgtsEem815HLW+IZC0/I8=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"3bd60c4c6cc745cd9f97e7f9b0d7742a"}'
+        time based on the issuer provider. Please check again later.","request_id":"8fd5b9cd11ee48d98d34f9c42925cd33"}'
     headers:
       cache-control: no-cache
       content-length: '1340'
       content-type: application/json; charset=utf-8
-      date: Wed, 18 Sep 2019 20:48:15 GMT
+      date: Wed, 02 Oct 2019 19:08:06 GMT
       expires: '-1'
-      location: https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0&request_id=3bd60c4c6cc745cd9f97e7f9b0d7742a
+      location: https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0&request_id=8fd5b9cd11ee48d98d34f9c42925cd33
       pragma: no-cache
       retry-after: '10'
       server: Microsoft-IIS/10.0
       strict-transport-security: max-age=31536000;includeSubDomains
       x-aspnet-version: 4.0.30319
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.174.72;act_addr_fam=InterNetwork;
+      x-ms-keyvault-network-info: addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.1.0.878
       x-powered-by: ASP.NET
@@ -99,19 +99,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: GET
     uri: https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqels3Z9HdB7hEBOglj0tvPHfb5RUp64BLg0eejsQBzpODvd7+sMfgQJNYUbkY15/5B1sOVnrspbVL4UzTKnCdAZ3DpzMkemMGlq+vp1g0dSwdwa08JnOnSyifuWu5fmknYKR50pUoMnNzls0n+TI9XPR6Il4sqSRQavsV1povy5NaHNeZv90Ud9e8+D+pc0lm35vi2oeslrPyIOCliSXLYA1mLiFbxrWUjM0tW1Y/8Mz2Fzy6rHe+sujNweef8bTH7RV/7+Srrl3hqVvl7uv0kTHmyz9BbGHQjDCAKUxwgncS8geOkYUwbFEtFfUxtCQxOrzBhxmUoiSnT++siBG6wIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBADqSLli62pOgpQtsNEt60xrDWf4GafdMf4v+O2p3/Z6Opas4chpb+MXAxPMW6DWa1S/iqmtQQk+C7jF8114hximsUVSo25Vzks+Oz8vR2Dkl+YwCdUpv/hFr62WWl/MSJ2D6svPTlRZDcBBn2f1JcucUJWDWs5lt8tXr/GqFW0AuuTyqwFqA5Hnkhny1FBMAZK8VFro0UiaKvRJ5UceTVU3uKQTNcjqHH4VbvKCY1NCpS2H33vTEcoFk1FtVU4wpll/5KUpykpxc2yGaQZ1X4kluyc4UmL+6aiM4LgZCsrnd27KvdJDtZjcDOgB0PfWVbA6xZghFy50XUJbrZMSe7K0=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwsAcpXkyGyexDh98HG3tUQyQhWYFIhjZRBivCUa4597f0eLZDPOHjHmKOXJJnVKdaH6jMJpYZrQtQhmseztK0bjEJ4gv6EHbPhy/jY0iSAUuMUtBuyjgxx6/sLDKIYA0mGFEVqvue6SAJ3UjYBMHxE7Gtkv+sOjL2+anALtuN56mm+OJ3QinHJQWtGW3g7yEiKPVm5LcKLvT4V4QOL8LjgpN+zy3ljDcyrBkdTS898rcooSxH8z0jgvPeYy4NVwFv24W1C5mHTrsaHvrDGINDgzqiObOMQ3n6C5iLO+0fm5bZTz2rSBgB7GURvwHZTs+ssM5mIDY5lW+FET5rGvIpQIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAAXYTq4Q1C+c/CAqigVeHK6iG8WNsYrbZO4CII8AJS0/dQe9TK/IPPFNW4QzO0xxshAdmb2ac4phnag5WIIb7Ce0Nv1UsBQOD/h2CoLtNx7/hR0Qh7cyWG30RlBBeoVF2aOlJy7pDEm0qhgIBSoR2mY4kKGrPNt373GL5AwvFmIy3WgwM/uZvAHSPjuLK5GN+RT6parbpWIUMMsJ8Qi705rChe1NMcjdvjz0cRyyzWT+O/UB7dM7PGpsZniyBb3yoBlsJDxhbIV2wkKAxKm2fCHWnG0hGosIOlSwGxSWzCfKUdPoQzD170iuKnSI4lkQiDbgtsEem815HLW+IZC0/I8=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"3bd60c4c6cc745cd9f97e7f9b0d7742a"}'
+        time based on the issuer provider. Please check again later.","request_id":"8fd5b9cd11ee48d98d34f9c42925cd33"}'
     headers:
       cache-control: no-cache
       content-length: '1340'
       content-type: application/json; charset=utf-8
-      date: Wed, 18 Sep 2019 20:48:15 GMT
+      date: Wed, 02 Oct 2019 19:08:06 GMT
       expires: '-1'
       pragma: no-cache
       retry-after: '10'
@@ -119,7 +119,7 @@ interactions:
       strict-transport-security: max-age=31536000;includeSubDomains
       x-aspnet-version: 4.0.30319
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.174.72;act_addr_fam=InterNetwork;
+      x-ms-keyvault-network-info: addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.1.0.878
       x-powered-by: ASP.NET
@@ -140,19 +140,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: GET
     uri: https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqels3Z9HdB7hEBOglj0tvPHfb5RUp64BLg0eejsQBzpODvd7+sMfgQJNYUbkY15/5B1sOVnrspbVL4UzTKnCdAZ3DpzMkemMGlq+vp1g0dSwdwa08JnOnSyifuWu5fmknYKR50pUoMnNzls0n+TI9XPR6Il4sqSRQavsV1povy5NaHNeZv90Ud9e8+D+pc0lm35vi2oeslrPyIOCliSXLYA1mLiFbxrWUjM0tW1Y/8Mz2Fzy6rHe+sujNweef8bTH7RV/7+Srrl3hqVvl7uv0kTHmyz9BbGHQjDCAKUxwgncS8geOkYUwbFEtFfUxtCQxOrzBhxmUoiSnT++siBG6wIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBADqSLli62pOgpQtsNEt60xrDWf4GafdMf4v+O2p3/Z6Opas4chpb+MXAxPMW6DWa1S/iqmtQQk+C7jF8114hximsUVSo25Vzks+Oz8vR2Dkl+YwCdUpv/hFr62WWl/MSJ2D6svPTlRZDcBBn2f1JcucUJWDWs5lt8tXr/GqFW0AuuTyqwFqA5Hnkhny1FBMAZK8VFro0UiaKvRJ5UceTVU3uKQTNcjqHH4VbvKCY1NCpS2H33vTEcoFk1FtVU4wpll/5KUpykpxc2yGaQZ1X4kluyc4UmL+6aiM4LgZCsrnd27KvdJDtZjcDOgB0PfWVbA6xZghFy50XUJbrZMSe7K0=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwsAcpXkyGyexDh98HG3tUQyQhWYFIhjZRBivCUa4597f0eLZDPOHjHmKOXJJnVKdaH6jMJpYZrQtQhmseztK0bjEJ4gv6EHbPhy/jY0iSAUuMUtBuyjgxx6/sLDKIYA0mGFEVqvue6SAJ3UjYBMHxE7Gtkv+sOjL2+anALtuN56mm+OJ3QinHJQWtGW3g7yEiKPVm5LcKLvT4V4QOL8LjgpN+zy3ljDcyrBkdTS898rcooSxH8z0jgvPeYy4NVwFv24W1C5mHTrsaHvrDGINDgzqiObOMQ3n6C5iLO+0fm5bZTz2rSBgB7GURvwHZTs+ssM5mIDY5lW+FET5rGvIpQIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAAXYTq4Q1C+c/CAqigVeHK6iG8WNsYrbZO4CII8AJS0/dQe9TK/IPPFNW4QzO0xxshAdmb2ac4phnag5WIIb7Ce0Nv1UsBQOD/h2CoLtNx7/hR0Qh7cyWG30RlBBeoVF2aOlJy7pDEm0qhgIBSoR2mY4kKGrPNt373GL5AwvFmIy3WgwM/uZvAHSPjuLK5GN+RT6parbpWIUMMsJ8Qi705rChe1NMcjdvjz0cRyyzWT+O/UB7dM7PGpsZniyBb3yoBlsJDxhbIV2wkKAxKm2fCHWnG0hGosIOlSwGxSWzCfKUdPoQzD170iuKnSI4lkQiDbgtsEem815HLW+IZC0/I8=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"3bd60c4c6cc745cd9f97e7f9b0d7742a"}'
+        time based on the issuer provider. Please check again later.","request_id":"8fd5b9cd11ee48d98d34f9c42925cd33"}'
     headers:
       cache-control: no-cache
       content-length: '1340'
       content-type: application/json; charset=utf-8
-      date: Wed, 18 Sep 2019 20:48:25 GMT
+      date: Wed, 02 Oct 2019 19:08:17 GMT
       expires: '-1'
       pragma: no-cache
       retry-after: '10'
@@ -160,7 +160,7 @@ interactions:
       strict-transport-security: max-age=31536000;includeSubDomains
       x-aspnet-version: 4.0.30319
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.174.72;act_addr_fam=InterNetwork;
+      x-ms-keyvault-network-info: addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.1.0.878
       x-powered-by: ASP.NET
@@ -181,19 +181,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: GET
     uri: https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqels3Z9HdB7hEBOglj0tvPHfb5RUp64BLg0eejsQBzpODvd7+sMfgQJNYUbkY15/5B1sOVnrspbVL4UzTKnCdAZ3DpzMkemMGlq+vp1g0dSwdwa08JnOnSyifuWu5fmknYKR50pUoMnNzls0n+TI9XPR6Il4sqSRQavsV1povy5NaHNeZv90Ud9e8+D+pc0lm35vi2oeslrPyIOCliSXLYA1mLiFbxrWUjM0tW1Y/8Mz2Fzy6rHe+sujNweef8bTH7RV/7+Srrl3hqVvl7uv0kTHmyz9BbGHQjDCAKUxwgncS8geOkYUwbFEtFfUxtCQxOrzBhxmUoiSnT++siBG6wIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBADqSLli62pOgpQtsNEt60xrDWf4GafdMf4v+O2p3/Z6Opas4chpb+MXAxPMW6DWa1S/iqmtQQk+C7jF8114hximsUVSo25Vzks+Oz8vR2Dkl+YwCdUpv/hFr62WWl/MSJ2D6svPTlRZDcBBn2f1JcucUJWDWs5lt8tXr/GqFW0AuuTyqwFqA5Hnkhny1FBMAZK8VFro0UiaKvRJ5UceTVU3uKQTNcjqHH4VbvKCY1NCpS2H33vTEcoFk1FtVU4wpll/5KUpykpxc2yGaQZ1X4kluyc4UmL+6aiM4LgZCsrnd27KvdJDtZjcDOgB0PfWVbA6xZghFy50XUJbrZMSe7K0=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwsAcpXkyGyexDh98HG3tUQyQhWYFIhjZRBivCUa4597f0eLZDPOHjHmKOXJJnVKdaH6jMJpYZrQtQhmseztK0bjEJ4gv6EHbPhy/jY0iSAUuMUtBuyjgxx6/sLDKIYA0mGFEVqvue6SAJ3UjYBMHxE7Gtkv+sOjL2+anALtuN56mm+OJ3QinHJQWtGW3g7yEiKPVm5LcKLvT4V4QOL8LjgpN+zy3ljDcyrBkdTS898rcooSxH8z0jgvPeYy4NVwFv24W1C5mHTrsaHvrDGINDgzqiObOMQ3n6C5iLO+0fm5bZTz2rSBgB7GURvwHZTs+ssM5mIDY5lW+FET5rGvIpQIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAAXYTq4Q1C+c/CAqigVeHK6iG8WNsYrbZO4CII8AJS0/dQe9TK/IPPFNW4QzO0xxshAdmb2ac4phnag5WIIb7Ce0Nv1UsBQOD/h2CoLtNx7/hR0Qh7cyWG30RlBBeoVF2aOlJy7pDEm0qhgIBSoR2mY4kKGrPNt373GL5AwvFmIy3WgwM/uZvAHSPjuLK5GN+RT6parbpWIUMMsJ8Qi705rChe1NMcjdvjz0cRyyzWT+O/UB7dM7PGpsZniyBb3yoBlsJDxhbIV2wkKAxKm2fCHWnG0hGosIOlSwGxSWzCfKUdPoQzD170iuKnSI4lkQiDbgtsEem815HLW+IZC0/I8=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"3bd60c4c6cc745cd9f97e7f9b0d7742a"}'
+        time based on the issuer provider. Please check again later.","request_id":"8fd5b9cd11ee48d98d34f9c42925cd33"}'
     headers:
       cache-control: no-cache
       content-length: '1340'
       content-type: application/json; charset=utf-8
-      date: Wed, 18 Sep 2019 20:48:36 GMT
+      date: Wed, 02 Oct 2019 19:08:27 GMT
       expires: '-1'
       pragma: no-cache
       retry-after: '10'
@@ -201,7 +201,7 @@ interactions:
       strict-transport-security: max-age=31536000;includeSubDomains
       x-aspnet-version: 4.0.30319
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.174.72;act_addr_fam=InterNetwork;
+      x-ms-keyvault-network-info: addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.1.0.878
       x-powered-by: ASP.NET
@@ -222,19 +222,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: GET
     uri: https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqels3Z9HdB7hEBOglj0tvPHfb5RUp64BLg0eejsQBzpODvd7+sMfgQJNYUbkY15/5B1sOVnrspbVL4UzTKnCdAZ3DpzMkemMGlq+vp1g0dSwdwa08JnOnSyifuWu5fmknYKR50pUoMnNzls0n+TI9XPR6Il4sqSRQavsV1povy5NaHNeZv90Ud9e8+D+pc0lm35vi2oeslrPyIOCliSXLYA1mLiFbxrWUjM0tW1Y/8Mz2Fzy6rHe+sujNweef8bTH7RV/7+Srrl3hqVvl7uv0kTHmyz9BbGHQjDCAKUxwgncS8geOkYUwbFEtFfUxtCQxOrzBhxmUoiSnT++siBG6wIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBADqSLli62pOgpQtsNEt60xrDWf4GafdMf4v+O2p3/Z6Opas4chpb+MXAxPMW6DWa1S/iqmtQQk+C7jF8114hximsUVSo25Vzks+Oz8vR2Dkl+YwCdUpv/hFr62WWl/MSJ2D6svPTlRZDcBBn2f1JcucUJWDWs5lt8tXr/GqFW0AuuTyqwFqA5Hnkhny1FBMAZK8VFro0UiaKvRJ5UceTVU3uKQTNcjqHH4VbvKCY1NCpS2H33vTEcoFk1FtVU4wpll/5KUpykpxc2yGaQZ1X4kluyc4UmL+6aiM4LgZCsrnd27KvdJDtZjcDOgB0PfWVbA6xZghFy50XUJbrZMSe7K0=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwsAcpXkyGyexDh98HG3tUQyQhWYFIhjZRBivCUa4597f0eLZDPOHjHmKOXJJnVKdaH6jMJpYZrQtQhmseztK0bjEJ4gv6EHbPhy/jY0iSAUuMUtBuyjgxx6/sLDKIYA0mGFEVqvue6SAJ3UjYBMHxE7Gtkv+sOjL2+anALtuN56mm+OJ3QinHJQWtGW3g7yEiKPVm5LcKLvT4V4QOL8LjgpN+zy3ljDcyrBkdTS898rcooSxH8z0jgvPeYy4NVwFv24W1C5mHTrsaHvrDGINDgzqiObOMQ3n6C5iLO+0fm5bZTz2rSBgB7GURvwHZTs+ssM5mIDY5lW+FET5rGvIpQIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAAXYTq4Q1C+c/CAqigVeHK6iG8WNsYrbZO4CII8AJS0/dQe9TK/IPPFNW4QzO0xxshAdmb2ac4phnag5WIIb7Ce0Nv1UsBQOD/h2CoLtNx7/hR0Qh7cyWG30RlBBeoVF2aOlJy7pDEm0qhgIBSoR2mY4kKGrPNt373GL5AwvFmIy3WgwM/uZvAHSPjuLK5GN+RT6parbpWIUMMsJ8Qi705rChe1NMcjdvjz0cRyyzWT+O/UB7dM7PGpsZniyBb3yoBlsJDxhbIV2wkKAxKm2fCHWnG0hGosIOlSwGxSWzCfKUdPoQzD170iuKnSI4lkQiDbgtsEem815HLW+IZC0/I8=","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"3bd60c4c6cc745cd9f97e7f9b0d7742a"}'
+        time based on the issuer provider. Please check again later.","request_id":"8fd5b9cd11ee48d98d34f9c42925cd33"}'
     headers:
       cache-control: no-cache
       content-length: '1340'
       content-type: application/json; charset=utf-8
-      date: Wed, 18 Sep 2019 20:48:46 GMT
+      date: Wed, 02 Oct 2019 19:08:36 GMT
       expires: '-1'
       pragma: no-cache
       retry-after: '10'
@@ -242,7 +242,7 @@ interactions:
       strict-transport-security: max-age=31536000;includeSubDomains
       x-aspnet-version: 4.0.30319
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.174.72;act_addr_fam=InterNetwork;
+      x-ms-keyvault-network-info: addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.1.0.878
       x-powered-by: ASP.NET
@@ -263,24 +263,24 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: GET
     uri: https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqels3Z9HdB7hEBOglj0tvPHfb5RUp64BLg0eejsQBzpODvd7+sMfgQJNYUbkY15/5B1sOVnrspbVL4UzTKnCdAZ3DpzMkemMGlq+vp1g0dSwdwa08JnOnSyifuWu5fmknYKR50pUoMnNzls0n+TI9XPR6Il4sqSRQavsV1povy5NaHNeZv90Ud9e8+D+pc0lm35vi2oeslrPyIOCliSXLYA1mLiFbxrWUjM0tW1Y/8Mz2Fzy6rHe+sujNweef8bTH7RV/7+Srrl3hqVvl7uv0kTHmyz9BbGHQjDCAKUxwgncS8geOkYUwbFEtFfUxtCQxOrzBhxmUoiSnT++siBG6wIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBADqSLli62pOgpQtsNEt60xrDWf4GafdMf4v+O2p3/Z6Opas4chpb+MXAxPMW6DWa1S/iqmtQQk+C7jF8114hximsUVSo25Vzks+Oz8vR2Dkl+YwCdUpv/hFr62WWl/MSJ2D6svPTlRZDcBBn2f1JcucUJWDWs5lt8tXr/GqFW0AuuTyqwFqA5Hnkhny1FBMAZK8VFro0UiaKvRJ5UceTVU3uKQTNcjqHH4VbvKCY1NCpS2H33vTEcoFk1FtVU4wpll/5KUpykpxc2yGaQZ1X4kluyc4UmL+6aiM4LgZCsrnd27KvdJDtZjcDOgB0PfWVbA6xZghFy50XUJbrZMSe7K0=","cancellation_requested":false,"status":"completed","target":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert","request_id":"3bd60c4c6cc745cd9f97e7f9b0d7742a"}'
+      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwsAcpXkyGyexDh98HG3tUQyQhWYFIhjZRBivCUa4597f0eLZDPOHjHmKOXJJnVKdaH6jMJpYZrQtQhmseztK0bjEJ4gv6EHbPhy/jY0iSAUuMUtBuyjgxx6/sLDKIYA0mGFEVqvue6SAJ3UjYBMHxE7Gtkv+sOjL2+anALtuN56mm+OJ3QinHJQWtGW3g7yEiKPVm5LcKLvT4V4QOL8LjgpN+zy3ljDcyrBkdTS898rcooSxH8z0jgvPeYy4NVwFv24W1C5mHTrsaHvrDGINDgzqiObOMQ3n6C5iLO+0fm5bZTz2rSBgB7GURvwHZTs+ssM5mIDY5lW+FET5rGvIpQIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAAXYTq4Q1C+c/CAqigVeHK6iG8WNsYrbZO4CII8AJS0/dQe9TK/IPPFNW4QzO0xxshAdmb2ac4phnag5WIIb7Ce0Nv1UsBQOD/h2CoLtNx7/hR0Qh7cyWG30RlBBeoVF2aOlJy7pDEm0qhgIBSoR2mY4kKGrPNt373GL5AwvFmIy3WgwM/uZvAHSPjuLK5GN+RT6parbpWIUMMsJ8Qi705rChe1NMcjdvjz0cRyyzWT+O/UB7dM7PGpsZniyBb3yoBlsJDxhbIV2wkKAxKm2fCHWnG0hGosIOlSwGxSWzCfKUdPoQzD170iuKnSI4lkQiDbgtsEem815HLW+IZC0/I8=","cancellation_requested":false,"status":"completed","target":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert","request_id":"8fd5b9cd11ee48d98d34f9c42925cd33"}'
     headers:
       cache-control: no-cache
       content-length: '1255'
       content-type: application/json; charset=utf-8
-      date: Wed, 18 Sep 2019 20:48:50 GMT
+      date: Wed, 02 Oct 2019 19:08:42 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-IIS/10.0
       strict-transport-security: max-age=31536000;includeSubDomains
       x-aspnet-version: 4.0.30319
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.174.72;act_addr_fam=InterNetwork;
+      x-ms-keyvault-network-info: addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.1.0.878
       x-powered-by: ASP.NET
@@ -301,24 +301,24 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: GET
     uri: https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/b6a44e4cd90e4f72b2f2f5e242283195","kid":"https://vault91f91eda.vault.azure.net/keys/unknownIssuerCert/b6a44e4cd90e4f72b2f2f5e242283195","sid":"https://vault91f91eda.vault.azure.net/secrets/unknownIssuerCert/b6a44e4cd90e4f72b2f2f5e242283195","x5t":"YQY1vmj7iynajXAcAi4C8HY-R0A","cer":"MIIDWjCCAkKgAwIBAgIQTwSLVHAhTluHlts5rdRYjDANBgkqhkiG9w0BAQsFADAaMRgwFgYDVQQDDA8qLm1pY3Jvc29mdC5jb20wHhcNMTkwOTE4MjAzODQ2WhcNMjEwOTE4MjA0ODQ2WjAaMRgwFgYDVQQDDA8qLm1pY3Jvc29mdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCp6Wzdn0d0HuEQE6CWPS288d9vlFSnrgEuDR56OxAHOk4O93v6wx+BAk1hRuRjXn/kHWw5WeuyltUvhTNMqcJ0BncOnMyR6YwaWr6+nWDR1LB3BrTwmc6dLKJ+5a7l+aSdgpHnSlSgyc3OWzSf5Mj1c9HoiXiypJFBq+xXWmi/Lk1oc15m/3RR317z4P6lzSWbfm+Lah6yWs/Ig4KWJJctgDWYuIVvGtZSMzS1bVj/wzPYXPLqsd76y6M3B55/xtMftFX/v5KuuXeGpW+Xu6/SRMebLP0FsYdCMMIApTHCCdxLyB46RhTBsUS0V9TG0JDE6vMGHGZSiJKdP76yIEbrAgMBAAGjgZswgZgwDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFB9EsorU/rhqTn3U9UG50FC+XlofMB0GA1UdDgQWBBQfRLKK1P64ak591PVBudBQvl5aHzANBgkqhkiG9w0BAQsFAAOCAQEATqRR0IMCv+5rfbEpLh9gulp+9X2AUtsS+8ngQjSciNujrjxnm0af44WD8gctHh5uh6LbraSh4/ympi0dSFyogaZmX4qeycoMu7LLE4g0Y1jktxGAoD/YKcHtQyalyeV8i2Q94ZCXekstmqqXw3/PRtlJFZiu1QyhUdbztyL11+jfC5Pal5VU7Ukiih0h1EqNp+rU1pWSgAvFZTAaAN9mkEutwYbkDd7SJWoBG3rl+RUdbiKFIhuMlKhioac83tJIlwgez+MquwQMZHNGNgDNgDhji8+VhJMv/3WW6lAopyWNFVynmF1tPDGqDSTIJjRno9VsTpLAeu2SBm/FGF5q5A==","attributes":{"enabled":true,"nbf":1568839126,"exp":1631998126,"created":1568839726,"updated":1568839726,"recoveryLevel":"Purgeable"},"policy":{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.microsoft.com","sans":{"dns_names":["sdk.azure-int.net"]},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":24,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1568839696,"updated":1568839696}},"pending":{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending"}}'
+      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/c7afdeda9f7246d3acd52f9c0a244e60","kid":"https://vault91f91eda.vault.azure.net/keys/unknownIssuerCert/c7afdeda9f7246d3acd52f9c0a244e60","sid":"https://vault91f91eda.vault.azure.net/secrets/unknownIssuerCert/c7afdeda9f7246d3acd52f9c0a244e60","x5t":"DyAxPoE4vlhIteS9Nsbd4ErGJzg","cer":"MIIDWjCCAkKgAwIBAgIQHzrNcfwnQpSk01mb4VpzMzANBgkqhkiG9w0BAQsFADAaMRgwFgYDVQQDDA8qLm1pY3Jvc29mdC5jb20wHhcNMTkxMDAyMTg1ODM5WhcNMjExMDAyMTkwODM5WjAaMRgwFgYDVQQDDA8qLm1pY3Jvc29mdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDCwByleTIbJ7EOH3wcbe1RDJCFZgUiGNlEGK8JRrjn3t/R4tkM84eMeYo5ckmdUp1ofqMwmlhmtC1CGax7O0rRuMQniC/oQds+HL+NjSJIBS4xS0G7KODHHr+wsMohgDSYYURWq+57pIAndSNgEwfETsa2S/6w6Mvb5qcAu243nqab44ndCKcclBa0ZbeDvISIo9Wbktwou9PhXhA4vwuOCk37PLeWMNzKsGR1NLz3ytyihLEfzPSOC895jLg1XAW/bhbULmYdOuxoe+sMYg0ODOqI5s4xDefoLmIs77R+bltlPPatIGAHsZRG/AdlOz6ywzmYgNjmVb4URPmsa8ilAgMBAAGjgZswgZgwDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFOQkt47pJayv/CSd+tWoghUUL7DGMB0GA1UdDgQWBBTkJLeO6SWsr/wknfrVqIIVFC+wxjANBgkqhkiG9w0BAQsFAAOCAQEAmjTwwrden80dOkZDxUxXUGZ4VuT6I9xOJbddhaRLGRTpKl0tj2Dh2//kUK+fUzQeJ7FXA5xnyTzDZTCJLsRNqCoxBoUboG9kLNbvulw7D/TuN8rxxYlHOwu6MCJZIMoy1kIQV3UA3KN7nv8bme1DyJSQiKfgeKd/hfcOskpWFyCVCBB6PbW1t1L1TK5QO92QJZHtXaVP6nhSv11PZ9STHYW89C2TmcBZoSg6BZD4G1HlvtikR8UH58ExruSVtOm3Y0FB2/LFV7UX3RfrUDx29zFPMF4mlq4+8jBOPB8cyJrufb1kf04NBmQ5PXA717ijgKYAk7OrZNv+OV7OcGRgWg==","attributes":{"enabled":true,"nbf":1570042719,"exp":1633201719,"created":1570043319,"updated":1570043319,"recoveryLevel":"Purgeable"},"policy":{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.microsoft.com","sans":{"dns_names":["sdk.azure-int.net"]},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":24,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1570043286,"updated":1570043286}},"pending":{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending"}}'
     headers:
       cache-control: no-cache
       content-length: '2407'
       content-type: application/json; charset=utf-8
-      date: Wed, 18 Sep 2019 20:48:55 GMT
+      date: Wed, 02 Oct 2019 19:08:47 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-IIS/10.0
       strict-transport-security: max-age=31536000;includeSubDomains
       x-aspnet-version: 4.0.30319
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.174.72;act_addr_fam=InterNetwork;
+      x-ms-keyvault-network-info: addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.1.0.878
       x-powered-by: ASP.NET
@@ -337,64 +337,26 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/pkcs10
-      User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
-    method: GET
-    uri: https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0
-  response:
-    body:
-      string: MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqels3Z9HdB7hEBOglj0tvPHfb5RUp64BLg0eejsQBzpODvd7+sMfgQJNYUbkY15/5B1sOVnrspbVL4UzTKnCdAZ3DpzMkemMGlq+vp1g0dSwdwa08JnOnSyifuWu5fmknYKR50pUoMnNzls0n+TI9XPR6Il4sqSRQavsV1povy5NaHNeZv90Ud9e8+D+pc0lm35vi2oeslrPyIOCliSXLYA1mLiFbxrWUjM0tW1Y/8Mz2Fzy6rHe+sujNweef8bTH7RV/7+Srrl3hqVvl7uv0kTHmyz9BbGHQjDCAKUxwgncS8geOkYUwbFEtFfUxtCQxOrzBhxmUoiSnT++siBG6wIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBADqSLli62pOgpQtsNEt60xrDWf4GafdMf4v+O2p3/Z6Opas4chpb+MXAxPMW6DWa1S/iqmtQQk+C7jF8114hximsUVSo25Vzks+Oz8vR2Dkl+YwCdUpv/hFr62WWl/MSJ2D6svPTlRZDcBBn2f1JcucUJWDWs5lt8tXr/GqFW0AuuTyqwFqA5Hnkhny1FBMAZK8VFro0UiaKvRJ5UceTVU3uKQTNcjqHH4VbvKCY1NCpS2H33vTEcoFk1FtVU4wpll/5KUpykpxc2yGaQZ1X4kluyc4UmL+6aiM4LgZCsrnd27KvdJDtZjcDOgB0PfWVbA6xZghFy50XUJbrZMSe7K0=
-    headers:
-      cache-control: no-cache
-      content-length: '956'
-      content-type: application/pkcs10; charset=utf-8
-      date: Wed, 18 Sep 2019 20:48:55 GMT
-      expires: '-1'
-      pragma: no-cache
-      server: Microsoft-IIS/10.0
-      strict-transport-security: max-age=31536000;includeSubDomains
-      x-aspnet-version: 4.0.30319
-      x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.174.72;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.1.0.878
-      x-powered-by: ASP.NET
-    status:
-      code: 200
-      message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - vault91f91eda.vault.azure.net
-        - /certificates/unknownIssuerCert/pending
-        - api-version=7.0
-        - ''
-- request:
-    body: null
-    headers:
-      Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
     method: GET
     uri: https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqels3Z9HdB7hEBOglj0tvPHfb5RUp64BLg0eejsQBzpODvd7+sMfgQJNYUbkY15/5B1sOVnrspbVL4UzTKnCdAZ3DpzMkemMGlq+vp1g0dSwdwa08JnOnSyifuWu5fmknYKR50pUoMnNzls0n+TI9XPR6Il4sqSRQavsV1povy5NaHNeZv90Ud9e8+D+pc0lm35vi2oeslrPyIOCliSXLYA1mLiFbxrWUjM0tW1Y/8Mz2Fzy6rHe+sujNweef8bTH7RV/7+Srrl3hqVvl7uv0kTHmyz9BbGHQjDCAKUxwgncS8geOkYUwbFEtFfUxtCQxOrzBhxmUoiSnT++siBG6wIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBADqSLli62pOgpQtsNEt60xrDWf4GafdMf4v+O2p3/Z6Opas4chpb+MXAxPMW6DWa1S/iqmtQQk+C7jF8114hximsUVSo25Vzks+Oz8vR2Dkl+YwCdUpv/hFr62WWl/MSJ2D6svPTlRZDcBBn2f1JcucUJWDWs5lt8tXr/GqFW0AuuTyqwFqA5Hnkhny1FBMAZK8VFro0UiaKvRJ5UceTVU3uKQTNcjqHH4VbvKCY1NCpS2H33vTEcoFk1FtVU4wpll/5KUpykpxc2yGaQZ1X4kluyc4UmL+6aiM4LgZCsrnd27KvdJDtZjcDOgB0PfWVbA6xZghFy50XUJbrZMSe7K0=","cancellation_requested":false,"status":"completed","target":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert","request_id":"3bd60c4c6cc745cd9f97e7f9b0d7742a"}'
+      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwsAcpXkyGyexDh98HG3tUQyQhWYFIhjZRBivCUa4597f0eLZDPOHjHmKOXJJnVKdaH6jMJpYZrQtQhmseztK0bjEJ4gv6EHbPhy/jY0iSAUuMUtBuyjgxx6/sLDKIYA0mGFEVqvue6SAJ3UjYBMHxE7Gtkv+sOjL2+anALtuN56mm+OJ3QinHJQWtGW3g7yEiKPVm5LcKLvT4V4QOL8LjgpN+zy3ljDcyrBkdTS898rcooSxH8z0jgvPeYy4NVwFv24W1C5mHTrsaHvrDGINDgzqiObOMQ3n6C5iLO+0fm5bZTz2rSBgB7GURvwHZTs+ssM5mIDY5lW+FET5rGvIpQIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAAXYTq4Q1C+c/CAqigVeHK6iG8WNsYrbZO4CII8AJS0/dQe9TK/IPPFNW4QzO0xxshAdmb2ac4phnag5WIIb7Ce0Nv1UsBQOD/h2CoLtNx7/hR0Qh7cyWG30RlBBeoVF2aOlJy7pDEm0qhgIBSoR2mY4kKGrPNt373GL5AwvFmIy3WgwM/uZvAHSPjuLK5GN+RT6parbpWIUMMsJ8Qi705rChe1NMcjdvjz0cRyyzWT+O/UB7dM7PGpsZniyBb3yoBlsJDxhbIV2wkKAxKm2fCHWnG0hGosIOlSwGxSWzCfKUdPoQzD170iuKnSI4lkQiDbgtsEem815HLW+IZC0/I8=","cancellation_requested":false,"status":"completed","target":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert","request_id":"8fd5b9cd11ee48d98d34f9c42925cd33"}'
     headers:
       cache-control: no-cache
       content-length: '1255'
       content-type: application/json; charset=utf-8
-      date: Wed, 18 Sep 2019 20:48:56 GMT
+      date: Wed, 02 Oct 2019 19:08:47 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-IIS/10.0
       strict-transport-security: max-age=31536000;includeSubDomains
       x-aspnet-version: 4.0.30319
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.174.72;act_addr_fam=InterNetwork;
+      x-ms-keyvault-network-info: addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.1.0.878
       x-powered-by: ASP.NET
@@ -415,24 +377,62 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.6.6 (Windows-10-10.0.18362-SP0)
-    method: DELETE
-    uri: https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert?api-version=7.0
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
+    method: GET
+    uri: https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending?api-version=7.0
   response:
     body:
-      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/b6a44e4cd90e4f72b2f2f5e242283195","kid":"https://vault91f91eda.vault.azure.net/keys/unknownIssuerCert/b6a44e4cd90e4f72b2f2f5e242283195","sid":"https://vault91f91eda.vault.azure.net/secrets/unknownIssuerCert/b6a44e4cd90e4f72b2f2f5e242283195","x5t":"YQY1vmj7iynajXAcAi4C8HY-R0A","cer":"MIIDWjCCAkKgAwIBAgIQTwSLVHAhTluHlts5rdRYjDANBgkqhkiG9w0BAQsFADAaMRgwFgYDVQQDDA8qLm1pY3Jvc29mdC5jb20wHhcNMTkwOTE4MjAzODQ2WhcNMjEwOTE4MjA0ODQ2WjAaMRgwFgYDVQQDDA8qLm1pY3Jvc29mdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCp6Wzdn0d0HuEQE6CWPS288d9vlFSnrgEuDR56OxAHOk4O93v6wx+BAk1hRuRjXn/kHWw5WeuyltUvhTNMqcJ0BncOnMyR6YwaWr6+nWDR1LB3BrTwmc6dLKJ+5a7l+aSdgpHnSlSgyc3OWzSf5Mj1c9HoiXiypJFBq+xXWmi/Lk1oc15m/3RR317z4P6lzSWbfm+Lah6yWs/Ig4KWJJctgDWYuIVvGtZSMzS1bVj/wzPYXPLqsd76y6M3B55/xtMftFX/v5KuuXeGpW+Xu6/SRMebLP0FsYdCMMIApTHCCdxLyB46RhTBsUS0V9TG0JDE6vMGHGZSiJKdP76yIEbrAgMBAAGjgZswgZgwDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFB9EsorU/rhqTn3U9UG50FC+XlofMB0GA1UdDgQWBBQfRLKK1P64ak591PVBudBQvl5aHzANBgkqhkiG9w0BAQsFAAOCAQEATqRR0IMCv+5rfbEpLh9gulp+9X2AUtsS+8ngQjSciNujrjxnm0af44WD8gctHh5uh6LbraSh4/ympi0dSFyogaZmX4qeycoMu7LLE4g0Y1jktxGAoD/YKcHtQyalyeV8i2Q94ZCXekstmqqXw3/PRtlJFZiu1QyhUdbztyL11+jfC5Pal5VU7Ukiih0h1EqNp+rU1pWSgAvFZTAaAN9mkEutwYbkDd7SJWoBG3rl+RUdbiKFIhuMlKhioac83tJIlwgez+MquwQMZHNGNgDNgDhji8+VhJMv/3WW6lAopyWNFVynmF1tPDGqDSTIJjRno9VsTpLAeu2SBm/FGF5q5A==","attributes":{"enabled":true,"nbf":1568839126,"exp":1631998126,"created":1568839726,"updated":1568839726,"recoveryLevel":"Purgeable"},"policy":{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.microsoft.com","sans":{"dns_names":["sdk.azure-int.net"]},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":24,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1568839696,"updated":1568839696}},"pending":{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending"}}'
+      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending","issuer":{"name":"Self"},"csr":"MIICyDCCAbACAQAwGjEYMBYGA1UEAwwPKi5taWNyb3NvZnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwsAcpXkyGyexDh98HG3tUQyQhWYFIhjZRBivCUa4597f0eLZDPOHjHmKOXJJnVKdaH6jMJpYZrQtQhmseztK0bjEJ4gv6EHbPhy/jY0iSAUuMUtBuyjgxx6/sLDKIYA0mGFEVqvue6SAJ3UjYBMHxE7Gtkv+sOjL2+anALtuN56mm+OJ3QinHJQWtGW3g7yEiKPVm5LcKLvT4V4QOL8LjgpN+zy3ljDcyrBkdTS898rcooSxH8z0jgvPeYy4NVwFv24W1C5mHTrsaHvrDGINDgzqiObOMQ3n6C5iLO+0fm5bZTz2rSBgB7GURvwHZTs+ssM5mIDY5lW+FET5rGvIpQIDAQABoGkwZwYJKoZIhvcNAQkOMVowWDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAAXYTq4Q1C+c/CAqigVeHK6iG8WNsYrbZO4CII8AJS0/dQe9TK/IPPFNW4QzO0xxshAdmb2ac4phnag5WIIb7Ce0Nv1UsBQOD/h2CoLtNx7/hR0Qh7cyWG30RlBBeoVF2aOlJy7pDEm0qhgIBSoR2mY4kKGrPNt373GL5AwvFmIy3WgwM/uZvAHSPjuLK5GN+RT6parbpWIUMMsJ8Qi705rChe1NMcjdvjz0cRyyzWT+O/UB7dM7PGpsZniyBb3yoBlsJDxhbIV2wkKAxKm2fCHWnG0hGosIOlSwGxSWzCfKUdPoQzD170iuKnSI4lkQiDbgtsEem815HLW+IZC0/I8=","cancellation_requested":false,"status":"completed","target":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert","request_id":"8fd5b9cd11ee48d98d34f9c42925cd33"}'
     headers:
       cache-control: no-cache
-      content-length: '2407'
+      content-length: '1255'
       content-type: application/json; charset=utf-8
-      date: Wed, 18 Sep 2019 20:48:56 GMT
+      date: Wed, 02 Oct 2019 19:08:47 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-IIS/10.0
       strict-transport-security: max-age=31536000;includeSubDomains
       x-aspnet-version: 4.0.30319
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.174.72;act_addr_fam=InterNetwork;
+      x-ms-keyvault-network-info: addr=167.220.2.94;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.1.0.878
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: !!python/object/new:yarl.URL
+      state: !!python/tuple
+      - !!python/object/new:urllib.parse.SplitResult
+        - https
+        - vault91f91eda.vault.azure.net
+        - /certificates/unknownIssuerCert/pending
+        - api-version=7.0
+        - ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.0.0b4 Python/3.5.4 (Windows-10-10.0.18362-SP0)
+    method: DELETE
+    uri: https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert?api-version=7.0
+  response:
+    body:
+      string: '{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/c7afdeda9f7246d3acd52f9c0a244e60","kid":"https://vault91f91eda.vault.azure.net/keys/unknownIssuerCert/c7afdeda9f7246d3acd52f9c0a244e60","sid":"https://vault91f91eda.vault.azure.net/secrets/unknownIssuerCert/c7afdeda9f7246d3acd52f9c0a244e60","x5t":"DyAxPoE4vlhIteS9Nsbd4ErGJzg","cer":"MIIDWjCCAkKgAwIBAgIQHzrNcfwnQpSk01mb4VpzMzANBgkqhkiG9w0BAQsFADAaMRgwFgYDVQQDDA8qLm1pY3Jvc29mdC5jb20wHhcNMTkxMDAyMTg1ODM5WhcNMjExMDAyMTkwODM5WjAaMRgwFgYDVQQDDA8qLm1pY3Jvc29mdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDCwByleTIbJ7EOH3wcbe1RDJCFZgUiGNlEGK8JRrjn3t/R4tkM84eMeYo5ckmdUp1ofqMwmlhmtC1CGax7O0rRuMQniC/oQds+HL+NjSJIBS4xS0G7KODHHr+wsMohgDSYYURWq+57pIAndSNgEwfETsa2S/6w6Mvb5qcAu243nqab44ndCKcclBa0ZbeDvISIo9Wbktwou9PhXhA4vwuOCk37PLeWMNzKsGR1NLz3ytyihLEfzPSOC895jLg1XAW/bhbULmYdOuxoe+sMYg0ODOqI5s4xDefoLmIs77R+bltlPPatIGAHsZRG/AdlOz6ywzmYgNjmVb4URPmsa8ilAgMBAAGjgZswgZgwDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMBwGA1UdEQQVMBOCEXNkay5henVyZS1pbnQubmV0MB8GA1UdIwQYMBaAFOQkt47pJayv/CSd+tWoghUUL7DGMB0GA1UdDgQWBBTkJLeO6SWsr/wknfrVqIIVFC+wxjANBgkqhkiG9w0BAQsFAAOCAQEAmjTwwrden80dOkZDxUxXUGZ4VuT6I9xOJbddhaRLGRTpKl0tj2Dh2//kUK+fUzQeJ7FXA5xnyTzDZTCJLsRNqCoxBoUboG9kLNbvulw7D/TuN8rxxYlHOwu6MCJZIMoy1kIQV3UA3KN7nv8bme1DyJSQiKfgeKd/hfcOskpWFyCVCBB6PbW1t1L1TK5QO92QJZHtXaVP6nhSv11PZ9STHYW89C2TmcBZoSg6BZD4G1HlvtikR8UH58ExruSVtOm3Y0FB2/LFV7UX3RfrUDx29zFPMF4mlq4+8jBOPB8cyJrufb1kf04NBmQ5PXA717ijgKYAk7OrZNv+OV7OcGRgWg==","attributes":{"enabled":true,"nbf":1570042719,"exp":1633201719,"created":1570043319,"updated":1570043319,"recoveryLevel":"Purgeable"},"policy":{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.microsoft.com","sans":{"dns_names":["sdk.azure-int.net"]},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":24,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1570043286,"updated":1570043286}},"pending":{"id":"https://vault91f91eda.vault.azure.net/certificates/unknownIssuerCert/pending"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '2407'
+      content-type: application/json; charset=utf-8
+      date: Wed, 02 Oct 2019 19:08:48 GMT
+      expires: '-1'
+      pragma: no-cache
+      server: Microsoft-IIS/10.0
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-aspnet-version: 4.0.30319
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: addr=167.220.2.94;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
       x-ms-keyvault-service-version: 1.1.0.878
       x-powered-by: ASP.NET

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
@@ -516,11 +516,11 @@ class CertificateClientTests(KeyVaultTestCase):
             ),
         )
 
-        # get pending certiificate signing request
+        # get pending certificate signing request
         certificate = client.create_certificate(
             name=cert_name, policy=CertificatePolicy._from_certificate_policy_bundle(cert_policy)
         ).wait()
-        pending_version_csr = client.get_pending_certificate_signing_request(name=cert_name)
+        pending_version_csr = client.get_certificate_operation(name=cert_name).csr
         try:
             self.assertEqual(client.get_certificate_operation(name=cert_name).csr, pending_version_csr)
         except Exception as ex:

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client_async.py
@@ -535,7 +535,8 @@ class CertificateClientTests(KeyVaultTestCase):
             name=cert_name, policy=CertificatePolicy._from_certificate_policy_bundle(cert_policy)
         )
         await create_certificate_poller
-        pending_version_csr = await client.get_pending_certificate_signing_request(name=cert_name)
+        operation = await client.get_certificate_operation(name=cert_name)
+        pending_version_csr = operation.csr
         try:
             self.assertEqual((await client.get_certificate_operation(name=cert_name)).csr, pending_version_csr)
         except Exception as ex:


### PR DESCRIPTION
A certificate operation retrieved via `get_certificate_operation()` contains the same bytes as `get_pending_certificate_signing_request()`, making the latter redundant.