### PR TITLE
Ignoring Azure Directory explicitly to avoid path issues

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -24,7 +24,7 @@ deps =
 
 
 [testenv]
-default_pytest_params = --junitxml={toxinidir}/test-junit-{envname}.xml --verbose --durations=10
+default_pytest_params = --junitxml={toxinidir}/test-junit-{envname}.xml --verbose --durations=10 --ignore=azure
 pre-deps =
   wheel
 skip_install = true


### PR DESCRIPTION
This resolves the issues with plugins not resolving their parent package properly. 

