### PR TITLE
Handle ImportError when constructing DefaultAzureCredential

### DIFF
--- a/sdk/identity/azure-identity/HISTORY.md
+++ b/sdk/identity/azure-identity/HISTORY.md
@@ -1,6 +1,8 @@
 # Release History
 
 ### 1.1.0b1 Unreleased
+- Constructing `DefaultAzureCredential` no longer raises `ImportError` on Python
+3.8 on Windows ([8294](https://github.com/Azure/azure-sdk-for-python/pull/8294))
 
 
 ### 2019-11-05 1.0.1

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -43,7 +43,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
                 username = os.environ.get(EnvironmentVariables.AZURE_USERNAME)
                 shared_cache = SharedTokenCacheCredential(username=username, authority=authority, **kwargs)
                 credentials.append(shared_cache)
-            except ImportError as ex:
+            except Exception as ex:  # pylint:disable=broad-except
                 # transitive dependency pywin32 doesn't support 3.8 (https://github.com/mhammond/pywin32/issues/1431)
                 _LOGGER.info("Shared token cache is unavailable: '%s'", ex)
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import logging
 import os
 
 from .._constants import EnvironmentVariables
@@ -9,6 +10,8 @@ from .chained import ChainedTokenCredential
 from .environment import EnvironmentCredential
 from .managed_identity import ManagedIdentityCredential
 from .user import SharedTokenCacheCredential
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class DefaultAzureCredential(ChainedTokenCredential):
@@ -35,10 +38,13 @@ class DefaultAzureCredential(ChainedTokenCredential):
 
         # SharedTokenCacheCredential is part of the default only on supported platforms.
         if SharedTokenCacheCredential.supported():
-            credentials.append(
-                SharedTokenCacheCredential(
-                    username=os.environ.get(EnvironmentVariables.AZURE_USERNAME), authority=authority, **kwargs
-                )
-            )
+            try:
+                # username is only required to disambiguate, when the cache contains tokens for multiple identities
+                username = os.environ.get(EnvironmentVariables.AZURE_USERNAME)
+                shared_cache = SharedTokenCacheCredential(username=username, authority=authority, **kwargs)
+                credentials.append(shared_cache)
+            except ImportError as ex:
+                # transitive dependency pywin32 doesn't support 3.8 (https://github.com/mhammond/pywin32/issues/1431)
+                _LOGGER.info("Shared token cache is unavailable: '{}'".format(ex))
 
         super(DefaultAzureCredential, self).__init__(*credentials)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -45,6 +45,6 @@ class DefaultAzureCredential(ChainedTokenCredential):
                 credentials.append(shared_cache)
             except ImportError as ex:
                 # transitive dependency pywin32 doesn't support 3.8 (https://github.com/mhammond/pywin32/issues/1431)
-                _LOGGER.info("Shared token cache is unavailable: '{}'".format(ex))
+                _LOGGER.info("Shared token cache is unavailable: '%s'", ex)
 
         super(DefaultAzureCredential, self).__init__(*credentials)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -45,6 +45,6 @@ class DefaultAzureCredential(ChainedTokenCredential):
                 credentials.append(shared_cache)
             except ImportError as ex:
                 # transitive dependency pywin32 doesn't support 3.8 (https://github.com/mhammond/pywin32/issues/1431)
-                _LOGGER.info("Shared token cache is unavailable: '{}'".format(ex))
+                _LOGGER.info("Shared token cache is unavailable: '%s'", ex)
 
         super().__init__(*credentials)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -43,7 +43,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
                 username = os.environ.get(EnvironmentVariables.AZURE_USERNAME)
                 shared_cache = SharedTokenCacheCredential(username=username, authority=authority, **kwargs)
                 credentials.append(shared_cache)
-            except ImportError as ex:
+            except Exception as ex:  # pylint:disable=broad-except
                 # transitive dependency pywin32 doesn't support 3.8 (https://github.com/mhammond/pywin32/issues/1431)
                 _LOGGER.info("Shared token cache is unavailable: '%s'", ex)
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import logging
 import os
 
 from ..._constants import EnvironmentVariables
@@ -9,6 +10,8 @@ from .chained import ChainedTokenCredential
 from .environment import EnvironmentCredential
 from .managed_identity import ManagedIdentityCredential
 from .user import SharedTokenCacheCredential
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class DefaultAzureCredential(ChainedTokenCredential):
@@ -35,10 +38,13 @@ class DefaultAzureCredential(ChainedTokenCredential):
 
         # SharedTokenCacheCredential is part of the default only on supported platforms.
         if SharedTokenCacheCredential.supported():
-            credentials.append(
-                SharedTokenCacheCredential(
-                    username=os.environ.get(EnvironmentVariables.AZURE_USERNAME), authority=authority, **kwargs
-                )
-            )
+            try:
+                # username is only required to disambiguate, when the cache contains tokens for multiple identities
+                username = os.environ.get(EnvironmentVariables.AZURE_USERNAME)
+                shared_cache = SharedTokenCacheCredential(username=username, authority=authority, **kwargs)
+                credentials.append(shared_cache)
+            except ImportError as ex:
+                # transitive dependency pywin32 doesn't support 3.8 (https://github.com/mhammond/pywin32/issues/1431)
+                _LOGGER.info("Shared token cache is unavailable: '{}'".format(ex))
 
         super().__init__(*credentials)


### PR DESCRIPTION
As described in #8292, `SharedTokenCacheCredential` raises an `ImportError` in Python 3.8 running on Windows. `DefaultAzureCredential` is therefore unusable on 3.8/win because it constructs `SharedTokenCacheCredential`. With this change, `DefaultAzureCredential` expects the exception and will not attempt to use the shared token cache on 3.8/win.

With this change:
- `DefaultAzureCredential` works on 3.8/win minus the shared token cache, whose unavailability it logs
- `SharedTokenCacheCredential` still allows the exception to propagate