### PR TITLE
Publish the packages artifact.

### DIFF
--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -59,6 +59,13 @@ steps:
       artifactName: 'artifacts' 
       targetPath: $(Build.ArtifactStagingDirectory)
 
+  # Duplicating  the task above to introduce a packages artifact for consistency
+  # with the other pipelines. Also using the newer YAML shortcut. Once we get
+  # past release successfully with unified pipelines we'll look at getting rid
+  # of the duplicated "artifacts" artifact.
+  - publish: $(Build.ArtifactStagingDirectory)
+    artifact: packages 
+
   - task: PublishBuildArtifacts@1
     condition: succeededOrFailed()
     displayName: 'Publish Artifacts'


### PR DESCRIPTION
@scbedd this is a quick change to the publishing logic for the Python pipelines. At this point its a duplicated publish but I want to get these artifacts consistent with the rest of the unified pipelines in terms of the artifact name that we publish to. However I didn't want to break the existing release pipeline just ahead of release day - therefore I am publishing the artifacts twice.

The good news is that it should be pretty close to a no-op due to deduplication. Once we are past release we can address this duplication / inconsistency. I'm just going through making sure everything is locked down for release.