### PR TITLE
Cleanup redundant matrix entries for live tests now that pypy is in the live matrix

### DIFF
--- a/sdk/appconfiguration/tests.yml
+++ b/sdk/appconfiguration/tests.yml
@@ -10,23 +10,6 @@ resources:
 jobs:
   - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
     parameters:
-      Matrix:
-        Linux_Python35:
-          OSName: 'Linux'
-          OSVmImage: 'ubuntu-16.04'
-          PythonVersion: '3.5'
-        MacOs_Python37:
-          OSName: 'MacOS'
-          OSVmImage: 'macOS-10.14'
-          PythonVersion: '3.7'
-        Windows_Python27:
-          OSName: 'Windows'
-          OSVmImage: 'windows-2019'
-          PythonVersion: '2.7'
-        Linux_Pypy3:
-          OSName: 'Linux'
-          OSVmImage: 'ubuntu-16.04'
-          PythonVersion: 'pypy3'
       BuildTargetingString: $(BuildTargetingString)
       ServiceDirectory: appconfiguration
       EnvVars:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client.py
@@ -22,6 +22,7 @@
 """Create, read, and delete databases in the Azure Cosmos DB SQL API service.
 """
 
+# pylint: disable=unused-import
 from typing import Any, Dict, Mapping, Optional, Union, cast, Iterable, List
 
 import six

--- a/sdk/cosmos/tests.yml
+++ b/sdk/cosmos/tests.yml
@@ -4,23 +4,6 @@ jobs:
   - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
     parameters:
       MaxParallel: 1
-      Matrix:
-        Linux_Python35:
-          OSName: 'Linux'
-          OSVmImage: 'ubuntu-16.04'
-          PythonVersion: '3.5'
-        MacOs_Python37:
-          OSName: 'MacOS'
-          OSVmImage: 'macOS-10.14'
-          PythonVersion: '3.7'
-        Windows_Python27:
-          OSName: 'Windows'
-          OSVmImage: 'windows-2019'
-          PythonVersion: '2.7'
-        Linux_Pypy3:
-          OSName: 'Linux'
-          OSVmImage: 'ubuntu-16.04'
-          PythonVersion: 'pypy3'
       ServiceDirectory: cosmos
       TestMarkArgument: not globaldb
       EnvVars:

--- a/sdk/storage/tests.yml
+++ b/sdk/storage/tests.yml
@@ -11,23 +11,6 @@ jobs:
   - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
     parameters:
       MaxParallel: 1
-      Matrix:
-        Linux_Python35:
-          OSName: 'Linux'
-          OSVmImage: 'ubuntu-16.04'
-          PythonVersion: '3.5'
-        MacOs_Python37:
-          OSName: 'MacOS'
-          OSVmImage: 'macOS-10.14'
-          PythonVersion: '3.7'
-        Windows_Python27:
-          OSName: 'Windows'
-          OSVmImage: 'windows-2019'
-          PythonVersion: '2.7'
-        Linux_Pypy3:
-          OSName: 'Linux'
-          OSVmImage: 'ubuntu-16.04'
-          PythonVersion: 'pypy3'
       BuildTargetingString: $(BuildTargetingString)
       ServiceDirectory: storage
       EnvVars:


### PR DESCRIPTION
This PR put pypy in the default live tests matrix (yay) https://github.com/Azure/azure-sdk-for-python/pull/7541

This DRYs up entries that were made redundant by that change.