### PR TITLE
Use HttpLoggingPolicy

### DIFF
--- a/eng/tox/import_all.py
+++ b/eng/tox/import_all.py
@@ -18,6 +18,7 @@ logging.getLogger().setLevel(logging.INFO)
 excluded_packages = [
     "azure.core.tracing.opencensus", 
     "azure.eventhub.checkpointstoreblob.aio",
+    "azure.identity",
     "azure.keyvault.certificates", # Github issue 7879
     "azure.keyvault.keys", # Github issue 7879
     "azure.keyvault.secrets", # Github issue 7879

--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -190,7 +190,7 @@ class AuthnClient(AuthnClientBase):
             ContentDecodePolicy(),
             config.retry_policy,
             config.logging_policy,
-            DistributedTracingPolicy(),
+            DistributedTracingPolicy(**kwargs),
             HttpLoggingPolicy(**kwargs),
         ]
         if not transport:

--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -14,6 +14,7 @@ from azure.core.exceptions import ClientAuthenticationError
 from azure.core.pipeline import Pipeline
 from azure.core.pipeline.policies import (
     ContentDecodePolicy,
+    HttpLoggingPolicy,
     NetworkTraceLoggingPolicy,
     ProxyPolicy,
     RetryPolicy,
@@ -190,6 +191,7 @@ class AuthnClient(AuthnClientBase):
             config.retry_policy,
             config.logging_policy,
             DistributedTracingPolicy(),
+            HttpLoggingPolicy(**kwargs),
         ]
         if not transport:
             transport = RequestsTransport(**kwargs)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -70,7 +70,7 @@ class _ManagedIdentityBase(object):
             config.headers_policy,
             config.retry_policy,
             config.logging_policy,
-            DistributedTracingPolicy(),
+            DistributedTracingPolicy(**kwargs),
             HttpLoggingPolicy(**kwargs),
         ]
         self._client = client_cls(endpoint=endpoint, config=config, policies=policies, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -11,6 +11,7 @@ from azure.core.pipeline.policies import (
     ContentDecodePolicy,
     DistributedTracingPolicy,
     HeadersPolicy,
+    HttpLoggingPolicy,
     NetworkTraceLoggingPolicy,
     RetryPolicy,
 )
@@ -70,6 +71,7 @@ class _ManagedIdentityBase(object):
             config.retry_policy,
             config.logging_policy,
             DistributedTracingPolicy(),
+            HttpLoggingPolicy(**kwargs),
         ]
         self._client = client_cls(endpoint=endpoint, config=config, policies=policies, **kwargs)
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
@@ -88,7 +88,7 @@ class MsalTransportAdapter(object):
             ContentDecodePolicy(),
             config.retry_policy,
             config.logging_policy,
-            DistributedTracingPolicy(),
+            DistributedTracingPolicy(**kwargs),
             HttpLoggingPolicy(**kwargs),
         ]
         if not transport:

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
@@ -12,6 +12,7 @@ from azure.core.pipeline import Pipeline
 from azure.core.pipeline.policies import (
     ContentDecodePolicy,
     DistributedTracingPolicy,
+    HttpLoggingPolicy,
     NetworkTraceLoggingPolicy,
     ProxyPolicy,
     RetryPolicy,
@@ -88,6 +89,7 @@ class MsalTransportAdapter(object):
             config.retry_policy,
             config.logging_policy,
             DistributedTracingPolicy(),
+            HttpLoggingPolicy(**kwargs),
         ]
         if not transport:
             transport = RequestsTransport(**kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
@@ -14,6 +14,7 @@ from azure.core.pipeline.policies import (
     AsyncRetryPolicy,
     ContentDecodePolicy,
     DistributedTracingPolicy,
+    HttpLoggingPolicy,
     NetworkTraceLoggingPolicy,
     ProxyPolicy,
 )
@@ -44,6 +45,7 @@ class AsyncAuthnClient(AuthnClientBase):  # pylint:disable=async-client-bad-name
             config.retry_policy,
             config.logging_policy,
             DistributedTracingPolicy(),
+            HttpLoggingPolicy(**kwargs),
         ]
         if not transport:
             transport = AioHttpTransport(**kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
@@ -44,7 +44,7 @@ class AsyncAuthnClient(AuthnClientBase):  # pylint:disable=async-client-bad-name
             ContentDecodePolicy(),
             config.retry_policy,
             config.logging_policy,
-            DistributedTracingPolicy(),
+            DistributedTracingPolicy(**kwargs),
             HttpLoggingPolicy(**kwargs),
         ]
         if not transport:

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/msal_transport_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/msal_transport_adapter.py
@@ -42,7 +42,7 @@ class MsalTransportAdapter:
         policies = policies or [
             config.retry_policy,
             config.logging_policy,
-            DistributedTracingPolicy(),
+            DistributedTracingPolicy(**kwargs),
             HttpLoggingPolicy(**kwargs),
         ]
         self._transport = transport or AioHttpTransport(configuration=config)

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/msal_transport_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/msal_transport_adapter.py
@@ -10,7 +10,12 @@ from typing import TYPE_CHECKING
 
 from azure.core.configuration import Configuration
 from azure.core.pipeline import AsyncPipeline
-from azure.core.pipeline.policies import AsyncRetryPolicy, DistributedTracingPolicy, NetworkTraceLoggingPolicy
+from azure.core.pipeline.policies import (
+    AsyncRetryPolicy,
+    DistributedTracingPolicy,
+    HttpLoggingPolicy,
+    NetworkTraceLoggingPolicy,
+)
 from azure.core.pipeline.transport import AioHttpTransport, HttpRequest
 
 from azure.identity._internal import MsalTransportResponse
@@ -34,7 +39,12 @@ class MsalTransportAdapter:
     ) -> None:
 
         config = config or self._create_config(**kwargs)
-        policies = policies or [config.retry_policy, config.logging_policy, DistributedTracingPolicy()]
+        policies = policies or [
+            config.retry_policy,
+            config.logging_policy,
+            DistributedTracingPolicy(),
+            HttpLoggingPolicy(**kwargs),
+        ]
         self._transport = transport or AioHttpTransport(configuration=config)
         atexit.register(self._close_transport_session)  # prevent aiohttp warnings
         self._pipeline = AsyncPipeline(transport=self._transport, policies=policies)

--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -70,7 +70,7 @@ setup(
         ]
     ),
     install_requires=[
-        "azure-core<2.0.0,>=1.0.0b2",
+        "azure-core<2.0.0,>=1.0.0b5",
         "cryptography>=2.1.4",
         "msal~=0.4.1",
         "msal-extensions~=0.1.1",

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
@@ -81,7 +81,7 @@ class AsyncKeyVaultClientBase:
     @staticmethod
     def _build_pipeline(config: Configuration, transport: AsyncHttpTransport, **kwargs: "**Any") -> AsyncPipeline:
         logging_policy = HttpLoggingPolicy(**kwargs)
-        logging_policy.allowed_header_namers.add("x-ms-keyvault-network-info")
+        logging_policy.allowed_header_names.add("x-ms-keyvault-network-info")
         policies = [
             config.headers_policy,
             config.user_agent_policy,

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
@@ -80,6 +80,8 @@ class AsyncKeyVaultClientBase:
 
     @staticmethod
     def _build_pipeline(config: Configuration, transport: AsyncHttpTransport, **kwargs: "**Any") -> AsyncPipeline:
+        logging_policy = HttpLoggingPolicy(**kwargs)
+        logging_policy.allowed_header_namers.add("x-ms-keyvault-network-info")
         policies = [
             config.headers_policy,
             config.user_agent_policy,
@@ -89,7 +91,7 @@ class AsyncKeyVaultClientBase:
             config.authentication_policy,
             config.logging_policy,
             DistributedTracingPolicy(**kwargs),
-            HttpLoggingPolicy(**kwargs),
+            logging_policy,
         ]
 
         if transport is None:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
@@ -6,7 +6,7 @@ from typing import Any, TYPE_CHECKING
 
 from azure.core.configuration import Configuration
 from azure.core.pipeline import AsyncPipeline
-from azure.core.pipeline.policies import UserAgentPolicy, DistributedTracingPolicy
+from azure.core.pipeline.policies import UserAgentPolicy, DistributedTracingPolicy, HttpLoggingPolicy
 from azure.core.pipeline.transport import AsyncHttpTransport
 
 from ._generated import KeyVaultClient
@@ -89,6 +89,7 @@ class AsyncKeyVaultClientBase:
             config.authentication_policy,
             config.logging_policy,
             DistributedTracingPolicy(),
+            HttpLoggingPolicy(**kwargs),
         ]
 
         if transport is None:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
@@ -88,7 +88,7 @@ class AsyncKeyVaultClientBase:
             config.retry_policy,
             config.authentication_policy,
             config.logging_policy,
-            DistributedTracingPolicy(),
+            DistributedTracingPolicy(**kwargs),
             HttpLoggingPolicy(**kwargs),
         ]
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
@@ -5,7 +5,7 @@
 from typing import TYPE_CHECKING
 
 from azure.core.pipeline import Pipeline
-from azure.core.pipeline.policies import UserAgentPolicy, DistributedTracingPolicy
+from azure.core.pipeline.policies import UserAgentPolicy, DistributedTracingPolicy, HttpLoggingPolicy
 from azure.core.pipeline.transport import RequestsTransport
 from ._generated import KeyVaultClient
 from .challenge_auth_policy import ChallengeAuthPolicy
@@ -89,6 +89,7 @@ class KeyVaultClientBase(object):
             config.authentication_policy,
             config.logging_policy,
             DistributedTracingPolicy(),
+            HttpLoggingPolicy(**kwargs),
         ]
 
         if transport is None:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
@@ -81,7 +81,7 @@ class KeyVaultClientBase(object):
     def _build_pipeline(self, config, transport, **kwargs):
         # type: (Configuration, HttpTransport, **Any) -> Pipeline
         logging_policy = HttpLoggingPolicy(**kwargs)
-        logging_policy.allowed_header_namers.add("x-ms-keyvault-network-info")
+        logging_policy.allowed_header_names.add("x-ms-keyvault-network-info")
         policies = [
             config.headers_policy,
             config.user_agent_policy,

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
@@ -88,7 +88,7 @@ class KeyVaultClientBase(object):
             config.retry_policy,
             config.authentication_policy,
             config.logging_policy,
-            DistributedTracingPolicy(),
+            DistributedTracingPolicy(**kwargs),
             HttpLoggingPolicy(**kwargs),
         ]
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
@@ -80,6 +80,8 @@ class KeyVaultClientBase(object):
     # pylint:disable=no-self-use
     def _build_pipeline(self, config, transport, **kwargs):
         # type: (Configuration, HttpTransport, **Any) -> Pipeline
+        logging_policy = HttpLoggingPolicy(**kwargs)
+        logging_policy.allowed_header_namers.add("x-ms-keyvault-network-info")
         policies = [
             config.headers_policy,
             config.user_agent_policy,
@@ -89,7 +91,7 @@ class KeyVaultClientBase(object):
             config.authentication_policy,
             config.logging_policy,
             DistributedTracingPolicy(**kwargs),
-            HttpLoggingPolicy(**kwargs),
+            logging_policy,
         ]
 
         if transport is None:

--- a/sdk/keyvault/azure-keyvault-certificates/setup.py
+++ b/sdk/keyvault/azure-keyvault-certificates/setup.py
@@ -78,7 +78,7 @@ setup(
             "azure.keyvault",
         ]
     ),
-    install_requires=["azure-core<2.0.0,>=1.0.0b2", "azure-common~=1.1", "msrest>=0.5.0"],
+    install_requires=["azure-core<2.0.0,>=1.0.0b5", "azure-common~=1.1", "msrest>=0.5.0"],
     extras_require={
         ":python_version<'3.0'": ["azure-keyvault-nspkg"],
         ":python_version<'3.4'": ["enum34>=1.0.4"],

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
@@ -81,7 +81,7 @@ class AsyncKeyVaultClientBase:
     @staticmethod
     def _build_pipeline(config: Configuration, transport: AsyncHttpTransport, **kwargs: "**Any") -> AsyncPipeline:
         logging_policy = HttpLoggingPolicy(**kwargs)
-        logging_policy.allowed_header_namers.add("x-ms-keyvault-network-info")
+        logging_policy.allowed_header_names.add("x-ms-keyvault-network-info")
         policies = [
             config.headers_policy,
             config.user_agent_policy,

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
@@ -80,6 +80,8 @@ class AsyncKeyVaultClientBase:
 
     @staticmethod
     def _build_pipeline(config: Configuration, transport: AsyncHttpTransport, **kwargs: "**Any") -> AsyncPipeline:
+        logging_policy = HttpLoggingPolicy(**kwargs)
+        logging_policy.allowed_header_namers.add("x-ms-keyvault-network-info")
         policies = [
             config.headers_policy,
             config.user_agent_policy,
@@ -89,7 +91,7 @@ class AsyncKeyVaultClientBase:
             config.authentication_policy,
             config.logging_policy,
             DistributedTracingPolicy(**kwargs),
-            HttpLoggingPolicy(**kwargs),
+            logging_policy,
         ]
 
         if transport is None:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
@@ -6,7 +6,7 @@ from typing import Any, TYPE_CHECKING
 
 from azure.core.configuration import Configuration
 from azure.core.pipeline import AsyncPipeline
-from azure.core.pipeline.policies import UserAgentPolicy, DistributedTracingPolicy
+from azure.core.pipeline.policies import UserAgentPolicy, DistributedTracingPolicy, HttpLoggingPolicy
 from azure.core.pipeline.transport import AsyncHttpTransport
 
 from ._generated import KeyVaultClient
@@ -89,6 +89,7 @@ class AsyncKeyVaultClientBase:
             config.authentication_policy,
             config.logging_policy,
             DistributedTracingPolicy(),
+            HttpLoggingPolicy(**kwargs),
         ]
 
         if transport is None:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
@@ -88,7 +88,7 @@ class AsyncKeyVaultClientBase:
             config.retry_policy,
             config.authentication_policy,
             config.logging_policy,
-            DistributedTracingPolicy(),
+            DistributedTracingPolicy(**kwargs),
             HttpLoggingPolicy(**kwargs),
         ]
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
@@ -82,7 +82,7 @@ class KeyVaultClientBase(object):
     def _build_pipeline(self, config, transport, **kwargs):
         # type: (Configuration, HttpTransport, **Any) -> Pipeline
         logging_policy = HttpLoggingPolicy(**kwargs)
-        logging_policy.allowed_header_namers.add("x-ms-keyvault-network-info")
+        logging_policy.allowed_header_names.add("x-ms-keyvault-network-info")
         policies = [
             config.headers_policy,
             config.user_agent_policy,

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
@@ -89,7 +89,7 @@ class KeyVaultClientBase(object):
             config.retry_policy,
             config.authentication_policy,
             config.logging_policy,
-            DistributedTracingPolicy(),
+            DistributedTracingPolicy(**kwargs),
             HttpLoggingPolicy(**kwargs),
         ]
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
@@ -81,6 +81,8 @@ class KeyVaultClientBase(object):
     # pylint:disable=no-self-use
     def _build_pipeline(self, config, transport, **kwargs):
         # type: (Configuration, HttpTransport, **Any) -> Pipeline
+        logging_policy = HttpLoggingPolicy(**kwargs)
+        logging_policy.allowed_header_namers.add("x-ms-keyvault-network-info")
         policies = [
             config.headers_policy,
             config.user_agent_policy,
@@ -90,7 +92,7 @@ class KeyVaultClientBase(object):
             config.authentication_policy,
             config.logging_policy,
             DistributedTracingPolicy(**kwargs),
-            HttpLoggingPolicy(**kwargs),
+            logging_policy,
         ]
 
         if transport is None:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from azure.core.configuration import Configuration
 from azure.core.pipeline import Pipeline
-from azure.core.pipeline.policies import UserAgentPolicy, DistributedTracingPolicy
+from azure.core.pipeline.policies import UserAgentPolicy, DistributedTracingPolicy, HttpLoggingPolicy
 from azure.core.pipeline.transport import RequestsTransport
 from ._generated import KeyVaultClient
 from .challenge_auth_policy import ChallengeAuthPolicy
@@ -90,6 +90,7 @@ class KeyVaultClientBase(object):
             config.authentication_policy,
             config.logging_policy,
             DistributedTracingPolicy(),
+            HttpLoggingPolicy(**kwargs),
         ]
 
         if transport is None:

--- a/sdk/keyvault/azure-keyvault-keys/setup.py
+++ b/sdk/keyvault/azure-keyvault-keys/setup.py
@@ -78,7 +78,7 @@ setup(
             "azure.keyvault",
         ]
     ),
-    install_requires=["azure-core<2.0.0,>=1.0.0b2", "azure-common~=1.1", "cryptography>=2.1.4", "msrest>=0.5.0"],
+    install_requires=["azure-core<2.0.0,>=1.0.0b5", "azure-common~=1.1", "cryptography>=2.1.4", "msrest>=0.5.0"],
     extras_require={
         ":python_version<'3.0'": ["azure-keyvault-nspkg"],
         ":python_version<'3.4'": ["enum34>=1.0.4"],

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
@@ -81,7 +81,7 @@ class AsyncKeyVaultClientBase:
     @staticmethod
     def _build_pipeline(config: Configuration, transport: AsyncHttpTransport, **kwargs: "**Any") -> AsyncPipeline:
         logging_policy = HttpLoggingPolicy(**kwargs)
-        logging_policy.allowed_header_namers.add("x-ms-keyvault-network-info")
+        logging_policy.allowed_header_names.add("x-ms-keyvault-network-info")
         policies = [
             config.headers_policy,
             config.user_agent_policy,

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
@@ -80,6 +80,8 @@ class AsyncKeyVaultClientBase:
 
     @staticmethod
     def _build_pipeline(config: Configuration, transport: AsyncHttpTransport, **kwargs: "**Any") -> AsyncPipeline:
+        logging_policy = HttpLoggingPolicy(**kwargs)
+        logging_policy.allowed_header_namers.add("x-ms-keyvault-network-info")
         policies = [
             config.headers_policy,
             config.user_agent_policy,
@@ -89,7 +91,7 @@ class AsyncKeyVaultClientBase:
             config.authentication_policy,
             config.logging_policy,
             DistributedTracingPolicy(**kwargs),
-            HttpLoggingPolicy(**kwargs),
+            logging_policy,
         ]
 
         if transport is None:

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
@@ -6,7 +6,7 @@ from typing import Any, TYPE_CHECKING
 
 from azure.core.configuration import Configuration
 from azure.core.pipeline import AsyncPipeline
-from azure.core.pipeline.policies import UserAgentPolicy, DistributedTracingPolicy
+from azure.core.pipeline.policies import UserAgentPolicy, DistributedTracingPolicy, HttpLoggingPolicy
 from azure.core.pipeline.transport import AsyncHttpTransport
 
 from ._generated import KeyVaultClient
@@ -89,6 +89,7 @@ class AsyncKeyVaultClientBase:
             config.authentication_policy,
             config.logging_policy,
             DistributedTracingPolicy(),
+            HttpLoggingPolicy(**kwargs),
         ]
 
         if transport is None:

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
@@ -88,7 +88,7 @@ class AsyncKeyVaultClientBase:
             config.retry_policy,
             config.authentication_policy,
             config.logging_policy,
-            DistributedTracingPolicy(),
+            DistributedTracingPolicy(**kwargs),
             HttpLoggingPolicy(**kwargs),
         ]
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
@@ -82,7 +82,7 @@ class KeyVaultClientBase(object):
     def _build_pipeline(self, config, transport, **kwargs):
         # type: (Configuration, HttpTransport, **Any) -> Pipeline
         logging_policy = HttpLoggingPolicy(**kwargs)
-        logging_policy.allowed_header_namers.add("x-ms-keyvault-network-info")
+        logging_policy.allowed_header_names.add("x-ms-keyvault-network-info")
         policies = [
             config.headers_policy,
             config.user_agent_policy,

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
@@ -89,7 +89,7 @@ class KeyVaultClientBase(object):
             config.retry_policy,
             config.authentication_policy,
             config.logging_policy,
-            DistributedTracingPolicy(),
+            DistributedTracingPolicy(**kwargs),
             HttpLoggingPolicy(**kwargs),
         ]
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
@@ -81,6 +81,8 @@ class KeyVaultClientBase(object):
     # pylint:disable=no-self-use
     def _build_pipeline(self, config, transport, **kwargs):
         # type: (Configuration, HttpTransport, **Any) -> Pipeline
+        logging_policy = HttpLoggingPolicy(**kwargs)
+        logging_policy.allowed_header_namers.add("x-ms-keyvault-network-info")
         policies = [
             config.headers_policy,
             config.user_agent_policy,
@@ -90,7 +92,7 @@ class KeyVaultClientBase(object):
             config.authentication_policy,
             config.logging_policy,
             DistributedTracingPolicy(**kwargs),
-            HttpLoggingPolicy(**kwargs),
+            logging_policy,
         ]
 
         if transport is None:

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from azure.core.configuration import Configuration
 from azure.core.pipeline import Pipeline
-from azure.core.pipeline.policies import UserAgentPolicy, DistributedTracingPolicy
+from azure.core.pipeline.policies import UserAgentPolicy, DistributedTracingPolicy, HttpLoggingPolicy
 from azure.core.pipeline.transport import RequestsTransport
 from ._generated import KeyVaultClient
 from .challenge_auth_policy import ChallengeAuthPolicy
@@ -90,6 +90,7 @@ class KeyVaultClientBase(object):
             config.authentication_policy,
             config.logging_policy,
             DistributedTracingPolicy(),
+            HttpLoggingPolicy(**kwargs),
         ]
 
         if transport is None:

--- a/sdk/keyvault/azure-keyvault-secrets/setup.py
+++ b/sdk/keyvault/azure-keyvault-secrets/setup.py
@@ -78,7 +78,7 @@ setup(
             "azure.keyvault",
         ]
     ),
-    install_requires=["azure-core<2.0.0,>=1.0.0b2", "azure-common~=1.1", "msrest>=0.5.0"],
+    install_requires=["azure-core<2.0.0,>=1.0.0b5", "azure-common~=1.1", "msrest>=0.5.0"],
     extras_require={
         ":python_version<'3.0'": ["azure-keyvault-nspkg"],
         ":python_version<'3.4'": ["enum34>=1.0.4"],

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -6,7 +6,7 @@ azure-cognitiveservices-language-nspkg
 azure-cognitiveservices-search-nspkg
 azure-cognitiveservices-vision-nspkg
 azure-common~=1.1
-azure-core<2.0.0,>=1.0.0b4
+azure-core<2.0.0,>=1.0.0b5
 azure-cosmosdb-table~=1.0
 azure-datalake-store~=0.0.18
 azure-eventhub<6.0.0,>=5.0.0b3
@@ -114,10 +114,6 @@ opencensus>=0.6.0
 opencensus-ext-threading
 opencensus-ext-azure>=0.3.1
 #override azure-cognitiveservices-inkrecognizer azure-core<2.0.0,>=1.0.0b2
-#override azure-identity azure-core<2.0.0,>=1.0.0b2
-#override azure-keyvault-certificates azure-core<2.0.0,>=1.0.0b2
-#override azure-keyvault-keys azure-core<2.0.0,>=1.0.0b2
-#override azure-keyvault-secrets azure-core<2.0.0,>=1.0.0b2
 #override azure-eventhub-checkpointstoreblob-aio azure-storage-blob<=12.0.0b4,>=12.0.0b2
 #override azure-eventhub-checkpointstoreblob-aio aiohttp<4.0,>=3.0
 #override azure-eventhub uamqp<2.0,>=1.2.3


### PR DESCRIPTION
Adds `HttpLoggingPolicy` to pipelines throughout azure-identity and azure-keyvault-*. I also noticed the tracing policy takes kwargs now, so I pass them now.