### PR TITLE
disabling the import_all check. no dev feeds means that this feature …

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -94,7 +94,7 @@ jobs:
         CoverageArg: $(CoverageArg)
         PythonVersion: $(PythonVersion)
         BuildTargetingString: ${{ parameters.BuildTargetingString }}
-        ToxTestEnv: 'whl,sdist,depends'
+        ToxTestEnv: 'whl,sdist'
         BeforeTestSteps: 
           - task: DownloadPipelineArtifact@0
             inputs:


### PR DESCRIPTION
…technically can't work correctly. will re-enable with another source for the packages