### PR TITLE
Revise -keys and -secrets public APIs

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-keys/HISTORY.md
@@ -13,6 +13,7 @@ detail the new keyword arguments):
   - `import_key` now has positional parameters `name` and `key`
 - `CryptographyClient` operations return class instances instead of tuples. The
 new classes have the same attributes as the tuples.
+- Renamed `list_keys` to `list_properties_of_keys`
 
 
 ## 4.0.0b4 (2019-10-08)

--- a/sdk/keyvault/azure-keyvault-keys/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-keys/HISTORY.md
@@ -7,8 +7,7 @@
 [docs](https://azure.github.io/azure-sdk-for-python/ref/azure.keyvault.keys.html)
 detail the new keyword arguments):
   - `create_key` now has positional parameters `name` and `key_type`
-  - `create_ec_key` and `create_rsa_key` now have positional parameters `name`
-     and `hsm`
+  - `create_ec_key` and `create_rsa_key` now have one positional parameter, `name`
   - `update_key_properties` now has two positional parameters, `name` and
      (optional) `version`
   - `import_key` now has positional parameters `name` and `key`

--- a/sdk/keyvault/azure-keyvault-keys/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-keys/HISTORY.md
@@ -11,6 +11,8 @@ detail the new keyword arguments):
   - `update_key_properties` now has two positional parameters, `name` and
      (optional) `version`
   - `import_key` now has positional parameters `name` and `key`
+- `CryptographyClient` operations return class instances instead of tuples. The
+new classes have the same attributes as the tuples.
 
 
 ## 4.0.0b4 (2019-10-08)

--- a/sdk/keyvault/azure-keyvault-keys/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-keys/HISTORY.md
@@ -8,7 +8,7 @@
 detail the new keyword arguments):
   - `create_key` now has positional parameters `name` and `key_type`
   - `create_ec_key` and `create_rsa_key` now have positional parameters `name` and `hsm`
-  - `update_key_properties` now has one positional parameter, `name`
+  - `get_key` and `update_key_properties` now have one positional parameter, `name`
   - `import_key` now has positional parameters `name` and `key`
 
 

--- a/sdk/keyvault/azure-keyvault-keys/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-keys/HISTORY.md
@@ -14,6 +14,8 @@ detail the new keyword arguments):
 - `CryptographyClient` operations return class instances instead of tuples. The
 new classes have the same attributes as the tuples.
 - Renamed `list_keys` to `list_properties_of_keys`
+- `Key` properties `created`, `expires`, and `updated` renamed to `created_on`,
+`expires_on`, and `updated_on`
 
 
 ## 4.0.0b4 (2019-10-08)

--- a/sdk/keyvault/azure-keyvault-keys/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-keys/HISTORY.md
@@ -1,6 +1,15 @@
 # Release History
 
 ## 4.0.0b5
+### Breaking changes:
+- Removed `KeyClient.get_cryptography_client()` and `CryptographyClient.get_key()`
+- Moved the optional parameters of several methods into kwargs (
+[docs](https://azure.github.io/azure-sdk-for-python/ref/azure.keyvault.keys.html)
+detail the new keyword arguments):
+  - `create_key` now has positional parameters `name` and `key_type`
+  - `create_ec_key` and `create_rsa_key` now have positional parameters `name` and `hsm`
+  - `update_key_properties` now has one positional parameter, `name`
+  - `import_key` now has positional parameters `name` and `key`
 
 
 ## 4.0.0b4 (2019-10-08)

--- a/sdk/keyvault/azure-keyvault-keys/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-keys/HISTORY.md
@@ -7,8 +7,10 @@
 [docs](https://azure.github.io/azure-sdk-for-python/ref/azure.keyvault.keys.html)
 detail the new keyword arguments):
   - `create_key` now has positional parameters `name` and `key_type`
-  - `create_ec_key` and `create_rsa_key` now have positional parameters `name` and `hsm`
-  - `get_key` and `update_key_properties` now have one positional parameter, `name`
+  - `create_ec_key` and `create_rsa_key` now have positional parameters `name`
+     and `hsm`
+  - `update_key_properties` now has two positional parameters, `name` and
+     (optional) `version`
   - `import_key` now has positional parameters `name` and `key`
 
 

--- a/sdk/keyvault/azure-keyvault-keys/README.md
+++ b/sdk/keyvault/azure-keyvault-keys/README.md
@@ -156,12 +156,12 @@ of that key is created.
 # Create an RSA key
 rsa_key = key_client.create_rsa_key("rsa-key-name", size=2048)
 print(rsa_key.name)
-print(rsa_key.key.kty)
+print(rsa_key.key_type)
 
 # Create an elliptic curve key
 ec_key = key_client.create_ec_key("ec-key-name", curve="P-256")
 print(ec_key.name)
-print(ec_key.key.kty)
+print(ec_key.key_type)
 ```
 
 ### Retrieve a Key
@@ -251,12 +251,12 @@ key_client = KeyClient(vault_endpoint=vault_endpoint, credential=credential)
 # Create an RSA key
 rsa_key = await key_client.create_rsa_key("rsa-key-name", size=2048)
 print(rsa_key.name)
-print(rsa_key.key.kty)
+print(rsa_key.key_type)
 
 # Create an elliptic curve key
 ec_key = await key_client.create_ec_key("ec-key-name", curve="P-256")
 print(ec_key.name)
-print(ec_key.key.kty)
+print(ec_key.key_type)
 ```
 
 ### Asynchronously list keys

--- a/sdk/keyvault/azure-keyvault-keys/README.md
+++ b/sdk/keyvault/azure-keyvault-keys/README.md
@@ -156,12 +156,12 @@ of that key is created.
 # Create an RSA key
 rsa_key = key_client.create_rsa_key("rsa-key-name", size=2048)
 print(rsa_key.name)
-print(rsa_key.key_material.kty)
+print(rsa_key.key.kty)
 
 # Create an elliptic curve key
 ec_key = key_client.create_ec_key("ec-key-name", curve="P-256")
 print(ec_key.name)
-print(ec_key.key_material.kty)
+print(ec_key.key.kty)
 ```
 
 ### Retrieve a Key
@@ -251,12 +251,12 @@ key_client = KeyClient(vault_endpoint=vault_endpoint, credential=credential)
 # Create an RSA key
 rsa_key = await key_client.create_rsa_key("rsa-key-name", size=2048)
 print(rsa_key.name)
-print(rsa_key.key_material.kty)
+print(rsa_key.key.kty)
 
 # Create an elliptic curve key
 ec_key = await key_client.create_ec_key("ec-key-name", curve="P-256")
 print(ec_key.name)
-print(ec_key.key_material.kty)
+print(ec_key.key.kty)
 ```
 
 ### Asynchronously list keys

--- a/sdk/keyvault/azure-keyvault-keys/README.md
+++ b/sdk/keyvault/azure-keyvault-keys/README.md
@@ -154,12 +154,12 @@ of that key is created.
 
 ```python
 # Create an RSA key
-rsa_key = key_client.create_rsa_key("rsa-key-name", hsm=False, size=2048)
+rsa_key = key_client.create_rsa_key("rsa-key-name", size=2048)
 print(rsa_key.name)
 print(rsa_key.key_material.kty)
 
 # Create an elliptic curve key
-ec_key = key_client.create_ec_key("ec-key-name", hsm=False, curve="P-256")
+ec_key = key_client.create_ec_key("ec-key-name", curve="P-256")
 print(ec_key.name)
 print(ec_key.key_material.kty)
 ```
@@ -249,12 +249,12 @@ credential = DefaultAzureCredential()
 key_client = KeyClient(vault_endpoint=vault_endpoint, credential=credential)
 
 # Create an RSA key
-rsa_key = await key_client.create_rsa_key("rsa-key-name", hsm=False, size=2048)
+rsa_key = await key_client.create_rsa_key("rsa-key-name", size=2048)
 print(rsa_key.name)
 print(rsa_key.key_material.kty)
 
 # Create an elliptic curve key
-ec_key = await key_client.create_ec_key("ec-key-name", hsm=False, curve="P-256")
+ec_key = await key_client.create_ec_key("ec-key-name", curve="P-256")
 print(ec_key.name)
 print(ec_key.key_material.kty)
 ```

--- a/sdk/keyvault/azure-keyvault-keys/README.md
+++ b/sdk/keyvault/azure-keyvault-keys/README.md
@@ -200,7 +200,7 @@ print(deleted_key.deleted_date)
 This example lists all the keys in the client's vault.
 
 ```python
-keys = key_client.list_keys()
+keys = key_client.list_properties_of_keys()
 
 for key in keys:
     # the list doesn't include values or versions of the keys
@@ -263,7 +263,7 @@ print(ec_key.key_material.kty)
 This example lists all the keys in the client's vault:
 
 ```python
-keys = key_client.list_keys()
+keys = key_client.list_properties_of_keys()
 
 async for key in keys:
     print(key.name)

--- a/sdk/keyvault/azure-keyvault-keys/README.md
+++ b/sdk/keyvault/azure-keyvault-keys/README.md
@@ -214,13 +214,13 @@ wrap/unwrap, sign/verify) using a particular key.
 ```py
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.keys import KeyClient
-from azure.keyvault.keys.crypto import EncryptionAlgorithm
+from azure.keyvault.keys.crypto import CryptographyClient, EncryptionAlgorithm
 
 credential = DefaultAzureCredential()
 key_client = KeyClient(vault_endpoint=vault_endpoint, credential=credential)
 
 key = key_client.get_key("mykey")
-crypto_client = key_client.get_cryptography_client(key)
+crypto_client = CryptographyClient(key, credential=credential)
 
 result = crypto_client.encrypt(EncryptionAlgorithm.rsa_oaep, plaintext)
 decrypted = crypto_client.decrypt(result.algorithm, result.ciphertext)

--- a/sdk/keyvault/azure-keyvault-keys/README.md
+++ b/sdk/keyvault/azure-keyvault-keys/README.md
@@ -181,7 +181,7 @@ updated_key_properties = key_client.update_key_properties("key-name", tags=tags)
 
 print(updated_key_properties.name)
 print(updated_key_properties.version)
-print(updated_key_properties.updated)
+print(updated_key_properties.updated_on)
 print(updated_key_properties.tags)
 ```
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
@@ -451,7 +451,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         Keyword arguments
             - **enabled** (bool): Whether the key is enabled for use.
-            - **hsm** (bool): Whether the key should be backed by a hardware security module
+            - **hardware_protected** (bool): Whether the key should be backed by a hardware security module
             - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
             - **expires_on** (:class:`~datetime.datetime`): Expiry date of the key in UTC
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
@@ -464,6 +464,12 @@ class KeyClient(AsyncKeyVaultClientBase):
         else:
             attributes = None
         bundle = await self._client.import_key(
-            self.vault_endpoint, name, key=key._to_generated_model(), key_attributes=attributes, **kwargs
+            self.vault_endpoint,
+            name,
+            key=key._to_generated_model(),
+            key_attributes=attributes,
+            hsm=kwargs.pop("hardware_protected", None),
+            **kwargs
         )
         return Key._from_key_bundle(bundle)
+

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
@@ -58,7 +58,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             - **enabled** (bool): Whether the key is enabled for use.
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
             - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
-            - **expires** (:class:`~datetime.datetime`): Expiry date of the key in UTC
+            - **expires_on** (:class:`~datetime.datetime`): Expiry date of the key in UTC
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -70,10 +70,10 @@ class KeyClient(AsyncKeyVaultClientBase):
         """
         enabled = kwargs.pop("enabled", None)
         not_before = kwargs.pop("not_before", None)
-        expires = kwargs.pop("expires", None)
+        expires_on = kwargs.pop("expires_on", None)
 
-        if enabled is not None or not_before is not None or expires is not None:
-            attributes = self._client.models.KeyAttributes(enabled=enabled, not_before=not_before, expires=expires)
+        if enabled is not None or not_before is not None or expires_on is not None:
+            attributes = self._client.models.KeyAttributes(enabled=enabled, not_before=not_before, expires=expires_on)
         else:
             attributes = None
 
@@ -104,7 +104,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             - **key_operations** (list[str or :class:`~azure.keyvault.keys.enums.KeyOperation`]): Allowed key operations
             - **enabled** (bool): Whether the key is enabled for use.
             - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
-            - **expires** (:class:`~datetime.datetime`): Expiry date of the key in UTC
+            - **expires_on** (:class:`~datetime.datetime`): Expiry date of the key in UTC
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
 
         Example:
@@ -135,7 +135,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             - **enabled** (bool): Whether the key is enabled for use.
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
             - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
-            - **expires** (:class:`~datetime.datetime`): Expiry date of the key in UTC
+            - **expires_on** (:class:`~datetime.datetime`): Expiry date of the key in UTC
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -354,7 +354,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             - **enabled** (bool): Whether the key is enabled for use.
             - **key_operations** (list[str or :class:`~azure.keyvault.keys.enums.KeyOperation`]): Allowed key operations
             - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
-            - **expires** (:class:`~datetime.datetime`): Expiry date of the key in UTC
+            - **expires_on** (:class:`~datetime.datetime`): Expiry date of the key in UTC
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
 
         Example:
@@ -367,9 +367,9 @@ class KeyClient(AsyncKeyVaultClientBase):
         """
         enabled = kwargs.pop("enabled", None)
         not_before = kwargs.pop("not_before", None)
-        expires = kwargs.pop("expires", None)
-        if enabled is not None or not_before is not None or expires is not None:
-            attributes = self._client.models.KeyAttributes(enabled=enabled, not_before=not_before, expires=expires)
+        expires_on = kwargs.pop("expires_on", None)
+        if enabled is not None or not_before is not None or expires_on is not None:
+            attributes = self._client.models.KeyAttributes(enabled=enabled, not_before=not_before, expires=expires_on)
         else:
             attributes = None
         bundle = await self._client.update_key(
@@ -451,14 +451,14 @@ class KeyClient(AsyncKeyVaultClientBase):
             - **enabled** (bool): Whether the key is enabled for use.
             - **hsm** (bool): Whether the key should be backed by a hardware security module
             - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
-            - **expires** (:class:`~datetime.datetime`): Expiry date of the key in UTC
+            - **expires_on** (:class:`~datetime.datetime`): Expiry date of the key in UTC
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
         """
         enabled = kwargs.pop("enabled", None)
         not_before = kwargs.pop("not_before", None)
-        expires = kwargs.pop("expires", None)
-        if enabled is not None or not_before is not None or expires is not None:
-            attributes = self._client.models.KeyAttributes(enabled=enabled, not_before=not_before, expires=expires)
+        expires_on = kwargs.pop("expires_on", None)
+        if enabled is not None or not_before is not None or expires_on is not None:
+            attributes = self._client.models.KeyAttributes(enabled=enabled, not_before=not_before, expires=expires_on)
         else:
             attributes = None
         bundle = await self._client.import_key(

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
@@ -11,7 +11,6 @@ from azure.keyvault.keys.models import DeletedKey, JsonWebKey, Key, KeyPropertie
 from azure.keyvault.keys._shared import AsyncKeyVaultClientBase
 
 from .._shared.exceptions import error_map as _error_map
-from ..crypto.aio import CryptographyClient
 
 
 if TYPE_CHECKING:
@@ -36,24 +35,6 @@ class KeyClient(AsyncKeyVaultClientBase):
     """
 
     # pylint:disable=protected-access
-
-    def get_cryptography_client(self, key: Union[Key, str], **kwargs: Any) -> CryptographyClient:
-        """
-        Get a :class:`~azure.keyvault.keys.crypto.aio.CryptographyClient` capable of performing cryptographic operations
-        with a key.
-
-        :param key:
-            Either a :class:`~azure.keyvault.keys.Key` instance as returned by
-            :func:`~azure.keyvault.keys.aio.KeyClient.get_key`, or a string. If a string, the value must be the full
-            identifier of an Azure Key Vault key with a version.
-        :type key: str or :class:`~azure.keyvault.keys.Key`
-        :rtype: :class:`~azure.keyvault.keys.crypto.aio.CryptographyClient`
-        """
-
-        # the initializer requires a credential but won't actually use it in this case because we pass in this
-        # KeyClient's generated client, whose pipeline (and auth policy) is fully configured
-        credential = object()
-        return CryptographyClient(key, credential, generated_client=self._client, **kwargs)
 
     @distributed_trace_async
     async def create_key(self, name: str, key_type: "Union[str, KeyType]", **kwargs: "Any") -> Key:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
@@ -89,18 +89,19 @@ class KeyClient(AsyncKeyVaultClientBase):
         return Key._from_key_bundle(bundle)
 
     @distributed_trace_async
-    async def create_rsa_key(self, name: str, hsm: bool, **kwargs: "Any") -> Key:
+    async def create_rsa_key(self, name: str, **kwargs: "Any") -> Key:
         """Create a new RSA key. If ``name`` is already in use, create a new version of the key. Requires the
         keys/create permission.
 
         :param str name: The name for the new key
-        :param bool hsm: Whether the key should be created in a hardware security module
         :returns: The created key
         :rtype: ~azure.keyvault.keys.models.Key
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Keyword arguments
             - **size** (int): Key size in bits, for example 2048, 3072, or 4096.
+            - **hardware_protected** (bool): Whether the key should be created in a hardware security module.
+              Defaults to ``False``.
             - **key_operations** (list[str or :class:`~azure.keyvault.keys.enums.KeyOperation`]): Allowed key operations
             - **enabled** (bool): Whether the key is enabled for use.
             - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
@@ -115,15 +116,15 @@ class KeyClient(AsyncKeyVaultClientBase):
                 :caption: Create RSA key
                 :dedent: 8
         """
+        hsm = kwargs.pop("hardware_protected", False)
         return await self.create_key(name, key_type="RSA-HSM" if hsm else "RSA", **kwargs)
 
     @distributed_trace_async
-    async def create_ec_key(self, name: str, hsm: bool, **kwargs: "Any") -> Key:
+    async def create_ec_key(self, name: str, **kwargs: "Any") -> Key:
         """Create a new elliptic curve key. If ``name`` is already in use, create a new version of the key. Requires
         the keys/create permission.
 
         :param str name: The name for the new key. Key Vault will generate the key's version.
-        :param bool hsm: Whether the key should be created in a hardware security module
         :returns: The created key
         :rtype: ~azure.keyvault.keys.models.Key
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
@@ -131,6 +132,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         Keyword arguments
             - **curve** (:class:`~azure.keyvault.keys.enums.KeyCurveName` or str):
               Elliptic curve name. Defaults to the NIST P-256 elliptic curve.
+            - **hardware_protected** (bool): Whether the key should be created in a hardware security module.
+              Defaults to ``False``.
             - **key_operations** (list[str or :class:`~azure.keyvault.keys.enums.KeyOperation`]): Allowed key operations
             - **enabled** (bool): Whether the key is enabled for use.
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
@@ -145,6 +148,7 @@ class KeyClient(AsyncKeyVaultClientBase):
                 :caption: Create an elliptic curve key
                 :dedent: 8
         """
+        hsm = kwargs.pop("hardware_protected", False)
         return await self.create_key(name, key_type="EC-HSM" if hsm else "EC", **kwargs)
 
     @distributed_trace_async

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
@@ -245,7 +245,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_keys(self, **kwargs: "Any") -> "AsyncIterable[KeyProperties]":
+    def list_properties_of_keys(self, **kwargs: "Any") -> "AsyncIterable[KeyProperties]":
         """List identifiers, attributes, and tags of all keys in the vault. Requires the keys/list permission.
 
         :returns: An iterator of keys without their cryptographic material or version information

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
@@ -148,7 +148,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return await self.create_key(name, key_type="EC-HSM" if hsm else "EC", **kwargs)
 
     @distributed_trace_async
-    async def delete_key(self, name: str, **kwargs: "**Any") -> DeletedKey:
+    async def delete_key(self, name: str, **kwargs: "Any") -> DeletedKey:
         """Delete all versions of a key and its cryptographic material. Requires the keys/delete permission.
 
         :param str name: The name of the key to delete.
@@ -170,7 +170,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace_async
-    async def get_key(self, name: str, version: Optional[str] = None, **kwargs: "**Any") -> Key:
+    async def get_key(self, name: str, version: "Optional[str]" = None, **kwargs: "Any") -> Key:
         """Get a key's attributes and, if it's an asymmetric key, its public material. Requires the keys/get permission.
 
         :param str name: The name of the key to get.
@@ -196,7 +196,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return Key._from_key_bundle(bundle)
 
     @distributed_trace_async
-    async def get_deleted_key(self, name: str, **kwargs: "**Any") -> DeletedKey:
+    async def get_deleted_key(self, name: str, **kwargs: "Any") -> DeletedKey:
         """Get a deleted key. This is only possible in a vault with soft-delete enabled. Requires the keys/get
         permission.
 
@@ -219,7 +219,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace
-    def list_deleted_keys(self, **kwargs: "**Any") -> AsyncIterable[DeletedKey]:
+    def list_deleted_keys(self, **kwargs: "Any") -> "AsyncIterable[DeletedKey]":
         """List all deleted keys, including the public part of each. This is only possible in a vault with soft-delete
         enabled. Requires the keys/list permission.
 
@@ -243,7 +243,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_keys(self, **kwargs: "**Any") -> AsyncIterable[KeyProperties]:
+    def list_keys(self, **kwargs: "Any") -> "AsyncIterable[KeyProperties]":
         """List identifiers, attributes, and tags of all keys in the vault. Requires the keys/list permission.
 
         :returns: An iterator of keys without their cryptographic material or version information
@@ -266,7 +266,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_key_versions(self, name: str, **kwargs: "**Any") -> AsyncIterable[KeyProperties]:
+    def list_key_versions(self, name: str, **kwargs: "Any") -> "AsyncIterable[KeyProperties]":
         """List the identifiers, attributes, and tags of a key's versions. Requires the keys/list permission.
 
         :param str name: The name of the key
@@ -291,7 +291,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def purge_deleted_key(self, name: str, **kwargs: "**Any") -> None:
+    async def purge_deleted_key(self, name: str, **kwargs: "Any") -> None:
         """Permanently delete the specified key. This is only possible in vaults with soft-delete enabled. If a vault
         does not have soft-delete enabled, :func:`delete_key` is permanent, and this method will return an error.
 
@@ -312,7 +312,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         await self._client.purge_deleted_key(self.vault_endpoint, name, **kwargs)
 
     @distributed_trace_async
-    async def recover_deleted_key(self, name: str, **kwargs: "**Any") -> Key:
+    async def recover_deleted_key(self, name: str, **kwargs: "Any") -> Key:
         """Recover a deleted key to its latest version. This is only possible in vaults with soft-delete enabled. If a
         vault does not have soft-delete enabled, :func:`delete_key` is permanent, and this method will return an error.
         Attempting to recover an non-deleted key will also return an error.
@@ -382,7 +382,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return Key._from_key_bundle(bundle)
 
     @distributed_trace_async
-    async def backup_key(self, name: str, **kwargs: "**Any") -> bytes:
+    async def backup_key(self, name: str, **kwargs: "Any") -> bytes:
         """Back up a key in a protected form that can't be used outside Azure Key Vault. This is intended to allow
         copying a key from one vault to another. Requires the key/backup permission.
 
@@ -408,7 +408,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace_async
-    async def restore_key(self, backup: bytes, **kwargs: "**Any") -> Key:
+    async def restore_key(self, backup: bytes, **kwargs: "Any") -> Key:
         """Restore a key backup to the vault. This imports all versions of the key, with its name, attributes, and
         access control policies. Requires the keys/restore permission.
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
@@ -472,4 +472,3 @@ class KeyClient(AsyncKeyVaultClientBase):
             **kwargs
         )
         return Key._from_key_bundle(bundle)
-

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/client.py
@@ -434,39 +434,36 @@ class KeyClient(AsyncKeyVaultClientBase):
         return Key._from_key_bundle(bundle)
 
     @distributed_trace_async
-    async def import_key(
-        self,
-        name: str,
-        key: JsonWebKey,
-        hsm: Optional[bool] = None,
-        not_before: Optional[datetime] = None,
-        expires: Optional[datetime] = None,
-        **kwargs: "**Any",
-    ) -> Key:
+    async def import_key(self, name: str, key: JsonWebKey, **kwargs: "Any") -> Key:
         """Import an externally created key. If ``name`` is already in use, import the key as a new version. Requires
         the keys/import permission.
 
         :param str name: Name for the imported key
         :param key: The JSON web key to import
         :type key: ~azure.keyvault.keys.models.JsonWebKey
-        :param bool hsm: (optional) Whether to import as a hardware key (HSM) or software key
-        :param expires: (optional) Expiry date of the key in UTC
-        :param datetime.datetime not_before: (optional) Not before date of the key in UTC
         :returns: The imported key
         :rtype: ~azure.keyvault.keys.models.Key
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Keyword arguments
-            - *enabled (bool)* - Whether the key is enabled for use.
-            - *tags (dict[str, str])* - Application specific metadata in the form of key-value pairs.
-
+            - **enabled** (bool): Whether the key is enabled for use.
+            - **hsm** (bool): Whether the key should be backed by a hardware security module
+            - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
+            - **expires** (:class:`~datetime.datetime`): Expiry date of the key in UTC
+            - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
         """
         enabled = kwargs.pop("enabled", None)
+        not_before = kwargs.pop("not_before", None)
+        expires = kwargs.pop("expires", None)
         if enabled is not None or not_before is not None or expires is not None:
             attributes = self._client.models.KeyAttributes(enabled=enabled, not_before=not_before, expires=expires)
         else:
             attributes = None
         bundle = await self._client.import_key(
-            self.vault_endpoint, name, key=key._to_generated_model(), hsm=hsm, key_attributes=attributes, **kwargs
+            self.vault_endpoint,
+            name,
+            key=key._to_generated_model(),
+            key_attributes=attributes,
+            **kwargs,
         )
         return Key._from_key_bundle(bundle)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
@@ -62,7 +62,7 @@ class KeyClient(KeyVaultClientBase):
             - **enabled** (bool): Whether the key is enabled for use.
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
             - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
-            - **expires** (:class:`~datetime.datetime`): Expiry date of the key in UTC
+            - **expires_on** (:class:`~datetime.datetime`): Expiry date of the key in UTC
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -74,9 +74,9 @@ class KeyClient(KeyVaultClientBase):
         """
         enabled = kwargs.pop("enabled", None)
         not_before = kwargs.pop("not_before", None)
-        expires = kwargs.pop("expires", None)
-        if enabled is not None or not_before is not None or expires is not None:
-            attributes = self._client.models.KeyAttributes(enabled=enabled, not_before=not_before, expires=expires)
+        expires_on = kwargs.pop("expires_on", None)
+        if enabled is not None or not_before is not None or expires_on is not None:
+            attributes = self._client.models.KeyAttributes(enabled=enabled, not_before=not_before, expires=expires_on)
         else:
             attributes = None
 
@@ -108,7 +108,7 @@ class KeyClient(KeyVaultClientBase):
             - **key_operations** (list[str or :class:`~azure.keyvault.keys.enums.KeyOperation`]): Allowed key operations
             - **enabled** (bool): Whether the key is enabled for use.
             - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
-            - **expires** (:class:`~datetime.datetime`): Expiry date of the key in UTC
+            - **expires_on** (:class:`~datetime.datetime`): Expiry date of the key in UTC
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
 
         Example:
@@ -140,7 +140,7 @@ class KeyClient(KeyVaultClientBase):
             - **enabled** (bool): Whether the key is enabled for use.
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
             - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
-            - **expires** (:class:`~datetime.datetime`): Expiry date of the key in UTC
+            - **expires_on** (:class:`~datetime.datetime`): Expiry date of the key in UTC
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -369,7 +369,7 @@ class KeyClient(KeyVaultClientBase):
             - **enabled** (bool): Whether the key is enabled for use.
             - **key_operations** (list[str or :class:`~azure.keyvault.keys.enums.KeyOperation`]): Allowed key operations
             - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
-            - **expires** (:class:`~datetime.datetime`): Expiry date of the key in UTC
+            - **expires_on** (:class:`~datetime.datetime`): Expiry date of the key in UTC
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
 
         Example:
@@ -382,9 +382,9 @@ class KeyClient(KeyVaultClientBase):
         """
         enabled = kwargs.pop("enabled", None)
         not_before = kwargs.pop("not_before", None)
-        expires = kwargs.pop("expires", None)
-        if enabled is not None or not_before is not None or expires is not None:
-            attributes = self._client.models.KeyAttributes(enabled=enabled, not_before=not_before, expires=expires)
+        expires_on = kwargs.pop("expires_on", None)
+        if enabled is not None or not_before is not None or expires_on is not None:
+            attributes = self._client.models.KeyAttributes(enabled=enabled, not_before=not_before, expires=expires_on)
         else:
             attributes = None
         bundle = self._client.update_key(
@@ -469,14 +469,14 @@ class KeyClient(KeyVaultClientBase):
             - **enabled** (bool): Whether the key is enabled for use.
             - **hsm** (bool): Whether the key should be backed by a hardware security module
             - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
-            - **expires** (:class:`~datetime.datetime`): Expiry date of the key in UTC
+            - **expires_on** (:class:`~datetime.datetime`): Expiry date of the key in UTC
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
         """
         enabled = kwargs.pop("enabled", None)
         not_before = kwargs.pop("not_before", None)
-        expires = kwargs.pop("expires", None)
-        if enabled is not None or not_before is not None or expires is not None:
-            attributes = self._client.models.KeyAttributes(enabled=enabled, not_before=not_before, expires=expires)
+        expires_on = kwargs.pop("expires_on", None)
+        if enabled is not None or not_before is not None or expires_on is not None:
+            attributes = self._client.models.KeyAttributes(enabled=enabled, not_before=not_before, expires=expires_on)
         else:
             attributes = None
         bundle = self._client.import_key(

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
@@ -6,7 +6,6 @@ from azure.core.tracing.decorator import distributed_trace
 
 from ._shared import KeyVaultClientBase
 from ._shared.exceptions import error_map as _error_map
-from .crypto import CryptographyClient
 from .models import Key, KeyProperties, DeletedKey
 
 try:
@@ -39,25 +38,6 @@ class KeyClient(KeyVaultClientBase):
     """
 
     # pylint:disable=protected-access
-
-    def get_cryptography_client(self, key, **kwargs):
-        # type: (Union[Key, str], **Any) -> CryptographyClient
-        """
-        Get a :class:`~azure.keyvault.keys.crypto.CryptographyClient` capable of performing cryptographic operations
-        with a key.
-
-        :param key:
-            Either a :class:`~azure.keyvault.keys.Key` instance as returned by
-            :func:`~azure.keyvault.keys.KeyClient.get_key`, or a string. If a string, the value must be the full
-            identifier of an Azure Key Vault key with a version.
-        :type key: str or :class:`~azure.keyvault.keys.Key`
-        :rtype: :class:`~azure.keyvault.keys.crypto.CryptographyClient`
-        """
-
-        # the initializer requires a credential but won't actually use it in this case because we pass in this
-        # KeyClient's generated client, whose pipeline (and auth policy) is fully configured
-        credential = object()
-        return CryptographyClient(key, credential, generated_client=self._client, **kwargs)
 
     @distributed_trace
     def create_key(self, name, key_type, **kwargs):

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
@@ -468,7 +468,7 @@ class KeyClient(KeyVaultClientBase):
 
         Keyword arguments
             - **enabled** (bool): Whether the key is enabled for use.
-            - **hsm** (bool): Whether the key should be backed by a hardware security module
+            - **hardware_protected** (bool): Whether the key should be backed by a hardware security module
             - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
             - **expires_on** (:class:`~datetime.datetime`): Expiry date of the key in UTC
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
@@ -485,6 +485,7 @@ class KeyClient(KeyVaultClientBase):
             name,
             key=key._to_generated_model(),
             key_attributes=attributes,
+            hsm=kwargs.pop("hardware_protected", None),
             **kwargs
         )
         return Key._from_key_bundle(bundle)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
@@ -176,8 +176,8 @@ class KeyClient(KeyVaultClientBase):
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace
-    def get_key(self, name, version=None, **kwargs):
-        # type: (str, Optional[str], **Any) -> Key
+    def get_key(self, name, **kwargs):
+        # type: (str, **Any) -> Key
         """Get a key's attributes and, if it's an asymmetric key, its public material. Requires the keys/get permission.
 
         :param str name: The name of the key to get.
@@ -188,6 +188,9 @@ class KeyClient(KeyVaultClientBase):
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
+        Keyword arguments
+            - **version** (str): A specific version of the key to get. If unspecified, gets the latest version.
+
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
                 :start-after: [START get_key]
@@ -197,7 +200,7 @@ class KeyClient(KeyVaultClientBase):
                 :dedent: 8
         """
         bundle = self._client.get_key(
-            self.vault_endpoint, name, key_version=version or "", error_map=_error_map, **kwargs
+            self.vault_endpoint, name, key_version=kwargs.pop("version", ""), error_map=_error_map, **kwargs
         )
         return Key._from_key_bundle(bundle)
 
@@ -477,10 +480,6 @@ class KeyClient(KeyVaultClientBase):
         else:
             attributes = None
         bundle = self._client.import_key(
-            self.vault_endpoint,
-            name,
-            key=key._to_generated_model(),
-            key_attributes=attributes,
-            **kwargs
+            self.vault_endpoint, name, key=key._to_generated_model(), key_attributes=attributes, **kwargs
         )
         return Key._from_key_bundle(bundle)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
@@ -349,25 +349,12 @@ class KeyClient(KeyVaultClientBase):
         return Key._from_key_bundle(bundle)
 
     @distributed_trace
-    def update_key_properties(
-        self,
-        name,  # type: str
-        version=None,  # type: Optional[str]
-        key_operations=None,  # type: Optional[List[str]]
-        expires=None,  # type: Optional[datetime]
-        not_before=None,  # type: Optional[datetime]
-        **kwargs  # type: Any
-    ):
-        # type: (...) -> Key
+    def update_key_properties(self, name, **kwargs):
+        # type: (str, **Any) -> Key
         """Change attributes of a key. Cannot change a key's cryptographic material. Requires the keys/update
         permission.
 
         :param str name: The name of key to update
-        :param str version: (optional) The version of the key to update
-        :param key_operations: (optional) Allowed key operations
-        :type key_operations: list(str or ~azure.keyvault.keys.enums.KeyOperation)
-        :param datetime.datetime expires: (optional) Expiry date of the key in UTC
-        :param datetime.datetime not_before: (optional) Not before date of the key in UTC
         :returns: The updated key
         :rtype: ~azure.keyvault.keys.models.Key
         :raises:
@@ -375,8 +362,12 @@ class KeyClient(KeyVaultClientBase):
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Keyword arguments
-            - *enabled (bool)* - Whether the key is enabled for use.
-            - *tags (dict[str, str])* - Application specific metadata in the form of key-value pairs.
+            - **version** (str): The version of the key to update. If unspecified, the latest version is updated.
+            - **enabled** (bool): Whether the key is enabled for use.
+            - **key_operations** (list[str or :class:`~azure.keyvault.keys.enums.KeyOperation`]): Allowed key operations
+            - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
+            - **expires** (:class:`~datetime.datetime`): Expiry date of the key in UTC
+            - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -387,6 +378,8 @@ class KeyClient(KeyVaultClientBase):
                 :dedent: 8
         """
         enabled = kwargs.pop("enabled", None)
+        not_before = kwargs.pop("not_before", None)
+        expires = kwargs.pop("expires", None)
         if enabled is not None or not_before is not None or expires is not None:
             attributes = self._client.models.KeyAttributes(enabled=enabled, not_before=not_before, expires=expires)
         else:
@@ -394,8 +387,8 @@ class KeyClient(KeyVaultClientBase):
         bundle = self._client.update_key(
             self.vault_endpoint,
             name,
-            key_version=version or "",
-            key_ops=key_operations,
+            key_version=kwargs.pop("version", ""),
+            key_ops=kwargs.pop("key_operations", None),
             key_attributes=attributes,
             error_map=_error_map,
             **kwargs

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
@@ -255,7 +255,7 @@ class KeyClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_keys(self, **kwargs):
+    def list_properties_of_keys(self, **kwargs):
         # type: (**Any) -> ItemPaged[KeyProperties]
         """List identifiers, attributes, and tags of all keys in the vault. Requires the keys/list permission.
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
@@ -92,19 +92,20 @@ class KeyClient(KeyVaultClientBase):
         return Key._from_key_bundle(bundle)
 
     @distributed_trace
-    def create_rsa_key(self, name, hsm, **kwargs):
-        # type: (str, bool, **Any) -> Key
+    def create_rsa_key(self, name, **kwargs):
+        # type: (str, **Any) -> Key
         """Create a new RSA key. If ``name`` is already in use, create a new version of the key. Requires the
         keys/create permission.
 
         :param str name: The name for the new key
-        :param bool hsm: Whether the key should be created in a hardware security module
         :returns: The created key
         :rtype: ~azure.keyvault.keys.models.Key
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Keyword arguments
             - **size** (int): Key size in bits, for example 2048, 3072, or 4096.
+            - **hardware_protected** (bool): Whether the key should be created in a hardware security module.
+              Defaults to ``False``.
             - **key_operations** (list[str or :class:`~azure.keyvault.keys.enums.KeyOperation`]): Allowed key operations
             - **enabled** (bool): Whether the key is enabled for use.
             - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
@@ -119,16 +120,16 @@ class KeyClient(KeyVaultClientBase):
                 :caption: Create RSA key
                 :dedent: 8
         """
+        hsm = kwargs.pop("hardware_protected", False)
         return self.create_key(name, key_type="RSA-HSM" if hsm else "RSA", **kwargs)
 
     @distributed_trace
-    def create_ec_key(self, name, hsm, **kwargs):
-        # type: (str, bool, **Any) -> Key
+    def create_ec_key(self, name, **kwargs):
+        # type: (str, **Any) -> Key
         """Create a new elliptic curve key. If ``name`` is already in use, create a new version of the key. Requires
         the keys/create permission.
 
         :param str name: The name for the new key. Key Vault will generate the key's version.
-        :param bool hsm: Whether the key should be created in a hardware security module
         :returns: The created key
         :rtype: ~azure.keyvault.keys.models.Key
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
@@ -136,6 +137,8 @@ class KeyClient(KeyVaultClientBase):
         Keyword arguments
             - **curve** (:class:`~azure.keyvault.keys.enums.KeyCurveName` or str):
               Elliptic curve name. Defaults to the NIST P-256 elliptic curve.
+            - **hardware_protected** (bool): Whether the key should be created in a hardware security module.
+              Defaults to ``False``.
             - **key_operations** (list[str or :class:`~azure.keyvault.keys.enums.KeyOperation`]): Allowed key operations
             - **enabled** (bool): Whether the key is enabled for use.
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
@@ -150,6 +153,7 @@ class KeyClient(KeyVaultClientBase):
                 :caption: Create an elliptic curve key
                 :dedent: 8
         """
+        hsm = kwargs.pop("hardware_protected", False)
         return self.create_key(name, key_type="EC-HSM" if hsm else "EC", **kwargs)
 
     @distributed_trace

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/client.py
@@ -450,40 +450,37 @@ class KeyClient(KeyVaultClientBase):
         return Key._from_key_bundle(bundle)
 
     @distributed_trace
-    def import_key(
-        self,
-        name,  # type: str
-        key,  # type: JsonWebKey
-        hsm=None,  # type: Optional[bool]
-        not_before=None,  # type: Optional[datetime]
-        expires=None,  # type: Optional[datetime]
-        **kwargs  # type: Any
-    ):
-        # type: (...) -> Key
+    def import_key(self, name, key, **kwargs):
+        # type: (str, JsonWebKey, **Any) -> Key
         """Import an externally created key. If ``name`` is already in use, import the key as a new version. Requires
         the keys/import permission.
 
         :param str name: Name for the imported key
         :param key: The JSON web key to import
         :type key: ~azure.keyvault.keys.models.JsonWebKey
-        :param bool hsm: (optional) Whether to import as a hardware key (HSM) or software key
-        :param expires: (optional) Expiry date of the key in UTC
-        :param datetime.datetime not_before: (optional) Not before date of the key in UTC
         :returns: The imported key
         :rtype: ~azure.keyvault.keys.models.Key
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Keyword arguments
-            - *enabled (bool)* - Whether the key is enabled for use.
-            - *tags (dict[str, str])* - Application specific metadata in the form of key-value pairs.
-
+            - **enabled** (bool): Whether the key is enabled for use.
+            - **hsm** (bool): Whether the key should be backed by a hardware security module
+            - **not_before** (:class:`~datetime.datetime`): Not before date of the key in UTC
+            - **expires** (:class:`~datetime.datetime`): Expiry date of the key in UTC
+            - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
         """
         enabled = kwargs.pop("enabled", None)
+        not_before = kwargs.pop("not_before", None)
+        expires = kwargs.pop("expires", None)
         if enabled is not None or not_before is not None or expires is not None:
             attributes = self._client.models.KeyAttributes(enabled=enabled, not_before=not_before, expires=expires)
         else:
             attributes = None
         bundle = self._client.import_key(
-            self.vault_endpoint, name, key=key._to_generated_model(), hsm=hsm, key_attributes=attributes, **kwargs
+            self.vault_endpoint,
+            name,
+            key=key._to_generated_model(),
+            key_attributes=attributes,
+            **kwargs
         )
         return Key._from_key_bundle(bundle)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/__init__.py
@@ -2,18 +2,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-# pylint:disable=wrong-import-position
-from collections import namedtuple
-
-DecryptResult = namedtuple("DecryptResult", ["decrypted_bytes"])
-EncryptResult = namedtuple("EncryptResult", ["key_id", "algorithm", "ciphertext", "authentication_tag"])
-SignResult = namedtuple("SignResult", ["key_id", "algorithm", "signature"])
-VerifyResult = namedtuple("VerifyResult", ["result"])
-UnwrapKeyResult = namedtuple("UnwrapKeyResult", ["unwrapped_bytes"])
-WrapKeyResult = namedtuple("WrapKeyResult", ["key_id", "algorithm", "encrypted_key"])
-
-from .client import CryptographyClient
 from .enums import EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
+from ._models import DecryptResult, EncryptResult, SignResult, UnwrapKeyResult, VerifyResult, WrapKeyResult
+from .client import CryptographyClient
 
 
 __all__ = [

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
@@ -1,0 +1,87 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from . import EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
+
+
+class DecryptResult:
+    """The result of a decrypt operation.
+
+    :param bytes decrypted_bytes: The decrypted bytes
+    """
+
+    def __init__(self, decrypted_bytes):
+        # type: (bytes) -> None
+        self.decrypted_bytes = decrypted_bytes
+
+
+class EncryptResult:
+    """The result of an encrypt operation.
+
+    :param str key_id: The encryption key's Key Vault identifier
+    :param algorithm: The encryption algorithm used
+    :type algorithm: ~azure.keyvault.keys.crypto.EncryptionAlgorithm
+    :param bytes ciphertext: The encrypted bytes
+    """
+
+    def __init__(self, key_id, algorithm, ciphertext):
+        # type: (str, EncryptionAlgorithm, bytes) -> None
+        self.key_id = key_id
+        self.algorithm = algorithm
+        self.ciphertext = ciphertext
+
+
+class SignResult:
+    """The result of a sign operation.
+
+    :param str key_id: The signing key's Key Vault identifier
+    :param algorithm: The signature algorithm used
+    :type algorithm: ~azure.keyvault.keys.crypto.SignatureAlgorithm
+    :param bytes signature:
+    """
+
+    def __init__(self, key_id, algorithm, signature):
+        # type: (str, SignatureAlgorithm, bytes) -> None
+        self.key_id = key_id
+        self.algorithm = algorithm
+        self.signature = signature
+
+
+class VerifyResult:
+    """The result of a verify operation.
+
+    :param bool result: Whether the signature is valid
+    """
+
+    def __init__(self, result):
+        self.result = result
+
+
+class UnwrapKeyResult:
+    """The result of an unwrap key operation.
+
+    :param bytes unwrapped_bytes: The unwrapped key's bytes
+    """
+
+    def __init__(self, unwrapped_bytes):
+        self.unwrapped_bytes = unwrapped_bytes
+
+
+class WrapKeyResult:
+    """The result of a wrap key operation.
+
+    :param str key_id: The wrapping key's Key Vault identifier
+    :param algorithm: The key wrap algorithm used
+    :type algorithm: ~azure.keyvault.keys.crypto.KeyWrapAlgorithm
+    :param bytes encrypted_key: The encrypted key bytes
+    """
+
+    def __init__(self, key_id, algorithm, encrypted_key):
+        # type: (str, KeyWrapAlgorithm, bytes) -> None
+        self.key_id = key_id
+        self.algorithm = algorithm
+        self.encrypted_key = encrypted_key

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/client.py
@@ -131,7 +131,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             if not key:
                 return None
 
-            if key.key.kty.lower().startswith("ec"):
+            if key.key_type.lower().startswith("ec"):
                 self._internal_key = EllipticCurveKey.from_jwk(key.key)
             else:
                 self._internal_key = RsaKey.from_jwk(key.key)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/client.py
@@ -72,7 +72,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         if isinstance(key, Key):
             self._key = key
             self._key_id = parse_vault_id(key.id)
-            self._allowed_ops = frozenset(self._key.key.key_ops)
+            self._allowed_ops = frozenset(self._key.key_operations)
         elif isinstance(key, str):
             self._key = None
             self._key_id = parse_vault_id(key)
@@ -115,7 +115,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
                 self._key = await self._client.get_key(
                     self._key_id.vault_endpoint, self._key_id.name, self._key_id.version, **kwargs
                 )
-                self._allowed_ops = frozenset(self._key.key.key_ops)
+                self._allowed_ops = frozenset(self._key.key_operations)
             except HttpResponseError as ex:
                 # if we got a 403, we don't have keys/get permission and won't try to get the key again
                 # (other errors may be transient)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/client.py
@@ -102,7 +102,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         return "/".join(self._key_id)
 
     @distributed_trace_async
-    async def get_key(self, **kwargs: "Any") -> "Optional[Key]":
+    async def _get_key(self, **kwargs: "Any") -> "Optional[Key]":
         """
         Get the client's :class:`~azure.keyvault.keys.models.Key`.
         Can be `None`, if the client lacks keys/get permission.
@@ -127,7 +127,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         id and lacks keys/get permission."""
 
         if not self._internal_key:
-            key = await self.get_key(**kwargs)
+            key = await self._get_key(**kwargs)
             if not key:
                 return None
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/client.py
@@ -72,7 +72,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         if isinstance(key, Key):
             self._key = key
             self._key_id = parse_vault_id(key.id)
-            self._allowed_ops = frozenset(self._key.key_material.key_ops)
+            self._allowed_ops = frozenset(self._key.key.key_ops)
         elif isinstance(key, str):
             self._key = None
             self._key_id = parse_vault_id(key)
@@ -115,7 +115,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
                 self._key = await self._client.get_key(
                     self._key_id.vault_endpoint, self._key_id.name, self._key_id.version, **kwargs
                 )
-                self._allowed_ops = frozenset(self._key.key_material.key_ops)
+                self._allowed_ops = frozenset(self._key.key.key_ops)
             except HttpResponseError as ex:
                 # if we got a 403, we don't have keys/get permission and won't try to get the key again
                 # (other errors may be transient)
@@ -131,10 +131,10 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             if not key:
                 return None
 
-            if key.key_material.kty.lower().startswith("ec"):
-                self._internal_key = EllipticCurveKey.from_jwk(key.key_material)
+            if key.key.kty.lower().startswith("ec"):
+                self._internal_key = EllipticCurveKey.from_jwk(key.key)
             else:
-                self._internal_key = RsaKey.from_jwk(key.key_material)
+                self._internal_key = RsaKey.from_jwk(key.key)
 
         return self._internal_key
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/client.py
@@ -75,7 +75,7 @@ class CryptographyClient(KeyVaultClientBase):
         if isinstance(key, Key):
             self._key = key
             self._key_id = parse_vault_id(key.id)
-            self._allowed_ops = frozenset(self._key.key.key_ops)
+            self._allowed_ops = frozenset(self._key.key_operations)
         elif isinstance(key, six.text_type):
             self._key = None
             self._key_id = parse_vault_id(key)
@@ -120,7 +120,7 @@ class CryptographyClient(KeyVaultClientBase):
                 self._key = self._client.get_key(
                     self._key_id.vault_endpoint, self._key_id.name, self._key_id.version, **kwargs
                 )
-                self._allowed_ops = frozenset(self._key.key.key_ops)
+                self._allowed_ops = frozenset(self._key.key_operations)
             except HttpResponseError as ex:
                 # if we got a 403, we don't have keys/get permission and won't try to get the key again
                 # (other errors may be transient)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/client.py
@@ -75,7 +75,7 @@ class CryptographyClient(KeyVaultClientBase):
         if isinstance(key, Key):
             self._key = key
             self._key_id = parse_vault_id(key.id)
-            self._allowed_ops = frozenset(self._key.key_material.key_ops)
+            self._allowed_ops = frozenset(self._key.key.key_ops)
         elif isinstance(key, six.text_type):
             self._key = None
             self._key_id = parse_vault_id(key)
@@ -120,7 +120,7 @@ class CryptographyClient(KeyVaultClientBase):
                 self._key = self._client.get_key(
                     self._key_id.vault_endpoint, self._key_id.name, self._key_id.version, **kwargs
                 )
-                self._allowed_ops = frozenset(self._key.key_material.key_ops)
+                self._allowed_ops = frozenset(self._key.key.key_ops)
             except HttpResponseError as ex:
                 # if we got a 403, we don't have keys/get permission and won't try to get the key again
                 # (other errors may be transient)
@@ -137,10 +137,10 @@ class CryptographyClient(KeyVaultClientBase):
             if not key:
                 return None
 
-            if key.key_material.kty.lower().startswith("ec"):
-                self._internal_key = EllipticCurveKey.from_jwk(key.key_material)
+            if key.key.kty.lower().startswith("ec"):
+                self._internal_key = EllipticCurveKey.from_jwk(key.key)
             else:
-                self._internal_key = RsaKey.from_jwk(key.key_material)
+                self._internal_key = RsaKey.from_jwk(key.key)
 
         return self._internal_key
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/client.py
@@ -106,7 +106,7 @@ class CryptographyClient(KeyVaultClientBase):
         return "/".join(self._key_id)
 
     @distributed_trace
-    def get_key(self, **kwargs):
+    def _get_key(self, **kwargs):
         # type: (**Any) -> Optional[Key]
         """
         Get the client's :class:`~azure.keyvault.keys.models.Key`.
@@ -133,7 +133,7 @@ class CryptographyClient(KeyVaultClientBase):
         id and lacks keys/get permission."""
 
         if not self._internal_key:
-            key = self.get_key(**kwargs)
+            key = self._get_key(**kwargs)
             if not key:
                 return None
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/client.py
@@ -137,7 +137,7 @@ class CryptographyClient(KeyVaultClientBase):
             if not key:
                 return None
 
-            if key.key.kty.lower().startswith("ec"):
+            if key.key_type.lower().startswith("ec"):
                 self._internal_key = EllipticCurveKey.from_jwk(key.key)
             else:
                 self._internal_key = RsaKey.from_jwk(key.key)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/models.py
@@ -143,7 +143,7 @@ class KeyProperties(object):
         return self._attributes.created
 
     @property
-    def updated(self):
+    def updated_on(self):
         # type: () -> datetime
         """
         When the key was last updated, in UTC

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/models.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from typing import Any, Dict, Optional
     from datetime import datetime
     from ._shared._generated.v7_0 import models as _models
+    from .enums import KeyOperation
 
 KeyOperationResult = namedtuple("KeyOperationResult", ["id", "value"])
 
@@ -240,8 +241,14 @@ class Key(object):
     @property
     def key_type(self):
         # type: () -> str
-        """The key's type"""
+        """The key's type. See :class:`~azure.keyvault.keys.enums.KeyType` for possible values."""
         return self._key_material.kty
+
+    @property
+    def key_operations(self):
+        # type: () -> list[KeyOperation]
+        """Permitted operations. See :class:`~azure.keyvault.keys.enums.KeyOperation` for possible values."""
+        return self._key_material.key_ops
 
 
 class DeletedKey(Key):

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/models.py
@@ -232,7 +232,7 @@ class Key(object):
         return self._properties
 
     @property
-    def key_material(self):
+    def key(self):
         # type: () -> _models.JsonWebKey
         """The JSON web key"""
         return self._key_material

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/models.py
@@ -237,6 +237,12 @@ class Key(object):
         """The JSON web key"""
         return self._key_material
 
+    @property
+    def key_type(self):
+        # type: () -> str
+        """The key's type"""
+        return self._key_material.kty
+
 
 class DeletedKey(Key):
     """A deleted key's id, attributes, and cryptographic material, as well as when it will be purged"""

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/models.py
@@ -122,7 +122,7 @@ class KeyProperties(object):
         return self._attributes.not_before
 
     @property
-    def expires(self):
+    def expires_on(self):
         # type: () -> datetime
         """
         When the key will expire, in UTC

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/models.py
@@ -133,7 +133,7 @@ class KeyProperties(object):
         return self._attributes.expires
 
     @property
-    def created(self):
+    def created_on(self):
         # type: () -> datetime
         """
         When the key was created, in UTC

--- a/sdk/keyvault/azure-keyvault-keys/samples/backup_restore_operations.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/backup_restore_operations.py
@@ -40,7 +40,7 @@ try:
     # if the key already exists in the Key Vault, then a new version of the key is created.
     print("\n.. Create Key")
     key = client.create_key("keyName", "RSA")
-    print("Key with name '{0}' created with key type '{1}'".format(key.name, key.key.kty))
+    print("Key with name '{0}' created with key type '{1}'".format(key.name, key.key_type))
 
     # Backups are good to have, if in case keys gets deleted accidentally.
     # For long term storage, it is ideal to write the backup to a file.

--- a/sdk/keyvault/azure-keyvault-keys/samples/backup_restore_operations.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/backup_restore_operations.py
@@ -40,7 +40,7 @@ try:
     # if the key already exists in the Key Vault, then a new version of the key is created.
     print("\n.. Create Key")
     key = client.create_key("keyName", "RSA")
-    print("Key with name '{0}' created with key type '{1}'".format(key.name, key.key_material.kty))
+    print("Key with name '{0}' created with key type '{1}'".format(key.name, key.key.kty))
 
     # Backups are good to have, if in case keys gets deleted accidentally.
     # For long term storage, it is ideal to write the backup to a file.

--- a/sdk/keyvault/azure-keyvault-keys/samples/backup_restore_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/backup_restore_operations_async.py
@@ -41,7 +41,7 @@ async def run_sample():
         # if the key already exists in the Key Vault, then a new version of the key is created.
         print("\n.. Create Key")
         key = await client.create_key("keyName", "RSA")
-        print("Key with name '{0}' created with key type '{1}'".format(key.name, key.key.kty))
+        print("Key with name '{0}' created with key type '{1}'".format(key.name, key.key_type))
 
         # Backups are good to have, if in case keys gets deleted accidentally.
         # For long term storage, it is ideal to write the backup to a file.

--- a/sdk/keyvault/azure-keyvault-keys/samples/backup_restore_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/backup_restore_operations_async.py
@@ -41,7 +41,7 @@ async def run_sample():
         # if the key already exists in the Key Vault, then a new version of the key is created.
         print("\n.. Create Key")
         key = await client.create_key("keyName", "RSA")
-        print("Key with name '{0}' created with key type '{1}'".format(key.name, key.key_material.kty))
+        print("Key with name '{0}' created with key type '{1}'".format(key.name, key.key.kty))
 
         # Backups are good to have, if in case keys gets deleted accidentally.
         # For long term storage, it is ideal to write the backup to a file.

--- a/sdk/keyvault/azure-keyvault-keys/samples/hello_world.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/hello_world.py
@@ -45,7 +45,7 @@ try:
     key_size = 2048
     key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
     key_name = "rsaKeyName"
-    rsa_key = client.create_rsa_key(key_name, size=key_size, hsm=False, key_operations=key_ops)
+    rsa_key = client.create_rsa_key(key_name, size=key_size, key_operations=key_ops)
     print("RSA Key with name '{0}' created of type '{1}'.".format(rsa_key.name, rsa_key.key_material.kty))
 
     # Let's create an Elliptic Curve key with algorithm curve type P-256.
@@ -53,7 +53,7 @@ try:
     print("\n.. Create an EC Key")
     key_curve = "P-256"
     key_name = "ECKeyName"
-    ec_key = client.create_ec_key(key_name, curve=key_curve, hsm=False)
+    ec_key = client.create_ec_key(key_name, curve=key_curve)
     print("EC Key with name '{0}' created of type '{1}'.".format(ec_key.name, ec_key.key_material.kty))
 
     # Let's get the rsa key details using its name

--- a/sdk/keyvault/azure-keyvault-keys/samples/hello_world.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/hello_world.py
@@ -70,7 +70,7 @@ try:
         ec_key.name, ec_key.properties.version, expires_on=expires, enabled=False
     )
     print(
-        "Key with name '{0}' was updated on date '{1}'".format(updated_ec_key.name, updated_ec_key.properties.updated)
+        "Key with name '{0}' was updated on date '{1}'".format(updated_ec_key.name, updated_ec_key.properties.updated_on)
     )
     print(
         "Key with name '{0}' was updated to expire on '{1}'".format(

--- a/sdk/keyvault/azure-keyvault-keys/samples/hello_world.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/hello_world.py
@@ -67,14 +67,14 @@ try:
     print("\n.. Update a Key by name")
     expires = datetime.datetime.utcnow() + datetime.timedelta(days=365)
     updated_ec_key = client.update_key_properties(
-        ec_key.name, ec_key.properties.version, expires=expires, enabled=False
+        ec_key.name, ec_key.properties.version, expires_on=expires, enabled=False
     )
     print(
         "Key with name '{0}' was updated on date '{1}'".format(updated_ec_key.name, updated_ec_key.properties.updated)
     )
     print(
         "Key with name '{0}' was updated to expire on '{1}'".format(
-            updated_ec_key.name, updated_ec_key.properties.expires
+            updated_ec_key.name, updated_ec_key.properties.expires_on
         )
     )
 

--- a/sdk/keyvault/azure-keyvault-keys/samples/hello_world.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/hello_world.py
@@ -46,7 +46,7 @@ try:
     key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
     key_name = "rsaKeyName"
     rsa_key = client.create_rsa_key(key_name, size=key_size, key_operations=key_ops)
-    print("RSA Key with name '{0}' created of type '{1}'.".format(rsa_key.name, rsa_key.key_material.kty))
+    print("RSA Key with name '{0}' created of type '{1}'.".format(rsa_key.name, rsa_key.key.kty))
 
     # Let's create an Elliptic Curve key with algorithm curve type P-256.
     # if the key already exists in the Key Vault, then a new version of the key is created.
@@ -54,7 +54,7 @@ try:
     key_curve = "P-256"
     key_name = "ECKeyName"
     ec_key = client.create_ec_key(key_name, curve=key_curve)
-    print("EC Key with name '{0}' created of type '{1}'.".format(ec_key.name, ec_key.key_material.kty))
+    print("EC Key with name '{0}' created of type '{1}'.".format(ec_key.name, ec_key.key.kty))
 
     # Let's get the rsa key details using its name
     print("\n.. Get a Key by its name")

--- a/sdk/keyvault/azure-keyvault-keys/samples/hello_world.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/hello_world.py
@@ -46,7 +46,7 @@ try:
     key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
     key_name = "rsaKeyName"
     rsa_key = client.create_rsa_key(key_name, size=key_size, key_operations=key_ops)
-    print("RSA Key with name '{0}' created of type '{1}'.".format(rsa_key.name, rsa_key.key.kty))
+    print("RSA Key with name '{0}' created of type '{1}'.".format(rsa_key.name, rsa_key.key_type))
 
     # Let's create an Elliptic Curve key with algorithm curve type P-256.
     # if the key already exists in the Key Vault, then a new version of the key is created.
@@ -54,7 +54,7 @@ try:
     key_curve = "P-256"
     key_name = "ECKeyName"
     ec_key = client.create_ec_key(key_name, curve=key_curve)
-    print("EC Key with name '{0}' created of type '{1}'.".format(ec_key.name, ec_key.key.kty))
+    print("EC Key with name '{0}' created of type '{1}'.".format(ec_key.name, ec_key.key_type))
 
     # Let's get the rsa key details using its name
     print("\n.. Get a Key by its name")

--- a/sdk/keyvault/azure-keyvault-keys/samples/hello_world_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/hello_world_async.py
@@ -47,7 +47,7 @@ async def run_sample():
         key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
         key_name = "rsaKeyName"
         rsa_key = await client.create_rsa_key(key_name, size=key_size, key_operations=key_ops)
-        print("RSA Key with name '{0}' created of type '{1}'.".format(rsa_key.name, rsa_key.key.kty))
+        print("RSA Key with name '{0}' created of type '{1}'.".format(rsa_key.name, rsa_key.key_type))
 
         # Let's create an Elliptic Curve key with algorithm curve type P-256.
         # if the key already exists in the Key Vault, then a new version of the key is created.
@@ -55,7 +55,7 @@ async def run_sample():
         key_curve = "P-256"
         key_name = "ECKeyName"
         ec_key = await client.create_ec_key(key_name, curve=key_curve)
-        print("EC Key with name '{0}' created of type {1}.".format(ec_key.name, ec_key.key.kty))
+        print("EC Key with name '{0}' created of type {1}.".format(ec_key.name, ec_key.key_type))
 
         # Let's get the rsa key details using its name
         print("\n.. Get a Key using it's name")

--- a/sdk/keyvault/azure-keyvault-keys/samples/hello_world_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/hello_world_async.py
@@ -46,7 +46,7 @@ async def run_sample():
         key_size = 2048
         key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
         key_name = "rsaKeyName"
-        rsa_key = await client.create_rsa_key(key_name, size=key_size, hsm=False, key_operations=key_ops)
+        rsa_key = await client.create_rsa_key(key_name, size=key_size, key_operations=key_ops)
         print("RSA Key with name '{0}' created of type '{1}'.".format(rsa_key.name, rsa_key.key_material.kty))
 
         # Let's create an Elliptic Curve key with algorithm curve type P-256.
@@ -54,7 +54,7 @@ async def run_sample():
         print("\n.. Create an EC Key")
         key_curve = "P-256"
         key_name = "ECKeyName"
-        ec_key = await client.create_ec_key(key_name, curve=key_curve, hsm=False)
+        ec_key = await client.create_ec_key(key_name, curve=key_curve)
         print("EC Key with name '{0}' created of type {1}.".format(ec_key.name, ec_key.key_material.kty))
 
         # Let's get the rsa key details using its name

--- a/sdk/keyvault/azure-keyvault-keys/samples/hello_world_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/hello_world_async.py
@@ -23,11 +23,11 @@ from azure.core.exceptions import HttpResponseError
 #
 # 1. Create a new RSA Key (create_rsa_key)
 #
-# 2. Create a new EC Key (create_rsa_key)
+# 2. Create a new EC Key (create_ec_key)
 #
 # 3. Get an existing key (get_key)
 #
-# 4. Update an existing key (set_key)
+# 4. Update an existing key's properties (update_key_properties)
 #
 # 5. Delete a key (delete_key)
 # ----------------------------------------------------------------------------------------------------------
@@ -66,9 +66,9 @@ async def run_sample():
         # for cryptographic operations. The update method allows the user to modify the metadata (key attributes)
         # associated with a key previously stored within Key Vault.
         print("\n.. Update a Key by name")
-        expires = datetime.datetime.utcnow() + datetime.timedelta(days=365)
+        expires_on = datetime.datetime.utcnow() + datetime.timedelta(days=365)
         updated_ec_key = await client.update_key_properties(
-            ec_key.name, ec_key.properties.version, expires=expires, enabled=False
+            ec_key.name, version=ec_key.properties.version, expires_on=expires_on, enabled=False
         )
         print(
             "Key with name '{0}' was updated on date '{1}'".format(
@@ -77,7 +77,7 @@ async def run_sample():
         )
         print(
             "Key with name '{0}' was updated to expire on '{1}'".format(
-                updated_ec_key.name, updated_ec_key.properties.expires
+                updated_ec_key.name, updated_ec_key.properties.expires_on
             )
         )
 

--- a/sdk/keyvault/azure-keyvault-keys/samples/hello_world_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/hello_world_async.py
@@ -72,7 +72,7 @@ async def run_sample():
         )
         print(
             "Key with name '{0}' was updated on date '{1}'".format(
-                updated_ec_key.name, updated_ec_key.properties.updated
+                updated_ec_key.name, updated_ec_key.properties.updated_on
             )
         )
         print(

--- a/sdk/keyvault/azure-keyvault-keys/samples/hello_world_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/hello_world_async.py
@@ -47,7 +47,7 @@ async def run_sample():
         key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
         key_name = "rsaKeyName"
         rsa_key = await client.create_rsa_key(key_name, size=key_size, key_operations=key_ops)
-        print("RSA Key with name '{0}' created of type '{1}'.".format(rsa_key.name, rsa_key.key_material.kty))
+        print("RSA Key with name '{0}' created of type '{1}'.".format(rsa_key.name, rsa_key.key.kty))
 
         # Let's create an Elliptic Curve key with algorithm curve type P-256.
         # if the key already exists in the Key Vault, then a new version of the key is created.
@@ -55,7 +55,7 @@ async def run_sample():
         key_curve = "P-256"
         key_name = "ECKeyName"
         ec_key = await client.create_ec_key(key_name, curve=key_curve)
-        print("EC Key with name '{0}' created of type {1}.".format(ec_key.name, ec_key.key_material.kty))
+        print("EC Key with name '{0}' created of type {1}.".format(ec_key.name, ec_key.key.kty))
 
         # Let's get the rsa key details using its name
         print("\n.. Get a Key using it's name")

--- a/sdk/keyvault/azure-keyvault-keys/samples/list_operations.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/list_operations.py
@@ -55,7 +55,7 @@ try:
     # List operations don 't return the keys with their type information.
     # So, for each returned key we call get_key to get the key with its type information.
     print("\n.. List keys from the Key Vault")
-    keys = client.list_keys()
+    keys = client.list_properties_of_keys()
     for key in keys:
         retrieved_key = client.get_key(key.name)
         print(

--- a/sdk/keyvault/azure-keyvault-keys/samples/list_operations.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/list_operations.py
@@ -47,8 +47,8 @@ try:
     print("\n.. Create Key")
     rsa_key = client.create_rsa_key("rsaKeyName")
     ec_key = client.create_ec_key("ecKeyName")
-    print("Key with name '{0}' was created of type '{1}'.".format(rsa_key.name, rsa_key.key_material.kty))
-    print("Key with name '{0}' was created of type '{1}'.".format(ec_key.name, ec_key.key_material.kty))
+    print("Key with name '{0}' was created of type '{1}'.".format(rsa_key.name, rsa_key.key.kty))
+    print("Key with name '{0}' was created of type '{1}'.".format(ec_key.name, ec_key.key.kty))
 
     # You need to check the type of all the keys in the vault.
     # Let's list the keys and print their key types.
@@ -59,7 +59,7 @@ try:
     for key in keys:
         retrieved_key = client.get_key(key.name)
         print(
-            "Key with name '{0}' with type '{1}' was found.".format(retrieved_key.name, retrieved_key.key_material.kty)
+            "Key with name '{0}' with type '{1}' was found.".format(retrieved_key.name, retrieved_key.key.kty)
         )
 
     # The rsa key size now should now be 3072, default - 2048. So you want to update the key in Key Vault to ensure

--- a/sdk/keyvault/azure-keyvault-keys/samples/list_operations.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/list_operations.py
@@ -45,8 +45,8 @@ try:
     # Let's create keys with RSA and EC type. If the key
     # already exists in the Key Vault, then a new version of the key is created.
     print("\n.. Create Key")
-    rsa_key = client.create_rsa_key("rsaKeyName", hsm=False)
-    ec_key = client.create_ec_key("ecKeyName", hsm=False)
+    rsa_key = client.create_rsa_key("rsaKeyName")
+    ec_key = client.create_ec_key("ecKeyName")
     print("Key with name '{0}' was created of type '{1}'.".format(rsa_key.name, rsa_key.key_material.kty))
     print("Key with name '{0}' was created of type '{1}'.".format(ec_key.name, ec_key.key_material.kty))
 
@@ -65,7 +65,7 @@ try:
     # The rsa key size now should now be 3072, default - 2048. So you want to update the key in Key Vault to ensure
     # it reflects the new key size. Calling create_rsa_key on an existing key creates a new version of the key in
     # the Key Vault with the new key size.
-    new_key = client.create_rsa_key(rsa_key.name, hsm=False, size=3072)
+    new_key = client.create_rsa_key(rsa_key.name, size=3072)
     print("New version was created for Key with name '{0}' with the updated size.".format(new_key.name))
 
     # You should have more than one version of the rsa key at this time. Lets print all the versions of this key.

--- a/sdk/keyvault/azure-keyvault-keys/samples/list_operations.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/list_operations.py
@@ -47,8 +47,8 @@ try:
     print("\n.. Create Key")
     rsa_key = client.create_rsa_key("rsaKeyName")
     ec_key = client.create_ec_key("ecKeyName")
-    print("Key with name '{0}' was created of type '{1}'.".format(rsa_key.name, rsa_key.key.kty))
-    print("Key with name '{0}' was created of type '{1}'.".format(ec_key.name, ec_key.key.kty))
+    print("Key with name '{0}' was created of type '{1}'.".format(rsa_key.name, rsa_key.key_type))
+    print("Key with name '{0}' was created of type '{1}'.".format(ec_key.name, ec_key.key_type))
 
     # You need to check the type of all the keys in the vault.
     # Let's list the keys and print their key types.
@@ -59,7 +59,7 @@ try:
     for key in keys:
         retrieved_key = client.get_key(key.name)
         print(
-            "Key with name '{0}' with type '{1}' was found.".format(retrieved_key.name, retrieved_key.key.kty)
+            "Key with name '{0}' with type '{1}' was found.".format(retrieved_key.name, retrieved_key.key_type)
         )
 
     # The rsa key size now should now be 3072, default - 2048. So you want to update the key in Key Vault to ensure

--- a/sdk/keyvault/azure-keyvault-keys/samples/list_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/list_operations_async.py
@@ -46,8 +46,8 @@ async def run_sample():
         print("\n.. Create Key")
         rsa_key = await client.create_rsa_key("rsaKeyName")
         ec_key = await client.create_ec_key("ecKey1Name")
-        print("Key with name '{0}' was created of type '{1}'.".format(rsa_key.name, rsa_key.key.kty))
-        print("Key with name '{0}' was created of type '{1}'.".format(ec_key.name, ec_key.key.kty))
+        print("Key with name '{0}' was created of type '{1}'.".format(rsa_key.name, rsa_key.key_type))
+        print("Key with name '{0}' was created of type '{1}'.".format(ec_key.name, ec_key.key_type))
 
         # You need to check the type of all the keys in the vault.
         # Let's list the keys and print their key types.
@@ -59,7 +59,7 @@ async def run_sample():
             retrieved_key = await client.get_key(key.name)
             print(
                 "Key with name '{0}' with type '{1}' was found.".format(
-                    retrieved_key.name, retrieved_key.key.kty
+                    retrieved_key.name, retrieved_key.key_type
                 )
             )
 

--- a/sdk/keyvault/azure-keyvault-keys/samples/list_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/list_operations_async.py
@@ -44,8 +44,8 @@ async def run_sample():
         # Let's create keys with RSA and EC type. If the key
         # already exists in the Key Vault, then a new version of the key is created.
         print("\n.. Create Key")
-        rsa_key = await client.create_rsa_key("rsaKeyName", hsm=False)
-        ec_key = await client.create_ec_key("ecKey1Name", hsm=False)
+        rsa_key = await client.create_rsa_key("rsaKeyName")
+        ec_key = await client.create_ec_key("ecKey1Name")
         print("Key with name '{0}' was created of type '{1}'.".format(rsa_key.name, rsa_key.key_material.kty))
         print("Key with name '{0}' was created of type '{1}'.".format(ec_key.name, ec_key.key_material.kty))
 
@@ -66,7 +66,7 @@ async def run_sample():
         # The rsa key size now should now be 3072, default - 2048. So you want to update the key in Key Vault to ensure
         # it reflects the new key size. Calling create_rsa_key on an existing key creates a new version of the key in
         # the Key Vault with the new key size.
-        new_key = await client.create_rsa_key(rsa_key.name, hsm=False, size=3072)
+        new_key = await client.create_rsa_key(rsa_key.name, size=3072)
         print("New version was created for Key with name '{0}' with the updated size.".format(new_key.name))
 
         # You should have more than one version of the rsa key at this time. Lets print all the versions of this key.

--- a/sdk/keyvault/azure-keyvault-keys/samples/list_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/list_operations_async.py
@@ -54,7 +54,7 @@ async def run_sample():
         # List operations don 't return the keys with their type information.
         # So, for each returned key we call get_key to get the key with its type information.
         print("\n.. List keys from the Key Vault")
-        keys = client.list_keys()
+        keys = client.list_properties_of_keys()
         async for key in keys:
             retrieved_key = await client.get_key(key.name)
             print(

--- a/sdk/keyvault/azure-keyvault-keys/samples/list_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/list_operations_async.py
@@ -46,8 +46,8 @@ async def run_sample():
         print("\n.. Create Key")
         rsa_key = await client.create_rsa_key("rsaKeyName")
         ec_key = await client.create_ec_key("ecKey1Name")
-        print("Key with name '{0}' was created of type '{1}'.".format(rsa_key.name, rsa_key.key_material.kty))
-        print("Key with name '{0}' was created of type '{1}'.".format(ec_key.name, ec_key.key_material.kty))
+        print("Key with name '{0}' was created of type '{1}'.".format(rsa_key.name, rsa_key.key.kty))
+        print("Key with name '{0}' was created of type '{1}'.".format(ec_key.name, ec_key.key.kty))
 
         # You need to check the type of all the keys in the vault.
         # Let's list the keys and print their key types.
@@ -59,7 +59,7 @@ async def run_sample():
             retrieved_key = await client.get_key(key.name)
             print(
                 "Key with name '{0}' with type '{1}' was found.".format(
-                    retrieved_key.name, retrieved_key.key_material.kty
+                    retrieved_key.name, retrieved_key.key.kty
                 )
             )
 

--- a/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations.py
@@ -40,8 +40,8 @@ credential = DefaultAzureCredential()
 client = KeyClient(vault_endpoint=VAULT_ENDPOINT, credential=credential)
 try:
     print("\n.. Create keys")
-    rsa_key = client.create_rsa_key("rsaKeyName", hsm=False)
-    ec_key = client.create_ec_key("ecKeyName", hsm=False)
+    rsa_key = client.create_rsa_key("rsaKeyName")
+    ec_key = client.create_ec_key("ecKeyName")
     print("Created key '{0}' of type '{1}'.".format(rsa_key.name, rsa_key.key_material.kty))
     print("Created key '{0}' of type '{1}'.".format(ec_key.name, ec_key.key_material.kty))
 

--- a/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations.py
@@ -42,8 +42,8 @@ try:
     print("\n.. Create keys")
     rsa_key = client.create_rsa_key("rsaKeyName")
     ec_key = client.create_ec_key("ecKeyName")
-    print("Created key '{0}' of type '{1}'.".format(rsa_key.name, rsa_key.key_material.kty))
-    print("Created key '{0}' of type '{1}'.".format(ec_key.name, ec_key.key_material.kty))
+    print("Created key '{0}' of type '{1}'.".format(rsa_key.name, rsa_key.key.kty))
+    print("Created key '{0}' of type '{1}'.".format(ec_key.name, ec_key.key.kty))
 
     print("\n.. Delete the keys")
     for key_name in (ec_key.name, rsa_key.name):

--- a/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations.py
@@ -42,8 +42,8 @@ try:
     print("\n.. Create keys")
     rsa_key = client.create_rsa_key("rsaKeyName")
     ec_key = client.create_ec_key("ecKeyName")
-    print("Created key '{0}' of type '{1}'.".format(rsa_key.name, rsa_key.key.kty))
-    print("Created key '{0}' of type '{1}'.".format(ec_key.name, ec_key.key.kty))
+    print("Created key '{0}' of type '{1}'.".format(rsa_key.name, rsa_key.key_type))
+    print("Created key '{0}' of type '{1}'.".format(ec_key.name, ec_key.key_type))
 
     print("\n.. Delete the keys")
     for key_name in (ec_key.name, rsa_key.name):

--- a/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations_async.py
@@ -41,8 +41,8 @@ async def run_sample():
     client = KeyClient(vault_endpoint=VAULT_ENDPOINT, credential=credential)
     try:
         print("\n.. Create keys")
-        rsa_key = await client.create_rsa_key("rsaKeyName", hsm=False)
-        ec_key = await client.create_ec_key("ecKeyName", hsm=False)
+        rsa_key = await client.create_rsa_key("rsaKeyName")
+        ec_key = await client.create_ec_key("ecKeyName")
         print("Created key '{0}' of type '{1}'.".format(rsa_key.name, rsa_key.key_material.kty))
         print("Created key '{0}' of type '{1}'.".format(ec_key.name, ec_key.key_material.kty))
 

--- a/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations_async.py
@@ -43,8 +43,8 @@ async def run_sample():
         print("\n.. Create keys")
         rsa_key = await client.create_rsa_key("rsaKeyName")
         ec_key = await client.create_ec_key("ecKeyName")
-        print("Created key '{0}' of type '{1}'.".format(rsa_key.name, rsa_key.key_material.kty))
-        print("Created key '{0}' of type '{1}'.".format(ec_key.name, ec_key.key_material.kty))
+        print("Created key '{0}' of type '{1}'.".format(rsa_key.name, rsa_key.key.kty))
+        print("Created key '{0}' of type '{1}'.".format(ec_key.name, ec_key.key.kty))
 
         print("\n.. Delete the keys")
         for key_name in (ec_key.name, rsa_key.name):

--- a/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations_async.py
@@ -43,8 +43,8 @@ async def run_sample():
         print("\n.. Create keys")
         rsa_key = await client.create_rsa_key("rsaKeyName")
         ec_key = await client.create_ec_key("ecKeyName")
-        print("Created key '{0}' of type '{1}'.".format(rsa_key.name, rsa_key.key.kty))
-        print("Created key '{0}' of type '{1}'.".format(ec_key.name, ec_key.key.kty))
+        print("Created key '{0}' of type '{1}'.".format(rsa_key.name, rsa_key.key_type))
+        print("Created key '{0}' of type '{1}'.".format(ec_key.name, ec_key.key_type))
 
         print("\n.. Delete the keys")
         for key_name in (ec_key.name, rsa_key.name):

--- a/sdk/keyvault/azure-keyvault-keys/tests/keys_vault_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/keys_vault_client.py
@@ -9,6 +9,7 @@ except ImportError:
 
 from azure.keyvault.keys._shared import KeyVaultClientBase
 from azure.keyvault.keys import KeyClient
+from azure.keyvault.keys.crypto import CryptographyClient
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import
@@ -24,7 +25,11 @@ class VaultClient(KeyVaultClientBase):
         super(VaultClient, self).__init__(
             vault_endpoint, credential, transport=transport, api_version=api_version, **kwargs
         )
+        self._credential = credential
         self._keys = KeyClient(self.vault_endpoint, credential, generated_client=self._client, **kwargs)
+
+    def get_cryptography_client(self, key):
+        return CryptographyClient(key, self._credential)
 
     @property
     def keys(self):

--- a/sdk/keyvault/azure-keyvault-keys/tests/keys_vault_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/keys_vault_client_async.py
@@ -10,6 +10,7 @@ from azure.core.pipeline.transport import AsyncioRequestsTransport, HttpTranspor
 from msrest.serialization import Model
 
 from azure.keyvault.keys.aio import KeyClient
+from azure.keyvault.keys.crypto.aio import CryptographyClient
 from azure.keyvault.keys._shared import AsyncKeyVaultClientBase
 
 if TYPE_CHECKING:
@@ -34,7 +35,11 @@ class VaultClient(AsyncKeyVaultClientBase):
         super(VaultClient, self).__init__(
             vault_endpoint, credential, transport=transport, api_version=api_version, **kwargs
         )
+        self._credential = credential
         self._keys = KeyClient(self.vault_endpoint, credential, generated_client=self._client, **kwargs)
+
+    def get_cryptography_client(self, key):
+        return CryptographyClient(key, self._credential)
 
     @property
     def keys(self):

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -28,7 +28,8 @@ class CryptoClientTests(KeyVaultTestCase):
         self.assertTrue(key.n and key.e, "Bad RSA public material.")
         self.assertEqual(key_ops, key.key_ops, "keyOps should be '{}', but is '{}'".format(key_ops, key.key_ops))
         self.assertTrue(
-            key_attributes.properties.created and key_attributes.properties.updated, "Missing required date attributes."
+            key_attributes.properties.created_on and key_attributes.properties.updated,
+            "Missing required date attributes.",
         )
 
     def _import_test_key(self, client, name):
@@ -77,9 +78,7 @@ class CryptoClientTests(KeyVaultTestCase):
         imported_key = self._import_test_key(key_client, key_name)
         crypto_client = vault_client.get_cryptography_client(imported_key.id)
 
-        result = crypto_client.encrypt(
-            EncryptionAlgorithm.rsa_oaep, self.plaintext
-        )
+        result = crypto_client.encrypt(EncryptionAlgorithm.rsa_oaep, self.plaintext)
         self.assertEqual(result.key_id, imported_key.id)
 
         result = crypto_client.decrypt(result.algorithm, result.ciphertext)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -130,7 +130,7 @@ class CryptoClientTests(KeyVaultTestCase):
         """Encrypt locally, decrypt with Key Vault"""
 
         key_client = vault_client.keys
-        key = key_client.create_rsa_key("encrypt-local", size=4096, hsm=False)
+        key = key_client.create_rsa_key("encrypt-local", size=4096)
         crypto_client = vault_client.get_cryptography_client(key)
 
         for encrypt_algorithm in EncryptionAlgorithm:
@@ -146,7 +146,7 @@ class CryptoClientTests(KeyVaultTestCase):
         """Wrap locally, unwrap with Key Vault"""
 
         key_client = vault_client.keys
-        key = key_client.create_rsa_key("wrap-local", size=4096, hsm=False)
+        key = key_client.create_rsa_key("wrap-local", size=4096)
         crypto_client = vault_client.get_cryptography_client(key)
 
         for wrap_algorithm in KeyWrapAlgorithm:
@@ -164,7 +164,7 @@ class CryptoClientTests(KeyVaultTestCase):
         key_client = vault_client.keys
 
         for size in (2048, 3072, 4096):
-            key = key_client.create_rsa_key("rsa-verify-{}".format(size), size=size, hsm=False)
+            key = key_client.create_rsa_key("rsa-verify-{}".format(size), size=size)
             crypto_client = vault_client.get_cryptography_client(key)
             for signature_algorithm, hash_function in (
                 (SignatureAlgorithm.ps256, hashlib.sha256),
@@ -197,7 +197,7 @@ class CryptoClientTests(KeyVaultTestCase):
         }
 
         for curve, (signature_algorithm, hash_function) in matrix.items():
-            key = key_client.create_ec_key("ec-verify-{}".format(curve.value), curve=curve, hsm=False)
+            key = key_client.create_ec_key("ec-verify-{}".format(curve.value), curve=curve)
             crypto_client = vault_client.get_cryptography_client(key)
 
             digest = hash_function(self.plaintext).digest()

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -75,7 +75,7 @@ class CryptoClientTests(KeyVaultTestCase):
         key_client = vault_client.keys
 
         imported_key = self._import_test_key(key_client, key_name)
-        crypto_client = key_client.get_cryptography_client(imported_key.id)
+        crypto_client = vault_client.get_cryptography_client(imported_key.id)
 
         key_id, algorithm, ciphertext, authentication_tag = crypto_client.encrypt(
             EncryptionAlgorithm.rsa_oaep, self.plaintext
@@ -98,7 +98,7 @@ class CryptoClientTests(KeyVaultTestCase):
         digest = md.digest()
 
         imported_key = self._import_test_key(key_client, key_name)
-        crypto_client = key_client.get_cryptography_client(imported_key.id)
+        crypto_client = vault_client.get_cryptography_client(imported_key.id)
 
         key_id, algorithm, signature = crypto_client.sign(SignatureAlgorithm.rs256, digest)
         self.assertEqual(key_id, imported_key.id)
@@ -114,7 +114,7 @@ class CryptoClientTests(KeyVaultTestCase):
 
         created_key = key_client.create_key(key_name, "RSA")
         self.assertIsNotNone(created_key)
-        crypto_client = key_client.get_cryptography_client(created_key.id)
+        crypto_client = vault_client.get_cryptography_client(created_key.id)
 
         # Wrap a key with the created key, then unwrap it. The wrapped key's bytes should round-trip.
         key_bytes = self.plaintext
@@ -131,7 +131,7 @@ class CryptoClientTests(KeyVaultTestCase):
 
         key_client = vault_client.keys
         key = key_client.create_rsa_key("encrypt-local", size=4096, hsm=False)
-        crypto_client = key_client.get_cryptography_client(key)
+        crypto_client = vault_client.get_cryptography_client(key)
 
         for encrypt_algorithm in EncryptionAlgorithm:
             key_id, algorithm, ciphertext, tag = crypto_client.encrypt(encrypt_algorithm, self.plaintext)
@@ -147,7 +147,7 @@ class CryptoClientTests(KeyVaultTestCase):
 
         key_client = vault_client.keys
         key = key_client.create_rsa_key("wrap-local", size=4096, hsm=False)
-        crypto_client = key_client.get_cryptography_client(key)
+        crypto_client = vault_client.get_cryptography_client(key)
 
         for wrap_algorithm in KeyWrapAlgorithm:
             key_id, algorithm, encrypted_key = crypto_client.wrap_key(wrap_algorithm, self.plaintext)
@@ -165,7 +165,7 @@ class CryptoClientTests(KeyVaultTestCase):
 
         for size in (2048, 3072, 4096):
             key = key_client.create_rsa_key("rsa-verify-{}".format(size), size=size, hsm=False)
-            crypto_client = key_client.get_cryptography_client(key)
+            crypto_client = vault_client.get_cryptography_client(key)
             for signature_algorithm, hash_function in (
                 (SignatureAlgorithm.ps256, hashlib.sha256),
                 (SignatureAlgorithm.ps384, hashlib.sha384),
@@ -198,7 +198,7 @@ class CryptoClientTests(KeyVaultTestCase):
 
         for curve, (signature_algorithm, hash_function) in matrix.items():
             key = key_client.create_ec_key("ec-verify-{}".format(curve.value), curve=curve, hsm=False)
-            crypto_client = key_client.get_cryptography_client(key)
+            crypto_client = vault_client.get_cryptography_client(key)
 
             digest = hash_function(self.plaintext).digest()
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -28,7 +28,7 @@ class CryptoClientTests(KeyVaultTestCase):
         self.assertTrue(key.n and key.e, "Bad RSA public material.")
         self.assertEqual(key_ops, key.key_ops, "keyOps should be '{}', but is '{}'".format(key_ops, key.key_ops))
         self.assertTrue(
-            key_attributes.properties.created_on and key_attributes.properties.updated,
+            key_attributes.properties.created_on and key_attributes.properties.updated_on,
             "Missing required date attributes.",
         )
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -21,7 +21,7 @@ class CryptoClientTests(KeyVaultTestCase):
 
     def _validate_rsa_key_bundle(self, key_attributes, vault, key_name, kty, key_ops):
         prefix = "/".join(s.strip("/") for s in [vault, "keys", key_name])
-        key = key_attributes.key_material
+        key = key_attributes.key
         kid = key_attributes.id
         self.assertTrue(kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid))
         self.assertEqual(key.kty, kty, "kty should by '{}', but is '{}'".format(key, key.kty))

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -21,7 +21,7 @@ class CryptoClientTests(AsyncKeyVaultTestCase):
 
     def _validate_rsa_key_bundle(self, key_attributes, vault, key_name, kty, key_ops):
         prefix = "/".join(s.strip("/") for s in [vault, "keys", key_name])
-        key = key_attributes.key_material
+        key = key_attributes.key
         kid = key_attributes.id
         self.assertTrue(kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid))
         self.assertEqual(key.kty, kty, "kty should by '{}', but is '{}'".format(key, key.kty))

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -28,7 +28,7 @@ class CryptoClientTests(AsyncKeyVaultTestCase):
         self.assertTrue(key.n and key.e, "Bad RSA public material.")
         self.assertEqual(key_ops, key.key_ops, "keyOps should be '{}', but is '{}'".format(key_ops, key.key_ops))
         self.assertTrue(
-            key_attributes.properties.created_on and key_attributes.properties.updated,
+            key_attributes.properties.created_on and key_attributes.properties.updated_on,
             "Missing required date attributes.",
         )
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -76,7 +76,7 @@ class CryptoClientTests(AsyncKeyVaultTestCase):
         key_client = vault_client.keys
 
         imported_key = await self._import_test_key(key_client, key_name)
-        crypto_client = key_client.get_cryptography_client(imported_key)
+        crypto_client = vault_client.get_cryptography_client(imported_key)
 
         key_id, algorithm, ciphertext, authentication_tag = await crypto_client.encrypt(
             EncryptionAlgorithm.rsa_oaep, self.plaintext
@@ -100,7 +100,7 @@ class CryptoClientTests(AsyncKeyVaultTestCase):
         digest = md.digest()
 
         imported_key = await self._import_test_key(key_client, key_name)
-        crypto_client = key_client.get_cryptography_client(imported_key)
+        crypto_client = vault_client.get_cryptography_client(imported_key)
 
         key_id, algorithm, signature = await crypto_client.sign(SignatureAlgorithm.rs256, digest)
         self.assertEqual(key_id, imported_key.id)
@@ -117,7 +117,7 @@ class CryptoClientTests(AsyncKeyVaultTestCase):
 
         created_key = await key_client.create_key(key_name, "RSA")
         self.assertIsNotNone(created_key)
-        crypto_client = key_client.get_cryptography_client(created_key)
+        crypto_client = vault_client.get_cryptography_client(created_key)
 
         # Wrap a key with the created key, then unwrap it. The wrapped key's bytes should round-trip.
         key_bytes = self.plaintext
@@ -135,7 +135,7 @@ class CryptoClientTests(AsyncKeyVaultTestCase):
 
         key_client = vault_client.keys
         key = await key_client.create_rsa_key("encrypt-local", size=4096, hsm=False)
-        crypto_client = key_client.get_cryptography_client(key)
+        crypto_client = vault_client.get_cryptography_client(key)
 
         for encrypt_algorithm in EncryptionAlgorithm:
             key_id, algorithm, ciphertext, tag = await crypto_client.encrypt(encrypt_algorithm, self.plaintext)
@@ -152,7 +152,7 @@ class CryptoClientTests(AsyncKeyVaultTestCase):
 
         key_client = vault_client.keys
         key = await key_client.create_rsa_key("wrap-local", size=4096, hsm=False)
-        crypto_client = key_client.get_cryptography_client(key)
+        crypto_client = vault_client.get_cryptography_client(key)
 
         for wrap_algorithm in KeyWrapAlgorithm:
             key_id, algorithm, encrypted_key = await crypto_client.wrap_key(wrap_algorithm, self.plaintext)
@@ -171,7 +171,7 @@ class CryptoClientTests(AsyncKeyVaultTestCase):
 
         for size in (2048, 3072, 4096):
             key = await key_client.create_rsa_key("rsa-verify-{}".format(size), size=size, hsm=False)
-            crypto_client = key_client.get_cryptography_client(key)
+            crypto_client = vault_client.get_cryptography_client(key)
             for signature_algorithm, hash_function in (
                 (SignatureAlgorithm.ps256, hashlib.sha256),
                 (SignatureAlgorithm.ps384, hashlib.sha384),
@@ -205,7 +205,7 @@ class CryptoClientTests(AsyncKeyVaultTestCase):
 
         for curve, (signature_algorithm, hash_function) in matrix.items():
             key = await key_client.create_ec_key("ec-verify-{}".format(curve.value), curve=curve, hsm=False)
-            crypto_client = key_client.get_cryptography_client(key)
+            crypto_client = vault_client.get_cryptography_client(key)
 
             digest = hash_function(self.plaintext).digest()
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -134,7 +134,7 @@ class CryptoClientTests(AsyncKeyVaultTestCase):
         """Encrypt locally, decrypt with Key Vault"""
 
         key_client = vault_client.keys
-        key = await key_client.create_rsa_key("encrypt-local", size=4096, hsm=False)
+        key = await key_client.create_rsa_key("encrypt-local", size=4096)
         crypto_client = vault_client.get_cryptography_client(key)
 
         for encrypt_algorithm in EncryptionAlgorithm:
@@ -151,7 +151,7 @@ class CryptoClientTests(AsyncKeyVaultTestCase):
         """Wrap locally, unwrap with Key Vault"""
 
         key_client = vault_client.keys
-        key = await key_client.create_rsa_key("wrap-local", size=4096, hsm=False)
+        key = await key_client.create_rsa_key("wrap-local", size=4096)
         crypto_client = vault_client.get_cryptography_client(key)
 
         for wrap_algorithm in KeyWrapAlgorithm:
@@ -170,7 +170,7 @@ class CryptoClientTests(AsyncKeyVaultTestCase):
         key_client = vault_client.keys
 
         for size in (2048, 3072, 4096):
-            key = await key_client.create_rsa_key("rsa-verify-{}".format(size), size=size, hsm=False)
+            key = await key_client.create_rsa_key("rsa-verify-{}".format(size), size=size)
             crypto_client = vault_client.get_cryptography_client(key)
             for signature_algorithm, hash_function in (
                 (SignatureAlgorithm.ps256, hashlib.sha256),
@@ -204,7 +204,7 @@ class CryptoClientTests(AsyncKeyVaultTestCase):
         }
 
         for curve, (signature_algorithm, hash_function) in matrix.items():
-            key = await key_client.create_ec_key("ec-verify-{}".format(curve.value), curve=curve, hsm=False)
+            key = await key_client.create_ec_key("ec-verify-{}".format(curve.value), curve=curve)
             crypto_client = vault_client.get_cryptography_client(key)
 
             digest = hash_function(self.plaintext).digest()

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -28,7 +28,8 @@ class CryptoClientTests(AsyncKeyVaultTestCase):
         self.assertTrue(key.n and key.e, "Bad RSA public material.")
         self.assertEqual(key_ops, key.key_ops, "keyOps should be '{}', but is '{}'".format(key_ops, key.key_ops))
         self.assertTrue(
-            key_attributes.properties.created and key_attributes.properties.updated, "Missing required date attributes."
+            key_attributes.properties.created_on and key_attributes.properties.updated,
+            "Missing required date attributes.",
         )
 
     async def _import_test_key(self, client, name):
@@ -78,9 +79,7 @@ class CryptoClientTests(AsyncKeyVaultTestCase):
         imported_key = await self._import_test_key(key_client, key_name)
         crypto_client = vault_client.get_cryptography_client(imported_key)
 
-        result = await crypto_client.encrypt(
-            EncryptionAlgorithm.rsa_oaep, self.plaintext
-        )
+        result = await crypto_client.encrypt(EncryptionAlgorithm.rsa_oaep, self.plaintext)
         self.assertEqual(result.key_id, imported_key.id)
 
         result = await crypto_client.decrypt(result.algorithm, result.ciphertext)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto.py
@@ -15,7 +15,7 @@ class TestCryptoExamples(KeyVaultTestCase):
     def test_encrypt_decrypt(self, vault_client, **kwargs):
         key_client = vault_client.keys
         key_name = self.get_resource_name("crypto-test-encrypt-key")
-        key = key_client.create_rsa_key(key_name, hsm=False)
+        key = key_client.create_rsa_key(key_name)
         client = vault_client.get_cryptography_client(key)
 
         # [START encrypt]
@@ -43,7 +43,7 @@ class TestCryptoExamples(KeyVaultTestCase):
     def test_wrap_unwrap(self, vault_client, **kwargs):
         key_client = vault_client.keys
         key_name = self.get_resource_name("crypto-test-wrapping-key")
-        key = key_client.create_rsa_key(key_name, hsm=False)
+        key = key_client.create_rsa_key(key_name)
         client = vault_client.get_cryptography_client(key)
 
         key_bytes = b"5063e6aaa845f150200547944fd199679c98ed6f99da0a0b2dafeaf1f4684496fd532c1c229968cb9dee44957fcef7ccef59ceda0b362e56bcd78fd3faee5781c623c0bb22b35beabde0664fd30e0e824aba3dd1b0afffc4a3d955ede20cf6a854d52cfd"
@@ -70,7 +70,7 @@ class TestCryptoExamples(KeyVaultTestCase):
     def test_sign_verify(self, vault_client, **kwargs):
         key_client = vault_client.keys
         key_name = self.get_resource_name("crypto-test-wrapping-key")
-        key = key_client.create_rsa_key(key_name, hsm=False)
+        key = key_client.create_rsa_key(key_name)
         client = vault_client.get_cryptography_client(key)
 
         # [START sign]

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto.py
@@ -16,7 +16,7 @@ class TestCryptoExamples(KeyVaultTestCase):
         key_client = vault_client.keys
         key_name = self.get_resource_name("crypto-test-encrypt-key")
         key = key_client.create_rsa_key(key_name, hsm=False)
-        client = key_client.get_cryptography_client(key)
+        client = vault_client.get_cryptography_client(key)
 
         # [START encrypt]
 
@@ -44,7 +44,7 @@ class TestCryptoExamples(KeyVaultTestCase):
         key_client = vault_client.keys
         key_name = self.get_resource_name("crypto-test-wrapping-key")
         key = key_client.create_rsa_key(key_name, hsm=False)
-        client = key_client.get_cryptography_client(key)
+        client = vault_client.get_cryptography_client(key)
 
         key_bytes = b"5063e6aaa845f150200547944fd199679c98ed6f99da0a0b2dafeaf1f4684496fd532c1c229968cb9dee44957fcef7ccef59ceda0b362e56bcd78fd3faee5781c623c0bb22b35beabde0664fd30e0e824aba3dd1b0afffc4a3d955ede20cf6a854d52cfd"
 
@@ -71,7 +71,7 @@ class TestCryptoExamples(KeyVaultTestCase):
         key_client = vault_client.keys
         key_name = self.get_resource_name("crypto-test-wrapping-key")
         key = key_client.create_rsa_key(key_name, hsm=False)
-        client = key_client.get_cryptography_client(key)
+        client = vault_client.get_cryptography_client(key)
 
         # [START sign]
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto.py
@@ -22,8 +22,11 @@ class TestCryptoExamples(KeyVaultTestCase):
 
         from azure.keyvault.keys.crypto import EncryptionAlgorithm
 
-        # encrypt returns a tuple with the ciphertext and the metadata required to decrypt it
-        key_id, algorithm, ciphertext, authentication_tag = client.encrypt(EncryptionAlgorithm.rsa_oaep, b"plaintext")
+        # the result holds the ciphertext and identifies the encryption key and algorithm used
+        result = client.encrypt(EncryptionAlgorithm.rsa_oaep, b"plaintext")
+        ciphertext = result.ciphertext
+        print(result.key_id)
+        print(result.algorithm)
 
         # [END encrypt]
 
@@ -52,15 +55,18 @@ class TestCryptoExamples(KeyVaultTestCase):
 
         from azure.keyvault.keys.crypto import KeyWrapAlgorithm
 
-        # wrap returns a tuple with the wrapped bytes and the metadata required to unwrap the key
-        key_id, wrap_algorithm, wrapped_bytes = client.wrap_key(KeyWrapAlgorithm.rsa_oaep, key_bytes)
+        # the result holds the encrypted key and identifies the encryption key and algorithm used
+        result = client.wrap_key(KeyWrapAlgorithm.rsa_oaep, key_bytes)
+        encrypted_key = result.encrypted_key
+        print(result.key_id)
+        print(result.algorithm)
 
         # [END wrap]
 
         # [START unwrap]
         from azure.keyvault.keys.crypto import KeyWrapAlgorithm
 
-        result = client.unwrap_key(KeyWrapAlgorithm.rsa_oaep, wrapped_bytes)
+        result = client.unwrap_key(KeyWrapAlgorithm.rsa_oaep, encrypted_key)
         unwrapped_bytes = result.unwrapped_bytes
 
         # [END unwrap]
@@ -81,7 +87,12 @@ class TestCryptoExamples(KeyVaultTestCase):
         digest = hashlib.sha256(b"plaintext").digest()
 
         # sign returns a tuple with the signature and the metadata required to verify it
-        key_id, algorithm, signature = client.sign(SignatureAlgorithm.rs256, digest)
+        result = client.sign(SignatureAlgorithm.rs256, digest)
+
+        # the result contains the signature and identifies the key and algorithm used
+        print(result.key_id)
+        print(result.algorithm)
+        signature = result.signature
 
         # [END sign]
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto_async.py
@@ -24,9 +24,10 @@ class TestCryptoExamples(AsyncKeyVaultTestCase):
         from azure.keyvault.keys.crypto import EncryptionAlgorithm
 
         # encrypt returns a tuple with the ciphertext and the metadata required to decrypt it
-        key_id, algorithm, ciphertext, authentication_tag = await client.encrypt(
-            EncryptionAlgorithm.rsa_oaep, b"plaintext"
-        )
+        result = await client.encrypt(EncryptionAlgorithm.rsa_oaep, b"plaintext")
+        print(result.key_id)
+        print(result.algorithm)
+        ciphertext = result.ciphertext
 
         # [END encrypt]
 
@@ -57,14 +58,17 @@ class TestCryptoExamples(AsyncKeyVaultTestCase):
         from azure.keyvault.keys.crypto import KeyWrapAlgorithm
 
         # wrap returns a tuple with the wrapped bytes and the metadata required to unwrap the key
-        key_id, wrap_algorithm, wrapped_bytes = await client.wrap_key(KeyWrapAlgorithm.rsa_oaep, key_bytes)
+        result = await client.wrap_key(KeyWrapAlgorithm.rsa_oaep, key_bytes)
+        print(result.key_id)
+        print(result.algorithm)
+        encrypted_key = result.encrypted_key
 
         # [END wrap]
 
         # [START unwrap]
         from azure.keyvault.keys.crypto import KeyWrapAlgorithm
 
-        result = await client.unwrap_key(KeyWrapAlgorithm.rsa_oaep, wrapped_bytes)
+        result = await client.unwrap_key(KeyWrapAlgorithm.rsa_oaep, encrypted_key)
 
         # [END unwrap]
 
@@ -85,7 +89,10 @@ class TestCryptoExamples(AsyncKeyVaultTestCase):
         digest = hashlib.sha256(b"plaintext").digest()
 
         # sign returns a tuple with the signature and the metadata required to verify it
-        key_id, algorithm, signature = await client.sign(SignatureAlgorithm.rs256, digest)
+        result = await client.sign(SignatureAlgorithm.rs256, digest)
+        print(result.key_id)
+        print(result.algorithm)
+        signature = result.signature
 
         # [END sign]
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto_async.py
@@ -17,7 +17,7 @@ class TestCryptoExamples(AsyncKeyVaultTestCase):
         key_client = vault_client.keys
         key_name = self.get_resource_name("crypto-test-encrypt-key")
         key = await key_client.create_rsa_key(key_name, hsm=False)
-        client = key_client.get_cryptography_client(key)
+        client = vault_client.get_cryptography_client(key)
 
         # [START encrypt]
 
@@ -48,7 +48,7 @@ class TestCryptoExamples(AsyncKeyVaultTestCase):
         key_client = vault_client.keys
         key_name = self.get_resource_name("crypto-test-wrapping-key")
         key = await key_client.create_rsa_key(key_name, hsm=False)
-        client = key_client.get_cryptography_client(key)
+        client = vault_client.get_cryptography_client(key)
 
         key_bytes = b"5063e6aaa845f150200547944fd199679c98ed6f99da0a0b2dafeaf1f4684496fd532c1c229968cb9dee44957fcef7ccef59ceda0b362e56bcd78fd3faee5781c623c0bb22b35beabde0664fd30e0e824aba3dd1b0afffc4a3d955ede20cf6a854d52cfd"
 
@@ -75,7 +75,7 @@ class TestCryptoExamples(AsyncKeyVaultTestCase):
         key_client = vault_client.keys
         key_name = self.get_resource_name("crypto-test-wrapping-key")
         key = await key_client.create_rsa_key(key_name, hsm=False)
-        client = key_client.get_cryptography_client(key)
+        client = vault_client.get_cryptography_client(key)
 
         # [START sign]
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_examples_crypto_async.py
@@ -16,7 +16,7 @@ class TestCryptoExamples(AsyncKeyVaultTestCase):
     async def test_encrypt_decrypt_async(self, vault_client, **kwargs):
         key_client = vault_client.keys
         key_name = self.get_resource_name("crypto-test-encrypt-key")
-        key = await key_client.create_rsa_key(key_name, hsm=False)
+        key = await key_client.create_rsa_key(key_name)
         client = vault_client.get_cryptography_client(key)
 
         # [START encrypt]
@@ -47,7 +47,7 @@ class TestCryptoExamples(AsyncKeyVaultTestCase):
     async def test_wrap_unwrap_async(self, vault_client, **kwargs):
         key_client = vault_client.keys
         key_name = self.get_resource_name("crypto-test-wrapping-key")
-        key = await key_client.create_rsa_key(key_name, hsm=False)
+        key = await key_client.create_rsa_key(key_name)
         client = vault_client.get_cryptography_client(key)
 
         key_bytes = b"5063e6aaa845f150200547944fd199679c98ed6f99da0a0b2dafeaf1f4684496fd532c1c229968cb9dee44957fcef7ccef59ceda0b362e56bcd78fd3faee5781c623c0bb22b35beabde0664fd30e0e824aba3dd1b0afffc4a3d955ede20cf6a854d52cfd"
@@ -74,7 +74,7 @@ class TestCryptoExamples(AsyncKeyVaultTestCase):
     async def test_sign_verify_async(self, vault_client, **kwargs):
         key_client = vault_client.keys
         key_name = self.get_resource_name("crypto-test-wrapping-key")
-        key = await key_client.create_rsa_key(key_name, hsm=False)
+        key = await key_client.create_rsa_key(key_name)
         client = vault_client.get_cryptography_client(key)
 
         # [START sign]

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -141,7 +141,7 @@ class KeyClientTests(KeyVaultTestCase):
         created_rsa_key = self._create_rsa_key(client, key_name="crud-rsa-key", hsm=False)
 
         # get the created key with version
-        key = client.get_key(created_rsa_key.name, created_rsa_key.properties.version)
+        key = client.get_key(created_rsa_key.name, version=created_rsa_key.properties.version)
         self.assertEqual(key.properties.version, created_rsa_key.properties.version)
         self._assert_key_attributes_equal(created_rsa_key.properties, key.properties)
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -141,7 +141,7 @@ class KeyClientTests(KeyVaultTestCase):
         created_rsa_key = self._create_rsa_key(client, key_name="crud-rsa-key", hsm=False)
 
         # get the created key with version
-        key = client.get_key(created_rsa_key.name, version=created_rsa_key.properties.version)
+        key = client.get_key(created_rsa_key.name, created_rsa_key.properties.version)
         self.assertEqual(key.properties.version, created_rsa_key.properties.version)
         self._assert_key_attributes_equal(created_rsa_key.properties, key.properties)
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -82,7 +82,7 @@ class KeyClientTests(KeyVaultTestCase):
         self.assertEqual(tags, key_bundle.properties.tags)
         self.assertEqual(key.id, key_bundle.id)
         self.assertNotEqual(key.properties.updated, key_bundle.properties.updated)
-        self.assertEqual(key_ops, key_bundle.key.key_ops)
+        self.assertEqual(key_ops, key_bundle.key_operations)
         return key_bundle
 
     def _import_test_key(self, client, name):

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -158,7 +158,7 @@ class KeyClientTests(KeyVaultTestCase):
         # delete the new key
         deleted_key = client.delete_key(created_rsa_key.name)
         self.assertIsNotNone(deleted_key)
-        self.assertEqual(created_rsa_key.key.kty, deleted_key.key.kty)
+        self.assertEqual(created_rsa_key.key_type, deleted_key.key_type)
         self.assertEqual(deleted_key.id, created_rsa_key.id)
         self.assertTrue(
             deleted_key.recovery_id and deleted_key.deleted_date and deleted_key.scheduled_purge_date,
@@ -185,7 +185,7 @@ class KeyClientTests(KeyVaultTestCase):
 
         # create key
         created_bundle = client.create_key(key_name, key_type)
-        self.assertEqual(key_type, created_bundle.key.kty)
+        self.assertEqual(key_type, created_bundle.key_type)
 
         # backup key
         key_backup = client.backup_key(created_bundle.name)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -26,23 +26,23 @@ class KeyClientTests(KeyVaultTestCase):
         self.assertEqual(k1.tags, k2.tags)
         self.assertEqual(k1.recovery_level, k2.recovery_level)
 
-    def _create_rsa_key(self, client, key_name, hsm):
+    def _create_rsa_key(self, client, key_name, hsm=False):
         # create key with optional arguments
         key_size = 2048
         key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
         tags = {"purpose": "unit test", "test name ": "CreateRSAKeyTest"}
-        created_key = client.create_rsa_key(key_name, hsm=hsm, size=key_size, key_operations=key_ops, tags=tags)
+        created_key = client.create_rsa_key(key_name, hardware_protected=hsm, size=key_size, key_operations=key_ops, tags=tags)
         self.assertTrue(created_key.properties.tags, "Missing the optional key attributes.")
         self.assertEqual(tags, created_key.properties.tags)
         kty = "RSA-HSM" if hsm else "RSA"
         self._validate_rsa_key_bundle(created_key, client.vault_endpoint, key_name, kty, key_ops)
         return created_key
 
-    def _create_ec_key(self, client, key_name, hsm):
+    def _create_ec_key(self, client, key_name, hsm=False):
         # create ec key with optional arguments
         enabled = True
         tags = {"purpose": "unit test", "test name": "CreateECKeyTest"}
-        created_key = client.create_ec_key(key_name, hsm=hsm, enabled=enabled, tags=tags)
+        created_key = client.create_ec_key(key_name, hardware_protected=hsm, enabled=enabled, tags=tags)
         key_type = "EC-HSM" if hsm else "EC"
         self.assertTrue(created_key.properties.enabled, "Missing the optional key attributes.")
         self.assertEqual(enabled, created_key.properties.enabled)
@@ -131,14 +131,14 @@ class KeyClientTests(KeyVaultTestCase):
         # create ec key
         self._create_ec_key(client, key_name="crud-ec-key", hsm=True)
         # create ec with curve
-        created_ec_key_curve = client.create_ec_key(name="crud-P-256-ec-key", hsm=False, curve="P-256")
+        created_ec_key_curve = client.create_ec_key(name="crud-P-256-ec-key", curve="P-256")
         self.assertEqual("P-256", created_ec_key_curve.key_material.crv)
 
         # import key
         self._import_test_key(client, "import-test-key")
 
         # create rsa key
-        created_rsa_key = self._create_rsa_key(client, key_name="crud-rsa-key", hsm=False)
+        created_rsa_key = self._create_rsa_key(client, key_name="crud-rsa-key")
 
         # get the created key with version
         key = client.get_key(created_rsa_key.name, created_rsa_key.properties.version)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -22,7 +22,7 @@ class KeyClientTests(KeyVaultTestCase):
         self.assertEqual(k1.not_before, k2.not_before)
         self.assertEqual(k1.expires_on, k2.expires_on)
         self.assertEqual(k1.created_on, k2.created_on)
-        self.assertEqual(k1.updated, k2.updated)
+        self.assertEqual(k1.updated_on, k2.updated_on)
         self.assertEqual(k1.tags, k2.tags)
         self.assertEqual(k1.recovery_level, k2.recovery_level)
 
@@ -59,7 +59,7 @@ class KeyClientTests(KeyVaultTestCase):
         self.assertTrue(kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid))
         self.assertEqual(key.kty, kty, "kty should by '{}', but is '{}'".format(key, key.kty))
         self.assertTrue(
-            key_attributes.properties.created_on and key_attributes.properties.updated, "Missing required date attributes."
+            key_attributes.properties.created_on and key_attributes.properties.updated_on, "Missing required date attributes."
         )
 
     def _validate_rsa_key_bundle(self, key_attributes, vault, key_name, kty, key_ops):
@@ -71,7 +71,7 @@ class KeyClientTests(KeyVaultTestCase):
         self.assertTrue(key.n and key.e, "Bad RSA public material.")
         self.assertEqual(key_ops, key.key_ops, "keyOps should be '{}', but is '{}'".format(key_ops, key.key_ops))
         self.assertTrue(
-            key_attributes.properties.created_on and key_attributes.properties.updated, "Missing required date attributes."
+            key_attributes.properties.created_on and key_attributes.properties.updated_on, "Missing required date attributes."
         )
 
     def _update_key_properties(self, client, key):
@@ -81,7 +81,7 @@ class KeyClientTests(KeyVaultTestCase):
         key_bundle = client.update_key_properties(key.name, key_operations=key_ops, expires_on=expires, tags=tags)
         self.assertEqual(tags, key_bundle.properties.tags)
         self.assertEqual(key.id, key_bundle.id)
-        self.assertNotEqual(key.properties.updated, key_bundle.properties.updated)
+        self.assertNotEqual(key.properties.updated_on, key_bundle.properties.updated_on)
         self.assertEqual(key_ops, key_bundle.key_operations)
         return key_bundle
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -53,7 +53,7 @@ class KeyClientTests(KeyVaultTestCase):
     def _validate_ec_key_bundle(self, key_attributes, vault, key_name, kty):
         key_curve = "P-256"
         prefix = "/".join(s.strip("/") for s in [vault, "keys", key_name])
-        key = key_attributes.key_material
+        key = key_attributes.key
         kid = key_attributes.id
         self.assertEqual(key_curve, key.crv)
         self.assertTrue(kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid))
@@ -64,7 +64,7 @@ class KeyClientTests(KeyVaultTestCase):
 
     def _validate_rsa_key_bundle(self, key_attributes, vault, key_name, kty, key_ops):
         prefix = "/".join(s.strip("/") for s in [vault, "keys", key_name])
-        key = key_attributes.key_material
+        key = key_attributes.key
         kid = key_attributes.id
         self.assertTrue(kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid))
         self.assertEqual(key.kty, kty, "kty should by '{}', but is '{}'".format(key, key.kty))
@@ -82,7 +82,7 @@ class KeyClientTests(KeyVaultTestCase):
         self.assertEqual(tags, key_bundle.properties.tags)
         self.assertEqual(key.id, key_bundle.id)
         self.assertNotEqual(key.properties.updated, key_bundle.properties.updated)
-        self.assertEqual(key_ops, key_bundle.key_material.key_ops)
+        self.assertEqual(key_ops, key_bundle.key.key_ops)
         return key_bundle
 
     def _import_test_key(self, client, name):
@@ -132,7 +132,7 @@ class KeyClientTests(KeyVaultTestCase):
         self._create_ec_key(client, key_name="crud-ec-key", hsm=True)
         # create ec with curve
         created_ec_key_curve = client.create_ec_key(name="crud-P-256-ec-key", curve="P-256")
-        self.assertEqual("P-256", created_ec_key_curve.key_material.crv)
+        self.assertEqual("P-256", created_ec_key_curve.key.crv)
 
         # import key
         self._import_test_key(client, "import-test-key")
@@ -158,7 +158,7 @@ class KeyClientTests(KeyVaultTestCase):
         # delete the new key
         deleted_key = client.delete_key(created_rsa_key.name)
         self.assertIsNotNone(deleted_key)
-        self.assertEqual(created_rsa_key.key_material.kty, deleted_key.key_material.kty)
+        self.assertEqual(created_rsa_key.key.kty, deleted_key.key.kty)
         self.assertEqual(deleted_key.id, created_rsa_key.id)
         self.assertTrue(
             deleted_key.recovery_id and deleted_key.deleted_date and deleted_key.scheduled_purge_date,
@@ -185,7 +185,7 @@ class KeyClientTests(KeyVaultTestCase):
 
         # create key
         created_bundle = client.create_key(key_name, key_type)
-        self.assertEqual(key_type, created_bundle.key_material.kty)
+        self.assertEqual(key_type, created_bundle.key.kty)
 
         # backup key
         key_backup = client.backup_key(created_bundle.name)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -20,7 +20,7 @@ class KeyClientTests(KeyVaultTestCase):
         self.assertEqual(k1.vault_endpoint, k2.vault_endpoint)
         self.assertEqual(k1.enabled, k2.enabled)
         self.assertEqual(k1.not_before, k2.not_before)
-        self.assertEqual(k1.expires, k2.expires)
+        self.assertEqual(k1.expires_on, k2.expires_on)
         self.assertEqual(k1.created, k2.created)
         self.assertEqual(k1.updated, k2.updated)
         self.assertEqual(k1.tags, k2.tags)
@@ -78,7 +78,7 @@ class KeyClientTests(KeyVaultTestCase):
         expires = date_parse.parse("2050-01-02T08:00:00.000Z")
         tags = {"foo": "updated tag"}
         key_ops = ["decrypt", "encrypt"]
-        key_bundle = client.update_key_properties(key.name, key_operations=key_ops, expires=expires, tags=tags)
+        key_bundle = client.update_key_properties(key.name, key_operations=key_ops, expires_on=expires, tags=tags)
         self.assertEqual(tags, key_bundle.properties.tags)
         self.assertEqual(key.id, key_bundle.id)
         self.assertNotEqual(key.properties.updated, key_bundle.properties.updated)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -215,7 +215,7 @@ class KeyClientTests(KeyVaultTestCase):
             expected[key.name] = key
 
         # list keys
-        result = client.list_keys(max_page_size=max_keys)
+        result = client.list_properties_of_keys(max_page_size=max_keys)
         for key in result:
             if key.name in expected.keys():
                 self._assert_key_attributes_equal(expected[key.name].properties, key)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -21,7 +21,7 @@ class KeyClientTests(KeyVaultTestCase):
         self.assertEqual(k1.enabled, k2.enabled)
         self.assertEqual(k1.not_before, k2.not_before)
         self.assertEqual(k1.expires_on, k2.expires_on)
-        self.assertEqual(k1.created, k2.created)
+        self.assertEqual(k1.created_on, k2.created_on)
         self.assertEqual(k1.updated, k2.updated)
         self.assertEqual(k1.tags, k2.tags)
         self.assertEqual(k1.recovery_level, k2.recovery_level)
@@ -59,7 +59,7 @@ class KeyClientTests(KeyVaultTestCase):
         self.assertTrue(kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid))
         self.assertEqual(key.kty, kty, "kty should by '{}', but is '{}'".format(key, key.kty))
         self.assertTrue(
-            key_attributes.properties.created and key_attributes.properties.updated, "Missing required date attributes."
+            key_attributes.properties.created_on and key_attributes.properties.updated, "Missing required date attributes."
         )
 
     def _validate_rsa_key_bundle(self, key_attributes, vault, key_name, kty, key_ops):
@@ -71,7 +71,7 @@ class KeyClientTests(KeyVaultTestCase):
         self.assertTrue(key.n and key.e, "Bad RSA public material.")
         self.assertEqual(key_ops, key.key_ops, "keyOps should be '{}', but is '{}'".format(key_ops, key.key_ops))
         self.assertTrue(
-            key_attributes.properties.created and key_attributes.properties.updated, "Missing required date attributes."
+            key_attributes.properties.created_on and key_attributes.properties.updated, "Missing required date attributes."
         )
 
     def _update_key_properties(self, client, key):

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -147,7 +147,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         created_rsa_key = await self._create_rsa_key(client, key_name="crud-rsa-key", hsm=False)
 
         # get the created key with version
-        key = await client.get_key(created_rsa_key.name, created_rsa_key.properties.version)
+        key = await client.get_key(created_rsa_key.name, version=created_rsa_key.properties.version)
         self.assertEqual(key.properties.version, created_rsa_key.properties.version)
         self._assert_key_attributes_equal(created_rsa_key.properties, key.properties)
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -55,7 +55,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
     def _validate_ec_key_bundle(self, key_attributes, vault, key_name, kty):
         key_curve = "P-256"
         prefix = "/".join(s.strip("/") for s in [vault, "keys", key_name])
-        key = key_attributes.key_material
+        key = key_attributes.key
         kid = key_attributes.id
         self.assertEqual(key_curve, key.crv)
         self.assertTrue(kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid))
@@ -66,7 +66,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
 
     def _validate_rsa_key_bundle(self, key_attributes, vault, key_name, kty, key_ops):
         prefix = "/".join(s.strip("/") for s in [vault, "keys", key_name])
-        key = key_attributes.key_material
+        key = key_attributes.key
         kid = key_attributes.id
         self.assertTrue(kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid))
         self.assertEqual(key.kty, kty, "kty should by '{}', but is '{}'".format(key, key.kty))
@@ -139,7 +139,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         await self._create_ec_key(client, key_name="crud-ec-key", hsm=True)
         # create ec with curve
         created_ec_key_curve = await client.create_ec_key(name="crud-P-256-ec-key", curve="P-256")
-        self.assertEqual("P-256", created_ec_key_curve.key_material.crv)
+        self.assertEqual("P-256", created_ec_key_curve.key.crv)
 
         # import key
         await self._import_test_key(client, "import-test-key")
@@ -166,7 +166,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         # delete the new key
         deleted_key = await client.delete_key(created_rsa_key.name)
         self.assertIsNotNone(deleted_key)
-        self.assertEqual(created_rsa_key.key_material, deleted_key.key_material)
+        self.assertEqual(created_rsa_key.key, deleted_key.key)
         self.assertEqual(deleted_key.id, created_rsa_key.id)
         self.assertTrue(
             deleted_key.recovery_id and deleted_key.deleted_date and deleted_key.scheduled_purge_date,

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -28,23 +28,23 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         self.assertEqual(k1.tags, k2.tags)
         self.assertEqual(k1.recovery_level, k2.recovery_level)
 
-    async def _create_rsa_key(self, client, key_name, hsm):
+    async def _create_rsa_key(self, client, key_name, hsm=False):
         # create key with optional arguments
         key_size = 2048
         key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
         tags = {"purpose": "unit test", "test name ": "CreateRSAKeyTest"}
-        created_key = await client.create_rsa_key(key_name, hsm=hsm, size=key_size, key_operations=key_ops, tags=tags)
+        created_key = await client.create_rsa_key(key_name, hardware_protected=hsm, size=key_size, key_operations=key_ops, tags=tags)
         self.assertTrue(created_key.properties.tags, "Missing the optional key attributes.")
         self.assertEqual(tags, created_key.properties.tags)
         key_type = "RSA-HSM" if hsm else "RSA"
         self._validate_rsa_key_bundle(created_key, client.vault_endpoint, key_name, key_type, key_ops)
         return created_key
 
-    async def _create_ec_key(self, client, key_name, hsm):
+    async def _create_ec_key(self, client, key_name, hsm=False):
         # create ec key with optional arguments
         enabled = True
         tags = {"purpose": "unit test", "test name": "CreateECKeyTest"}
-        created_key = await client.create_ec_key(key_name, hsm=hsm, enabled=enabled, tags=tags)
+        created_key = await client.create_ec_key(key_name, hardware_protected=hsm, enabled=enabled, tags=tags)
         self.assertTrue(created_key.properties.enabled, "Missing the optional key attributes.")
         self.assertEqual(enabled, created_key.properties.enabled)
         self.assertEqual(tags, created_key.properties.tags)
@@ -138,13 +138,13 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         # create ec key
         await self._create_ec_key(client, key_name="crud-ec-key", hsm=True)
         # create ec with curve
-        created_ec_key_curve = await client.create_ec_key(name="crud-P-256-ec-key", hsm=False, curve="P-256")
+        created_ec_key_curve = await client.create_ec_key(name="crud-P-256-ec-key", curve="P-256")
         self.assertEqual("P-256", created_ec_key_curve.key_material.crv)
 
         # import key
         await self._import_test_key(client, "import-test-key")
         # create rsa key
-        created_rsa_key = await self._create_rsa_key(client, key_name="crud-rsa-key", hsm=False)
+        created_rsa_key = await self._create_rsa_key(client, key_name="crud-rsa-key")
 
         # get the created key with version
         key = await client.get_key(created_rsa_key.name, created_rsa_key.properties.version)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -22,7 +22,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         self.assertEqual(k1.vault_endpoint, k2.vault_endpoint)
         self.assertEqual(k1.enabled, k2.enabled)
         self.assertEqual(k1.not_before, k2.not_before)
-        self.assertEqual(k1.expires, k2.expires)
+        self.assertEqual(k1.expires_on, k2.expires_on)
         self.assertEqual(k1.created, k2.created)
         self.assertEqual(k1.updated, k2.updated)
         self.assertEqual(k1.tags, k2.tags)
@@ -79,7 +79,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
     async def _update_key_properties(self, client, key):
         expires = date_parse.parse("2050-01-02T08:00:00.000Z")
         tags = {"foo": "updated tag"}
-        key_bundle = await client.update_key_properties(key.name, expires=expires, tags=tags)
+        key_bundle = await client.update_key_properties(key.name, expires_on=expires, tags=tags)
         self.assertEqual(tags, key_bundle.properties.tags)
         self.assertEqual(key.id, key_bundle.id)
         self.assertNotEqual(key.properties.updated, key_bundle.properties.updated)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -147,7 +147,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         created_rsa_key = await self._create_rsa_key(client, key_name="crud-rsa-key", hsm=False)
 
         # get the created key with version
-        key = await client.get_key(created_rsa_key.name, version=created_rsa_key.properties.version)
+        key = await client.get_key(created_rsa_key.name, created_rsa_key.properties.version)
         self.assertEqual(key.properties.version, created_rsa_key.properties.version)
         self._assert_key_attributes_equal(created_rsa_key.properties, key.properties)
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -23,7 +23,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         self.assertEqual(k1.enabled, k2.enabled)
         self.assertEqual(k1.not_before, k2.not_before)
         self.assertEqual(k1.expires_on, k2.expires_on)
-        self.assertEqual(k1.created, k2.created)
+        self.assertEqual(k1.created_on, k2.created_on)
         self.assertEqual(k1.updated, k2.updated)
         self.assertEqual(k1.tags, k2.tags)
         self.assertEqual(k1.recovery_level, k2.recovery_level)
@@ -33,7 +33,9 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         key_size = 2048
         key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
         tags = {"purpose": "unit test", "test name ": "CreateRSAKeyTest"}
-        created_key = await client.create_rsa_key(key_name, hardware_protected=hsm, size=key_size, key_operations=key_ops, tags=tags)
+        created_key = await client.create_rsa_key(
+            key_name, hardware_protected=hsm, size=key_size, key_operations=key_ops, tags=tags
+        )
         self.assertTrue(created_key.properties.tags, "Missing the optional key attributes.")
         self.assertEqual(tags, created_key.properties.tags)
         key_type = "RSA-HSM" if hsm else "RSA"
@@ -61,7 +63,8 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         self.assertTrue(kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid))
         self.assertEqual(key.kty, kty, "kty should by '{}', but is '{}'".format(key, key.kty))
         self.assertTrue(
-            key_attributes.properties.created and key_attributes.properties.updated, "Missing required date attributes."
+            key_attributes.properties.created_on and key_attributes.properties.updated,
+            "Missing required date attributes.",
         )
 
     def _validate_rsa_key_bundle(self, key_attributes, vault, key_name, kty, key_ops):
@@ -73,7 +76,8 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         self.assertTrue(key.n and key.e, "Bad RSA public material.")
         self.assertEqual(key_ops, key.key_ops, "keyOps should be '{}', but is '{}'".format(key_ops, key.key_ops))
         self.assertTrue(
-            key_attributes.properties.created and key_attributes.properties.updated, "Missing required date attributes."
+            key_attributes.properties.created_on and key_attributes.properties.updated,
+            "Missing required date attributes.",
         )
 
     async def _update_key_properties(self, client, key):

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -24,7 +24,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         self.assertEqual(k1.not_before, k2.not_before)
         self.assertEqual(k1.expires_on, k2.expires_on)
         self.assertEqual(k1.created_on, k2.created_on)
-        self.assertEqual(k1.updated, k2.updated)
+        self.assertEqual(k1.updated_on, k2.updated_on)
         self.assertEqual(k1.tags, k2.tags)
         self.assertEqual(k1.recovery_level, k2.recovery_level)
 
@@ -63,7 +63,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         self.assertTrue(kid.index(prefix) == 0, "Key Id should start with '{}', but value is '{}'".format(prefix, kid))
         self.assertEqual(key.kty, kty, "kty should by '{}', but is '{}'".format(key, key.kty))
         self.assertTrue(
-            key_attributes.properties.created_on and key_attributes.properties.updated,
+            key_attributes.properties.created_on and key_attributes.properties.updated_on,
             "Missing required date attributes.",
         )
 
@@ -76,7 +76,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         self.assertTrue(key.n and key.e, "Bad RSA public material.")
         self.assertEqual(key_ops, key.key_ops, "keyOps should be '{}', but is '{}'".format(key_ops, key.key_ops))
         self.assertTrue(
-            key_attributes.properties.created_on and key_attributes.properties.updated,
+            key_attributes.properties.created_on and key_attributes.properties.updated_on,
             "Missing required date attributes.",
         )
 
@@ -86,7 +86,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         key_bundle = await client.update_key_properties(key.name, expires_on=expires, tags=tags)
         self.assertEqual(tags, key_bundle.properties.tags)
         self.assertEqual(key.id, key_bundle.id)
-        self.assertNotEqual(key.properties.updated, key_bundle.properties.updated)
+        self.assertNotEqual(key.properties.updated_on, key_bundle.properties.updated_on)
         return key_bundle
 
     async def _validate_key_list(self, keys, expected):

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -199,7 +199,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
             expected[key.name] = key
 
         # list keys
-        result = client.list_keys(max_page_size=max_keys)
+        result = client.list_properties_of_keys(max_page_size=max_keys)
         async for key in result:
             if key.name in expected.keys():
                 self._assert_key_attributes_equal(expected[key.name].properties, key)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -47,7 +47,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
 
         print(key.name)
         print(key.id)
-        print(key.key.kty)
+        print(key.key_type)
         print(key.properties.expires_on)
 
         # [END create_key]
@@ -62,7 +62,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
 
         print(key.id)
         print(key.name)
-        print(key.key.kty)
+        print(key.key_type)
         print(key.key.key_ops)
 
         # [END create_rsa_key]
@@ -75,7 +75,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
 
         print(ec_key.id)
         print(ec_key.properties.version)
-        print(ec_key.key.kty)
+        print(ec_key.key_type)
         print(ec_key.key.crv)
 
         # [END create_ec_key]
@@ -91,7 +91,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         print(key.id)
         print(key.name)
         print(key.properties.version)
-        print(key.key.kty)
+        print(key.key_type)
         print(key.properties.vault_endpoint)
 
         # [END get_key]
@@ -106,7 +106,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         print(updated_key.properties.updated)
         print(updated_key.properties.expires_on)
         print(updated_key.properties.tags)
-        print(key.key.kty)
+        print(key.key_type)
 
         # [END update_key]
         # [START delete_key]

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -40,15 +40,15 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         # [START create_key]
         from dateutil import parser as date_parse
 
-        expires = date_parse.parse("2050-02-02T08:00:00.000Z")
+        expires_on = date_parse.parse("2050-02-02T08:00:00.000Z")
 
         # create a key with optional arguments
-        key = key_client.create_key("key-name", "RSA-HSM", expires=expires)
+        key = key_client.create_key("key-name", "RSA-HSM", expires_on=expires_on)
 
         print(key.name)
         print(key.id)
         print(key.key_material.kty)
-        print(key.properties.expires)
+        print(key.properties.expires_on)
 
         # [END create_key]
         # [START create_rsa_key]
@@ -98,13 +98,13 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         # [START update_key]
 
         # update attributes of an existing key
-        expires = date_parse.parse("2050-01-02T08:00:00.000Z")
+        expires_on = date_parse.parse("2050-01-02T08:00:00.000Z")
         tags = {"foo": "updated tag"}
-        updated_key = key_client.update_key_properties(key.name, expires=expires, tags=tags)
+        updated_key = key_client.update_key_properties(key.name, expires_on=expires_on, tags=tags)
 
         print(updated_key.properties.version)
         print(updated_key.properties.updated)
-        print(updated_key.properties.expires)
+        print(updated_key.properties.expires_on)
         print(updated_key.properties.tags)
         print(key.key_material.kty)
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -86,7 +86,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
 
         # alternatively, specify a version
         key_version = key.properties.version
-        key = key_client.get_key("key-name", key_version)
+        key = key_client.get_key("key-name", version=key_version)
 
         print(key.id)
         print(key.name)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -58,7 +58,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
 
         # create an rsa key with size specification
         # RSA key can be created with default size of '2048'
-        key = key_client.create_rsa_key("key-name", hsm=True, size=key_size, key_operations=key_ops)
+        key = key_client.create_rsa_key("key-name", hardware_protected=True, size=key_size, key_operations=key_ops)
 
         print(key.id)
         print(key.name)
@@ -71,7 +71,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
 
         # create an EC (Elliptic curve) key with curve specification
         # EC key can be created with default curve of 'P-256'
-        ec_key = key_client.create_ec_key("key-name", hsm=False, curve=key_curve)
+        ec_key = key_client.create_ec_key("key-name", curve=key_curve)
 
         print(ec_key.id)
         print(ec_key.properties.version)
@@ -130,9 +130,9 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         key_client = vault_client.keys
 
         for i in range(4):
-            key_client.create_ec_key("key{}".format(i), hsm=False)
+            key_client.create_ec_key("key{}".format(i))
         for i in range(4):
-            key_client.create_rsa_key("key{}".format(i), hsm=False)
+            key_client.create_rsa_key("key{}".format(i))
 
         # [START list_keys]
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -63,7 +63,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         print(key.id)
         print(key.name)
         print(key.key_type)
-        print(key.key.key_ops)
+        print(key.key_operations)
 
         # [END create_rsa_key]
         # [START create_ec_key]

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -137,7 +137,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         # [START list_keys]
 
         # get an iterator of keys
-        keys = key_client.list_keys()
+        keys = key_client.list_properties_of_keys()
 
         for key in keys:
             print(key.id)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -47,7 +47,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
 
         print(key.name)
         print(key.id)
-        print(key.key_material.kty)
+        print(key.key.kty)
         print(key.properties.expires_on)
 
         # [END create_key]
@@ -62,8 +62,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
 
         print(key.id)
         print(key.name)
-        print(key.key_material.kty)
-        print(key.key_material.key_ops)
+        print(key.key.kty)
+        print(key.key.key_ops)
 
         # [END create_rsa_key]
         # [START create_ec_key]
@@ -75,8 +75,8 @@ class TestExamplesKeyVault(KeyVaultTestCase):
 
         print(ec_key.id)
         print(ec_key.properties.version)
-        print(ec_key.key_material.kty)
-        print(ec_key.key_material.crv)
+        print(ec_key.key.kty)
+        print(ec_key.key.crv)
 
         # [END create_ec_key]
         # [START get_key]
@@ -91,7 +91,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         print(key.id)
         print(key.name)
         print(key.properties.version)
-        print(key.key_material.kty)
+        print(key.key.kty)
         print(key.properties.vault_endpoint)
 
         # [END get_key]
@@ -106,7 +106,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         print(updated_key.properties.updated)
         print(updated_key.properties.expires_on)
         print(updated_key.properties.tags)
-        print(key.key_material.kty)
+        print(key.key.kty)
 
         # [END update_key]
         # [START delete_key]

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -103,7 +103,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         updated_key = key_client.update_key_properties(key.name, expires_on=expires_on, tags=tags)
 
         print(updated_key.properties.version)
-        print(updated_key.properties.updated)
+        print(updated_key.properties.updated_on)
         print(updated_key.properties.expires_on)
         print(updated_key.properties.tags)
         print(key.key_type)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -86,7 +86,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
 
         # alternatively, specify a version
         key_version = key.properties.version
-        key = key_client.get_key("key-name", version=key_version)
+        key = key_client.get_key("key-name", key_version)
 
         print(key.id)
         print(key.name)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -80,7 +80,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
 
         # alternatively, specify a version
         key_version = key.properties.version
-        key = await key_client.get_key("key-name", version=key_version)
+        key = await key_client.get_key("key-name", key_version)
 
         print(key.id)
         print(key.name)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -97,7 +97,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         updated_key = await key_client.update_key_properties(key.name, expires_on=expires_on, tags=tags)
 
         print(updated_key.properties.version)
-        print(updated_key.properties.updated)
+        print(updated_key.properties.updated_on)
         print(updated_key.properties.expires_on)
         print(updated_key.properties.tags)
         print(updated_key.key_type)
@@ -138,7 +138,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
             print(key.id)
             print(key.created_on)
             print(key.name)
-            print(key.updated)
+            print(key.updated_on)
             print(key.enabled)
 
         # [END list_keys]
@@ -149,7 +149,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
 
         async for key in key_versions:
             print(key.id)
-            print(key.updated)
+            print(key.updated_on)
             print(key.properties.version)
             print(key.expires_on)
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -54,7 +54,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         # [START create_rsa_key]
 
         # create an rsa key in a hardware security module
-        key = await key_client.create_rsa_key("key-name", hsm=True, size=2048)
+        key = await key_client.create_rsa_key("key-name", hardware_protected=True, size=2048)
 
         print(key.id)
         print(key.name)
@@ -65,7 +65,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
 
         # create an elliptic curve (ec) key
         key_curve = "P-256"
-        ec_key = await key_client.create_ec_key("key-name", hsm=False, curve=key_curve)
+        ec_key = await key_client.create_ec_key("key-name", curve=key_curve)
 
         print(ec_key.id)
         print(ec_key.name)
@@ -125,9 +125,9 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         key_client = vault_client.keys
 
         for i in range(4):
-            await key_client.create_ec_key("key{}".format(i), hsm=False)
+            await key_client.create_ec_key("key{}".format(i))
         for i in range(4):
-            await key_client.create_rsa_key("key{}".format(i), hsm=False)
+            await key_client.create_rsa_key("key{}".format(i))
 
         # [START list_keys]
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -80,7 +80,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
 
         # alternatively, specify a version
         key_version = key.properties.version
-        key = await key_client.get_key("key-name", key_version)
+        key = await key_client.get_key("key-name", version=key_version)
 
         print(key.id)
         print(key.name)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -46,7 +46,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
 
         print(key.id)
         print(key.name)
-        print(key.key_material.kty)
+        print(key.key.kty)
         print(key.properties.enabled)
         print(key.properties.expires_on)
 
@@ -58,7 +58,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
 
         print(key.id)
         print(key.name)
-        print(key.key_material.kty)
+        print(key.key.kty)
 
         # [END create_rsa_key]
         # [START create_ec_key]
@@ -69,8 +69,8 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
 
         print(ec_key.id)
         print(ec_key.name)
-        print(ec_key.key_material.kty)
-        print(ec_key.key_material.crv)
+        print(ec_key.key.kty)
+        print(ec_key.key.crv)
 
         # [END create_ec_key]
         # [START get_key]
@@ -85,7 +85,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         print(key.id)
         print(key.name)
         print(key.properties.version)
-        print(key.key_material.kty)
+        print(key.key.kty)
         print(key.properties.vault_endpoint)
 
         # [END get_key]
@@ -100,7 +100,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         print(updated_key.properties.updated)
         print(updated_key.properties.expires_on)
         print(updated_key.properties.tags)
-        print(updated_key.key_material.kty)
+        print(updated_key.key.kty)
 
         # [END update_key]
         # [START delete_key]

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -132,7 +132,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         # [START list_keys]
 
         # list keys
-        keys = key_client.list_keys()
+        keys = key_client.list_properties_of_keys()
 
         async for key in keys:
             print(key.id)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -46,7 +46,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
 
         print(key.id)
         print(key.name)
-        print(key.key.kty)
+        print(key.key_type)
         print(key.properties.enabled)
         print(key.properties.expires_on)
 
@@ -58,7 +58,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
 
         print(key.id)
         print(key.name)
-        print(key.key.kty)
+        print(key.key_type)
 
         # [END create_rsa_key]
         # [START create_ec_key]
@@ -69,7 +69,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
 
         print(ec_key.id)
         print(ec_key.name)
-        print(ec_key.key.kty)
+        print(ec_key.key_type)
         print(ec_key.key.crv)
 
         # [END create_ec_key]
@@ -85,7 +85,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         print(key.id)
         print(key.name)
         print(key.properties.version)
-        print(key.key.kty)
+        print(key.key_type)
         print(key.properties.vault_endpoint)
 
         # [END get_key]
@@ -100,7 +100,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         print(updated_key.properties.updated)
         print(updated_key.properties.expires_on)
         print(updated_key.properties.tags)
-        print(updated_key.key.kty)
+        print(updated_key.key_type)
 
         # [END update_key]
         # [START delete_key]

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -136,7 +136,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
 
         async for key in keys:
             print(key.id)
-            print(key.created)
+            print(key.created_on)
             print(key.name)
             print(key.updated)
             print(key.enabled)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -39,16 +39,16 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
 
         key_size = 2048
         key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
-        expires = date_parse.parse("2050-02-02T08:00:00.000Z")
+        expires_on = date_parse.parse("2050-02-02T08:00:00.000Z")
 
         # create a key with optional arguments
-        key = await key_client.create_key("key-name", "RSA", size=key_size, key_operations=key_ops, expires=expires)
+        key = await key_client.create_key("key-name", "RSA", size=key_size, key_operations=key_ops, expires_on=expires_on)
 
         print(key.id)
         print(key.name)
         print(key.key_material.kty)
         print(key.properties.enabled)
-        print(key.properties.expires)
+        print(key.properties.expires_on)
 
         # [END create_key]
         # [START create_rsa_key]
@@ -92,13 +92,13 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         # [START update_key]
 
         # update attributes of an existing key
-        expires = date_parse.parse("2050-01-02T08:00:00.000Z")
+        expires_on = date_parse.parse("2050-01-02T08:00:00.000Z")
         tags = {"foo": "updated tag"}
-        updated_key = await key_client.update_key_properties(key.name, expires=expires, tags=tags)
+        updated_key = await key_client.update_key_properties(key.name, expires_on=expires_on, tags=tags)
 
         print(updated_key.properties.version)
         print(updated_key.properties.updated)
-        print(updated_key.properties.expires)
+        print(updated_key.properties.expires_on)
         print(updated_key.properties.tags)
         print(updated_key.key_material.kty)
 
@@ -151,7 +151,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
             print(key.id)
             print(key.updated)
             print(key.properties.version)
-            print(key.expires)
+            print(key.expires_on)
 
         # [END list_key_versions]
         # [START list_deleted_keys]

--- a/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
@@ -10,6 +10,11 @@ detail the new keyword arguments):
     (optional) `version`
 - `Key.key_material` renamed to `Key.key`
 
+### New features:
+- `Key` has new properties:
+  - `key_operations` is a list of permitted operations
+  - `key_type` is the key's type, e.g. "RSA" or "EC"
+  
 
 ## 4.0.0b4 (2019-10-08)
 ### Breaking changes:

--- a/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
@@ -8,13 +8,8 @@ detail the new keyword arguments):
   - `set_secret` now has positional parameters `name` and `value`
   - `update_secret_properties` now has positional parameters `name` and
     (optional) `version`
-- `Key.key_material` renamed to `Key.key`
+- Renamed `list_secrets` to `list_properties_of_secrets`
 
-### New features:
-- `Key` has new properties:
-  - `key_operations` is a list of permitted operations
-  - `key_type` is the key's type, e.g. "RSA" or "EC"
-  
 
 ## 4.0.0b4 (2019-10-08)
 ### Breaking changes:

--- a/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
@@ -6,7 +6,8 @@
 [docs](https://azure.github.io/azure-sdk-for-python/ref/azure.keyvault.secrets.html)
 detail the new keyword arguments):
   - `set_secret` now has positional parameters `name` and `value`
-  - `get_secret`, `update_secret`, and `update_secret_properties` now have positional parameter `name`
+  - `update_secret_properties` now has positional parameters `name` and
+    (optional) `version`
 
 
 ## 4.0.0b4 (2019-10-08)

--- a/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
@@ -9,7 +9,8 @@ detail the new keyword arguments):
   - `update_secret_properties` now has positional parameters `name` and
     (optional) `version`
 - Renamed `list_secrets` to `list_properties_of_secrets`
-
+- `Secret`  properties `created`, `expires`, and `updated` renamed to `created_on`,
+`expires_on`, and `updated_on`
 
 ## 4.0.0b4 (2019-10-08)
 ### Breaking changes:

--- a/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
@@ -1,6 +1,12 @@
 # Release History
 
 ## 4.0.0b5
+### Breaking changes:
+- Moved optional parameters of two methods into kwargs (
+[docs](https://azure.github.io/azure-sdk-for-python/ref/azure.keyvault.secrets.html)
+detail the new keyword arguments):
+  - `set_secret` now has positional parameters `name` and `value`
+  - `update_secret` and `update_secret_properties` now have positional parameter `name`
 
 
 ## 4.0.0b4 (2019-10-08)

--- a/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
@@ -6,7 +6,7 @@
 [docs](https://azure.github.io/azure-sdk-for-python/ref/azure.keyvault.secrets.html)
 detail the new keyword arguments):
   - `set_secret` now has positional parameters `name` and `value`
-  - `update_secret` and `update_secret_properties` now have positional parameter `name`
+  - `get_secret`, `update_secret`, and `update_secret_properties` now have positional parameter `name`
 
 
 ## 4.0.0b4 (2019-10-08)

--- a/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
+++ b/sdk/keyvault/azure-keyvault-secrets/HISTORY.md
@@ -8,6 +8,7 @@ detail the new keyword arguments):
   - `set_secret` now has positional parameters `name` and `value`
   - `update_secret_properties` now has positional parameters `name` and
     (optional) `version`
+- `Key.key_material` renamed to `Key.key`
 
 
 ## 4.0.0b4 (2019-10-08)

--- a/sdk/keyvault/azure-keyvault-secrets/README.md
+++ b/sdk/keyvault/azure-keyvault-secrets/README.md
@@ -179,7 +179,7 @@ value; use [`set_secret`](#create-a-secret) to set a secret's value.
 
     updated_secret_properties = secret_client.update_secret_properties("secret-name", content_type=content_type, tags=tags)
 
-    print(updated_secret_properties.updated)
+    print(updated_secret_properties.updated_on)
     print(updated_secret_properties.content_type)
     print(updated_secret_properties.tags)
 ```

--- a/sdk/keyvault/azure-keyvault-secrets/README.md
+++ b/sdk/keyvault/azure-keyvault-secrets/README.md
@@ -200,7 +200,7 @@ This example lists all the secrets in the vault. The list doesn't include
 secret values; use [`get_secret`](#retrieve-a-secret) to get a secret's value.
 
 ```python
-    secret_properties = secret_client.list_secrets()
+    secret_properties = secret_client.list_properties_of_secrets()
 
     for secret_property in secret_properties:
         # the list doesn't include values or versions of the secrets
@@ -231,10 +231,11 @@ This example creates a secret in the Key Vault with the specified optional argum
 ```
 
 ### Async list secrets
-This example lists all the secrets in the specified Key Vault.
+This example lists properties of all the secrets in the specified Key Vault.
+Note that secret values are not included.
 
 ```python
-    secret_properties = secret_client.list_secrets()
+    secret_properties = secret_client.list_properties_of_secrets()
 
     async for secret_property in secret_properties:
         # the list doesn't include values or versions of the secrets

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/client.py
@@ -143,7 +143,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         return SecretProperties._from_secret_bundle(bundle)  # pylint: disable=protected-access
 
     @distributed_trace
-    def list_secrets(self, **kwargs: "**Any") -> AsyncIterable[SecretProperties]:
+    def list_properties_of_secrets(self, **kwargs: "Any") -> AsyncIterable[SecretProperties]:
         """List the latest identifier and attributes of all secrets in the vault, not including their values. Requires
         the secrets/list permission.
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/client.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from datetime import datetime
-from typing import Any, AsyncIterable, Optional, Dict
+from typing import Any, AsyncIterable, Dict
 
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.decorator_async import distributed_trace_async
@@ -32,7 +32,7 @@ class SecretClient(AsyncKeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace_async
-    async def get_secret(self, name: str, version: Optional[str] = None, **kwargs: "**Any") -> Secret:
+    async def get_secret(self, name: str, **kwargs: "Any") -> Secret:
         """Get a secret. Requires the secrets/get permission.
 
         :param str name: The name of the secret
@@ -42,6 +42,9 @@ class SecretClient(AsyncKeyVaultClientBase):
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
+        Keyword arguments
+            - **version** (str): A specific version of the key to get. If unspecified, gets the latest version.
+
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
                 :start-after: [START get_secret]
@@ -50,7 +53,9 @@ class SecretClient(AsyncKeyVaultClientBase):
                 :caption: Get a secret
                 :dedent: 8
         """
-        bundle = await self._client.get_secret(self.vault_endpoint, name, version or "", error_map=_error_map, **kwargs)
+        bundle = await self._client.get_secret(
+            self.vault_endpoint, name, kwargs.pop("version", ""), error_map=_error_map, **kwargs
+        )
         return Secret._from_secret_bundle(bundle)
 
     @distributed_trace_async

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/client.py
@@ -73,7 +73,7 @@ class SecretClient(AsyncKeyVaultClientBase):
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
             - **content_type** (str): An arbitrary string indicating the type of the secret, e.g. 'password'
             - **not_before** (:class:`~datetime.datetime`): Not before date of the secret in UTC
-            - **expires** (:class:`~datetime.datetime`): Expiry date of the secret in UTC
+            - **expires_on** (:class:`~datetime.datetime`): Expiry date of the secret in UTC
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -85,9 +85,11 @@ class SecretClient(AsyncKeyVaultClientBase):
         """
         enabled = kwargs.pop("enabled", None)
         not_before = kwargs.pop("not_before", None)
-        expires = kwargs.pop("expires", None)
-        if enabled is not None or not_before is not None or expires is not None:
-            attributes = self._client.models.SecretAttributes(enabled=enabled, not_before=not_before, expires=expires)
+        expires_on = kwargs.pop("expires_on", None)
+        if enabled is not None or not_before is not None or expires_on is not None:
+            attributes = self._client.models.SecretAttributes(
+                enabled=enabled, not_before=not_before, expires=expires_on
+            )
         else:
             attributes = None
         bundle = await self._client.set_secret(self.vault_endpoint, name, value, secret_attributes=attributes, **kwargs)
@@ -111,7 +113,7 @@ class SecretClient(AsyncKeyVaultClientBase):
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
             - **content_type** (str): An arbitrary string indicating the type of the secret, e.g. 'password'
             - **not_before** (:class:`~datetime.datetime`): Not before date of the secret in UTC
-            - **expires** (:class:`~datetime.datetime`): Expiry date of the secret in UTC
+            - **expires_on** (:class:`~datetime.datetime`): Expiry date of the secret in UTC
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -123,9 +125,11 @@ class SecretClient(AsyncKeyVaultClientBase):
         """
         enabled = kwargs.pop("enabled", None)
         not_before = kwargs.pop("not_before", None)
-        expires = kwargs.pop("expires", None)
-        if enabled is not None or not_before is not None or expires is not None:
-            attributes = self._client.models.SecretAttributes(enabled=enabled, not_before=not_before, expires=expires)
+        expires_on = kwargs.pop("expires_on", None)
+        if enabled is not None or not_before is not None or expires_on is not None:
+            attributes = self._client.models.SecretAttributes(
+                enabled=enabled, not_before=not_before, expires=expires_on
+            )
         else:
             attributes = None
         bundle = await self._client.update_secret(

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/client.py
@@ -50,35 +50,25 @@ class SecretClient(AsyncKeyVaultClientBase):
                 :caption: Get a secret
                 :dedent: 8
         """
-        bundle = await self._client.get_secret(
-            self.vault_endpoint, name, version or "", error_map=_error_map, **kwargs
-        )
+        bundle = await self._client.get_secret(self.vault_endpoint, name, version or "", error_map=_error_map, **kwargs)
         return Secret._from_secret_bundle(bundle)
 
     @distributed_trace_async
-    async def set_secret(
-        self,
-        name: str,
-        value: str,
-        content_type: Optional[str] = None,
-        not_before: Optional[datetime] = None,
-        expires: Optional[datetime] = None,
-        **kwargs: "**Any"
-    ) -> Secret:
+    async def set_secret(self, name: str, value: str, **kwargs: "Any") -> Secret:
         """Set a secret value. Create a new secret if ``name`` is not in use. If it is, create a new version of the
         secret.
 
         :param str name: The name of the secret
         :param str value: The value of the secret
-        :param str content_type: (optional) An arbitrary string indicating the type of the secret, e.g. 'password'
-        :param datetime.datetime not_before: (optional) Not before date of the secret in UTC
-        :param datetime.datetime expires: (optional) Expiry date of the secret in UTC
         :rtype: ~azure.keyvault.secrets.models.Secret
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Keyword arguments
-            - *enabled (bool)* - Whether the secret is enabled for use.
-            - *tags (dict[str, str])* - Application specific metadata in the form of key-value pairs.
+            - **enabled** (bool): Whether the secret is enabled for use.
+            - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
+            - **content_type** (str): An arbitrary string indicating the type of the secret, e.g. 'password'
+            - **not_before** (:class:`~datetime.datetime`): Not before date of the secret in UTC
+            - **expires** (:class:`~datetime.datetime`): Expiry date of the secret in UTC
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -88,19 +78,14 @@ class SecretClient(AsyncKeyVaultClientBase):
                 :caption: Set a secret's value
                 :dedent: 8
         """
-        enabled = kwargs.pop('enabled', None)
+        enabled = kwargs.pop("enabled", None)
+        not_before = kwargs.pop("not_before", None)
+        expires = kwargs.pop("expires", None)
         if enabled is not None or not_before is not None or expires is not None:
             attributes = self._client.models.SecretAttributes(enabled=enabled, not_before=not_before, expires=expires)
         else:
             attributes = None
-        bundle = await self._client.set_secret(
-            self.vault_endpoint,
-            name,
-            value,
-            secret_attributes=attributes,
-            content_type=content_type,
-            **kwargs
-        )
+        bundle = await self._client.set_secret(self.vault_endpoint, name, value, secret_attributes=attributes, **kwargs)
         return Secret._from_secret_bundle(bundle)
 
     @distributed_trace_async
@@ -141,7 +126,7 @@ class SecretClient(AsyncKeyVaultClientBase):
                 :caption: Updates a secret's attributes
                 :dedent: 8
         """
-        enabled = kwargs.pop('enabled', None)
+        enabled = kwargs.pop("enabled", None)
         if enabled is not None or not_before is not None or expires is not None:
             attributes = self._client.models.SecretAttributes(enabled=enabled, not_before=not_before, expires=expires)
         else:
@@ -226,9 +211,7 @@ class SecretClient(AsyncKeyVaultClientBase):
                 :caption: Back up a secret
                 :dedent: 8
         """
-        backup_result = await self._client.backup_secret(
-            self.vault_endpoint, name, error_map=_error_map, **kwargs
-        )
+        backup_result = await self._client.backup_secret(self.vault_endpoint, name, error_map=_error_map, **kwargs)
         return backup_result.value
 
     @distributed_trace_async
@@ -250,9 +233,7 @@ class SecretClient(AsyncKeyVaultClientBase):
                 :caption: Restore a backed up secret
                 :dedent: 8
         """
-        bundle = await self._client.restore_secret(
-            self.vault_endpoint, backup, error_map=_error_map, **kwargs
-        )
+        bundle = await self._client.restore_secret(self.vault_endpoint, backup, error_map=_error_map, **kwargs)
         return SecretProperties._from_secret_bundle(bundle)
 
     @distributed_trace_async
@@ -273,9 +254,7 @@ class SecretClient(AsyncKeyVaultClientBase):
                 :caption: Delete a secret
                 :dedent: 8
         """
-        bundle = await self._client.delete_secret(
-            self.vault_endpoint, name, error_map=_error_map, **kwargs
-        )
+        bundle = await self._client.delete_secret(self.vault_endpoint, name, error_map=_error_map, **kwargs)
         return DeletedSecret._from_deleted_secret_bundle(bundle)
 
     @distributed_trace_async
@@ -297,9 +276,7 @@ class SecretClient(AsyncKeyVaultClientBase):
                 :caption: Get a deleted secret
                 :dedent: 8
         """
-        bundle = await self._client.get_deleted_secret(
-            self.vault_endpoint, name, error_map=_error_map, **kwargs
-        )
+        bundle = await self._client.get_deleted_secret(self.vault_endpoint, name, error_map=_error_map, **kwargs)
         return DeletedSecret._from_deleted_secret_bundle(bundle)
 
     @distributed_trace

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
@@ -83,15 +83,16 @@ class SecretClient(KeyVaultClientBase):
 
         :param str name: The name of the secret
         :param str value: The value of the secret
-        :param str content_type: (optional) An arbitrary string indicating the type of the secret, e.g. 'password'
-        :param datetime.datetime not_before: (optional) Not before date of the secret in UTC
-        :param datetime.datetime expires: (optional) Expiry date of the secret in UTC
         :rtype: ~azure.keyvault.secrets.models.Secret
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Keyword arguments
-            - *enabled (bool)* - Whether the secret is enabled for use.
-            - *tags (dict[str, str])* - Application specific metadata in the form of key-value pairs.
+            - **enabled** (bool): Whether the secret is enabled for use.
+            - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
+            - **content_type** (str): An arbitrary string indicating the type of the secret, e.g. 'password'
+            - **content_type** (str): An arbitrary string indicating the type of the secret, e.g. 'password'
+            - **not_before** (:class:`~datetime.datetime`): Not before date of the secret in UTC
+            - **expires** (:class:`~datetime.datetime`): Expiry date of the secret in UTC
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
@@ -39,8 +39,8 @@ class SecretClient(KeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace
-    def get_secret(self, name, **kwargs):
-        # type: (str, **Any) -> Secret
+    def get_secret(self, name, version=None, **kwargs):
+        # type: (str, str, **Any) -> Secret
         """Get a secret. Requires the secrets/get permission.
 
         :param str name: The name of the secret
@@ -49,9 +49,6 @@ class SecretClient(KeyVaultClientBase):
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
-
-        Keyword arguments
-            - **version** (str): A specific version of the secret to get. If unspecified, gets the latest version.
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -64,7 +61,7 @@ class SecretClient(KeyVaultClientBase):
         bundle = self._client.get_secret(
             vault_base_url=self._vault_endpoint,
             secret_name=name,
-            secret_version=kwargs.pop("version", ""),
+            secret_version=version or "",
             error_map=_error_map,
             **kwargs
         )
@@ -112,20 +109,20 @@ class SecretClient(KeyVaultClientBase):
         return Secret._from_secret_bundle(bundle)
 
     @distributed_trace
-    def update_secret_properties(self, name, **kwargs):
-        # type: (str, **Any) -> SecretProperties
+    def update_secret_properties(self, name, version=None, **kwargs):
+        # type: (str, Optional[str], **Any) -> SecretProperties
         """Update a secret's attributes, such as its tags or whether it's enabled. Requires the secrets/set permission.
 
         **This method can't change a secret's value.** Use :func:`set_secret` to change values.
 
         :param str name: Name of the secret
+        :param str version: (optional) Version of the secret to update. If unspecified, the latest version is updated.
         :rtype: ~azure.keyvault.secrets.models.SecretProperties
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Keyword arguments
-            - **version** (str): Version of the secret to update. If unspecified, the latest version is updated.
             - **enabled** (bool): Whether the secret is enabled for use.
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
             - **content_type** (str): An arbitrary string indicating the type of the secret, e.g. 'password'
@@ -153,7 +150,7 @@ class SecretClient(KeyVaultClientBase):
         bundle = self._client.update_secret(
             self.vault_endpoint,
             name,
-            secret_version=kwargs.pop("version", ""),
+            secret_version=version or "",
             secret_attributes=attributes,
             error_map=_error_map,
             **kwargs

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
@@ -39,8 +39,8 @@ class SecretClient(KeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace
-    def get_secret(self, name, version=None, **kwargs):
-        # type: (str, str, **Any) -> Secret
+    def get_secret(self, name, **kwargs):
+        # type: (str, **Any) -> Secret
         """Get a secret. Requires the secrets/get permission.
 
         :param str name: The name of the secret
@@ -49,6 +49,9 @@ class SecretClient(KeyVaultClientBase):
         :raises:
             :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
             :class:`~azure.core.exceptions.HttpResponseError` for other errors
+
+        Keyword arguments
+            - **version** (str): A specific version of the secret to get. If unspecified, gets the latest version.
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -61,7 +64,7 @@ class SecretClient(KeyVaultClientBase):
         bundle = self._client.get_secret(
             vault_base_url=self._vault_endpoint,
             secret_name=name,
-            secret_version=version or "",
+            secret_version=kwargs.pop("version", ""),
             error_map=_error_map,
             **kwargs
         )

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
@@ -86,7 +86,7 @@ class SecretClient(KeyVaultClientBase):
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
             - **content_type** (str): An arbitrary string indicating the type of the secret, e.g. 'password'
             - **not_before** (:class:`~datetime.datetime`): Not before date of the secret in UTC
-            - **expires** (:class:`~datetime.datetime`): Expiry date of the secret in UTC
+            - **expires_on** (:class:`~datetime.datetime`): Expiry date of the secret in UTC
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -99,9 +99,11 @@ class SecretClient(KeyVaultClientBase):
         """
         enabled = kwargs.pop("enabled", None)
         not_before = kwargs.pop("not_before", None)
-        expires = kwargs.pop("expires", None)
-        if enabled is not None or not_before is not None or expires is not None:
-            attributes = self._client.models.SecretAttributes(enabled=enabled, not_before=not_before, expires=expires)
+        expires_on = kwargs.pop("expires_on", None)
+        if enabled is not None or not_before is not None or expires_on is not None:
+            attributes = self._client.models.SecretAttributes(
+                enabled=enabled, not_before=not_before, expires=expires_on
+            )
         else:
             attributes = None
         bundle = self._client.set_secret(
@@ -128,7 +130,7 @@ class SecretClient(KeyVaultClientBase):
             - **tags** (dict[str, str]): Application specific metadata in the form of key-value pairs.
             - **content_type** (str): An arbitrary string indicating the type of the secret, e.g. 'password'
             - **not_before** (:class:`~datetime.datetime`): Not before date of the secret in UTC
-            - **expires** (:class:`~datetime.datetime`): Expiry date of the secret in UTC
+            - **expires_on** (:class:`~datetime.datetime`): Expiry date of the secret in UTC
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -141,9 +143,11 @@ class SecretClient(KeyVaultClientBase):
         """
         enabled = kwargs.pop("enabled", None)
         not_before = kwargs.pop("not_before", None)
-        expires = kwargs.pop("expires", None)
-        if enabled is not None or not_before is not None or expires is not None:
-            attributes = self._client.models.SecretAttributes(enabled=enabled, not_before=not_before, expires=expires)
+        expires_on = kwargs.pop("expires_on", None)
+        if enabled is not None or not_before is not None or expires_on is not None:
+            attributes = self._client.models.SecretAttributes(
+                enabled=enabled, not_before=not_before, expires=expires_on
+            )
         else:
             attributes = None
         bundle = self._client.update_secret(

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/client.py
@@ -161,7 +161,7 @@ class SecretClient(KeyVaultClientBase):
         return SecretProperties._from_secret_bundle(bundle)  # pylint: disable=protected-access
 
     @distributed_trace
-    def list_secrets(self, **kwargs):
+    def list_properties_of_secrets(self, **kwargs):
         # type: (**Any) -> ItemPaged[SecretProperties]
         """List the latest identifier and attributes of all secrets in the vault, not including their values. Requires
         the secrets/list permission.

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/models.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/models.py
@@ -107,7 +107,7 @@ class SecretProperties(object):
         return self._attributes.expires
 
     @property
-    def created(self):
+    def created_on(self):
         # type: () -> datetime
         """
         When the secret was created, in UTC

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/models.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/models.py
@@ -97,7 +97,7 @@ class SecretProperties(object):
         return self._attributes.not_before
 
     @property
-    def expires(self):
+    def expires_on(self):
         # type: () -> datetime
         """
         When the secret expires, in UTC

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/models.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/models.py
@@ -117,7 +117,7 @@ class SecretProperties(object):
         return self._attributes.created
 
     @property
-    def updated(self):
+    def updated_on(self):
         # type: () -> datetime
         """
         When the secret was last updated, in UTC

--- a/sdk/keyvault/azure-keyvault-secrets/samples/hello_world.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/hello_world.py
@@ -43,9 +43,9 @@ def run_sample():
         # if the secret already exists in the Key Vault, then a new version of the secret is created.
         print("\n.. Create Secret")
         expires = datetime.datetime.utcnow() + datetime.timedelta(days=365)
-        secret = client.set_secret("helloWorldSecretName", "helloWorldSecretValue", expires=expires)
+        secret = client.set_secret("helloWorldSecretName", "helloWorldSecretValue", expires_on=expires)
         print("Secret with name '{0}' created with value '{1}'".format(secret.name, secret.value))
-        print("Secret with name '{0}' expires on '{1}'".format(secret.name, secret.properties.expires))
+        print("Secret with name '{0}' expires on '{1}'".format(secret.name, secret.properties.expires_on))
 
         # Let's get the bank secret using its name
         print("\n.. Get a Secret by name")
@@ -56,12 +56,12 @@ def run_sample():
         # The update method can be used to update the expiry attribute of the secret. It cannot be used to update
         # the value of the secret.
         print("\n.. Update a Secret by name")
-        expires = bank_secret.properties.expires + datetime.timedelta(days=365)
-        updated_secret_properties = client.update_secret_properties(secret.name, expires=expires)
+        expires = bank_secret.properties.expires_on + datetime.timedelta(days=365)
+        updated_secret_properties = client.update_secret_properties(secret.name, expires_on=expires)
         print("Secret with name '{0}' was updated on date '{1}'".format(secret.name, updated_secret_properties.updated))
         print(
             "Secret with name '{0}' was updated to expire on '{1}'".format(
-                secret.name, updated_secret_properties.expires
+                secret.name, updated_secret_properties.expires_on
             )
         )
 

--- a/sdk/keyvault/azure-keyvault-secrets/samples/hello_world.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/hello_world.py
@@ -58,7 +58,7 @@ def run_sample():
         print("\n.. Update a Secret by name")
         expires = bank_secret.properties.expires_on + datetime.timedelta(days=365)
         updated_secret_properties = client.update_secret_properties(secret.name, expires_on=expires)
-        print("Secret with name '{0}' was updated on date '{1}'".format(secret.name, updated_secret_properties.updated))
+        print("Secret with name '{0}' was updated on date '{1}'".format(secret.name, updated_secret_properties.updated_on))
         print(
             "Secret with name '{0}' was updated to expire on '{1}'".format(
                 secret.name, updated_secret_properties.expires_on

--- a/sdk/keyvault/azure-keyvault-secrets/samples/hello_world_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/hello_world_async.py
@@ -60,7 +60,7 @@ async def run_sample():
         updated_secret_properties = await client.update_secret_properties(secret.name, expires_on=expires_on)
         print(
             "Secret with name '{0}' was updated on date '{1}'".format(
-                updated_secret_properties.name, updated_secret_properties.updated
+                updated_secret_properties.name, updated_secret_properties.updated_on
             )
         )
         print(

--- a/sdk/keyvault/azure-keyvault-secrets/samples/hello_world_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/hello_world_async.py
@@ -21,11 +21,11 @@ from azure.core.exceptions import HttpResponseError
 # ----------------------------------------------------------------------------------------------------------
 # Sample - demonstrates the basic CRUD operations on a vault(secret) resource for Azure Key Vault
 #
-# 1. Create a new Secret (set_secret)
+# 1. Create a new secret (set_secret)
 #
 # 2. Get an existing secret (get_secret)
 #
-# 3. Update an existing secret (set_secret)
+# 3. Update an existing secret's properties (update_secret_properties)
 #
 # 4. Delete a secret (delete_secret)
 #
@@ -42,10 +42,10 @@ async def run_sample():
         # Let's create a secret holding bank account credentials valid for 1 year.
         # if the secret already exists in the key vault, then a new version of the secret is created.
         print("\n.. Create Secret")
-        expires = datetime.datetime.utcnow() + datetime.timedelta(days=365)
-        secret = await client.set_secret("helloWorldSecretName", "helloWorldSecretValue", expires=expires)
+        expires_on = datetime.datetime.utcnow() + datetime.timedelta(days=365)
+        secret = await client.set_secret("helloWorldSecretName", "helloWorldSecretValue", expires_on=expires_on)
         print("Secret with name '{0}' created with value '{1}'".format(secret.name, secret.value))
-        print("Secret with name '{0}' expires on '{1}'".format(secret.name, secret.properties.expires))
+        print("Secret with name '{0}' expires on '{1}'".format(secret.name, secret.properties.expires_on))
 
         # Let's get the bank secret using its name
         print("\n.. Get a Secret by name")
@@ -56,8 +56,8 @@ async def run_sample():
         # The update method can be used to update the expiry attribute of the secret. It cannot be used to update
         # the value of the secret.
         print("\n.. Update a Secret by name")
-        expires = bank_secret.properties.expires + datetime.timedelta(days=365)
-        updated_secret_properties = await client.update_secret_properties(secret.name, expires=expires)
+        expires_on = bank_secret.properties.expires_on + datetime.timedelta(days=365)
+        updated_secret_properties = await client.update_secret_properties(secret.name, expires_on=expires_on)
         print(
             "Secret with name '{0}' was updated on date '{1}'".format(
                 updated_secret_properties.name, updated_secret_properties.updated
@@ -65,7 +65,7 @@ async def run_sample():
         )
         print(
             "Secret with name '{0}' was updated to expire on '{1}'".format(
-                updated_secret_properties.name, updated_secret_properties.expires
+                updated_secret_properties.name, updated_secret_properties.expires_on
             )
         )
 

--- a/sdk/keyvault/azure-keyvault-secrets/samples/list_operations.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/list_operations.py
@@ -105,8 +105,8 @@ def run_sample():
 
 
 if __name__ == "__main__":
-    # try:
-    run_sample()
+    try:
+        run_sample()
 
-    # except Exception as e:
-        # print("Top level Error: {0}".format(str(e)))
+    except Exception as e:
+        print("Top level Error: {0}".format(str(e)))

--- a/sdk/keyvault/azure-keyvault-secrets/samples/list_operations.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/list_operations.py
@@ -52,7 +52,7 @@ def run_sample():
         # List operations don 't return the secrets with value information.
         # So, for each returned secret we call get_secret to get the secret with its value information.
         print("\n.. List secrets from the Key Vault")
-        secrets = client.list_secrets()
+        secrets = client.list_properties_of_secrets()
         for secret in secrets:
             retrieved_secret = client.get_secret(secret.name)
             print(

--- a/sdk/keyvault/azure-keyvault-secrets/samples/list_operations.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/list_operations.py
@@ -74,7 +74,7 @@ def run_sample():
         for secret_version in secret_versions:
             print(
                 "Bank Secret with name '{0}' has version: '{1}'.".format(
-                    secret_version.name, secret_version.properties.version
+                    secret_version.name, secret_version.version
                 )
             )
 
@@ -105,8 +105,8 @@ def run_sample():
 
 
 if __name__ == "__main__":
-    try:
-        run_sample()
+    # try:
+    run_sample()
 
-    except Exception as e:
-        print("Top level Error: {0}".format(str(e)))
+    # except Exception as e:
+        # print("Top level Error: {0}".format(str(e)))

--- a/sdk/keyvault/azure-keyvault-secrets/samples/list_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/list_operations_async.py
@@ -76,7 +76,7 @@ async def run_sample():
         print("\n.. List versions of the secret using its name")
         secret_versions = client.list_secret_versions(bank_secret.name)
         async for secret in secret_versions:
-            print("Bank Secret with name '{0}' has version: '{1}'".format(secret.name, secret.properties.version))
+            print("Bank Secret with name '{0}' has version: '{1}'".format(secret.name, secret.version))
 
         # The bank account and storage accounts got closed. Let's delete bank and storage accounts secrets.
         await client.delete_secret(bank_secret.name)

--- a/sdk/keyvault/azure-keyvault-secrets/samples/list_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/list_operations_async.py
@@ -54,7 +54,7 @@ async def run_sample():
         # List operations don 't return the secrets with value information.
         # So, for each returned secret we call get_secret to get the secret with its value information.
         print("\n.. List secrets from the Key Vault")
-        secrets = client.list_secrets()
+        secrets = client.list_properties_of_secrets()
         async for secret in secrets:
             retrieved_secret = await client.get_secret(secret.name)
             print(

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
@@ -74,7 +74,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         )
 
         print(updated_secret_properties.version)
-        print(updated_secret_properties.updated)
+        print(updated_secret_properties.updated_on)
         print(updated_secret_properties.content_type)
         print(updated_secret_properties.tags)
 
@@ -124,7 +124,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
             # the list doesn't include the values at each version
             print(secret.id)
             print(secret.enabled)
-            print(secret.updated)
+            print(secret.updated_on)
 
         # [END list_secret_versions]
         # [START list_deleted_secrets]

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
@@ -55,7 +55,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         secret = secret_client.get_secret("secret-name")
 
         # alternatively, specify a version
-        secret = secret_client.get_secret("secret-name", secret.properties.version)
+        secret = secret_client.get_secret("secret-name", version=secret.properties.version)
 
         print(secret.id)
         print(secret.name)

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
@@ -55,7 +55,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         secret = secret_client.get_secret("secret-name")
 
         # alternatively, specify a version
-        secret = secret_client.get_secret("secret-name", version=secret.properties.version)
+        secret = secret_client.get_secret("secret-name", secret.properties.version)
 
         print(secret.id)
         print(secret.name)

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
@@ -105,7 +105,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         # [START list_secrets]
 
         # list secrets
-        secrets = secret_client.list_secrets()
+        secrets = secret_client.list_properties_of_secrets()
 
         for secret in secrets:
             # the list doesn't include values or versions of the secrets

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
@@ -39,14 +39,14 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         # [START set_secret]
         from dateutil import parser as date_parse
 
-        expires = date_parse.parse("2050-02-02T08:00:00.000Z")
+        expires_on = date_parse.parse("2050-02-02T08:00:00.000Z")
 
         # create a secret, setting optional arguments
-        secret = secret_client.set_secret("secret-name", "secret-value", expires=expires)
+        secret = secret_client.set_secret("secret-name", "secret-value", expires_on=expires_on)
 
         print(secret.name)
         print(secret.properties.version)
-        print(secret.properties.expires)
+        print(secret.properties.expires_on)
 
         # [END set_secret]
         # [START get_secret]

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
@@ -57,7 +57,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         secret = await secret_client.get_secret("secret-name")
 
         # alternatively, specify a version
-        secret = await secret_client.get_secret("secret-name", version=secret_version)
+        secret = await secret_client.get_secret("secret-name", secret_version)
 
         print(secret.id)
         print(secret.name)

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
@@ -107,7 +107,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         # [START list_secrets]
 
         # gets a list of secrets in the vault
-        secrets = secret_client.list_secrets()
+        secrets = secret_client.list_properties_of_secrets()
 
         async for secret in secrets:
             # the list doesn't include values or versions of the secrets

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
@@ -38,15 +38,15 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         # [START set_secret]
         from dateutil import parser as date_parse
 
-        expires = date_parse.parse("2050-02-02T08:00:00.000Z")
+        expires_on = date_parse.parse("2050-02-02T08:00:00.000Z")
 
         # create a secret, setting optional arguments
-        secret = await secret_client.set_secret("secret-name", "secret-value", enabled=True, expires=expires)
+        secret = await secret_client.set_secret("secret-name", "secret-value", enabled=True, expires_on=expires_on)
 
         print(secret.id)
         print(secret.name)
         print(secret.properties.enabled)
-        print(secret.properties.expires)
+        print(secret.properties.expires_on)
 
         # [END set_secret]
 

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
@@ -75,7 +75,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         )
 
         print(updated_secret_properties.version)
-        print(updated_secret_properties.updated)
+        print(updated_secret_properties.updated_on)
         print(updated_secret_properties.content_type)
         print(updated_secret_properties.tags)
 
@@ -125,7 +125,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
             # the list doesn't include the versions' values
             print(secret.id)
             print(secret.enabled)
-            print(secret.updated)
+            print(secret.updated_on)
 
         # [END list_secret_versions]
         # [START list_deleted_secrets]

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
@@ -57,7 +57,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         secret = await secret_client.get_secret("secret-name")
 
         # alternatively, specify a version
-        secret = await secret_client.get_secret("secret-name", secret_version)
+        secret = await secret_client.get_secret("secret-name", version=secret_version)
 
         print(secret.id)
         print(secret.name)

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
@@ -73,12 +73,12 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
         self.assertEqual(tags, created.properties.tags)
 
         # get secret without version
-        retrieved_secret = await client.get_secret(created.name, "")
+        retrieved_secret = await client.get_secret(created.name, version="")
         self.assertEqual(created.id, retrieved_secret.id)
         self._assert_secret_attributes_equal(created.properties, retrieved_secret.properties)
 
         # get secret with version
-        secret_with_version = await client.get_secret(created.name, created.properties.version)
+        secret_with_version = await client.get_secret(created.name, version=created.properties.version)
         self.assertEqual(created.id, retrieved_secret.id)
         self._assert_secret_attributes_equal(created.properties, secret_with_version.properties)
 

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
@@ -20,7 +20,7 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
         self.assertEqual(s1.content_type, s2.content_type)
         self.assertEqual(s1.enabled, s2.enabled)
         self.assertEqual(s1.not_before, s2.not_before)
-        self.assertEqual(s1.expires, s2.expires)
+        self.assertEqual(s1.expires_on, s2.expires_on)
         self.assertEqual(s1.created, s2.created)
         self.assertEqual(s1.updated, s2.updated)
         self.assertEqual(s1.recovery_level, s2.recovery_level)
@@ -91,14 +91,14 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
                 secret.name,
                 version=secret.properties.version,
                 content_type=content_type,
-                expires=expires,
+                expires_on=expires,
                 tags=tags,
                 enabled=enabled,
             )
             self.assertEqual(tags, updated_secret.tags)
             self.assertEqual(secret.id, updated_secret.id)
             self.assertEqual(content_type, updated_secret.content_type)
-            self.assertEqual(expires, updated_secret.expires)
+            self.assertEqual(expires, updated_secret.expires_on)
             self.assertNotEqual(secret.properties.enabled, updated_secret.enabled)
             self.assertNotEqual(secret.properties.updated, updated_secret.updated)
             return updated_secret

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
@@ -136,7 +136,7 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
                 expected[secret_name] = secret
 
         # list secrets
-        result = client.list_secrets(max_results=max_secrets)
+        result = client.list_properties_of_secrets(max_results=max_secrets)
         await self._validate_secret_list(result, expected)
 
     @ResourceGroupPreparer()

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
@@ -89,7 +89,7 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
             enabled = not secret.properties.enabled
             updated_secret = await client.update_secret_properties(
                 secret.name,
-                secret.properties.version,
+                version=secret.properties.version,
                 content_type=content_type,
                 expires=expires,
                 tags=tags,

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
@@ -21,7 +21,7 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
         self.assertEqual(s1.enabled, s2.enabled)
         self.assertEqual(s1.not_before, s2.not_before)
         self.assertEqual(s1.expires_on, s2.expires_on)
-        self.assertEqual(s1.created, s2.created)
+        self.assertEqual(s1.created_on, s2.created_on)
         self.assertEqual(s1.updated, s2.updated)
         self.assertEqual(s1.recovery_level, s2.recovery_level)
         self.assertEqual(s1.key_id, s2.key_id)
@@ -36,7 +36,7 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
             "value should be '{}', but is '{}'".format(secret_value, secret_attributes.value),
         )
         self.assertTrue(
-            secret_attributes.properties.created and secret_attributes.properties.updated,
+            secret_attributes.properties.created_on and secret_attributes.properties.updated,
             "Missing required date attributes.",
         )
 

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
@@ -73,12 +73,12 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
         self.assertEqual(tags, created.properties.tags)
 
         # get secret without version
-        retrieved_secret = await client.get_secret(created.name, version="")
+        retrieved_secret = await client.get_secret(created.name, "")
         self.assertEqual(created.id, retrieved_secret.id)
         self._assert_secret_attributes_equal(created.properties, retrieved_secret.properties)
 
         # get secret with version
-        secret_with_version = await client.get_secret(created.name, version=created.properties.version)
+        secret_with_version = await client.get_secret(created.name, created.properties.version)
         self.assertEqual(created.id, retrieved_secret.id)
         self._assert_secret_attributes_equal(created.properties, secret_with_version.properties)
 

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
@@ -22,7 +22,7 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
         self.assertEqual(s1.not_before, s2.not_before)
         self.assertEqual(s1.expires_on, s2.expires_on)
         self.assertEqual(s1.created_on, s2.created_on)
-        self.assertEqual(s1.updated, s2.updated)
+        self.assertEqual(s1.updated_on, s2.updated_on)
         self.assertEqual(s1.recovery_level, s2.recovery_level)
         self.assertEqual(s1.key_id, s2.key_id)
 
@@ -36,7 +36,7 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
             "value should be '{}', but is '{}'".format(secret_value, secret_attributes.value),
         )
         self.assertTrue(
-            secret_attributes.properties.created_on and secret_attributes.properties.updated,
+            secret_attributes.properties.created_on and secret_attributes.properties.updated_on,
             "Missing required date attributes.",
         )
 
@@ -100,7 +100,7 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
             self.assertEqual(content_type, updated_secret.content_type)
             self.assertEqual(expires, updated_secret.expires_on)
             self.assertNotEqual(secret.properties.enabled, updated_secret.enabled)
-            self.assertNotEqual(secret.properties.updated, updated_secret.updated)
+            self.assertNotEqual(secret.properties.updated_on, updated_secret.updated_on)
             return updated_secret
 
         # update secret with version

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
@@ -84,7 +84,7 @@ class SecretClientTests(KeyVaultTestCase):
 
         self._assert_secret_attributes_equal(created.properties, client.get_secret(created.name).properties)
         self._assert_secret_attributes_equal(
-            created.properties, client.get_secret(created.name, created.properties.version).properties
+            created.properties, client.get_secret(created.name, version=created.properties.version).properties
         )
 
         def _update_secret(secret):

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
@@ -20,7 +20,7 @@ class SecretClientTests(KeyVaultTestCase):
         self.assertEqual(s1.enabled, s2.enabled)
         self.assertEqual(s1.not_before, s2.not_before)
         self.assertEqual(s1.expires_on, s2.expires_on)
-        self.assertEqual(s1.created, s2.created)
+        self.assertEqual(s1.created_on, s2.created_on)
         self.assertEqual(s1.updated, s2.updated)
         self.assertEqual(s1.recovery_level, s2.recovery_level)
         self.assertEqual(s1.key_id, s2.key_id)
@@ -35,7 +35,7 @@ class SecretClientTests(KeyVaultTestCase):
             "value should be '{}', but is '{}'".format(secret_value, secret_attributes.value),
         )
         self.assertTrue(
-            secret_attributes.properties.created and secret_attributes.properties.updated,
+            secret_attributes.properties.created_on and secret_attributes.properties.updated,
             "Missing required date attributes.",
         )
 

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
@@ -84,7 +84,7 @@ class SecretClientTests(KeyVaultTestCase):
 
         self._assert_secret_attributes_equal(created.properties, client.get_secret(created.name).properties)
         self._assert_secret_attributes_equal(
-            created.properties, client.get_secret(created.name, version=created.properties.version).properties
+            created.properties, client.get_secret(created.name, created.properties.version).properties
         )
 
         def _update_secret(secret):

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
@@ -19,7 +19,7 @@ class SecretClientTests(KeyVaultTestCase):
         self.assertEqual(s1.content_type, s2.content_type)
         self.assertEqual(s1.enabled, s2.enabled)
         self.assertEqual(s1.not_before, s2.not_before)
-        self.assertEqual(s1.expires, s2.expires)
+        self.assertEqual(s1.expires_on, s2.expires_on)
         self.assertEqual(s1.created, s2.created)
         self.assertEqual(s1.updated, s2.updated)
         self.assertEqual(s1.recovery_level, s2.recovery_level)
@@ -72,14 +72,14 @@ class SecretClientTests(KeyVaultTestCase):
             enabled=enabled,
             content_type=content_type,
             not_before=not_before,
-            expires=expires,
+            expires_on=expires,
             tags=tags,
         )
         self._validate_secret_bundle(created, vault_client.vault_endpoint, secret_name, secret_value)
         self.assertEqual(content_type, created.properties.content_type)
         self.assertEqual(enabled, created.properties.enabled)
         self.assertEqual(not_before, created.properties.not_before)
-        self.assertEqual(expires, created.properties.expires)
+        self.assertEqual(expires, created.properties.expires_on)
         self.assertEqual(tags, created.properties.tags)
 
         self._assert_secret_attributes_equal(created.properties, client.get_secret(created.name).properties)
@@ -96,14 +96,14 @@ class SecretClientTests(KeyVaultTestCase):
                 secret.name,
                 version=secret.properties.version,
                 content_type=content_type,
-                expires=expires,
+                expires_on=expires,
                 tags=tags,
                 enabled=enabled,
             )
             self.assertEqual(tags, updated_secret.tags)
             self.assertEqual(secret.id, updated_secret.id)
             self.assertEqual(content_type, updated_secret.content_type)
-            self.assertEqual(expires, updated_secret.expires)
+            self.assertEqual(expires, updated_secret.expires_on)
             self.assertNotEqual(secret.properties.enabled, updated_secret.enabled)
             self.assertNotEqual(secret.properties.updated, updated_secret.updated)
             return updated_secret

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
@@ -94,7 +94,7 @@ class SecretClientTests(KeyVaultTestCase):
             enabled = not secret.properties.enabled
             updated_secret = client.update_secret_properties(
                 secret.name,
-                secret.properties.version,
+                version=secret.properties.version,
                 content_type=content_type,
                 expires=expires,
                 tags=tags,

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
@@ -140,7 +140,7 @@ class SecretClientTests(KeyVaultTestCase):
                 expected[secret.name] = secret
 
         # list secrets
-        result = list(client.list_secrets(max_page_size=max_secrets))
+        result = list(client.list_properties_of_secrets(max_page_size=max_secrets))
         self._validate_secret_list(result, expected)
 
     @ResourceGroupPreparer()

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
@@ -21,7 +21,7 @@ class SecretClientTests(KeyVaultTestCase):
         self.assertEqual(s1.not_before, s2.not_before)
         self.assertEqual(s1.expires_on, s2.expires_on)
         self.assertEqual(s1.created_on, s2.created_on)
-        self.assertEqual(s1.updated, s2.updated)
+        self.assertEqual(s1.updated_on, s2.updated_on)
         self.assertEqual(s1.recovery_level, s2.recovery_level)
         self.assertEqual(s1.key_id, s2.key_id)
 
@@ -35,7 +35,7 @@ class SecretClientTests(KeyVaultTestCase):
             "value should be '{}', but is '{}'".format(secret_value, secret_attributes.value),
         )
         self.assertTrue(
-            secret_attributes.properties.created_on and secret_attributes.properties.updated,
+            secret_attributes.properties.created_on and secret_attributes.properties.updated_on,
             "Missing required date attributes.",
         )
 
@@ -105,7 +105,7 @@ class SecretClientTests(KeyVaultTestCase):
             self.assertEqual(content_type, updated_secret.content_type)
             self.assertEqual(expires, updated_secret.expires_on)
             self.assertNotEqual(secret.properties.enabled, updated_secret.enabled)
-            self.assertNotEqual(secret.properties.updated, updated_secret.updated)
+            self.assertNotEqual(secret.properties.updated_on, updated_secret.updated_on)
             return updated_secret
 
         if self.is_live:


### PR DESCRIPTION
Moving optional parameters into kwargs and reducing public API around `CryptographyClient`.

Closes #7780, closes #7781, closes #7782, closes #7783, closes #7784.