### PR TITLE
Call proper process_error_async inside eventHubPartitionPump

### DIFF
--- a/sdk/eventhub/azure-eventhubs/azure/eventprocessorhost/eh_partition_pump.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventprocessorhost/eh_partition_pump.py
@@ -67,7 +67,7 @@ class EventHubPartitionPump(PartitionPump):
                 _logger.warning(
                     "%r,%r PartitionPumpWarning: Failure starting client or receiver: %r",
                     self.host.guid, self.partition_context.partition_id, last_exception)
-                await self.process_error_async(self.partition_context, last_exception)
+                await self.processor.process_error_async(self.partition_context, last_exception)
                 self.set_pump_status("Errored")
             else:
                 self.running = loop.create_task(self.partition_receiver.run())

--- a/sdk/eventhub/azure-eventhubs/tests/asynctests/test_eh_partition_pump.py
+++ b/sdk/eventhub/azure-eventhubs/tests/asynctests/test_eh_partition_pump.py
@@ -7,7 +7,6 @@ import unittest
 import asyncio
 import logging
 import pytest
-from collections import namedtuple
 
 async def wait_and_close(host):
     """

--- a/sdk/eventhub/azure-eventhubs/tests/asynctests/test_eh_partition_pump.py
+++ b/sdk/eventhub/azure-eventhubs/tests/asynctests/test_eh_partition_pump.py
@@ -7,7 +7,7 @@ import unittest
 import asyncio
 import logging
 import pytest
-
+from collections import namedtuple
 
 async def wait_and_close(host):
     """
@@ -28,3 +28,19 @@ def test_partition_pump_async(eh_partition_pump):
         eh_partition_pump.open_async(),
         wait_and_close(eh_partition_pump))
     loop.run_until_complete(tasks)
+
+
+@pytest.mark.liveTest
+def test_partition_pump_failure(eh_partition_pump):
+    loop = asyncio.get_event_loop()
+    
+    original_open_async = eh_partition_pump.open_clients_async
+
+    # force the EventHubPartitionPump to fail when calling run_async, but in such a way that it triggers
+    # the process_error_async that was broken per bug #8227
+    async def mock_failing_run_clients_async():
+        await original_open_async()        
+        eh_partition_pump.eh_client.run_async = None
+    eh_partition_pump.open_clients_async = mock_failing_run_clients_async
+
+    loop.run_until_complete(eh_partition_pump.open_async())


### PR DESCRIPTION
With this fix it does not throw exceptions due to improper #s of arguments.

Adds a unit test to validate this flow.

Note: This is to address [this bug](https://github.com/Azure/azure-sdk-for-python/issues/8227) 