### PR TITLE
[AutoPR cdn/resource-manager] [CDN] Add missing customHttpsParameters field of CustomDomainProperties.

### DIFF
--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/__init__.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/__init__.py
@@ -204,7 +204,7 @@ from .cdn_management_client_enums import (
     CustomHttpsProvisioningState,
     CustomHttpsProvisioningSubstate,
     ProtocolType,
-    MinimumTLSVersion,
+    MinimumTlsVersion,
     CertificateType,
     ResourceType,
 )
@@ -323,7 +323,7 @@ __all__ = [
     'CustomHttpsProvisioningState',
     'CustomHttpsProvisioningSubstate',
     'ProtocolType',
-    'MinimumTLSVersion',
+    'MinimumTlsVersion',
     'CertificateType',
     'ResourceType',
 ]

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/__init__.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/__init__.py
@@ -204,6 +204,7 @@ from .cdn_management_client_enums import (
     CustomHttpsProvisioningState,
     CustomHttpsProvisioningSubstate,
     ProtocolType,
+    MinimumTLSVersion,
     CertificateType,
     ResourceType,
 )
@@ -322,6 +323,7 @@ __all__ = [
     'CustomHttpsProvisioningState',
     'CustomHttpsProvisioningSubstate',
     'ProtocolType',
+    'MinimumTLSVersion',
     'CertificateType',
     'ResourceType',
 ]

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/__init__.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/__init__.py
@@ -66,9 +66,9 @@ try:
     from .load_parameters_py3 import LoadParameters
     from .origin_py3 import Origin
     from .origin_update_parameters_py3 import OriginUpdateParameters
+    from .custom_domain_https_parameters_py3 import CustomDomainHttpsParameters
     from .custom_domain_py3 import CustomDomain
     from .custom_domain_parameters_py3 import CustomDomainParameters
-    from .custom_domain_https_parameters_py3 import CustomDomainHttpsParameters
     from .cdn_certificate_source_parameters_py3 import CdnCertificateSourceParameters
     from .cdn_managed_https_parameters_py3 import CdnManagedHttpsParameters
     from .key_vault_certificate_source_parameters_py3 import KeyVaultCertificateSourceParameters
@@ -146,9 +146,9 @@ except (SyntaxError, ImportError):
     from .load_parameters import LoadParameters
     from .origin import Origin
     from .origin_update_parameters import OriginUpdateParameters
+    from .custom_domain_https_parameters import CustomDomainHttpsParameters
     from .custom_domain import CustomDomain
     from .custom_domain_parameters import CustomDomainParameters
-    from .custom_domain_https_parameters import CustomDomainHttpsParameters
     from .cdn_certificate_source_parameters import CdnCertificateSourceParameters
     from .cdn_managed_https_parameters import CdnManagedHttpsParameters
     from .key_vault_certificate_source_parameters import KeyVaultCertificateSourceParameters
@@ -265,9 +265,9 @@ __all__ = [
     'LoadParameters',
     'Origin',
     'OriginUpdateParameters',
+    'CustomDomainHttpsParameters',
     'CustomDomain',
     'CustomDomainParameters',
-    'CustomDomainHttpsParameters',
     'CdnCertificateSourceParameters',
     'CdnManagedHttpsParameters',
     'KeyVaultCertificateSourceParameters',

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/cdn_managed_https_parameters.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/cdn_managed_https_parameters.py
@@ -24,7 +24,7 @@ class CdnManagedHttpsParameters(CustomDomainHttpsParameters):
     :type protocol_type: str or ~azure.mgmt.cdn.models.ProtocolType
     :param minimum_tls_version: TLS protocol version that will be used for
      Https. Possible values include: 'None', 'TLS10', 'TLS12'
-    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTLSVersion
+    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTlsVersion
     :param certificate_source: Required. Constant filled by server.
     :type certificate_source: str
     :param certificate_source_parameters: Required. Defines the certificate
@@ -41,7 +41,7 @@ class CdnManagedHttpsParameters(CustomDomainHttpsParameters):
 
     _attribute_map = {
         'protocol_type': {'key': 'protocolType', 'type': 'str'},
-        'minimum_tls_version': {'key': 'minimumTLSVersion', 'type': 'MinimumTLSVersion'},
+        'minimum_tls_version': {'key': 'minimumTlsVersion', 'type': 'MinimumTlsVersion'},
         'certificate_source': {'key': 'certificateSource', 'type': 'str'},
         'certificate_source_parameters': {'key': 'certificateSourceParameters', 'type': 'CdnCertificateSourceParameters'},
     }

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/cdn_managed_https_parameters.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/cdn_managed_https_parameters.py
@@ -22,6 +22,9 @@ class CdnManagedHttpsParameters(CustomDomainHttpsParameters):
      used for secure delivery. Possible values include: 'ServerNameIndication',
      'IPBased'
     :type protocol_type: str or ~azure.mgmt.cdn.models.ProtocolType
+    :param minimum_tls_version: TLS protocol version that will be used for
+     Https. Possible values include: 'None', 'TLS10', 'TLS12'
+    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTLSVersion
     :param certificate_source: Required. Constant filled by server.
     :type certificate_source: str
     :param certificate_source_parameters: Required. Defines the certificate
@@ -38,6 +41,7 @@ class CdnManagedHttpsParameters(CustomDomainHttpsParameters):
 
     _attribute_map = {
         'protocol_type': {'key': 'protocolType', 'type': 'str'},
+        'minimum_tls_version': {'key': 'minimumTLSVersion', 'type': 'MinimumTLSVersion'},
         'certificate_source': {'key': 'certificateSource', 'type': 'str'},
         'certificate_source_parameters': {'key': 'certificateSourceParameters', 'type': 'CdnCertificateSourceParameters'},
     }

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/cdn_managed_https_parameters_py3.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/cdn_managed_https_parameters_py3.py
@@ -24,7 +24,7 @@ class CdnManagedHttpsParameters(CustomDomainHttpsParameters):
     :type protocol_type: str or ~azure.mgmt.cdn.models.ProtocolType
     :param minimum_tls_version: TLS protocol version that will be used for
      Https. Possible values include: 'None', 'TLS10', 'TLS12'
-    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTLSVersion
+    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTlsVersion
     :param certificate_source: Required. Constant filled by server.
     :type certificate_source: str
     :param certificate_source_parameters: Required. Defines the certificate
@@ -41,7 +41,7 @@ class CdnManagedHttpsParameters(CustomDomainHttpsParameters):
 
     _attribute_map = {
         'protocol_type': {'key': 'protocolType', 'type': 'str'},
-        'minimum_tls_version': {'key': 'minimumTLSVersion', 'type': 'MinimumTLSVersion'},
+        'minimum_tls_version': {'key': 'minimumTlsVersion', 'type': 'MinimumTlsVersion'},
         'certificate_source': {'key': 'certificateSource', 'type': 'str'},
         'certificate_source_parameters': {'key': 'certificateSourceParameters', 'type': 'CdnCertificateSourceParameters'},
     }

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/cdn_managed_https_parameters_py3.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/cdn_managed_https_parameters_py3.py
@@ -22,6 +22,9 @@ class CdnManagedHttpsParameters(CustomDomainHttpsParameters):
      used for secure delivery. Possible values include: 'ServerNameIndication',
      'IPBased'
     :type protocol_type: str or ~azure.mgmt.cdn.models.ProtocolType
+    :param minimum_tls_version: TLS protocol version that will be used for
+     Https. Possible values include: 'None', 'TLS10', 'TLS12'
+    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTLSVersion
     :param certificate_source: Required. Constant filled by server.
     :type certificate_source: str
     :param certificate_source_parameters: Required. Defines the certificate
@@ -38,11 +41,12 @@ class CdnManagedHttpsParameters(CustomDomainHttpsParameters):
 
     _attribute_map = {
         'protocol_type': {'key': 'protocolType', 'type': 'str'},
+        'minimum_tls_version': {'key': 'minimumTLSVersion', 'type': 'MinimumTLSVersion'},
         'certificate_source': {'key': 'certificateSource', 'type': 'str'},
         'certificate_source_parameters': {'key': 'certificateSourceParameters', 'type': 'CdnCertificateSourceParameters'},
     }
 
-    def __init__(self, *, protocol_type, certificate_source_parameters, **kwargs) -> None:
-        super(CdnManagedHttpsParameters, self).__init__(protocol_type=protocol_type, **kwargs)
+    def __init__(self, *, protocol_type, certificate_source_parameters, minimum_tls_version=None, **kwargs) -> None:
+        super(CdnManagedHttpsParameters, self).__init__(protocol_type=protocol_type, minimum_tls_version=minimum_tls_version, **kwargs)
         self.certificate_source_parameters = certificate_source_parameters
         self.certificate_source = 'Cdn'

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/cdn_management_client_enums.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/cdn_management_client_enums.py
@@ -275,6 +275,13 @@ class ProtocolType(str, Enum):
     ip_based = "IPBased"
 
 
+class MinimumTLSVersion(str, Enum):
+
+    none = "None"
+    tls10 = "TLS10"
+    tls12 = "TLS12"
+
+
 class CertificateType(str, Enum):
 
     shared = "Shared"

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/cdn_management_client_enums.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/cdn_management_client_enums.py
@@ -275,7 +275,7 @@ class ProtocolType(str, Enum):
     ip_based = "IPBased"
 
 
-class MinimumTLSVersion(str, Enum):
+class MinimumTlsVersion(str, Enum):
 
     none = "None"
     tls10 = "TLS10"

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/custom_domain.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/custom_domain.py
@@ -50,6 +50,10 @@ class CustomDomain(ProxyResource):
      'CertificateDeleted'
     :vartype custom_https_provisioning_substate: str or
      ~azure.mgmt.cdn.models.CustomHttpsProvisioningSubstate
+    :param custom_https_parameters: Certificate parameters for securing custom
+     HTTPS
+    :type custom_https_parameters:
+     ~azure.mgmt.cdn.models.CustomDomainHttpsParameters
     :param validation_data: Special validation or data may be required when
      delivering CDN to some regions due to local compliance reasons. E.g. ICP
      license number of a custom domain is required to deliver content in China.
@@ -77,6 +81,7 @@ class CustomDomain(ProxyResource):
         'resource_state': {'key': 'properties.resourceState', 'type': 'str'},
         'custom_https_provisioning_state': {'key': 'properties.customHttpsProvisioningState', 'type': 'str'},
         'custom_https_provisioning_substate': {'key': 'properties.customHttpsProvisioningSubstate', 'type': 'str'},
+        'custom_https_parameters': {'key': 'properties.customHttpsParameters', 'type': 'CustomDomainHttpsParameters'},
         'validation_data': {'key': 'properties.validationData', 'type': 'str'},
         'provisioning_state': {'key': 'properties.provisioningState', 'type': 'str'},
     }
@@ -87,5 +92,6 @@ class CustomDomain(ProxyResource):
         self.resource_state = None
         self.custom_https_provisioning_state = None
         self.custom_https_provisioning_substate = None
+        self.custom_https_parameters = kwargs.get('custom_https_parameters', None)
         self.validation_data = kwargs.get('validation_data', None)
         self.provisioning_state = None

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/custom_domain_https_parameters.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/custom_domain_https_parameters.py
@@ -24,6 +24,9 @@ class CustomDomainHttpsParameters(Model):
      used for secure delivery. Possible values include: 'ServerNameIndication',
      'IPBased'
     :type protocol_type: str or ~azure.mgmt.cdn.models.ProtocolType
+    :param minimum_tls_version: TLS protocol version that will be used for
+     Https. Possible values include: 'None', 'TLS10', 'TLS12'
+    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTLSVersion
     :param certificate_source: Required. Constant filled by server.
     :type certificate_source: str
     """
@@ -35,6 +38,7 @@ class CustomDomainHttpsParameters(Model):
 
     _attribute_map = {
         'protocol_type': {'key': 'protocolType', 'type': 'str'},
+        'minimum_tls_version': {'key': 'minimumTLSVersion', 'type': 'MinimumTLSVersion'},
         'certificate_source': {'key': 'certificateSource', 'type': 'str'},
     }
 
@@ -45,4 +49,5 @@ class CustomDomainHttpsParameters(Model):
     def __init__(self, **kwargs):
         super(CustomDomainHttpsParameters, self).__init__(**kwargs)
         self.protocol_type = kwargs.get('protocol_type', None)
+        self.minimum_tls_version = kwargs.get('minimum_tls_version', None)
         self.certificate_source = None

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/custom_domain_https_parameters.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/custom_domain_https_parameters.py
@@ -26,7 +26,7 @@ class CustomDomainHttpsParameters(Model):
     :type protocol_type: str or ~azure.mgmt.cdn.models.ProtocolType
     :param minimum_tls_version: TLS protocol version that will be used for
      Https. Possible values include: 'None', 'TLS10', 'TLS12'
-    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTLSVersion
+    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTlsVersion
     :param certificate_source: Required. Constant filled by server.
     :type certificate_source: str
     """
@@ -38,7 +38,7 @@ class CustomDomainHttpsParameters(Model):
 
     _attribute_map = {
         'protocol_type': {'key': 'protocolType', 'type': 'str'},
-        'minimum_tls_version': {'key': 'minimumTLSVersion', 'type': 'MinimumTLSVersion'},
+        'minimum_tls_version': {'key': 'minimumTlsVersion', 'type': 'MinimumTlsVersion'},
         'certificate_source': {'key': 'certificateSource', 'type': 'str'},
     }
 

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/custom_domain_https_parameters_py3.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/custom_domain_https_parameters_py3.py
@@ -24,6 +24,9 @@ class CustomDomainHttpsParameters(Model):
      used for secure delivery. Possible values include: 'ServerNameIndication',
      'IPBased'
     :type protocol_type: str or ~azure.mgmt.cdn.models.ProtocolType
+    :param minimum_tls_version: TLS protocol version that will be used for
+     Https. Possible values include: 'None', 'TLS10', 'TLS12'
+    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTLSVersion
     :param certificate_source: Required. Constant filled by server.
     :type certificate_source: str
     """
@@ -35,6 +38,7 @@ class CustomDomainHttpsParameters(Model):
 
     _attribute_map = {
         'protocol_type': {'key': 'protocolType', 'type': 'str'},
+        'minimum_tls_version': {'key': 'minimumTLSVersion', 'type': 'MinimumTLSVersion'},
         'certificate_source': {'key': 'certificateSource', 'type': 'str'},
     }
 
@@ -42,7 +46,8 @@ class CustomDomainHttpsParameters(Model):
         'certificate_source': {'Cdn': 'CdnManagedHttpsParameters', 'AzureKeyVault': 'UserManagedHttpsParameters'}
     }
 
-    def __init__(self, *, protocol_type, **kwargs) -> None:
+    def __init__(self, *, protocol_type, minimum_tls_version=None, **kwargs) -> None:
         super(CustomDomainHttpsParameters, self).__init__(**kwargs)
         self.protocol_type = protocol_type
+        self.minimum_tls_version = minimum_tls_version
         self.certificate_source = None

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/custom_domain_https_parameters_py3.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/custom_domain_https_parameters_py3.py
@@ -26,7 +26,7 @@ class CustomDomainHttpsParameters(Model):
     :type protocol_type: str or ~azure.mgmt.cdn.models.ProtocolType
     :param minimum_tls_version: TLS protocol version that will be used for
      Https. Possible values include: 'None', 'TLS10', 'TLS12'
-    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTLSVersion
+    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTlsVersion
     :param certificate_source: Required. Constant filled by server.
     :type certificate_source: str
     """
@@ -38,7 +38,7 @@ class CustomDomainHttpsParameters(Model):
 
     _attribute_map = {
         'protocol_type': {'key': 'protocolType', 'type': 'str'},
-        'minimum_tls_version': {'key': 'minimumTLSVersion', 'type': 'MinimumTLSVersion'},
+        'minimum_tls_version': {'key': 'minimumTlsVersion', 'type': 'MinimumTlsVersion'},
         'certificate_source': {'key': 'certificateSource', 'type': 'str'},
     }
 

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/custom_domain_py3.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/custom_domain_py3.py
@@ -50,6 +50,10 @@ class CustomDomain(ProxyResource):
      'CertificateDeleted'
     :vartype custom_https_provisioning_substate: str or
      ~azure.mgmt.cdn.models.CustomHttpsProvisioningSubstate
+    :param custom_https_parameters: Certificate parameters for securing custom
+     HTTPS
+    :type custom_https_parameters:
+     ~azure.mgmt.cdn.models.CustomDomainHttpsParameters
     :param validation_data: Special validation or data may be required when
      delivering CDN to some regions due to local compliance reasons. E.g. ICP
      license number of a custom domain is required to deliver content in China.
@@ -77,15 +81,17 @@ class CustomDomain(ProxyResource):
         'resource_state': {'key': 'properties.resourceState', 'type': 'str'},
         'custom_https_provisioning_state': {'key': 'properties.customHttpsProvisioningState', 'type': 'str'},
         'custom_https_provisioning_substate': {'key': 'properties.customHttpsProvisioningSubstate', 'type': 'str'},
+        'custom_https_parameters': {'key': 'properties.customHttpsParameters', 'type': 'CustomDomainHttpsParameters'},
         'validation_data': {'key': 'properties.validationData', 'type': 'str'},
         'provisioning_state': {'key': 'properties.provisioningState', 'type': 'str'},
     }
 
-    def __init__(self, *, host_name: str, validation_data: str=None, **kwargs) -> None:
+    def __init__(self, *, host_name: str, custom_https_parameters=None, validation_data: str=None, **kwargs) -> None:
         super(CustomDomain, self).__init__(**kwargs)
         self.host_name = host_name
         self.resource_state = None
         self.custom_https_provisioning_state = None
         self.custom_https_provisioning_substate = None
+        self.custom_https_parameters = custom_https_parameters
         self.validation_data = validation_data
         self.provisioning_state = None

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/user_managed_https_parameters.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/user_managed_https_parameters.py
@@ -22,6 +22,9 @@ class UserManagedHttpsParameters(CustomDomainHttpsParameters):
      used for secure delivery. Possible values include: 'ServerNameIndication',
      'IPBased'
     :type protocol_type: str or ~azure.mgmt.cdn.models.ProtocolType
+    :param minimum_tls_version: TLS protocol version that will be used for
+     Https. Possible values include: 'None', 'TLS10', 'TLS12'
+    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTLSVersion
     :param certificate_source: Required. Constant filled by server.
     :type certificate_source: str
     :param certificate_source_parameters: Required. Defines the certificate
@@ -38,6 +41,7 @@ class UserManagedHttpsParameters(CustomDomainHttpsParameters):
 
     _attribute_map = {
         'protocol_type': {'key': 'protocolType', 'type': 'str'},
+        'minimum_tls_version': {'key': 'minimumTLSVersion', 'type': 'MinimumTLSVersion'},
         'certificate_source': {'key': 'certificateSource', 'type': 'str'},
         'certificate_source_parameters': {'key': 'certificateSourceParameters', 'type': 'KeyVaultCertificateSourceParameters'},
     }

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/user_managed_https_parameters.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/user_managed_https_parameters.py
@@ -24,7 +24,7 @@ class UserManagedHttpsParameters(CustomDomainHttpsParameters):
     :type protocol_type: str or ~azure.mgmt.cdn.models.ProtocolType
     :param minimum_tls_version: TLS protocol version that will be used for
      Https. Possible values include: 'None', 'TLS10', 'TLS12'
-    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTLSVersion
+    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTlsVersion
     :param certificate_source: Required. Constant filled by server.
     :type certificate_source: str
     :param certificate_source_parameters: Required. Defines the certificate
@@ -41,7 +41,7 @@ class UserManagedHttpsParameters(CustomDomainHttpsParameters):
 
     _attribute_map = {
         'protocol_type': {'key': 'protocolType', 'type': 'str'},
-        'minimum_tls_version': {'key': 'minimumTLSVersion', 'type': 'MinimumTLSVersion'},
+        'minimum_tls_version': {'key': 'minimumTlsVersion', 'type': 'MinimumTlsVersion'},
         'certificate_source': {'key': 'certificateSource', 'type': 'str'},
         'certificate_source_parameters': {'key': 'certificateSourceParameters', 'type': 'KeyVaultCertificateSourceParameters'},
     }

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/user_managed_https_parameters_py3.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/user_managed_https_parameters_py3.py
@@ -22,6 +22,9 @@ class UserManagedHttpsParameters(CustomDomainHttpsParameters):
      used for secure delivery. Possible values include: 'ServerNameIndication',
      'IPBased'
     :type protocol_type: str or ~azure.mgmt.cdn.models.ProtocolType
+    :param minimum_tls_version: TLS protocol version that will be used for
+     Https. Possible values include: 'None', 'TLS10', 'TLS12'
+    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTLSVersion
     :param certificate_source: Required. Constant filled by server.
     :type certificate_source: str
     :param certificate_source_parameters: Required. Defines the certificate
@@ -38,11 +41,12 @@ class UserManagedHttpsParameters(CustomDomainHttpsParameters):
 
     _attribute_map = {
         'protocol_type': {'key': 'protocolType', 'type': 'str'},
+        'minimum_tls_version': {'key': 'minimumTLSVersion', 'type': 'MinimumTLSVersion'},
         'certificate_source': {'key': 'certificateSource', 'type': 'str'},
         'certificate_source_parameters': {'key': 'certificateSourceParameters', 'type': 'KeyVaultCertificateSourceParameters'},
     }
 
-    def __init__(self, *, protocol_type, certificate_source_parameters, **kwargs) -> None:
-        super(UserManagedHttpsParameters, self).__init__(protocol_type=protocol_type, **kwargs)
+    def __init__(self, *, protocol_type, certificate_source_parameters, minimum_tls_version=None, **kwargs) -> None:
+        super(UserManagedHttpsParameters, self).__init__(protocol_type=protocol_type, minimum_tls_version=minimum_tls_version, **kwargs)
         self.certificate_source_parameters = certificate_source_parameters
         self.certificate_source = 'AzureKeyVault'

--- a/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/user_managed_https_parameters_py3.py
+++ b/sdk/cdn/azure-mgmt-cdn/azure/mgmt/cdn/models/user_managed_https_parameters_py3.py
@@ -24,7 +24,7 @@ class UserManagedHttpsParameters(CustomDomainHttpsParameters):
     :type protocol_type: str or ~azure.mgmt.cdn.models.ProtocolType
     :param minimum_tls_version: TLS protocol version that will be used for
      Https. Possible values include: 'None', 'TLS10', 'TLS12'
-    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTLSVersion
+    :type minimum_tls_version: str or ~azure.mgmt.cdn.models.MinimumTlsVersion
     :param certificate_source: Required. Constant filled by server.
     :type certificate_source: str
     :param certificate_source_parameters: Required. Defines the certificate
@@ -41,7 +41,7 @@ class UserManagedHttpsParameters(CustomDomainHttpsParameters):
 
     _attribute_map = {
         'protocol_type': {'key': 'protocolType', 'type': 'str'},
-        'minimum_tls_version': {'key': 'minimumTLSVersion', 'type': 'MinimumTLSVersion'},
+        'minimum_tls_version': {'key': 'minimumTlsVersion', 'type': 'MinimumTlsVersion'},
         'certificate_source': {'key': 'certificateSource', 'type': 'str'},
         'certificate_source_parameters': {'key': 'certificateSourceParameters', 'type': 'KeyVaultCertificateSourceParameters'},
     }


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/7441