### PR TITLE
Do not require AZURE_USERNAME for shared cache

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -216,7 +216,7 @@ class AuthnClient(AuthnClientBase):
         token = self._deserialize_and_cache_token(response=response, scopes=scopes, request_time=request_time)
         return token
 
-    def obtain_token_by_refresh_token(self, scopes, username):
+    def obtain_token_by_refresh_token(self, scopes, username=None):
         # type: (Iterable[str], Optional[str]) -> AccessToken
         """Acquire an access token using a cached refresh token. Raises ClientAuthenticationError if that fails.
         This is only used by SharedTokenCacheCredential and isn't robust enough for anything else."""

--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 import abc
 import calendar
+import os
 import time
 
 from msal import TokenCache
@@ -98,6 +99,7 @@ class AuthnClientBase(ABC):
 
     @abc.abstractmethod
     def obtain_token_by_refresh_token(self, scopes, username):
+        # type: (Iterable[str], Optional[str]) -> AccessToken
         pass
 
     def _deserialize_and_cache_token(self, response, scopes, request_time):
@@ -215,12 +217,27 @@ class AuthnClient(AuthnClientBase):
         return token
 
     def obtain_token_by_refresh_token(self, scopes, username):
-        # type: (Iterable[str], str) -> Optional[AccessToken]
-        """Acquire an access token using a cached refresh token. Returns ``None`` when that fails, or the cache has no
-        refresh token. This is only used by SharedTokenCacheCredential and isn't robust enough for anything else."""
+        # type: (Iterable[str], Optional[str]) -> AccessToken
+        """Acquire an access token using a cached refresh token. Raises ClientAuthenticationError if that fails.
+        This is only used by SharedTokenCacheCredential and isn't robust enough for anything else."""
 
-        # find account matching username
-        accounts = self._cache.find(TokenCache.CredentialType.ACCOUNT, query={"username": username})
+        # if an username is provided, restrict our search to accounts that have that username
+        query = {"username": username} if username else {}
+        accounts = self._cache.find(TokenCache.CredentialType.ACCOUNT, query=query)
+
+        # if more than one account was returned, ensure that that they all have the same home_account_id. If so,
+        # we'll treat them as equal, otherwise we can't know which one to pick, so we'll raise an error.
+        if len(accounts) > 1 and any(
+            account.get("home_account_id") != accounts[0].get("home_account_id") for account in accounts):
+            message = ("Multiple accounts were discovered in the shared token cache. To fix, set the AZURE_USERNAME "
+                       "environment variable to the preferred username, or specify it when constructing "
+                       "SharedTokenCacheCredential.  {}"
+                       "Discoverd accounts: {}").format(os.linesep, ', '.join({u.get("username") for u in accounts}))
+            if username:
+                message = ("Multiple entries found for the user account '{}' were found in the shared token cache. "
+                           "This is not currently supported by SharedTokenCacheCredential").format(username)
+            raise ClientAuthenticationError(message=message)
+
         for account in accounts:
             # try each refresh token that might work, return the first access token acquired
             for token in self.get_refresh_tokens(scopes, account):
@@ -240,7 +257,11 @@ class AuthnClient(AuthnClientBase):
                 except ClientAuthenticationError:
                     continue
 
-        return None
+        message = "No cached token found"
+        if username:
+            message += " for '{}'".format(username)
+
+        raise ClientAuthenticationError(message=message)
 
     @staticmethod
     def _create_config(**kwargs):

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -20,9 +20,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
     1. A service principal configured by environment variables. See :class:`~azure.identity.EnvironmentCredential` for
        more details.
     2. An Azure managed identity. See :class:`~azure.identity.ManagedIdentityCredential` for more details.
-    3. On Windows only: a user who has signed in with a Microsoft application, such as Visual Studio. This requires a
-       value for the environment variable ``AZURE_USERNAME``. See :class:`~azure.identity.SharedTokenCacheCredential`
-       for more details.
+    3. On Windows only: a user who has signed in with a Microsoft application, such as Visual Studio. If multiple
+       identities are in the cache, then the value of  the environment variable ``AZURE_USERNAME`` is used to select
+       which identity to use. See :class:`~azure.identity.SharedTokenCacheCredential` for more details.
 
     Keyword arguments
         - **authority** (str): Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
@@ -34,15 +34,8 @@ class DefaultAzureCredential(ChainedTokenCredential):
         authority = kwargs.pop("authority", None)
         credentials = [EnvironmentCredential(authority=authority, **kwargs), ManagedIdentityCredential(**kwargs)]
 
-        # SharedTokenCacheCredential is part of the default only on supported platforms, when $AZURE_USERNAME has a
-        # value (because the cache may contain tokens for multiple identities and we can only choose one arbitrarily
-        # without more information from the user), and when $AZURE_PASSWORD has no value (because when $AZURE_USERNAME
-        # and $AZURE_PASSWORD are set, EnvironmentCredential will be used instead)
-        if (
-            SharedTokenCacheCredential.supported()
-            and EnvironmentVariables.AZURE_USERNAME in os.environ
-            and EnvironmentVariables.AZURE_PASSWORD not in os.environ
-        ):
+        # SharedTokenCacheCredential is part of the default only on supported platforms.
+        if SharedTokenCacheCredential.supported():
             credentials.append(
                 SharedTokenCacheCredential(
                     username=os.environ.get(EnvironmentVariables.AZURE_USERNAME), authority=authority, **kwargs

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user.py
@@ -123,8 +123,8 @@ class SharedTokenCacheCredential(object):
           defines authorities for other clouds.
     """
 
-    def __init__(self, username, **kwargs):  # pylint:disable=unused-argument
-        # type: (str, **Any) -> None
+    def __init__(self, username=None, **kwargs):  # pylint:disable=unused-argument
+        # type: (Optional[str], **Any) -> None
 
         self._username = username
 
@@ -161,11 +161,7 @@ class SharedTokenCacheCredential(object):
         if not self._client:
             raise ClientAuthenticationError(message="Shared token cache unavailable")
 
-        token = self._client.obtain_token_by_refresh_token(scopes, self._username)
-        if not token:
-            raise ClientAuthenticationError(message="No cached token found for '{}'".format(self._username))
-
-        return token
+        return self._client.obtain_token_by_refresh_token(scopes, self._username)
 
     @staticmethod
     def supported():

--- a/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
@@ -68,7 +68,9 @@ class AsyncAuthnClient(AuthnClientBase):  # pylint:disable=async-client-bad-name
         token = self._deserialize_and_cache_token(response=response, scopes=scopes, request_time=request_time)
         return token
 
-    async def obtain_token_by_refresh_token(self, scopes: "Iterable[str]", username: "Optional[str]") -> "AccessToken":
+    async def obtain_token_by_refresh_token(
+        self, scopes: "Iterable[str]", username: "Optional[str]" = None
+    ) -> "AccessToken":
         """Acquire an access token using a cached refresh token. Raises ClientAuthenticationError if that fails.
         This is only used by SharedTokenCacheCredential and isn't robust enough for anything else."""
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -20,9 +20,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
     1. A service principal configured by environment variables. See :class:`~azure.identity.aio.EnvironmentCredential`
        for more details.
     2. An Azure managed identity. See :class:`~azure.identity.aio.ManagedIdentityCredential` for more details.
-    3. On Windows only: a user who has signed in with a Microsoft application, such as Visual Studio. This requires a
-       value for the environment variable ``AZURE_USERNAME``. See
-       :class:`~azure.identity.aio.SharedTokenCacheCredential` for more details.
+    3. On Windows only: a user who has signed in with a Microsoft application, such as Visual Studio. If multiple
+       identities are in the cache, then the value of  the environment variable ``AZURE_USERNAME`` is used to select
+       which identity to use. See :class:`~azure.identity.aio.SharedTokenCacheCredential` for more details.
 
     Keyword arguments
         - **authority** (str): Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
@@ -34,15 +34,8 @@ class DefaultAzureCredential(ChainedTokenCredential):
         authority = kwargs.pop("authority", None)
         credentials = [EnvironmentCredential(authority=authority, **kwargs), ManagedIdentityCredential(**kwargs)]
 
-        # SharedTokenCacheCredential is part of the default only on supported platforms, when $AZURE_USERNAME has a
-        # value (because the cache may contain tokens for multiple identities and we can only choose one arbitrarily
-        # without more information from the user), and when $AZURE_PASSWORD has no value (because when $AZURE_USERNAME
-        # and $AZURE_PASSWORD are set, EnvironmentCredential will be used instead)
-        if (
-            SharedTokenCacheCredential.supported()
-            and EnvironmentVariables.AZURE_USERNAME in os.environ
-            and EnvironmentVariables.AZURE_PASSWORD not in os.environ
-        ):
+        # SharedTokenCacheCredential is part of the default only on supported platforms.
+        if SharedTokenCacheCredential.supported():
             credentials.append(
                 SharedTokenCacheCredential(
                     username=os.environ.get(EnvironmentVariables.AZURE_USERNAME), authority=authority, **kwargs

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/user.py
@@ -45,11 +45,7 @@ class SharedTokenCacheCredential(SyncSharedTokenCacheCredential):
         if not self._client:
             raise ClientAuthenticationError(message="Shared token cache unavailable")
 
-        token = await self._client.obtain_token_by_refresh_token(scopes, self._username)
-        if not token:
-            raise ClientAuthenticationError(message="No cached token found for '{}'".format(self._username))
-
-        return token
+        return await self._client.obtain_token_by_refresh_token(scopes, self._username)
 
     @staticmethod
     def _get_auth_client(cache: "msal_extensions.FileTokenCache") -> "AuthnClientBase":

--- a/sdk/identity/azure-identity/tests/test_identity.py
+++ b/sdk/identity/azure-identity/tests/test_identity.py
@@ -247,36 +247,13 @@ def test_default_credential_shared_cache_use(mock_credential):
     assert mock_credential.supported.call_count == 1
     mock_credential.supported.reset_mock()
 
-    # unsupported platform, $AZURE_USERNAME set, $AZURE_PASSWORD not set -> default credential shouldn't use shared cache
-    credential = DefaultAzureCredential()
-    assert mock_credential.call_count == 0
-    assert mock_credential.supported.call_count == 1
-
     mock_credential.supported = Mock(return_value=True)
 
-    # supported platform, $AZURE_USERNAME not set -> default credential shouldn't use shared cache
+    # supported platform -> default credential should use shared cache
     credential = DefaultAzureCredential()
-    assert mock_credential.call_count == 0
+    assert mock_credential.call_count == 1
     assert mock_credential.supported.call_count == 1
     mock_credential.supported.reset_mock()
-
-    # supported platform, $AZURE_USERNAME and $AZURE_PASSWORD set -> default credential shouldn't use shared cache
-    # (EnvironmentCredential should be used when both variables are set)
-    with patch.dict("os.environ", {"AZURE_USERNAME": "foo@bar.com", "AZURE_PASSWORD": "***"}):
-        credential = DefaultAzureCredential()
-        assert mock_credential.call_count == 0
-
-    # supported platform, $AZURE_USERNAME set, $AZURE_PASSWORD not set -> default credential should use shared cache
-    with patch.dict("os.environ", {"AZURE_USERNAME": "foo@bar.com"}):
-        expected_token = AccessToken("***", 42)
-        mock_credential.return_value = Mock(get_token=lambda *_: expected_token)
-
-        credential = DefaultAzureCredential()
-        assert mock_credential.call_count == 1
-
-        token = credential.get_token("scope")
-        assert token == expected_token
-
 
 def test_device_code_credential():
     expected_token = "access-token"


### PR DESCRIPTION
Previously, a username was required when using the
SharedTokenCacheCredential, in order to handle the case where multiple
identities were found in the cache. Since it is common to have only a
single account in your user cache (e.g. you have signed in with only a
single identity), we should allow reading from the cache even when an
explicit AZURE_USERNAME is not specified, if there is exactly one
account in the cache.

When username is unset, if we can not find a token in the cache or we
find multiple tokens, a `ClientAuthenticationError` error is raised,
with the text "No cached token found".  This is similar to how other
cache related failures are handled by the API (they raise this error
with similar text but it includes a hint about what username was used.)

As part of this work, `DefaultAzureCredential` now unconditionally uses
the shared cache on supported platforms.

This behavior matches how we handle this case in both the .NET and Java
SDKs.

Fixes #7944