### PR TITLE
Ensure error_map is used consistently

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/client.py
@@ -11,7 +11,7 @@ from azure.core.polling import LROPoller
 from azure.core.tracing.decorator import distributed_trace
 
 from ._shared import KeyVaultClientBase
-from ._shared.exceptions import error_map
+from ._shared.exceptions import error_map as _error_map
 from .models import (
     Certificate,
     CertificateProperties,
@@ -138,7 +138,7 @@ class CertificateClient(KeyVaultClientBase):
                 :dedent: 8
         """
         bundle = self._client.get_certificate(
-            vault_base_url=self.vault_url, certificate_name=name, certificate_version="", error_map=error_map, **kwargs
+            vault_base_url=self.vault_url, certificate_name=name, certificate_version="", error_map=_error_map, **kwargs
         )
         return Certificate._from_certificate_bundle(certificate_bundle=bundle)
 
@@ -170,7 +170,7 @@ class CertificateClient(KeyVaultClientBase):
             vault_base_url=self.vault_url,
             certificate_name=name,
             certificate_version=version,
-            error_map=error_map,
+            error_map=_error_map,
             **kwargs
         )
         return Certificate._from_certificate_bundle(certificate_bundle=bundle)
@@ -201,7 +201,7 @@ class CertificateClient(KeyVaultClientBase):
                 :dedent: 8
         """
         bundle = self._client.delete_certificate(
-            vault_base_url=self.vault_url, certificate_name=name, error_map=error_map, **kwargs
+            vault_base_url=self.vault_url, certificate_name=name, error_map=_error_map, **kwargs
         )
         return DeletedCertificate._from_deleted_certificate_bundle(deleted_certificate_bundle=bundle)
 
@@ -231,7 +231,7 @@ class CertificateClient(KeyVaultClientBase):
                 :dedent: 8
         """
         bundle = self._client.get_deleted_certificate(
-            vault_base_url=self.vault_url, certificate_name=name, error_map=error_map, **kwargs
+            vault_base_url=self.vault_url, certificate_name=name, error_map=_error_map, **kwargs
         )
         return DeletedCertificate._from_deleted_certificate_bundle(deleted_certificate_bundle=bundle)
 
@@ -447,7 +447,7 @@ class CertificateClient(KeyVaultClientBase):
                 :dedent: 8
         """
         backup_result = self._client.backup_certificate(
-            vault_base_url=self.vault_url, certificate_name=name, error_map=error_map, **kwargs
+            vault_base_url=self.vault_url, certificate_name=name, error_map=_error_map, **kwargs
         )
         return backup_result.value
 
@@ -670,7 +670,7 @@ class CertificateClient(KeyVaultClientBase):
         """
 
         bundle = self._client.get_certificate_operation(
-            vault_base_url=self.vault_url, certificate_name=name, error_map=error_map, **kwargs
+            vault_base_url=self.vault_url, certificate_name=name, error_map=_error_map, **kwargs
         )
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
 
@@ -796,7 +796,7 @@ class CertificateClient(KeyVaultClientBase):
         response = pipeline_response.http_response
 
         if response.status_code not in [200]:
-            self._client.map_error(status_code=response.status_code, response=response, error_map=error_map)
+            self._client.map_error(status_code=response.status_code, response=response, error_map=_error_map)
             raise self._client.models.KeyVaultErrorException(response, self._client._deserialize)
 
         deserialized = None
@@ -830,7 +830,7 @@ class CertificateClient(KeyVaultClientBase):
                 :dedent: 8
         """
         issuer_bundle = self._client.get_certificate_issuer(
-            vault_base_url=self.vault_url, issuer_name=name, error_map=error_map, **kwargs
+            vault_base_url=self.vault_url, issuer_name=name, error_map=_error_map, **kwargs
         )
         return Issuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
@@ -10,7 +10,7 @@ from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.keyvault.keys.models import DeletedKey, JsonWebKey, Key, KeyProperties
 from azure.keyvault.keys._shared import AsyncKeyVaultClientBase
 
-from .._shared.exceptions import error_map
+from .._shared.exceptions import error_map as _error_map
 from ..crypto.aio import CryptographyClient
 
 
@@ -231,7 +231,7 @@ class KeyClient(AsyncKeyVaultClientBase):
                 :caption: Delete a key
                 :dedent: 8
         """
-        bundle = await self._client.delete_key(self.vault_url, name, error_map=error_map, **kwargs)
+        bundle = await self._client.delete_key(self.vault_url, name, _error_map=_error_map, **kwargs)
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace_async
@@ -257,7 +257,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         if version is None:
             version = ""
 
-        bundle = await self._client.get_key(self.vault_url, name, version, error_map=error_map, **kwargs)
+        bundle = await self._client.get_key(self.vault_url, name, version, _error_map=_error_map, **kwargs)
         return Key._from_key_bundle(bundle)
 
     @distributed_trace_async
@@ -280,7 +280,7 @@ class KeyClient(AsyncKeyVaultClientBase):
                 :caption: Get a deleted key
                 :dedent: 8
         """
-        bundle = await self._client.get_deleted_key(self.vault_url, name, error_map=error_map, **kwargs)
+        bundle = await self._client.get_deleted_key(self.vault_url, name, _error_map=_error_map, **kwargs)
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace
@@ -449,7 +449,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             key_ops=key_operations,
             tags=tags,
             key_attributes=attributes,
-            error_map=error_map,
+            _error_map=_error_map,
             **kwargs,
         )
         return Key._from_key_bundle(bundle)
@@ -477,7 +477,7 @@ class KeyClient(AsyncKeyVaultClientBase):
                 :caption: Get a key backup
                 :dedent: 8
         """
-        backup_result = await self._client.backup_key(self.vault_url, name, error_map=error_map, **kwargs)
+        backup_result = await self._client.backup_key(self.vault_url, name, _error_map=_error_map, **kwargs)
         return backup_result.value
 
     @distributed_trace_async
@@ -503,7 +503,7 @@ class KeyClient(AsyncKeyVaultClientBase):
                 :caption: Restore a key backup
                 :dedent: 8
         """
-        bundle = await self._client.restore_key(self.vault_url, backup, error_map=error_map, **kwargs)
+        bundle = await self._client.restore_key(self.vault_url, backup, _error_map=_error_map, **kwargs)
         return Key._from_key_bundle(bundle)
 
     @distributed_trace_async

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
@@ -5,7 +5,7 @@
 from azure.core.tracing.decorator import distributed_trace
 
 from ._shared import KeyVaultClientBase
-from ._shared.exceptions import error_map
+from ._shared.exceptions import error_map as _error_map
 from .crypto import CryptographyClient
 from .models import Key, KeyProperties, DeletedKey
 
@@ -245,7 +245,7 @@ class KeyClient(KeyVaultClientBase):
                 :caption: Delete a key
                 :dedent: 8
         """
-        bundle = self._client.delete_key(self.vault_url, name, error_map=error_map, **kwargs)
+        bundle = self._client.delete_key(self.vault_url, name, error_map=_error_map, **kwargs)
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace
@@ -269,7 +269,7 @@ class KeyClient(KeyVaultClientBase):
                 :caption: Get a key
                 :dedent: 8
         """
-        bundle = self._client.get_key(self.vault_url, name, key_version=version or "", error_map=error_map, **kwargs)
+        bundle = self._client.get_key(self.vault_url, name, key_version=version or "", error_map=_error_map, **kwargs)
         return Key._from_key_bundle(bundle)
 
     @distributed_trace
@@ -294,7 +294,7 @@ class KeyClient(KeyVaultClientBase):
                 :dedent: 8
         """
         # TODO: which exception is raised when soft-delete is not enabled
-        bundle = self._client.get_deleted_key(self.vault_url, name, error_map=error_map, **kwargs)
+        bundle = self._client.get_deleted_key(self.vault_url, name, error_map=_error_map, **kwargs)
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace
@@ -468,7 +468,7 @@ class KeyClient(KeyVaultClientBase):
             key_ops=key_operations,
             tags=tags,
             key_attributes=attributes,
-            error_map=error_map,
+            error_map=_error_map,
             **kwargs
         )
         return Key._from_key_bundle(bundle)
@@ -497,7 +497,7 @@ class KeyClient(KeyVaultClientBase):
                 :caption: Get a key backup
                 :dedent: 8
         """
-        backup_result = self._client.backup_key(self.vault_url, name, error_map=error_map, **kwargs)
+        backup_result = self._client.backup_key(self.vault_url, name, error_map=_error_map, **kwargs)
         return backup_result.value
 
     @distributed_trace
@@ -524,7 +524,7 @@ class KeyClient(KeyVaultClientBase):
                 :caption: Restore a key backup
                 :dedent: 8
         """
-        bundle = self._client.restore_key(self.vault_url, backup, error_map=error_map, **kwargs)
+        bundle = self._client.restore_key(self.vault_url, backup, error_map=_error_map, **kwargs)
         return Key._from_key_bundle(bundle)
 
     @distributed_trace

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/client.py
@@ -5,12 +5,12 @@
 from datetime import datetime
 from typing import Any, AsyncIterable, Optional, Dict
 
-from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.decorator_async import distributed_trace_async
 
 from azure.keyvault.secrets.models import Secret, DeletedSecret, SecretProperties
 from .._shared import AsyncKeyVaultClientBase
+from .._shared.exceptions import error_map as _error_map
 
 
 class SecretClient(AsyncKeyVaultClientBase):
@@ -51,7 +51,7 @@ class SecretClient(AsyncKeyVaultClientBase):
                 :dedent: 8
         """
         bundle = await self._client.get_secret(
-            self.vault_url, name, version or "", error_map={404: ResourceNotFoundError}, **kwargs
+            self.vault_url, name, version or "", error_map=_error_map, **kwargs
         )
         return Secret._from_secret_bundle(bundle)
 
@@ -144,7 +144,7 @@ class SecretClient(AsyncKeyVaultClientBase):
             content_type=content_type,
             tags=tags,
             secret_attributes=attributes,
-            error_map={404: ResourceNotFoundError},
+            error_map=_error_map,
             **kwargs
         )
         return SecretProperties._from_secret_bundle(bundle)  # pylint: disable=protected-access
@@ -219,7 +219,7 @@ class SecretClient(AsyncKeyVaultClientBase):
                 :dedent: 8
         """
         backup_result = await self._client.backup_secret(
-            self.vault_url, name, error_map={404: ResourceNotFoundError}, **kwargs
+            self.vault_url, name, error_map=_error_map, **kwargs
         )
         return backup_result.value
 
@@ -243,7 +243,7 @@ class SecretClient(AsyncKeyVaultClientBase):
                 :dedent: 8
         """
         bundle = await self._client.restore_secret(
-            self.vault_url, backup, error_map={409: ResourceExistsError}, **kwargs
+            self.vault_url, backup, error_map=_error_map, **kwargs
         )
         return SecretProperties._from_secret_bundle(bundle)
 
@@ -266,7 +266,7 @@ class SecretClient(AsyncKeyVaultClientBase):
                 :dedent: 8
         """
         bundle = await self._client.delete_secret(
-            self.vault_url, name, error_map={404: ResourceNotFoundError}, **kwargs
+            self.vault_url, name, error_map=_error_map, **kwargs
         )
         return DeletedSecret._from_deleted_secret_bundle(bundle)
 
@@ -290,7 +290,7 @@ class SecretClient(AsyncKeyVaultClientBase):
                 :dedent: 8
         """
         bundle = await self._client.get_deleted_secret(
-            self.vault_url, name, error_map={404: ResourceNotFoundError}, **kwargs
+            self.vault_url, name, error_map=_error_map, **kwargs
         )
         return DeletedSecret._from_deleted_secret_bundle(bundle)
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
@@ -2,10 +2,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
 from azure.core.tracing.decorator import distributed_trace
 
 from ._shared import KeyVaultClientBase
+from ._shared.exceptions import error_map as _error_map
 from .models import Secret, DeletedSecret, SecretProperties
 
 try:
@@ -62,7 +62,7 @@ class SecretClient(KeyVaultClientBase):
             vault_base_url=self._vault_url,
             secret_name=name,
             secret_version=version or "",
-            error_map={404: ResourceNotFoundError},
+            error_map=_error_map,
             **kwargs
         )
         return Secret._from_secret_bundle(bundle)
@@ -166,7 +166,7 @@ class SecretClient(KeyVaultClientBase):
             content_type=content_type,
             tags=tags,
             secret_attributes=attributes,
-            error_map={404: ResourceNotFoundError},
+            error_map=_error_map,
             **kwargs
         )
         return SecretProperties._from_secret_bundle(bundle)  # pylint: disable=protected-access
@@ -247,7 +247,7 @@ class SecretClient(KeyVaultClientBase):
 
         """
         backup_result = self._client.backup_secret(
-            self.vault_url, name, error_map={404: ResourceNotFoundError}, **kwargs
+            self.vault_url, name, error_map=_error_map, **kwargs
         )
         return backup_result.value
 
@@ -272,7 +272,7 @@ class SecretClient(KeyVaultClientBase):
                 :dedent: 8
 
         """
-        bundle = self._client.restore_secret(self.vault_url, backup, error_map={409: ResourceExistsError}, **kwargs)
+        bundle = self._client.restore_secret(self.vault_url, backup, error_map=_error_map, **kwargs)
         return SecretProperties._from_secret_bundle(bundle)
 
     @distributed_trace
@@ -295,7 +295,7 @@ class SecretClient(KeyVaultClientBase):
                 :dedent: 8
 
         """
-        bundle = self._client.delete_secret(self.vault_url, name, error_map={404: ResourceNotFoundError}, **kwargs)
+        bundle = self._client.delete_secret(self.vault_url, name, error_map=_error_map, **kwargs)
         return DeletedSecret._from_deleted_secret_bundle(bundle)
 
     @distributed_trace
@@ -319,7 +319,7 @@ class SecretClient(KeyVaultClientBase):
                 :dedent: 8
 
         """
-        bundle = self._client.get_deleted_secret(self.vault_url, name, error_map={404: ResourceNotFoundError}, **kwargs)
+        bundle = self._client.get_deleted_secret(self.vault_url, name, error_map=_error_map, **kwargs)
         return DeletedSecret._from_deleted_secret_bundle(bundle)
 
     @distributed_trace


### PR DESCRIPTION
#7086 missed parts of `SecretClient`. This change also imports `error_map` in all client modules with an underscored name to avoid publicizing it.