### PR TITLE
extending pypy timeout for nightly build

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-nightly.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-nightly.yml
@@ -39,7 +39,7 @@ jobs:
     dependsOn:
        - 'Build'
 
-    timeoutInMinutes: 270
+    timeoutInMinutes: 300
 
     strategy:
       matrix:


### PR DESCRIPTION
Going to be swapping to unified pipelines soon anyway. 