### PR TITLE
Add tracing policy to credential pipelines

### DIFF
--- a/sdk/identity/azure-identity/HISTORY.md
+++ b/sdk/identity/azure-identity/HISTORY.md
@@ -1,6 +1,13 @@
 # Release History
 
 ## 1.0.0b5
+### Breaking changes:
+- Async credentials now default to [`aiohttp`](https://pypi.org/project/aiohttp/)
+for transport but the library does not require it as a dependency because the
+async API is optional. To use async credentials, please install
+[`aiohttp`](https://pypi.org/project/aiohttp/) or see
+[azure-core documentation](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/core/azure-core/README.md#transport)
+for information about customizing the transport.
 
 
 ## 1.0.0b4 (2019-10-07)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -7,7 +7,13 @@ import os
 from azure.core.configuration import Configuration
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
-from azure.core.pipeline.policies import ContentDecodePolicy, HeadersPolicy, NetworkTraceLoggingPolicy, RetryPolicy
+from azure.core.pipeline.policies import (
+    ContentDecodePolicy,
+    DistributedTracingPolicy,
+    HeadersPolicy,
+    NetworkTraceLoggingPolicy,
+    RetryPolicy,
+)
 
 from .._authn_client import AuthnClient
 from .._constants import Endpoints, EnvironmentVariables
@@ -58,7 +64,13 @@ class _ManagedIdentityBase(object):
         # type: (str, Type, Optional[Configuration], Optional[str], Any) -> None
         self._client_id = client_id
         config = config or self._create_config(**kwargs)
-        policies = [ContentDecodePolicy(), config.headers_policy, config.retry_policy, config.logging_policy]
+        policies = [
+            ContentDecodePolicy(),
+            config.headers_policy,
+            config.retry_policy,
+            config.logging_policy,
+            DistributedTracingPolicy(),
+        ]
         self._client = client_cls(endpoint=endpoint, config=config, policies=policies, **kwargs)
 
     @staticmethod

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
@@ -9,7 +9,13 @@ import json
 from azure.core.configuration import Configuration
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.pipeline import Pipeline
-from azure.core.pipeline.policies import ContentDecodePolicy, NetworkTraceLoggingPolicy, ProxyPolicy, RetryPolicy
+from azure.core.pipeline.policies import (
+    ContentDecodePolicy,
+    DistributedTracingPolicy,
+    NetworkTraceLoggingPolicy,
+    ProxyPolicy,
+    RetryPolicy,
+)
 from azure.core.pipeline.transport import HttpRequest, RequestsTransport
 
 try:
@@ -77,7 +83,12 @@ class MsalTransportAdapter(object):
 
     def _build_pipeline(self, config=None, policies=None, transport=None, **kwargs):
         config = config or self._create_config(**kwargs)
-        policies = policies or [ContentDecodePolicy(), config.retry_policy, config.logging_policy]
+        policies = policies or [
+            ContentDecodePolicy(),
+            config.retry_policy,
+            config.logging_policy,
+            DistributedTracingPolicy(),
+        ]
         if not transport:
             transport = RequestsTransport(**kwargs)
         return Pipeline(transport=transport, policies=policies)

--- a/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
@@ -5,7 +5,6 @@
 import time
 from typing import TYPE_CHECKING
 
-
 from msal import TokenCache
 from azure.core.configuration import Configuration
 from azure.core.credentials import AccessToken
@@ -14,11 +13,11 @@ from azure.core.pipeline import AsyncPipeline
 from azure.core.pipeline.policies import (
     AsyncRetryPolicy,
     ContentDecodePolicy,
+    DistributedTracingPolicy,
     NetworkTraceLoggingPolicy,
     ProxyPolicy,
-    DistributedTracingPolicy
 )
-from azure.core.pipeline.transport import AsyncioRequestsTransport
+from azure.core.pipeline.transport import AioHttpTransport
 
 from .._authn_client import AuthnClientBase
 
@@ -47,7 +46,7 @@ class AsyncAuthnClient(AuthnClientBase):  # pylint:disable=async-client-bad-name
             DistributedTracingPolicy(),
         ]
         if not transport:
-            transport = AsyncioRequestsTransport(**kwargs)
+            transport = AioHttpTransport(**kwargs)
         self._pipeline = AsyncPipeline(transport=transport, policies=policies)
         super().__init__(**kwargs)
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -12,8 +12,6 @@ from .client_credential import CertificateCredential, ClientSecretCredential
 if TYPE_CHECKING:
     from typing import Any, Optional, Union
     from azure.core.credentials import AccessToken
-    from azure.core.pipeline.policies import HTTPPolicy
-    from azure.core.pipeline.transport import AsyncHttpTransport
 
 
 class EnvironmentCredential:
@@ -51,7 +49,7 @@ class EnvironmentCredential:
                 **kwargs
             )
 
-    async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":  # pylint:disable=unused-argument
+    async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":
         """Asynchronously request an access token for `scopes`.
 
         :param str scopes: desired scopes for the token


### PR DESCRIPTION
Adding the tracing policy to a couple pipelines which lacked it, and correcting a pipeline's default async transport.

Closes #7769 