### PR TITLE
Expose close() method from PipelineClient in Storage Blobs

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/_azure_blob_storage.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/_azure_blob_storage.py
@@ -74,6 +74,8 @@ class AzureBlobStorage(object):
         self.block_blob = BlockBlobOperations(
             self._client, self._config, self._serialize, self._deserialize)
 
+    def close(self):
+        self._client.close()
     def __enter__(self):
         self._client.__enter__()
         return self

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/aio/_azure_blob_storage_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/aio/_azure_blob_storage_async.py
@@ -75,6 +75,8 @@ class AzureBlobStorage(object):
         self.block_blob = BlockBlobOperations(
             self._client, self._config, self._serialize, self._deserialize)
 
+    async def close(self):
+        await self._client.close()
     async def __aenter__(self):
         await self._client.__aenter__()
         return self

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/aio/operations_async/_block_blob_operations_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/aio/operations_async/_block_blob_operations_async.py
@@ -37,7 +37,7 @@ class BlockBlobOperations:
         self._config = config
         self.x_ms_blob_type = "BlockBlob"
 
-    async def upload(self, body, content_length, timeout=None, metadata=None, tier=None, request_id=None, blob_http_headers=None, lease_access_conditions=None, cpk_info=None, modified_access_conditions=None, *, cls=None, **kwargs):
+    async def upload(self, body, content_length, timeout=None, transactional_content_md5=None, metadata=None, tier=None, request_id=None, blob_http_headers=None, lease_access_conditions=None, cpk_info=None, modified_access_conditions=None, *, cls=None, **kwargs):
         """The Upload Block Blob operation updates the content of an existing
         block blob. Updating an existing block blob overwrites any existing
         metadata on the blob. Partial updates are not supported with Put Blob;
@@ -54,6 +54,9 @@ class BlockBlobOperations:
          href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
          Timeouts for Blob Service Operations.</a>
         :type timeout: int
+        :param transactional_content_md5: Specify the transactional md5 for
+         the body, to be validated by the service.
+        :type transactional_content_md5: bytearray
         :param metadata: Optional. Specifies a user-defined name-value pair
          associated with the blob. If no name-value pairs are specified, the
          operation will copy the metadata from the source blob or file to the
@@ -150,6 +153,8 @@ class BlockBlobOperations:
         # Construct headers
         header_parameters = {}
         header_parameters['Content-Type'] = 'application/octet-stream'
+        if transactional_content_md5 is not None:
+            header_parameters['Content-MD5'] = self._serialize.header("transactional_content_md5", transactional_content_md5, 'bytearray')
         header_parameters['Content-Length'] = self._serialize.header("content_length", content_length, 'long')
         if metadata is not None:
             header_parameters['x-ms-meta'] = self._serialize.header("metadata", metadata, 'str')

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/operations/_block_blob_operations.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/operations/_block_blob_operations.py
@@ -37,7 +37,7 @@ class BlockBlobOperations(object):
         self._config = config
         self.x_ms_blob_type = "BlockBlob"
 
-    def upload(self, body, content_length, timeout=None, metadata=None, tier=None, request_id=None, blob_http_headers=None, lease_access_conditions=None, cpk_info=None, modified_access_conditions=None, cls=None, **kwargs):
+    def upload(self, body, content_length, timeout=None, transactional_content_md5=None, metadata=None, tier=None, request_id=None, blob_http_headers=None, lease_access_conditions=None, cpk_info=None, modified_access_conditions=None, cls=None, **kwargs):
         """The Upload Block Blob operation updates the content of an existing
         block blob. Updating an existing block blob overwrites any existing
         metadata on the blob. Partial updates are not supported with Put Blob;
@@ -54,6 +54,9 @@ class BlockBlobOperations(object):
          href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
          Timeouts for Blob Service Operations.</a>
         :type timeout: int
+        :param transactional_content_md5: Specify the transactional md5 for
+         the body, to be validated by the service.
+        :type transactional_content_md5: bytearray
         :param metadata: Optional. Specifies a user-defined name-value pair
          associated with the blob. If no name-value pairs are specified, the
          operation will copy the metadata from the source blob or file to the
@@ -150,6 +153,8 @@ class BlockBlobOperations(object):
         # Construct headers
         header_parameters = {}
         header_parameters['Content-Type'] = 'application/octet-stream'
+        if transactional_content_md5 is not None:
+            header_parameters['Content-MD5'] = self._serialize.header("transactional_content_md5", transactional_content_md5, 'bytearray')
         header_parameters['Content-Length'] = self._serialize.header("content_length", content_length, 'long')
         if metadata is not None:
             header_parameters['x-ms-meta'] = self._serialize.header("metadata", metadata, 'str')

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
@@ -113,6 +113,9 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
     def __exit__(self, *args):
         self._client.__exit__(*args)
 
+    def close(self):
+        self._client.close()
+
     @property
     def url(self):
         """The full endpoint URL to this entity, including SAS token if used.

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client_async.py
@@ -57,7 +57,7 @@ class AsyncStorageAccountHostsMixin(object):
 
     async def __aexit__(self, *args):
         await self._client.__aexit__(*args)
-    
+
     async def close(self):
         await self._client.close()
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client_async.py
@@ -57,6 +57,9 @@ class AsyncStorageAccountHostsMixin(object):
 
     async def __aexit__(self, *args):
         await self._client.__aexit__(*args)
+    
+    async def close(self):
+        await self._client.close()
 
     def _create_pipeline(self, credential, **kwargs):
         # type: (Any, **Any) -> Tuple[Configuration, Pipeline]

--- a/sdk/storage/azure-storage-blob/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-blob/tests/_shared/testcase.py
@@ -11,6 +11,7 @@ import inspect
 import os
 import os.path
 import time
+from datetime import datetime, timedelta
 
 try:
     import unittest.mock as mock
@@ -20,6 +21,7 @@ except ImportError:
 import zlib
 import math
 import sys
+import string
 import random
 import re
 import logging
@@ -31,6 +33,7 @@ except ImportError:
     from io import StringIO
 
 from azure.core.credentials import AccessToken
+from azure.storage.blob import generate_account_sas, AccountSasPermissions, ResourceTypes
 
 try:
     from devtools_testutils import mgmt_settings_real as settings
@@ -254,6 +257,18 @@ class StorageTestCase(AzureMgmtTestCase):
                 self.get_settings_value("CLIENT_SECRET"),
             )
         return self.generate_fake_token()
+
+    def generate_sas_token(self):
+        fake_key = 'a'*30 + 'b'*30
+
+        return '?' + generate_account_sas(
+            account_name = 'test', # name of the storage account
+            account_key = fake_key, # key for the storage account
+            resource_types = ResourceTypes(object=True),
+            permission = AccountSasPermissions(read=True,list=True),
+            start = datetime.now() - timedelta(hours = 24),
+            expiry = datetime.now() + timedelta(days = 8)
+        )
 
     def generate_fake_token(self):
         return FakeTokenCredential()

--- a/sdk/storage/azure-storage-blob/tests/test_blob_client.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_client.py
@@ -33,7 +33,7 @@ _CONNECTION_ENDPOINTS_SECONDARY = {'blob': 'BlobSecondaryEndpoint'}
 class StorageClientTest(StorageTestCase):
     def setUp(self):
         super(StorageClientTest, self).setUp()
-        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Z%2FRHIX5Xcg0Mq2rqI3OlWTjEg2tYkboXr1P9ZUXDtkk%3D'
+        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Y%2FoUshaLLnoTPass'
         self.token_credential = self.generate_oauth_token()
 
     # --Helpers-----------------------------------------------------------------
@@ -574,5 +574,14 @@ class StorageClientTest(StorageTestCase):
                     self.assertEqual(
                         str(e.exception), "Connection string missing required connection details.")
 
+    @GlobalStorageAccountPreparer()
+    def test_closing_pipeline_client(self, resource_group, location, storage_account, storage_account_key):
+        # Arrange
+        for client, url in SERVICES.items():
+            # Act
+            service = client(
+                self.account_url(storage_account.name, "blob"), credential=storage_account_key, container_name='foo', blob_name='bar')
 
+            # Assert
+            assert hasattr(service, 'close')
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_blob_client.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_client.py
@@ -33,7 +33,7 @@ _CONNECTION_ENDPOINTS_SECONDARY = {'blob': 'BlobSecondaryEndpoint'}
 class StorageClientTest(StorageTestCase):
     def setUp(self):
         super(StorageClientTest, self).setUp()
-        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Y%2FoUshaLLnoTPass'
+        self.sas_token = self.generate_sas_token()
         self.token_credential = self.generate_oauth_token()
 
     # --Helpers-----------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_blob_client.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_client.py
@@ -587,4 +587,13 @@ class StorageClientTest(StorageTestCase):
                 assert hasattr(service, 'close')
                 service.close()
 
+    @GlobalStorageAccountPreparer()
+    def test_closing_pipeline_client_simple(self, resource_group, location, storage_account, storage_account_key):
+        # Arrange
+        for client, url in SERVICES.items():
+            # Act
+            service = client(
+                self.account_url(storage_account.name, "blob"), credential=storage_account_key, container_name='foo', blob_name='bar')
+            service.close()
+
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_blob_client.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_client.py
@@ -583,5 +583,8 @@ class StorageClientTest(StorageTestCase):
                 self.account_url(storage_account.name, "blob"), credential=storage_account_key, container_name='foo', blob_name='bar')
 
             # Assert
-            assert hasattr(service, 'close')
+            with service:
+                assert hasattr(service, 'close')
+                service.close()
+
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_client_async.py
@@ -558,5 +558,7 @@ class StorageClientTestAsync(AsyncStorageTestCase):
                 self.account_url(storage_account.name, "blob"), credential=storage_account_key, container_name='foo', blob_name='bar')
 
             # Assert
-            assert hasattr(service, 'close')
+            with servcie:
+                assert hasattr(service, 'close')
+                service.close()
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_client_async.py
@@ -46,7 +46,7 @@ class AiohttpTestTransport(AioHttpTransport):
 class StorageClientTestAsync(AsyncStorageTestCase):
     def setUp(self):
         super(StorageClientTestAsync, self).setUp()
-        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Z%2FRHIX5Xcg0Mq2rqI3OlWTjEg2tYkboXr1P9ZUXDtkk%3D'
+        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Y%2FoUshaLLnoTPass'
         self.token_credential = self.generate_oauth_token()
 
     # --Helpers-----------------------------------------------------------------
@@ -548,4 +548,15 @@ class StorageClientTestAsync(AsyncStorageTestCase):
         custom_headers = {'User-Agent': 'customer_user_agent'}
         await service.get_service_properties(raw_response_hook=callback, headers=custom_headers)
 
+    @GlobalStorageAccountPreparer()
+    def test_closing_pipeline_client(self, resource_group, location, storage_account, storage_account_key):
+        # Arrange
+
+        for client, url in SERVICES.items():
+            # Act
+            service = client(
+                self.account_url(storage_account.name, "blob"), credential=storage_account_key, container_name='foo', blob_name='bar')
+
+            # Assert
+            assert hasattr(service, 'close')
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_client_async.py
@@ -46,7 +46,7 @@ class AiohttpTestTransport(AioHttpTransport):
 class StorageClientTestAsync(AsyncStorageTestCase):
     def setUp(self):
         super(StorageClientTestAsync, self).setUp()
-        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Y%2FoUshaLLnoTPass'
+        self.sas_token = self.generate_sas_token()
         self.token_credential = self.generate_oauth_token()
 
     # --Helpers-----------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_client_async.py
@@ -558,7 +558,7 @@ class StorageClientTestAsync(AsyncStorageTestCase):
                 self.account_url(storage_account.name, "blob"), credential=storage_account_key, container_name='foo', blob_name='bar')
 
             # Assert
-            with servcie:
+            with service:
                 assert hasattr(service, 'close')
                 service.close()
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_client_async.py
@@ -561,4 +561,15 @@ class StorageClientTestAsync(AsyncStorageTestCase):
             async with service:
                 assert hasattr(service, 'close')
                 service.close()
+
+    @GlobalStorageAccountPreparer()
+    async def test_closing_pipeline_client_simple(self, resource_group, location, storage_account, storage_account_key):
+        # Arrange
+
+        for client, url in SERVICES.items():
+            # Act
+            service = client(
+                self.account_url(storage_account.name, "blob"), credential=storage_account_key, container_name='foo', blob_name='bar')
+            service.close()
+                
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_client_async.py
@@ -549,7 +549,7 @@ class StorageClientTestAsync(AsyncStorageTestCase):
         await service.get_service_properties(raw_response_hook=callback, headers=custom_headers)
 
     @GlobalStorageAccountPreparer()
-    def test_closing_pipeline_client(self, resource_group, location, storage_account, storage_account_key):
+    async def test_closing_pipeline_client(self, resource_group, location, storage_account, storage_account_key):
         # Arrange
 
         for client, url in SERVICES.items():
@@ -558,7 +558,7 @@ class StorageClientTestAsync(AsyncStorageTestCase):
                 self.account_url(storage_account.name, "blob"), credential=storage_account_key, container_name='foo', blob_name='bar')
 
             # Assert
-            with service:
+            async with service:
                 assert hasattr(service, 'close')
                 service.close()
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -341,7 +341,7 @@ class StorageCommonBlobTestAsync(AsyncStorageTestCase):
     @AsyncStorageTestCase.await_prepared_test
     async def test_create_blob_with_aiohttp_async(self, resource_group, location, storage_account, storage_account_key):
         await self._setup(storage_account.name, storage_account_key)
-        blob = self.bsc.get_blob_client(self.container_name, "gutenberg")
+        blob = self.bsc.get_blob_client(self.container_name, "gutenberg_async")
         # Act
         uri = "http://www.gutenberg.org/files/59466/59466-0.txt"
         async with aiohttp.ClientSession() as session:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/_azure_file_storage.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/_azure_file_storage.py
@@ -26,13 +26,13 @@ class AzureFileStorage(object):
 
 
     :ivar service: Service operations
-    :vartype service: azure.storage.fileshare._generated.operations.ServiceOperations
+    :vartype service: azure.storage.fileshare.operations.ServiceOperations
     :ivar share: Share operations
-    :vartype share: azure.storage.fileshare._generated.operations.ShareOperations
+    :vartype share: azure.storage.fileshare.operations.ShareOperations
     :ivar directory: Directory operations
-    :vartype directory: azure.storage.fileshare._generated.operations.DirectoryOperations
+    :vartype directory: azure.storage.fileshare.operations.DirectoryOperations
     :ivar file: File operations
-    :vartype file: azure.storage.fileshare._generated.operations.FileOperations
+    :vartype file: azure.storage.fileshare.operations.FileOperations
 
     :param version: Specifies the version of the operation to use for this
      request.
@@ -62,6 +62,8 @@ class AzureFileStorage(object):
         self.file = FileOperations(
             self._client, self._config, self._serialize, self._deserialize)
 
+    def close(self):
+        self._client.close()
     def __enter__(self):
         self._client.__enter__()
         return self

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/_azure_file_storage_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/_azure_file_storage_async.py
@@ -26,13 +26,13 @@ class AzureFileStorage(object):
 
 
     :ivar service: Service operations
-    :vartype service: azure.storage.fileshare._generated.aio.operations_async.ServiceOperations
+    :vartype service: azure.storage.fileshare.aio.operations_async.ServiceOperations
     :ivar share: Share operations
-    :vartype share: azure.storage.fileshare._generated.aio.operations_async.ShareOperations
+    :vartype share: azure.storage.fileshare.aio.operations_async.ShareOperations
     :ivar directory: Directory operations
-    :vartype directory: azure.storage.fileshare._generated.aio.operations_async.DirectoryOperations
+    :vartype directory: azure.storage.fileshare.aio.operations_async.DirectoryOperations
     :ivar file: File operations
-    :vartype file: azure.storage.fileshare._generated.aio.operations_async.FileOperations
+    :vartype file: azure.storage.fileshare.aio.operations_async.FileOperations
 
     :param version: Specifies the version of the operation to use for this
      request.
@@ -63,6 +63,8 @@ class AzureFileStorage(object):
         self.file = FileOperations(
             self._client, self._config, self._serialize, self._deserialize)
 
+    async def close(self):
+        await self._client.close()
     async def __aenter__(self):
         await self._client.__aenter__()
         return self

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/operations_async/_directory_operations_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/operations_async/_directory_operations_async.py
@@ -74,7 +74,7 @@ class DirectoryOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -150,7 +150,7 @@ class DirectoryOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -216,7 +216,7 @@ class DirectoryOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -289,7 +289,7 @@ class DirectoryOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "properties"
@@ -364,7 +364,7 @@ class DirectoryOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "metadata"
@@ -442,9 +442,9 @@ class DirectoryOperations:
         :return: ListFilesAndDirectoriesSegmentResponse or the result of
          cls(response)
         :rtype:
-         ~azure.storage.fileshare._generated.models.ListFilesAndDirectoriesSegmentResponse
+         ~azure.storage.fileshare.models.ListFilesAndDirectoriesSegmentResponse
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "list"
@@ -531,9 +531,9 @@ class DirectoryOperations:
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: ListHandlesResponse or the result of cls(response)
-        :rtype: ~azure.storage.fileshare._generated.models.ListHandlesResponse
+        :rtype: ~azure.storage.fileshare.models.ListHandlesResponse
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "listhandles"
@@ -620,7 +620,7 @@ class DirectoryOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "forceclosehandles"

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/operations_async/_file_operations_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/operations_async/_file_operations_async.py
@@ -78,13 +78,14 @@ class FileOperations:
          x-ms-file-permission-key should be specified.
         :type file_permission_key: str
         :param file_http_headers: Additional parameters for the operation
-        :type file_http_headers: ~azure.storage.fileshare._generated.models.FileHTTPHeaders
+        :type file_http_headers:
+         ~azure.storage.fileshare.models.FileHTTPHeaders
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         file_content_type = None
@@ -195,7 +196,7 @@ class FileOperations:
         :return: object or the result of cls(response)
         :rtype: Generator
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -325,7 +326,7 @@ class FileOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -403,7 +404,7 @@ class FileOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -475,13 +476,14 @@ class FileOperations:
          x-ms-file-permission-key should be specified.
         :type file_permission_key: str
         :param file_http_headers: Additional parameters for the operation
-        :type file_http_headers: ~azure.storage.fileshare._generated.models.FileHTTPHeaders
+        :type file_http_headers:
+         ~azure.storage.fileshare.models.FileHTTPHeaders
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         file_content_type = None
@@ -588,7 +590,7 @@ class FileOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "metadata"
@@ -653,7 +655,7 @@ class FileOperations:
          that indicates the range to clear, up to maximum file size. Possible
          values include: 'update', 'clear'
         :type file_range_write: str or
-         ~azure.storage.fileshare._generated.models.FileRangeWriteType
+         ~azure.storage.fileshare.models.FileRangeWriteType
         :param content_length: Specifies the number of bytes being transmitted
          in the request body. When the x-ms-write header is set to clear, the
          value of this header must be set to zero.
@@ -677,7 +679,7 @@ class FileOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "range"
@@ -763,13 +765,13 @@ class FileOperations:
         :param source_modified_access_conditions: Additional parameters for
          the operation
         :type source_modified_access_conditions:
-         ~azure.storage.fileshare._generated.models.SourceModifiedAccessConditions
+         ~azure.storage.fileshare.models.SourceModifiedAccessConditions
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         source_if_match_crc64 = None
@@ -850,9 +852,9 @@ class FileOperations:
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: list or the result of cls(response)
-        :rtype: list[~azure.storage.fileshare._generated.models.Range]
+        :rtype: list[~azure.storage.fileshare.models.Range]
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "rangelist"
@@ -934,7 +936,7 @@ class FileOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -996,7 +998,7 @@ class FileOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "copy"
@@ -1064,9 +1066,9 @@ class FileOperations:
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: ListHandlesResponse or the result of cls(response)
-        :rtype: ~azure.storage.fileshare._generated.models.ListHandlesResponse
+        :rtype: ~azure.storage.fileshare.models.ListHandlesResponse
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "listhandles"
@@ -1148,7 +1150,7 @@ class FileOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "forceclosehandles"

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/operations_async/_service_operations_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/operations_async/_service_operations_async.py
@@ -44,7 +44,7 @@ class ServiceOperations:
 
         :param storage_service_properties: The StorageService properties.
         :type storage_service_properties:
-         ~azure.storage.fileshare._generated.models.StorageServiceProperties
+         ~azure.storage.fileshare.models.StorageServiceProperties
         :param timeout: The timeout parameter is expressed in seconds. For
          more information, see <a
          href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting
@@ -55,7 +55,7 @@ class ServiceOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "properties"
@@ -113,9 +113,9 @@ class ServiceOperations:
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: StorageServiceProperties or the result of cls(response)
-        :rtype: ~azure.storage.fileshare._generated.models.StorageServiceProperties
+        :rtype: ~azure.storage.fileshare.models.StorageServiceProperties
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "properties"
@@ -185,7 +185,7 @@ class ServiceOperations:
         :param include: Include this parameter to specify one or more datasets
          to include in the response.
         :type include: list[str or
-         ~azure.storage.fileshare._generated.models.ListSharesIncludeType]
+         ~azure.storage.fileshare.models.ListSharesIncludeType]
         :param timeout: The timeout parameter is expressed in seconds. For
          more information, see <a
          href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting
@@ -194,9 +194,9 @@ class ServiceOperations:
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: ListSharesResponse or the result of cls(response)
-        :rtype: ~azure.storage.fileshare._generated.models.ListSharesResponse
+        :rtype: ~azure.storage.fileshare.models.ListSharesResponse
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "list"

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/operations_async/_share_operations_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/operations_async/_share_operations_async.py
@@ -56,7 +56,7 @@ class ShareOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -119,7 +119,7 @@ class ShareOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -181,13 +181,13 @@ class ShareOperations:
          base share and all of its snapshots. Possible values include:
          'include'
         :type delete_snapshots: str or
-         ~azure.storage.fileshare._generated.models.DeleteSnapshotsOptionType
+         ~azure.storage.fileshare.models.DeleteSnapshotsOptionType
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -246,7 +246,7 @@ class ShareOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "snapshot"
@@ -298,7 +298,8 @@ class ShareOperations:
 
         :param share_permission: A permission (a security descriptor) at the
          share level.
-        :type share_permission: ~azure.storage.fileshare._generated.models.SharePermission
+        :type share_permission:
+         ~azure.storage.fileshare.models.SharePermission
         :param timeout: The timeout parameter is expressed in seconds. For
          more information, see <a
          href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting
@@ -309,7 +310,7 @@ class ShareOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "filepermission"
@@ -356,12 +357,11 @@ class ShareOperations:
             return cls(response, None, response_headers)
     create_permission.metadata = {'url': '/{shareName}'}
 
-    async def get_permission(self, file_permission_key=None, timeout=None, *, cls=None, **kwargs):
+    async def get_permission(self, file_permission_key, timeout=None, *, cls=None, **kwargs):
         """Returns the permission (security descriptor) for a given key.
 
         :param file_permission_key: Key of the permission to be set for the
-         directory/file. Note: Only one of the x-ms-file-permission or
-         x-ms-file-permission-key should be specified.
+         directory/file.
         :type file_permission_key: str
         :param timeout: The timeout parameter is expressed in seconds. For
          more information, see <a
@@ -371,9 +371,9 @@ class ShareOperations:
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: SharePermission or the result of cls(response)
-        :rtype: ~azure.storage.fileshare._generated.models.SharePermission
+        :rtype: ~azure.storage.fileshare.models.SharePermission
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "filepermission"
@@ -395,8 +395,7 @@ class ShareOperations:
         # Construct headers
         header_parameters = {}
         header_parameters['Accept'] = 'application/json'
-        if file_permission_key is not None:
-            header_parameters['x-ms-file-permission-key'] = self._serialize.header("file_permission_key", file_permission_key, 'str')
+        header_parameters['x-ms-file-permission-key'] = self._serialize.header("file_permission_key", file_permission_key, 'str')
         header_parameters['x-ms-version'] = self._serialize.header("self._config.version", self._config.version, 'str')
 
         # Construct and send request
@@ -440,7 +439,7 @@ class ShareOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "properties"
@@ -502,7 +501,7 @@ class ShareOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "metadata"
@@ -560,9 +559,9 @@ class ShareOperations:
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: list or the result of cls(response)
-        :rtype: list[~azure.storage.fileshare._generated.models.SignedIdentifier]
+        :rtype: list[~azure.storage.fileshare.models.SignedIdentifier]
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "acl"
@@ -618,7 +617,8 @@ class ShareOperations:
         """Sets a stored access policy for use with shared access signatures.
 
         :param share_acl: The ACL for the share.
-        :type share_acl: list[~azure.storage.fileshare._generated.models.SignedIdentifier]
+        :type share_acl:
+         list[~azure.storage.fileshare.models.SignedIdentifier]
         :param timeout: The timeout parameter is expressed in seconds. For
          more information, see <a
          href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting
@@ -629,7 +629,7 @@ class ShareOperations:
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "acl"
@@ -692,9 +692,9 @@ class ShareOperations:
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: ShareStats or the result of cls(response)
-        :rtype: ~azure.storage.fileshare._generated.models.ShareStats
+        :rtype: ~azure.storage.fileshare.models.ShareStats
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "stats"

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/models/_azure_file_storage_enums.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/models/_azure_file_storage_enums.py
@@ -74,6 +74,12 @@ class StorageErrorCode(str, Enum):
     share_snapshot_operation_not_supported = "ShareSnapshotOperationNotSupported"
     share_has_snapshots = "ShareHasSnapshots"
     container_quota_downgrade_not_allowed = "ContainerQuotaDowngradeNotAllowed"
+    authorization_source_ip_mismatch = "AuthorizationSourceIPMismatch"
+    authorization_protocol_mismatch = "AuthorizationProtocolMismatch"
+    authorization_permission_mismatch = "AuthorizationPermissionMismatch"
+    authorization_service_mismatch = "AuthorizationServiceMismatch"
+    authorization_resource_type_mismatch = "AuthorizationResourceTypeMismatch"
+    feature_version_mismatch = "FeatureVersionMismatch"
 
 
 class DeleteSnapshotsOptionType(str, Enum):

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/models/_models.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/models/_models.py
@@ -174,7 +174,7 @@ class FileItem(Model):
     :param name: Required.
     :type name: str
     :param properties: Required.
-    :type properties: ~azure.storage.fileshare._generated.models.FileProperty
+    :type properties: ~azure.storage.fileshare.models.FileProperty
     """
 
     _validation = {
@@ -230,9 +230,9 @@ class FilesAndDirectoriesListSegment(Model):
     All required parameters must be populated in order to send to Azure.
 
     :param directory_items: Required.
-    :type directory_items: list[~azure.storage.fileshare._generated.models.DirectoryItem]
+    :type directory_items: list[~azure.storage.fileshare.models.DirectoryItem]
     :param file_items: Required.
-    :type file_items: list[~azure.storage.fileshare._generated.models.FileItem]
+    :type file_items: list[~azure.storage.fileshare.models.FileItem]
     """
 
     _validation = {
@@ -337,7 +337,8 @@ class ListFilesAndDirectoriesSegmentResponse(Model):
     :param max_results:
     :type max_results: int
     :param segment: Required.
-    :type segment: ~azure.storage.fileshare._generated.models.FilesAndDirectoriesListSegment
+    :type segment:
+     ~azure.storage.fileshare.models.FilesAndDirectoriesListSegment
     :param next_marker: Required.
     :type next_marker: str
     """
@@ -385,7 +386,7 @@ class ListHandlesResponse(Model):
     All required parameters must be populated in order to send to Azure.
 
     :param handle_list:
-    :type handle_list: list[~azure.storage.fileshare._generated.models.HandleItem]
+    :type handle_list: list[~azure.storage.fileshare.models.HandleItem]
     :param next_marker: Required.
     :type next_marker: str
     """
@@ -422,7 +423,7 @@ class ListSharesResponse(Model):
     :param max_results:
     :type max_results: int
     :param share_items:
-    :type share_items: list[~azure.storage.fileshare._generated.models.ShareItem]
+    :type share_items: list[~azure.storage.fileshare.models.ShareItem]
     :param next_marker: Required.
     :type next_marker: str
     """
@@ -468,7 +469,7 @@ class Metrics(Model):
      statistics for called API operations.
     :type include_apis: bool
     :param retention_policy:
-    :type retention_policy: ~azure.storage.fileshare._generated.models.RetentionPolicy
+    :type retention_policy: ~azure.storage.fileshare.models.RetentionPolicy
     """
 
     _validation = {
@@ -566,7 +567,7 @@ class ShareItem(Model):
     :param snapshot:
     :type snapshot: str
     :param properties: Required.
-    :type properties: ~azure.storage.fileshare._generated.models.ShareProperties
+    :type properties: ~azure.storage.fileshare.models.ShareProperties
     :param metadata:
     :type metadata: dict[str, str]
     """
@@ -687,7 +688,7 @@ class SignedIdentifier(Model):
     :param id: Required. A unique id.
     :type id: str
     :param access_policy: The access policy.
-    :type access_policy: ~azure.storage.fileshare._generated.models.AccessPolicy
+    :type access_policy: ~azure.storage.fileshare.models.AccessPolicy
     """
 
     _validation = {
@@ -770,12 +771,12 @@ class StorageServiceProperties(Model):
 
     :param hour_metrics: A summary of request statistics grouped by API in
      hourly aggregates for files.
-    :type hour_metrics: ~azure.storage.fileshare._generated.models.Metrics
+    :type hour_metrics: ~azure.storage.fileshare.models.Metrics
     :param minute_metrics: A summary of request statistics grouped by API in
      minute aggregates for files.
-    :type minute_metrics: ~azure.storage.fileshare._generated.models.Metrics
+    :type minute_metrics: ~azure.storage.fileshare.models.Metrics
     :param cors: The set of CORS rules.
-    :type cors: list[~azure.storage.fileshare._generated.models.CorsRule]
+    :type cors: list[~azure.storage.fileshare.models.CorsRule]
     """
 
     _attribute_map = {

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/models/_models_py3.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/models/_models_py3.py
@@ -174,7 +174,7 @@ class FileItem(Model):
     :param name: Required.
     :type name: str
     :param properties: Required.
-    :type properties: ~azure.storage.fileshare._generated.models.FileProperty
+    :type properties: ~azure.storage.fileshare.models.FileProperty
     """
 
     _validation = {
@@ -230,9 +230,9 @@ class FilesAndDirectoriesListSegment(Model):
     All required parameters must be populated in order to send to Azure.
 
     :param directory_items: Required.
-    :type directory_items: list[~azure.storage.fileshare._generated.models.DirectoryItem]
+    :type directory_items: list[~azure.storage.fileshare.models.DirectoryItem]
     :param file_items: Required.
-    :type file_items: list[~azure.storage.fileshare._generated.models.FileItem]
+    :type file_items: list[~azure.storage.fileshare.models.FileItem]
     """
 
     _validation = {
@@ -337,7 +337,8 @@ class ListFilesAndDirectoriesSegmentResponse(Model):
     :param max_results:
     :type max_results: int
     :param segment: Required.
-    :type segment: ~azure.storage.fileshare._generated.models.FilesAndDirectoriesListSegment
+    :type segment:
+     ~azure.storage.fileshare.models.FilesAndDirectoriesListSegment
     :param next_marker: Required.
     :type next_marker: str
     """
@@ -385,7 +386,7 @@ class ListHandlesResponse(Model):
     All required parameters must be populated in order to send to Azure.
 
     :param handle_list:
-    :type handle_list: list[~azure.storage.fileshare._generated.models.HandleItem]
+    :type handle_list: list[~azure.storage.fileshare.models.HandleItem]
     :param next_marker: Required.
     :type next_marker: str
     """
@@ -422,7 +423,7 @@ class ListSharesResponse(Model):
     :param max_results:
     :type max_results: int
     :param share_items:
-    :type share_items: list[~azure.storage.fileshare._generated.models.ShareItem]
+    :type share_items: list[~azure.storage.fileshare.models.ShareItem]
     :param next_marker: Required.
     :type next_marker: str
     """
@@ -468,7 +469,7 @@ class Metrics(Model):
      statistics for called API operations.
     :type include_apis: bool
     :param retention_policy:
-    :type retention_policy: ~azure.storage.fileshare._generated.models.RetentionPolicy
+    :type retention_policy: ~azure.storage.fileshare.models.RetentionPolicy
     """
 
     _validation = {
@@ -566,7 +567,7 @@ class ShareItem(Model):
     :param snapshot:
     :type snapshot: str
     :param properties: Required.
-    :type properties: ~azure.storage.fileshare._generated.models.ShareProperties
+    :type properties: ~azure.storage.fileshare.models.ShareProperties
     :param metadata:
     :type metadata: dict[str, str]
     """
@@ -687,7 +688,7 @@ class SignedIdentifier(Model):
     :param id: Required. A unique id.
     :type id: str
     :param access_policy: The access policy.
-    :type access_policy: ~azure.storage.fileshare._generated.models.AccessPolicy
+    :type access_policy: ~azure.storage.fileshare.models.AccessPolicy
     """
 
     _validation = {
@@ -770,12 +771,12 @@ class StorageServiceProperties(Model):
 
     :param hour_metrics: A summary of request statistics grouped by API in
      hourly aggregates for files.
-    :type hour_metrics: ~azure.storage.fileshare._generated.models.Metrics
+    :type hour_metrics: ~azure.storage.fileshare.models.Metrics
     :param minute_metrics: A summary of request statistics grouped by API in
      minute aggregates for files.
-    :type minute_metrics: ~azure.storage.fileshare._generated.models.Metrics
+    :type minute_metrics: ~azure.storage.fileshare.models.Metrics
     :param cors: The set of CORS rules.
-    :type cors: list[~azure.storage.fileshare._generated.models.CorsRule]
+    :type cors: list[~azure.storage.fileshare.models.CorsRule]
     """
 
     _attribute_map = {

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_directory_operations.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_directory_operations.py
@@ -74,7 +74,7 @@ class DirectoryOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -150,7 +150,7 @@ class DirectoryOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -216,7 +216,7 @@ class DirectoryOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -289,7 +289,7 @@ class DirectoryOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "properties"
@@ -364,7 +364,7 @@ class DirectoryOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "metadata"
@@ -442,9 +442,9 @@ class DirectoryOperations(object):
         :return: ListFilesAndDirectoriesSegmentResponse or the result of
          cls(response)
         :rtype:
-         ~azure.storage.fileshare._generated.models.ListFilesAndDirectoriesSegmentResponse
+         ~azure.storage.fileshare.models.ListFilesAndDirectoriesSegmentResponse
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "list"
@@ -531,9 +531,9 @@ class DirectoryOperations(object):
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: ListHandlesResponse or the result of cls(response)
-        :rtype: ~azure.storage.fileshare._generated.models.ListHandlesResponse
+        :rtype: ~azure.storage.fileshare.models.ListHandlesResponse
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "listhandles"
@@ -620,7 +620,7 @@ class DirectoryOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "forceclosehandles"

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_file_operations.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_file_operations.py
@@ -78,13 +78,14 @@ class FileOperations(object):
          x-ms-file-permission-key should be specified.
         :type file_permission_key: str
         :param file_http_headers: Additional parameters for the operation
-        :type file_http_headers: ~azure.storage.fileshare._generated.models.FileHTTPHeaders
+        :type file_http_headers:
+         ~azure.storage.fileshare.models.FileHTTPHeaders
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         file_content_type = None
@@ -195,7 +196,7 @@ class FileOperations(object):
         :return: object or the result of cls(response)
         :rtype: Generator
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -324,7 +325,7 @@ class FileOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -402,7 +403,7 @@ class FileOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -474,13 +475,14 @@ class FileOperations(object):
          x-ms-file-permission-key should be specified.
         :type file_permission_key: str
         :param file_http_headers: Additional parameters for the operation
-        :type file_http_headers: ~azure.storage.fileshare._generated.models.FileHTTPHeaders
+        :type file_http_headers:
+         ~azure.storage.fileshare.models.FileHTTPHeaders
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         file_content_type = None
@@ -587,7 +589,7 @@ class FileOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "metadata"
@@ -652,7 +654,7 @@ class FileOperations(object):
          that indicates the range to clear, up to maximum file size. Possible
          values include: 'update', 'clear'
         :type file_range_write: str or
-         ~azure.storage.fileshare._generated.models.FileRangeWriteType
+         ~azure.storage.fileshare.models.FileRangeWriteType
         :param content_length: Specifies the number of bytes being transmitted
          in the request body. When the x-ms-write header is set to clear, the
          value of this header must be set to zero.
@@ -676,7 +678,7 @@ class FileOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "range"
@@ -762,13 +764,13 @@ class FileOperations(object):
         :param source_modified_access_conditions: Additional parameters for
          the operation
         :type source_modified_access_conditions:
-         ~azure.storage.fileshare._generated.models.SourceModifiedAccessConditions
+         ~azure.storage.fileshare.models.SourceModifiedAccessConditions
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         source_if_match_crc64 = None
@@ -849,9 +851,9 @@ class FileOperations(object):
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: list or the result of cls(response)
-        :rtype: list[~azure.storage.fileshare._generated.models.Range]
+        :rtype: list[~azure.storage.fileshare.models.Range]
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "rangelist"
@@ -933,7 +935,7 @@ class FileOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -995,7 +997,7 @@ class FileOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "copy"
@@ -1063,9 +1065,9 @@ class FileOperations(object):
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: ListHandlesResponse or the result of cls(response)
-        :rtype: ~azure.storage.fileshare._generated.models.ListHandlesResponse
+        :rtype: ~azure.storage.fileshare.models.ListHandlesResponse
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "listhandles"
@@ -1147,7 +1149,7 @@ class FileOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "forceclosehandles"

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_service_operations.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_service_operations.py
@@ -44,7 +44,7 @@ class ServiceOperations(object):
 
         :param storage_service_properties: The StorageService properties.
         :type storage_service_properties:
-         ~azure.storage.fileshare._generated.models.StorageServiceProperties
+         ~azure.storage.fileshare.models.StorageServiceProperties
         :param timeout: The timeout parameter is expressed in seconds. For
          more information, see <a
          href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting
@@ -55,7 +55,7 @@ class ServiceOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "properties"
@@ -113,9 +113,9 @@ class ServiceOperations(object):
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: StorageServiceProperties or the result of cls(response)
-        :rtype: ~azure.storage.fileshare._generated.models.StorageServiceProperties
+        :rtype: ~azure.storage.fileshare.models.StorageServiceProperties
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "properties"
@@ -185,7 +185,7 @@ class ServiceOperations(object):
         :param include: Include this parameter to specify one or more datasets
          to include in the response.
         :type include: list[str or
-         ~azure.storage.fileshare._generated.models.ListSharesIncludeType]
+         ~azure.storage.fileshare.models.ListSharesIncludeType]
         :param timeout: The timeout parameter is expressed in seconds. For
          more information, see <a
          href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting
@@ -194,9 +194,9 @@ class ServiceOperations(object):
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: ListSharesResponse or the result of cls(response)
-        :rtype: ~azure.storage.fileshare._generated.models.ListSharesResponse
+        :rtype: ~azure.storage.fileshare.models.ListSharesResponse
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "list"

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_share_operations.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_share_operations.py
@@ -56,7 +56,7 @@ class ShareOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -119,7 +119,7 @@ class ShareOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -181,13 +181,13 @@ class ShareOperations(object):
          base share and all of its snapshots. Possible values include:
          'include'
         :type delete_snapshots: str or
-         ~azure.storage.fileshare._generated.models.DeleteSnapshotsOptionType
+         ~azure.storage.fileshare.models.DeleteSnapshotsOptionType
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         # Construct URL
@@ -246,7 +246,7 @@ class ShareOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "snapshot"
@@ -298,7 +298,8 @@ class ShareOperations(object):
 
         :param share_permission: A permission (a security descriptor) at the
          share level.
-        :type share_permission: ~azure.storage.fileshare._generated.models.SharePermission
+        :type share_permission:
+         ~azure.storage.fileshare.models.SharePermission
         :param timeout: The timeout parameter is expressed in seconds. For
          more information, see <a
          href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting
@@ -309,7 +310,7 @@ class ShareOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "filepermission"
@@ -356,12 +357,11 @@ class ShareOperations(object):
             return cls(response, None, response_headers)
     create_permission.metadata = {'url': '/{shareName}'}
 
-    def get_permission(self, file_permission_key=None, timeout=None, cls=None, **kwargs):
+    def get_permission(self, file_permission_key, timeout=None, cls=None, **kwargs):
         """Returns the permission (security descriptor) for a given key.
 
         :param file_permission_key: Key of the permission to be set for the
-         directory/file. Note: Only one of the x-ms-file-permission or
-         x-ms-file-permission-key should be specified.
+         directory/file.
         :type file_permission_key: str
         :param timeout: The timeout parameter is expressed in seconds. For
          more information, see <a
@@ -371,9 +371,9 @@ class ShareOperations(object):
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: SharePermission or the result of cls(response)
-        :rtype: ~azure.storage.fileshare._generated.models.SharePermission
+        :rtype: ~azure.storage.fileshare.models.SharePermission
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "filepermission"
@@ -395,8 +395,7 @@ class ShareOperations(object):
         # Construct headers
         header_parameters = {}
         header_parameters['Accept'] = 'application/json'
-        if file_permission_key is not None:
-            header_parameters['x-ms-file-permission-key'] = self._serialize.header("file_permission_key", file_permission_key, 'str')
+        header_parameters['x-ms-file-permission-key'] = self._serialize.header("file_permission_key", file_permission_key, 'str')
         header_parameters['x-ms-version'] = self._serialize.header("self._config.version", self._config.version, 'str')
 
         # Construct and send request
@@ -440,7 +439,7 @@ class ShareOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "properties"
@@ -502,7 +501,7 @@ class ShareOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "metadata"
@@ -560,9 +559,9 @@ class ShareOperations(object):
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: list or the result of cls(response)
-        :rtype: list[~azure.storage.fileshare._generated.models.SignedIdentifier]
+        :rtype: list[~azure.storage.fileshare.models.SignedIdentifier]
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "acl"
@@ -618,7 +617,8 @@ class ShareOperations(object):
         """Sets a stored access policy for use with shared access signatures.
 
         :param share_acl: The ACL for the share.
-        :type share_acl: list[~azure.storage.fileshare._generated.models.SignedIdentifier]
+        :type share_acl:
+         list[~azure.storage.fileshare.models.SignedIdentifier]
         :param timeout: The timeout parameter is expressed in seconds. For
          more information, see <a
          href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting
@@ -629,7 +629,7 @@ class ShareOperations(object):
         :return: None or the result of cls(response)
         :rtype: None
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "acl"
@@ -692,9 +692,9 @@ class ShareOperations(object):
         :param callable cls: A custom type or function that will be passed the
          direct response
         :return: ShareStats or the result of cls(response)
-        :rtype: ~azure.storage.fileshare._generated.models.ShareStats
+        :rtype: ~azure.storage.fileshare.models.ShareStats
         :raises:
-         :class:`StorageErrorException<azure.storage.fileshare._generated.models.StorageErrorException>`
+         :class:`StorageErrorException<azure.storage.fileshare.models.StorageErrorException>`
         """
         error_map = kwargs.pop('error_map', None)
         comp = "stats"

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py
@@ -113,6 +113,9 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
     def __exit__(self, *args):
         self._client.__exit__(*args)
 
+    def close(self):
+        self._client.close()
+
     @property
     def url(self):
         """The full endpoint URL to this entity, including SAS token if used.

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client_async.py
@@ -58,6 +58,9 @@ class AsyncStorageAccountHostsMixin(object):
     async def __aexit__(self, *args):
         await self._client.__aexit__(*args)
 
+    async def close(self):
+        await self._client.close()
+
     def _create_pipeline(self, credential, **kwargs):
         # type: (Any, **Any) -> Tuple[Configuration, Pipeline]
         self._credential_policy = None

--- a/sdk/storage/azure-storage-file-share/tests/filetestcase.py
+++ b/sdk/storage/azure-storage-file-share/tests/filetestcase.py
@@ -12,6 +12,7 @@ import os
 import os.path
 import time
 from unittest import SkipTest
+from datetime import datetime, timedelta
 
 import adal
 import vcr
@@ -19,10 +20,13 @@ import zlib
 import math
 import uuid
 import unittest
+import string
 import sys
 import random
 import file_settings_fake as fake_settings
 import logging
+
+from azure.storage.fileshare import generate_account_sas, AccountSasPermissions, ResourceTypes
 
 try:
     from cStringIO import StringIO      # Python 2
@@ -157,6 +161,19 @@ class FileTestCase(unittest.TestCase):
             self.settings.PROTOCOL,
             self.settings.REMOTE_STORAGE_ACCOUNT_NAME
         )
+
+    def generate_sas_token(self):
+        fake_key = 'a'*30 + 'b'*30
+
+        return '?' + generate_account_sas(
+            account_name = 'test', # name of the storage account
+            account_key = fake_key, # key for the storage account
+            resource_types = ResourceTypes(object=True),
+            permission = AccountSasPermissions(read=True,list=True),
+            start = datetime.now() - timedelta(hours = 24),
+            expiry = datetime.now() + timedelta(days = 8)
+        )
+
 
     def get_random_bytes(self, size):
         if self.test_mode.lower() == TestMode.run_live_no_record.lower():

--- a/sdk/storage/azure-storage-file-share/tests/test_file_client.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_client.py
@@ -39,7 +39,7 @@ class StorageFileClientTest(FileTestCase):
         super(StorageFileClientTest, self).setUp()
         self.account_name = self.settings.STORAGE_ACCOUNT_NAME
         self.account_key = self.settings.STORAGE_ACCOUNT_KEY
-        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Z%2FRHIX5Xcg0Mq2rqI3OlWTjEg2tYkboXr1P9ZUXDtkk%3D'
+        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Y%2FoUshaLLnoTPass'
         self.token_credential = self.generate_oauth_token()
 
     # --Helpers-----------------------------------------------------------------

--- a/sdk/storage/azure-storage-file-share/tests/test_file_client.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_client.py
@@ -426,7 +426,7 @@ class StorageFileClientTest(FileTestCase):
                 self.get_file_url(), credential=self.account_key, share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
-            with servcie:
+            with service:
                 assert hasattr(service, 'close')
                 service.close()
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-file-share/tests/test_file_client.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_client.py
@@ -417,7 +417,7 @@ class StorageFileClientTest(FileTestCase):
                     self.assertEqual(
                         str(e.exception), "Connection string missing required connection details.")
 
-    def test_closing_pipeline_client_async(self):
+    def test_closing_pipeline_client(self):
         # Arrange
 
         for client, url in SERVICES.items():
@@ -429,6 +429,16 @@ class StorageFileClientTest(FileTestCase):
             with service:
                 assert hasattr(service, 'close')
                 service.close()
+
+    def test_closing_pipeline_client_simple(self):
+        # Arrange
+
+        for client, url in SERVICES.items():
+            # Act
+            service = client(
+                self.get_file_url(), credential=self.account_key, share_name='foo', directory_path='bar', file_path='baz')
+            service.close()
+
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/storage/azure-storage-file-share/tests/test_file_client.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_client.py
@@ -39,7 +39,7 @@ class StorageFileClientTest(FileTestCase):
         super(StorageFileClientTest, self).setUp()
         self.account_name = self.settings.STORAGE_ACCOUNT_NAME
         self.account_key = self.settings.STORAGE_ACCOUNT_KEY
-        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Y%2FoUshaLLnoTPass'
+        self.sas_token = self.generate_sas_token()
         self.token_credential = self.generate_oauth_token()
 
     # --Helpers-----------------------------------------------------------------

--- a/sdk/storage/azure-storage-file-share/tests/test_file_client.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_client.py
@@ -417,6 +417,16 @@ class StorageFileClientTest(FileTestCase):
                     self.assertEqual(
                         str(e.exception), "Connection string missing required connection details.")
 
+    def test_closing_pipeline_client_async(self):
+        # Arrange
+
+        for client, url in SERVICES.items():
+            # Act
+            service = client(
+                self.get_file_url(), credential=self.account_key, share_name='foo', directory_path='bar', file_path='baz')
+
+            # Assert
+            assert hasattr(service, 'close')
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/storage/azure-storage-file-share/tests/test_file_client.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_client.py
@@ -426,7 +426,9 @@ class StorageFileClientTest(FileTestCase):
                 self.get_file_url(), credential=self.account_key, share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
-            assert hasattr(service, 'close')
+            with servcie:
+                assert hasattr(service, 'close')
+                service.close()
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/storage/azure-storage-file-share/tests/test_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_client_async.py
@@ -51,7 +51,7 @@ class StorageFileClientTest(FileTestCase):
         super(StorageFileClientTest, self).setUp()
         self.account_name = self.settings.STORAGE_ACCOUNT_NAME
         self.account_key = self.settings.STORAGE_ACCOUNT_KEY
-        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Y%2FoUshaLLnoTPass'
+        self.sas_token = self.generate_sas_token()
         self.token_credential = self.generate_oauth_token()
 
     # --Helpers-----------------------------------------------------------------

--- a/sdk/storage/azure-storage-file-share/tests/test_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_client_async.py
@@ -409,6 +409,17 @@ class StorageFileClientTest(FileTestCase):
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self._test_user_agent_append_async())
 
+    def test_closing_pipeline_client_async(self):
+        # Arrange
+
+        for client, url in SERVICES.items():
+            # Act
+            service = client(
+                self.get_file_url(), credential=self.account_key, share_name='foo', directory_path='bar', file_path='baz')
+
+            # Assert
+            assert hasattr(service, 'close')
+
 
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/sdk/storage/azure-storage-file-share/tests/test_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_client_async.py
@@ -51,7 +51,7 @@ class StorageFileClientTest(FileTestCase):
         super(StorageFileClientTest, self).setUp()
         self.account_name = self.settings.STORAGE_ACCOUNT_NAME
         self.account_key = self.settings.STORAGE_ACCOUNT_KEY
-        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Z%2FRHIX5Xcg0Mq2rqI3OlWTjEg2tYkboXr1P9ZUXDtkk%3D'
+        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Y%2FoUshaLLnoTPass'
         self.token_credential = self.generate_oauth_token()
 
     # --Helpers-----------------------------------------------------------------

--- a/sdk/storage/azure-storage-file-share/tests/test_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_client_async.py
@@ -418,7 +418,7 @@ class StorageFileClientTest(FileTestCase):
                 self.get_file_url(), credential=self.account_key, share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
-            with servcie:
+            with service:
                 assert hasattr(service, 'close')
                 service.close()
 

--- a/sdk/storage/azure-storage-file-share/tests/test_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_client_async.py
@@ -418,7 +418,9 @@ class StorageFileClientTest(FileTestCase):
                 self.get_file_url(), credential=self.account_key, share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
-            assert hasattr(service, 'close')
+            with servcie:
+                assert hasattr(service, 'close')
+                service.close()
 
 
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-file-share/tests/test_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_client_async.py
@@ -409,7 +409,7 @@ class StorageFileClientTest(FileTestCase):
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self._test_user_agent_append_async())
 
-    def test_closing_pipeline_client_async(self):
+    async def test_closing_pipeline_client_async(self):
         # Arrange
 
         for client, url in SERVICES.items():
@@ -418,7 +418,7 @@ class StorageFileClientTest(FileTestCase):
                 self.get_file_url(), credential=self.account_key, share_name='foo', directory_path='bar', file_path='baz')
 
             # Assert
-            with service:
+            async with service:
                 assert hasattr(service, 'close')
                 service.close()
 

--- a/sdk/storage/azure-storage-file-share/tests/test_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_client_async.py
@@ -422,6 +422,15 @@ class StorageFileClientTest(FileTestCase):
                 assert hasattr(service, 'close')
                 service.close()
 
+    async def test_closing_pipeline_client_simple_async(self):
+        # Arrange
+
+        for client, url in SERVICES.items():
+            # Act
+            service = client(
+                self.get_file_url(), credential=self.account_key, share_name='foo', directory_path='bar', file_path='baz')
+            service.close()
+
 
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_generated/_azure_queue_storage.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_generated/_azure_queue_storage.py
@@ -59,6 +59,8 @@ class AzureQueueStorage(object):
         self.message_id = MessageIdOperations(
             self._client, self._config, self._serialize, self._deserialize)
 
+    def close(self):
+        self._client.close()
     def __enter__(self):
         self._client.__enter__()
         return self

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_generated/aio/_azure_queue_storage_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_generated/aio/_azure_queue_storage_async.py
@@ -60,6 +60,8 @@ class AzureQueueStorage(object):
         self.message_id = MessageIdOperations(
             self._client, self._config, self._serialize, self._deserialize)
 
+    async def close(self):
+        await self._client.close()
     async def __aenter__(self):
         await self._client.__aenter__()
         return self

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_generated/models/_azure_queue_storage_enums.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_generated/models/_azure_queue_storage_enums.py
@@ -65,6 +65,12 @@ class StorageErrorCode(str, Enum):
     queue_disabled = "QueueDisabled"
     queue_not_empty = "QueueNotEmpty"
     queue_not_found = "QueueNotFound"
+    authorization_source_ip_mismatch = "AuthorizationSourceIPMismatch"
+    authorization_protocol_mismatch = "AuthorizationProtocolMismatch"
+    authorization_permission_mismatch = "AuthorizationPermissionMismatch"
+    authorization_service_mismatch = "AuthorizationServiceMismatch"
+    authorization_resource_type_mismatch = "AuthorizationResourceTypeMismatch"
+    feature_version_mismatch = "FeatureVersionMismatch"
 
 
 class GeoReplicationStatusType(str, Enum):

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py
@@ -113,6 +113,9 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
     def __exit__(self, *args):
         self._client.__exit__(*args)
 
+    def close(self):
+        self._client.close()
+
     @property
     def url(self):
         """The full endpoint URL to this entity, including SAS token if used.

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client_async.py
@@ -58,6 +58,9 @@ class AsyncStorageAccountHostsMixin(object):
     async def __aexit__(self, *args):
         await self._client.__aexit__(*args)
 
+    async def close(self):
+        await self._client.close()
+
     def _create_pipeline(self, credential, **kwargs):
         # type: (Any, **Any) -> Tuple[Configuration, Pipeline]
         self._credential_policy = None

--- a/sdk/storage/azure-storage-queue/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-queue/tests/_shared/testcase.py
@@ -11,6 +11,7 @@ import inspect
 import os
 import os.path
 import time
+from datetime import datetime, timedelta
 
 try:
     import unittest.mock as mock
@@ -20,6 +21,7 @@ except ImportError:
 import zlib
 import math
 import sys
+import string
 import random
 import re
 import logging
@@ -31,6 +33,7 @@ except ImportError:
     from io import StringIO
 
 from azure.core.credentials import AccessToken
+from azure.storage.queue import generate_account_sas, AccountSasPermissions, ResourceTypes
 
 try:
     from devtools_testutils import mgmt_settings_real as settings
@@ -254,6 +257,18 @@ class StorageTestCase(AzureMgmtTestCase):
                 self.get_settings_value("CLIENT_SECRET"),
             )
         return self.generate_fake_token()
+
+    def generate_sas_token(self):
+        fake_key = 'a'*30 + 'b'*30
+
+        return '?' + generate_account_sas(
+            account_name = 'test', # name of the storage account
+            account_key = fake_key, # key for the storage account
+            resource_types = ResourceTypes(object=True),
+            permission = AccountSasPermissions(read=True,list=True),
+            start = datetime.now() - timedelta(hours = 24),
+            expiry = datetime.now() + timedelta(days = 8)
+        )
 
     def generate_fake_token(self):
         return FakeTokenCredential()

--- a/sdk/storage/azure-storage-queue/tests/test_queue_client.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_client.py
@@ -484,7 +484,7 @@ class StorageQueueClientTest(StorageTestCase):
                 self.account_url(storage_account.name, "queue"), credential=storage_account_key, queue_name='queue')
 
             # Assert
-            with servcie:
+            with service:
                 assert hasattr(service, 'close')
                 service.close()
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-queue/tests/test_queue_client.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_client.py
@@ -27,7 +27,7 @@ _CONNECTION_ENDPOINTS_SECONDARY = {'queue': 'QueueSecondaryEndpoint'}
 class StorageQueueClientTest(StorageTestCase):
     def setUp(self):
         super(StorageQueueClientTest, self).setUp()
-        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Y%2FoUshaLLnoTPass'
+        self.sas_token = self.generate_sas_token()
         self.token_credential = self.generate_oauth_token()
 
     # --Helpers-----------------------------------------------------------------

--- a/sdk/storage/azure-storage-queue/tests/test_queue_client.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_client.py
@@ -475,6 +475,17 @@ class StorageQueueClientTest(StorageTestCase):
                     self.assertEqual(
                         str(e.exception), "Connection string missing required connection details.")
 
+    @GlobalStorageAccountPreparer()
+    def test_closing_pipeline_client(self, resource_group, location, storage_account, storage_account_key):
+        # Arrange
+        for client, url in SERVICES.items():
+            # Act
+            service = client(
+                self.account_url(storage_account.name, "queue"), credential=storage_account_key, queue_name='queue')
+
+            # Assert
+            exists = hasattr(service, 'close')
+            self.assertTrue(exists)
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/storage/azure-storage-queue/tests/test_queue_client.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_client.py
@@ -484,8 +484,9 @@ class StorageQueueClientTest(StorageTestCase):
                 self.account_url(storage_account.name, "queue"), credential=storage_account_key, queue_name='queue')
 
             # Assert
-            exists = hasattr(service, 'close')
-            self.assertTrue(exists)
+            with servcie:
+                assert hasattr(service, 'close')
+                service.close()
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/storage/azure-storage-queue/tests/test_queue_client.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_client.py
@@ -27,7 +27,7 @@ _CONNECTION_ENDPOINTS_SECONDARY = {'queue': 'QueueSecondaryEndpoint'}
 class StorageQueueClientTest(StorageTestCase):
     def setUp(self):
         super(StorageQueueClientTest, self).setUp()
-        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Z%2FRHIX5Xcg0Mq2rqI3OlWTjEg2tYkboXr1P9ZUXDtkk%3D'
+        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Y%2FoUshaLLnoTPass'
         self.token_credential = self.generate_oauth_token()
 
     # --Helpers-----------------------------------------------------------------

--- a/sdk/storage/azure-storage-queue/tests/test_queue_client.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_client.py
@@ -487,6 +487,15 @@ class StorageQueueClientTest(StorageTestCase):
             with service:
                 assert hasattr(service, 'close')
                 service.close()
+
+    @GlobalStorageAccountPreparer()
+    def test_closing_pipeline_client_simple(self, resource_group, location, storage_account, storage_account_key):
+        # Arrange
+        for client, url in SERVICES.items():
+            # Act
+            service = client(
+                self.account_url(storage_account.name, "queue"), credential=storage_account_key, queue_name='queue')
+            service.close()
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/storage/azure-storage-queue/tests/test_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_client_async.py
@@ -41,7 +41,7 @@ class AiohttpTestTransport(AioHttpTransport):
 class StorageQueueClientTestAsync(AsyncStorageTestCase):
     def setUp(self):
         super(StorageQueueClientTestAsync, self).setUp()
-        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Z%2FRHIX5Xcg0Mq2rqI3OlWTjEg2tYkboXr1P9ZUXDtkk%3D'
+        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Y%2FoUshaLLnoTPass'
         self.token_credential = self.generate_oauth_token()
 
     # --Helpers-----------------------------------------------------------------

--- a/sdk/storage/azure-storage-queue/tests/test_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_client_async.py
@@ -41,7 +41,7 @@ class AiohttpTestTransport(AioHttpTransport):
 class StorageQueueClientTestAsync(AsyncStorageTestCase):
     def setUp(self):
         super(StorageQueueClientTestAsync, self).setUp()
-        self.sas_token = '?sv=2015-04-05&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sr=b&sp=rw&sip=168.1.5.60-168.1.5.70&spr=https&sig=Y%2FoUshaLLnoTPass'
+        self.sas_token = self.generate_sas_token()
         self.token_credential = self.generate_oauth_token()
 
     # --Helpers-----------------------------------------------------------------

--- a/sdk/storage/azure-storage-queue/tests/test_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_client_async.py
@@ -470,6 +470,17 @@ class StorageQueueClientTestAsync(AsyncStorageTestCase):
         custom_headers = {'User-Agent': 'customer_user_agent'}
         await service.get_service_properties(raw_response_hook=callback, headers=custom_headers)
 
+    @GlobalStorageAccountPreparer()
+    def test_closing_pipeline_client(self, resource_group, location, storage_account, storage_account_key):
+        # Arrange
+        for client, url in SERVICES.items():
+            # Act
+            service = client(
+                self.account_url(storage_account.name, "queue"), credential=storage_account_key, queue_name='queue')
+
+            # Assert
+            exists = hasattr(service, 'close')
+            self.assertTrue(exists)
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/storage/azure-storage-queue/tests/test_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_client_async.py
@@ -479,7 +479,7 @@ class StorageQueueClientTestAsync(AsyncStorageTestCase):
                 self.account_url(storage_account.name, "queue"), credential=storage_account_key, queue_name='queue')
 
             # Assert
-            with servcie:
+            with service:
                 assert hasattr(service, 'close')
                 service.close()
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-queue/tests/test_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_client_async.py
@@ -471,7 +471,7 @@ class StorageQueueClientTestAsync(AsyncStorageTestCase):
         await service.get_service_properties(raw_response_hook=callback, headers=custom_headers)
 
     @GlobalStorageAccountPreparer()
-    async def test_closing_pipeline_client(self, resource_group, location, storage_account, storage_account_key):
+    async def test_closing_pipeline_client_async(self, resource_group, location, storage_account, storage_account_key):
         # Arrange
         for client, url in SERVICES.items():
             # Act
@@ -482,6 +482,16 @@ class StorageQueueClientTestAsync(AsyncStorageTestCase):
             async with service:
                 assert hasattr(service, 'close')
                 service.close()
+
+    @GlobalStorageAccountPreparer()
+    async def test_closing_pipeline_client_simple_async(self, resource_group, location, storage_account, storage_account_key):
+        # Arrange
+        for client, url in SERVICES.items():
+            # Act
+            service = client(
+                self.account_url(storage_account.name, "queue"), credential=storage_account_key, queue_name='queue')
+            service.close()
+
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/storage/azure-storage-queue/tests/test_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_client_async.py
@@ -471,7 +471,7 @@ class StorageQueueClientTestAsync(AsyncStorageTestCase):
         await service.get_service_properties(raw_response_hook=callback, headers=custom_headers)
 
     @GlobalStorageAccountPreparer()
-    def test_closing_pipeline_client(self, resource_group, location, storage_account, storage_account_key):
+    async def test_closing_pipeline_client(self, resource_group, location, storage_account, storage_account_key):
         # Arrange
         for client, url in SERVICES.items():
             # Act
@@ -479,7 +479,7 @@ class StorageQueueClientTestAsync(AsyncStorageTestCase):
                 self.account_url(storage_account.name, "queue"), credential=storage_account_key, queue_name='queue')
 
             # Assert
-            with service:
+            async with service:
                 assert hasattr(service, 'close')
                 service.close()
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-queue/tests/test_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_client_async.py
@@ -479,8 +479,9 @@ class StorageQueueClientTestAsync(AsyncStorageTestCase):
                 self.account_url(storage_account.name, "queue"), credential=storage_account_key, queue_name='queue')
 
             # Assert
-            exists = hasattr(service, 'close')
-            self.assertTrue(exists)
+            with servcie:
+                assert hasattr(service, 'close')
+                service.close()
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes Azure#8564

- Regenerate _generated code.
- Expose close() in Mixin