### PR TITLE
Stop modifying internal_response body

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies_async.py
@@ -54,7 +54,6 @@ class AsyncStorageResponseHook(AsyncHTTPPolicy):
 
         response = await self.next.send(request)
         await response.http_response.load_body()
-        response.http_response.internal_response.body = response.http_response.body()
 
         will_retry = is_retry(response, request.context.options.get('mode'))
         if not will_retry and download_stream_current is not None:

--- a/sdk/storage/azure-storage-file/azure/storage/file/_shared/policies_async.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/_shared/policies_async.py
@@ -54,7 +54,6 @@ class AsyncStorageResponseHook(AsyncHTTPPolicy):
 
         response = await self.next.send(request)
         await response.http_response.load_body()
-        response.http_response.internal_response.body = response.http_response.body()
 
         will_retry = is_retry(response, request.context.options.get('mode'))
         if not will_retry and download_stream_current is not None:

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies_async.py
@@ -54,7 +54,6 @@ class AsyncStorageResponseHook(AsyncHTTPPolicy):
 
         response = await self.next.send(request)
         await response.http_response.load_body()
-        response.http_response.internal_response.body = response.http_response.body()
 
         will_retry = is_retry(response, request.context.options.get('mode'))
         if not will_retry and download_stream_current is not None:


### PR DESCRIPTION
SDK accesses `internal_response` member of HTTP response and modifies it. This is not necessary and should not be done.

Resolves #7532 