### PR TITLE
Add default azure credential sample for blob, in new location under /samples

### DIFF
--- a/sdk/storage/azure-storage-blob/README.md
+++ b/sdk/storage/azure-storage-blob/README.md
@@ -210,6 +210,54 @@ async for blob in container.list_blobs():
 print(blob_list)
 ```
 
+## Optional Configuration
+
+Optional keyword arguments that can be passed in at the client and per-operation level. 
+
+### Retry Policy configuration
+
+Use the following keyword arguments when instantiating a client to configure the retry policy:
+
+* _retry_total_ (int): Total number of retries to allow. Takes precedence over other counts.
+    Pass in `retry_total=0` if you do not want to retry on requests. Defaults to 10.
+* _retry_connect_ (int): How many connection-related errors to retry on. Defaults to 3.
+* _retry_read_ (int): How many times to retry on read errors. Defaults to 3.
+* _retry_status_ (int): How many times to retry on bad status codes. Defaults to 3.
+* _retry_to_secondary_ (bool): Whether the request should be retried to secondary, if able.
+    This should only be enabled of RA-GRS accounts are used and potentially stale data can be handled.
+    Defaults to `False`.
+
+### Encryption configuration
+
+Use the following keyword arguments when instantiating a client to configure encryption:
+
+* _require_encryption_ (bool): If set to True, will enforce that objects are encrypted and decrypt them.
+* _key_encryption_key_ (object): The user-provided key-encryption-key. The instance must implement the following methods:
+    - `wrap_key(key)`--wraps the specified key using an algorithm of the user's choice. 
+    - `get_key_wrap_algorithm()`--returns the algorithm used to wrap the specified symmetric key.
+    - `get_kid()`--returns a string key id for this key-encryption-key.
+* _key_resolver_function_ (callable): The user-provided key resolver. Uses the kid string to return a key-encryption-key
+    implementing the interface defined above.
+
+### Other client / per-operation configuration
+
+Other optional configuration keyword arguments that can be specified on the client or per-operation.
+
+**Client keyword arguments:**
+
+* _connection_timeout_ (int): Optionally sets the connect and read timeout value, in seconds.
+* _transport_ (Any): User-provided transport to send the HTTP request.
+
+**Per-operation keyword arguments:**
+
+* _raw_response_hook_ (callable): The given callback uses the response returned from the service.
+* _raw_request_hook_ (callable): The given callback uses the request before being sent to service.
+* _client_request_id_ (str): Optional user specified identification of the request.
+* _user_agent_ (str): Appends the custom value to the user-agent header to be sent with the request.
+* _logging_enable_ (bool): Enables logging at the DEBUG level. Defaults to False. Can also be passed in at
+the client level to enable it for all requests.
+* _headers_ (dict): Pass in custom headers as key, value pairs. E.g. `headers={'CustomValue': value}`
+
 ## Troubleshooting
 Storage Blob clients raise exceptions defined in [Azure Core](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/core/azure-core/docs/exceptions.md).
 All Blob service operations will throw a `StorageErrorException` on failure with helpful [error codes](https://docs.microsoft.com/rest/api/storageservices/blob-service-error-codes).

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -102,6 +102,19 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
         account URL already has a SAS token. The value can be a SAS token string, an account
         shared access key, or an instance of a TokenCredentials class from azure.identity.
         If the URL already has a SAS token, specifying an explicit credential will take priority.
+    :keyword int max_block_size: The maximum chunk size for uploading a block blob in chunks.
+        Defaults to 4*1024*1024, or 4MB.
+    :keyword int max_single_put_size: If the blob size is less than max_single_put_size, then the blob will be
+        uploaded with only one http PUT request. If the blob size is larger than max_single_put_size,
+        the blob will be uploaded in chunks. Defaults to 64*1024*1024, or 64MB.
+    :keyword int min_large_block_upload_threshold: The minimum chunk size required to use the memory efficient
+        algorithm when uploading a block blob. Defaults to 4*1024*1024+1.
+    :keyword bool use_byte_buffer: Use a byte buffer for block blob uploads. Defaults to False.
+    :keyword int max_page_size: The maximum chunk size for uploading a page blob. Defaults to 4*1024*1024, or 4MB.
+    :keyword int max_single_get_size: The maximum size for a blob to be downloaded in a single call,
+        the exceeded part will be downloaded in chunks (could be parallel). Defaults to 32*1024*1024, or 32MB.
+    :keyword int max_chunk_get_size: The maximum chunk size used for downloading a blob. Defaults to 4*1024*1024,
+        or 4MB.
 
     .. admonition:: Example:
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_service_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_service_client.py
@@ -83,6 +83,19 @@ class BlobServiceClient(StorageAccountHostsMixin):
         account URL already has a SAS token. The value can be a SAS token string, an account
         shared access key, or an instance of a TokenCredentials class from azure.identity.
         If the URL already has a SAS token, specifying an explicit credential will take priority.
+    :keyword int max_block_size: The maximum chunk size for uploading a block blob in chunks.
+        Defaults to 4*1024*1024, or 4MB.
+    :keyword int max_single_put_size: If the blob size is less than max_single_put_size, then the blob will be
+        uploaded with only one http PUT request. If the blob size is larger than max_single_put_size,
+        the blob will be uploaded in chunks. Defaults to 64*1024*1024, or 64MB.
+    :keyword int min_large_block_upload_threshold: The minimum chunk size required to use the memory efficient
+        algorithm when uploading a block blob. Defaults to 4*1024*1024+1.
+    :keyword bool use_byte_buffer: Use a byte buffer for block blob uploads. Defaults to False.
+    :keyword int max_page_size: The maximum chunk size for uploading a page blob. Defaults to 4*1024*1024, or 4MB.
+    :keyword int max_single_get_size: The maximum size for a blob to be downloaded in a single call,
+        the exceeded part will be downloaded in chunks (could be parallel). Defaults to 32*1024*1024, or 32MB.
+    :keyword int max_chunk_get_size: The maximum chunk size used for downloading a blob. Defaults to 4*1024*1024,
+        or 4MB.
 
     .. admonition:: Example:
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
@@ -93,6 +93,19 @@ class ContainerClient(StorageAccountHostsMixin):
         account URL already has a SAS token. The value can be a SAS token string, an account
         shared access key, or an instance of a TokenCredentials class from azure.identity.
         If the URL already has a SAS token, specifying an explicit credential will take priority.
+    :keyword int max_block_size: The maximum chunk size for uploading a block blob in chunks.
+        Defaults to 4*1024*1024, or 4MB.
+    :keyword int max_single_put_size: If the blob size is less than max_single_put_size, then the blob will be
+        uploaded with only one http PUT request. If the blob size is larger than max_single_put_size,
+        the blob will be uploaded in chunks. Defaults to 64*1024*1024, or 64MB.
+    :keyword int min_large_block_upload_threshold: The minimum chunk size required to use the memory efficient
+        algorithm when uploading a block blob. Defaults to 4*1024*1024+1.
+    :keyword bool use_byte_buffer: Use a byte buffer for block blob uploads. Defaults to False.
+    :keyword int max_page_size: The maximum chunk size for uploading a page blob. Defaults to 4*1024*1024, or 4MB.
+    :keyword int max_single_get_size: The maximum size for a blob to be downloaded in a single call,
+        the exceeded part will be downloaded in chunks (could be parallel). Defaults to 32*1024*1024, or 32MB.
+    :keyword int max_chunk_get_size: The maximum chunk size used for downloading a blob. Defaults to 4*1024*1024,
+        or 4MB.
 
     .. admonition:: Example:
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -81,6 +81,19 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase):  # pylint: disa
         account URL already has a SAS token. The value can be a SAS token string, an account
         shared access key, or an instance of a TokenCredentials class from azure.identity.
         If the URL already has a SAS token, specifying an explicit credential will take priority.
+    :keyword int max_block_size: The maximum chunk size for uploading a block blob in chunks.
+        Defaults to 4*1024*1024, or 4MB.
+    :keyword int max_single_put_size: If the blob size is less than max_single_put_size, then the blob will be
+        uploaded with only one http PUT request. If the blob size is larger than max_single_put_size,
+        the blob will be uploaded in chunks. Defaults to 64*1024*1024, or 64MB.
+    :keyword int min_large_block_upload_threshold: The minimum chunk size required to use the memory efficient
+        algorithm when uploading a block blob. Defaults to 4*1024*1024+1.
+    :keyword bool use_byte_buffer: Use a byte buffer for block blob uploads. Defaults to False.
+    :keyword int max_page_size: The maximum chunk size for uploading a page blob. Defaults to 4*1024*1024, or 4MB.
+    :keyword int max_single_get_size: The maximum size for a blob to be downloaded in a single call,
+        the exceeded part will be downloaded in chunks (could be parallel). Defaults to 32*1024*1024, or 32MB.
+    :keyword int max_chunk_get_size: The maximum chunk size used for downloading a blob. Defaults to 4*1024*1024,
+        or 4MB.
 
     .. admonition:: Example:
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_service_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_service_client_async.py
@@ -81,6 +81,19 @@ class BlobServiceClient(AsyncStorageAccountHostsMixin, BlobServiceClientBase):
         account URL already has a SAS token. The value can be a SAS token string, an account
         shared access key, or an instance of a TokenCredentials class from azure.identity.
         If the URL already has a SAS token, specifying an explicit credential will take priority.
+    :keyword int max_block_size: The maximum chunk size for uploading a block blob in chunks.
+        Defaults to 4*1024*1024, or 4MB.
+    :keyword int max_single_put_size: If the blob size is less than max_single_put_size, then the blob will be
+        uploaded with only one http PUT request. If the blob size is larger than max_single_put_size,
+        the blob will be uploaded in chunks. Defaults to 64*1024*1024, or 64MB.
+    :keyword int min_large_block_upload_threshold: The minimum chunk size required to use the memory efficient
+        algorithm when uploading a block blob. Defaults to 4*1024*1024+1.
+    :keyword bool use_byte_buffer: Use a byte buffer for block blob uploads. Defaults to False.
+    :keyword int max_page_size: The maximum chunk size for uploading a page blob. Defaults to 4*1024*1024, or 4MB.
+    :keyword int max_single_get_size: The maximum size for a blob to be downloaded in a single call,
+        the exceeded part will be downloaded in chunks (could be parallel). Defaults to 32*1024*1024, or 32MB.
+    :keyword int max_chunk_get_size: The maximum chunk size used for downloading a blob. Defaults to 4*1024*1024,
+        or 4MB.
 
     .. admonition:: Example:
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_container_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_container_client_async.py
@@ -85,6 +85,19 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase):
         account URL already has a SAS token. The value can be a SAS token string, an account
         shared access key, or an instance of a TokenCredentials class from azure.identity.
         If the URL already has a SAS token, specifying an explicit credential will take priority.
+    :keyword int max_block_size: The maximum chunk size for uploading a block blob in chunks.
+        Defaults to 4*1024*1024, or 4MB.
+    :keyword int max_single_put_size: If the blob size is less than max_single_put_size, then the blob will be
+        uploaded with only one http PUT request. If the blob size is larger than max_single_put_size,
+        the blob will be uploaded in chunks. Defaults to 64*1024*1024, or 64MB.
+    :keyword int min_large_block_upload_threshold: The minimum chunk size required to use the memory efficient
+        algorithm when uploading a block blob. Defaults to 4*1024*1024+1.
+    :keyword bool use_byte_buffer: Use a byte buffer for block blob uploads. Defaults to False.
+    :keyword int max_page_size: The maximum chunk size for uploading a page blob. Defaults to 4*1024*1024, or 4MB.
+    :keyword int max_single_get_size: The maximum size for a blob to be downloaded in a single call,
+        the exceeded part will be downloaded in chunks (could be parallel). Defaults to 32*1024*1024, or 32MB.
+    :keyword int max_chunk_get_size: The maximum chunk size used for downloading a blob. Defaults to 4*1024*1024,
+        or 4MB.
 
     .. admonition:: Example:
 

--- a/sdk/storage/azure-storage-blob/samples/blob_samples_authentication.py
+++ b/sdk/storage/azure-storage-blob/samples/blob_samples_authentication.py
@@ -1,0 +1,31 @@
+# coding: utf-8
+
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+class AuthSamples(object):
+    oauth_url = "{}://{}.blob.core.windows.net".format(
+        os.getenv(PROTOCOL),
+        os.getenv(OAUTH_STORAGE_ACCOUNT_NAME)
+    )
+
+    def auth_default_azure_credential(self):
+        # [START create_blob_service_client_oauth]
+        # Get a credential for authentication
+        # Default Azure Credentials attempt a chained set of authentication methods, per documentation here: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/identity/azure-identity
+        # For example user (who must be an Azure Event Hubs Data Owner role) to be logged in can be specified by the environment variable AZURE_USERNAME
+        # Alternately, one can specify the AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_CLIENT_SECRET to use the EnvironmentCredentialClass.
+        # The docs above specify all mechanisms which the defaultCredential internally support.
+        from azure.identity import DefaultAzureCredential
+        default_credential = DefaultAzureCredential()
+ 
+        # Instantiate a BlobServiceClient using a token credential
+        from azure.storage.blob import BlobServiceClient
+        blob_service_client = BlobServiceClient(account_url=self.oauth_url, credential=default_credential)
+        # [END create_blob_service_client_oauth]
+ 
+        # Get account information for the Blob Service
+        account_info = blob_service_client.get_service_properties()

--- a/sdk/storage/azure-storage-blob/samples/blob_samples_authentication.py
+++ b/sdk/storage/azure-storage-blob/samples/blob_samples_authentication.py
@@ -8,8 +8,8 @@
 
 class AuthSamples(object):
     oauth_url = "{}://{}.blob.core.windows.net".format(
-        os.getenv(PROTOCOL),
-        os.getenv(OAUTH_STORAGE_ACCOUNT_NAME)
+        os.getenv("PROTOCOL"),
+        os.getenv("OAUTH_STORAGE_ACCOUNT_NAME")
     )
 
     def auth_default_azure_credential(self):

--- a/sdk/storage/azure-storage-blob/samples/blob_samples_authentication.py
+++ b/sdk/storage/azure-storage-blob/samples/blob_samples_authentication.py
@@ -6,6 +6,8 @@
 # license information.
 # --------------------------------------------------------------------------
 
+import os
+
 class AuthSamples(object):
     oauth_url = "{}://{}.blob.core.windows.net".format(
         os.getenv("PROTOCOL"),

--- a/sdk/storage/azure-storage-blob/samples/sample_delete_blob.py
+++ b/sdk/storage/azure-storage-blob/samples/sample_delete_blob.py
@@ -1,0 +1,26 @@
+from azure.storage.blob import BlobServiceClient, ContainerClient
+import os
+
+
+SOURCE_FOLDER = "./sample-blobs/"
+
+def batch_delete_blobs_sample(local_path):
+	# Set the connection string and container name values to initialize the Container Client
+    connection_string = os.getenv('STORAGE_CONN_STR')
+
+    blob_service_client = BlobServiceClient.from_connection_string(conn_str=connection_string)
+	# Create a ContainerClient to use the batch_delete function on a Blob Container
+    container_client = blob_service_client.get_container_client("mycontainername")
+
+	# Upload blobs
+    for filename in os.listdir(local_path):
+        with open(local_path+filename, "rb") as data:
+            container_client.upload_blob(name=filename, data=data, blob_type="BlockBlob")
+
+	# List blobs in storage account
+    blob_list = [b.name for b in list(container_client.list_blobs())]
+
+	# Delete blobs
+    container_client.delete_blobs(*blob_list)
+
+batch_delete_blobs_sample(SOURCE_FOLDER)

--- a/sdk/storage/azure-storage-file/README.md
+++ b/sdk/storage/azure-storage-file/README.md
@@ -214,6 +214,43 @@ async for item in parent_dir.list_directories_and_files():
 print(my_files)
 ```
 
+## Optional Configuration
+
+Optional keyword arguments that can be passed in at the client and per-operation level. 
+
+### Retry Policy configuration
+
+Use the following keyword arguments when instantiating a client to configure the retry policy:
+
+* _retry_total_ (int): Total number of retries to allow. Takes precedence over other counts.
+    Pass in `retry_total=0` if you do not want to retry on requests. Defaults to 10.
+* _retry_connect_ (int): How many connection-related errors to retry on. Defaults to 3.
+* _retry_read_ (int): How many times to retry on read errors. Defaults to 3.
+* _retry_status_ (int): How many times to retry on bad status codes. Defaults to 3.
+* _retry_to_secondary_ (bool): Whether the request should be retried to secondary, if able.
+    This should only be enabled of RA-GRS accounts are used and potentially stale data can be handled.
+    Defaults to `False`.
+
+### Other client / per-operation configuration
+
+Other optional configuration keyword arguments that can be specified on the client or per-operation.
+
+**Client keyword arguments:**
+
+* _connection_timeout_ (int): Optionally sets the connect and read timeout value, in seconds.
+* _transport_ (Any): User-provided transport to send the HTTP request.
+
+**Per-operation keyword arguments:**
+
+* _raw_response_hook_ (callable): The given callback uses the response returned from the service.
+* _raw_request_hook_ (callable): The given callback uses the request before being sent to service.
+* _client_request_id_ (str): Optional user specified identification of the request.
+* _user_agent_ (str): Appends the custom value to the user-agent header to be sent with the request.
+* _logging_enable_ (bool): Enables logging at the DEBUG level. Defaults to False. Can also be passed in at
+the client level to enable it for all requests.
+* _headers_ (dict): Pass in custom headers as key, value pairs. E.g. `headers={'CustomValue': value}`
+
+
 ## Troubleshooting
 Storage File clients raise exceptions defined in [Azure Core](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/core/azure-core/docs/exceptions.md).
 All File service operations will throw a `StorageErrorException` on failure with helpful [error codes](https://docs.microsoft.com/rest/api/storageservices/file-service-error-codes).

--- a/sdk/storage/azure-storage-file/azure/storage/file/_directory_client.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/_directory_client.py
@@ -79,6 +79,7 @@ class DirectoryClient(StorageAccountHostsMixin):
         The credential with which to authenticate. This is optional if the
         account URL already has a SAS token. The value can be a SAS token string or an account
         shared access key.
+    :keyword int max_range_size: The maximum range size used for a file upload. Defaults to 4*1024*1024.
     """
     def __init__( # type: ignore
             self, account_url,  # type: str

--- a/sdk/storage/azure-storage-file/azure/storage/file/_file_client.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/_file_client.py
@@ -128,6 +128,7 @@ class FileClient(StorageAccountHostsMixin):
         The credential with which to authenticate. This is optional if the
         account URL already has a SAS token. The value can be a SAS token string or an account
         shared access key.
+    :keyword int max_range_size: The maximum range size used for a file upload. Defaults to 4*1024*1024.
     """
     def __init__( # type: ignore
             self, account_url,  # type: str

--- a/sdk/storage/azure-storage-file/azure/storage/file/_file_service_client.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/_file_service_client.py
@@ -64,6 +64,7 @@ class FileServiceClient(StorageAccountHostsMixin):
         The credential with which to authenticate. This is optional if the
         account URL already has a SAS token. The value can be a SAS token string or an account
         shared access key.
+    :keyword int max_range_size: The maximum range size used for a file upload. Defaults to 4*1024*1024.
 
     .. admonition:: Example:
 

--- a/sdk/storage/azure-storage-file/azure/storage/file/_share_client.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/_share_client.py
@@ -74,6 +74,7 @@ class ShareClient(StorageAccountHostsMixin):
         The credential with which to authenticate. This is optional if the
         account URL already has a SAS token. The value can be a SAS token string or an account
         shared access key.
+    :keyword int max_range_size: The maximum range size used for a file upload. Defaults to 4*1024*1024.
     """
     def __init__( # type: ignore
             self, account_url,  # type: str

--- a/sdk/storage/azure-storage-file/azure/storage/file/aio/_directory_client_async.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/aio/_directory_client_async.py
@@ -77,6 +77,7 @@ class DirectoryClient(AsyncStorageAccountHostsMixin, DirectoryClientBase):
         shared access key.
     :keyword loop:
         The event loop to run the asynchronous tasks.
+    :keyword int max_range_size: The maximum range size used for a file upload. Defaults to 4*1024*1024.
     """
     def __init__( # type: ignore
             self, account_url,  # type: str

--- a/sdk/storage/azure-storage-file/azure/storage/file/aio/_file_client_async.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/aio/_file_client_async.py
@@ -124,6 +124,7 @@ class FileClient(AsyncStorageAccountHostsMixin, FileClientBase):
         shared access key.
     :keyword loop:
         The event loop to run the asynchronous tasks.
+    :keyword int max_range_size: The maximum range size used for a file upload. Defaults to 4*1024*1024.
     """
 
     def __init__(  # type: ignore

--- a/sdk/storage/azure-storage-file/azure/storage/file/aio/_file_service_client_async.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/aio/_file_service_client_async.py
@@ -67,6 +67,7 @@ class FileServiceClient(AsyncStorageAccountHostsMixin, FileServiceClientBase):
         shared access key.
     :keyword loop:
         The event loop to run the asynchronous tasks.
+    :keyword int max_range_size: The maximum range size used for a file upload. Defaults to 4*1024*1024.
 
     .. admonition:: Example:
 

--- a/sdk/storage/azure-storage-file/azure/storage/file/aio/_share_client_async.py
+++ b/sdk/storage/azure-storage-file/azure/storage/file/aio/_share_client_async.py
@@ -72,6 +72,7 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
         shared access key.
     :keyword loop:
         The event loop to run the asynchronous tasks.
+    :keyword int max_range_size: The maximum range size used for a file upload. Defaults to 4*1024*1024.
     """
     def __init__( # type: ignore
             self, account_url,  # type: str

--- a/sdk/storage/azure-storage-queue/README.md
+++ b/sdk/storage/azure-storage-queue/README.md
@@ -208,6 +208,43 @@ async for message in response:
     await queue.delete_message(message)
 ```
 
+## Optional Configuration
+
+Optional keyword arguments that can be passed in at the client and per-operation level. 
+
+### Retry Policy configuration
+
+Use the following keyword arguments when instantiating a client to configure the retry policy:
+
+* _retry_total_ (int): Total number of retries to allow. Takes precedence over other counts.
+    Pass in `retry_total=0` if you do not want to retry on requests. Defaults to 10.
+* _retry_connect_ (int): How many connection-related errors to retry on. Defaults to 3.
+* _retry_read_ (int): How many times to retry on read errors. Defaults to 3.
+* _retry_status_ (int): How many times to retry on bad status codes. Defaults to 3.
+* _retry_to_secondary_ (bool): Whether the request should be retried to secondary, if able.
+    This should only be enabled of RA-GRS accounts are used and potentially stale data can be handled.
+    Defaults to `False`.
+
+### Other client / per-operation configuration
+
+Other optional configuration keyword arguments that can be specified on the client or per-operation.
+
+**Client keyword arguments:**
+
+* _connection_timeout_ (int): Optionally sets the connect and read timeout value, in seconds.
+* _transport_ (Any): User-provided transport to send the HTTP request.
+
+**Per-operation keyword arguments:**
+
+* _raw_response_hook_ (callable): The given callback uses the response returned from the service.
+* _raw_request_hook_ (callable): The given callback uses the request before being sent to service.
+* _client_request_id_ (str): Optional user specified identification of the request.
+* _user_agent_ (str): Appends the custom value to the user-agent header to be sent with the request.
+* _logging_enable_ (bool): Enables logging at the DEBUG level. Defaults to False. Can also be passed in at
+the client level to enable it for all requests.
+* _headers_ (dict): Pass in custom headers as key, value pairs. E.g. `headers={'CustomValue': value}`
+
+
 ## Troubleshooting
 Storage Queue clients raise exceptions defined in [Azure Core](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/core/azure-core/docs/exceptions.md).
 All Queue service operations will throw a `StorageErrorException` on failure with helpful [error codes](https://docs.microsoft.com/rest/api/storageservices/queue-service-error-codes).

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
@@ -67,6 +67,12 @@ class QueueClient(StorageAccountHostsMixin):
         The credentials with which to authenticate. This is optional if the
         account URL already has a SAS token. The value can be a SAS token string, an account
         shared access key, or an instance of a TokenCredentials class from azure.identity.
+    :keyword encode_policy: The encoding policy to use on outgoing messages.
+        Default is not to encode messages. Other options include :class:`TextBase64EncodePolicy`,
+        :class:`BinaryBase64EncodePolicy` or `None`.
+    :keyword decode_policy: The decoding policy to use on incoming messages.
+        Default value is not to decode messages. Other options include :class:`TextBase64DecodePolicy`,
+        :class:`BinaryBase64DecodePolicy` or `None`.
 
     .. admonition:: Example:
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
@@ -83,6 +83,12 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase):
         The credentials with which to authenticate. This is optional if the
         account URL already has a SAS token. The value can be a SAS token string, an account
         shared access key, or an instance of a TokenCredentials class from azure.identity.
+    :keyword encode_policy: The encoding policy to use on outgoing messages.
+        Default is not to encode messages. Other options include :class:`TextBase64EncodePolicy`,
+        :class:`BinaryBase64EncodePolicy` or `None`.
+    :keyword decode_policy: The decoding policy to use on incoming messages.
+        Default value is not to decode messages. Other options include :class:`TextBase64DecodePolicy`,
+        :class:`BinaryBase64DecodePolicy` or `None`.
 
     .. admonition:: Example:
 


### PR DESCRIPTION
As subject says.
Forked from prior PR so that EH and Blob samples can go in distinctly.