### PR TITLE
Resolve Storage Doc Generation Failures

### DIFF
--- a/doc/sphinx/generate_doc.py
+++ b/doc/sphinx/generate_doc.py
@@ -119,11 +119,8 @@ def generate_doc(config_path, output_directory = "./ref/", project_pattern=None)
                 ))
 
         for multiapi_namespace in MULTIAPI_VERSION_NAMESPACE:
-            #if namespace.startswith(multiapi_namespace):
             if namespace.split(".")[0:3] == multiapi_namespace.split(".")[0:3]:
                 _LOGGER.info("MultiAPI namespace on %s", multiapi_namespace)
-                _LOGGER.info("namespacejoined %s", ".".join(namespace.split(".")[0:3]))
-                _LOGGER.info("multiapi_namespace %s", ".".join(multiapi_namespace.split(".")[0:3]))
                 api_package = namespace.split(multiapi_namespace+".")[1]
                 multiapi_found_apiversion.setdefault(multiapi_namespace, []).append(api_package)
                 break

--- a/doc/sphinx/generate_doc.py
+++ b/doc/sphinx/generate_doc.py
@@ -119,8 +119,11 @@ def generate_doc(config_path, output_directory = "./ref/", project_pattern=None)
                 ))
 
         for multiapi_namespace in MULTIAPI_VERSION_NAMESPACE:
-            if namespace.startswith(multiapi_namespace):
+            #if namespace.startswith(multiapi_namespace):
+            if namespace.split(".")[0:3] == multiapi_namespace.split(".")[0:3]:
                 _LOGGER.info("MultiAPI namespace on %s", multiapi_namespace)
+                _LOGGER.info("namespacejoined %s", ".".join(namespace.split(".")[0:3]))
+                _LOGGER.info("multiapi_namespace %s", ".".join(multiapi_namespace.split(".")[0:3]))
                 api_package = namespace.split(multiapi_namespace+".")[1]
                 multiapi_found_apiversion.setdefault(multiapi_namespace, []).append(api_package)
                 break


### PR DESCRIPTION
There was a less visible bug in `generate_doc.py`. When additional `azure.mgmt.storage` (at least _starting_ with that) namespaces were added in the `package_service_mapping.json` documentation generation began failing the storage ci build.

Getting more specific than `startswith` resolves the problem.