### PR TITLE
Update azure-identity docs

### DIFF
--- a/sdk/identity/azure-identity/HISTORY.md
+++ b/sdk/identity/azure-identity/HISTORY.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b5
+## 1.0.0 (2019-10-29)
 ### Breaking changes:
 - Async credentials now default to [`aiohttp`](https://pypi.org/project/aiohttp/)
 for transport but the library does not require it as a dependency because the

--- a/sdk/identity/azure-identity/HISTORY.md
+++ b/sdk/identity/azure-identity/HISTORY.md
@@ -26,6 +26,14 @@ the Azure CLI's client ID will be used.
   described in
   [`azure-core` documentation](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/core/azure-core/docs/configuration.md)
 
+### Fixes and improvements:
+- Authenticating with a single sign-on shared with other Microsoft applications
+only requires a username when multiple users have signed in
+([#8095](https://github.com/Azure/azure-sdk-for-python/pull/8095))
+- `DefaultAzureCredential` accepts an `authority` keyword argument, enabling
+its use in national clouds
+([#8154](https://github.com/Azure/azure-sdk-for-python/pull/8154))
+
 ### Dependency changes
 - Adopted [`msal_extensions`](https://pypi.org/project/msal-extensions/) 0.1.2
 - Constrained [`msal`](https://pypi.org/project/msal/) requirement to >=0.4.1,

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -89,7 +89,7 @@ To authenticate as a service principal, provide configuration in
 [environment variables](#environment-variables) as described in the next section.
 
 Authenticating as a managed identity requires no configuration but is only
-possible on a supported platform. See Azure Active Directory's
+possible in a supported hosting environment. See Azure Active Directory's
 [managed identity documentation](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/services-support-managed-identities)
 for more information.
 

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -93,7 +93,7 @@ possible in a supported hosting environment. See Azure Active Directory's
 [managed identity documentation](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/services-support-managed-identities)
 for more information.
 
-### Single sign-on
+#### Single sign-on
 During local development on Windows, [DefaultAzureCredential][default_cred_ref]
 can authenticate using a single sign-on shared with Microsoft applications, for
 example Visual Studio 2019. This may require additional configuration when

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -127,8 +127,7 @@ variables:
 >|`AZURE_CLIENT_ID`|id of an Azure Active Directory application
 >|`AZURE_USERNAME`|a username (usually an email address)
 >|`AZURE_PASSWORD`|that user's password
-
-> ***Note**: username/password authentication is not supported in the async API (`azure.identity.aio`)*
+> Note: username/password authentication is not supported by the async API (`azure.identity.aio`)
 
 Configuration is attempted in the above order. For example, if values for a
 client secret and certificate are both present, the client secret will be used.

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -79,7 +79,7 @@ the [azure.identity.aio][ref_docs_aio] namespace, supported on Python 3.5.3+.
 See the [async credentials](#async-credentials) example for details. Async user
 credentials will be part of a future release.
 
-## `DefaultAzureCredential`
+## DefaultAzureCredential
 [DefaultAzureCredential][default_cred_ref] is appropriate for most
 applications intended to run in Azure. It can authenticate as a service
 principal, managed identity, or user, and can be configured for local
@@ -127,6 +127,7 @@ variables:
 >|`AZURE_CLIENT_ID`|id of an Azure Active Directory application
 >|`AZURE_USERNAME`|a username (usually an email address)
 >|`AZURE_PASSWORD`|that user's password
+
 > Note: username/password authentication is not supported by the async API
 ([azure.identity.aio][ref_docs_aio])
 

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -82,7 +82,7 @@ credentials will be part of a future release.
 ## `DefaultAzureCredential`
 [`DefaultAzureCredential`][default_cred_ref] is appropriate for most
 applications intended to run in Azure. It can authenticate as a service
-principal, managed identity, or user, and  can be configured for local
+principal, managed identity, or user, and can be configured for local
 development and production environments without code changes.
 
 To authenticate as a service principal, provide configuration in

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -30,23 +30,23 @@ this [Azure CLI](https://docs.microsoft.com/cli/azure) snippet. Before using
 it, replace "http://my-application" with a more appropriate name for your
 service principal.
 
- * Create a service principal:
-    ```sh
-    az ad sp create-for-rbac --name http://my-application --skip-assignment
-    ```
-    Example output:
-    ```json
-    {
-        "appId": "generated-app-id",
-        "displayName": "app-name",
-        "name": "http://my-application",
-        "password": "random-password",
-        "tenant": "tenant-id"
-    }
-    ```
-  * Azure Identity can authenticate as this service principal using its tenant
-  id ("tenant" above), client id ("appId" above), and client secret ("password"
-  above).
+Create a service principal:
+```sh
+az ad sp create-for-rbac --name http://my-application --skip-assignment
+```
+
+Example output:
+```json
+{
+    "appId": "generated-app-id",
+    "displayName": "app-name",
+    "name": "http://my-application",
+    "password": "random-password",
+    "tenant": "tenant-id"
+}
+```
+Azure Identity can authenticate as this service principal using its tenant id
+("tenant" above), client id ("appId" above), and client secret ("password" above).
 
 
 # Key concepts

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -16,8 +16,6 @@ This library is in preview and currently supports:
 ## Prerequisites
 - an [Azure subscription](https://azure.microsoft.com/free/)
 - Python 2.7 or 3.5.3+
-- an Azure Active Directory service principal. If you need to create one, you
-can use the Azure Portal, or [Azure CLI](#creating-a-service-principal-with-the-azure-cli)
 
 ## Install the package
 Install Azure Identity with pip:
@@ -26,45 +24,47 @@ pip install azure-identity
 ```
 
 #### Creating a Service Principal with the Azure CLI
-Use this [Azure CLI](https://docs.microsoft.com/cli/azure) snippet to create/get
-client secret credentials.
+This library doesn't require a service principal, but Azure applications
+commonly use them for authentication. If you need to create one, you can use
+this [Azure CLI](https://docs.microsoft.com/cli/azure) snippet. Before using
+it, replace "http://my-application" with a more appropriate name for your
+service principal.
 
  * Create a service principal:
     ```sh
-    az ad sp create-for-rbac -n <your-application-name> --skip-assignment
+    az ad sp create-for-rbac --name http://my-application --skip-assignment
     ```
     Example output:
     ```json
     {
-        "appId": "generated-app-ID",
+        "appId": "generated-app-id",
         "displayName": "app-name",
-        "name": "http://app-name",
+        "name": "http://my-application",
         "password": "random-password",
-        "tenant": "tenant-ID"
+        "tenant": "tenant-id"
     }
     ```
-* Use the output to set  **AZURE_CLIENT_ID** (appId), **AZURE_CLIENT_SECRET**
-(password) and **AZURE_TENANT_ID** (tenant)
-[environment variables](#environment-variables).
+  * Azure Identity can authenticate as this service principal using its tenant
+  id ("tenant" above), client id ("appId" above), and client secret ("password"
+  above).
 
 
 # Key concepts
 ## Credentials
 A credential is a class which contains or can obtain the data needed for a
-service client to authenticate requests. Service clients across Azure SDK
-accept credentials as constructor parameters. See
-[next steps](#client-library-support) below for a list of client libraries
-accepting Azure Identity credentials.
+service client to authenticate requests. Service clients across the Azure SDK
+accept credentials as constructor parameters, as described in their
+documentation. The [next steps](#client-library-support) section below contains
+a partial list of client libraries accepting Azure Identity credentials.
 
-Credential classes are defined in the `azure.identity` namespace. These differ
-in the types of Azure Active Directory identities they can authenticate, and in
-configuration:
+Credential classes are found in the `azure.identity` namespace. They differ
+in the types of identities they can authenticate as, and in their configuration:
 
 |credential class|identity|configuration
 |-|-|-
-|`DefaultAzureCredential`|service principal, managed identity, user|none for managed identity, [environment variables](#environment-variables) for service principal or user authentication
+|[`DefaultAzureCredential`](#defaultazurecredential)|service principal, managed identity, user|none for managed identity, [environment variables](#environment-variables) for service principal or user authentication
 |`ManagedIdentityCredential`|managed identity|none
-|`EnvironmentCredential`|service principal|[environment variables](#environment-variables)
+|`EnvironmentCredential`|service principal, user|[environment variables](#environment-variables)
 |`ClientSecretCredential`|service principal|constructor parameters
 |`CertificateCredential`|service principal|constructor parameters
 |[`DeviceCodeCredential`](https://azure.github.io/azure-sdk-for-python/ref/azure.identity.html#azure.identity.credentials.DeviceCodeCredential)|user|constructor parameters
@@ -74,31 +74,31 @@ configuration:
 Credentials can be chained together and tried in turn until one succeeds; see
 [chaining credentials](#chaining-credentials) for details.
 
-Service principal and managed identity credentials have an async equivalent in
+Service principal and managed identity credentials have async equivalents in
 the `azure.identity.aio` namespace, supported on Python 3.5.3+. See the
 [async credentials](#async-credentials) example for details. Async user
 credentials will be part of a future release.
 
 ## DefaultAzureCredential
 `DefaultAzureCredential` is appropriate for most applications intended to run
-in Azure. It authenticates as a service principal or managed identity,
-depending on its environment, and can be configured to work both during local
-development and when deployed to the cloud.
+in Azure. It can authenticate as a service principal, managed identity, or user,
+and  can be configured for local development and production environments without
+code changes.
 
-To authenticate as a service principal, provide configuration in environment
-variables as described in the next section.
+To authenticate as a service principal, provide configuration in
+[environment variables](#environment-variables) as described in the next section.
 
-Authenticating as a managed identity requires no configuration, but does
-require platform support. See the
+Authenticating as a managed identity requires no configuration but is only
+possible on a supported platform. See Azure Active Directory's
 [managed identity documentation](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/services-support-managed-identities)
 for more information.
 
 ### Single sign-on
 During local development on Windows, `DefaultAzureCredential` can authenticate
 using a single sign-on shared with Microsoft applications, for example Visual
-Studio 2019. Because you may have multiple signed in identities, to
-authenticate this way you must set the environment variable `AZURE_USERNAME`
-with your desired identity's username (typically an email address).
+Studio 2019. This may require additional configuration when multiple identities
+have signed in. In that case, set the environment variable `AZURE_USERNAME`
+with the desired identity's username (typically an email address).
 
 ## Environment variables
 
@@ -109,16 +109,16 @@ variables:
 #### Service principal with secret
 >|variable name|value
 >|-|-
->|`AZURE_CLIENT_ID`|service principal's app id
->|`AZURE_TENANT_ID`|id of the principal's Azure Active Directory tenant
->|`AZURE_CLIENT_SECRET`|one of the service principal's client secrets
+>|`AZURE_CLIENT_ID`|id of an Azure Active Directory application
+>|`AZURE_TENANT_ID`|id of the application's Azure Active Directory tenant
+>|`AZURE_CLIENT_SECRET`|one of the application's client secrets
 
 #### Service principal with certificate
 >|variable name|value
 >|-|-
->|`AZURE_CLIENT_ID`|service principal's app id
->|`AZURE_TENANT_ID`|id of the principal's Azure Active Directory tenant
->|`AZURE_CLIENT_CERTIFICATE_PATH`|path to a PEM-encoded certificate file including private key (without password)
+>|`AZURE_CLIENT_ID`|id of an Azure Active Directory application
+>|`AZURE_TENANT_ID`|id of the application's Azure Active Directory tenant
+>|`AZURE_CLIENT_CERTIFICATE_PATH`|path to a PEM-encoded certificate file including private key (without password protection)
 
 #### Username and password
 >|variable name|value
@@ -127,46 +127,46 @@ variables:
 >|`AZURE_USERNAME`|a username (usually an email address)
 >|`AZURE_PASSWORD`|that user's password
 
-Configuration is attempted in the above order. For example, if both
-`AZURE_CLIENT_SECRET` and `AZURE_CLIENT_CERTIFICATE_PATH` have values,
-`AZURE_CLIENT_SECRET` will be used.
+> ***Note**: username/password authentication is not supported in the async API (`azure.identity.aio`)*
+
+Configuration is attempted in the above order. For example, if values for a
+client secret and certificate are both present, the client secret will be used.
 
 # Examples
 ## Authenticating with `DefaultAzureCredential`
 This example demonstrates authenticating the `BlobServiceClient` from the
-[`azure-storage-blob`][azure_storage_blob] library using
-`DefaultAzureCredential`.
+[`azure-storage-blob`][azure_storage_blob] library using `DefaultAzureCredential`.
+
 ```py
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient
 
-# The default credential first checks environment variables for configuration as described above.
+# This credential first checks environment variables for configuration as described above.
 # If environment configuration is incomplete, it will try managed identity.
 credential = DefaultAzureCredential()
 
 client = BlobServiceClient(account_url, credential=credential)
 ```
-Executing this on a development machine requires first
-[configuring the environment][#environment-variables] with appropriate values
-for your service principal.
 
 ## Authenticating a service principal with a client secret:
 This example demonstrates authenticating the `KeyClient` from the
 [`azure-keyvault-keys`][azure_keyvault_keys] library using
 `ClientSecretCredential`.
+
 ```py
 from azure.identity import ClientSecretCredential
 from azure.keyvault.keys import KeyClient
 
 credential = ClientSecretCredential(tenant_id, client_id, client_secret)
 
-client = KeyClient(vault_endpoint, credential)
+client = KeyClient("https://my-vault.vault.azure.net", credential)
 ```
 
 ## Authenticating a service principal with a certificate:
 This example demonstrates authenticating the `SecretClient` from the
 [`azure-keyvault-secrets`][azure_keyvault_secrets] library using
 `CertificateCredential`.
+
 ```py
 from azure.identity import CertificateCredential
 from azure.keyvault.secrets import SecretClient
@@ -175,26 +175,27 @@ from azure.keyvault.secrets import SecretClient
 cert_path = "/app/certs/certificate.pem"
 credential = CertificateCredential(tenant_id, client_id, cert_path)
 
-client = SecretClient(vault_endpoint, credential)
+client = SecretClient("https://my-vault.vault.azure.net", credential)
 ```
 
 ## Chaining credentials:
-The ChainedTokenCredential class links multiple credential instances to be tried
+`ChainedTokenCredential` links multiple credential instances to be tried
 sequentially when authenticating. The following example demonstrates creating a
 credential which will attempt to authenticate using managed identity, and fall
-back to client secret authentication if a managed identity is unavailable in the
-current environment. This example demonstrates authenticating an `EventHubClient`
-from the [`azure-eventhubs`][azure_eventhubs] client library.
+back to a service principal if a managed identity is unavailable. This example
+uses the `EventHubClient` from the [`azure-eventhubs`][azure_eventhubs] client
+library.
+
 ```py
 from azure.eventhub import EventHubClient
 from azure.identity import ChainedTokenCredential, ClientSecretCredential, ManagedIdentityCredential
 
 managed_identity = ManagedIdentityCredential()
-client_secret = ClientSecretCredential(tenant_id, client_id, client_secret)
+service_principal = ClientSecretCredential(tenant_id, client_id, client_secret)
 
-# when an access token is requested, the chain will try each
+# when an access token is needed, the chain will try each
 # credential in order, stopping when one provides a token
-credential_chain = ChainedTokenCredential(managed_identity, client_secret)
+credential_chain = ChainedTokenCredential(managed_identity, service_principal)
 
 # the ChainedTokenCredential can be used anywhere a credential is required
 client = EventHubClient(host, event_hub_path, credential_chain)
@@ -208,22 +209,18 @@ such as [`aiohttp`](https://pypi.org/project/aiohttp/). See
 for more information.
 
 This example demonstrates authenticating the asynchronous `SecretClient` from
-[`azure-keyvault-secrets`][azure_keyvault_secrets] with asynchronous credentials.
+[`azure-keyvault-secrets`][azure_keyvault_secrets] with an asynchronous
+credential.
+
 ```py
 # most credentials have async equivalents supported on Python 3.5.3+
 from azure.identity.aio import DefaultAzureCredential
+from azure.keyvault.secrets.aio import SecretClient
 
+# async credentials have the same API and configuration as their synchronous
+# counterparts, and are used with (async) Azure SDK clients in the same way
 default_credential = DefaultAzureCredential()
-
-# async credentials have the same API and configuration their synchronous counterparts,
-from azure.identity.aio import ClientSecretCredential
-
-credential = ClientSecretCredential(tenant_id, client_id, client_secret)
-
-# and are used with async Azure SDK clients in the same way
-from azure.keyvault.aio import SecretClient
-
-client = SecretClient(vault_url, credential)
+client = SecretClient("https://my-vault.vault.azure.net", default_credential)
 ```
 
 # Troubleshooting
@@ -239,11 +236,11 @@ Azure Active Directory
 
 # Next steps
 ## Client library support
-Currently the following client libraries support authenticating with Azure
-Identity credentials. You can learn more about them, and find additional
-documentation on using these client libraries along with samples, at the links
-below.
+This is an incomplete list of client libraries accepting Azure Identity
+credentials. You can learn more about these libraries, and find additional
+documentation of them, at the links below.
 - [azure-eventhubs][azure_eventhubs]
+- [azure-keyvault-certificates](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-certificates)
 - [azure-keyvault-keys][azure_keyvault_keys]
 - [azure-keyvault-secrets][azure_keyvault_secrets]
 - [azure-storage-blob][azure_storage_blob]

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -9,7 +9,7 @@ This library is in preview and currently supports:
 
   [Source code](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/identity/azure-identity/azure/identity)
   | [Package (PyPI)](https://pypi.org/project/azure-identity/)
-  | [API reference documentation](https://azure.github.io/azure-sdk-for-python/ref/azure.identity.html)
+  | [API reference documentation][ref_docs]
   | [Azure Active Directory documentation](https://docs.microsoft.com/en-us/azure/active-directory/)
 
 # Getting started
@@ -63,13 +63,13 @@ in the types of identities they can authenticate as, and in their configuration:
 |credential class|identity|configuration
 |-|-|-
 |[`DefaultAzureCredential`](#defaultazurecredential)|service principal, managed identity, user|none for managed identity, [environment variables](#environment-variables) for service principal or user authentication
-|`ManagedIdentityCredential`|managed identity|none
-|`EnvironmentCredential`|service principal, user|[environment variables](#environment-variables)
-|`ClientSecretCredential`|service principal|constructor parameters
-|`CertificateCredential`|service principal|constructor parameters
-|[`DeviceCodeCredential`](https://azure.github.io/azure-sdk-for-python/ref/azure.identity.html#azure.identity.credentials.DeviceCodeCredential)|user|constructor parameters
-|[`InteractiveBrowserCredential`](https://azure.github.io/azure-sdk-for-python/ref/azure.identity.html#azure.identity.InteractiveBrowserCredential)|user|constructor parameters
-|[`UsernamePasswordCredential`](https://azure.github.io/azure-sdk-for-python/ref/azure.identity.html#azure.identity.credentials.UsernamePasswordCredential)|user|constructor parameters
+|[`ManagedIdentityCredential`][managed_id_cred_ref]|managed identity|none
+|[`EnvironmentCredential`][environment_cred_ref]|service principal, user|[environment variables](#environment-variables)
+|[`ClientSecretCredential`][client_secret_cred_ref]|service principal|constructor parameters
+|[`CertificateCredential`][cert_cred_ref]|service principal|constructor parameters
+|[`DeviceCodeCredential`][device_code_cred_ref]|user|constructor parameters
+|[`InteractiveBrowserCredential`][interactive_cred_ref]|user|constructor parameters
+|[`UsernamePasswordCredential`][userpass_cred_ref]|user|constructor parameters
 
 Credentials can be chained together and tried in turn until one succeeds; see
 [chaining credentials](#chaining-credentials) for details.
@@ -79,11 +79,11 @@ the `azure.identity.aio` namespace, supported on Python 3.5.3+. See the
 [async credentials](#async-credentials) example for details. Async user
 credentials will be part of a future release.
 
-## DefaultAzureCredential
-`DefaultAzureCredential` is appropriate for most applications intended to run
-in Azure. It can authenticate as a service principal, managed identity, or user,
-and  can be configured for local development and production environments without
-code changes.
+## `DefaultAzureCredential`
+[`DefaultAzureCredential`][default_cred_ref] is appropriate for most
+applications intended to run in Azure. It can authenticate as a service
+principal, managed identity, or user, and  can be configured for local
+development and production environments without code changes.
 
 To authenticate as a service principal, provide configuration in
 [environment variables](#environment-variables) as described in the next section.
@@ -94,15 +94,16 @@ possible on a supported platform. See Azure Active Directory's
 for more information.
 
 ### Single sign-on
-During local development on Windows, `DefaultAzureCredential` can authenticate
-using a single sign-on shared with Microsoft applications, for example Visual
-Studio 2019. This may require additional configuration when multiple identities
-have signed in. In that case, set the environment variable `AZURE_USERNAME`
-with the desired identity's username (typically an email address).
+During local development on Windows, [`DefaultAzureCredential`][default_cred_ref]
+can authenticate using a single sign-on shared with Microsoft applications, for
+example Visual Studio 2019. This may require additional configuration when
+multiple identities have signed in. In that case, set the environment variable
+`AZURE_USERNAME` with the desired identity's username (typically an email
+address).
 
 ## Environment variables
-
-`DefaultAzureCredential` and `EnvironmentCredential` can be configured with
+[`DefaultAzureCredential`][default_cred_ref] and
+[`EnvironmentCredential`][environment_cred_ref] can be configured with
 environment variables. Each type of authentication requires values for specific
 variables:
 
@@ -135,7 +136,8 @@ client secret and certificate are both present, the client secret will be used.
 # Examples
 ## Authenticating with `DefaultAzureCredential`
 This example demonstrates authenticating the `BlobServiceClient` from the
-[`azure-storage-blob`][azure_storage_blob] library using `DefaultAzureCredential`.
+[`azure-storage-blob`][azure_storage_blob] library using
+[`DefaultAzureCredential`][default_cred_ref].
 
 ```py
 from azure.identity import DefaultAzureCredential
@@ -151,7 +153,7 @@ client = BlobServiceClient(account_url, credential=credential)
 ## Authenticating a service principal with a client secret:
 This example demonstrates authenticating the `KeyClient` from the
 [`azure-keyvault-keys`][azure_keyvault_keys] library using
-`ClientSecretCredential`.
+[`ClientSecretCredential`][client_secret_cred_ref].
 
 ```py
 from azure.identity import ClientSecretCredential
@@ -165,7 +167,7 @@ client = KeyClient("https://my-vault.vault.azure.net", credential)
 ## Authenticating a service principal with a certificate:
 This example demonstrates authenticating the `SecretClient` from the
 [`azure-keyvault-secrets`][azure_keyvault_secrets] library using
-`CertificateCredential`.
+[`CertificateCredential`][cert_cred_ref].
 
 ```py
 from azure.identity import CertificateCredential
@@ -179,12 +181,12 @@ client = SecretClient("https://my-vault.vault.azure.net", credential)
 ```
 
 ## Chaining credentials:
-`ChainedTokenCredential` links multiple credential instances to be tried
-sequentially when authenticating. The following example demonstrates creating a
-credential which will attempt to authenticate using managed identity, and fall
-back to a service principal if a managed identity is unavailable. This example
-uses the `EventHubClient` from the [`azure-eventhubs`][azure_eventhubs] client
-library.
+[`ChainedTokenCredential`][chain_cred_ref] links multiple credential instances
+to be tried sequentially when authenticating. The following example demonstrates
+creating a credential which will attempt to authenticate using managed identity,
+and fall back to a service principal if a managed identity is unavailable. This
+example uses the `EventHubClient` from the [`azure-eventhubs`][azure_eventhubs]
+client library.
 
 ```py
 from azure.eventhub import EventHubClient
@@ -227,18 +229,21 @@ client = SecretClient("https://my-vault.vault.azure.net", default_credential)
 ## General
 Credentials raise `azure.core.exceptions.ClientAuthenticationError` when they fail
 to authenticate. `ClientAuthenticationError` has a `message` attribute which
-describes why authentication failed. When raised by `ChainedTokenCredential`,
+describes why authentication failed. When raised by
+[`DefaultAzureCredential`](#defaultazurecredential) or `ChainedTokenCredential`,
 the message collects error messages from each credential in the chain.
 
 For more details on handling Azure Active Directory errors please refer to the
 Azure Active Directory
 [error code documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-aadsts-error-codes).
 
+
 # Next steps
 ## Client library support
 This is an incomplete list of client libraries accepting Azure Identity
 credentials. You can learn more about these libraries, and find additional
 documentation of them, at the links below.
+- [azure-appconfiguration](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/appconfiguration/azure-appconfiguration)
 - [azure-eventhubs][azure_eventhubs]
 - [azure-keyvault-certificates](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-certificates)
 - [azure-keyvault-keys][azure_keyvault_keys]
@@ -249,6 +254,7 @@ documentation of them, at the links below.
 ## Provide Feedback
 If you encounter bugs or have suggestions, please
 [open an issue](https://github.com/Azure/azure-sdk-for-python/issues).
+
 
 # Contributing
 This project welcomes contributions and suggestions. Most contributions require
@@ -272,5 +278,16 @@ additional questions or comments.
 [azure_keyvault_keys]: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-keys
 [azure_keyvault_secrets]: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-secrets
 [azure_storage_blob]: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/storage/azure-storage-blob
+
+[ref_docs]: https://aka.ms/azsdk-python-identity-docs
+[cert_cred_ref]: https://aka.ms/azsdk-python-identity-cert-cred-ref
+[chain_cred_ref]: https://aka.ms/azsdk-python-identity-chain-cred-ref
+[client_secret_cred_ref]: https://aka.ms/azsdk-python-identity-client-secret-cred-ref
+[default_cred_ref]: https://aka.ms/azsdk-python-identity-default-cred-ref
+[device_code_cred_ref]: https://aka.ms/azsdk-python-identity-device-code-cred-ref
+[environment_cred_ref]: https://aka.ms/azsdk-python-identity-environment-cred-ref
+[interactive_cred_ref]: https://aka.ms/azsdk-python-identity-interactive-cred-ref
+[managed_id_cred_ref]: https://aka.ms/azsdk-python-identity-managed-id-cred-ref
+[userpass_cred_ref]: https://aka.ms/azsdk-python-identity-userpass-cred-ref
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-python%2Fsdk%2Fidentity%2Fazure-identity%2FREADME.png)

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -75,8 +75,8 @@ Credentials can be chained together and tried in turn until one succeeds; see
 [chaining credentials](#chaining-credentials) for details.
 
 Service principal and managed identity credentials have async equivalents in
-the `azure.identity.aio` namespace, supported on Python 3.5.3+. See the
-[async credentials](#async-credentials) example for details. Async user
+the [azure.identity.aio][ref_docs_aio] namespace, supported on Python 3.5.3+.
+See the [async credentials](#async-credentials) example for details. Async user
 credentials will be part of a future release.
 
 ## `DefaultAzureCredential`
@@ -127,7 +127,8 @@ variables:
 >|`AZURE_CLIENT_ID`|id of an Azure Active Directory application
 >|`AZURE_USERNAME`|a username (usually an email address)
 >|`AZURE_PASSWORD`|that user's password
-> Note: username/password authentication is not supported by the async API (`azure.identity.aio`)
+> Note: username/password authentication is not supported by the async API
+([azure.identity.aio][ref_docs_aio])
 
 Configuration is attempted in the above order. For example, if values for a
 client secret and certificate are both present, the client secret will be used.
@@ -204,8 +205,8 @@ client = EventHubClient(host, event_hub_path, credential_chain)
 
 ## Async credentials:
 This library includes an async API supported on Python 3.5+. To use the async
-credentials in `azure.identity.aio`, you must first install an async transport,
-such as [aiohttp](https://pypi.org/project/aiohttp/). See
+credentials in [azure.identity.aio][ref_docs_aio], you must first install an
+async transport, such as [aiohttp](https://pypi.org/project/aiohttp/). See
 [azure-core documentation](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/core/azure-core/README.md#transport)
 for more information.
 
@@ -279,9 +280,11 @@ additional questions or comments.
 [azure_storage_blob]: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/storage/azure-storage-blob
 
 [ref_docs]: https://aka.ms/azsdk-python-identity-docs
+[ref_docs_aio]: https://aka.ms/azsdk-python-identity-aio-docs
 [cert_cred_ref]: https://aka.ms/azsdk-python-identity-cert-cred-ref
 [chain_cred_ref]: https://aka.ms/azsdk-python-identity-chain-cred-ref
 [client_secret_cred_ref]: https://aka.ms/azsdk-python-identity-client-secret-cred-ref
+[client_secret_cred_aio_ref]: https://aka.ms/azsdk-python-identity-client-secret-cred-aio-ref
 [default_cred_ref]: https://aka.ms/azsdk-python-identity-default-cred-ref
 [device_code_cred_ref]: https://aka.ms/azsdk-python-identity-device-code-cred-ref
 [environment_cred_ref]: https://aka.ms/azsdk-python-identity-environment-cred-ref

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -62,14 +62,14 @@ in the types of identities they can authenticate as, and in their configuration:
 
 |credential class|identity|configuration
 |-|-|-
-|[`DefaultAzureCredential`](#defaultazurecredential)|service principal, managed identity, user|none for managed identity, [environment variables](#environment-variables) for service principal or user authentication
-|[`ManagedIdentityCredential`][managed_id_cred_ref]|managed identity|none
-|[`EnvironmentCredential`][environment_cred_ref]|service principal, user|[environment variables](#environment-variables)
-|[`ClientSecretCredential`][client_secret_cred_ref]|service principal|constructor parameters
-|[`CertificateCredential`][cert_cred_ref]|service principal|constructor parameters
-|[`DeviceCodeCredential`][device_code_cred_ref]|user|constructor parameters
-|[`InteractiveBrowserCredential`][interactive_cred_ref]|user|constructor parameters
-|[`UsernamePasswordCredential`][userpass_cred_ref]|user|constructor parameters
+|[DefaultAzureCredential](#defaultazurecredential)|service principal, managed identity, user|none for managed identity, [environment variables](#environment-variables) for service principal or user authentication
+|[ManagedIdentityCredential][managed_id_cred_ref]|managed identity|none
+|[EnvironmentCredential][environment_cred_ref]|service principal, user|[environment variables](#environment-variables)
+|[ClientSecretCredential][client_secret_cred_ref]|service principal|constructor parameters
+|[CertificateCredential][cert_cred_ref]|service principal|constructor parameters
+|[DeviceCodeCredential][device_code_cred_ref]|user|constructor parameters
+|[InteractiveBrowserCredential][interactive_cred_ref]|user|constructor parameters
+|[UsernamePasswordCredential][userpass_cred_ref]|user|constructor parameters
 
 Credentials can be chained together and tried in turn until one succeeds; see
 [chaining credentials](#chaining-credentials) for details.
@@ -80,7 +80,7 @@ the `azure.identity.aio` namespace, supported on Python 3.5.3+. See the
 credentials will be part of a future release.
 
 ## `DefaultAzureCredential`
-[`DefaultAzureCredential`][default_cred_ref] is appropriate for most
+[DefaultAzureCredential][default_cred_ref] is appropriate for most
 applications intended to run in Azure. It can authenticate as a service
 principal, managed identity, or user, and can be configured for local
 development and production environments without code changes.
@@ -94,7 +94,7 @@ possible in a supported hosting environment. See Azure Active Directory's
 for more information.
 
 ### Single sign-on
-During local development on Windows, [`DefaultAzureCredential`][default_cred_ref]
+During local development on Windows, [DefaultAzureCredential][default_cred_ref]
 can authenticate using a single sign-on shared with Microsoft applications, for
 example Visual Studio 2019. This may require additional configuration when
 multiple identities have signed in. In that case, set the environment variable
@@ -102,8 +102,8 @@ multiple identities have signed in. In that case, set the environment variable
 address).
 
 ## Environment variables
-[`DefaultAzureCredential`][default_cred_ref] and
-[`EnvironmentCredential`][environment_cred_ref] can be configured with
+[DefaultAzureCredential][default_cred_ref] and
+[EnvironmentCredential][environment_cred_ref] can be configured with
 environment variables. Each type of authentication requires values for specific
 variables:
 
@@ -136,8 +136,8 @@ client secret and certificate are both present, the client secret will be used.
 # Examples
 ## Authenticating with `DefaultAzureCredential`
 This example demonstrates authenticating the `BlobServiceClient` from the
-[`azure-storage-blob`][azure_storage_blob] library using
-[`DefaultAzureCredential`][default_cred_ref].
+[azure-storage-blob][azure_storage_blob] library using
+[DefaultAzureCredential][default_cred_ref].
 
 ```py
 from azure.identity import DefaultAzureCredential
@@ -152,8 +152,8 @@ client = BlobServiceClient(account_url, credential=credential)
 
 ## Authenticating a service principal with a client secret:
 This example demonstrates authenticating the `KeyClient` from the
-[`azure-keyvault-keys`][azure_keyvault_keys] library using
-[`ClientSecretCredential`][client_secret_cred_ref].
+[azure-keyvault-keys][azure_keyvault_keys] library using
+[ClientSecretCredential][client_secret_cred_ref].
 
 ```py
 from azure.identity import ClientSecretCredential
@@ -166,8 +166,8 @@ client = KeyClient("https://my-vault.vault.azure.net", credential)
 
 ## Authenticating a service principal with a certificate:
 This example demonstrates authenticating the `SecretClient` from the
-[`azure-keyvault-secrets`][azure_keyvault_secrets] library using
-[`CertificateCredential`][cert_cred_ref].
+[azure-keyvault-secrets][azure_keyvault_secrets] library using
+[CertificateCredential][cert_cred_ref].
 
 ```py
 from azure.identity import CertificateCredential
@@ -181,11 +181,11 @@ client = SecretClient("https://my-vault.vault.azure.net", credential)
 ```
 
 ## Chaining credentials:
-[`ChainedTokenCredential`][chain_cred_ref] links multiple credential instances
+[ChainedTokenCredential][chain_cred_ref] links multiple credential instances
 to be tried sequentially when authenticating. The following example demonstrates
 creating a credential which will attempt to authenticate using managed identity,
 and fall back to a service principal if a managed identity is unavailable. This
-example uses the `EventHubClient` from the [`azure-eventhubs`][azure_eventhubs]
+example uses the `EventHubClient` from the [azure-eventhubs][azure_eventhubs]
 client library.
 
 ```py
@@ -206,12 +206,12 @@ client = EventHubClient(host, event_hub_path, credential_chain)
 ## Async credentials:
 This library includes an async API supported on Python 3.5+. To use the async
 credentials in `azure.identity.aio`, you must first install an async transport,
-such as [`aiohttp`](https://pypi.org/project/aiohttp/). See
+such as [aiohttp](https://pypi.org/project/aiohttp/). See
 [azure-core documentation](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/core/azure-core/README.md#transport)
 for more information.
 
 This example demonstrates authenticating the asynchronous `SecretClient` from
-[`azure-keyvault-secrets`][azure_keyvault_secrets] with an asynchronous
+[azure-keyvault-secrets][azure_keyvault_secrets] with an asynchronous
 credential.
 
 ```py
@@ -230,7 +230,7 @@ client = SecretClient("https://my-vault.vault.azure.net", default_credential)
 Credentials raise `azure.core.exceptions.ClientAuthenticationError` when they fail
 to authenticate. `ClientAuthenticationError` has a `message` attribute which
 describes why authentication failed. When raised by
-[`DefaultAzureCredential`](#defaultazurecredential) or `ChainedTokenCredential`,
+[DefaultAzureCredential](#defaultazurecredential) or `ChainedTokenCredential`,
 the message collects error messages from each credential in the chain.
 
 For more details on handling Azure Active Directory errors please refer to the

--- a/sdk/identity/azure-identity/azure/identity/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/__init__.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+"""Credentials for Azure SDK clients."""
+
 from ._constants import KnownAuthorities
 from ._credentials import (
     AuthorizationCodeCredential,

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -46,6 +46,8 @@ class AuthorizationCodeCredential(object):
         the credential will return a cached access token or redeem a refresh token, if it acquired a refresh token upon
         redeeming the authorization code.
 
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
         :param str scopes: desired scopes for the access token
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -26,9 +26,6 @@ if TYPE_CHECKING:
 class InteractiveBrowserCredential(PublicClientCredential):
     """Opens a browser to interactively authenticate a user.
 
-    This is an interactive flow: ``get_token`` opens a browser to a login URL provided by Azure Active Directory, and
-    waits for the user to authenticate there.
-
     :func:`~get_token` opens a browser to a login URL provided by Azure Active Directory and authenticates a user
     there with the authorization code flow. Azure Active Directory documentation describes this flow in more detail:
     https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -59,6 +59,8 @@ class InteractiveBrowserCredential(PublicClientCredential):
         This will open a browser to a login page and listen on localhost for a request indicating authentication has
         completed.
 
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
         :param str scopes: desired scopes for the token
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -35,11 +35,10 @@ class ChainedTokenCredential(object):
         # type: (*str, **Any) -> AccessToken
         """Request a token from each chained credential, in order, returning the first token received.
 
-        If none provides a token, raises :class:`azure.core.exceptions.ClientAuthenticationError` with an
-        error message from each credential.
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
         :param str scopes: desired scopes for the token
-        :raises ~azure.core.exceptions.ClientAuthenticationError:
+        :raises ~azure.core.exceptions.ClientAuthenticationError: when no credential in the chain provides a token
         """
         history = []
         for credential in self.credentials:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 class ChainedTokenCredential(object):
     """A sequence of credentials that is itself a credential.
 
-    Its ``get_token`` method calls ``get_token`` on each credential in the sequence, in order, returning the first
+    Its :func:`get_token` method calls ``get_token`` on each credential in the sequence, in order, returning the first
     valid token received.
 
     :param credentials: credential instances to form the chain

--- a/sdk/identity/azure-identity/azure/identity/_credentials/client_credential.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/client_credential.py
@@ -37,6 +37,8 @@ class ClientSecretCredential(ClientSecretCredentialBase):
         # type: (*str, **Any) -> AccessToken
         """Request an access token for `scopes`.
 
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
         :param str scopes: desired scopes for the token
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError:
@@ -69,6 +71,8 @@ class CertificateCredential(CertificateCredentialBase):
     def get_token(self, *scopes, **kwargs):  # pylint:disable=unused-argument
         # type: (*str, **Any) -> AccessToken
         """Request an access token for `scopes`.
+
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
         :param str scopes: desired scopes for the token
         :rtype: :class:`azure.core.credentials.AccessToken`

--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -79,6 +79,8 @@ class EnvironmentCredential:
         # type: (*str, **Any) -> AccessToken
         """Request an access token for `scopes`.
 
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
         :param str scopes: desired scopes for the token
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -53,6 +53,8 @@ class ManagedIdentityCredential(object):
         # type: (*str, **Any) -> AccessToken
         """Request an access token for `scopes`.
 
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
         :param str scopes: desired scopes for the token
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user.py
@@ -28,11 +28,11 @@ if TYPE_CHECKING:
 class DeviceCodeCredential(PublicClientCredential):
     """Authenticates users through the device code flow.
 
-    When ``get_token`` is called, this credential acquires a verification URL and code from Azure Active Directory. A
-    user must browse to the URL, enter the code, and authenticate with Azure Active Directory. If the user
+    When :func:`get_token` is called, this credential acquires a verification URL and code from Azure Active Directory.
+    A user must browse to the URL, enter the code, and authenticate with Azure Active Directory. If the user
     authenticates successfully, the credential receives an access token.
 
-    This credential doesn't cache tokens--each ``get_token`` call begins a new authentication flow.
+    This credential doesn't cache tokens--each :func:`get_token` call begins a new authentication flow.
 
     For more information about the device code flow, see Azure Active Directory documentation:
     https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-device-code

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user.py
@@ -69,6 +69,8 @@ class DeviceCodeCredential(PublicClientCredential):
 
         This credential won't cache the token. Each call begins a new authentication flow.
 
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
         :param str scopes: desired scopes for the token
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError:
@@ -151,6 +153,8 @@ class SharedTokenCacheCredential(object):
 
         If no access token is cached, attempt to acquire one using a cached refresh token.
 
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
         :param str scopes: desired scopes for the token
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises:
@@ -213,6 +217,8 @@ class UsernamePasswordCredential(PublicClientCredential):
     def get_token(self, *scopes, **kwargs):  # pylint:disable=unused-argument
         # type: (*str, **Any) -> AccessToken
         """Request an access token for `scopes`.
+
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
         :param str scopes: desired scopes for the token
         :rtype: :class:`azure.core.credentials.AccessToken`

--- a/sdk/identity/azure-identity/azure/identity/aio/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/__init__.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+"""Credentials for asynchronous Azure SDK clients."""
+
 from ._credentials import (
     AuthorizationCodeCredential,
     CertificateCredential,

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -52,6 +52,8 @@ class AuthorizationCodeCredential(object):
         the credential will return a cached access token or redeem a refresh token, if it acquired a refresh token upon
         redeeming the authorization code.
 
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
         :param str scopes: desired scopes for the access token
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 class ChainedTokenCredential(SyncChainedTokenCredential):
     """A sequence of credentials that is itself a credential.
 
-    Its ``get_token`` method calls ``get_token`` on each credential in the sequence, in order, returning the first
+    Its :func:`get_token` method calls ``get_token`` on each credential in the sequence, in order, returning the first
     valid token received.
 
     :param credentials: credential instances to form the chain

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
@@ -28,6 +28,8 @@ class ChainedTokenCredential(SyncChainedTokenCredential):
         If no credential provides a token, raises :class:`azure.core.exceptions.ClientAuthenticationError`
         with an error message from each credential.
 
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
         :param str scopes: desired scopes for the token
         :raises ~azure.core.exceptions.ClientAuthenticationError:
         """

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_credential.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_credential.py
@@ -31,6 +31,8 @@ class ClientSecretCredential(ClientSecretCredentialBase):
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":  # pylint:disable=unused-argument
         """Asynchronously request an access token for `scopes`.
 
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
         :param str scopes: desired scopes for the token
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError:
@@ -61,6 +63,8 @@ class CertificateCredential(CertificateCredentialBase):
 
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":  # pylint:disable=unused-argument
         """Asynchronously request an access token for `scopes`.
+
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
         :param str scopes: desired scopes for the token
         :rtype: :class:`azure.core.credentials.AccessToken`

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -53,6 +53,8 @@ class EnvironmentCredential:
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":
         """Asynchronously request an access token for `scopes`.
 
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
         :param str scopes: desired scopes for the token
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -40,6 +40,8 @@ class ManagedIdentityCredential(object):
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":  # pylint:disable=unused-argument
         """Asynchronously request an access token for `scopes`.
 
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
         :param str scopes: desired scopes for the token
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/user.py
@@ -28,6 +28,8 @@ class SharedTokenCacheCredential(SyncSharedTokenCacheCredential):
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":  # pylint:disable=unused-argument
         """Get an access token for `scopes` from the shared cache.
 
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
         If no access token is cached, attempt to acquire one using a cached refresh token.
 
         :param str scopes: desired scopes for the token


### PR DESCRIPTION
* adds ref doc links to the readme and revises its content
* adds package-level docstrings for the benefit of docs.microsoft.com
* adds a note on every `get_token` to discourage customers from thinking they must use it
* updates history