### PR TITLE
Remove period from EnvironmentCredential error msg

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -86,5 +86,5 @@ class EnvironmentCredential:
         :raises ~azure.core.exceptions.ClientAuthenticationError:
         """
         if not self._credential:
-            raise ClientAuthenticationError(message="Incomplete environment configuration.")
+            raise ClientAuthenticationError(message="Incomplete environment configuration")
         return self._credential.get_token(*scopes, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -60,5 +60,5 @@ class EnvironmentCredential:
         :raises ~azure.core.exceptions.ClientAuthenticationError:
         """
         if not self._credential:
-            raise ClientAuthenticationError(message="Incomplete environment configuration.")
+            raise ClientAuthenticationError(message="Incomplete environment configuration")
         return await self._credential.get_token(*scopes, **kwargs)


### PR DESCRIPTION
Resolves #8555 

I verified that all ClientAuthencationError messages do not end in a period, so making EnvironmentCredential consistent with the others.

I considered writing a test for this change, but decided not to, because it is a string change, that is unlikely to regress and adding code to test for this would add more code to maintain.  LMK if you'd like to discuss.