### PR TITLE
Fix batch add tasks failure message

### DIFF
--- a/sdk/batch/azure-batch/azure/batch/custom/custom_errors.py
+++ b/sdk/batch/azure-batch/azure/batch/custom/custom_errors.py
@@ -38,7 +38,5 @@ class CreateTasksErrorException(Exception):
                 result = failure_tasks[0]
                 self.message = \
                     "Task with id `%s` failed due to client error - %s::%s" % \
-                    result.task_id,\
-                    result.error.code,\
-                    result.error.message
+                    (result.task_id, result.error.code, result.error.message)
         super(CreateTasksErrorException, self).__init__(self.message)


### PR DESCRIPTION
Fix string formatting when only one task fails in a batch operation. 

Stack Trace:
```python 
TypeError: not enough arguments for format string
  File "/task-clean-timeline-azure/app/tasks/list_camera_assets.py", line 48, in main
    asyncio.run(remove_from_azure(list_parameters))
  File "asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "uvloop/loop.pyx", line 1451, in uvloop.loop.Loop.run_until_complete
  File "/task-clean-timeline-azure/app/tasks/list_camera_assets.py", line 86, in remove_from_azure
    await save_batch_delete_tasks(loop, batch_tasks)
  File "concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/task-clean-timeline-azure/app/tasks/list_camera_assets.py", line 153, in <lambda>
    job_id=AZ_BATCH_ACCOUNT_REMOVE_JOB_ID, value=batch_tasks
  File "/usr/local/lib/python3.7/site-packages/azure/batch/custom/patch.py", line 282, in bulk_add_collection
    task_workflow_manager.errors)
  File "/usr/local/lib/python3.7/site-packages/azure/batch/custom/custom_errors.py", line 41, in __init__
    result.task_id,\
```