### PR TITLE
Correct import_key parameter type

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-keys/HISTORY.md
@@ -1,8 +1,14 @@
 # Release History
 
 ## 4.0.0b4
+### Breaking changes:
 - Enums 'JsonWebKeyCurveName', 'JsonWebKeyOperation', and 'JsonWebKeyType' have
 been renamed to 'KeyCurveName', 'KeyOperation', and 'KeyType', respectively.
+
+### Fixes and improvements:
+- The `key` argument to `import_key` should be an instance of `azure.keyvault.keys.JsonWebKey`
+([#7590](https://github.com/Azure/azure-sdk-for-python/pull/7590))
+
 
 ## 4.0.0b3 (2019-09-11)
 ### Breaking changes:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/__init__.py
@@ -4,5 +4,6 @@
 # -------------------------------------
 from .client import KeyClient
 from .enums import KeyCurveName, KeyOperation, KeyType
+from .models import JsonWebKey
 
-__all__ = ["KeyCurveName", "KeyOperation", "KeyType", "KeyClient"]
+__all__ = ["JsonWebKey", "KeyCurveName", "KeyOperation", "KeyType", "KeyClient"]

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
@@ -539,6 +539,6 @@ class KeyClient(AsyncKeyVaultClientBase):
         else:
             attributes = None
         bundle = await self._client.import_key(
-            self.vault_url, name, key=key, hsm=hsm, key_attributes=attributes, tags=tags, **kwargs
+            self.vault_url, name, key=key._to_generated_model(), hsm=hsm, key_attributes=attributes, tags=tags, **kwargs
         )
         return Key._from_key_bundle(bundle)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from typing import Any, Dict, List, Optional, Union
     from datetime import datetime
     from azure.core.paging import ItemPaged
+    from .models import JsonWebKey
 
 
 class KeyClient(KeyVaultClientBase):
@@ -530,7 +531,7 @@ class KeyClient(KeyVaultClientBase):
     def import_key(
         self,
         name,  # type: str
-        key,  # type: List[str]
+        key,  # type: JsonWebKey
         hsm=None,  # type: Optional[bool]
         enabled=None,  # type: Optional[bool]
         not_before=None,  # type: Optional[datetime]
@@ -560,6 +561,6 @@ class KeyClient(KeyVaultClientBase):
         else:
             attributes = None
         bundle = self._client.import_key(
-            self.vault_url, name, key=key, hsm=hsm, key_attributes=attributes, tags=tags, **kwargs
+            self.vault_url, name, key=key._to_generated_model(), hsm=hsm, key_attributes=attributes, tags=tags, **kwargs
         )
         return Key._from_key_bundle(bundle)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/models.py
@@ -4,6 +4,7 @@
 # -------------------------------------
 from collections import namedtuple
 from ._shared import parse_vault_id
+from ._shared._generated.v7_0.models import JsonWebKey as _JsonWebKey
 
 try:
     from typing import TYPE_CHECKING
@@ -17,6 +18,7 @@ if TYPE_CHECKING:
     from ._shared._generated.v7_0 import models as _models
 
 KeyOperationResult = namedtuple("KeyOperationResult", ["id", "value"])
+
 
 class JsonWebKey(object):
     # pylint:disable=too-many-instance-attributes
@@ -43,25 +45,19 @@ class JsonWebKey(object):
     :param bytes y: Y component of an EC public key.
     """
 
+    FIELDS = ("kid", "kty", "key_ops", "n", "e", "d", "dp", "dq", "qi", "p", "q", "k", "t", "crv", "x", "y")
+
     def __init__(self, **kwargs):
         # type: (**Any) -> None
-        super(JsonWebKey, self).__init__(**kwargs)
-        self.kid = kwargs.get("kid", None)
-        self.kty = kwargs.get("kty", None)
-        self.key_ops = kwargs.get("key_ops", None)
-        self.n = kwargs.get("n", None)
-        self.e = kwargs.get("e", None)
-        self.d = kwargs.get("d", None)
-        self.dp = kwargs.get("dp", None)
-        self.dq = kwargs.get("dq", None)
-        self.qi = kwargs.get("qi", None)
-        self.p = kwargs.get("p", None)
-        self.q = kwargs.get("q", None)
-        self.k = kwargs.get("k", None)
-        self.t = kwargs.get("t", None)
-        self.crv = kwargs.get("crv", None)
-        self.x = kwargs.get("x", None)
-        self.y = kwargs.get("y", None)
+        for field in self.FIELDS:
+            setattr(self, field, kwargs.get(field))
+
+    def _to_generated_model(self):
+        # type: () -> _JsonWebKey
+        jwk = _JsonWebKey()
+        for field in self.FIELDS:
+            setattr(jwk, field, getattr(self, field))
+        return jwk
 
 
 class KeyProperties(object):
@@ -205,8 +201,8 @@ class Key(object):
         # type: (_models.KeyBundle) -> Key
         """Construct a Key from an autorest-generated KeyBundle"""
         return cls(
-            properties=KeyProperties._from_key_bundle(key_bundle),  #pylint: disable=protected-access
-            key_material=key_bundle.key
+            properties=KeyProperties._from_key_bundle(key_bundle),  # pylint: disable=protected-access
+            key_material=key_bundle.key,
         )
 
     @property
@@ -243,7 +239,7 @@ class DeletedKey(Key):
         key_material=None,  # type: _models.JsonWebKey
         deleted_date=None,  # type: Optional[datetime]
         recovery_id=None,  # type: Optional[str]
-        scheduled_purge_date=None  # type: Optional[datetime]
+        scheduled_purge_date=None,  # type: Optional[datetime]
     ):
         # type: (...) -> None
         super(DeletedKey, self).__init__(properties, key_material)
@@ -256,11 +252,11 @@ class DeletedKey(Key):
         # type: (_models.DeletedKeyBundle) -> DeletedKey
         """Construct a DeletedKey from an autorest-generated DeletedKeyBundle"""
         return cls(
-            properties=KeyProperties._from_key_bundle(deleted_key_bundle),  #pylint: disable=protected-access
+            properties=KeyProperties._from_key_bundle(deleted_key_bundle),  # pylint: disable=protected-access
             key_material=deleted_key_bundle.key,
             deleted_date=deleted_key_bundle.deleted_date,
             recovery_id=deleted_key_bundle.recovery_id,
-            scheduled_purge_date=deleted_key_bundle.scheduled_purge_date
+            scheduled_purge_date=deleted_key_bundle.scheduled_purge_date,
         )
 
     @classmethod
@@ -268,10 +264,10 @@ class DeletedKey(Key):
         # type: (_models.DeletedKeyItem) -> DeletedKey
         """Construct a DeletedKey from an autorest-generated DeletedKeyItem"""
         return cls(
-            properties=KeyProperties._from_key_item(deleted_key_item),  #pylint: disable=protected-access
+            properties=KeyProperties._from_key_item(deleted_key_item),  # pylint: disable=protected-access
             deleted_date=deleted_key_item.deleted_date,
             recovery_id=deleted_key_item.recovery_id,
-            scheduled_purge_date=deleted_key_item.scheduled_purge_date
+            scheduled_purge_date=deleted_key_item.scheduled_purge_date,
         )
 
     @property

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -5,9 +5,8 @@
 import codecs
 import hashlib
 
-from azure.keyvault.keys import KeyCurveName
+from azure.keyvault.keys import JsonWebKey, KeyCurveName
 from azure.keyvault.keys.crypto import EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
-from azure.keyvault.keys.models import JsonWebKey
 from azure.mgmt.keyvault.models import KeyPermissions, Permissions
 from devtools_testutils import ResourceGroupPreparer
 from keys_preparer import VaultClientPreparer

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -7,7 +7,7 @@ import hashlib
 
 from azure.keyvault.keys import KeyCurveName
 from azure.keyvault.keys.crypto import EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
-from azure.keyvault.keys._shared._generated.v7_0.models import JsonWebKey
+from azure.keyvault.keys.models import JsonWebKey
 from azure.mgmt.keyvault.models import KeyPermissions, Permissions
 from devtools_testutils import ResourceGroupPreparer
 from keys_preparer import VaultClientPreparer

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -5,9 +5,8 @@
 import codecs
 import hashlib
 
-from azure.keyvault.keys import KeyCurveName
+from azure.keyvault.keys import JsonWebKey, KeyCurveName
 from azure.keyvault.keys.crypto import CryptographyClient, EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
-from azure.keyvault.keys.models import JsonWebKey
 from azure.mgmt.keyvault.models import KeyPermissions, Permissions
 from devtools_testutils import ResourceGroupPreparer
 from keys_async_preparer import AsyncVaultClientPreparer

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -7,7 +7,7 @@ import hashlib
 
 from azure.keyvault.keys import KeyCurveName
 from azure.keyvault.keys.crypto import CryptographyClient, EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
-from azure.keyvault.keys._shared._generated.v7_0.models import JsonWebKey
+from azure.keyvault.keys.models import JsonWebKey
 from azure.mgmt.keyvault.models import KeyPermissions, Permissions
 from devtools_testutils import ResourceGroupPreparer
 from keys_async_preparer import AsyncVaultClientPreparer
@@ -28,7 +28,9 @@ class CryptoClientTests(AsyncKeyVaultTestCase):
         self.assertEqual(key.kty, kty, "kty should by '{}', but is '{}'".format(key, key.kty))
         self.assertTrue(key.n and key.e, "Bad RSA public material.")
         self.assertEqual(key_ops, key.key_ops, "keyOps should be '{}', but is '{}'".format(key_ops, key.key_ops))
-        self.assertTrue(key_attributes.properties.created and key_attributes.properties.updated, "Missing required date attributes.")
+        self.assertTrue(
+            key_attributes.properties.created and key_attributes.properties.updated, "Missing required date attributes."
+        )
 
     async def _import_test_key(self, client, name):
         def _to_bytes(hex):

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -8,7 +8,7 @@ import functools
 import time
 
 from azure.core.exceptions import ResourceNotFoundError
-from azure.keyvault.keys._shared._generated.v7_0.models import JsonWebKey
+from azure.keyvault.keys.models import JsonWebKey
 from keys_preparer import VaultClientPreparer
 from keys_test_case import KeyVaultTestCase
 from devtools_testutils import ResourceGroupPreparer

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -11,7 +11,7 @@ from devtools_testutils import ResourceGroupPreparer
 from keys_async_preparer import AsyncVaultClientPreparer
 from keys_async_test_case import AsyncKeyVaultTestCase
 
-from azure.keyvault.keys._shared._generated.v7_0.models import JsonWebKey
+from azure.keyvault.keys.models import JsonWebKey
 
 from dateutil import parser as date_parse
 


### PR DESCRIPTION
This makes `import_key` accept our handwritten `azure.keyvault.keys.JsonWebKey`, adds a method to convert that class to its autorest-generated equivalent for serialization, and ensures tests are passing instances of the correct class.