### PR TITLE
Nightly build is failing due version conflict between storage datalak…

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/setup.py
+++ b/sdk/storage/azure-storage-file-datalake/setup.py
@@ -93,7 +93,7 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.0.0",
         "msrest>=0.6.10",
-        "azure-storage-blob<13.0.0,>=12.0.0"
+        "azure-storage-blob~=12.0"
     ],
     extras_require={
         ":python_version<'3.0'": ['futures', 'azure-storage-nspkg<4.0.0,>=3.0.0'],

--- a/sdk/storage/azure-storage-file-datalake/setup.py
+++ b/sdk/storage/azure-storage-file-datalake/setup.py
@@ -93,7 +93,7 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.0.0",
         "msrest>=0.6.10",
-        "azure-storage-blob>=12.0.0"
+        "azure-storage-blob<13.0.0,>=12.0.0"
     ],
     extras_require={
         ":python_version<'3.0'": ['futures', 'azure-storage-nspkg<4.0.0,>=3.0.0'],

--- a/sdk/storage/azure-storage-file-datalake/setup.py
+++ b/sdk/storage/azure-storage-file-datalake/setup.py
@@ -93,7 +93,7 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.0.0",
         "msrest>=0.6.10",
-        "azure-storage-blob~=12.0.0"
+        "azure-storage-blob>=12.0.0"
     ],
     extras_require={
         ":python_version<'3.0'": ['futures', 'azure-storage-nspkg<4.0.0,>=3.0.0'],

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -110,7 +110,7 @@ six>=1.6
 #override azure-storage-queue msrest>=0.6.10
 #override azure-storage-file-share msrest>=0.6.10
 #override azure-storage-file-datalake msrest>=0.6.10
-#override azure-storage-file-datalake azure-storage-blob~=12.0.0
+#override azure-storage-file-datalake azure-storage-blob<13.0.0,>=12.0.0
 opencensus>=0.6.0
 opencensus-ext-threading
 opencensus-ext-azure>=0.3.1

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -110,7 +110,7 @@ six>=1.6
 #override azure-storage-queue msrest>=0.6.10
 #override azure-storage-file-share msrest>=0.6.10
 #override azure-storage-file-datalake msrest>=0.6.10
-#override azure-storage-file-datalake azure-storage-blob<13.0.0,>=12.0.0
+#override azure-storage-file-datalake azure-storage-blob~=12.0
 opencensus>=0.6.0
 opencensus-ext-threading
 opencensus-ext-azure>=0.3.1


### PR DESCRIPTION
Azure-storage-file-datalake has dependency to 12.0.0 as per setup.py and causing to install 12.0.0 version of azure-storage-blob during nightly build global test instead of latest 12.1.0b1 and causing test failures for new test cases added for azure-storage-blob.

Fix is to update azure-storage-blob dependency to >=12.0.0 in azure-storage-file-datalake
