### PR TITLE
Reduce min check runs to 1.

### DIFF
--- a/eng/CHECKENFORCER
+++ b/eng/CHECKENFORCER
@@ -1,2 +1,2 @@
 format: v0.1-alpha
-minimumCheckRuns: 2
+minimumCheckRuns: 1


### PR DESCRIPTION
After some investigation as to why check-enforcer wasn't turning green on some PRs it turns out that the ```cla/license``` check doesn't get returned by a checkrun lookup. Perhaps this is because it is using a legacy API which renders it invisible to Check Enforcer. Fortunately the fix is simple - just reduce the min-check run count to 1 since ```cla/license``` is itself required so we don't need to guard it anyway.