### PR TITLE
Revise azure-identity

### DIFF
--- a/sdk/eventhub/azure-eventhubs/stress/azure_eventhub_stress.py
+++ b/sdk/eventhub/azure-eventhubs/stress/azure_eventhub_stress.py
@@ -146,11 +146,10 @@ class StressTestRunner(object):
                                     network_tracing=False)
         elif self.args.aad_client_id:
             client = client_class(host=self.args.address,
-                                    event_hub_path=self.args.eventhub,
-                                    credential=ClientSecretCredential(
-                                        self.args.aad_client_id, self.args.aad_secret, self.args.tenant_id
-                                    ),
-                                    network_tracing=False)
+                                  event_hub_path=self.args.eventhub,
+                                  credential=ClientSecretCredential(self.args.tenant_id, self.args.aad_client_id,
+                                                                    self.args.aad_secret),
+                                  network_tracing=False)
         else:
             raise ValueError("Argument error. Must have one of connection string, sas and aad credentials")
 

--- a/sdk/identity/azure-identity/HISTORY.md
+++ b/sdk/identity/azure-identity/HISTORY.md
@@ -9,6 +9,20 @@ async API is optional. To use async credentials, please install
 [azure-core documentation](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/core/azure-core/README.md#transport)
 for information about customizing the transport.
 - Renamed `ClientSecretCredential` parameter "`secret`" to "`client_secret`"
+- All credentials with `tenant_id` and `client_id` positional parameters now accept them in that order
+- Changes to `InteractiveBrowserCredential` parameters
+  - positional parameter `client_id` is now an optional keyword argument. If no value is provided,
+the Azure CLI's client ID will be used.
+  - Optional keyword argument `tenant` renamed `tenant_id`
+- Changes to `DeviceCodeCredential`
+  - optional positional parameter `prompt_callback` is now a keyword argument
+  - optional keyword argument `tenant` renamed `tenant_id`
+- Changes to `ManagedIdentityCredential`
+  - now accepts no positional arguments, and only one keyword argument:
+  `client_id`
+  - transport configuration is now done through keyword arguments as
+  described in
+  [`azure-core` documentation](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/core/azure-core/docs/configuration.md)
 
 
 ## 1.0.0b4 (2019-10-07)

--- a/sdk/identity/azure-identity/HISTORY.md
+++ b/sdk/identity/azure-identity/HISTORY.md
@@ -16,6 +16,8 @@ the Azure CLI's client ID will be used.
   - Optional keyword argument `tenant` renamed `tenant_id`
 - Changes to `DeviceCodeCredential`
   - optional positional parameter `prompt_callback` is now a keyword argument
+  - `prompt_callback`'s third argument is now a `datetime` representing the
+  expiration time of the device code
   - optional keyword argument `tenant` renamed `tenant_id`
 - Changes to `ManagedIdentityCredential`
   - now accepts no positional arguments, and only one keyword argument:

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -158,7 +158,7 @@ This example demonstrates authenticating the `KeyClient` from the
 from azure.identity import ClientSecretCredential
 from azure.keyvault.keys import KeyClient
 
-credential = ClientSecretCredential(client_id, client_secret, tenant_id)
+credential = ClientSecretCredential(tenant_id, client_id, client_secret)
 
 client = KeyClient(vault_endpoint, credential)
 ```
@@ -173,7 +173,7 @@ from azure.keyvault.secrets import SecretClient
 
 # requires a PEM-encoded certificate with private key, not protected with a password
 cert_path = "/app/certs/certificate.pem"
-credential = CertificateCredential(client_id, tenant_id, cert_path)
+credential = CertificateCredential(tenant_id, client_id, cert_path)
 
 client = SecretClient(vault_endpoint, credential)
 ```
@@ -190,7 +190,7 @@ from azure.eventhub import EventHubClient
 from azure.identity import ChainedTokenCredential, ClientSecretCredential, ManagedIdentityCredential
 
 managed_identity = ManagedIdentityCredential()
-client_secret = ClientSecretCredential(client_id, client_secret, tenant_id)
+client_secret = ClientSecretCredential(tenant_id, client_id, client_secret)
 
 # when an access token is requested, the chain will try each
 # credential in order, stopping when one provides a token
@@ -218,7 +218,7 @@ default_credential = DefaultAzureCredential()
 # async credentials have the same API and configuration their synchronous counterparts,
 from azure.identity.aio import ClientSecretCredential
 
-credential = ClientSecretCredential(client_id, client_secret, tenant_id)
+credential = ClientSecretCredential(tenant_id, client_id, client_secret)
 
 # and are used with async Azure SDK clients in the same way
 from azure.keyvault.aio import SecretClient

--- a/sdk/identity/azure-identity/azure/identity/_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_base.py
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
 class ClientSecretCredentialBase(object):
     """Sans I/O base for client secret credentials"""
 
-    def __init__(self, client_id, secret, tenant_id, **kwargs):  # pylint:disable=unused-argument
-        # type: (str, str, str, Mapping[str, Any]) -> None
+    def __init__(self, tenant_id, client_id, secret, **kwargs):  # pylint:disable=unused-argument
+        # type: (str, str, str, **Any) -> None
         if not client_id:
             raise ValueError("client_id should be the id of an Azure Active Directory application")
         if not secret:
@@ -41,10 +41,9 @@ class ClientSecretCredentialBase(object):
 class CertificateCredentialBase(object):
     """Sans I/O base for certificate credentials"""
 
-    def __init__(self, client_id, tenant_id, certificate_path, **kwargs):  # pylint:disable=unused-argument
-        # type: (str, str, str, Mapping[str, Any]) -> None
+    def __init__(self, tenant_id, client_id, certificate_path, **kwargs):  # pylint:disable=unused-argument
+        # type: (str, str, str, **Any) -> None
         if not certificate_path:
-            # TODO: support PFX
             raise ValueError(
                 "certificate_path must be the path to a PEM file containing an "
                 "x509 certificate and its private key, not protected with a password"
@@ -55,7 +54,6 @@ class CertificateCredentialBase(object):
         with open(certificate_path, "rb") as f:
             pem_bytes = f.read()
 
-        # TODO: support pem password
         private_key = serialization.load_pem_private_key(pem_bytes, password=None, backend=default_backend())
         cert = x509.load_pem_x509_certificate(pem_bytes, default_backend())
         fingerprint = cert.fingerprint(hashes.SHA1())

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -19,8 +19,8 @@ class AuthorizationCodeCredential(object):
     See https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow for more information
     about the authentication flow.
 
-    :param str client_id: the application's client ID
     :param str tenant_id: ID of the application's Azure Active Directory tenant. Also called its 'directory' ID.
+    :param str client_id: the application's client ID
     :param str authorization_code: the authorization code from the user's log-in
     :param str redirect_uri: The application's redirect URI. Must match the URI used to request the authorization code.
     :param str client_secret: One of the application's client secrets. Required only for web apps and web APIs.
@@ -31,12 +31,12 @@ class AuthorizationCodeCredential(object):
           authorities for other clouds.
     """
 
-    def __init__(self, client_id, tenant_id, authorization_code, redirect_uri, client_secret=None, **kwargs):
+    def __init__(self, tenant_id, client_id, authorization_code, redirect_uri, client_secret=None, **kwargs):
         # type: (str, str, str, str, Optional[str], **Any) -> None
         self._authorization_code = authorization_code  # type: Optional[str]
         self._client_id = client_id
         self._client_secret = client_secret
-        self._client = kwargs.pop("client", None) or AadClient(client_id, tenant_id, **kwargs)
+        self._client = kwargs.pop("client", None) or AadClient(tenant_id, client_id, **kwargs)
         self._redirect_uri = redirect_uri
 
     def get_token(self, *scopes, **kwargs):

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -25,9 +25,9 @@ class AuthorizationCodeCredential(object):
     :param str redirect_uri: The application's redirect URI. Must match the URI used to request the authorization code.
 
     Keyword arguments
-        - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
-          authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities` defines
-          authorities for other clouds.
+        - **authority** (str): Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+          the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
+          defines authorities for other clouds.
         - **client_secret** (str): One of the application's client secrets. Required only for web apps and web APIs.
     """
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -23,19 +23,19 @@ class AuthorizationCodeCredential(object):
     :param str client_id: the application's client ID
     :param str authorization_code: the authorization code from the user's log-in
     :param str redirect_uri: The application's redirect URI. Must match the URI used to request the authorization code.
-    :param str client_secret: One of the application's client secrets. Required only for web apps and web APIs.
 
     Keyword arguments
         - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
           authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities` defines
           authorities for other clouds.
+        - **client_secret** (str): One of the application's client secrets. Required only for web apps and web APIs.
     """
 
-    def __init__(self, tenant_id, client_id, authorization_code, redirect_uri, client_secret=None, **kwargs):
-        # type: (str, str, str, str, Optional[str], **Any) -> None
+    def __init__(self, tenant_id, client_id, authorization_code, redirect_uri, **kwargs):
+        # type: (str, str, str, str, **Any) -> None
         self._authorization_code = authorization_code  # type: Optional[str]
         self._client_id = client_id
-        self._client_secret = client_secret
+        self._client_secret = kwargs.pop("client_secret", None)
         self._client = kwargs.pop("client", None) or AadClient(tenant_id, client_id, **kwargs)
         self._redirect_uri = redirect_uri
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -36,8 +36,8 @@ class InteractiveBrowserCredential(PublicClientCredential):
         - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
           authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities` defines
           authorities for other clouds.
-        - **tenant (str)**: a tenant ID or a domain associated with a tenant. Defaults to the 'organizations' tenant,
-          which can authenticate work or school accounts.
+        - **tenant_id (str)**: an Azure Active Directory tenant ID. Defaults to the 'organizations' tenant, which can
+          authenticate work or school accounts.
         - **client_id** (str): Client ID of the Azure Active Directory application users will sign in to. If
           unspecified, the Azure CLI's ID will be used.
         - **timeout (int)**: seconds to wait for the user to complete authentication. Defaults to 300 (5 minutes).

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -24,23 +24,24 @@ if TYPE_CHECKING:
 
 
 class InteractiveBrowserCredential(PublicClientCredential):
-    """Authenticates a user through the authorization code flow.
+    """Opens a browser to interactively authenticate a user.
 
     This is an interactive flow: ``get_token`` opens a browser to a login URL provided by Azure Active Directory, and
     waits for the user to authenticate there.
 
-    Azure Active Directory documentation describes the authorization code flow in more detail:
+    :func:`~get_token` opens a browser to a login URL provided by Azure Active Directory and authenticates a user
+    there with the authorization code flow. Azure Active Directory documentation describes this flow in more detail:
     https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code
 
     Keyword arguments
-        - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
-          authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities` defines
-          authorities for other clouds.
-        - **tenant_id (str)**: an Azure Active Directory tenant ID. Defaults to the 'organizations' tenant, which can
+        - **authority** (str): Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+          the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
+          defines authorities for other clouds.
+        - **tenant_id** (str): an Azure Active Directory tenant ID. Defaults to the 'organizations' tenant, which can
           authenticate work or school accounts.
         - **client_id** (str): Client ID of the Azure Active Directory application users will sign in to. If
           unspecified, the Azure CLI's ID will be used.
-        - **timeout (int)**: seconds to wait for the user to complete authentication. Defaults to 300 (5 minutes).
+        - **timeout** (int): seconds to wait for the user to complete authentication. Defaults to 300 (5 minutes).
 
     """
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -10,6 +10,7 @@ import webbrowser
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
 
+from .._constants import AZURE_CLI_CLIENT_ID
 from .._internal import AuthCodeRedirectServer, PublicClientCredential, wrap_exceptions
 
 try:
@@ -31,22 +32,23 @@ class InteractiveBrowserCredential(PublicClientCredential):
     Azure Active Directory documentation describes the authorization code flow in more detail:
     https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code
 
-    :param str client_id: the application's client ID
-
     Keyword arguments
         - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
           authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities` defines
           authorities for other clouds.
         - **tenant (str)**: a tenant ID or a domain associated with a tenant. Defaults to the 'organizations' tenant,
           which can authenticate work or school accounts.
+        - **client_id** (str): Client ID of the Azure Active Directory application users will sign in to. If
+          unspecified, the Azure CLI's ID will be used.
         - **timeout (int)**: seconds to wait for the user to complete authentication. Defaults to 300 (5 minutes).
 
     """
 
-    def __init__(self, client_id, **kwargs):
-        # type: (str, **Any) -> None
+    def __init__(self, **kwargs):
+        # type: (**Any) -> None
         self._timeout = kwargs.pop("timeout", 300)
         self._server_class = kwargs.pop("server_class", AuthCodeRedirectServer)  # facilitate mocking
+        client_id = kwargs.pop("client_id", AZURE_CLI_CLIENT_ID)
         super(InteractiveBrowserCredential, self).__init__(client_id=client_id, **kwargs)
 
     @wrap_exceptions

--- a/sdk/identity/azure-identity/azure/identity/_credentials/client_credential.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/client_credential.py
@@ -19,9 +19,9 @@ if TYPE_CHECKING:
 class ClientSecretCredential(ClientSecretCredentialBase):
     """Authenticates as a service principal using a client ID and client secret.
 
+    :param str tenant_id: ID of the service principal's tenant. Also called its 'directory' ID.
     :param str client_id: the service principal's client ID
     :param str client_secret: one of the service principal's client secrets
-    :param str tenant_id: ID of the service principal's tenant. Also called its 'directory' ID.
 
     Keyword arguments
         - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
@@ -29,9 +29,9 @@ class ClientSecretCredential(ClientSecretCredentialBase):
           authorities for other clouds.
     """
 
-    def __init__(self, client_id, client_secret, tenant_id, **kwargs):
-        # type: (str, str, str, Mapping[str, Any]) -> None
-        super(ClientSecretCredential, self).__init__(client_id, client_secret, tenant_id, **kwargs)
+    def __init__(self, tenant_id, client_id, client_secret, **kwargs):
+        # type: (str, str, str, **Any) -> None
+        super(ClientSecretCredential, self).__init__(tenant_id, client_id, client_secret, **kwargs)
         self._client = AuthnClient(tenant=tenant_id, **kwargs)
 
     def get_token(self, *scopes, **kwargs):  # pylint:disable=unused-argument
@@ -52,8 +52,8 @@ class ClientSecretCredential(ClientSecretCredentialBase):
 class CertificateCredential(CertificateCredentialBase):
     """Authenticates as a service principal using a certificate.
 
-    :param str client_id: the service principal's client ID
     :param str tenant_id: ID of the service principal's tenant. Also called its 'directory' ID.
+    :param str client_id: the service principal's client ID
     :param str certificate_path: path to a PEM-encoded certificate file including the private key
 
     Keyword arguments
@@ -62,8 +62,8 @@ class CertificateCredential(CertificateCredentialBase):
           authorities for other clouds.
     """
 
-    def __init__(self, client_id, tenant_id, certificate_path, **kwargs):
-        # type: (str, str, str, Mapping[str, Any]) -> None
+    def __init__(self, tenant_id, client_id, certificate_path, **kwargs):
+        # type: (str, str, str, **Any) -> None
         self._client = AuthnClient(tenant=tenant_id, **kwargs)
         super(CertificateCredential, self).__init__(client_id, tenant_id, certificate_path, **kwargs)
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/client_credential.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/client_credential.py
@@ -24,9 +24,9 @@ class ClientSecretCredential(ClientSecretCredentialBase):
     :param str client_secret: one of the service principal's client secrets
 
     Keyword arguments
-        - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
-          authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities` defines
-          authorities for other clouds.
+        - **authority** (str): Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+          the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
+          defines authorities for other clouds.
     """
 
     def __init__(self, tenant_id, client_id, client_secret, **kwargs):
@@ -54,12 +54,13 @@ class CertificateCredential(CertificateCredentialBase):
 
     :param str tenant_id: ID of the service principal's tenant. Also called its 'directory' ID.
     :param str client_id: the service principal's client ID
-    :param str certificate_path: path to a PEM-encoded certificate file including the private key
+    :param str certificate_path: path to a PEM-encoded certificate file including the private key.
+      This file must not be password-protected.
 
     Keyword arguments
-        - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
-          authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities` defines
-          authorities for other clouds.
+        - **authority** (str): Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+          the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
+          defines authorities for other clouds.
     """
 
     def __init__(self, tenant_id, client_id, certificate_path, **kwargs):

--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -29,14 +29,15 @@ class EnvironmentCredential:
     a user with a username and password. Configuration is attempted in this order, using these environment variables:
 
     Service principal with secret:
+      - **AZURE_TENANT_ID**: ID of the service principal's tenant. Also called its 'directory' ID.
       - **AZURE_CLIENT_ID**: the service principal's client ID
       - **AZURE_CLIENT_SECRET**: one of the service principal's client secrets
-      - **AZURE_TENANT_ID**: ID of the service principal's tenant. Also called its 'directory' ID.
 
     Service principal with certificate:
-      - **AZURE_CLIENT_ID**: the service principal's client ID
-      - **AZURE_CLIENT_CERTIFICATE_PATH**: path to a PEM-encoded certificate file including the private key
       - **AZURE_TENANT_ID**: ID of the service principal's tenant. Also called its 'directory' ID.
+      - **AZURE_CLIENT_ID**: the service principal's client ID
+      - **AZURE_CLIENT_CERTIFICATE_PATH**: path to a PEM-encoded certificate file including the private key. The
+        certificate must not be password-protected.
 
     User with username and password:
       - **AZURE_CLIENT_ID**: the application's client ID

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -29,9 +29,12 @@ if TYPE_CHECKING:
 
 
 class ManagedIdentityCredential(object):
-    """Authenticates with a managed identity in an App Service, Azure VM or Cloud Shell environment.
+    """Authenticates with an Azure managed identity in any hosting environment which supports managed identities.
 
-    Keyword arguments:
+    See the Azure Active Directory documentation for more information about managed identities:
+    https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
+
+    Keyword arguments
         - **client_id** (str): ID of a user-assigned identity. Leave unspecified to use a system-assigned identity.
     """
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -31,8 +31,8 @@ if TYPE_CHECKING:
 class ManagedIdentityCredential(object):
     """Authenticates with a managed identity in an App Service, Azure VM or Cloud Shell environment.
 
-    :param str client_id:
-        (optional) client ID of a user-assigned identity. Leave unspecified to use a system-assigned identity.
+    Keyword arguments:
+        - **client_id** (str): ID of a user-assigned identity. Leave unspecified to use a system-assigned identity.
     """
 
     def __new__(cls, *args, **kwargs):
@@ -42,8 +42,8 @@ class ManagedIdentityCredential(object):
 
     # the below methods are never called, because ManagedIdentityCredential can't be instantiated;
     # they exist so tooling gets accurate signatures for Imds- and MsiCredential
-    def __init__(self, client_id=None, **kwargs):
-        # type: (Optional[str], Any) -> None
+    def __init__(self, **kwargs):
+        # type: (**Any) -> None
         pass
 
     def get_token(self, *scopes, **kwargs):  # pylint:disable=unused-argument,no-self-use
@@ -109,8 +109,8 @@ class _ManagedIdentityBase(object):
 class ImdsCredential(_ManagedIdentityBase):
     """Authenticates with a managed identity via the IMDS endpoint.
 
-    :param config: optional configuration for the underlying HTTP pipeline
-    :type config: :class:`azure.core.configuration`
+    Keyword arguments:
+        - **client_id** (str): ID of a user-assigned identity. Leave unspecified to use a system-assigned identity.
     """
 
     def __init__(self, **kwargs):
@@ -161,8 +161,8 @@ class ImdsCredential(_ManagedIdentityBase):
 class MsiCredential(_ManagedIdentityBase):
     """Authenticates via the MSI endpoint in an App Service or Cloud Shell environment.
 
-    :param config: optional configuration for the underlying HTTP pipeline
-    :type config: :class:`azure.core.configuration`
+    Keyword arguments:
+      - **client_id** (str): ID of a user-assigned identity. Leave unspecified to use a system-assigned identity.
     """
 
     def __init__(self, config=None, **kwargs):

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user.py
@@ -40,12 +40,12 @@ class DeviceCodeCredential(PublicClientCredential):
     :param str client_id: the application's ID
 
     Keyword arguments
-        - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
-          authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities` defines
-          authorities for other clouds.
-        - **tenant_id (str)**: an Azure Active Directory tenant ID. Defaults to the 'organizations' tenant, which can
+        - **authority** (str): Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+          the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
+          defines authorities for other clouds.
+        - **tenant_id** (str): an Azure Active Directory tenant ID. Defaults to the 'organizations' tenant, which can
           authenticate work or school accounts. **Required for single-tenant applications.**
-        - **timeout (int)** - seconds to wait for the user to authenticate. Defaults to the validity period of the
+        - **timeout** (int): seconds to wait for the user to authenticate. Defaults to the validity period of the
           device code as set by Azure Active Directory, which also prevails when ``timeout`` is longer.
         - **prompt_callback** (Callable[str, str, datetime.datetime]): A callback enabling control of how authentication
           instructions are presented. Must accept arguments (``verification_uri``, ``user_code``, ``expires_on``):
@@ -118,9 +118,9 @@ class SharedTokenCacheCredential(object):
         may contain tokens for multiple identities.
 
     Keyword arguments
-        - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
-          authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities` defines
-          authorities for other clouds.
+        - **authority** (str): Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+          the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
+          defines authorities for other clouds.
     """
 
     def __init__(self, username, **kwargs):  # pylint:disable=unused-argument
@@ -170,6 +170,10 @@ class SharedTokenCacheCredential(object):
     @staticmethod
     def supported():
         # type: () -> bool
+        """Whether the shared token cache is supported on the current platform.
+
+        :rtype: bool
+        """
         return sys.platform.startswith("win")
 
     @staticmethod
@@ -185,7 +189,8 @@ class UsernamePasswordCredential(PublicClientCredential):
     authentication flows.
 
     Authentication with this credential is not interactive, so it is **not compatible with any form of
-    multi-factor authentication or consent prompting**. The application must already have the user's consent.
+    multi-factor authentication or consent prompting**. The application must already have consent from the user or
+    a directory admin.
 
     This credential can only authenticate work and school accounts; Microsoft accounts are not supported.
     See this document for more information about account types:
@@ -196,12 +201,11 @@ class UsernamePasswordCredential(PublicClientCredential):
     :param str password: the user's password
 
     Keyword arguments
-        - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
-          authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities` defines
-          authorities for other clouds.
-        - **tenant (str)** - tenant ID or a domain associated with a tenant. If not provided, defaults to the
+        - **authority** (str): Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+          the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
+          defines authorities for other clouds.
+        - **tenant_id** (str) - tenant ID or a domain associated with a tenant. If not provided, defaults to the
           'organizations' tenant, which supports only Azure Active Directory work or school accounts.
-
     """
 
     def __init__(self, client_id, username, password, **kwargs):

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user.py
@@ -49,8 +49,8 @@ class DeviceCodeCredential(PublicClientCredential):
         - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
           authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities` defines
           authorities for other clouds.
-        - **tenant (str)** - tenant ID or a domain associated with a tenant. If not provided, defaults to the
-          'organizations' tenant, which supports only Azure Active Directory work or school accounts.
+        - **tenant_id (str)**: an Azure Active Directory tenant ID. Defaults to the 'organizations' tenant, which can
+          authenticate work or school accounts.
         - **timeout (int)** - seconds to wait for the user to authenticate. Defaults to the validity period of the
           device code as set by Azure Active Directory, which also prevails when ``timeout`` is longer.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user.py
@@ -44,7 +44,7 @@ class DeviceCodeCredential(PublicClientCredential):
           authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities` defines
           authorities for other clouds.
         - **tenant_id (str)**: an Azure Active Directory tenant ID. Defaults to the 'organizations' tenant, which can
-          authenticate work or school accounts.
+          authenticate work or school accounts. **Required for single-tenant applications.**
         - **timeout (int)** - seconds to wait for the user to authenticate. Defaults to the validity period of the
           device code as set by Azure Active Directory, which also prevails when ``timeout`` is longer.
         - **prompt_callback** (Callable[str, str, datetime.datetime]): A callback enabling control of how authentication

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user.py
@@ -37,13 +37,6 @@ class DeviceCodeCredential(PublicClientCredential):
     https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-device-code
 
     :param str client_id: the application's ID
-    :param prompt_callback:
-        (optional) A callback enabling control of how authentication instructions are presented.
-        Must accept arguments (``verification_uri``, ``user_code``, ``expires_in``):
-            - ``verification_uri`` (str) the URL the user must visit
-            - ``user_code`` (str) the code the user must enter there
-            - ``expires_in`` (int) the number of seconds the code will be valid
-        If not provided, the credential will print instructions to stdout.
 
     Keyword arguments
         - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
@@ -53,13 +46,18 @@ class DeviceCodeCredential(PublicClientCredential):
           authenticate work or school accounts.
         - **timeout (int)** - seconds to wait for the user to authenticate. Defaults to the validity period of the
           device code as set by Azure Active Directory, which also prevails when ``timeout`` is longer.
-
+        - **prompt_callback** (Callable[str, str, str]): A callback enabling control of how authentication instructions
+          are presented. Must accept arguments (``verification_uri``, ``user_code``, ``expires_in``):
+            - ``verification_uri`` (str) the URL the user must visit
+            - ``user_code`` (str) the code the user must enter there
+            - ``expires_in`` (int) the number of seconds the code will be valid
+          If not provided, the credential will print instructions to stdout.
     """
 
-    def __init__(self, client_id, prompt_callback=None, **kwargs):
-        # type: (str, Optional[Callable[[str, str, str], None]], Any) -> None
+    def __init__(self, client_id, **kwargs):
+        # type: (str, **Any) -> None
         self._timeout = kwargs.pop("timeout", None)  # type: Optional[int]
-        self._prompt_callback = prompt_callback
+        self._prompt_callback = kwargs.pop("prompt_callback", None)
         super(DeviceCodeCredential, self).__init__(client_id=client_id, **kwargs)
 
     @wrap_exceptions

--- a/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
@@ -31,12 +31,12 @@ if TYPE_CHECKING:
 class AadClientBase(ABC):
     """Sans I/O methods for AAD clients wrapping MSAL's OAuth client"""
 
-    def __init__(self, client_id, tenant, **kwargs):
+    def __init__(self, tenant_id, client_id, **kwargs):
         # type: (str, str, **Any) -> None
         authority = kwargs.pop("authority", KnownAuthorities.AZURE_PUBLIC_CLOUD)
         if authority[-1] == "/":
             authority = authority[:-1]
-        token_endpoint = "https://" + "/".join((authority, tenant, "oauth2/v2.0/token"))
+        token_endpoint = "https://" + "/".join((authority, tenant_id, "oauth2/v2.0/token"))
         config = {"token_endpoint": token_endpoint}
 
         self._client = Client(server_configuration=config, client_id=client_id)

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
@@ -36,9 +36,9 @@ class MsalCredential(ABC):
 
     def __init__(self, client_id, client_credential=None, **kwargs):
         # type: (str, Optional[Union[str, Mapping[str, str]]], **Any) -> None
-        tenant = kwargs.pop("tenant", None) or "organizations"
+        tenant_id = kwargs.pop("tenant_id", "organizations")
         authority = kwargs.pop("authority", KnownAuthorities.AZURE_PUBLIC_CLOUD)
-        self._base_url = "https://" + "/".join((authority.strip("/"), tenant.strip("/")))
+        self._base_url = "https://" + "/".join((authority.strip("/"), tenant_id.strip("/")))
         self._client_credential = client_credential
         self._client_id = client_id
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -24,12 +24,12 @@ class AuthorizationCodeCredential(object):
     :param str client_id: the application's client ID
     :param str authorization_code: the authorization code from the user's log-in
     :param str redirect_uri: The application's redirect URI. Must match the URI used to request the authorization code.
-    :param str client_secret: One of the application's client secrets. Required only for web apps and web APIs.
 
     Keyword arguments
         - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
           authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities` defines
           authorities for other clouds.
+        - **client_secret** (str): One of the application's client secrets. Required only for web apps and web APIs.
     """
 
     def __init__(
@@ -38,12 +38,11 @@ class AuthorizationCodeCredential(object):
         client_id: str,
         authorization_code: str,
         redirect_uri: str,
-        client_secret: "Optional[str]" = None,
         **kwargs: "Any"
     ) -> None:
         self._authorization_code = authorization_code  # type: Optional[str]
         self._client_id = client_id
-        self._client_secret = client_secret
+        self._client_secret = kwargs.pop("client_secret", None)
         self._client = kwargs.pop("client", None) or AadClient(tenant_id, client_id, **kwargs)
         self._redirect_uri = redirect_uri
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -20,8 +20,8 @@ class AuthorizationCodeCredential(object):
     See https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow for more information
     about the authentication flow.
 
-    :param str client_id: the application's client ID
     :param str tenant_id: ID of the application's Azure Active Directory tenant. Also called its 'directory' ID.
+    :param str client_id: the application's client ID
     :param str authorization_code: the authorization code from the user's log-in
     :param str redirect_uri: The application's redirect URI. Must match the URI used to request the authorization code.
     :param str client_secret: One of the application's client secrets. Required only for web apps and web APIs.
@@ -34,8 +34,8 @@ class AuthorizationCodeCredential(object):
 
     def __init__(
         self,
-        client_id: str,
         tenant_id: str,
+        client_id: str,
         authorization_code: str,
         redirect_uri: str,
         client_secret: "Optional[str]" = None,
@@ -44,7 +44,7 @@ class AuthorizationCodeCredential(object):
         self._authorization_code = authorization_code  # type: Optional[str]
         self._client_id = client_id
         self._client_secret = client_secret
-        self._client = kwargs.pop("client", None) or AadClient(client_id, tenant_id, **kwargs)
+        self._client = kwargs.pop("client", None) or AadClient(tenant_id, client_id, **kwargs)
         self._redirect_uri = redirect_uri
 
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -26,9 +26,9 @@ class AuthorizationCodeCredential(object):
     :param str redirect_uri: The application's redirect URI. Must match the URI used to request the authorization code.
 
     Keyword arguments
-        - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
-          authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities` defines
-          authorities for other clouds.
+        - **authority** (str): Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+          the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
+          defines authorities for other clouds.
         - **client_secret** (str): One of the application's client secrets. Required only for web apps and web APIs.
     """
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_credential.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_credential.py
@@ -20,9 +20,9 @@ class ClientSecretCredential(ClientSecretCredentialBase):
     :param str client_secret: one of the service principal's client secrets
 
     Keyword arguments
-        - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
-          authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities` defines
-          authorities for other clouds.
+        - **authority** (str): Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+          the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
+          defines authorities for other clouds.
     """
 
     def __init__(self, tenant_id: str, client_id: str, client_secret: str, **kwargs: "Any") -> None:
@@ -49,11 +49,12 @@ class CertificateCredential(CertificateCredentialBase):
     :param str tenant_id: ID of the service principal's tenant. Also called its 'directory' ID.
     :param str client_id: the service principal's client ID
     :param str certificate_path: path to a PEM-encoded certificate file including the private key
+      This file must not be password-protected.
 
     Keyword arguments
-        - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
-          authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities` defines
-          authorities for other clouds.
+        - **authority** (str): Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+          the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
+          defines authorities for other clouds.
     """
 
     def __init__(self, tenant_id: str, client_id: str, certificate_path: str, **kwargs: "Mapping[str, Any]") -> None:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_credential.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_credential.py
@@ -15,9 +15,9 @@ if TYPE_CHECKING:
 class ClientSecretCredential(ClientSecretCredentialBase):
     """Authenticates as a service principal using a client ID and client secret.
 
+    :param str tenant_id: ID of the service principal's tenant. Also called its 'directory' ID.
     :param str client_id: the service principal's client ID
     :param str client_secret: one of the service principal's client secrets
-    :param str tenant_id: ID of the service principal's tenant. Also called its 'directory' ID.
 
     Keyword arguments
         - **authority**: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com', the
@@ -25,8 +25,8 @@ class ClientSecretCredential(ClientSecretCredentialBase):
           authorities for other clouds.
     """
 
-    def __init__(self, client_id: str, client_secret: str, tenant_id: str, **kwargs: "Mapping[str, Any]") -> None:
-        super(ClientSecretCredential, self).__init__(client_id, client_secret, tenant_id, **kwargs)
+    def __init__(self, tenant_id: str, client_id: str, client_secret: str, **kwargs: "Any") -> None:
+        super(ClientSecretCredential, self).__init__(tenant_id, client_id, client_secret, **kwargs)
         self._client = AsyncAuthnClient(tenant=tenant_id, **kwargs)
 
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":  # pylint:disable=unused-argument
@@ -46,8 +46,8 @@ class ClientSecretCredential(ClientSecretCredentialBase):
 class CertificateCredential(CertificateCredentialBase):
     """Authenticates as a service principal using a certificate.
 
-    :param str client_id: the service principal's client ID
     :param str tenant_id: ID of the service principal's tenant. Also called its 'directory' ID.
+    :param str client_id: the service principal's client ID
     :param str certificate_path: path to a PEM-encoded certificate file including the private key
 
     Keyword arguments
@@ -56,8 +56,8 @@ class CertificateCredential(CertificateCredentialBase):
           authorities for other clouds.
     """
 
-    def __init__(self, client_id: str, tenant_id: str, certificate_path: str, **kwargs: "Mapping[str, Any]") -> None:
-        super(CertificateCredential, self).__init__(client_id, tenant_id, certificate_path, **kwargs)
+    def __init__(self, tenant_id: str, client_id: str, certificate_path: str, **kwargs: "Mapping[str, Any]") -> None:
+        super(CertificateCredential, self).__init__(tenant_id, client_id, certificate_path, **kwargs)
         self._client = AsyncAuthnClient(tenant=tenant_id, **kwargs)
 
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":  # pylint:disable=unused-argument

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -21,14 +21,15 @@ class EnvironmentCredential:
     a user with a username and password. Configuration is attempted in this order, using these environment variables:
 
     Service principal with secret:
+      - **AZURE_TENANT_ID**: ID of the service principal's tenant. Also called its 'directory' ID.
       - **AZURE_CLIENT_ID**: the service principal's client ID
       - **AZURE_CLIENT_SECRET**: one of the service principal's client secrets
-      - **AZURE_TENANT_ID**: ID of the service principal's tenant. Also called its 'directory' ID.
 
     Service principal with certificate:
-      - **AZURE_CLIENT_ID**: the service principal's client ID
-      - **AZURE_CLIENT_CERTIFICATE_PATH**: path to a PEM-encoded certificate file including the private key
       - **AZURE_TENANT_ID**: ID of the service principal's tenant. Also called its 'directory' ID.
+      - **AZURE_CLIENT_ID**: the service principal's client ID
+      - **AZURE_CLIENT_CERTIFICATE_PATH**: path to a PEM-encoded certificate file including the private key The
+        certificate must not be password-protected.
     """
 
     def __init__(self, **kwargs: "Any") -> None:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -21,8 +21,8 @@ if TYPE_CHECKING:
 class ManagedIdentityCredential(object):
     """Authenticates with a managed identity in an App Service, Azure VM or Cloud Shell environment.
 
-    :param str client_id:
-        (optional) client ID of a user-assigned identity. Leave unspecified to use a system-assigned identity.
+    Keyword arguments:
+        - **client_id** (str): ID of a user-assigned identity. Leave unspecified to use a system-assigned identity.
     """
 
     def __new__(cls, *args, **kwargs):
@@ -32,7 +32,7 @@ class ManagedIdentityCredential(object):
 
     # the below methods are never called, because ManagedIdentityCredential can't be instantiated;
     # they exist so tooling gets accurate signatures for Imds- and MsiCredential
-    def __init__(self, client_id: "Optional[str]" = None, **kwargs: "Any") -> None:
+    def __init__(self, **kwargs: "Any") -> None:
         pass
 
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":  # pylint:disable=unused-argument
@@ -61,8 +61,8 @@ class _AsyncManagedIdentityBase(_ManagedIdentityBase):
 class ImdsCredential(_AsyncManagedIdentityBase):
     """Asynchronously authenticates with a managed identity via the IMDS endpoint.
 
-    :param config: optional configuration for the underlying HTTP pipeline
-    :type config: :class:`azure.core.configuration`
+    Keyword arguments:
+        - **client_id** (str): ID of a user-assigned identity. Leave unspecified to use a system-assigned identity.
     """
 
     def __init__(self, config: "Optional[Configuration]" = None, **kwargs: "Any") -> None:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -19,9 +19,12 @@ if TYPE_CHECKING:
 
 
 class ManagedIdentityCredential(object):
-    """Authenticates with a managed identity in an App Service, Azure VM or Cloud Shell environment.
+    """Authenticates with an Azure managed identity in any hosting environment which supports managed identities.
 
-    Keyword arguments:
+    See the Azure Active Directory documentation for more information about managed identities:
+    https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
+
+    Keyword arguments
         - **client_id** (str): ID of a user-assigned identity. Leave unspecified to use a system-assigned identity.
     """
 

--- a/sdk/identity/azure-identity/tests/test_aad_client.py
+++ b/sdk/identity/azure-identity/tests/test_aad_client.py
@@ -31,7 +31,7 @@ def test_uses_msal_correctly():
     transport = Mock()
     session.get = session.post = transport
 
-    client = MockClient("client id", "tenant id", session=session)
+    client = MockClient("tenant id", "client id", session=session)
 
     # MSAL will raise on each call because the mock transport returns nothing useful.
     # That's okay because we only want to verify the transport was called, i.e. that
@@ -55,7 +55,7 @@ def test_error_reporting():
     response = Mock(status_code=403, json=lambda: error_response)
     transport = Mock(return_value=response)
     session = Mock(get=transport, post=transport)
-    client = MockClient("client id", "tenant id", session=session)
+    client = MockClient("tenant id", "client id", session=session)
 
     fns = [
         functools.partial(client.obtain_token_by_authorization_code, "code", "uri", "scope"),
@@ -76,7 +76,7 @@ def test_exceptions_do_not_expose_secrets():
     response = Mock(status_code=403, json=lambda: body)
     transport = Mock(return_value=response)
     session = Mock(get=transport, post=transport)
-    client = MockClient("client id", "tenant id", session=session)
+    client = MockClient("tenant id", "client id", session=session)
 
     fns = [
         functools.partial(client.obtain_token_by_authorization_code, "code", "uri", "scope"),
@@ -100,16 +100,16 @@ def test_exceptions_do_not_expose_secrets():
 
 def test_request_url():
     authority = "authority.com"
-    tenant = "expected_tenant"
+    tenant_id = "expected_tenant"
 
     def send(request, **_):
         scheme, netloc, path, _, _, _ = urlparse(request.url)
         assert scheme == "https"
         assert netloc == authority
-        assert path.startswith("/" + tenant)
+        assert path.startswith("/" + tenant_id)
         return mock_response(json_payload={"token_type": "Bearer", "expires_in": 42, "access_token": "***"})
 
-    client = AadClient("client id", tenant, transport=Mock(send=send), authority=authority)
+    client = AadClient(tenant_id, "client id", transport=Mock(send=send), authority=authority)
 
     client.obtain_token_by_authorization_code("code", "uri", "scope")
     client.obtain_token_by_refresh_token("refresh token", "scope")

--- a/sdk/identity/azure-identity/tests/test_aad_client_async.py
+++ b/sdk/identity/azure-identity/tests/test_aad_client_async.py
@@ -25,7 +25,7 @@ async def test_uses_msal_correctly():
     transport = Mock()
     session = Mock(get=transport, post=transport)
 
-    client = MockClient("client id", "tenant id", session=session)
+    client = MockClient("tenant id", "client id", session=session)
 
     # MSAL will raise on each call because the mock transport returns nothing useful.
     # That's okay because we only want to verify the transport was called, i.e. that
@@ -53,7 +53,7 @@ async def test_request_url():
         assert path.startswith("/" + tenant)
         return mock_response(json_payload={"token_type": "Bearer", "expires_in": 42, "access_token": "***"})
 
-    client = AadClient("client id", tenant, transport=Mock(send=send), authority=authority)
+    client = AadClient(tenant, "client id", transport=Mock(send=send), authority=authority)
 
     await client.obtain_token_by_authorization_code("code", "uri", "scope")
     await client.obtain_token_by_refresh_token("refresh token", "scope")

--- a/sdk/identity/azure-identity/tests/test_identity.py
+++ b/sdk/identity/azure-identity/tests/test_identity.py
@@ -48,7 +48,9 @@ def test_client_secret_credential_cache():
     mock_send = Mock(return_value=mock_response(json_payload=token_payload))
     scope = "scope"
 
-    credential = ClientSecretCredential("client_id", "secret", tenant_id="some-guid", transport=Mock(send=mock_send))
+    credential = ClientSecretCredential(
+        tenant_id="some-guid", client_id="client_id", client_secret="secret", transport=Mock(send=mock_send)
+    )
 
     # get_token initially returns the expired token because the credential
     # doesn't check whether tokens it receives from the service have expired
@@ -86,9 +88,7 @@ def test_client_secret_credential():
         ],
     )
 
-    token = ClientSecretCredential(
-        client_id=client_id, client_secret=secret, tenant_id=tenant_id, transport=transport
-    ).get_token("scope")
+    token = ClientSecretCredential(tenant_id, client_id, secret, transport=transport).get_token("scope")
 
     # not validating expires_on because doing so requires monkeypatching time, and this is tested elsewhere
     assert token.token == access_token

--- a/sdk/identity/azure-identity/tests/test_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_identity_async.py
@@ -43,7 +43,7 @@ async def test_client_secret_credential_cache():
     transport = Mock(send=asyncio.coroutine(mock_send))
     scope = "scope"
 
-    credential = ClientSecretCredential("client_id", "secret", tenant_id="some-guid", transport=transport)
+    credential = ClientSecretCredential("tenant-id", "client-id", "secret", transport=transport)
 
     # get_token initially returns the expired token because the credential
     # doesn't check whether tokens it receives from the service have expired
@@ -83,7 +83,7 @@ async def test_client_secret_credential():
     )
 
     token = await ClientSecretCredential(
-        client_id=client_id, client_secret=secret, tenant_id=tenant_id, transport=transport
+        tenant_id=tenant_id, client_id=client_id, client_secret=secret, transport=transport
     ).get_token("scope")
 
     # not validating expires_on because doing so requires monkeypatching time, and this is tested elsewhere
@@ -255,10 +255,7 @@ async def test_managed_identity_app_service():
         exception.message = success_message
         raise exception
 
-    environment = {
-        EnvironmentVariables.MSI_SECRET: msi_secret,
-        EnvironmentVariables.MSI_ENDPOINT: "https://foo.bar",
-    }
+    environment = {EnvironmentVariables.MSI_SECRET: msi_secret, EnvironmentVariables.MSI_ENDPOINT: "https://foo.bar"}
     with pytest.raises(Exception) as ex:
         with patch("os.environ", environment):
             await ManagedIdentityCredential(transport=Mock(send=validate_request)).get_token("https://scope")
@@ -321,7 +318,7 @@ async def test_default_credential_shared_cache_use():
         # supported platform, $AZURE_USERNAME set, $AZURE_PASSWORD not set -> default credential should use shared cache
         with patch.dict("os.environ", {"AZURE_USERNAME": "foo@bar.com"}):
             expected_token = AccessToken("***", 42)
-            mock_credential.return_value=Mock(get_token=asyncio.coroutine(lambda *_: expected_token))
+            mock_credential.return_value = Mock(get_token=asyncio.coroutine(lambda *_: expected_token))
 
             credential = DefaultAzureCredential()
             assert mock_credential.call_count == 1

--- a/sdk/identity/azure-identity/tests/test_live.py
+++ b/sdk/identity/azure-identity/tests/test_live.py
@@ -45,7 +45,7 @@ def test_confidential_client_credential(live_identity_settings):
         client_id=live_identity_settings["client_id"],
         client_credential=live_identity_settings["client_secret"],
         authority=KnownAuthorities.AZURE_PUBLIC_CLOUD,
-        tenant=live_identity_settings["tenant_id"],
+        tenant_id=live_identity_settings["tenant_id"],
     )
     token = credential.get_token(ARM_SCOPE)
     assert token

--- a/sdk/identity/azure-identity/tests/test_live.py
+++ b/sdk/identity/azure-identity/tests/test_live.py
@@ -10,8 +10,8 @@ ARM_SCOPE = "https://management.azure.com/.default"
 
 def test_certificate_credential(live_certificate_settings):
     credential = CertificateCredential(
-        live_certificate_settings["client_id"],
         live_certificate_settings["tenant_id"],
+        live_certificate_settings["client_id"],
         live_certificate_settings["cert_path"],
     )
     token = credential.get_token(ARM_SCOPE)
@@ -22,9 +22,9 @@ def test_certificate_credential(live_certificate_settings):
 
 def test_client_secret_credential(live_identity_settings):
     credential = ClientSecretCredential(
+        live_identity_settings["tenant_id"],
         live_identity_settings["client_id"],
         live_identity_settings["client_secret"],
-        live_identity_settings["tenant_id"],
     )
     token = credential.get_token(ARM_SCOPE)
     assert token

--- a/sdk/identity/azure-identity/tests/test_live_async.py
+++ b/sdk/identity/azure-identity/tests/test_live_async.py
@@ -18,8 +18,8 @@ ARM_SCOPE = "https://management.azure.com/.default"
 @pytest.mark.asyncio
 async def test_certificate_credential(live_certificate_settings):
     credential = CertificateCredential(
-        live_certificate_settings["client_id"],
         live_certificate_settings["tenant_id"],
+        live_certificate_settings["client_id"],
         live_certificate_settings["cert_path"],
     )
     token = await credential.get_token(ARM_SCOPE)
@@ -31,9 +31,9 @@ async def test_certificate_credential(live_certificate_settings):
 @pytest.mark.asyncio
 async def test_client_secret_credential(live_identity_settings):
     credential = ClientSecretCredential(
+        live_identity_settings["tenant_id"],
         live_identity_settings["client_id"],
         live_identity_settings["client_secret"],
-        live_identity_settings["tenant_id"],
     )
     token = await credential.get_token(ARM_SCOPE)
     assert token

--- a/sdk/storage/azure-storage-blob/tests/test_blob_samples_authentication.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_samples_authentication.py
@@ -89,9 +89,9 @@ class TestAuthSamples(StorageTestCase):
         # Get a token credential for authentication
         from azure.identity import ClientSecretCredential
         token_credential = ClientSecretCredential(
+            self.active_directory_tenant_id,
             self.active_directory_application_id,
-            self.active_directory_application_secret,
-            self.active_directory_tenant_id
+            self.active_directory_application_secret
         )
 
         # Instantiate a BlobServiceClient using a token credential

--- a/sdk/storage/azure-storage-blob/tests/test_blob_samples_authentication_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_samples_authentication_async.py
@@ -106,11 +106,8 @@ class TestAuthSamplesAsync(StorageTestCase):
         # [START create_blob_service_client_oauth]
         # Get a token credential for authentication
         from azure.identity.aio import ClientSecretCredential
-        token_credential = ClientSecretCredential(
-            self.active_directory_application_id,
-            self.active_directory_application_secret,
-            self.active_directory_tenant_id
-        )
+        token_credential = ClientSecretCredential(self.active_directory_tenant_id, self.active_directory_application_id,
+                                                  self.active_directory_application_secret)
 
         # Instantiate a BlobServiceClient using a token credential
         from azure.storage.blob.aio import BlobServiceClient

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -196,11 +196,9 @@ class StorageCommonBlobTestAsync(StorageTestCase):
     def _generate_oauth_token(self):
         from azure.identity.aio import ClientSecretCredential
 
-        return ClientSecretCredential(
-            self.settings.ACTIVE_DIRECTORY_APPLICATION_ID,
-            self.settings.ACTIVE_DIRECTORY_APPLICATION_SECRET,
-            self.settings.ACTIVE_DIRECTORY_TENANT_ID
-        )
+        return ClientSecretCredential(self.settings.ACTIVE_DIRECTORY_TENANT_ID,
+                                      self.settings.ACTIVE_DIRECTORY_APPLICATION_ID,
+                                      self.settings.ACTIVE_DIRECTORY_APPLICATION_SECRET)
 
     @record
     def test_blob_exists(self):

--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -81,9 +81,9 @@ class StorageContainerTest(StorageTestCase):
     def _generate_oauth_token(self):
 
         return ClientSecretCredential(
+            self.settings.ACTIVE_DIRECTORY_TENANT_ID,
             self.settings.ACTIVE_DIRECTORY_APPLICATION_ID,
-            self.settings.ACTIVE_DIRECTORY_APPLICATION_SECRET,
-            self.settings.ACTIVE_DIRECTORY_TENANT_ID
+            self.settings.ACTIVE_DIRECTORY_APPLICATION_SECRET
         )
 
     #--Test cases for containers -----------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/testcase.py
+++ b/sdk/storage/azure-storage-blob/tests/testcase.py
@@ -421,9 +421,9 @@ class StorageTestCase(unittest.TestCase):
         from azure.identity import ClientSecretCredential
 
         return ClientSecretCredential(
+            self.settings.ACTIVE_DIRECTORY_TENANT_ID,
             self.settings.ACTIVE_DIRECTORY_APPLICATION_ID,
-            self.settings.ACTIVE_DIRECTORY_APPLICATION_SECRET,
-            self.settings.ACTIVE_DIRECTORY_TENANT_ID
+            self.settings.ACTIVE_DIRECTORY_APPLICATION_SECRET
         )
 
     def generate_fake_token(self):

--- a/sdk/storage/azure-storage-file/tests/filetestcase.py
+++ b/sdk/storage/azure-storage-file/tests/filetestcase.py
@@ -409,9 +409,9 @@ class FileTestCase(unittest.TestCase):
             from azure.identity import ClientSecretCredential
 
             return ClientSecretCredential(
+                self.settings.ACTIVE_DIRECTORY_TENANT_ID,
                 self.settings.ACTIVE_DIRECTORY_APPLICATION_ID,
-                self.settings.ACTIVE_DIRECTORY_APPLICATION_SECRET,
-                self.settings.ACTIVE_DIRECTORY_TENANT_ID
+                self.settings.ACTIVE_DIRECTORY_APPLICATION_SECRET
             )
         except ImportError:
             return FakeTokenCredential('initial token')

--- a/sdk/storage/azure-storage-queue/tests/queuetestcase.py
+++ b/sdk/storage/azure-storage-queue/tests/queuetestcase.py
@@ -48,7 +48,7 @@ class FakeTokenCredential(object):
 class QueueTestCase(AzureMgmtTestCase):
     def connection_string(self, account, key):
         return "DefaultEndpointsProtocol=https;AccountName=" + account.name + ";AccountKey=" + str(key) + ";EndpointSuffix=core.windows.net"
-    
+
     def _account_url (self, name):
         return 'https://{}.queue.core.windows.net'.format(name)
 
@@ -163,9 +163,9 @@ class QueueTestCase(AzureMgmtTestCase):
         from azure.identity import ClientSecretCredential
 
         return ClientSecretCredential(
+            self.settings.ACTIVE_DIRECTORY_TENANT_ID,
             self.settings.ACTIVE_DIRECTORY_APPLICATION_ID,
-            self.settings.ACTIVE_DIRECTORY_APPLICATION_SECRET,
-            self.settings.ACTIVE_DIRECTORY_TENANT_ID
+            self.settings.ACTIVE_DIRECTORY_APPLICATION_SECRET
         )
 
     def generate_fake_token(self):

--- a/sdk/storage/azure-storage-queue/tests/test_queue_samples_authentication.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_samples_authentication.py
@@ -26,7 +26,7 @@ class TestQueueAuthSamples(QueueTestCase):
     active_directory_application_secret = settings.ACTIVE_DIRECTORY_APPLICATION_SECRET
     active_directory_tenant_id = settings.ACTIVE_DIRECTORY_TENANT_ID
 
-    @ResourceGroupPreparer()          
+    @ResourceGroupPreparer()
     @StorageAccountPreparer(name_prefix='pyacrstorage')
     def test_auth_connection_string(self, resource_group, location, storage_account, storage_account_key):
         # Instantiate a QueueServiceClient using a connection string
@@ -40,7 +40,7 @@ class TestQueueAuthSamples(QueueTestCase):
 
         assert properties is not None
 
-    @ResourceGroupPreparer()          
+    @ResourceGroupPreparer()
     @StorageAccountPreparer(name_prefix='pyacrstorage')
     def test_auth_shared_key(self, resource_group, location, storage_account, storage_account_key):
 
@@ -54,7 +54,7 @@ class TestQueueAuthSamples(QueueTestCase):
 
         assert properties is not None
 
-    @ResourceGroupPreparer()          
+    @ResourceGroupPreparer()
     @StorageAccountPreparer(name_prefix='pyacrstorage')
     def test_auth_active_directory(self, resource_group, location, storage_account, storage_account_key):
         if not self.is_live:
@@ -64,9 +64,9 @@ class TestQueueAuthSamples(QueueTestCase):
         # Get a token credential for authentication
         from azure.identity import ClientSecretCredential
         token_credential = ClientSecretCredential(
+            self.active_directory_tenant_id,
             self.active_directory_application_id,
-            self.active_directory_application_secret,
-            self.active_directory_tenant_id
+            self.active_directory_application_secret
         )
 
         # Instantiate a QueueServiceClient using a token credential
@@ -79,7 +79,7 @@ class TestQueueAuthSamples(QueueTestCase):
 
         assert properties is not None
 
-    @ResourceGroupPreparer()          
+    @ResourceGroupPreparer()
     @StorageAccountPreparer(name_prefix='pyacrstorage')
     def test_auth_shared_access_signature(self, resource_group, location, storage_account, storage_account_key):
         # SAS URL is calculated from storage key, so this test runs live only

--- a/sdk/storage/azure-storage-queue/tests/test_queue_samples_authentication_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_samples_authentication_async.py
@@ -61,11 +61,8 @@ class TestQueueAuthSamplesAsync(AsyncQueueTestCase):
         # [START async_create_queue_service_client_token]
         # Get a token credential for authentication
         from azure.identity import ClientSecretCredential
-        token_credential = ClientSecretCredential(
-            self.active_directory_application_id,
-            self.active_directory_application_secret,
-            self.active_directory_tenant_id
-        )
+        token_credential = ClientSecretCredential(self.active_directory_tenant_id, self.active_directory_application_id,
+                                                  self.active_directory_application_secret)
 
         # Instantiate a QueueServiceClient using a token credential
         from azure.storage.queue.aio import QueueServiceClient


### PR DESCRIPTION
- [x] consistently place `tenant_id` before `client_id` in signatures (closes #7951)
- [x] move optional `tenant_id` and `client_id` into kwargs
- [x] hide `azure.core.Configuration` usage (closes #7959)

Also proofread the docstrings while I was at it (closes #7828).