### PR TITLE
Storage Samples

### DIFF
--- a/sdk/storage/azure-storage-blob/samples/client_side_encryption.py
+++ b/sdk/storage/azure-storage-blob/samples/client_side_encryption.py
@@ -1,0 +1,271 @@
+# coding: utf-8
+
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+"""
+FILE: client_side_encryption.py
+
+DESCRIPTION:
+    This example contains sample code for the KeyWrapper and KeyResolver classes
+    needed to use Storage client side encryption, as well as code that illustrates
+    key usage patterns for client side encryption features.
+
+USAGE: python client_side_encryption.py
+"""
+
+import uuid
+from os import urandom
+
+from azure.common import AzureException
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric.padding import (
+    OAEP,
+    MGF1,
+)
+from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
+from cryptography.hazmat.primitives.hashes import SHA1
+from cryptography.hazmat.primitives.keywrap import (
+    aes_key_wrap,
+    aes_key_unwrap,
+)
+
+from azure.storage.blob import BlobServiceClient, BlobType, download_blob_from_url
+
+
+# Sample implementations of the encryption-related interfaces.
+class KeyWrapper:
+    def __init__(self, kid):
+        self.kek = urandom(32)
+        self.backend = default_backend()
+        self.kid = 'local:' + kid
+
+    def wrap_key(self, key, algorithm='A256KW'):
+        if algorithm == 'A256KW':
+            return aes_key_wrap(self.kek, key, self.backend)
+        raise ValueError('Unknown key wrap algorithm.')
+
+    def unwrap_key(self, key, algorithm):
+        if algorithm == 'A256KW':
+            return aes_key_unwrap(self.kek, key, self.backend)
+        raise ValueError('Unknown key wrap algorithm.')
+
+    def get_key_wrap_algorithm(self):
+        return 'A256KW'
+
+    def get_kid(self):
+        return self.kid
+
+
+class KeyResolver:
+    def __init__(self):
+        self.keys = {}
+
+    def put_key(self, key):
+        self.keys[key.get_kid()] = key
+
+    def resolve_key(self, kid):
+        return self.keys[kid]
+
+
+class RSAKeyWrapper:
+    def __init__(self, kid):
+        self.private_key = generate_private_key(public_exponent=65537,
+                                                key_size=2048,
+                                                backend=default_backend())
+        self.public_key = self.private_key.public_key()
+        self.kid = 'local:' + kid
+
+    def wrap_key(self, key, algorithm='RSA'):
+        if algorithm == 'RSA':
+            return self.public_key.encrypt(key,
+                                           OAEP(
+                                               mgf=MGF1(algorithm=SHA1()),
+                                               algorithm=SHA1(),
+                                               label=None)
+                                           )
+        raise ValueError('Unknown key wrap algorithm.')
+
+    def unwrap_key(self, key, algorithm):
+        if algorithm == 'RSA':
+            return self.private_key.decrypt(key,
+                                            OAEP(
+                                                mgf=MGF1(algorithm=SHA1()),
+                                                algorithm=SHA1(),
+                                                label=None)
+                                            )
+        raise ValueError('Unknown key wrap algorithm.')
+
+    def get_key_wrap_algorithm(self):
+        return 'RSA'
+
+    def get_kid(self):
+        return self.kid
+
+
+class BlobEncryptionSamples():
+    def __init__(self, account):
+        self.account = account
+
+    def run_all_samples(self):
+        self.put_encrypted_blob()
+        self.get_encrypted_blob()
+        self.get_encrypted_blob_key_encryption_key()
+        self.require_encryption()
+        self.alternate_key_algorithms()
+
+    def _get_resource_reference(self, prefix):
+        return '{}{}'.format(prefix, str(uuid.uuid4()).replace('-', ''))
+
+    def _get_blob_reference(self, prefix='blob'):
+        return self._get_resource_reference(prefix)
+
+    def _create_container(self, prefix='container'):
+        container_name = self._get_resource_reference(prefix)
+        self.container_client = self.account.get_container_client(container_name)
+        self.container_client.create_container()
+        return container_name
+
+    def put_encrypted_blob(self):
+        self._create_container()
+        try:
+            block_blob_name = self._get_blob_reference(prefix='block_blob_')
+            page_blob_name = self._get_blob_reference(prefix='page_blob_')
+
+            # KeyWrapper implements the key encryption key interface. Setting
+            # this property will tell the service to encrypt the blob. Blob encryption
+            # is supported only for uploading whole blobs and only at the time of creation.
+            kek = KeyWrapper('key1')
+            self.container_client.key_resolver_function = kek
+
+            self.container_client.upload_blob(block_blob_name, u'ABC', )
+            self.container_client.upload_blob(page_blob_name, b'ABC.' * 128, blob_type=BlobType.PageBlob)
+
+            # Even when encrypting, uploading large blobs will still automatically 
+            # chunk the data and parallelize the upload with max_connections
+            # defaulting to 2.
+            max_single_put_size = self.account._config.max_single_put_size
+            self.container_client.upload_blob(block_blob_name, b'ABC' * max_single_put_size, overwrite=True)
+        finally:
+            self.container_client.delete_container()
+
+    def get_encrypted_blob(self):
+        self._create_container()
+        try:
+            block_blob_name = self._get_blob_reference(prefix='block_blob')
+
+            kek = KeyWrapper('key1')
+            self.container_client.key_encryption_key = kek
+            data = urandom(13 * self.account._config.max_single_put_size + 1)
+
+            self.container_client.upload_blob(block_blob_name, data)
+
+            # Setting the key_resolver_function will tell the service to automatically
+            # try to decrypt retrieved blobs. The key_resolver is a function that
+            # takes in a key_id and returns a corresponding key_encryption_key.
+            key_resolver = KeyResolver()
+            key_resolver.put_key(kek)
+            self.container_client.key_resolver_function = key_resolver.resolve_key
+            
+            # Downloading works as usual with support for decrypting both entire blobs
+            # and decrypting range gets.
+            block_blob_client = self.container_client.get_blob_client(block_blob_name)
+            blob_full = block_blob_client.download_blob()
+            blob_range = block_blob_client.download_blob(offset=len(data) // 2,
+                                                         length=len(data) // 4)
+        finally:
+            self.container_client.delete_container()
+
+    def get_encrypted_blob_key_encryption_key(self):
+        self._create_container()
+        try:
+            block_blob_name = self._get_blob_reference(prefix='block_blob')
+            data = b'ABC'
+            kek = KeyWrapper('key1')
+            self.container_client.key_encryption_key = kek
+            self.container_client.upload_blob(block_blob_name, data)
+
+            # If the key_encryption_key property is set on download, the blobservice
+            # will try to decrypt blobs using that key. If both the key_resolver and 
+            # key_encryption_key are set, the result of the key_resolver will take precedence
+            # and the decryption will fail if that key is not successful.
+            self.container_client.key_resolver_function = None
+            blob = self.container_client.get_blob_client(block_blob_name).download_blob()
+        finally:
+            self.container_client.delete_container()
+
+    def require_encryption(self):
+        self._create_container()
+        try:
+            encrypted_blob_name = self._get_blob_reference(prefix='block_blob_')
+            unencrypted_blob_name = self._get_blob_reference(prefix='unencrypted_blob_')
+            data = b'ABC'
+            self.container_client.key_encryption_key = None
+            self.container_client.key_resolver_function = None
+            self.container_client.require_encryption = False
+
+            self.container_client.upload_blob(unencrypted_blob_name, data)
+
+            # If the require_encryption flag is set, the service object will throw if 
+            # there is no encryption policy set on upload.
+            self.container_client.require_encryption = True
+            try:
+                self.container_client.upload_blob(encrypted_blob_name, data)
+                raise Exception
+            except ValueError:
+                pass
+
+            # If the require_encryption flag is set, the service object will throw if
+            # there is no encryption policy set on download.
+            kek = KeyWrapper('key1')
+            key_resolver = KeyResolver()
+            key_resolver.put_key(kek)
+
+            self.container_client.key_encryption_key = kek
+            self.container_client.upload_blob(encrypted_blob_name, data)
+
+            self.container_client.key_encryption_key = None
+            try:
+                self.container_client.get_blob_client(encrypted_blob_name).download_blob()
+                raise Exception
+            except ValueError:
+                pass
+
+            # If the require_encryption flag is set, but the retrieved blob is not
+            # encrypted, the service object will throw.
+            self.container_client.key_resolver_function = key_resolver.resolve_key
+            try:
+                self.container_client.get_blob_client(unencrypted_blob_name).download_blob()
+                raise Exception
+            except ValueError:
+                pass
+        finally:
+            self.container_client.delete_container()
+
+    def alternate_key_algorithms(self):
+        self._create_container()
+        try:
+            block_blob_name = self._get_blob_reference(prefix='block_blob')
+
+            # The key wrapping algorithm used by the key_encryption_key 
+            # is entirely up to the choice of the user. For example,
+            # RSA may be used.
+            kek = RSAKeyWrapper('key2')
+            key_resolver = KeyResolver()
+            key_resolver.put_key(kek)
+            self.container_client.key_encryption_key = kek
+            self.container_client.key_resolver_function = key_resolver.resolve_key
+
+            self.container_client.upload_blob(block_blob_name, b'ABC')
+            blob = self.container_client.get_blob_client(block_blob_name).download_blob()
+        finally:
+            self.container_client.delete_container()
+
+# TODO: Fill in your connection string
+CONNECTION_STRING = ''
+account = BlobServiceClient.from_connection_string(CONNECTION_STRING)
+samples = BlobEncryptionSamples(account)
+samples.run_all_samples()

--- a/sdk/storage/azure-storage-blob/samples/client_side_encryption.py
+++ b/sdk/storage/azure-storage-blob/samples/client_side_encryption.py
@@ -12,13 +12,16 @@ FILE: client_side_encryption.py
 DESCRIPTION:
     This example contains sample code for the KeyWrapper and KeyResolver classes
     needed to use Storage client side encryption, as well as code that illustrates
-    key usage patterns for client side encryption features.
+    key usage patterns for client side encryption features. This sample expects that
+    the `AZURE_STORAGE_CONNECTION_STRING` environment variable is set. It SHOULD NOT
+    be hardcoded in any code derived from this sample.
 
 USAGE: python client_side_encryption.py
 """
 
+import os
+import sys
 import uuid
-from os import urandom
 
 from azure.common import AzureException
 from cryptography.hazmat.backends import default_backend
@@ -39,7 +42,7 @@ from azure.storage.blob import BlobServiceClient, BlobType, download_blob_from_u
 # Sample implementations of the encryption-related interfaces.
 class KeyWrapper:
     def __init__(self, kid):
-        self.kek = urandom(32)
+        self.kek = os.urandom(32)
         self.backend = default_backend()
         self.kid = 'local:' + kid
 
@@ -159,7 +162,7 @@ class BlobEncryptionSamples():
 
             kek = KeyWrapper('key1')
             self.container_client.key_encryption_key = kek
-            data = urandom(13 * self.account._config.max_single_put_size + 1)
+            data = os.urandom(13 * self.account._config.max_single_put_size + 1)
 
             self.container_client.upload_blob(block_blob_name, data)
 
@@ -264,8 +267,11 @@ class BlobEncryptionSamples():
         finally:
             self.container_client.delete_container()
 
-# TODO: Fill in your connection string
-CONNECTION_STRING = ''
+try:
+    CONNECTION_STRING = os.environ['AZURE_STORAGE_CONNECTION_STRING']
+except KeyError:
+    print("AZURE_STORAGE_CONNECTION_STRING must be set.")
+    sys.exit(1)
 account = BlobServiceClient.from_connection_string(CONNECTION_STRING)
 samples = BlobEncryptionSamples(account)
 samples.run_all_samples()

--- a/sdk/storage/azure-storage-blob/samples/walk_blob_hierarchy.py
+++ b/sdk/storage/azure-storage-blob/samples/walk_blob_hierarchy.py
@@ -12,7 +12,9 @@ FILE: walk_blob_hierarchy.py
 DESCRIPTION:
     This example walks the containers and blobs within a storage account,
     displaying them in a hierarchical structure and, when present, showing
-    the number of snapshots that are available per blob.
+    the number of snapshots that are available per blob. This sample expects
+    that the `AZURE_STORAGE_CONNECTION_STRING` environment variable is set.
+    It SHOULD NOT be hardcoded in any code derived from this sample.
 
 USAGE: python walk_blob_hierarchy.py
 
@@ -34,11 +36,16 @@ C: container3
 C: container4
 """
 
+import os
+import sys
 
 from azure.storage.blob import BlobServiceClient, BlobPrefix
 
-# TODO: Fill in your connection string
-CONNECTION_STRING = '' 
+try:
+    CONNECTION_STRING = os.environ['AZURE_STORAGE_CONNECTION_STRING']
+except KeyError:
+    print("AZURE_STORAGE_CONNECTION_STRING must be set.")
+    sys.exit(1)
 
 def walk_container(client, container):
     container_client = client.get_container_client(container.name)
@@ -68,10 +75,10 @@ def walk_container(client, container):
     walk_blob_hierarchy()
 
 try:
-
     service_client = BlobServiceClient.from_connection_string(CONNECTION_STRING)
     containers = service_client.list_containers()
     for container in containers:
         walk_container(service_client, container)
 except Exception as error:
     print(error)
+    sys.exit(1)

--- a/sdk/storage/azure-storage-blob/samples/walk_blob_hierarchy.py
+++ b/sdk/storage/azure-storage-blob/samples/walk_blob_hierarchy.py
@@ -1,0 +1,77 @@
+# coding: utf-8
+
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+"""
+FILE: walk_blob_hierarchy.py
+
+DESCRIPTION:
+    This example walks the containers and blobs within a storage account,
+    displaying them in a hierarchical structure and, when present, showing
+    the number of snapshots that are available per blob.
+
+USAGE: python walk_blob_hierarchy.py
+
+EXAMPLE OUTPUT:
+
+C: container1
+F:    folder1/
+F:       subfolder1/
+B:          test.rtf
+B:       test.rtf
+F:    folder2/
+B:       test.rtf
+B:    test.rtf (1 snapshots)
+B:    test2.rtf
+C: container2
+B:    demovid.mp4
+B:    mountain.jpg
+C: container3
+C: container4
+"""
+
+
+from azure.storage.blob import BlobServiceClient, BlobPrefix
+
+# TODO: Fill in your connection string
+CONNECTION_STRING = '' 
+
+def walk_container(client, container):
+    container_client = client.get_container_client(container.name)
+    print('C: {}'.format(container.name))
+    depth = 1
+    separator = '   '
+
+    def walk_blob_hierarchy(prefix=""):
+        nonlocal depth
+        # if I try to include=['snapshots'] here, I get an error that delimiter and snapshots are mutually exclusive
+        for item in container_client.walk_blobs(name_starts_with=prefix):
+            short_name = item.name[len(prefix):]
+            if isinstance(item, BlobPrefix):
+                print('F: ' + separator * depth + short_name)
+                depth += 1
+                walk_blob_hierarchy(prefix=item.name)
+                depth -= 1
+            else:
+                message = 'B: ' + separator * depth + short_name
+                # because delimiter and snapshots are mutually exclusive, the only way for me to check for the presence
+                # of snapshots is to re-query for each blob. This is very inefficient.
+                results = list(container_client.list_blobs(name_starts_with=item.name, include=['snapshots']))
+                num_snapshots = len(results) - 1
+                if num_snapshots:
+                    message += " ({} snapshots)".format(num_snapshots)
+                print(message)
+    walk_blob_hierarchy()
+
+try:
+
+    service_client = BlobServiceClient.from_connection_string(CONNECTION_STRING)
+    containers = service_client.list_containers()
+    for container in containers:
+        walk_container(service_client, container)
+except Exception as error:
+    print(error)

--- a/sdk/storage/azure-storage-blob/samples/walk_blob_hierarchy_async.py
+++ b/sdk/storage/azure-storage-blob/samples/walk_blob_hierarchy_async.py
@@ -1,0 +1,84 @@
+# coding: utf-8
+
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+"""
+FILE: walk_blob_hierarchy_async.py
+
+DESCRIPTION:
+    This example walks the containers and blobs within a storage account,
+    displaying them in a hierarchical structure and, when present, showing
+    the number of snapshots that are available per blob.
+
+USAGE: python walk_blob_hierarchy_async.py
+
+EXAMPLE OUTPUT:
+
+C: container1
+F:    folder1/
+F:       subfolder1/
+B:          test.rtf
+B:       test.rtf
+F:    folder2/
+B:       test.rtf
+B:    test.rtf (1 snapshots)
+B:    test2.rtf
+C: container2
+B:    demovid.mp4
+B:    mountain.jpg
+C: container3
+C: container4
+"""
+
+import asyncio
+
+from azure.storage.blob.aio import BlobServiceClient
+from azure.storage.blob.aio.models import BlobPrefix
+
+# TODO: Fill in your connection string
+CONNECTION_STRING = ''
+
+async def walk_container(client, container):
+    container_client = client.get_container_client(container.name)
+    print('C: {}'.format(container.name))
+    depth = 1
+    separator = '   '
+
+    async def walk_blob_hierarchy(prefix=""):
+        nonlocal depth
+        # if I try to include=['snapshots'] here, I get an error that delimiter and snapshots are mutually exclusive
+        async for item in container_client.walk_blobs(name_starts_with=prefix):
+            short_name = item.name[len(prefix):]
+            if isinstance(item, BlobPrefix):
+                print('F: ' + separator * depth + short_name)
+                depth += 1
+                await walk_blob_hierarchy(prefix=item.name)
+                depth -= 1
+            else:
+                message = 'B: ' + separator * depth + short_name
+                # because delimiter and snapshots are mutually exclusive, the only way for me to check for the presence
+                # of snapshots is to re-query for each blob. This is very inefficient.
+                snapshots = []
+                async for snapshot in container_client.list_blobs(name_starts_with=item.name, include=['snapshots']):
+                    snapshots.append(snapshot)
+                num_snapshots = len(snapshots) - 1
+                if num_snapshots:
+                    message += " ({} snapshots)".format(num_snapshots)
+                print(message)
+    await walk_blob_hierarchy()
+
+async def main():
+    try:
+        async with BlobServiceClient.from_connection_string(CONNECTION_STRING) as service_client:
+            containers = service_client.list_containers()
+            async for container in containers:
+                await walk_container(service_client, container)
+    except Exception as error:
+        print(error)
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/sdk/storage/azure-storage-blob/samples/walk_blob_hierarchy_async.py
+++ b/sdk/storage/azure-storage-blob/samples/walk_blob_hierarchy_async.py
@@ -12,7 +12,9 @@ FILE: walk_blob_hierarchy_async.py
 DESCRIPTION:
     This example walks the containers and blobs within a storage account,
     displaying them in a hierarchical structure and, when present, showing
-    the number of snapshots that are available per blob.
+    the number of snapshots that are available per blob. This sample expects
+    that the `AZURE_STORAGE_CONNECTION_STRING` environment variable is set.
+    It SHOULD NOT be hardcoded in any code derived from this sample.
 
 USAGE: python walk_blob_hierarchy_async.py
 
@@ -35,12 +37,17 @@ C: container4
 """
 
 import asyncio
+import os
+import sys
 
 from azure.storage.blob.aio import BlobServiceClient
 from azure.storage.blob.aio.models import BlobPrefix
 
-# TODO: Fill in your connection string
-CONNECTION_STRING = ''
+try:
+    CONNECTION_STRING = os.environ['AZURE_STORAGE_CONNECTION_STRING']
+except KeyError:
+    print("AZURE_STORAGE_CONNECTION_STRING must be set.")
+    sys.exit(1)
 
 async def walk_container(client, container):
     container_client = client.get_container_client(container.name)
@@ -79,6 +86,7 @@ async def main():
                 await walk_container(service_client, container)
     except Exception as error:
         print(error)
+        sys.exit(1)
 
 loop = asyncio.get_event_loop()
 loop.run_until_complete(main())


### PR DESCRIPTION
- **Sync and async sample for walking the blobs in a storage account**. The Java sample this is based on also lists the available snapshots, so I attempted to do this. However, since I cannot pass `include=['snapshots]` to the `walk_blobs` method (it says that delimiter and include are mutually exclusive) I'm forced to do a list call per blob, which is quite ugly.

- **Client-side encryption with local KEK**. Adapted from https://github.com/Azure/azure-storage-python/blob/master/samples/blob/encryption_usage.py 