### PR TITLE
Rename secret -> client_secret

### DIFF
--- a/sdk/eventhub/azure-eventhubs/examples/client_secret_auth.py
+++ b/sdk/eventhub/azure-eventhubs/examples/client_secret_auth.py
@@ -25,7 +25,7 @@ SECRET = os.environ.get('AAD_SECRET')
 TENANT_ID = os.environ.get('AAD_TENANT_ID')
 
 
-credential = ClientSecretCredential(client_id=CLIENT_ID, secret=SECRET, tenant_id=TENANT_ID)
+credential = ClientSecretCredential(client_id=CLIENT_ID, client_secret=SECRET, tenant_id=TENANT_ID)
 client = EventHubClient(host=HOSTNAME,
                         event_hub_path=EVENT_HUB,
                         credential=credential)

--- a/sdk/eventhub/azure-eventhubs/tests/livetest/asynctests/test_auth_async.py
+++ b/sdk/eventhub/azure-eventhubs/tests/livetest/asynctests/test_auth_async.py
@@ -21,7 +21,7 @@ async def test_client_secret_credential_async(aad_credential, live_eventhub):
         pytest.skip("No azure identity library")
 
     client_id, secret, tenant_id = aad_credential
-    credential = ClientSecretCredential(client_id=client_id, secret=secret, tenant_id=tenant_id)
+    credential = ClientSecretCredential(client_id=client_id, client_secret=secret, tenant_id=tenant_id)
     client = EventHubClient(host=live_eventhub['hostname'],
                             event_hub_path=live_eventhub['event_hub'],
                             credential=credential,

--- a/sdk/eventhub/azure-eventhubs/tests/livetest/synctests/test_auth.py
+++ b/sdk/eventhub/azure-eventhubs/tests/livetest/synctests/test_auth.py
@@ -17,7 +17,7 @@ def test_client_secret_credential(aad_credential, live_eventhub):
     except ImportError:
         pytest.skip("No azure identity library")
     client_id, secret, tenant_id = aad_credential
-    credential = ClientSecretCredential(client_id=client_id, secret=secret, tenant_id=tenant_id)
+    credential = ClientSecretCredential(client_id=client_id, client_secret=secret, tenant_id=tenant_id)
     client = EventHubClient(host=live_eventhub['hostname'],
                             event_hub_path=live_eventhub['event_hub'],
                             credential=credential,

--- a/sdk/identity/azure-identity/HISTORY.md
+++ b/sdk/identity/azure-identity/HISTORY.md
@@ -8,6 +8,7 @@ async API is optional. To use async credentials, please install
 [`aiohttp`](https://pypi.org/project/aiohttp/) or see
 [azure-core documentation](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/core/azure-core/README.md#transport)
 for information about customizing the transport.
+- Renamed `ClientSecretCredential` parameter "`secret`" to "`client_secret`"
 
 
 ## 1.0.0b4 (2019-10-07)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/client_credential.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/client_credential.py
@@ -20,7 +20,7 @@ class ClientSecretCredential(ClientSecretCredentialBase):
     """Authenticates as a service principal using a client ID and client secret.
 
     :param str client_id: the service principal's client ID
-    :param str secret: one of the service principal's client secrets
+    :param str client_secret: one of the service principal's client secrets
     :param str tenant_id: ID of the service principal's tenant. Also called its 'directory' ID.
 
     Keyword arguments
@@ -29,9 +29,9 @@ class ClientSecretCredential(ClientSecretCredentialBase):
           authorities for other clouds.
     """
 
-    def __init__(self, client_id, secret, tenant_id, **kwargs):
+    def __init__(self, client_id, client_secret, tenant_id, **kwargs):
         # type: (str, str, str, Mapping[str, Any]) -> None
-        super(ClientSecretCredential, self).__init__(client_id, secret, tenant_id, **kwargs)
+        super(ClientSecretCredential, self).__init__(client_id, client_secret, tenant_id, **kwargs)
         self._client = AuthnClient(tenant=tenant_id, **kwargs)
 
     def get_token(self, *scopes, **kwargs):  # pylint:disable=unused-argument

--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -54,7 +54,7 @@ class EnvironmentCredential:
         if all(os.environ.get(v) is not None for v in EnvironmentVariables.CLIENT_SECRET_VARS):
             self._credential = ClientSecretCredential(
                 client_id=os.environ[EnvironmentVariables.AZURE_CLIENT_ID],
-                secret=os.environ[EnvironmentVariables.AZURE_CLIENT_SECRET],
+                client_secret=os.environ[EnvironmentVariables.AZURE_CLIENT_SECRET],
                 tenant_id=os.environ[EnvironmentVariables.AZURE_TENANT_ID],
                 **kwargs
             )

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_credential.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_credential.py
@@ -16,7 +16,7 @@ class ClientSecretCredential(ClientSecretCredentialBase):
     """Authenticates as a service principal using a client ID and client secret.
 
     :param str client_id: the service principal's client ID
-    :param str secret: one of the service principal's client secrets
+    :param str client_secret: one of the service principal's client secrets
     :param str tenant_id: ID of the service principal's tenant. Also called its 'directory' ID.
 
     Keyword arguments
@@ -25,8 +25,8 @@ class ClientSecretCredential(ClientSecretCredentialBase):
           authorities for other clouds.
     """
 
-    def __init__(self, client_id: str, secret: str, tenant_id: str, **kwargs: "Mapping[str, Any]") -> None:
-        super(ClientSecretCredential, self).__init__(client_id, secret, tenant_id, **kwargs)
+    def __init__(self, client_id: str, client_secret: str, tenant_id: str, **kwargs: "Mapping[str, Any]") -> None:
+        super(ClientSecretCredential, self).__init__(client_id, client_secret, tenant_id, **kwargs)
         self._client = AsyncAuthnClient(tenant=tenant_id, **kwargs)
 
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":  # pylint:disable=unused-argument

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -37,7 +37,7 @@ class EnvironmentCredential:
         if all(os.environ.get(v) is not None for v in EnvironmentVariables.CLIENT_SECRET_VARS):
             self._credential = ClientSecretCredential(
                 client_id=os.environ[EnvironmentVariables.AZURE_CLIENT_ID],
-                secret=os.environ[EnvironmentVariables.AZURE_CLIENT_SECRET],
+                client_secret=os.environ[EnvironmentVariables.AZURE_CLIENT_SECRET],
                 tenant_id=os.environ[EnvironmentVariables.AZURE_TENANT_ID],
                 **kwargs
             )

--- a/sdk/identity/azure-identity/tests/test_identity.py
+++ b/sdk/identity/azure-identity/tests/test_identity.py
@@ -87,7 +87,7 @@ def test_client_secret_credential():
     )
 
     token = ClientSecretCredential(
-        client_id=client_id, secret=secret, tenant_id=tenant_id, transport=transport
+        client_id=client_id, client_secret=secret, tenant_id=tenant_id, transport=transport
     ).get_token("scope")
 
     # not validating expires_on because doing so requires monkeypatching time, and this is tested elsewhere

--- a/sdk/identity/azure-identity/tests/test_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_identity_async.py
@@ -83,7 +83,7 @@ async def test_client_secret_credential():
     )
 
     token = await ClientSecretCredential(
-        client_id=client_id, secret=secret, tenant_id=tenant_id, transport=transport
+        client_id=client_id, client_secret=secret, tenant_id=tenant_id, transport=transport
     ).get_token("scope")
 
     # not validating expires_on because doing so requires monkeypatching time, and this is tested elsewhere


### PR DESCRIPTION
This is more consistent with other languages and the environment variable (`AZURE_CLIENT_SECRET`).

Closes #7768 