### PR TITLE
Add upper bound to MSAL requirement

### DIFF
--- a/sdk/identity/azure-identity/HISTORY.md
+++ b/sdk/identity/azure-identity/HISTORY.md
@@ -26,6 +26,11 @@ the Azure CLI's client ID will be used.
   described in
   [`azure-core` documentation](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/core/azure-core/docs/configuration.md)
 
+### Dependency changes
+- Adopted [`msal_extensions`](https://pypi.org/project/msal-extensions/) 0.1.2
+- Constrained [`msal`](https://pypi.org/project/msal/) requirement to >=0.4.1,
+<1.0.0
+
 
 ## 1.0.0b4 (2019-10-07)
 ### New features:

--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -73,8 +73,8 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.0.0b5",
         "cryptography>=2.1.4",
-        "msal~=0.4.1",
-        "msal-extensions~=0.1.1",
+        "msal<1.0.0,>=0.4.1",
+        "msal-extensions~=0.1.2",
         "six>=1.6",
     ],
     extras_require={

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -91,8 +91,8 @@ cryptography>=2.1.4
 futures
 mock
 typing
-msal~=0.4.1
-msal-extensions~=0.1.1
+msal<1.0.0,>=0.4.1
+msal-extensions~=0.1.2
 msrest>=0.5.0
 msrestazure<2.0.0,>=0.4.32
 requests>=2.18.4


### PR DESCRIPTION
MSAL restricts breaking changes to major versions, so azure-identity should work as expected with any version from 0.4.1 up to (but not including) 1.0.0. Tests pass with MSAL 0.4.1 and the latest version, 0.8.0.

Closes #8108 