### PR TITLE
Tox helper method to get package name space

### DIFF
--- a/eng/tox/import_all.py
+++ b/eng/tox/import_all.py
@@ -18,11 +18,7 @@ logging.getLogger().setLevel(logging.INFO)
 excluded_packages = [
     "azure",
     "azure-mgmt",
-    "azure.core.tracing.opencensus",
-    "azure.eventhub.checkpointstoreblob.aio",
-    "azure.storage.fileshare", # Github issue 7879.
-    "azure.storage.filedatalake", # Github issue 7879.
-]
+    ]
 
 def should_run_import_all(package_name):
     return not (package_name in excluded_packages or "nspkg" in package_name)
@@ -42,17 +38,16 @@ if __name__ == "__main__":
 
     # get target package name from target package path
     pkg_dir = os.path.abspath(args.target_package)
-    pkg_name, _ = get_package_details(os.path.join(pkg_dir, 'setup.py'))
-    package_name = pkg_name.replace("-", ".")
+    package_name, namespace, _ = get_package_details(os.path.join(pkg_dir, 'setup.py'))
 
     if should_run_import_all(package_name):
         # import all modules from current package
         logging.info(
-            "Importing all modules from package [{0}] to verify dependency".format(
-                package_name
+            "Importing all modules from namespace [{0}] to verify dependency".format(
+                namespace
             )
         )
-        import_script_all = "from {0} import *".format(package_name)
+        import_script_all = "from {0} import *".format(namespace)
         exec(import_script_all)
         logging.info("Verified module dependency, no issues found")
     else:

--- a/eng/tox/prep_sphinx_env.py
+++ b/eng/tox/prep_sphinx_env.py
@@ -44,12 +44,6 @@ Indices and tables
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", ".."))
 sphinx_conf = os.path.join(root_dir, "doc", "sphinx", "individual_build_conf.py")
 
-# reference issue 8523 for eliminating this ridiculousness.
-UNFRIENDLY_PACKAGE_TO_NAMESPACE = {
-    'azure-storage-file-share': 'azure.storage.fileshare',
-    'azure-core-tracing-opencensus': 'azure.core.tracing.ext.opencensus_span',
-    'azure-eventhub-checkpointstoreblob-aio': 'azure.eventhub.extensions.checkpointstoreblobaio'
-}
 
 def should_build_docs(package_name):
     return not ("nspkg" in package_name or package_name in ["azure", "azure-mgmt", "azure-keyvault", "azure-documentdb", "azure-mgmt-documentdb", "azure-servicemanagement-legacy"])
@@ -98,10 +92,10 @@ def copy_conf(doc_folder):
     shutil.copy(sphinx_conf, os.path.join(doc_folder, 'conf.py'))
 
 
-def create_index(doc_folder, source_location, package_name):
+def create_index(doc_folder, source_location, namespace):
     index_content = ""
 
-    package_rst = "{}.rst".format(package_name.replace("-", "."))
+    package_rst = "{}.rst".format(namespace)
     content_destination = os.path.join(doc_folder, "index.rst")
 
     if not os.path.exists(doc_folder):
@@ -117,7 +111,7 @@ def create_index(doc_folder, source_location, package_name):
     elif rst_readmes:
         index_content = create_index_file(rst_readmes[0], package_rst)
     else:
-        logging.warning("No readmes detected for this package {}".format(package_name))
+        logging.warning("No readmes detected for this namespace {}".format(namespace))
         index_content = RST_EXTENSION_FOR_INDEX.format(package_rst)
 
     # write index
@@ -158,18 +152,15 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     package_path = os.path.abspath(args.target_package)
-    package_name, package_version = get_package_details(
+    package_name, namespace, package_version = get_package_details(
         os.path.join(package_path, "setup.py")
     )
-
-    if package_name in UNFRIENDLY_PACKAGE_TO_NAMESPACE.keys():
-        package_name = UNFRIENDLY_PACKAGE_TO_NAMESPACE[package_name]
 
     if should_build_docs(package_name):
         source_location = move_and_rename(unzip_sdist_to_directory(args.dist_dir))
         doc_folder = os.path.join(source_location, "docgen")
 
-        create_index(doc_folder, source_location, package_name)
+        create_index(doc_folder, source_location, namespace)
 
         site_folder = os.path.join(args.dist_dir, "site")
         write_version(site_folder, package_version)

--- a/eng/tox/run_sphinx_apidoc.py
+++ b/eng/tox/run_sphinx_apidoc.py
@@ -65,12 +65,12 @@ def sphinx_apidoc(working_directory):
         )
         exit(1)
 
-def mgmt_apidoc(working_directory, package_name):
+def mgmt_apidoc(working_directory, namespace):
     command_array = [
         sys.executable,
         generate_mgmt_script,
         "-p",
-        package_name.replace("-","."),
+        namespace,
         "-o",
         working_directory,
         "--verbose"
@@ -117,11 +117,11 @@ if __name__ == "__main__":
     package_dir = os.path.abspath(args.package_root)
     output_directory = os.path.join(target_dir, "unzipped/docgen")
 
-    pkg_name, pkg_version = get_package_details(os.path.join(package_dir, 'setup.py'))
+    pkg_name, namespace, pkg_version = get_package_details(os.path.join(package_dir, 'setup.py'))
 
     if should_build_docs(pkg_name):
         if is_mgmt_package(pkg_name):
-            mgmt_apidoc(output_directory, pkg_name)
+            mgmt_apidoc(output_directory, namespace)
         else:
             sphinx_apidoc(args.working_directory)
     else:

--- a/eng/tox/run_sphinx_build.py
+++ b/eng/tox/run_sphinx_build.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
     target_dir = os.path.abspath(args.working_directory)
     package_dir = os.path.abspath(args.package_root)
 
-    package_name, pkg_version = get_package_details(os.path.join(package_dir, 'setup.py'))
+    package_name, _, pkg_version = get_package_details(os.path.join(package_dir, 'setup.py'))
 
     if should_build_docs(package_name):
         sphinx_build(target_dir, output_dir)

--- a/eng/tox/tox_helper_tasks.py
+++ b/eng/tox/tox_helper_tasks.py
@@ -50,10 +50,15 @@ def get_package_details(setup_filename):
     os.chdir(current_dir)
     _, kwargs = global_vars["__setup_calls__"][0]
 
-    return kwargs["name"], kwargs["version"]
+    package_name = kwargs["name"]
+    # default namespace for the package
+    name_space = package_name.replace('-', '.')
+    if "packages" in kwargs.keys():
+        packages = kwargs["packages"]
+        if packages:
+            name_space = packages[0]
+            logging.info("Namespaces found for package {0}: {1}".format(package_name, packages))
 
-def get_package_namespace(setup_filename):
-    # traverse until meeting an improperly formatted __init__
-    pass
+    return package_name, name_space, kwargs["version"]
 
     


### PR DESCRIPTION
Few packages have different namespace than directory name and it causes an issue when directory name is used for testing. Tox helper method return both package name and namespace.