### PR TITLE
Resolve artifact name issues for cosmos ci.yml

### DIFF
--- a/sdk/cosmos/ci.yml
+++ b/sdk/cosmos/ci.yml
@@ -44,6 +44,6 @@ stages:
     Artifacts:
     - name: azure_cosmos
       safeName: azurecosmos
-    - name: azure_mgmt_cosmos
-      safeName: azuremgmtcosmos
+    - name: azure_mgmt_cosmosdb
+      safeName: azuremgmtcosmosdb
       


### PR DESCRIPTION
This should fix the `validation` build failing on no artifacts discovered.