### PR TITLE
Remove core and identity from dev_requirements

### DIFF
--- a/sdk/appconfiguration/azure-appconfiguration/dev_requirements.txt
+++ b/sdk/appconfiguration/azure-appconfiguration/dev_requirements.txt
@@ -1,4 +1,3 @@
-../../core/azure-core
 -e ../../../tools/azure-devtools
 -e ../../../tools/azure-sdk-tools
 aiohttp>=3.0; python_version >= '3.5'

--- a/sdk/core/azure-core-tracing-opencensus/dev_requirements.txt
+++ b/sdk/core/azure-core-tracing-opencensus/dev_requirements.txt
@@ -1,2 +1,1 @@
 -e ../../../tools/azure-sdk-tools
-../azure-core

--- a/sdk/cosmos/azure-cosmos/dev_requirements.txt
+++ b/sdk/cosmos/azure-cosmos/dev_requirements.txt
@@ -1,2 +1,1 @@
 -e ../../../tools/azure-sdk-tools
-../../core/azure-core

--- a/sdk/eventhub/azure-eventhubs-checkpointstoreblob-aio/dev_requirements.txt
+++ b/sdk/eventhub/azure-eventhubs-checkpointstoreblob-aio/dev_requirements.txt
@@ -1,4 +1,3 @@
 -e ../../../tools/azure-sdk-tools
-../../core/azure-core
 -e ../../storage/azure-storage-blob
 ../azure-eventhubs

--- a/sdk/eventhub/azure-eventhubs/dev_requirements.txt
+++ b/sdk/eventhub/azure-eventhubs/dev_requirements.txt
@@ -1,6 +1,4 @@
 -e ../../../tools/azure-sdk-tools
-../../core/azure-core
--e ../../identity/azure-identity
 -e ../../servicebus/azure-servicebus
 docutils>=0.14
 pygments>=2.2.0

--- a/sdk/identity/azure-identity/dev_requirements.txt
+++ b/sdk/identity/azure-identity/dev_requirements.txt
@@ -1,4 +1,3 @@
-../../core/azure-core
 aiohttp;python_full_version>="3.5.2"
 typing_extensions>=3.7.2
 

--- a/sdk/keyvault/azure-keyvault-certificates/dev_requirements.txt
+++ b/sdk/keyvault/azure-keyvault-certificates/dev_requirements.txt
@@ -1,7 +1,5 @@
-../../core/azure-core
 -e ../../../tools/azure-devtools
 -e ../../../tools/azure-sdk-tools
--e ../../identity/azure-identity
 -e ../azure-mgmt-keyvault
 ../azure-keyvault-nspkg
 aiohttp>=3.0; python_version >= '3.5'

--- a/sdk/keyvault/azure-keyvault-keys/dev_requirements.txt
+++ b/sdk/keyvault/azure-keyvault-keys/dev_requirements.txt
@@ -1,6 +1,4 @@
 -e ../../../tools/azure-devtools
-../../core/azure-core
--e ../../identity/azure-identity
 -e ../azure-mgmt-keyvault
 -e ../../../tools/azure-sdk-tools
 ../azure-keyvault-nspkg

--- a/sdk/keyvault/azure-keyvault-secrets/dev_requirements.txt
+++ b/sdk/keyvault/azure-keyvault-secrets/dev_requirements.txt
@@ -1,6 +1,4 @@
 -e ../../../tools/azure-devtools
-../../core/azure-core
--e ../../identity/azure-identity
 -e ../azure-mgmt-keyvault
 -e ../../../tools/azure-sdk-tools
 ../azure-keyvault-nspkg

--- a/sdk/storage/azure-storage-blob/dev_requirements.txt
+++ b/sdk/storage/azure-storage-blob/dev_requirements.txt
@@ -1,7 +1,5 @@
 -e ../../../tools/azure-devtools
 -e ../../../tools/azure-sdk-tools
-../../core/azure-core
--e ../../identity/azure-identity
 aiohttp>=3.0; python_version >= '3.5'
 pytest
 coverage

--- a/sdk/storage/azure-storage-file-share/dev_requirements.txt
+++ b/sdk/storage/azure-storage-file-share/dev_requirements.txt
@@ -1,5 +1,4 @@
 -e ../../../tools/azure-devtools
 -e ../../../tools/azure-sdk-tools
-../../core/azure-core
 aiohttp>=3.0; python_version >= '3.5'
 pytest

--- a/sdk/storage/azure-storage-queue/dev_requirements.txt
+++ b/sdk/storage/azure-storage-queue/dev_requirements.txt
@@ -1,6 +1,4 @@
 -e ../../../tools/azure-devtools
 -e ../../../tools/azure-sdk-tools
-../../core/azure-core
--e ../../identity/azure-identity
 aiohttp>=3.0; python_version >= '3.5'
 pytest


### PR DESCRIPTION
Changes to remove core and identity packages from dev_requirements to link the dependency to GA version.