### PR TITLE
[File and Queue] Client constructors

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/blob_client_async.py
@@ -64,7 +64,9 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase):  # pylint: disa
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str account_url: The full URI to the account.
+    :param str account_url:
+        The URI to the storage account. In order to create a client given the full URI to the blob,
+        use the `from_blob_url` classmethod.
     :param container_name: The container for the blob.
     :type container_name: str
     :param blob_name: The mame of the blob with which to interact.

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/container_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/container_client_async.py
@@ -73,9 +73,9 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase):
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str container_url:
-        The full URI to the container. This can also be a URL to the storage
-        account, in which case the blob container must also be specified.
+    :param str account_url:
+        The URI to the storage account. In order to create a client given the full URI to the container,
+        use the from_container_url classmethod.
     :param container_name:
         The name of the container for the blob.
     :type container_name: str or ~azure.storage.blob.ContainerProperties

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/blob_client.py
@@ -90,8 +90,9 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str account_url: The full URI to the account. This can also be a URL to the storage account
-        or container, in which case the blob and/or container must also be specified.
+    :param str account_url:
+        The URI to the storage account. In order to create a client given the full URI to the blob,
+        use the `from_blob_url` classmethod.
     :param container_name: The container for the blob.
     :type container_name: str
     :param blob_name: The blob with which to interact. If specified, this value will override

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/container_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/container_client.py
@@ -82,7 +82,8 @@ class ContainerClient(StorageAccountHostsMixin):
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
     :param str account_url:
-        The full URI to the storage account.
+        The URI to the storage account. In order to create a client given the full URI to the container,
+        use the from_container_url classmethod.
     :param container_name:
         The container for the blob.
     :type container_name: str

--- a/sdk/storage/azure-storage-file/HISTORY.md
+++ b/sdk/storage/azure-storage-file/HISTORY.md
@@ -1,5 +1,16 @@
 # Change Log azure-storage-file
 
+## Version 12.0.0:
+
+**Breaking changes**
+
+- `ShareClient` now accepts only `account_url` with mandatory a string param `share_name`. 
+To use a share_url, the method `from_share_url` must be used.
+- `DirectoryClient` now accepts only `account_url` with mandatory string params `share_name` and `directory_path`.
+To use a directory_url, the method `from_directory_url` must be used.
+- `FileClient` now accepts only `account_url` with mandatory string params `share_name` and 
+`file_path`. To use a file_url, the method `from_file_url` must be used.
+
 ## Version 12.0.0b4:
 
 **Breaking changes**

--- a/sdk/storage/azure-storage-file/azure/storage/file/aio/directory_client_async.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/aio/directory_client_async.py
@@ -59,12 +59,12 @@ class DirectoryClient(AsyncStorageAccountHostsMixin, DirectoryClientBase):
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str directory_url:
-        The full URI to the directory. This can also be a URL to the storage account
-        or share, in which case the directory and/or share must also be specified.
-    :param share: The share for the directory. If specified, this value will override
+    :param str account_url:
+        The URI to the account. The method `from_directory_url` must be used in order to 
+        use the full URI to the directory.
+    :param share_name: The share for the directory. If specified, this value will override
         a share value specified in the directory URL.
-    :type share: str or ~azure.storage.file.ShareProperties
+    :type share_name: str
     :param str directory_path:
         The directory path for the directory with which to interact.
         If specified, this value will override a directory value specified in the directory URL.
@@ -76,9 +76,9 @@ class DirectoryClient(AsyncStorageAccountHostsMixin, DirectoryClientBase):
         shared access key.
     """
     def __init__( # type: ignore
-            self, directory_url,  # type: str
-            share=None, # type: Optional[Union[str, ShareProperties]]
-            directory_path=None, # type: Optional[str]
+            self, account_url,  # type: str
+            share_name, # type: str
+            directory_path, # type: str
             snapshot=None,  # type: Optional[Union[str, Dict[str, Any]]]
             credential=None, # type: Optional[Any]
             loop=None,  # type: Any
@@ -87,8 +87,8 @@ class DirectoryClient(AsyncStorageAccountHostsMixin, DirectoryClientBase):
         # type: (...) -> None
         kwargs['retry_policy'] = kwargs.get('retry_policy') or ExponentialRetry(**kwargs)
         super(DirectoryClient, self).__init__(
-            directory_url,
-            share=share,
+            account_url,
+            share_name=share_name,
             directory_path=directory_path,
             snapshot=snapshot,
             credential=credential,
@@ -111,7 +111,7 @@ class DirectoryClient(AsyncStorageAccountHostsMixin, DirectoryClientBase):
         if self.directory_path:
             file_name = self.directory_path.rstrip('/') + "/" + file_name
         return FileClient(
-            self.url, file_path=file_name, snapshot=self.snapshot, credential=self.credential,
+            self.url, file_path=file_name, share_name=self.share_name, snapshot=self.snapshot, credential=self.credential,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
             _location_mode=self._location_mode, loop=self._loop, **kwargs)
 
@@ -137,7 +137,7 @@ class DirectoryClient(AsyncStorageAccountHostsMixin, DirectoryClientBase):
         """
         directory_path = self.directory_path.rstrip('/') + "/" + directory_name
         return DirectoryClient(
-            self.url, directory_path=directory_path, snapshot=self.snapshot, credential=self.credential,
+            self.url, share_name=self.share_name, directory_path=directory_path, snapshot=self.snapshot, credential=self.credential,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
             _location_mode=self._location_mode, loop=self._loop, **kwargs)
 

--- a/sdk/storage/azure-storage-file/azure/storage/file/aio/directory_client_async.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/aio/directory_client_async.py
@@ -60,10 +60,10 @@ class DirectoryClient(AsyncStorageAccountHostsMixin, DirectoryClientBase):
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
     :param str account_url:
-        The URI to the account. The method `from_directory_url` must be used in order to
-        use the full URI to the directory.
-    :param share_name: The share for the directory. If specified, this value will override
-        a share value specified in the directory URL.
+        The URI to the storage account. In order to create a client given the full URI to the
+        directory, use the from_directory_url classmethod.
+    :param share_name:
+        The name of the share for the directory.
     :type share_name: str
     :param str directory_path:
         The directory path for the directory with which to interact.

--- a/sdk/storage/azure-storage-file/azure/storage/file/aio/directory_client_async.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/aio/directory_client_async.py
@@ -60,7 +60,7 @@ class DirectoryClient(AsyncStorageAccountHostsMixin, DirectoryClientBase):
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
     :param str account_url:
-        The URI to the account. The method `from_directory_url` must be used in order to 
+        The URI to the account. The method `from_directory_url` must be used in order to
         use the full URI to the directory.
     :param share_name: The share for the directory. If specified, this value will override
         a share value specified in the directory URL.
@@ -111,9 +111,9 @@ class DirectoryClient(AsyncStorageAccountHostsMixin, DirectoryClientBase):
         if self.directory_path:
             file_name = self.directory_path.rstrip('/') + "/" + file_name
         return FileClient(
-            self.url, file_path=file_name, share_name=self.share_name, snapshot=self.snapshot, credential=self.credential,
-            _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
-            _location_mode=self._location_mode, loop=self._loop, **kwargs)
+            self.url, file_path=file_name, share_name=self.share_name, snapshot=self.snapshot,
+            credential=self.credential, _hosts=self._hosts, _configuration=self._config,
+            _pipeline=self._pipeline, _location_mode=self._location_mode, loop=self._loop, **kwargs)
 
     def get_subdirectory_client(self, directory_name, **kwargs):
         # type: (str, Any) -> DirectoryClient
@@ -137,9 +137,9 @@ class DirectoryClient(AsyncStorageAccountHostsMixin, DirectoryClientBase):
         """
         directory_path = self.directory_path.rstrip('/') + "/" + directory_name
         return DirectoryClient(
-            self.url, share_name=self.share_name, directory_path=directory_path, snapshot=self.snapshot, credential=self.credential,
-            _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
-            _location_mode=self._location_mode, loop=self._loop, **kwargs)
+            self.url, share_name=self.share_name, directory_path=directory_path, snapshot=self.snapshot,
+            credential=self.credential, _hosts=self._hosts, _configuration=self._config,
+            _pipeline=self._pipeline, _location_mode=self._location_mode, loop=self._loop, **kwargs)
 
     @distributed_trace_async
     async def create_directory( # type: ignore

--- a/sdk/storage/azure-storage-file/azure/storage/file/aio/file_client_async.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/aio/file_client_async.py
@@ -107,7 +107,7 @@ class FileClient(AsyncStorageAccountHostsMixin, FileClientBase):
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str account_url: The full URI to the account. The method `from_file_url` must be used 
+    :param str account_url: The full URI to the account. The method `from_file_url` must be used
         in order to use the full File URL.
     :param share_name: The share for the file. If specified, this value will override
         a share value specified in the file URL.
@@ -136,7 +136,8 @@ class FileClient(AsyncStorageAccountHostsMixin, FileClientBase):
         # type: (...) -> None
         kwargs["retry_policy"] = kwargs.get("retry_policy") or ExponentialRetry(**kwargs)
         super(FileClient, self).__init__(
-            account_url, share_name=share_name, file_path=file_path, snapshot=snapshot, credential=credential, loop=loop, **kwargs
+            account_url, share_name=share_name, file_path=file_path, snapshot=snapshot,
+            credential=credential, loop=loop, **kwargs
         )
         self._client = AzureFileStorage(version=VERSION, url=self.url, pipeline=self._pipeline, loop=loop)
         self._loop = loop

--- a/sdk/storage/azure-storage-file/azure/storage/file/aio/file_client_async.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/aio/file_client_async.py
@@ -107,10 +107,11 @@ class FileClient(AsyncStorageAccountHostsMixin, FileClientBase):
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str account_url: The full URI to the account. The method `from_file_url` must be used
-        in order to use the full File URL.
-    :param share_name: The share for the file. If specified, this value will override
-        a share value specified in the file URL.
+    :param str account_url:
+        The URI to the storage account. In order to create a client given the full URI to the
+        file, use the from_file_url classmethod.
+    :param share_name:
+        The name of the share for the file.
     :type share_name: str
     :param str file_path:
         The file path to the file with which to interact. If specified, this value will override

--- a/sdk/storage/azure-storage-file/azure/storage/file/aio/file_client_async.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/aio/file_client_async.py
@@ -107,11 +107,11 @@ class FileClient(AsyncStorageAccountHostsMixin, FileClientBase):
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str file_url: The full URI to the file. This can also be a URL to the storage account
-        or share, in which case the file and/or share must also be specified.
-    :param share: The share for the file. If specified, this value will override
+    :param str account_url: The full URI to the account. The method `from_file_url` must be used 
+        in order to use the full File URL.
+    :param share_name: The share for the file. If specified, this value will override
         a share value specified in the file URL.
-    :type share: str or ~azure.storage.file.ShareProperties
+    :type share_name: str
     :param str file_path:
         The file path to the file with which to interact. If specified, this value will override
         a file value specified in the file URL.
@@ -125,9 +125,9 @@ class FileClient(AsyncStorageAccountHostsMixin, FileClientBase):
 
     def __init__(  # type: ignore
         self,
-        file_url,  # type: str
-        share=None,  # type: Optional[Union[str, ShareProperties]]
-        file_path=None,  # type: Optional[str]
+        account_url,  # type: str
+        share_name,  # type: str
+        file_path,  # type: str
         snapshot=None,  # type: Optional[Union[str, Dict[str, Any]]]
         credential=None,  # type: Optional[Any]
         loop=None,  # type: Any
@@ -136,7 +136,7 @@ class FileClient(AsyncStorageAccountHostsMixin, FileClientBase):
         # type: (...) -> None
         kwargs["retry_policy"] = kwargs.get("retry_policy") or ExponentialRetry(**kwargs)
         super(FileClient, self).__init__(
-            file_url, share=share, file_path=file_path, snapshot=snapshot, credential=credential, loop=loop, **kwargs
+            account_url, share_name=share_name, file_path=file_path, snapshot=snapshot, credential=credential, loop=loop, **kwargs
         )
         self._client = AzureFileStorage(version=VERSION, url=self.url, pipeline=self._pipeline, loop=loop)
         self._loop = loop

--- a/sdk/storage/azure-storage-file/azure/storage/file/aio/file_service_client_async.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/aio/file_service_client_async.py
@@ -307,6 +307,10 @@ class FileServiceClient(AsyncStorageAccountHostsMixin, FileServiceClientBase):
                 :dedent: 8
                 :caption: Gets the share client.
         """
+        try:
+            share_name = share.name
+        except AttributeError:
+            share_name = share
         return ShareClient(
-            self.url, share=share, snapshot=snapshot, credential=self.credential, _hosts=self._hosts,
+            self.url, share_name=share_name, snapshot=snapshot, credential=self.credential, _hosts=self._hosts,
             _configuration=self._config, _pipeline=self._pipeline, _location_mode=self._location_mode, loop=self._loop)

--- a/sdk/storage/azure-storage-file/azure/storage/file/aio/share_client_async.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/aio/share_client_async.py
@@ -57,10 +57,11 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str account_url: The full URI to the account. The `from_share_url` method must be used
-    if you want to use the complete share URL.
-    :param share_name: The share with which to interact. If specified, this value will override
-        a share value specified in the share URL.
+    :param str account_url:
+        The URI to the storage account. In order to create a client given the full URI to the
+        share, use the from_share_url classmethod.
+    :param share_name:
+        The name of the share with which to interact.
     :type share_name: str
     :param str snapshot:
         An optional share snapshot on which to operate.

--- a/sdk/storage/azure-storage-file/azure/storage/file/aio/share_client_async.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/aio/share_client_async.py
@@ -100,8 +100,8 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
         :rtype: ~azure.storage.file.aio.directory_client_async.DirectoryClient
         """
         return DirectoryClient(
-            self.url, share_name=self.share_name, directory_path=directory_path or "", snapshot=self.snapshot, credential=self.credential,
-            _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
+            self.url, share_name=self.share_name, directory_path=directory_path or "", snapshot=self.snapshot,
+            credential=self.credential, _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
             _location_mode=self._location_mode, loop=self._loop)
 
     def get_file_client(self, file_path):
@@ -115,8 +115,9 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
         :rtype: ~azure.storage.file.aio.file_client_async.FileClient
         """
         return FileClient(
-            self.url, share_name=self.share_name, file_path=file_path, snapshot=self.snapshot, credential=self.credential, _hosts=self._hosts,
-            _configuration=self._config, _pipeline=self._pipeline, _location_mode=self._location_mode, loop=self._loop)
+            self.url, share_name=self.share_name, file_path=file_path, snapshot=self.snapshot,
+            credential=self.credential, _hosts=self._hosts, _configuration=self._config,
+            _pipeline=self._pipeline, _location_mode=self._location_mode, loop=self._loop)
 
     @distributed_trace_async
     async def create_share( # type: ignore

--- a/sdk/storage/azure-storage-file/azure/storage/file/aio/share_client_async.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/aio/share_client_async.py
@@ -57,10 +57,11 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str share_url: The full URI to the share.
-    :param share: The share with which to interact. If specified, this value will override
+    :param str account_url: The full URI to the account. The `from_share_url` method must be used
+    if you want to use the complete share URL.
+    :param share_name: The share with which to interact. If specified, this value will override
         a share value specified in the share URL.
-    :type share: str or ~azure.storage.file.ShareProperties
+    :type share_name: str
     :param str snapshot:
         An optional share snapshot on which to operate.
     :param credential:
@@ -69,8 +70,8 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
         shared access key.
     """
     def __init__( # type: ignore
-            self, share_url,  # type: str
-            share=None,  # type: Optional[Union[str, ShareProperties]]
+            self, account_url,  # type: str
+            share_name,  # type: str
             snapshot=None,  # type: Optional[Union[str, Dict[str, Any]]]
             credential=None,  # type: Optional[Any]
             loop=None,  # type: Any
@@ -79,8 +80,8 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
         # type: (...) -> None
         kwargs['retry_policy'] = kwargs.get('retry_policy') or ExponentialRetry(**kwargs)
         super(ShareClient, self).__init__(
-            share_url,
-            share=share,
+            account_url,
+            share_name=share_name,
             snapshot=snapshot,
             credential=credential,
             loop=loop,
@@ -99,7 +100,7 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
         :rtype: ~azure.storage.file.aio.directory_client_async.DirectoryClient
         """
         return DirectoryClient(
-            self.url, directory_path=directory_path or "", snapshot=self.snapshot, credential=self.credential,
+            self.url, share_name=self.share_name, directory_path=directory_path or "", snapshot=self.snapshot, credential=self.credential,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
             _location_mode=self._location_mode, loop=self._loop)
 
@@ -114,7 +115,7 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
         :rtype: ~azure.storage.file.aio.file_client_async.FileClient
         """
         return FileClient(
-            self.url, file_path=file_path, snapshot=self.snapshot, credential=self.credential, _hosts=self._hosts,
+            self.url, share_name=self.share_name, file_path=file_path, snapshot=self.snapshot, credential=self.credential, _hosts=self._hosts,
             _configuration=self._config, _pipeline=self._pipeline, _location_mode=self._location_mode, loop=self._loop)
 
     @distributed_trace_async

--- a/sdk/storage/azure-storage-file/azure/storage/file/directory_client.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/directory_client.py
@@ -63,7 +63,7 @@ class DirectoryClient(StorageAccountHostsMixin):
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
     :param str account_url:
-        The URI to the account. The method `from_directory_url` must be used in order to 
+        The URI to the account. The method `from_directory_url` must be used in order to
         use the full URI to the directory.
     :param share_name: The share for the directory. If specified, this value will override
         a share value specified in the directory URL.
@@ -126,6 +126,7 @@ class DirectoryClient(StorageAccountHostsMixin):
             credential=None, # type: Optional[Any]
             **kwargs # type: Optional[Any]
         ):
+        # type: (...) -> DirectoryClient
         """
         :param str directory_url:
             The full URI to the directory.
@@ -217,9 +218,9 @@ class DirectoryClient(StorageAccountHostsMixin):
         if self.directory_path:
             file_name = self.directory_path.rstrip('/') + "/" + file_name
         return FileClient(
-            self.url, file_path=file_name, share_name=self.share_name, napshot=self.snapshot, credential=self.credential,
-            _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
-            _location_mode=self._location_mode, **kwargs)
+            self.url, file_path=file_name, share_name=self.share_name, napshot=self.snapshot,
+            credential=self.credential, _hosts=self._hosts, _configuration=self._config,
+            _pipeline=self._pipeline, _location_mode=self._location_mode, **kwargs)
 
     def get_subdirectory_client(self, directory_name, **kwargs):
         # type: (str, Any) -> DirectoryClient
@@ -243,8 +244,8 @@ class DirectoryClient(StorageAccountHostsMixin):
         """
         directory_path = self.directory_path.rstrip('/') + "/" + directory_name
         return DirectoryClient(
-            self.url, share_name=self.share_name, directory_path=directory_path, snapshot=self.snapshot, credential=self.credential,
-            _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
+            self.url, share_name=self.share_name, directory_path=directory_path, snapshot=self.snapshot,
+            credential=self.credential, _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
             _location_mode=self._location_mode, **kwargs)
 
     @distributed_trace

--- a/sdk/storage/azure-storage-file/azure/storage/file/directory_client.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/directory_client.py
@@ -62,12 +62,12 @@ class DirectoryClient(StorageAccountHostsMixin):
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str directory_url:
-        The full URI to the directory. This can also be a URL to the storage account
-        or share, in which case the directory and/or share must also be specified.
-    :param share: The share for the directory. If specified, this value will override
+    :param str account_url:
+        The URI to the account. The method `from_directory_url` must be used in order to 
+        use the full URI to the directory.
+    :param share_name: The share for the directory. If specified, this value will override
         a share value specified in the directory URL.
-    :type share: str or ~azure.storage.file.ShareProperties
+    :type share_name: str
     :param str directory_path:
         The directory path for the directory with which to interact.
         If specified, this value will override a directory value specified in the directory URL.
@@ -79,30 +79,27 @@ class DirectoryClient(StorageAccountHostsMixin):
         shared access key.
     """
     def __init__( # type: ignore
-            self, directory_url,  # type: str
-            share=None, # type: Optional[Union[str, ShareProperties]]
-            directory_path=None, # type: Optional[str]
+            self, account_url,  # type: str
+            share_name, # type: str
+            directory_path, # type: str
             snapshot=None,  # type: Optional[Union[str, Dict[str, Any]]]
             credential=None, # type: Optional[Any]
             **kwargs # type: Optional[Any]
         ):
         # type: (...) -> None
         try:
-            if not directory_url.lower().startswith('http'):
-                directory_url = "https://" + directory_url
+            if not account_url.lower().startswith('http'):
+                account_url = "https://" + account_url
         except AttributeError:
-            raise ValueError("Share URL must be a string.")
-        parsed_url = urlparse(directory_url.rstrip('/'))
-        if not parsed_url.path and not share:
+            raise ValueError("Account URL must be a string.")
+        parsed_url = urlparse(account_url.rstrip('/'))
+        if not share_name:
             raise ValueError("Please specify a share name.")
         if not parsed_url.netloc:
-            raise ValueError("Invalid URL: {}".format(directory_url))
+            raise ValueError("Invalid URL: {}".format(account_url))
         if hasattr(credential, 'get_token'):
             raise ValueError("Token credentials not supported by the File service.")
 
-        share, path_dir = "", ""
-        if parsed_url.path:
-            share, _, path_dir = parsed_url.path.lstrip('/').partition('/')
         path_snapshot, sas_token = parse_query(parsed_url.query)
         if not sas_token and not credential:
             raise ValueError(
@@ -114,16 +111,51 @@ class DirectoryClient(StorageAccountHostsMixin):
                 self.snapshot = snapshot['snapshot'] # type: ignore
             except TypeError:
                 self.snapshot = snapshot or path_snapshot
-        try:
-            self.share_name = share.name # type: ignore
-        except AttributeError:
-            self.share_name = share or unquote(share)
-        self.directory_path = directory_path or path_dir
+
+        self.share_name = share_name
+        self.directory_path = directory_path
 
         self._query_str, credential = self._format_query_string(
             sas_token, credential, share_snapshot=self.snapshot)
         super(DirectoryClient, self).__init__(parsed_url, service='file', credential=credential, **kwargs)
         self._client = AzureFileStorage(version=VERSION, url=self.url, pipeline=self._pipeline)
+
+    @classmethod
+    def from_directory_url(cls, directory_url,  # type: str
+            snapshot=None,  # type: Optional[Union[str, Dict[str, Any]]]
+            credential=None, # type: Optional[Any]
+            **kwargs # type: Optional[Any]
+        ):
+        """
+        :param str directory_url:
+            The full URI to the directory.
+        :param str snapshot:
+            An optional share snapshot on which to operate.
+        :param credential:
+            The credential with which to authenticate. This is optional if the
+            account URL already has a SAS token. The value can be a SAS token string or an account
+            shared access key.
+        """
+        try:
+            if not directory_url.lower().startswith('http'):
+                directory_url = "https://" + directory_url
+        except AttributeError:
+            raise ValueError("Directory URL must be a string.")
+        parsed_url = urlparse(directory_url.rstrip('/'))
+        if not parsed_url.path and not parsed_url.netloc:
+            raise ValueError("Invalid URL: {}".format(directory_url))
+        account_url = parsed_url.netloc.rstrip('/') + "?" + parsed_url.query
+        path_snapshot, _ = parse_query(parsed_url.query)
+
+        share_name, _, path_dir = parsed_url.path.lstrip('/').partition('/')
+        share_name = unquote(share_name)
+
+        directory_path = path_dir
+        snapshot = snapshot or path_snapshot
+
+        return cls(
+            account_url=account_url, share_name=share_name, directory_path=directory_path,
+            credential=credential, **kwargs)
 
     def _format_url(self, hostname):
         """Format the endpoint URL according to the current location
@@ -145,7 +177,7 @@ class DirectoryClient(StorageAccountHostsMixin):
     @classmethod
     def from_connection_string(
             cls, conn_str,  # type: str
-            share=None, # type: Optional[Union[str, ShareProperties]]
+            share_name=None, # type: str
             directory_path=None, # type: Optional[str]
             credential=None, # type: Optional[Any]
             **kwargs # type: Any
@@ -155,9 +187,9 @@ class DirectoryClient(StorageAccountHostsMixin):
 
         :param str conn_str:
             A connection string to an Azure Storage account.
-        :param share: The share. This can either be the name of the share,
+        :param share_name: The share. This can either be the name of the share,
             or an instance of ShareProperties
-        :type share: str or ~azure.storage.file.ShareProperties
+        :type share_name: str
         :param str directory_path:
             The directory path.
         :param credential:
@@ -169,7 +201,7 @@ class DirectoryClient(StorageAccountHostsMixin):
         if 'secondary_hostname' not in kwargs:
             kwargs['secondary_hostname'] = secondary
         return cls(
-            account_url, share=share, directory_path=directory_path, credential=credential, **kwargs)
+            account_url, share_name=share_name, directory_path=directory_path, credential=credential, **kwargs)
 
     def get_file_client(self, file_name, **kwargs):
         # type: (str, Any) -> FileClient
@@ -185,7 +217,7 @@ class DirectoryClient(StorageAccountHostsMixin):
         if self.directory_path:
             file_name = self.directory_path.rstrip('/') + "/" + file_name
         return FileClient(
-            self.url, file_path=file_name, snapshot=self.snapshot, credential=self.credential,
+            self.url, file_path=file_name, share_name=self.share_name, napshot=self.snapshot, credential=self.credential,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
             _location_mode=self._location_mode, **kwargs)
 
@@ -211,7 +243,7 @@ class DirectoryClient(StorageAccountHostsMixin):
         """
         directory_path = self.directory_path.rstrip('/') + "/" + directory_name
         return DirectoryClient(
-            self.url, directory_path=directory_path, snapshot=self.snapshot, credential=self.credential,
+            self.url, share_name=self.share_name, directory_path=directory_path, snapshot=self.snapshot, credential=self.credential,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
             _location_mode=self._location_mode, **kwargs)
 

--- a/sdk/storage/azure-storage-file/azure/storage/file/directory_client.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/directory_client.py
@@ -63,10 +63,10 @@ class DirectoryClient(StorageAccountHostsMixin):
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
     :param str account_url:
-        The URI to the account. The method `from_directory_url` must be used in order to
-        use the full URI to the directory.
-    :param share_name: The share for the directory. If specified, this value will override
-        a share value specified in the directory URL.
+        The URI to the storage account. In order to create a client given the full URI to the directory,
+        use the from_directory_url classmethod.
+    :param share_name:
+        The name of the share for the directory.
     :type share_name: str
     :param str directory_path:
         The directory path for the directory with which to interact.

--- a/sdk/storage/azure-storage-file/azure/storage/file/file_client.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/file_client.py
@@ -114,10 +114,11 @@ class FileClient(StorageAccountHostsMixin):
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str account_url: The full URI to the account. The method `from_file_url` must be used
-        in order to use the full File URL.
-    :param share_name: The share for the file. If specified, this value will override
-        a share value specified in the file URL.
+    :param str account_url:
+        The URI to the storage account. In order to create a client given the full URI to the
+        file, use the from_file_url classmethod.
+    :param share_name:
+        The name of the share for the file.
     :type share_name: str
     :param str file_path:
         The file path to the file with which to interact. If specified, this value will override
@@ -181,7 +182,7 @@ class FileClient(StorageAccountHostsMixin):
             credential=None,  # type: Optional[Any]
             **kwargs  # type: Any
         ):
-        # type: (...) -> None
+        # type: (...) -> FileClient
         """A client to interact with a specific file, although that file may not yet exist.
 
         :param str file_url: The full URI to the file.

--- a/sdk/storage/azure-storage-file/azure/storage/file/file_client.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/file_client.py
@@ -114,7 +114,7 @@ class FileClient(StorageAccountHostsMixin):
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str account_url: The full URI to the account. The method `from_file_url` must be used 
+    :param str account_url: The full URI to the account. The method `from_file_url` must be used
         in order to use the full File URL.
     :param share_name: The share for the file. If specified, this value will override
         a share value specified in the file URL.
@@ -181,7 +181,7 @@ class FileClient(StorageAccountHostsMixin):
             credential=None,  # type: Optional[Any]
             **kwargs  # type: Any
         ):
-        # type: (...) -> None)
+        # type: (...) -> None
         """A client to interact with a specific file, although that file may not yet exist.
 
         :param str file_url: The full URI to the file.
@@ -205,7 +205,7 @@ class FileClient(StorageAccountHostsMixin):
 
         path_share, _, path_file = parsed_url.path.lstrip('/').partition('/')
         path_snapshot, _ = parse_query(parsed_url.query)
-        snapshot= snapshot or path_snapshot
+        snapshot = snapshot or path_snapshot
         share_name = unquote(path_share)
         file_path = [unquote(p) for p in path_file.split('/')]
         return cls(account_url, share_name, file_path, snapshot, credential, **kwargs)

--- a/sdk/storage/azure-storage-file/azure/storage/file/file_service_client.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/file_service_client.py
@@ -425,6 +425,10 @@ class FileServiceClient(StorageAccountHostsMixin):
                 :dedent: 8
                 :caption: Gets the share client.
         """
+        try:
+            share_name = share.name
+        except AttributeError:
+            share_name = share
         return ShareClient(
-            self.url, share=share, snapshot=snapshot, credential=self.credential, _hosts=self._hosts,
+            self.url, share_name=share_name, snapshot=snapshot, credential=self.credential, _hosts=self._hosts,
             _configuration=self._config, _pipeline=self._pipeline, _location_mode=self._location_mode)

--- a/sdk/storage/azure-storage-file/azure/storage/file/share_client.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/share_client.py
@@ -119,6 +119,7 @@ class ShareClient(StorageAccountHostsMixin):
             credential=None,  # type: Optional[Any]
             **kwargs  # type: Any
         ):
+        # type: (...) -> ShareClient
         """
         :param str share_url: The full URI to the share.
         :param share: The share with which to interact. If specified, this value will override
@@ -296,8 +297,8 @@ class ShareClient(StorageAccountHostsMixin):
         :rtype: ~azure.storage.file.DirectoryClient
         """
         return DirectoryClient(
-            self.url, share_name=self.share_name, directory_path=directory_path or "", snapshot=self.snapshot, credential=self.credential,
-            _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
+            self.url, share_name=self.share_name, directory_path=directory_path or "", snapshot=self.snapshot,
+            credential=self.credential, _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
             _location_mode=self._location_mode)
 
     def get_file_client(self, file_path):
@@ -311,8 +312,9 @@ class ShareClient(StorageAccountHostsMixin):
         :rtype: ~azure.storage.file.FileClient
         """
         return FileClient(
-            self.url, share_name=self.share_name, file_path=file_path, snapshot=self.snapshot, credential=self.credential, _hosts=self._hosts,
-            _configuration=self._config, _pipeline=self._pipeline, _location_mode=self._location_mode)
+            self.url, share_name=self.share_name, file_path=file_path, snapshot=self.snapshot,
+            credential=self.credential, _hosts=self._hosts, _configuration=self._config,
+            _pipeline=self._pipeline, _location_mode=self._location_mode)
 
     @distributed_trace
     def create_share( # type: ignore

--- a/sdk/storage/azure-storage-file/azure/storage/file/share_client.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/share_client.py
@@ -61,10 +61,11 @@ class ShareClient(StorageAccountHostsMixin):
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str account_url: The full URI to the account. The `from_share_url` method must be used
-    if you want to use the complete share URL.
-    :param share_name: The share with which to interact. If specified, this value will override
-        a share value specified in the share URL.
+    :param str account_url:
+        The URI to the storage account. In order to create a client given the full URI to the share,
+        use the from_share_url classmethod.
+    :param share_name:
+        The name of the share with which to interact.
     :type share_name: str
     :param str snapshot:
         An optional share snapshot on which to operate.
@@ -122,9 +123,6 @@ class ShareClient(StorageAccountHostsMixin):
         # type: (...) -> ShareClient
         """
         :param str share_url: The full URI to the share.
-        :param share: The share with which to interact. If specified, this value will override
-            a share value specified in the share URL.
-        :type share: str or ~azure.storage.file.ShareProperties
         :param str snapshot:
             An optional share snapshot on which to operate.
         :param credential:

--- a/sdk/storage/azure-storage-file/azure/storage/file/share_client.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/share_client.py
@@ -61,10 +61,11 @@ class ShareClient(StorageAccountHostsMixin):
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str share_url: The full URI to the share.
-    :param share: The share with which to interact. If specified, this value will override
+    :param str account_url: The full URI to the account. The `from_share_url` method must be used
+    if you want to use the complete share URL.
+    :param share_name: The share with which to interact. If specified, this value will override
         a share value specified in the share URL.
-    :type share: str or ~azure.storage.file.ShareProperties
+    :type share_name: str
     :param str snapshot:
         An optional share snapshot on which to operate.
     :param credential:
@@ -73,30 +74,27 @@ class ShareClient(StorageAccountHostsMixin):
         shared access key.
     """
     def __init__( # type: ignore
-            self, share_url,  # type: str
-            share=None,  # type: Optional[Union[str, ShareProperties]]
+            self, account_url,  # type: str
+            share_name,  # type: str
             snapshot=None,  # type: Optional[Union[str, Dict[str, Any]]]
             credential=None,  # type: Optional[Any]
             **kwargs  # type: Any
         ):
         # type: (...) -> None
         try:
-            if not share_url.lower().startswith('http'):
-                share_url = "https://" + share_url
+            if not account_url.lower().startswith('http'):
+                account_url = "https://" + account_url
         except AttributeError:
-            raise ValueError("Share URL must be a string.")
-        parsed_url = urlparse(share_url.rstrip('/'))
-        if not parsed_url.path and not share:
+            raise ValueError("Account URL must be a string.")
+        parsed_url = urlparse(account_url.rstrip('/'))
+        if not share_name:
             raise ValueError("Please specify a share name.")
         if not parsed_url.netloc:
-            raise ValueError("Invalid URL: {}".format(share_url))
+            raise ValueError("Invalid URL: {}".format(account_url))
         if hasattr(credential, 'get_token'):
             raise ValueError("Token credentials not supported by the File service.")
 
-        path_share = ""
         path_snapshot = None
-        if parsed_url.path:
-            path_share = parsed_url.path.lstrip('/').partition('/')[0]
         path_snapshot, sas_token = parse_query(parsed_url.query)
         if not sas_token and not credential:
             raise ValueError(
@@ -108,14 +106,45 @@ class ShareClient(StorageAccountHostsMixin):
                 self.snapshot = snapshot['snapshot'] # type: ignore
             except TypeError:
                 self.snapshot = snapshot or path_snapshot
-        try:
-            self.share_name = share.name # type: ignore
-        except AttributeError:
-            self.share_name = share or unquote(path_share)
+
+        self.share_name = share_name
         self._query_str, credential = self._format_query_string(
             sas_token, credential, share_snapshot=self.snapshot)
         super(ShareClient, self).__init__(parsed_url, service='file', credential=credential, **kwargs)
         self._client = AzureFileStorage(version=VERSION, url=self.url, pipeline=self._pipeline)
+
+    @classmethod
+    def from_share_url(cls, share_url,  # type: str
+            snapshot=None,  # type: Optional[Union[str, Dict[str, Any]]]
+            credential=None,  # type: Optional[Any]
+            **kwargs  # type: Any
+        ):
+        """
+        :param str share_url: The full URI to the share.
+        :param share: The share with which to interact. If specified, this value will override
+            a share value specified in the share URL.
+        :type share: str or ~azure.storage.file.ShareProperties
+        :param str snapshot:
+            An optional share snapshot on which to operate.
+        :param credential:
+            The credential with which to authenticate. This is optional if the
+            account URL already has a SAS token. The value can be a SAS token string or an account
+            shared access key.
+        """
+        try:
+            if not share_url.lower().startswith('http'):
+                share_url = "https://" + share_url
+        except AttributeError:
+            raise ValueError("Share URL must be a string.")
+        parsed_url = urlparse(share_url.rstrip('/'))
+        if not (parsed_url.path and parsed_url.netloc):
+            raise ValueError("Invalid URL: {}".format(share_url))
+        account_url = parsed_url.netloc.rstrip('/') + "?" + parsed_url.query
+        path_snapshot, _ = parse_query(parsed_url.query)
+        share_name = unquote(parsed_url.path.lstrip('/'))
+        snapshot = snapshot or unquote(path_snapshot)
+
+        return cls(account_url, share_name, snapshot, credential, **kwargs)
 
     def _format_url(self, hostname):
         """Format the endpoint URL according to the current location
@@ -133,7 +162,7 @@ class ShareClient(StorageAccountHostsMixin):
     @classmethod
     def from_connection_string(
             cls, conn_str,  # type: str
-            share, # type: Union[str, ShareProperties]
+            share_name, # type: str
             snapshot=None,  # type: Optional[str]
             credential=None, # type: Optional[Any]
             **kwargs # type: Any
@@ -143,9 +172,9 @@ class ShareClient(StorageAccountHostsMixin):
 
         :param str conn_str:
             A connection string to an Azure Storage account.
-        :param share: The share. This can either be the name of the share,
+        :param share_name: The share. This can either be the name of the share,
             or an instance of ShareProperties
-        :type share: str or ~azure.storage.file.ShareProperties
+        :type share_name: str
         :param str snapshot:
             The optional share snapshot on which to operate.
         :param credential:
@@ -166,7 +195,7 @@ class ShareClient(StorageAccountHostsMixin):
         if 'secondary_hostname' not in kwargs:
             kwargs['secondary_hostname'] = secondary
         return cls(
-            account_url, share=share, snapshot=snapshot, credential=credential, **kwargs)
+            account_url, share_name=share_name, snapshot=snapshot, credential=credential, **kwargs)
 
     def generate_shared_access_signature(
             self, permission=None,  # type: Optional[Union[ShareSasPermissions, str]]
@@ -267,7 +296,7 @@ class ShareClient(StorageAccountHostsMixin):
         :rtype: ~azure.storage.file.DirectoryClient
         """
         return DirectoryClient(
-            self.url, directory_path=directory_path or "", snapshot=self.snapshot, credential=self.credential,
+            self.url, share_name=self.share_name, directory_path=directory_path or "", snapshot=self.snapshot, credential=self.credential,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
             _location_mode=self._location_mode)
 
@@ -282,7 +311,7 @@ class ShareClient(StorageAccountHostsMixin):
         :rtype: ~azure.storage.file.FileClient
         """
         return FileClient(
-            self.url, file_path=file_path, snapshot=self.snapshot, credential=self.credential, _hosts=self._hosts,
+            self.url, share_name=self.share_name, file_path=file_path, snapshot=self.snapshot, credential=self.credential, _hosts=self._hosts,
             _configuration=self._config, _pipeline=self._pipeline, _location_mode=self._location_mode)
 
     @distributed_trace

--- a/sdk/storage/azure-storage-file/tests/test_file.py
+++ b/sdk/storage/azure-storage-file/tests/test_file.py
@@ -209,7 +209,7 @@ class StorageFileTest(FileTestCase):
         sas = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Z%2FRHIX5Xcg0Mq2rqI3OlWTjEg2tYkboXr1P9ZUXDtkk%3D'
         file_client = FileClient(
             self.get_file_url(),
-            share="vhds",
+            share_name="vhds",
             file_path="vhd_dir/my.vhd",
             credential=sas
         )
@@ -227,7 +227,7 @@ class StorageFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
 
@@ -247,7 +247,7 @@ class StorageFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
 
@@ -308,7 +308,7 @@ class StorageFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path="missingdir/" + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
 
@@ -329,7 +329,7 @@ class StorageFileTest(FileTestCase):
         # Act
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             snapshot=snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
@@ -349,7 +349,7 @@ class StorageFileTest(FileTestCase):
         # Act
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             snapshot=snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
@@ -449,7 +449,7 @@ class StorageFileTest(FileTestCase):
         file_props = file_client.get_file_properties()
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             snapshot=snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
@@ -472,7 +472,7 @@ class StorageFileTest(FileTestCase):
         snapshot = share_client.create_snapshot()
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             snapshot=snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
@@ -494,7 +494,7 @@ class StorageFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
 
@@ -551,7 +551,7 @@ class StorageFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
 
@@ -708,7 +708,7 @@ class StorageFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         file_client.create_file(1024)
@@ -726,7 +726,7 @@ class StorageFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         file_client.create_file(2048)
@@ -752,7 +752,7 @@ class StorageFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         file_client.create_file(1024)
@@ -761,7 +761,7 @@ class StorageFileTest(FileTestCase):
         snapshot = share_client.create_snapshot()
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             snapshot=snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
@@ -781,7 +781,7 @@ class StorageFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         file_client.create_file(2048)
@@ -793,7 +793,7 @@ class StorageFileTest(FileTestCase):
         snapshot = share_client.create_snapshot()
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             snapshot=snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
@@ -817,7 +817,7 @@ class StorageFileTest(FileTestCase):
         source_client = self._create_file()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path='file1copy',
             credential=self.settings.STORAGE_ACCOUNT_KEY)
 
@@ -842,7 +842,7 @@ class StorageFileTest(FileTestCase):
         target_file_name = 'targetfile'
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=target_file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         with self.assertRaises(HttpResponseError) as e:
@@ -867,7 +867,7 @@ class StorageFileTest(FileTestCase):
         target_file_name = 'targetfile'
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=target_file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         copy_resp = file_client.start_copy_from_url(source_url)
@@ -895,7 +895,7 @@ class StorageFileTest(FileTestCase):
         target_file_name = 'targetfile'
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=target_file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         copy_resp = file_client.start_copy_from_url(source_url)
@@ -916,7 +916,7 @@ class StorageFileTest(FileTestCase):
         target_file_name = 'targetfile'
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=target_file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         copy_resp = file_client.start_copy_from_url(source_file.url)
@@ -933,7 +933,7 @@ class StorageFileTest(FileTestCase):
         file_name = '啊齄丂狛狜'
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         file_client.upload_file(b'hello world')
@@ -950,7 +950,7 @@ class StorageFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
 
@@ -986,7 +986,7 @@ class StorageFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         file_client.upload_file(binary_data)
@@ -1007,7 +1007,7 @@ class StorageFileTest(FileTestCase):
         data = self.get_random_bytes(LARGE_FILE_SIZE)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1039,7 +1039,7 @@ class StorageFileTest(FileTestCase):
         index = 1024
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1065,7 +1065,7 @@ class StorageFileTest(FileTestCase):
         count = 1024
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1091,7 +1091,7 @@ class StorageFileTest(FileTestCase):
             stream.write(data)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1118,7 +1118,7 @@ class StorageFileTest(FileTestCase):
             stream.write(data)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1156,7 +1156,7 @@ class StorageFileTest(FileTestCase):
             stream.write(data)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1184,7 +1184,7 @@ class StorageFileTest(FileTestCase):
             stream.write(data)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1210,7 +1210,7 @@ class StorageFileTest(FileTestCase):
             stream.write(data)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1246,7 +1246,7 @@ class StorageFileTest(FileTestCase):
             stream.write(data)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1271,7 +1271,7 @@ class StorageFileTest(FileTestCase):
             stream.write(data)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1304,7 +1304,7 @@ class StorageFileTest(FileTestCase):
         data = text.encode('utf-8')
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1323,7 +1323,7 @@ class StorageFileTest(FileTestCase):
         data = text.encode('utf-16')
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1345,7 +1345,7 @@ class StorageFileTest(FileTestCase):
         encoded_data = data.encode('utf-8')
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1363,7 +1363,7 @@ class StorageFileTest(FileTestCase):
         data = self.get_random_bytes(512)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1383,7 +1383,7 @@ class StorageFileTest(FileTestCase):
         data = self.get_random_bytes(LARGE_FILE_SIZE)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1410,7 +1410,7 @@ class StorageFileTest(FileTestCase):
         # Act
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             credential=token)
         content = file_client.download_file().content_as_bytes()
@@ -1464,7 +1464,7 @@ class StorageFileTest(FileTestCase):
         # Act
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             credential=token)
 
@@ -1490,7 +1490,7 @@ class StorageFileTest(FileTestCase):
         # Act
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             credential=token)
         response = requests.get(file_client.url)
@@ -1520,7 +1520,7 @@ class StorageFileTest(FileTestCase):
         # Act
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             credential=token)
         response = requests.get(file_client.url)
@@ -1548,7 +1548,7 @@ class StorageFileTest(FileTestCase):
         )
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client_admin.file_name,
             credential=token)
 
@@ -1575,7 +1575,7 @@ class StorageFileTest(FileTestCase):
         )
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client_admin.file_name,
             credential=token)
 

--- a/sdk/storage/azure-storage-file/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file/tests/test_file_async.py
@@ -254,7 +254,7 @@ class StorageFileAsyncTest(FileTestCase):
         sas = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Z%2FRHIX5Xcg0Mq2rqI3OlWTjEg2tYkboXr1P9ZUXDtkk%3D'
         file_client = FileClient(
             self.get_file_url(),
-            share="vhds",
+            share_name="vhds",
             file_path="vhd_dir/my.vhd",
             credential=sas
         )
@@ -277,7 +277,7 @@ class StorageFileAsyncTest(FileTestCase):
         file_name = self._get_file_reference()
         async with FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY) as file_client:
 
@@ -302,7 +302,7 @@ class StorageFileAsyncTest(FileTestCase):
         file_name = self._get_file_reference()
         async with FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY) as file_client:
 
@@ -383,7 +383,7 @@ class StorageFileAsyncTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path="missingdir/" + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
 
@@ -408,7 +408,7 @@ class StorageFileAsyncTest(FileTestCase):
         # Act
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             snapshot=snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
@@ -433,7 +433,7 @@ class StorageFileAsyncTest(FileTestCase):
         # Act
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             snapshot=snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
@@ -553,7 +553,7 @@ class StorageFileAsyncTest(FileTestCase):
         file_props = await file_client.get_file_properties()
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             snapshot=snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
@@ -581,7 +581,7 @@ class StorageFileAsyncTest(FileTestCase):
         snapshot = await share_client.create_snapshot()
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             snapshot=snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
@@ -607,7 +607,7 @@ class StorageFileAsyncTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
 
@@ -681,7 +681,7 @@ class StorageFileAsyncTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             transport=AiohttpTestTransport())
@@ -877,7 +877,7 @@ class StorageFileAsyncTest(FileTestCase):
         await self._setup_share()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             transport=AiohttpTestTransport())
@@ -901,7 +901,7 @@ class StorageFileAsyncTest(FileTestCase):
         await self._setup_share()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             transport=AiohttpTestTransport())
@@ -933,7 +933,7 @@ class StorageFileAsyncTest(FileTestCase):
         await self._setup_share()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         await file_client.create_file(1024)
@@ -942,7 +942,7 @@ class StorageFileAsyncTest(FileTestCase):
         snapshot = await share_client.create_snapshot()
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             snapshot=snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
@@ -968,7 +968,7 @@ class StorageFileAsyncTest(FileTestCase):
         await self._setup_share()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             transport=AiohttpTestTransport())
@@ -981,7 +981,7 @@ class StorageFileAsyncTest(FileTestCase):
         snapshot = await share_client.create_snapshot()
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             snapshot=snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
@@ -1010,7 +1010,7 @@ class StorageFileAsyncTest(FileTestCase):
         source_client = await self._create_file()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path='file1copy',
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             transport=AiohttpTestTransport())
@@ -1041,7 +1041,7 @@ class StorageFileAsyncTest(FileTestCase):
         target_file_name = 'targetfile'
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=target_file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             transport=AiohttpTestTransport())
@@ -1072,7 +1072,7 @@ class StorageFileAsyncTest(FileTestCase):
         await self._setup_share()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=target_file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             transport=AiohttpTestTransport())
@@ -1107,7 +1107,7 @@ class StorageFileAsyncTest(FileTestCase):
         await self._setup_share()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=target_file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             transport=AiohttpTestTransport())
@@ -1134,7 +1134,7 @@ class StorageFileAsyncTest(FileTestCase):
         target_file_name = 'targetfile'
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=target_file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             transport=AiohttpTestTransport())
@@ -1157,7 +1157,7 @@ class StorageFileAsyncTest(FileTestCase):
         await self._setup_share()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             transport=AiohttpTestTransport())
@@ -1181,7 +1181,7 @@ class StorageFileAsyncTest(FileTestCase):
         await self._setup_share()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
 
@@ -1228,7 +1228,7 @@ class StorageFileAsyncTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         await file_client.upload_file(binary_data)
@@ -1256,7 +1256,7 @@ class StorageFileAsyncTest(FileTestCase):
         data = self.get_random_bytes(LARGE_FILE_SIZE)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1291,7 +1291,7 @@ class StorageFileAsyncTest(FileTestCase):
         index = 1024
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1323,7 +1323,7 @@ class StorageFileAsyncTest(FileTestCase):
         count = 1024
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1355,7 +1355,7 @@ class StorageFileAsyncTest(FileTestCase):
             stream.write(data)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1388,7 +1388,7 @@ class StorageFileAsyncTest(FileTestCase):
             stream.write(data)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1432,7 +1432,7 @@ class StorageFileAsyncTest(FileTestCase):
             stream.write(data)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1466,7 +1466,7 @@ class StorageFileAsyncTest(FileTestCase):
             stream.write(data)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1498,7 +1498,7 @@ class StorageFileAsyncTest(FileTestCase):
             stream.write(data)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1540,7 +1540,7 @@ class StorageFileAsyncTest(FileTestCase):
             stream.write(data)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1571,7 +1571,7 @@ class StorageFileAsyncTest(FileTestCase):
             stream.write(data)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1609,7 +1609,7 @@ class StorageFileAsyncTest(FileTestCase):
         data = text.encode('utf-8')
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1633,7 +1633,7 @@ class StorageFileAsyncTest(FileTestCase):
         data = text.encode('utf-16')
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1661,7 +1661,7 @@ class StorageFileAsyncTest(FileTestCase):
         encoded_data = data.encode('utf-8')
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1684,7 +1684,7 @@ class StorageFileAsyncTest(FileTestCase):
         data = self.get_random_bytes(512)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1710,7 +1710,7 @@ class StorageFileAsyncTest(FileTestCase):
         data = self.get_random_bytes(LARGE_FILE_SIZE)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_range_size=4 * 1024)
@@ -1741,7 +1741,7 @@ class StorageFileAsyncTest(FileTestCase):
         # Act
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             credential=token)
         content = await file_client.download_file()
@@ -1805,7 +1805,7 @@ class StorageFileAsyncTest(FileTestCase):
         # Act
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             credential=token)
 
@@ -1835,7 +1835,7 @@ class StorageFileAsyncTest(FileTestCase):
         # Act
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             credential=token)
         response = requests.get(file_client.url)
@@ -1869,7 +1869,7 @@ class StorageFileAsyncTest(FileTestCase):
         # Act
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client.file_name,
             credential=token)
         response = requests.get(file_client.url)
@@ -1901,7 +1901,7 @@ class StorageFileAsyncTest(FileTestCase):
         )
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client_admin.file_name,
             credential=token)
 
@@ -1933,7 +1933,7 @@ class StorageFileAsyncTest(FileTestCase):
         )
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=file_client_admin.file_name,
             credential=token)
 

--- a/sdk/storage/azure-storage-file/tests/test_file_client.py
+++ b/sdk/storage/azure-storage-file/tests/test_file_client.py
@@ -131,14 +131,6 @@ class StorageFileClientTest(FileTestCase):
                 str(e.exception),
                 'You need to provide either an account key or SAS token when creating a storage service.')
 
-    def test_create_service_missing_arguments(self):
-        # Arrange
-
-        for service_type in SERVICES:
-            # Act
-            with self.assertRaises(ValueError):
-                service_type(None)
-
     def test_create_service_with_socket_timeout(self):
         # Arrange
 

--- a/sdk/storage/azure-storage-file/tests/test_file_client.py
+++ b/sdk/storage/azure-storage-file/tests/test_file_client.py
@@ -59,7 +59,7 @@ class StorageFileClientTest(FileTestCase):
             # Act
             service = client(
                 self.get_file_url(), credential=self.account_key,
-                share='foo', directory_path='bar', file_path='baz')
+                share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
             self.validate_standard_account_endpoints(service, url)
@@ -72,7 +72,7 @@ class StorageFileClientTest(FileTestCase):
             # Act
             service = service_type(
                 self.get_file_url(), credential=self.sas_token,
-                share='foo', directory_path='bar', file_path='baz')
+                share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
             self.assertIsNotNone(service)
@@ -85,7 +85,7 @@ class StorageFileClientTest(FileTestCase):
             # token credential is not available for FileService
             with self.assertRaises(ValueError):
                 service_type(self.get_file_url(), credential=self.token_credential,
-                             share='foo', directory_path='bar', file_path='baz')
+                             share_name='foo', directory_path='bar', file_path='baz')
 
     def test_create_service_china(self):
         # Arrange
@@ -94,7 +94,7 @@ class StorageFileClientTest(FileTestCase):
             # Act
             service = service_type[0](
                 url, credential=self.account_key,
-                share='foo', directory_path='bar', file_path='baz')
+                share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
             self.assertIsNotNone(service)
@@ -111,7 +111,7 @@ class StorageFileClientTest(FileTestCase):
         for service_type in SERVICES.items():
             # Act
             service = service_type[0](
-                url, credential=self.account_key, share='foo', directory_path='bar', file_path='baz')
+                url, credential=self.account_key, share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
             self.validate_standard_account_endpoints(service, service_type[1], protocol='http')
@@ -125,7 +125,7 @@ class StorageFileClientTest(FileTestCase):
             # Passing an empty key to create account should fail.
             with self.assertRaises(ValueError) as e:
                 service_type(
-                    self.get_file_url(), share='foo', directory_path='bar', file_path='baz')
+                    self.get_file_url(), share_name='foo', directory_path='bar', file_path='baz')
 
             self.assertEqual(
                 str(e.exception),
@@ -146,10 +146,10 @@ class StorageFileClientTest(FileTestCase):
             # Act
             default_service = service_type[0](
                 self.get_file_url(), credential=self.account_key,
-                share='foo', directory_path='bar', file_path='baz')
+                share_name='foo', directory_path='bar', file_path='baz')
             service = service_type[0](
                 self.get_file_url(), credential=self.account_key, connection_timeout=22,
-                share='foo', directory_path='bar', file_path='baz')
+                share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
             self.validate_standard_account_endpoints(service, service_type[1])
@@ -165,7 +165,7 @@ class StorageFileClientTest(FileTestCase):
         for service_type in SERVICES.items():
             # Act
             service = service_type[0].from_connection_string(
-                conn_string, share='foo', directory_path='bar', file_path='baz')
+                conn_string, share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
             self.validate_standard_account_endpoints(service, service_type[1])
@@ -178,7 +178,7 @@ class StorageFileClientTest(FileTestCase):
         for service_type in SERVICES.items():
             # Act
             service = service_type[0].from_connection_string(
-                conn_string, share='foo', directory_path='bar', file_path='baz')
+                conn_string, share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
             self.assertIsNotNone(service)
@@ -193,7 +193,7 @@ class StorageFileClientTest(FileTestCase):
         for service_type in SERVICES.items():
             # Act
             service = service_type[0].from_connection_string(
-                conn_string, share='foo', directory_path='bar', file_path='baz')
+                conn_string, share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
             self.assertIsNotNone(service)
@@ -212,7 +212,7 @@ class StorageFileClientTest(FileTestCase):
             # Act
             with self.assertRaises(ValueError):
                 service_type[0].from_connection_string(
-                    conn_string, share='foo', directory_path='bar', file_path='baz')
+                    conn_string, share_name='foo', directory_path='bar', file_path='baz')
 
     def test_create_service_with_connection_string_fails_if_secondary_without_primary(self):
         for service_type in SERVICES.items():
@@ -225,7 +225,7 @@ class StorageFileClientTest(FileTestCase):
             # Fails if primary excluded
             with self.assertRaises(ValueError):
                 service_type[0].from_connection_string(
-                    conn_string, share='foo', directory_path='bar', file_path='baz')
+                    conn_string, share_name='foo', directory_path='bar', file_path='baz')
 
     def test_create_service_with_connection_string_succeeds_if_secondary_with_primary(self):
         for service_type in SERVICES.items():
@@ -237,7 +237,7 @@ class StorageFileClientTest(FileTestCase):
 
             # Act
             service = service_type[0].from_connection_string(
-                conn_string, share='foo', directory_path='bar', file_path='baz')
+                conn_string, share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
             self.assertIsNotNone(service)

--- a/sdk/storage/azure-storage-file/tests/test_file_client_async.py
+++ b/sdk/storage/azure-storage-file/tests/test_file_client_async.py
@@ -73,7 +73,7 @@ class StorageFileClientTest(FileTestCase):
             # Act
             service = client(
                 self.get_file_url(), credential=self.account_key,
-                share='foo', directory_path='bar', file_path='baz')
+                share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
             self.validate_standard_account_endpoints(service, url)
@@ -87,7 +87,7 @@ class StorageFileClientTest(FileTestCase):
             # Act
             service = service_type(
                 self.get_file_url(), credential=self.sas_token,
-                share='foo', directory_path='bar', file_path='baz')
+                share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
             self.assertIsNotNone(service)
@@ -101,7 +101,7 @@ class StorageFileClientTest(FileTestCase):
             # token credential is not available for FileService
             with self.assertRaises(ValueError):
                 service_type(self.get_file_url(), credential=self.token_credential,
-                             share='foo', directory_path='bar', file_path='baz')
+                             share_name='foo', directory_path='bar', file_path='baz')
 
     @record
     def test_create_service_china_async(self):
@@ -111,7 +111,7 @@ class StorageFileClientTest(FileTestCase):
             # Act
             service = service_type[0](
                 url, credential=self.account_key,
-                share='foo', directory_path='bar', file_path='baz')
+                share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
             self.assertIsNotNone(service)
@@ -128,7 +128,7 @@ class StorageFileClientTest(FileTestCase):
         for service_type in SERVICES.items():
             # Act
             service = service_type[0](
-                url, credential=self.account_key, share='foo', directory_path='bar', file_path='baz')
+                url, credential=self.account_key, share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
             self.validate_standard_account_endpoints(service, service_type[1], protocol='http')
@@ -142,7 +142,7 @@ class StorageFileClientTest(FileTestCase):
             # Passing an empty key to create account should fail.
             with self.assertRaises(ValueError) as e:
                 service_type(
-                    self.get_file_url(), share='foo', directory_path='bar', file_path='baz')
+                    self.get_file_url(), share_name='foo', directory_path='bar', file_path='baz')
 
             self.assertEqual(
                 str(e.exception),
@@ -165,10 +165,10 @@ class StorageFileClientTest(FileTestCase):
             # Act
             default_service = service_type[0](
                 self.get_file_url(), credential=self.account_key,
-                share='foo', directory_path='bar', file_path='baz')
+                share_name='foo', directory_path='bar', file_path='baz')
             service = service_type[0](
                 self.get_file_url(), credential=self.account_key, connection_timeout=22,
-                share='foo', directory_path='bar', file_path='baz')
+                share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
             self.validate_standard_account_endpoints(service, service_type[1])
@@ -185,7 +185,7 @@ class StorageFileClientTest(FileTestCase):
         for service_type in SERVICES.items():
             # Act
             service = service_type[0].from_connection_string(
-                conn_string, share='foo', directory_path='bar', file_path='baz')
+                conn_string, share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
             self.validate_standard_account_endpoints(service, service_type[1])
@@ -199,7 +199,7 @@ class StorageFileClientTest(FileTestCase):
         for service_type in SERVICES.items():
             # Act
             service = service_type[0].from_connection_string(
-                conn_string, share='foo', directory_path='bar', file_path='baz', transport=AiohttpTestTransport())
+                conn_string, share_name='foo', directory_path='bar', file_path='baz', transport=AiohttpTestTransport())
 
             # Assert
             self.assertIsNotNone(service)
@@ -215,7 +215,7 @@ class StorageFileClientTest(FileTestCase):
         for service_type in SERVICES.items():
             # Act
             service = service_type[0].from_connection_string(
-                conn_string, share='foo', directory_path='bar', file_path='baz', transport=AiohttpTestTransport())
+                conn_string, share_name='foo', directory_path='bar', file_path='baz', transport=AiohttpTestTransport())
 
             # Assert
             self.assertIsNotNone(service)
@@ -235,7 +235,7 @@ class StorageFileClientTest(FileTestCase):
             # Act
             with self.assertRaises(ValueError):
                 service_type[0].from_connection_string(
-                    conn_string, share='foo', directory_path='bar', file_path='baz', transport=AiohttpTestTransport())
+                    conn_string, share_name='foo', directory_path='bar', file_path='baz', transport=AiohttpTestTransport())
 
     @record
     def test_create_service_with_connection_string_fails_if_secondary_without_primary_async(self):
@@ -249,7 +249,7 @@ class StorageFileClientTest(FileTestCase):
             # Fails if primary excluded
             with self.assertRaises(ValueError):
                 service_type[0].from_connection_string(
-                    conn_string, share='foo', directory_path='bar', file_path='baz')
+                    conn_string, share_name='foo', directory_path='bar', file_path='baz')
 
     @record
     def test_create_service_with_connection_string_succeeds_if_secondary_with_primary_async(self):
@@ -262,7 +262,7 @@ class StorageFileClientTest(FileTestCase):
 
             # Act
             service = service_type[0].from_connection_string(
-                conn_string, share='foo', directory_path='bar', file_path='baz')
+                conn_string, share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
             self.assertIsNotNone(service)

--- a/sdk/storage/azure-storage-file/tests/test_file_client_async.py
+++ b/sdk/storage/azure-storage-file/tests/test_file_client_async.py
@@ -149,15 +149,6 @@ class StorageFileClientTest(FileTestCase):
                 'You need to provide either an account key or SAS token when creating a storage service.')
 
     @record
-    def test_create_service_missing_arguments_async(self):
-        # Arrange
-
-        for service_type in SERVICES:
-            # Act
-            with self.assertRaises(ValueError):
-                service_type(None)
-
-    @record
     def test_create_service_with_socket_timeout_async(self):
         # Arrange
 

--- a/sdk/storage/azure-storage-file/tests/test_file_samples_hello_world.py
+++ b/sdk/storage/azure-storage-file/tests/test_file_samples_hello_world.py
@@ -57,7 +57,7 @@ class TestHelloWorldSamples(FileTestCase):
     def test_create_file_share(self):
         # Instantiate the ShareClient from a connection string
         from azure.storage.file import ShareClient
-        share = ShareClient.from_connection_string(self.connection_string, share="myshare")
+        share = ShareClient.from_connection_string(self.connection_string, share_name="myshare")
 
         # Create the share
         share.create_share()
@@ -76,7 +76,7 @@ class TestHelloWorldSamples(FileTestCase):
     def test_upload_file_to_share(self):
         # Instantiate the ShareClient from a connection string
         from azure.storage.file import ShareClient
-        share = ShareClient.from_connection_string(self.connection_string, share="share")
+        share = ShareClient.from_connection_string(self.connection_string, share_name="share")
 
         # Create the share
         share.create_share()
@@ -85,7 +85,7 @@ class TestHelloWorldSamples(FileTestCase):
             # Instantiate the FileClient from a connection string
             # [START create_file_client]
             from azure.storage.file import FileClient
-            file = FileClient.from_connection_string(self.connection_string, share="share", file_path="myfile")
+            file = FileClient.from_connection_string(self.connection_string, share_name="share", file_path="myfile")
             # [END create_file_client]
 
             # Upload a file

--- a/sdk/storage/azure-storage-file/tests/test_file_samples_hello_world_async.py
+++ b/sdk/storage/azure-storage-file/tests/test_file_samples_hello_world_async.py
@@ -62,7 +62,7 @@ class TestHelloWorldSamples(FileTestCase):
     async def _test_create_file_share(self):
         # Instantiate the ShareClient from a connection string
         from azure.storage.file.aio import ShareClient
-        share = ShareClient.from_connection_string(self.connection_string, share="myshare")
+        share = ShareClient.from_connection_string(self.connection_string, share_name="myshare")
 
         # Create the share
         await share.create_share()
@@ -86,7 +86,7 @@ class TestHelloWorldSamples(FileTestCase):
     async def _test_upload_file_to_share(self):
         # Instantiate the ShareClient from a connection string
         from azure.storage.file.aio import ShareClient
-        share = ShareClient.from_connection_string(self.connection_string, share="share")
+        share = ShareClient.from_connection_string(self.connection_string, share_name='share')
 
         # Create the share
         await share.create_share()
@@ -95,7 +95,7 @@ class TestHelloWorldSamples(FileTestCase):
             # Instantiate the FileClient from a connection string
             # [START create_file_client]
             from azure.storage.file.aio import FileClient
-            file = FileClient.from_connection_string(self.connection_string, share="share", file_path="myfile")
+            file = FileClient.from_connection_string(self.connection_string, share_name='share', file_path="myfile")
             # [END create_file_client]
 
             # Upload a file

--- a/sdk/storage/azure-storage-file/tests/test_get_file.py
+++ b/sdk/storage/azure-storage-file/tests/test_get_file.py
@@ -62,7 +62,7 @@ class StorageGetFileTest(FileTestCase):
             byte_file = self.directory_name + '/' + self.byte_file
             file_client = FileClient(
                 self.get_file_url(),
-                share=self.share_name,
+                share_name=self.share_name,
                 file_path=byte_file,
                 credential=credential
             )
@@ -110,7 +110,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
                 self.get_file_url(),
-                share=self.share_name,
+                share_name=self.share_name,
                 file_path=self.directory_name + '/' + file_name,
                 credential=self.settings.STORAGE_ACCOUNT_KEY,
                 max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -132,7 +132,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
                 self.get_file_url(),
-                share=self.share_name,
+                share_name=self.share_name,
                 file_path=self.directory_name + '/' + file_name,
                 credential=self.settings.STORAGE_ACCOUNT_KEY,
                 max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -152,7 +152,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
                 self.get_file_url(),
-                share=self.share_name,
+                share_name=self.share_name,
                 file_path=self.directory_name + '/' + file_name,
                 credential=self.settings.STORAGE_ACCOUNT_KEY,
                 max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -174,7 +174,7 @@ class StorageGetFileTest(FileTestCase):
         # Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -194,7 +194,7 @@ class StorageGetFileTest(FileTestCase):
         # Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -223,7 +223,7 @@ class StorageGetFileTest(FileTestCase):
         # Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -254,7 +254,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -287,7 +287,7 @@ class StorageGetFileTest(FileTestCase):
         # Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -310,7 +310,7 @@ class StorageGetFileTest(FileTestCase):
         # Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -334,7 +334,7 @@ class StorageGetFileTest(FileTestCase):
         # Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -368,7 +368,7 @@ class StorageGetFileTest(FileTestCase):
         # Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -404,7 +404,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -445,14 +445,14 @@ class StorageGetFileTest(FileTestCase):
         share_snapshot = share_client.create_snapshot()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         file_client.delete_file()
 
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             snapshot=share_snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
@@ -480,14 +480,14 @@ class StorageGetFileTest(FileTestCase):
         share_snapshot = share_client.create_snapshot()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         file_client.delete_file()
 
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             snapshot=share_snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
@@ -525,14 +525,14 @@ class StorageGetFileTest(FileTestCase):
         share_snapshot = share_client.create_snapshot()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         file_client.delete_file()
 
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             snapshot=share_snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
@@ -569,7 +569,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         file_client.upload_file(file_data)
@@ -581,7 +581,7 @@ class StorageGetFileTest(FileTestCase):
 
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             snapshot=share_snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
@@ -619,7 +619,7 @@ class StorageGetFileTest(FileTestCase):
         # Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -645,7 +645,7 @@ class StorageGetFileTest(FileTestCase):
         # Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -670,7 +670,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -693,7 +693,7 @@ class StorageGetFileTest(FileTestCase):
         # Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -730,7 +730,7 @@ class StorageGetFileTest(FileTestCase):
         # Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -752,7 +752,7 @@ class StorageGetFileTest(FileTestCase):
         # Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -781,7 +781,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -809,7 +809,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -838,7 +838,7 @@ class StorageGetFileTest(FileTestCase):
         text_data = self.get_random_text_data(self.MAX_SINGLE_GET_SIZE + 1)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + text_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -861,7 +861,7 @@ class StorageGetFileTest(FileTestCase):
         text_data = self.get_random_text_data(self.MAX_SINGLE_GET_SIZE + 1)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + text_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -893,7 +893,7 @@ class StorageGetFileTest(FileTestCase):
         text_data = self.get_random_text_data(self.MAX_SINGLE_GET_SIZE + 1)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + text_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -925,7 +925,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -958,7 +958,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -979,7 +979,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1009,7 +1009,7 @@ class StorageGetFileTest(FileTestCase):
         # Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1035,7 +1035,7 @@ class StorageGetFileTest(FileTestCase):
         # Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1059,14 +1059,14 @@ class StorageGetFileTest(FileTestCase):
         share_snapshot = share_client.create_snapshot()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         file_client.delete_file()
 
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             snapshot=share_snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
@@ -1096,14 +1096,14 @@ class StorageGetFileTest(FileTestCase):
         share_snapshot = share_client.create_snapshot()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         file_client.delete_file()
 
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             snapshot=share_snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
@@ -1125,7 +1125,7 @@ class StorageGetFileTest(FileTestCase):
         byte_data = self.get_random_bytes(self.MAX_SINGLE_GET_SIZE)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1160,7 +1160,7 @@ class StorageGetFileTest(FileTestCase):
         byte_data = self.get_random_bytes(self.MAX_SINGLE_GET_SIZE + self.MAX_CHUNK_GET_SIZE)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1193,7 +1193,7 @@ class StorageGetFileTest(FileTestCase):
         # Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1212,7 +1212,7 @@ class StorageGetFileTest(FileTestCase):
 
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1240,7 +1240,7 @@ class StorageGetFileTest(FileTestCase):
         #Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1261,7 +1261,7 @@ class StorageGetFileTest(FileTestCase):
         # Arrange
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,

--- a/sdk/storage/azure-storage-file/tests/test_get_file_async.py
+++ b/sdk/storage/azure-storage-file/tests/test_get_file_async.py
@@ -99,7 +99,7 @@ class StorageGetFileTest(FileTestCase):
             byte_file = self.directory_name + '/' + self.byte_file
             file_client = FileClient(
                 self.get_file_url(),
-                share=self.share_name,
+                share_name=self.share_name,
                 file_path=byte_file,
                 credential=self.get_shared_key_credential()
             )
@@ -130,7 +130,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
                 self.get_file_url(),
-                share=self.share_name,
+                share_name=self.share_name,
                 file_path=self.directory_name + '/' + file_name,
                 credential=self.settings.STORAGE_ACCOUNT_KEY,
                 max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -158,7 +158,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
                 self.get_file_url(),
-                share=self.share_name,
+                share_name=self.share_name,
                 file_path=self.directory_name + '/' + file_name,
                 credential=self.settings.STORAGE_ACCOUNT_KEY,
                 max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -184,7 +184,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
                 self.get_file_url(),
-                share=self.share_name,
+                share_name=self.share_name,
                 file_path=self.directory_name + '/' + file_name,
                 credential=self.settings.STORAGE_ACCOUNT_KEY,
                 max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -214,7 +214,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -241,7 +241,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -276,7 +276,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -313,7 +313,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -353,7 +353,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -384,7 +384,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -414,7 +414,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -453,7 +453,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -494,7 +494,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -541,14 +541,14 @@ class StorageGetFileTest(FileTestCase):
         share_snapshot = await share_client.create_snapshot()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         await file_client.delete_file()
 
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             snapshot=share_snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
@@ -583,14 +583,14 @@ class StorageGetFileTest(FileTestCase):
         share_snapshot = await share_client.create_snapshot()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         await file_client.delete_file()
 
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             snapshot=share_snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
@@ -633,14 +633,14 @@ class StorageGetFileTest(FileTestCase):
         share_snapshot = await share_client.create_snapshot()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         await file_client.delete_file()
 
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             snapshot=share_snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
@@ -682,7 +682,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         await file_client.upload_file(file_data)
@@ -694,7 +694,7 @@ class StorageGetFileTest(FileTestCase):
 
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             snapshot=share_snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
@@ -738,7 +738,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -770,7 +770,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -801,7 +801,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -833,7 +833,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -874,7 +874,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -901,7 +901,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -935,7 +935,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -968,7 +968,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1003,7 +1003,7 @@ class StorageGetFileTest(FileTestCase):
         text_data = self.get_random_text_data(self.MAX_SINGLE_GET_SIZE + 1)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + text_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1033,7 +1033,7 @@ class StorageGetFileTest(FileTestCase):
         text_data = self.get_random_text_data(self.MAX_SINGLE_GET_SIZE + 1)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + text_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1071,7 +1071,7 @@ class StorageGetFileTest(FileTestCase):
         text_data = self.get_random_text_data(self.MAX_SINGLE_GET_SIZE + 1)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + text_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1109,7 +1109,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1148,7 +1148,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1175,7 +1175,7 @@ class StorageGetFileTest(FileTestCase):
         file_name = self._get_file_reference()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1211,7 +1211,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1243,7 +1243,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1272,14 +1272,14 @@ class StorageGetFileTest(FileTestCase):
         share_snapshot = await share_client.create_snapshot()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         await file_client.delete_file()
 
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             snapshot=share_snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
@@ -1315,14 +1315,14 @@ class StorageGetFileTest(FileTestCase):
         share_snapshot = await share_client.create_snapshot()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY)
         await file_client.delete_file()
 
         snapshot_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             snapshot=share_snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
@@ -1349,7 +1349,7 @@ class StorageGetFileTest(FileTestCase):
         byte_data = self.get_random_bytes(self.MAX_SINGLE_GET_SIZE)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1391,7 +1391,7 @@ class StorageGetFileTest(FileTestCase):
         byte_data = self.get_random_bytes(self.MAX_SINGLE_GET_SIZE + self.MAX_CHUNK_GET_SIZE)
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + file_name,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1431,7 +1431,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1457,7 +1457,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1490,7 +1490,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,
@@ -1516,7 +1516,7 @@ class StorageGetFileTest(FileTestCase):
         await self._setup()
         file_client = FileClient(
             self.get_file_url(),
-            share=self.share_name,
+            share_name=self.share_name,
             file_path=self.directory_name + '/' + self.byte_file,
             credential=self.settings.STORAGE_ACCOUNT_KEY,
             max_single_get_size=self.MAX_SINGLE_GET_SIZE,

--- a/sdk/storage/azure-storage-file/tests/test_share.py
+++ b/sdk/storage/azure-storage-file/tests/test_share.py
@@ -114,7 +114,7 @@ class StorageShareTest(FileTestCase):
         share_props = share.get_share_properties()
         snapshot_client = ShareClient(
             self.get_file_url(),
-            share=share.share_name,
+            share_name=share.share_name,
             snapshot=snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY
         )
@@ -156,7 +156,7 @@ class StorageShareTest(FileTestCase):
 
         snapshot_client = ShareClient(
             self.get_file_url(),
-            share=share.share_name,
+            share_name=share.share_name,
             snapshot=snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY
         )
@@ -731,7 +731,7 @@ class StorageShareTest(FileTestCase):
         )
         sas_client = FileClient(
             self.get_file_url(),
-            share=share.share_name,
+            share_name=share.share_name,
             file_path=dir_name + '/' + file_name,
             credential=token,
         )

--- a/sdk/storage/azure-storage-file/tests/test_share_async.py
+++ b/sdk/storage/azure-storage-file/tests/test_share_async.py
@@ -132,7 +132,7 @@ class StorageShareTest(FileTestCase):
         share_props = await share.get_share_properties()
         snapshot_client = ShareClient(
             self.get_file_url(),
-            share=share.share_name,
+            share_name=share.share_name,
             snapshot=snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY
         )
@@ -180,7 +180,7 @@ class StorageShareTest(FileTestCase):
 
         snapshot_client = ShareClient(
             self.get_file_url(),
-            share=share.share_name,
+            share_name=share.share_name,
             snapshot=snapshot,
             credential=self.settings.STORAGE_ACCOUNT_KEY
         )
@@ -877,7 +877,7 @@ class StorageShareTest(FileTestCase):
         )
         sas_client = FileClient(
             self.get_file_url(),
-            share=share.share_name,
+            share_name=share.share_name,
             file_path=dir_name + '/' + file_name,
             credential=token,
         )

--- a/sdk/storage/azure-storage-queue/HISTORY.md
+++ b/sdk/storage/azure-storage-queue/HISTORY.md
@@ -1,5 +1,12 @@
 # Change Log azure-storage-queue
 
+## Version 12.0.0:
+
+**Breaking changes**
+
+- `QueueClient` now accepts only `account_url` with mandatory a string param `queue_name`. 
+To use a queue_url, the method `from_queue_url` must be used.
+
 ## Version 12.0.0b4:
 
 **Breaking changes**

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/queue_client_async.py
@@ -74,8 +74,9 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase):
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str account_url: The URL to the storage account. The `from_queue_url` method should be used
-        if you want to use the full queue URI instead.
+    :param str account_url:
+        The URL to the storage account. In order to create a client given the full URI to the queue,
+        use the from_queue_url classmethod.
     :param queue_name: The name of the queue.
     :type queue_name: str
     :param credential:

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/queue_client_async.py
@@ -74,11 +74,10 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase):
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str queue_url: The full URI to the queue. This can also be a URL to the storage
-        account, in which case the queue must also be specified.
-    :param queue: The queue. If specified, this value will override
-        a queue value specified in the queue URL.
-    :type queue: str or ~azure.storage.queue.QueueProperties
+    :param str account_url: The URL to the storage account. The `from_queue_url` method should be used
+        if you want to use the full queue URI instead.
+    :param queue_name: The name of the queue.
+    :type queue_name: str
     :param credential:
         The credentials with which to authenticate. This is optional if the
         account URL already has a SAS token. The value can be a SAS token string, and account
@@ -103,15 +102,15 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase):
 
     def __init__(
         self,
-        queue_url,  # type: str
-        queue=None,  # type: Optional[Union[QueueProperties, str]]
+        account_url,  # type: str
+        queue_name,  # type: str
         credential=None,  # type: Optional[Any]
         loop=None,  # type: Any
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         kwargs["retry_policy"] = kwargs.get("retry_policy") or ExponentialRetry(**kwargs)
-        super(QueueClient, self).__init__(queue_url, queue=queue, credential=credential, loop=loop, **kwargs)
+        super(QueueClient, self).__init__(account_url, queue_name=queue_name, credential=credential, loop=loop, **kwargs)
         self._client = AzureQueueStorage(self.url, pipeline=self._pipeline, loop=loop)  # type: ignore
         self._loop = loop
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/queue_client_async.py
@@ -110,7 +110,9 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase):
     ):
         # type: (...) -> None
         kwargs["retry_policy"] = kwargs.get("retry_policy") or ExponentialRetry(**kwargs)
-        super(QueueClient, self).__init__(account_url, queue_name=queue_name, credential=credential, loop=loop, **kwargs)
+        super(QueueClient, self).__init__(
+            account_url, queue_name=queue_name, credential=credential, loop=loop, **kwargs
+        )
         self._client = AzureQueueStorage(self.url, pipeline=self._pipeline, loop=loop)  # type: ignore
         self._loop = loop
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/queue_service_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/queue_service_client_async.py
@@ -370,7 +370,7 @@ class QueueServiceClient(AsyncStorageAccountHostsMixin, QueueServiceClientBase):
         except AttributeError:
             queue_name = queue
         return QueueClient(
-            self.url, queue_name=queue_name, credential=self.credential, key_resolver_function=self.key_resolver_function,
-            require_encryption=self.require_encryption, key_encryption_key=self.key_encryption_key,
-            _pipeline=self._pipeline, _configuration=self._config, _location_mode=self._location_mode,
-            _hosts=self._hosts, loop=self._loop, **kwargs)
+            self.url, queue_name=queue_name, credential=self.credential,
+            key_resolver_function=self.key_resolver_function, require_encryption=self.require_encryption,
+            key_encryption_key=self.key_encryption_key, _pipeline=self._pipeline, _configuration=self._config,
+            _location_mode=self._location_mode, _hosts=self._hosts, loop=self._loop, **kwargs)

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/queue_service_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/queue_service_client_async.py
@@ -365,8 +365,12 @@ class QueueServiceClient(AsyncStorageAccountHostsMixin, QueueServiceClientBase):
                 :dedent: 8
                 :caption: Get the queue client.
         """
+        try:
+            queue_name = queue.name
+        except AttributeError:
+            queue_name = queue
         return QueueClient(
-            self.url, queue=queue, credential=self.credential, key_resolver_function=self.key_resolver_function,
+            self.url, queue_name=queue_name, credential=self.credential, key_resolver_function=self.key_resolver_function,
             require_encryption=self.require_encryption, key_encryption_key=self.key_encryption_key,
             _pipeline=self._pipeline, _configuration=self._config, _location_mode=self._location_mode,
             _hosts=self._hosts, loop=self._loop, **kwargs)

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/queue_client.py
@@ -43,7 +43,7 @@ class QueueClient(StorageAccountHostsMixin):
     """A client to interact with a specific Queue.
 
     :ivar str url:
-        The full endpoint URL to the Queue, including SAS token if used. This could be
+        The full endpoint URL to the account, including SAS token if used. This could be
         either the primary endpoint, or the secondard endpint depending on the current `location_mode`.
     :ivar str primary_endpoint:
         The full primary endpoint URL.
@@ -60,11 +60,10 @@ class QueueClient(StorageAccountHostsMixin):
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str queue_url: The full URI to the queue. This can also be a URL to the storage
-        account, in which case the queue must also be specified.
-    :param queue: The queue. If specified, this value will override
-        a queue value specified in the queue URL.
-    :type queue: str or ~azure.storage.queue.QueueProperties
+    :param str account_url: The URL to the storage account. The `from_queue_url` method should be used
+        if you want to use the full queue URI instead.
+    :param queue_name: The name of the queue.
+    :type queue_name: str
     :param credential:
         The credentials with which to authenticate. This is optional if the
         account URL already has a SAS token. The value can be a SAS token string, and account
@@ -80,39 +79,61 @@ class QueueClient(StorageAccountHostsMixin):
             :caption: Create the queue client with url and credential.
     """
     def __init__(
-            self, queue_url,  # type: str
-            queue=None,  # type: Optional[Union[QueueProperties, str]]
+            self, account_url,  # type: str
+            queue_name,  # type: str
             credential=None,  # type: Optional[Any]
             **kwargs  # type: Any
         ):
         # type: (...) -> None
         try:
-            if not queue_url.lower().startswith('http'):
-                queue_url = "https://" + queue_url
+            if not account_url.lower().startswith('http'):
+                account_url = "https://" + account_url
         except AttributeError:
-            raise ValueError("Queue URL must be a string.")
-        parsed_url = urlparse(queue_url.rstrip('/'))
-        if not parsed_url.path and not queue:
+            raise ValueError("Account URL must be a string.")
+        parsed_url = urlparse(account_url.rstrip('/'))
+        if not queue_name:
             raise ValueError("Please specify a queue name.")
         if not parsed_url.netloc:
             raise ValueError("Invalid URL: {}".format(parsed_url))
 
-        path_queue = ""
-        if parsed_url.path:
-            path_queue = parsed_url.path.lstrip('/').partition('/')[0]
         _, sas_token = parse_query(parsed_url.query)
         if not sas_token and not credential:
             raise ValueError("You need to provide either a SAS token or an account key to authenticate.")
-        try:
-            self.queue_name = queue.name # type: ignore
-        except AttributeError:
-            self.queue_name = queue or unquote(path_queue)
+
+        self.queue_name = queue_name
         self._query_str, credential = self._format_query_string(sas_token, credential)
         super(QueueClient, self).__init__(parsed_url, service='queue', credential=credential, **kwargs)
 
         self._config.message_encode_policy = kwargs.get('message_encode_policy') or TextXMLEncodePolicy()
         self._config.message_decode_policy = kwargs.get('message_decode_policy') or TextXMLDecodePolicy()
         self._client = AzureQueueStorage(self.url, pipeline=self._pipeline)
+
+    @classmethod
+    def from_queue_url(cls, queue_url, credential=None, **kwargs):
+        """A client to interact with a specific Queue.
+
+        :param str queue_url: The full URI to the queue, including SAS token if used. 
+        :param credential:
+            The credentials with which to authenticate. This is optional if the
+            account URL already has a SAS token. The value can be a SAS token string, and account
+            shared access key, or an instance of a TokenCredentials class from azure.identity.
+        """
+        try:
+            if not queue_url.lower().startswith('http'):
+                queue_url = "https://" + queue_url
+        except AttributeError:
+            raise ValueError("Queue URL must be a string.")
+        parsed_url = urlparse(queue_url.rstrip('/'))
+
+        if not parsed_url.netloc:
+            raise ValueError("Invalid URL: {}".format(queue_url))
+        account_url = parsed_url.netloc.rstrip('/') + "?" + parsed_url.query
+        try:
+            queue_name = unquote(parsed_url.path.lstrip('/'))
+        except AttributeError:
+            raise ValueError("Invalid URL: {}".format(queue_url))
+
+        return cls(account_url, queue_name=queue_name, credential=credential, **kwargs)
 
     def _format_url(self, hostname):
         """Format the endpoint URL according to the current location
@@ -130,7 +151,7 @@ class QueueClient(StorageAccountHostsMixin):
     @classmethod
     def from_connection_string(
             cls, conn_str,  # type: str
-            queue,  # type: Union[str, QueueProperties]
+            queue_name,  # type: str
             credential=None,  # type: Any
             **kwargs  # type: Any
         ):
@@ -139,9 +160,9 @@ class QueueClient(StorageAccountHostsMixin):
 
         :param str conn_str:
             A connection string to an Azure Storage account.
-        :param queue: The queue. This can either be the name of the queue,
+        :param queue_name: The queue. This can either be the name of the queue,
             or an instance of QueueProperties.
-        :type queue: str or ~azure.storage.queue.QueueProperties
+        :type queue_name: str or ~azure.storage.queue.QueueProperties
         :param credential:
             The credentials with which to authenticate. This is optional if the
             account URL already has a SAS token, or the connection string already has shared
@@ -161,7 +182,7 @@ class QueueClient(StorageAccountHostsMixin):
             conn_str, credential, 'queue')
         if 'secondary_hostname' not in kwargs:
             kwargs['secondary_hostname'] = secondary
-        return cls(account_url, queue=queue, credential=credential, **kwargs) # type: ignore
+        return cls(account_url, queue_name=queue_name, credential=credential, **kwargs) # type: ignore
 
     def generate_shared_access_signature(
             self, permission=None,  # type: Optional[Union[QueueSasPermissions, str]]

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/queue_client.py
@@ -110,9 +110,10 @@ class QueueClient(StorageAccountHostsMixin):
 
     @classmethod
     def from_queue_url(cls, queue_url, credential=None, **kwargs):
+        # type: (str, Optional[Any], Any) -> None
         """A client to interact with a specific Queue.
 
-        :param str queue_url: The full URI to the queue, including SAS token if used. 
+        :param str queue_url: The full URI to the queue, including SAS token if used.
         :param credential:
             The credentials with which to authenticate. This is optional if the
             account URL already has a SAS token. The value can be a SAS token string, and account

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/queue_client.py
@@ -60,8 +60,9 @@ class QueueClient(StorageAccountHostsMixin):
     :ivar str location_mode:
         The location mode that the client is currently using. By default
         this will be "primary". Options include "primary" and "secondary".
-    :param str account_url: The URL to the storage account. The `from_queue_url` method should be used
-        if you want to use the full queue URI instead.
+    :param str account_url:
+        The URL to the storage account. In order to create a client given the full URI to the queue,
+        use the from_queue_url classmethod.
     :param queue_name: The name of the queue.
     :type queue_name: str
     :param credential:

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/queue_service_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/queue_service_client.py
@@ -471,7 +471,7 @@ class QueueServiceClient(StorageAccountHostsMixin):
         except AttributeError:
             queue_name = queue
         return QueueClient(
-            self.url, queue_name=queue_name, credential=self.credential, key_resolver_function=self.key_resolver_function,
-            require_encryption=self.require_encryption, key_encryption_key=self.key_encryption_key,
-            _pipeline=self._pipeline, _configuration=self._config, _location_mode=self._location_mode,
-            _hosts=self._hosts, **kwargs)
+            self.url, queue_name=queue_name, credential=self.credential,
+            key_resolver_function=self.key_resolver_function, require_encryption=self.require_encryption,
+            key_encryption_key=self.key_encryption_key, _pipeline=self._pipeline, _configuration=self._config,
+            _location_mode=self._location_mode, _hosts=self._hosts, **kwargs)

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/queue_service_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/queue_service_client.py
@@ -466,8 +466,12 @@ class QueueServiceClient(StorageAccountHostsMixin):
                 :dedent: 8
                 :caption: Get the queue client.
         """
+        try:
+            queue_name = queue.name
+        except AttributeError:
+            queue_name = queue
         return QueueClient(
-            self.url, queue=queue, credential=self.credential, key_resolver_function=self.key_resolver_function,
+            self.url, queue_name=queue_name, credential=self.credential, key_resolver_function=self.key_resolver_function,
             require_encryption=self.require_encryption, key_encryption_key=self.key_encryption_key,
             _pipeline=self._pipeline, _configuration=self._config, _location_mode=self._location_mode,
             _hosts=self._hosts, **kwargs)

--- a/sdk/storage/azure-storage-queue/tests/test_queue_client.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_client.py
@@ -49,7 +49,7 @@ class StorageQueueClientTest(QueueTestCase):
         for client, url in SERVICES.items():
             # Act
             service = client(
-                self._account_url(storage_account.name), credential=storage_account_key, queue='foo')
+                self._account_url(storage_account.name), credential=storage_account_key, queue_name='foo')
 
             # Assert
             self.validate_standard_account_endpoints(service, url, storage_account.name, storage_account_key)
@@ -62,7 +62,7 @@ class StorageQueueClientTest(QueueTestCase):
         for service_type in SERVICES.items():
             # Act
             service = service_type[0].from_connection_string(
-                self.connection_string(storage_account, storage_account_key), queue="test")
+                self.connection_string(storage_account, storage_account_key), queue_name="test")
 
             # Assert
             self.validate_standard_account_endpoints(service, service_type[1], storage_account.name, storage_account_key)
@@ -76,7 +76,7 @@ class StorageQueueClientTest(QueueTestCase):
         for service_type in SERVICES:
             # Act
             service = service_type(
-                self._account_url(storage_account.name), credential=self.sas_token, queue='foo')
+                self._account_url(storage_account.name), credential=self.sas_token, queue_name='foo')
 
             # Assert
             self.assertIsNotNone(service)
@@ -90,7 +90,7 @@ class StorageQueueClientTest(QueueTestCase):
         for service_type in SERVICES:
             # Act
             service = service_type(
-                self._account_url(storage_account.name), credential=self.token_credential, queue='foo')
+                self._account_url(storage_account.name), credential=self.token_credential, queue_name='foo')
 
             # Assert
             self.assertIsNotNone(service)
@@ -106,7 +106,7 @@ class StorageQueueClientTest(QueueTestCase):
             # Act
             with self.assertRaises(ValueError):
                 url = self._account_url(storage_account.name).replace('https', 'http')
-                service_type(url, credential=self.token_credential, queue='foo')
+                service_type(url, credential=self.token_credential, queue_name='foo')
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(name_prefix='pyacrstorage')
@@ -117,7 +117,7 @@ class StorageQueueClientTest(QueueTestCase):
             # Act
             url = self._account_url(storage_account.name).replace('core.windows.net', 'core.chinacloudapi.cn')
             service = service_type[0](
-                url, credential=storage_account_key, queue='foo')
+                url, credential=storage_account_key, queue_name='foo')
 
             # Assert
             self.assertIsNotNone(service)
@@ -137,7 +137,7 @@ class StorageQueueClientTest(QueueTestCase):
             # Act
             url = self._account_url(storage_account.name).replace('https', 'http')
             service = service_type[0](
-                url, credential=storage_account_key, queue='foo')
+                url, credential=storage_account_key, queue_name='foo')
 
             # Assert
             self.validate_standard_account_endpoints(service, service_type[1], storage_account.name, storage_account_key)
@@ -152,22 +152,10 @@ class StorageQueueClientTest(QueueTestCase):
         for service_type in QUEUE_SERVICES:
             # Act
             with self.assertRaises(ValueError) as e:
-                test_service = service_type('testaccount', credential='', queue='foo')
+                test_service = service_type('testaccount', credential='', queue_name='foo')
 
             self.assertEqual(
                 str(e.exception), "You need to provide either a SAS token or an account key to authenticate.")
-
-    @ResourceGroupPreparer()
-    @StorageAccountPreparer(name_prefix='pyacrstorage')
-    def test_create_service_missing_arguments(self, resource_group, location, storage_account, storage_account_key):
-        # Arrange
-
-        for service_type in SERVICES:
-            # Act
-            with self.assertRaises(ValueError):
-                service = service_type(None)
-
-                # Assert
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(name_prefix='pyacrstorage')
@@ -177,10 +165,10 @@ class StorageQueueClientTest(QueueTestCase):
         for service_type in SERVICES.items():
             # Act
             default_service = service_type[0](
-                self._account_url(storage_account.name), credential=storage_account_key, queue='foo')
+                self._account_url(storage_account.name), credential=storage_account_key, queue_name='foo')
             service = service_type[0](
                 self._account_url(storage_account.name), credential=storage_account_key,
-                queue='foo', connection_timeout=22)
+                queue_name='foo', connection_timeout=22)
 
             # Assert
             self.validate_standard_account_endpoints(service, service_type[1], storage_account.name, storage_account_key)
@@ -196,7 +184,7 @@ class StorageQueueClientTest(QueueTestCase):
 
         for service_type in SERVICES.items():
             # Act
-            service = service_type[0].from_connection_string(conn_string, queue='foo')
+            service = service_type[0].from_connection_string(conn_string, queue_name='foo')
 
             # Assert
             self.validate_standard_account_endpoints(service, service_type[1], storage_account.name, storage_account_key)
@@ -210,7 +198,7 @@ class StorageQueueClientTest(QueueTestCase):
 
         for service_type in SERVICES:
             # Act
-            service = service_type.from_connection_string(conn_string, queue='foo')
+            service = service_type.from_connection_string(conn_string, queue_name='foo')
 
             # Assert
             self.assertIsNotNone(service)
@@ -227,7 +215,7 @@ class StorageQueueClientTest(QueueTestCase):
 
         for service_type in SERVICES.items():
             # Act
-            service = service_type[0].from_connection_string(conn_string, queue="foo")
+            service = service_type[0].from_connection_string(conn_string, queue_name="foo")
 
             # Assert
             self.assertIsNotNone(service)
@@ -250,7 +238,7 @@ class StorageQueueClientTest(QueueTestCase):
 
             # Act
             with self.assertRaises(ValueError):
-                service = service_type[0].from_connection_string(conn_string, queue="foo")
+                service = service_type[0].from_connection_string(conn_string, queue_name="foo")
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(name_prefix='pyacrstorage')
@@ -261,7 +249,7 @@ class StorageQueueClientTest(QueueTestCase):
                 storage_account.name, storage_account_key)
 
             # Act
-            service = service_type[0].from_connection_string(conn_string, queue="foo")
+            service = service_type[0].from_connection_string(conn_string, queue_name="foo")
 
             # Assert
             self.assertIsNotNone(service)
@@ -279,7 +267,7 @@ class StorageQueueClientTest(QueueTestCase):
                 storage_account.name, storage_account_key)
 
             # Act
-            service = service_type[0].from_connection_string(conn_string, queue="foo")
+            service = service_type[0].from_connection_string(conn_string, queue_name="foo")
 
             # Assert
             self.assertIsNotNone(service)
@@ -298,7 +286,7 @@ class StorageQueueClientTest(QueueTestCase):
 
             # Act
             service = service_type[0].from_connection_string(
-                conn_string, secondary_hostname="www-sec.mydomain.com", queue="foo")
+                conn_string, secondary_hostname="www-sec.mydomain.com", queue_name="foo")
 
             # Assert
             self.assertIsNotNone(service)
@@ -320,7 +308,7 @@ class StorageQueueClientTest(QueueTestCase):
 
             # Fails if primary excluded
             with self.assertRaises(ValueError):
-                service = service_type[0].from_connection_string(conn_string, queue="foo")
+                service = service_type[0].from_connection_string(conn_string, queue_name="foo")
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(name_prefix='pyacrstorage')
@@ -334,7 +322,7 @@ class StorageQueueClientTest(QueueTestCase):
                 _CONNECTION_ENDPOINTS_SECONDARY.get(service_type[1]))
 
             # Act
-            service = service_type[0].from_connection_string(conn_string, queue="foo")
+            service = service_type[0].from_connection_string(conn_string, queue_name="foo")
 
             # Assert
             self.assertIsNotNone(service)
@@ -440,7 +428,16 @@ class StorageQueueClientTest(QueueTestCase):
         custom_headers = {'User-Agent': 'customer_user_agent'}
         service.get_service_properties(raw_response_hook=callback, headers=custom_headers)
 
+    @ResourceGroupPreparer()
+    @StorageAccountPreparer(name_prefix='pyacrstorage')
+    def test_create_queue_client_with_complete_queue_url(self, resource_group, location, storage_account, storage_account_key):
+        # Arrange
+        queue_url = self._account_url(storage_account.name) + "/foo"
+        service = QueueClient(queue_url, queue_name='bar', credential=storage_account_key)
 
+            # Assert
+        self.assertEqual(service.scheme, 'https')
+        self.assertEqual(service.queue_name, 'bar')
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/storage/azure-storage-queue/tests/test_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_client_async.py
@@ -63,7 +63,7 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
         for client, url in SERVICES.items():
             # Act
             service = client(
-                self._account_url(storage_account.name), credential=storage_account_key, queue='foo', transport=AiohttpTestTransport())
+                self._account_url(storage_account.name), credential=storage_account_key, queue_name='foo', transport=AiohttpTestTransport())
 
             # Assert
             self.validate_standard_account_endpoints(service, url, storage_account, storage_account_key)
@@ -76,7 +76,7 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
         for service_type in SERVICES.items():
             # Act
             service = service_type[0].from_connection_string(
-                self.connection_string(storage_account, storage_account_key), queue="test")
+                self.connection_string(storage_account, storage_account_key), queue_name="test")
 
             # Assert
             self.validate_standard_account_endpoints(service, service_type[1], storage_account, storage_account_key)
@@ -90,7 +90,7 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
         for service_type in SERVICES:
             # Act
             service = service_type(
-                self._account_url(storage_account.name), credential=self.sas_token, queue='foo')
+                self._account_url(storage_account.name), credential=self.sas_token, queue_name='foo')
 
             # Assert
             self.assertIsNotNone(service)
@@ -104,7 +104,7 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
         for service_type in SERVICES:
             # Act
             service = service_type(
-                self._account_url(storage_account.name), credential=self.token_credential, queue='foo')
+                self._account_url(storage_account.name), credential=self.token_credential, queue_name='foo')
 
             # Assert
             self.assertIsNotNone(service)
@@ -120,7 +120,7 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
             # Act
             with self.assertRaises(ValueError):
                 url = self._account_url(storage_account.name).replace('https', 'http')
-                service_type(url, credential=self.token_credential, queue='foo')
+                service_type(url, credential=self.token_credential, queue_name='foo')
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(name_prefix='pyacrstorage')
@@ -131,7 +131,7 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
             # Act
             url = self._account_url(storage_account.name).replace('core.windows.net', 'core.chinacloudapi.cn')
             service = service_type[0](
-                url, credential=storage_account_key, queue='foo')
+                url, credential=storage_account_key, queue_name='foo')
 
             # Assert
             self.assertIsNotNone(service)
@@ -151,7 +151,7 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
             # Act
             url = self._account_url(storage_account.name).replace('https', 'http')
             service = service_type[0](
-                url, credential=storage_account_key, queue='foo')
+                url, credential=storage_account_key, queue_name='foo')
 
             # Assert
             self.validate_standard_account_endpoints(service, service_type[1], storage_account, storage_account_key)
@@ -166,21 +166,10 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
         for service_type in QUEUE_SERVICES:
             # Act
             with self.assertRaises(ValueError) as e:
-                test_service = service_type('testaccount', credential='', queue='foo')
+                test_service = service_type('testaccount', credential='', queue_name='foo')
 
             self.assertEqual(
                 str(e.exception), "You need to provide either a SAS token or an account key to authenticate.")
-
-    @ResourceGroupPreparer()
-    @StorageAccountPreparer(name_prefix='pyacrstorage')
-    def test_create_service_missing_arguments(self, resource_group, location, storage_account, storage_account_key):
-        # Arrange
-
-        for service_type in SERVICES:
-            # Act
-            with self.assertRaises(ValueError):
-                service = service_type(None)
-                # Assert
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(name_prefix='pyacrstorage')
@@ -190,10 +179,10 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
         for service_type in SERVICES.items():
             # Act
             default_service = service_type[0](
-                self._account_url(storage_account.name), credential=storage_account_key, queue='foo')
+                self._account_url(storage_account.name), credential=storage_account_key, queue_name='foo')
             service = service_type[0](
                 self._account_url(storage_account.name), credential=storage_account_key,
-                queue='foo', connection_timeout=22)
+                queue_name='foo', connection_timeout=22)
 
             # Assert
             self.validate_standard_account_endpoints(service, service_type[1], storage_account, storage_account_key)
@@ -209,7 +198,7 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
 
         for service_type in SERVICES.items():
             # Act
-            service = service_type[0].from_connection_string(conn_string, queue='foo')
+            service = service_type[0].from_connection_string(conn_string, queue_name='foo')
 
             # Assert
             self.validate_standard_account_endpoints(service, service_type[1], storage_account, storage_account_key)
@@ -223,7 +212,7 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
 
         for service_type in SERVICES:
             # Act
-            service = service_type.from_connection_string(conn_string, queue='foo')
+            service = service_type.from_connection_string(conn_string, queue_name='foo')
 
             # Assert
             self.assertIsNotNone(service)
@@ -240,7 +229,7 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
 
         for service_type in SERVICES.items():
             # Act
-            service = service_type[0].from_connection_string(conn_string, queue="foo")
+            service = service_type[0].from_connection_string(conn_string, queue_name="foo")
 
             # Assert
             self.assertIsNotNone(service)
@@ -263,7 +252,7 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
 
             # Act
             with self.assertRaises(ValueError):
-                service = service_type[0].from_connection_string(conn_string, queue="foo")
+                service = service_type[0].from_connection_string(conn_string, queue_name="foo")
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(name_prefix='pyacrstorage')
@@ -274,7 +263,7 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
                 storage_account.name, storage_account_key)
 
             # Act
-            service = service_type[0].from_connection_string(conn_string, queue="foo")
+            service = service_type[0].from_connection_string(conn_string, queue_name="foo")
 
             # Assert
             self.assertIsNotNone(service)
@@ -292,7 +281,7 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
                 storage_account.name, storage_account_key)
 
             # Act
-            service = service_type[0].from_connection_string(conn_string, queue="foo")
+            service = service_type[0].from_connection_string(conn_string, queue_name="foo")
 
             # Assert
             self.assertIsNotNone(service)
@@ -312,7 +301,7 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
 
             # Act
             service = service_type[0].from_connection_string(
-                conn_string, secondary_hostname="www-sec.mydomain.com", queue="foo")
+                conn_string, secondary_hostname="www-sec.mydomain.com", queue_name="foo")
 
             # Assert
             self.assertIsNotNone(service)
@@ -334,7 +323,7 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
 
             # Fails if primary excluded
             with self.assertRaises(ValueError):
-                service = service_type[0].from_connection_string(conn_string, queue="foo")
+                service = service_type[0].from_connection_string(conn_string, queue_name="foo")
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(name_prefix='pyacrstorage')
@@ -348,7 +337,7 @@ class StorageQueueClientTestAsync(AsyncQueueTestCase):
                 _CONNECTION_ENDPOINTS_SECONDARY.get(service_type[1]))
 
             # Act
-            service = service_type[0].from_connection_string(conn_string, queue="foo")
+            service = service_type[0].from_connection_string(conn_string, queue_name="foo")
 
             # Assert
             self.assertIsNotNone(service)

--- a/sdk/storage/azure-storage-queue/tests/test_queue_encodings.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_encodings.py
@@ -102,8 +102,8 @@ class StorageQueueEncodingTest(QueueTestCase):
         # Arrange.
         qsc = QueueServiceClient(self._account_url(storage_account.name), storage_account_key)
         queue = QueueClient(
-            queue_url=self._account_url(storage_account.name),
-            queue=self.get_resource_name(TEST_QUEUE_PREFIX),
+            account_url=self._account_url(storage_account.name),
+            queue_name=self.get_resource_name(TEST_QUEUE_PREFIX),
             credential=storage_account_key,
             message_encode_policy=TextBase64EncodePolicy(),
             message_decode_policy=TextBase64DecodePolicy())
@@ -119,8 +119,8 @@ class StorageQueueEncodingTest(QueueTestCase):
         # Arrange.
         qsc = QueueServiceClient(self._account_url(storage_account.name), storage_account_key)
         queue = QueueClient(
-            queue_url=self._account_url(storage_account.name),
-            queue=self.get_resource_name(TEST_QUEUE_PREFIX),
+            account_url=self._account_url(storage_account.name),
+            queue_name=self.get_resource_name(TEST_QUEUE_PREFIX),
             credential=storage_account_key,
             message_encode_policy=BinaryBase64EncodePolicy(),
             message_decode_policy=BinaryBase64DecodePolicy())
@@ -151,8 +151,8 @@ class StorageQueueEncodingTest(QueueTestCase):
         # Arrange
         qsc = QueueServiceClient(self._account_url(storage_account.name), storage_account_key)
         queue = QueueClient(
-            queue_url=self._account_url(storage_account.name),
-            queue=self.get_resource_name(TEST_QUEUE_PREFIX),
+            account_url=self._account_url(storage_account.name),
+            queue_name=self.get_resource_name(TEST_QUEUE_PREFIX),
             credential=storage_account_key,
             message_encode_policy=BinaryBase64EncodePolicy(),
             message_decode_policy=BinaryBase64DecodePolicy())
@@ -171,8 +171,8 @@ class StorageQueueEncodingTest(QueueTestCase):
         # Arrange
         qsc = QueueServiceClient(self._account_url(storage_account.name), storage_account_key)
         queue = QueueClient(
-            queue_url=self._account_url(storage_account.name),
-            queue=self.get_resource_name(TEST_QUEUE_PREFIX),
+            account_url=self._account_url(storage_account.name),
+            queue_name=self.get_resource_name(TEST_QUEUE_PREFIX),
             credential=storage_account_key,
             message_encode_policy=TextXMLEncodePolicy(),
             message_decode_policy=BinaryBase64DecodePolicy())

--- a/sdk/storage/azure-storage-queue/tests/test_queue_encodings_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_encodings_async.py
@@ -124,8 +124,8 @@ class StorageQueueEncodingTestAsync(AsyncQueueTestCase):
         # Arrange.
         qsc = QueueServiceClient(self._account_url(storage_account.name), storage_account_key, transport=AiohttpTestTransport())
         queue = QueueClient(
-            queue_url=self._account_url(storage_account.name),
-            queue=self.get_resource_name(TEST_QUEUE_PREFIX),
+            account_url=self._account_url(storage_account.name),
+            queue_name=self.get_resource_name(TEST_QUEUE_PREFIX),
             credential=storage_account_key,
             message_encode_policy=TextBase64EncodePolicy(),
             message_decode_policy=TextBase64DecodePolicy(),
@@ -143,8 +143,8 @@ class StorageQueueEncodingTestAsync(AsyncQueueTestCase):
         # Arrange.
         qsc = QueueServiceClient(self._account_url(storage_account.name), storage_account_key, transport=AiohttpTestTransport())
         queue = QueueClient(
-            queue_url=self._account_url(storage_account.name),
-            queue=self.get_resource_name(TEST_QUEUE_PREFIX),
+            account_url=self._account_url(storage_account.name),
+            queue_name=self.get_resource_name(TEST_QUEUE_PREFIX),
             credential=storage_account_key,
             message_encode_policy=BinaryBase64EncodePolicy(),
             message_decode_policy=BinaryBase64DecodePolicy(),
@@ -178,8 +178,8 @@ class StorageQueueEncodingTestAsync(AsyncQueueTestCase):
         # Arrange
         qsc = QueueServiceClient(self._account_url(storage_account.name), storage_account_key, transport=AiohttpTestTransport()) 
         queue = QueueClient(
-            queue_url=self._account_url(storage_account.name),
-            queue=self.get_resource_name(TEST_QUEUE_PREFIX),
+            account_url=self._account_url(storage_account.name),
+            queue_name=self.get_resource_name(TEST_QUEUE_PREFIX),
             credential=storage_account_key,
             message_encode_policy=BinaryBase64EncodePolicy(),
             message_decode_policy=BinaryBase64DecodePolicy(),
@@ -200,8 +200,8 @@ class StorageQueueEncodingTestAsync(AsyncQueueTestCase):
         # Arrange
         qsc = QueueServiceClient(self._account_url(storage_account.name), storage_account_key, transport=AiohttpTestTransport())
         queue = QueueClient(
-            queue_url=self._account_url(storage_account.name),
-            queue=self.get_resource_name(TEST_QUEUE_PREFIX),
+            account_url=self._account_url(storage_account.name),
+            queue_name=self.get_resource_name(TEST_QUEUE_PREFIX),
             credential=storage_account_key,
             message_encode_policy=TextXMLEncodePolicy(),
             message_decode_policy=BinaryBase64DecodePolicy(),

--- a/sdk/storage/azure-storage-queue/tests/test_queue_samples_message.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_samples_message.py
@@ -59,7 +59,7 @@ class TestMessageQueueSamples(QueueTestCase):
 
             # Authenticate with the sas token
             # [START create_queue_client]
-            q = QueueClient(
+            q = QueueClient.from_queue_url(
                 queue_url=queue_client.url,
                 credential=sas_token
             )

--- a/sdk/storage/azure-storage-queue/tests/test_queue_samples_message_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_samples_message_async.py
@@ -59,7 +59,7 @@ class TestMessageQueueSamples(AsyncQueueTestCase):
             # Authenticate with the sas token
             # [START async_create_queue_client]
             from azure.storage.queue.aio import QueueClient
-            q = QueueClient(
+            q = QueueClient.from_queue_url(
                 queue_url=queue_client.url,
                 credential=sas_token
             )


### PR DESCRIPTION
Resolves #7806 

**Breaking changes**

- Added new the following methods:
  -  `from_queue_url` in QueueClient
  -  `from_share_url` in ShareClient
  -  `from_directory_url` in DirectoryClient
   -  `from_file_url` in FileClient

- The default constructors for each of the above client now takes in only account_url with mandatory parameters such as share_name, file_path etc.