### PR TITLE
Propagate responses from stage_block().

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -1624,6 +1624,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             'validate_content': validate_content,
             'cpk_scope_info': cpk_scope_info,
             'cpk_info': cpk_info,
+            'cls': return_response_headers,
         }
         options.update(kwargs)
         return options
@@ -1635,7 +1636,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             length=None,  # type: Optional[int]
             **kwargs
         ):
-        # type: (...) -> None
+        # type: (...) -> Dict[str, Any]
         """Creates a new block to be committed as part of a blob.
 
         :param str block_id: A valid Base64 string value that identifies the
@@ -1674,7 +1675,8 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
 
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :rtype: None
+        :returns: Blob property dict.
+        :rtype: dict[str, Any]
         """
         options = self._stage_block_options(
             block_id,
@@ -1682,7 +1684,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             length=length,
             **kwargs)
         try:
-            self._client.block_blob.stage_block(**options)
+            return self._client.block_blob.stage_block(**options)
         except StorageErrorException as error:
             process_storage_error(error)
 
@@ -1737,7 +1739,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             source_content_md5=None,  # type: Optional[Union[bytes, bytearray]]
             **kwargs
         ):
-        # type: (...) -> None
+        # type: (...) -> Dict[str, Any]
         """Creates a new block to be committed as part of a blob where
         the contents are read from a URL.
 
@@ -1772,7 +1774,8 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
 
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :rtype: None
+        :returns: Blob property dict.
+        :rtype: dict[str, Any]
         """
         options = self._stage_block_from_url_options(
             block_id,
@@ -1782,7 +1785,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             source_content_md5=source_content_md5,
             **kwargs)
         try:
-            self._client.block_blob.stage_block_from_url(**options)
+            return self._client.block_blob.stage_block_from_url(**options)
         except StorageErrorException as error:
             process_storage_error(error)
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -1111,7 +1111,7 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase):  # pylint: disa
             length=length,
             **kwargs)
         try:
-            await self._client.block_blob.stage_block(**options)
+            return await self._client.block_blob.stage_block(**options)
         except StorageErrorException as error:
             process_storage_error(error)
 
@@ -1169,7 +1169,7 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase):  # pylint: disa
             source_content_md5=source_content_md5,
             **kwargs)
         try:
-            await self._client.block_blob.stage_block_from_url(**options)
+            return await self._client.block_blob.stage_block_from_url(**options)
         except StorageErrorException as error:
             process_storage_error(error)
 

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_block_blob.test_put_block_with_response.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_block_blob.test_put_block_with_response.yaml
@@ -1,0 +1,130 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      x-ms-date:
+      - Fri, 25 Oct 2019 18:40:59 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/utcontainer94f01222?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Fri, 25 Oct 2019 18:40:58 GMT
+      etag:
+      - '"0x8D7597AE0E37583"'
+      last-modified:
+      - Fri, 25 Oct 2019 18:40:59 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2019-02-02'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Fri, 25 Oct 2019 18:40:59 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/utcontainer94f01222/blob94f01222
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - 1B2M2Y8AsgTpgAmY7PhCfg==
+      date:
+      - Fri, 25 Oct 2019 18:40:58 GMT
+      etag:
+      - '"0x8D7597AE0F2F5A3"'
+      last-modified:
+      - Fri, 25 Oct 2019 18:40:59 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - AAAAAAAAAAA=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2019-02-02'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: block 0
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '7'
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      x-ms-date:
+      - Fri, 25 Oct 2019 18:40:59 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/utcontainer94f01222/blob94f01222?blockid=MA%3D%3D&comp=block
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Fri, 25 Oct 2019 18:40:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - qG0Ez70es10=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2019-02-02'
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_block_blob_async.test_put_block_with_response.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_block_blob_async.test_put_block_with_response.yaml
@@ -1,0 +1,113 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      x-ms-date:
+      - Fri, 25 Oct 2019 18:46:17 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/utcontainerab3149f?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Fri, 25 Oct 2019 18:46:17 GMT
+      etag: '"0x8D7597B9EE14925"'
+      last-modified: Fri, 25 Oct 2019 18:46:17 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2019-02-02'
+    status:
+      code: 201
+      message: Created
+    url: !!python/object/new:yarl.URL
+      state: !!python/tuple
+      - !!python/object/new:urllib.parse.SplitResult
+        - https
+        - pyacrstorageinrrev5kxink.blob.core.windows.net
+        - /utcontainerab3149f
+        - restype=container
+        - ''
+- request:
+    body: null
+    headers:
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Fri, 25 Oct 2019 18:46:18 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/utcontainerab3149f/blobab3149f
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      content-md5: 1B2M2Y8AsgTpgAmY7PhCfg==
+      date: Fri, 25 Oct 2019 18:46:17 GMT
+      etag: '"0x8D7597B9EEA3EDD"'
+      last-modified: Fri, 25 Oct 2019 18:46:17 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64: AAAAAAAAAAA=
+      x-ms-request-server-encrypted: 'true'
+      x-ms-version: '2019-02-02'
+    status:
+      code: 201
+      message: Created
+    url: !!python/object/new:yarl.URL
+      state: !!python/tuple
+      - !!python/object/new:urllib.parse.SplitResult
+        - https
+        - pyacrstorageinrrev5kxink.blob.core.windows.net
+        - /utcontainerab3149f/blobab3149f
+        - ''
+        - ''
+- request:
+    body: block 0
+    headers:
+      Content-Length:
+      - '7'
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - azsdk-python-storage-blob/12.0.0b5 Python/3.6.3 (Windows-10-10.0.18362-SP0)
+      x-ms-date:
+      - Fri, 25 Oct 2019 18:46:18 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/utcontainerab3149f/blobab3149f?blockid=MA%3D%3D&comp=block
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Fri, 25 Oct 2019 18:46:17 GMT
+      server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64: qG0Ez70es10=
+      x-ms-request-server-encrypted: 'true'
+      x-ms-version: '2019-02-02'
+    status:
+      code: 201
+      message: Created
+    url: !!python/object/new:yarl.URL
+      state: !!python/tuple
+      - !!python/object/new:urllib.parse.SplitResult
+        - https
+        - pyacrstorageinrrev5kxink.blob.core.windows.net
+        - /utcontainerab3149f/blobab3149f
+        - blockid=MA%3D%3D&comp=block
+        - ''
+version: 1

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob.py
@@ -87,10 +87,25 @@ class StorageBlockBlobTest(StorageTestCase):
 
         # Act
         for i in range(5):
-            resp = blob.stage_block(i, 'block {0}'.format(i).encode('utf-8'))
-            self.assertIsNone(resp)
+            headers = blob.stage_block(i, 'block {0}'.format(i).encode('utf-8'))
+            self.assertIn('content_crc64', headers)
 
         # Assert
+
+    @GlobalStorageAccountPreparer()
+    def test_put_block_with_response(self, resource_group, location, storage_account, storage_account_key):
+        self._setup(storage_account.name, storage_account_key)
+        blob = self._create_blob()
+
+        def return_response(resp, _, headers):
+            return (resp, headers)
+
+        # Act
+        resp, headers = blob.stage_block(0, 'block 0', cls=return_response)
+
+        # Assert
+        self.assertEqual(201, resp.status_code)
+        self.assertIn('x-ms-content-crc64', headers)
 
     @GlobalStorageAccountPreparer()
     def test_put_block_unicode(self, resource_group, location, storage_account, storage_account_key):
@@ -98,8 +113,8 @@ class StorageBlockBlobTest(StorageTestCase):
         blob = self._create_blob()
 
         # Act
-        resp = blob.stage_block('1', u'啊齄丂狛狜')
-        self.assertIsNone(resp)
+        headers = blob.stage_block('1', u'啊齄丂狛狜')
+        self.assertIn('content_crc64', headers)
 
         # Assert
 


### PR DESCRIPTION
When calling BlockBlobOperations.stage_block(), an optional callable can
be passed to handle the response and its return value is returned to the
caller of stage_block(). The patch modifies BlobClient to pass this
value back from its stage_block() method, as currently it is swallowed.

Fixes: #8565