### PR TITLE
Add mapping for new eventhub package in doc index generation

### DIFF
--- a/doc/sphinx/generate_versioned_index.py
+++ b/doc/sphinx/generate_versioned_index.py
@@ -89,7 +89,8 @@ LANDING_PAGE_LOCATION = "ref/{}.rst"
 
 PACKAGE_REDIRECTIONS = {
     "azure-eventhubs": "azure-eventhub",
-    "azure-eventhubs-checkpointstoreblob-aio": "azure-eventhub-checkpointstoreblob-aio"
+    "azure-eventhubs-checkpointstoreblob-aio": "azure-eventhub-checkpointstoreblob-aio",
+    "azure-eventhubs-checkpointstoreblob": "azure-eventhub-checkpointstoreblob"
 }
 
 def read_config_file(config_path=CONFIG_FILE):

--- a/sdk/eventhub/azure-eventhubs-checkpointstoreblob/dev_requirements.txt
+++ b/sdk/eventhub/azure-eventhubs-checkpointstoreblob/dev_requirements.txt
@@ -2,3 +2,4 @@
 ../../core/azure-core
 -e ../../storage/azure-storage-blob
 ../azure-eventhubs
+


### PR DESCRIPTION
New package in eventhubs needs to be excluded until namespace check is added.