### PR TITLE
Fix HdInsight Build

### DIFF
--- a/sdk/hdinsight/azure-mgmt-hdinsight/dev_requirements.txt
+++ b/sdk/hdinsight/azure-mgmt-hdinsight/dev_requirements.txt
@@ -1,4 +1,5 @@
 -e ../../../tools/azure-sdk-tools
+-e ../../core/azure-core
 -e ../../keyvault/azure-keyvault-keys
 -e ../../keyvault/azure-mgmt-keyvault
 -e ../../resources/azure-mgmt-msi/


### PR DESCRIPTION
Azure-mgmt-hdinsight has a dev dependency on azure-keyvault-keys. Azure-keyvault-keys has a dependency on an unreleased version of azure-core. Only way to resolve is to also require the local azure-core to resolve the irretrievable version.

Would rather the python 3.8 nightly build doesn't crash tonight :) 