### PR TITLE
Change path creation from concat to os.path.join

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user.py
@@ -135,7 +135,9 @@ class SharedTokenCacheCredential(object):
         if sys.platform.startswith("win") and "LOCALAPPDATA" in os.environ:
             from msal_extensions.token_cache import WindowsTokenCache
 
-            cache = WindowsTokenCache(cache_location=os.environ["LOCALAPPDATA"] + "/.IdentityService/msal.cache")
+            cache = WindowsTokenCache(
+                cache_location=os.path.join(os.environ["LOCALAPPDATA"], ".IdentityService", "msal.cache")
+            )
 
             # prevent writing to the shared cache
             # TODO: seperating deserializing access tokens from caching them would make this cleaner


### PR DESCRIPTION
Resolves #8517 

Updated to use os.path.join so the paths generated either all back slash or all forward slashes.

I discussed the test scenario with @chlowell and we decided that tests are not required for this change as it is an internal only change that doesn't have a reproducable issue on Windows, other than visually looking at the path.

I put the cache_location param on a new line, due to pylint line length checks.

![image](https://user-images.githubusercontent.com/2163001/68703728-077e8780-0540-11ea-926c-439c03604975.png)
