### PR TITLE
Autodoc should shows members grouped by type

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -63,6 +63,8 @@ intersphinx_mapping = {
     'msrest': ('http://msrest.readthedocs.io/en/latest/', None)
 }
 
+autodoc_member_order = 'groupwise'
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/doc/sphinx/individual_build_conf.py
+++ b/doc/sphinx/individual_build_conf.py
@@ -61,6 +61,8 @@ intersphinx_mapping = {
     'msrest': ('http://msrest.readthedocs.io/en/latest/', None)
 }
 
+autodoc_member_order = 'groupwise'
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
Was tested by @johanste and me, that's the default order we want:

> autodoc_member_order¶
> This value selects if automatically documented members are sorted alphabetical (value 'alphabetical'), by member type (value 'groupwise') or by source order (value 'bysource'). The default is alphabetical.
> 
> Note that for source order, the module must be a Python module with the source code available.