### PR TITLE
Live test job name issue for python 3.8

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -68,6 +68,9 @@ jobs:
     pool:
       vmImage: $(OSVmImage)
 
+    dependsOn:
+      - '${{ parameters.JobName }}_Linux_PyPy3'
+
     steps:
       - template: ../steps/build-test-python38.yml
         parameters:

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -68,9 +68,7 @@ jobs:
     pool:
       vmImage: $(OSVmImage)
 
-    dependsOn:
-    - ${{ each entry in parameters.Matrix }}:
-      - "${{ parameters.JobName }} ${{ entry.key }}"
+    dependsOn: ${{ parameters.JobName }}
 
     steps:
       - template: ../steps/build-test-python38.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -64,6 +64,7 @@ jobs:
 
     timeoutInMinutes: 120
     continueOnError: false
+    condition: succeededOrFailed()
 
     pool:
       vmImage: $(OSVmImage)

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -69,7 +69,8 @@ jobs:
       vmImage: $(OSVmImage)
 
     dependsOn:
-      - '${{ parameters.JobName }}_Linux_PyPy3'
+    - ${{ each entry in parameters.Matrix }}:
+      - "${{ parameters.JobName }} ${{ entry.key }}"
 
     steps:
       - template: ../steps/build-test-python38.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -54,7 +54,7 @@ jobs:
           AdditionalTestArgs: ${{ parameters.AdditionalTestArgs }}
           TestMarkArgument: ${{ parameters.TestMarkArgument }}
 
-  - job: 'Test_Linux_Python38'
+  - job: '${{ parameters.JobName }}_Linux_Python38'
     variables:
       skipComponentGovernanceDetection: true
       CoverageArg: --disablecov


### PR DESCRIPTION
Live test is triggered in parallel hence job name must have prefixed with package short name. 