### PR TITLE
Fix batch errors if server returns multiple request id

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies.py
@@ -131,20 +131,20 @@ class StorageHeadersPolicy(HeadersPolicy):
         custom_id = request.context.options.pop('client_request_id', None)
         request.http_request.headers['x-ms-client-request-id'] = custom_id or str(uuid.uuid1())
 
-    def on_response(self, request, response):
-        # raise exception if the echoed client request id from the service is not identical to the one we sent
-        if self.request_id_header_name in response.http_response.headers:
+    # def on_response(self, request, response):
+    #     # raise exception if the echoed client request id from the service is not identical to the one we sent
+    #     if self.request_id_header_name in response.http_response.headers:
 
-            client_request_id = request.http_request.headers.get(self.request_id_header_name)
+    #         client_request_id = request.http_request.headers.get(self.request_id_header_name)
 
-            if response.http_response.headers[self.request_id_header_name] != client_request_id:
-                raise AzureError(
-                    "Echoed client request ID: {} does not match sent client request ID: {}.  "
-                    "Service request ID: {}".format(
-                        response.http_response.headers[self.request_id_header_name], client_request_id,
-                        response.http_response.headers['x-ms-request-id']),
-                    response=response.http_response
-                )
+    #         if response.http_response.headers[self.request_id_header_name] != client_request_id:
+    #             raise AzureError(
+    #                 "Echoed client request ID: {} does not match sent client request ID: {}.  "
+    #                 "Service request ID: {}".format(
+    #                     response.http_response.headers[self.request_id_header_name], client_request_id,
+    #                     response.http_response.headers['x-ms-request-id']),
+    #                 response=response.http_response
+    #             )
 
 
 class StorageHosts(SansIOHTTPPolicy):

--- a/sdk/storage/azure-storage-file/azure/storage/file/_shared/policies.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/_shared/policies.py
@@ -131,20 +131,20 @@ class StorageHeadersPolicy(HeadersPolicy):
         custom_id = request.context.options.pop('client_request_id', None)
         request.http_request.headers['x-ms-client-request-id'] = custom_id or str(uuid.uuid1())
 
-    def on_response(self, request, response):
-        # raise exception if the echoed client request id from the service is not identical to the one we sent
-        if self.request_id_header_name in response.http_response.headers:
+    # def on_response(self, request, response):
+    #     # raise exception if the echoed client request id from the service is not identical to the one we sent
+    #     if self.request_id_header_name in response.http_response.headers:
 
-            client_request_id = request.http_request.headers.get(self.request_id_header_name)
+    #         client_request_id = request.http_request.headers.get(self.request_id_header_name)
 
-            if response.http_response.headers[self.request_id_header_name] != client_request_id:
-                raise AzureError(
-                    "Echoed client request ID: {} does not match sent client request ID: {}.  "
-                    "Service request ID: {}".format(
-                        response.http_response.headers[self.request_id_header_name], client_request_id,
-                        response.http_response.headers['x-ms-request-id']),
-                    response=response.http_response
-                )
+    #         if response.http_response.headers[self.request_id_header_name] != client_request_id:
+    #             raise AzureError(
+    #                 "Echoed client request ID: {} does not match sent client request ID: {}.  "
+    #                 "Service request ID: {}".format(
+    #                     response.http_response.headers[self.request_id_header_name], client_request_id,
+    #                     response.http_response.headers['x-ms-request-id']),
+    #                 response=response.http_response
+    #             )
 
 
 class StorageHosts(SansIOHTTPPolicy):

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies.py
@@ -131,20 +131,20 @@ class StorageHeadersPolicy(HeadersPolicy):
         custom_id = request.context.options.pop('client_request_id', None)
         request.http_request.headers['x-ms-client-request-id'] = custom_id or str(uuid.uuid1())
 
-    def on_response(self, request, response):
-        # raise exception if the echoed client request id from the service is not identical to the one we sent
-        if self.request_id_header_name in response.http_response.headers:
+    # def on_response(self, request, response):
+    #     # raise exception if the echoed client request id from the service is not identical to the one we sent
+    #     if self.request_id_header_name in response.http_response.headers:
 
-            client_request_id = request.http_request.headers.get(self.request_id_header_name)
+    #         client_request_id = request.http_request.headers.get(self.request_id_header_name)
 
-            if response.http_response.headers[self.request_id_header_name] != client_request_id:
-                raise AzureError(
-                    "Echoed client request ID: {} does not match sent client request ID: {}.  "
-                    "Service request ID: {}".format(
-                        response.http_response.headers[self.request_id_header_name], client_request_id,
-                        response.http_response.headers['x-ms-request-id']),
-                    response=response.http_response
-                )
+    #         if response.http_response.headers[self.request_id_header_name] != client_request_id:
+    #             raise AzureError(
+    #                 "Echoed client request ID: {} does not match sent client request ID: {}.  "
+    #                 "Service request ID: {}".format(
+    #                     response.http_response.headers[self.request_id_header_name], client_request_id,
+    #                     response.http_response.headers['x-ms-request-id']),
+    #                 response=response.http_response
+    #             )
 
 
 class StorageHosts(SansIOHTTPPolicy):


### PR DESCRIPTION
The echo policy is not robust enough to support multiple headers with same key.

After discussing with @johanste , the most secured fix right now for escrow is to disable this chek, and re-enable it when batch endpoints will be fixed.