### PR TITLE
Fix auto-headers for aiohttp (for real this time :))

### DIFF
--- a/sdk/core/azure-core/HISTORY.md
+++ b/sdk/core/azure-core/HISTORY.md
@@ -3,6 +3,12 @@
 
 -------------------
 
+## 2019-XX-XX Version 1.0.0
+
+### Bug fixes
+
+- Fix form-data with aiohttp transport  #7749
+
 ## 2019-10-07 Version 1.0.0b4
 
 ### Features
@@ -32,7 +38,7 @@
 - Tracing: `link` renamed `link_from_headers`  and `link` takes now a string
 - Tracing: opencensus implementation has been moved to the package `azure-core-tracing-opencensus`
 - Some modules and classes that were importables from several differente places have been removed:
-   
+
    - `azure.core.HttpResponseError` is now only `azure.core.exceptions.HttpResponseError`
    - `azure.core.Configuration` is now only `azure.core.configuration.Configuration`
    - `azure.core.HttpRequest` is now only `azure.core.pipeline.transport.HttpRequest`


### PR DESCRIPTION
In some scenario, aiohttp is setting content-type for us. This might be something we don't want, for instance for Storage it was breaking the signature (Content-Type being part of the signature, the signature didn't match anymore). First attempt to fix was then to say to aiohttp "whatever scenario, don't do auto-headers": https://github.com/Azure/azure-sdk-for-python/pull/6992

But this one broke the formdata tests: because when using "multipart/form-data" you really want aiohttp to do that for you (there is a boundary to generate, etc.).

So this PR is being more explicit: if we know for sure this request comes with no body: don't let aiohttp add automatically "Content-Type". I believe it's more accurate to what we wanted to fix anyway.

Side note @scbedd : if this issue https://github.com/Azure/azure-sdk-for-python/issues/4773 was implemented, we would have caught that earlier :/. No blaming, just to give context for the value that would bring #4773