### PR TITLE
Reduce timeout for Python 3.8 Nightly build

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-nightly.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-nightly.yml
@@ -105,7 +105,7 @@ jobs:
     dependsOn:
        - 'Build'
 
-    timeoutInMinutes: 300
+    timeoutInMinutes: 180
 
     pool:
       vmImage: 'ubuntu-16.04'


### PR DESCRIPTION
Reduced nightly build timeout to 120 minutes for Python 3.8