### PR TITLE
Prevent self.resource_moniker == None

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/resource_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/resource_testcase.py
@@ -43,7 +43,7 @@ class ResourceGroupPreparer(AzureMgmtPreparer):
             )
             self.test_class_instance.scrubber.register_name_pair(
                 name,
-                self.resource_moniker
+                self.moniker
             )
         else:
             self.resource = self.resource or FakeResource(


### PR DESCRIPTION
`self.resource_moniker` is initialized `None` by `AbstractPreparer`. `ResourceGroupPreparer.__init__` reassigns it only when `random_name_enabled == True`. Therefore when `not random_name_enabled` we call `register_name_pair(some_string, None)` and later, `str.replace(some_string, None)`, raising an error.

`self.moniker` prevents this by ensuring `self.resource_moniker is not None`.