### PR TITLE
add reprs to common user-facing classes

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -67,6 +67,10 @@ class ContainerProxy(object):
         self._is_system_key = None
         self._scripts = None  # type: Optional[ScriptsProxy]
 
+    def __repr__(self):
+        # type () -> str
+        return "<ContainerProxy [{}]>".format(self.container_link)[:1024]
+
     def _get_properties(self):
         # type: () -> Dict[str, Any]
         if self._properties is None:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client.py
@@ -194,7 +194,7 @@ class CosmosClient(object):
             url, auth=auth, consistency_level=consistency_level, connection_policy=connection_policy, **kwargs
         )
 
-    def __repr__(self):
+    def __repr__(self):  # pylint:disable=client-method-name-no-double-underscore
         # type () -> str
         return "<CosmosClient [{}]>".format(self.client_connection.url_connection)[:1024]
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client.py
@@ -194,6 +194,10 @@ class CosmosClient(object):
             url, auth=auth, consistency_level=consistency_level, connection_policy=connection_policy, **kwargs
         )
 
+    def __repr__(self):
+        # type () -> str
+        return "<CosmosClient [{}]>".format(self.client_connection.url_connection)[:1024]
+
     def __enter__(self):
         self.client_connection.pipeline_client.__enter__()
         return self

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
@@ -76,6 +76,10 @@ class DatabaseProxy(object):
         self.database_link = u"dbs/{}".format(self.id)
         self._properties = properties
 
+    def __repr__(self):
+        # type () -> str
+        return "<DatabaseProxy [{}]>".format(self.database_link)[:1024]
+
     @staticmethod
     def _get_container_id(container_or_id):
         # type: (Union[str, ContainerProxy, Dict[str, Any]]) -> str

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/partition_key.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/partition_key.py
@@ -54,6 +54,10 @@ class PartitionKey(dict):
         self.kind = kind
         self.version = version
 
+    def __repr__(self):
+        # type () -> str
+        return "<PartitionKey [{}]>".format(self.path)[:1024]
+
     @property
     def kind(self):
         return self["kind"]

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/user.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/user.py
@@ -47,6 +47,10 @@ class UserProxy(object):
         self.user_link = u"{}/users/{}".format(database_link, id)
         self._properties = properties
 
+    def __repr__(self):
+        # type () -> str
+        return "<User [{}]>".format(self.user_link)[:1024]
+
     def _get_permission_link(self, permission_or_id):
         # type: (Union[Permission, str, Dict[str, Any]]) -> str
         if isinstance(permission_or_id, six.string_types):

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/user.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/user.py
@@ -49,7 +49,7 @@ class UserProxy(object):
 
     def __repr__(self):
         # type () -> str
-        return "<User [{}]>".format(self.user_link)[:1024]
+        return "<UserProxy [{}]>".format(self.user_link)[:1024]
 
     def _get_permission_link(self, permission_or_id):
         # type: (Union[Permission, str, Dict[str, Any]]) -> str


### PR DESCRIPTION
Went with non-evalable scheme:

* `CosmosClient` may have long/complicated args, including credentials
* Other classes are not intended to be instantiated directly by users

Yields e.g. 
```
In [10]: c
Out[10]: <CosmosClient [https://brvandev-cosmos.documents.azure.com:443/]>

In [11]: c.get_database_client("foo")
Out[11]: <DatabaseProxy [dbs/foo]>

In [12]: c.get_database_client("foo").get_container_client("bar")
Out[12]: <ContainerProxy [dbs/foo/colls/bar]>

In [13]: PartitionKey("stuff")
Out[13]: <PartitionKey [stuff]>
```
