### PR TITLE
Correct App Service MSI query parameter

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -165,8 +165,7 @@ class ImdsCredential(_ManagedIdentityBase):
 class MsiCredential(_ManagedIdentityBase):
     """Authenticates via the MSI endpoint in an App Service or Cloud Shell environment.
 
-
-  :keyword str client_id: ID of a user-assigned identity. Leave unspecified to use a system-assigned identity.
+    :keyword str client_id: ID of a user-assigned identity. Leave unspecified to use a system-assigned identity.
     """
 
     def __init__(self, **kwargs):
@@ -207,7 +206,7 @@ class MsiCredential(_ManagedIdentityBase):
     def _request_app_service_token(self, scopes, resource, secret):
         params = {"api-version": "2017-09-01", "resource": resource}
         if self._client_id:
-            params["client_id"] = self._client_id
+            params["clientid"] = self._client_id
         return self._client.request_token(scopes, method="GET", headers={"secret": secret}, params=params)
 
     def _request_legacy_token(self, scopes, resource):

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -110,7 +110,10 @@ class ImdsCredential(_AsyncManagedIdentityBase):
 
 
 class MsiCredential(_AsyncManagedIdentityBase):
-    """Authenticates via the MSI endpoint in an App Service or Cloud Shell environment."""
+    """Authenticates via the MSI endpoint in an App Service or Cloud Shell environment.
+
+    :keyword str client_id: ID of a user-assigned identity. Leave unspecified to use a system-assigned identity.
+    """
 
     def __init__(self, **kwargs: "Any") -> None:
         self._endpoint = os.environ.get(EnvironmentVariables.MSI_ENDPOINT)
@@ -148,7 +151,7 @@ class MsiCredential(_AsyncManagedIdentityBase):
     async def _request_app_service_token(self, scopes, resource, secret):
         params = {"api-version": "2017-09-01", "resource": resource}
         if self._client_id:
-            params["client_id"] = self._client_id
+            params["clientid"] = self._client_id
         return await self._client.request_token(scopes, method="GET", headers={"secret": secret}, params=params)
 
     async def _request_legacy_token(self, scopes, resource):

--- a/sdk/identity/azure-identity/tests/test_managed_identity.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity.py
@@ -136,7 +136,7 @@ def test_app_service_user_assigned_identity():
                 url,
                 method="GET",
                 required_headers={"Metadata": "true", "secret": secret},
-                required_params={"api-version": "2017-09-01", "client_id": client_id, "resource": scope},
+                required_params={"api-version": "2017-09-01", "clientid": client_id, "resource": scope},
             )
         ],
         responses=[

--- a/sdk/identity/azure-identity/tests/test_managed_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity_async.py
@@ -136,7 +136,7 @@ async def test_app_service_user_assigned_identity():
                 url,
                 method="GET",
                 required_headers={"Metadata": "true", "secret": secret},
-                required_params={"api-version": "2017-09-01", "client_id": client_id, "resource": scope},
+                required_params={"api-version": "2017-09-01", "clientid": client_id, "resource": scope},
             )
         ],
         responses=[


### PR DESCRIPTION
Following azure/azure-sdk-for-js#6134, this changes the query parameter used to pass the client ID of a user-assigned managed identity in App Service environments from `client_id` to `clientid`.