### PR TITLE
Improved account filtering and tests for SharedTokenCacheCredential

### DIFF
--- a/sdk/identity/azure-identity/HISTORY.md
+++ b/sdk/identity/azure-identity/HISTORY.md
@@ -9,6 +9,8 @@
 ([8470](https://github.com/Azure/azure-sdk-for-python/pull/8470))
 - The credentials composing `DefaultAzureCredential` are configurable by keyword
 arguments ([8514](https://github.com/Azure/azure-sdk-for-python/pull/8514))
+- `SharedTokenCacheCredential` accepts an optional `tenant_id` keyword argument
+([8689](https://github.com/Azure/azure-sdk-for-python/pull/8689))
 
 
 ### 2019-11-05 1.0.1

--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
     from azure.core.pipeline.policies import HTTPPolicy
 
 
-
 class AuthnClientBase(ABC):
     """Sans I/O authentication client methods"""
 

--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -42,6 +42,31 @@ if TYPE_CHECKING:
     from azure.core.pipeline.policies import HTTPPolicy
 
 
+MULTIPLE_ACCOUNTS = """Multiple users were discovered in the shared token cache. If using DefaultAzureCredential, set
+the AZURE_USERNAME environment variable to the preferred username. Otherwise,
+specify it when constructing SharedTokenCacheCredential.\nDiscovered accounts: {}"""
+
+MULTIPLE_MATCHING_ACCOUNTS = """Found multiple accounts matching{}{}. If using DefaultAzureCredential, set environment
+variables AZURE_USERNAME and AZURE_TENANT_ID with the preferred username and tenant.
+Otherwise, specify them when constructing SharedTokenCacheCredential.\nDiscovered accounts: {}"""
+
+NO_ACCOUNTS = """The shared cache contains no accounts. To authenticate with SharedTokenCacheCredential, login through
+developer tooling supporting Azure single sign on"""
+
+NO_MATCHING_ACCOUNTS = """The cache contains no account matching the specified{}{}. To authenticate with
+SharedTokenCacheCredential, login through developer tooling supporting Azure single sign on.\nDiscovered accounts: {}"""
+
+NO_TOKEN = """Token acquisition failed for user '{}'. To fix, re-authenticate
+through developer tooling supporting Azure single sign on"""
+
+
+def _account_to_string(account):
+    username = account.get("username")
+    home_account_id = account.get("home_account_id", "").split(".")
+    tenant_id = home_account_id[-1] if len(home_account_id) == 2 else ""
+    return "(username: {}, tenant: {})".format(username, tenant_id)
+
+
 class AuthnClientBase(ABC):
     """Sans I/O authentication client methods"""
 
@@ -101,8 +126,8 @@ class AuthnClientBase(ABC):
         pass
 
     @abc.abstractmethod
-    def obtain_token_by_refresh_token(self, scopes, username):
-        # type: (Iterable[str], Optional[str]) -> AccessToken
+    def obtain_token_by_refresh_token(self, scopes, username, tenant_id):
+        # type: (Iterable[str], Optional[str], Optional[str]) -> AccessToken
         pass
 
     def _deserialize_and_cache_token(self, response, scopes, request_time):
@@ -219,60 +244,57 @@ class AuthnClient(AuthnClientBase):
         token = self._deserialize_and_cache_token(response=response, scopes=scopes, request_time=request_time)
         return token
 
-    def obtain_token_by_refresh_token(self, scopes, username=None):
-        # type: (Iterable[str], Optional[str]) -> AccessToken
+    def get_account(self, username=None, tenant_id=None):
+        # type: (Optional[str], Optional[str]) -> Mapping[str, str]
+        accounts = self._cache.find(TokenCache.CredentialType.ACCOUNT)
+        if not accounts:
+            raise ClientAuthenticationError(message=NO_ACCOUNTS)
+
+        # filter according to arguments
+        query = {"username": username} if username else {}
+        filtered_accounts = self._cache.find(TokenCache.CredentialType.ACCOUNT, query=query)
+        if tenant_id:
+            filtered_accounts = [a for a in filtered_accounts if a.get("home_account_id", "").endswith(tenant_id)]
+
+        if len(filtered_accounts) == 1:
+            return filtered_accounts[0]
+
+        cached_accounts = ", ".join(_account_to_string(account) for account in accounts)
+
+        if username or tenant_id:
+            # no, or multiple, matching accounts for the given username and/or tenant id
+            username_string = " username: {}".format(username) if username else ""
+            tenant_string = " tenant: {}".format(tenant_id) if tenant_id else ""
+            if not filtered_accounts:
+                message = NO_MATCHING_ACCOUNTS.format(username_string, tenant_string, cached_accounts)
+            else:
+                message = MULTIPLE_MATCHING_ACCOUNTS.format(username_string, tenant_string, cached_accounts)
+            raise ClientAuthenticationError(message=message)
+
+        # multiple cached accounts and no basis for selection
+        raise ClientAuthenticationError(message=MULTIPLE_ACCOUNTS.format(cached_accounts))
+
+    def obtain_token_by_refresh_token(self, scopes, username=None, tenant_id=None):
+        # type: (Iterable[str], Optional[str], Optional[str]) -> AccessToken
         """Acquire an access token using a cached refresh token. Raises ClientAuthenticationError if that fails.
         This is only used by SharedTokenCacheCredential and isn't robust enough for anything else."""
 
-        # if an username is provided, restrict our search to accounts that have that username
-        query = {"username": username} if username else {}
-        accounts = self._cache.find(TokenCache.CredentialType.ACCOUNT, query=query)
+        account = self.get_account(username, tenant_id)
+        environment = account.get("environment")
+        if not environment or environment not in self._auth_url:
+            # doubtful this account can get the access token we want but public cloud's a special case
+            # because its authority has an alias: for our purposes login.windows.net = login.microsoftonline.com
+            if not (environment == "login.windows.net" and KnownAuthorities.AZURE_PUBLIC_CLOUD in self._auth_url):
+                return None
 
-        # if more than one account was returned, ensure that that they all have the same home_account_id. If so,
-        # we'll treat them as equal, otherwise we can't know which one to pick, so we'll raise an error.
-        if len(accounts) > 1 and len({account.get("home_account_id") for account in accounts}) != 1:
-            if username:
-                message = (
-                    "Multiple entries found for user '{}' were found in the shared token cache. "
-                    "This is not currently supported by SharedTokenCacheCredential."
-                ).format(username)
-            else:
-                # TODO: we could identify usernames associated with exactly one home account id
-                message = (
-                    "Multiple users were discovered in the shared token cache. If using DefaultAzureCredential, set "
-                    "the AZURE_USERNAME environment variable to the preferred username. Otherwise, specify it when "
-                    "constructing SharedTokenCacheCredential."
-                    "\nDiscovered accounts: {}"
-                ).format(", ".join({account.get("username") for account in accounts}))
-            raise ClientAuthenticationError(message=message)
+        # try each refresh token, returning the first access token acquired
+        for token in self.get_refresh_tokens(scopes, account):
+            request = self.get_refresh_token_grant_request(token, scopes)
+            request_time = int(time.time())
+            response = self._pipeline.run(request, stream=False)
+            return self._deserialize_and_cache_token(response=response, scopes=scopes, request_time=request_time)
 
-        for account in accounts:
-            # ensure the account is associated with the token authority we expect to use
-            # ('environment' is an authority e.g. 'login.microsoftonline.com')
-            environment = account.get("environment")
-            if not environment or environment not in self._auth_url:
-                # doubtful this account can get the access token we want but public cloud's a special case
-                # because its authority has an alias: for our purposes login.windows.net = login.microsoftonline.com
-                if not (environment == "login.windows.net" and KnownAuthorities.AZURE_PUBLIC_CLOUD in self._auth_url):
-                    continue
-
-            # try each refresh token, returning the first access token acquired
-            for token in self.get_refresh_tokens(scopes, account):
-                request = self.get_refresh_token_grant_request(token, scopes)
-                request_time = int(time.time())
-                response = self._pipeline.run(request, stream=False)
-                try:
-                    return self._deserialize_and_cache_token(
-                        response=response, scopes=scopes, request_time=request_time
-                    )
-                except ClientAuthenticationError:
-                    continue
-
-        message = "No cached token found"
-        if username:
-            message += " for '{}'".format(username)
-
-        raise ClientAuthenticationError(message=message)
+        raise ClientAuthenticationError(message=NO_TOKEN.format(account.get("username")))
 
     @staticmethod
     def _create_config(**kwargs):

--- a/sdk/identity/azure-identity/azure/identity/_credentials/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/__init__.py
@@ -9,7 +9,8 @@ from .client_credential import CertificateCredential, ClientSecretCredential
 from .default import DefaultAzureCredential
 from .environment import EnvironmentCredential
 from .managed_identity import ManagedIdentityCredential
-from .user import DeviceCodeCredential, SharedTokenCacheCredential, UsernamePasswordCredential
+from .shared_cache import SharedTokenCacheCredential
+from .user import DeviceCodeCredential, UsernamePasswordCredential
 
 
 __all__ = [

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -12,7 +12,7 @@ from .browser import InteractiveBrowserCredential
 from .chained import ChainedTokenCredential
 from .environment import EnvironmentCredential
 from .managed_identity import ManagedIdentityCredential
-from .user import SharedTokenCacheCredential
+from .shared_cache import SharedTokenCacheCredential
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -50,7 +50,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
     """
 
     def __init__(self, **kwargs):
-        authority = kwargs.pop("authority", KnownAuthorities.AZURE_PUBLIC_CLOUD)
+        authority = kwargs.pop("authority", None) or KnownAuthorities.AZURE_PUBLIC_CLOUD
 
         shared_cache_username = kwargs.pop("shared_cache_username", os.environ.get(EnvironmentVariables.AZURE_USERNAME))
         shared_cache_tenant_id = kwargs.pop(

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -2,13 +2,21 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import abc
 import os
 import sys
 
-from azure.core.exceptions import ClientAuthenticationError
+from msal import TokenCache
 
-from .._authn_client import AuthnClient
-from .._internal import wrap_exceptions
+from azure.core.exceptions import ClientAuthenticationError
+from .._constants import AZURE_CLI_CLIENT_ID, KnownAuthorities
+from .._internal import AadClient, wrap_exceptions
+
+
+try:
+    ABC = abc.ABC
+except AttributeError:  # Python 2.7, abc exists, but not ABC
+    ABC = abc.ABCMeta("ABC", (object,), {"__slots__": ()})  # type: ignore
 
 try:
     from typing import TYPE_CHECKING
@@ -17,29 +25,35 @@ except ImportError:
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
-    from typing import Any, Optional
+    from typing import Any, Mapping, Optional
     import msal_extensions
     from azure.core.credentials import AccessToken
-    from .._authn_client import AuthnClientBase
+    from .._internal import AadClientBase
 
 
-class SharedTokenCacheCredential(object):
-    """Authenticates using tokens in the local cache shared between Microsoft applications.
+MULTIPLE_ACCOUNTS = """Multiple users were discovered in the shared token cache. If using DefaultAzureCredential, set
+the AZURE_USERNAME environment variable to the preferred username. Otherwise,
+specify it when constructing SharedTokenCacheCredential.\nDiscovered accounts: {}"""
 
-    :param str username:
-        Username (typically an email address) of the user to authenticate as. This is used when the local cache
-        contains tokens for multiple identities.
+MULTIPLE_MATCHING_ACCOUNTS = """Found multiple accounts matching{}{}. If using DefaultAzureCredential, set environment
+variables AZURE_USERNAME and AZURE_TENANT_ID with the preferred username and tenant.
+Otherwise, specify them when constructing SharedTokenCacheCredential.\nDiscovered accounts: {}"""
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
-        the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
-        defines authorities for other clouds.
-    :keyword str tenant_id: an Azure Active Directory tenant ID. Used to select an account when the cache contains
-        tokens for multiple identities.
-    """
+NO_ACCOUNTS = """The shared cache contains no accounts. To authenticate with SharedTokenCacheCredential, login through
+developer tooling supporting Azure single sign on"""
 
+NO_MATCHING_ACCOUNTS = """The cache contains no account matching the specified{}{}. To authenticate with
+SharedTokenCacheCredential, login through developer tooling supporting Azure single sign on.\nDiscovered accounts: {}"""
+
+NO_TOKEN = """Token acquisition failed for user '{}'. To fix, re-authenticate
+through developer tooling supporting Azure single sign on"""
+
+
+class SharedTokenCacheBase(ABC):
     def __init__(self, username=None, **kwargs):  # pylint:disable=unused-argument
         # type: (Optional[str], **Any) -> None
 
+        self._authority = kwargs.pop("authority", KnownAuthorities.AZURE_PUBLIC_CLOUD)
         self._username = username
         self._tenant_id = kwargs.pop("tenant_id", None)
 
@@ -55,9 +69,87 @@ class SharedTokenCacheCredential(object):
             cache.add = lambda *_: None
 
         if cache:
-            self._client = self._get_auth_client(cache=cache, **kwargs)  # type: Optional[AuthnClientBase]
+            self._cache = cache
+            self._client = self._get_auth_client(cache=cache, **kwargs)  # type: Optional[AadClientBase]
         else:
             self._client = None
+
+    @abc.abstractmethod
+    def _get_auth_client(self, **kwargs):
+        # type: (**Any) -> AadClientBase
+        pass
+
+    def _get_account(self, username=None, tenant_id=None):
+        # type: (Optional[str], Optional[str]) -> Mapping[str, str]
+        accounts = self._cache.find(TokenCache.CredentialType.ACCOUNT)
+        if not accounts:
+            raise ClientAuthenticationError(message=NO_ACCOUNTS)
+
+        # filter according to arguments
+        query = {"username": username} if username else {}
+        filtered_accounts = self._cache.find(TokenCache.CredentialType.ACCOUNT, query=query)
+        if tenant_id:
+            filtered_accounts = [a for a in filtered_accounts if a.get("home_account_id", "").endswith(tenant_id)]
+
+        if len(filtered_accounts) == 1:
+            account = filtered_accounts[0]
+            environment = account.get("environment")
+            if not environment or environment not in self._authority:
+                # doubtful this account can get the access token we want but public cloud's a special case
+                # because its authority has an alias: for our purposes login.windows.net = login.microsoftonline.com
+                if not (environment == "login.windows.net" and self._authority == KnownAuthorities.AZURE_PUBLIC_CLOUD):
+                    raise ClientAuthenticationError(message="No token for {}".format(self._authority))
+            return account
+
+        cached_accounts = ", ".join(_account_to_string(account) for account in accounts)
+
+        if username or tenant_id:
+            # no, or multiple, matching accounts for the given username and/or tenant id
+            username_string = " username: {}".format(username) if username else ""
+            tenant_string = " tenant: {}".format(tenant_id) if tenant_id else ""
+            if not filtered_accounts:
+                message = NO_MATCHING_ACCOUNTS.format(username_string, tenant_string, cached_accounts)
+            else:
+                message = MULTIPLE_MATCHING_ACCOUNTS.format(username_string, tenant_string, cached_accounts)
+            raise ClientAuthenticationError(message=message)
+
+        # multiple cached accounts and no basis for selection
+        raise ClientAuthenticationError(message=MULTIPLE_ACCOUNTS.format(cached_accounts))
+
+    def _get_refresh_tokens(self, scopes, account):
+        """Yields all an account's cached refresh tokens except those which have a scope (which is unexpected) that
+        isn't a superset of ``scopes``."""
+
+        for token in self._cache.find(
+            TokenCache.CredentialType.REFRESH_TOKEN, query={"home_account_id": account.get("home_account_id")}
+        ):
+            if "target" in token and not all((scope in token["target"] for scope in scopes)):
+                continue
+            yield token
+
+    @staticmethod
+    def supported():
+        # type: () -> bool
+        """Whether the shared token cache is supported on the current platform.
+
+        :rtype: bool
+        """
+        return sys.platform.startswith("win")
+
+
+class SharedTokenCacheCredential(SharedTokenCacheBase):
+    """Authenticates using tokens in the local cache shared between Microsoft applications.
+
+    :param str username:
+        Username (typically an email address) of the user to authenticate as. This is used when the local cache
+        contains tokens for multiple identities.
+
+    :keyword str authority: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+        the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
+        defines authorities for other clouds.
+    :keyword str tenant_id: an Azure Active Directory tenant ID. Used to select an account when the cache contains
+        tokens for multiple identities.
+    """
 
     @wrap_exceptions
     def get_token(self, *scopes, **kwargs):  # pylint:disable=unused-argument
@@ -78,18 +170,22 @@ class SharedTokenCacheCredential(object):
         if not self._client:
             raise ClientAuthenticationError(message="Shared token cache unavailable")
 
-        return self._client.obtain_token_by_refresh_token(scopes, self._username, self._tenant_id)
+        account = self._get_account(self._username, self._tenant_id)
 
-    @staticmethod
-    def supported():
-        # type: () -> bool
-        """Whether the shared token cache is supported on the current platform.
+        # try each refresh token, returning the first access token acquired
+        for refresh_token in self._get_refresh_tokens(scopes, account):
+            token = self._client.obtain_token_by_refresh_token(refresh_token, scopes)
+            return token
 
-        :rtype: bool
-        """
-        return sys.platform.startswith("win")
+        raise ClientAuthenticationError(message=NO_TOKEN.format(account.get("username")))
 
-    @staticmethod
-    def _get_auth_client(**kwargs):
-        # type: (msal_extensions.FileTokenCache) -> AuthnClientBase
-        return AuthnClient(tenant="common", **kwargs)
+    def _get_auth_client(self, **kwargs):
+        # type: (**Any) -> AadClientBase
+        return AadClient(tenant_id="common", client_id=AZURE_CLI_CLIENT_ID, **kwargs)
+
+
+def _account_to_string(account):
+    username = account.get("username")
+    home_account_id = account.get("home_account_id", "").split(".")
+    tenant_id = home_account_id[-1] if len(home_account_id) == 2 else ""
+    return "(username: {}, tenant: {})".format(username, tenant_id)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -56,7 +56,7 @@ class SharedTokenCacheCredential(SharedTokenCacheBase):
         account = self._get_account(self._username, self._tenant_id)
 
         # try each refresh token, returning the first access token acquired
-        for refresh_token in self._get_refresh_tokens(scopes, account):
+        for refresh_token in self._get_refresh_tokens(account):
             token = self._client.obtain_token_by_refresh_token(refresh_token, scopes)
             return token
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -2,21 +2,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-import abc
-import os
-import sys
-
-from msal import TokenCache
 
 from azure.core.exceptions import ClientAuthenticationError
-from .._constants import AZURE_CLI_CLIENT_ID, KnownAuthorities
+from .._constants import AZURE_CLI_CLIENT_ID
 from .._internal import AadClient, wrap_exceptions
-
-
-try:
-    ABC = abc.ABC
-except AttributeError:  # Python 2.7, abc exists, but not ABC
-    ABC = abc.ABCMeta("ABC", (object,), {"__slots__": ()})  # type: ignore
+from .._internal.shared_token_cache import NO_TOKEN, SharedTokenCacheBase
 
 try:
     from typing import TYPE_CHECKING
@@ -25,144 +15,9 @@ except ImportError:
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
-    from typing import Any, Iterable, List, Mapping, Optional
-    import msal_extensions
+    from typing import Any, Mapping
     from azure.core.credentials import AccessToken
     from .._internal import AadClientBase
-
-    CacheItem = Mapping[str, str]
-
-
-MULTIPLE_ACCOUNTS = """Multiple users were discovered in the shared token cache. If using DefaultAzureCredential, set
-the AZURE_USERNAME environment variable to the preferred username. Otherwise,
-specify it when constructing SharedTokenCacheCredential.\nDiscovered accounts: {}"""
-
-MULTIPLE_MATCHING_ACCOUNTS = """Found multiple accounts matching{}{}. If using DefaultAzureCredential, set environment
-variables AZURE_USERNAME and AZURE_TENANT_ID with the preferred username and tenant.
-Otherwise, specify them when constructing SharedTokenCacheCredential.\nDiscovered accounts: {}"""
-
-NO_ACCOUNTS = """The shared cache contains no signed-in accounts. To authenticate with SharedTokenCacheCredential, login
-through developer tooling supporting Azure single sign on"""
-
-NO_MATCHING_ACCOUNTS = """The cache contains no account matching the specified{}{}. To authenticate with
-SharedTokenCacheCredential, login through developer tooling supporting Azure single sign on.\nDiscovered accounts: {}"""
-
-NO_TOKEN = """Token acquisition failed for user '{}'. To fix, re-authenticate
-through developer tooling supporting Azure single sign on"""
-
-_PUBLIC_CLOUD_ALIASES = {"login.windows.net", "login.microsoft.com", "sts.windows.net"}
-
-
-class SharedTokenCacheBase(ABC):
-    def __init__(self, username=None, **kwargs):  # pylint:disable=unused-argument
-        # type: (Optional[str], **Any) -> None
-
-        self._authority = kwargs.pop("authority", KnownAuthorities.AZURE_PUBLIC_CLOUD)
-        self._username = username
-        self._tenant_id = kwargs.pop("tenant_id", None)
-
-        cache = kwargs.pop("_cache", None)  # for ease of testing
-
-        if not cache and sys.platform.startswith("win") and "LOCALAPPDATA" in os.environ:
-            from msal_extensions.token_cache import WindowsTokenCache
-
-            cache = WindowsTokenCache(cache_location=os.environ["LOCALAPPDATA"] + "/.IdentityService/msal.cache")
-
-            # prevent writing to the shared cache
-            # TODO: seperating deserializing access tokens from caching them would make this cleaner
-            cache.add = lambda *_, **__: None
-
-        if cache:
-            self._cache = cache
-            self._client = self._get_auth_client(cache=cache, **kwargs)  # type: Optional[AadClientBase]
-        else:
-            self._client = None
-
-    @abc.abstractmethod
-    def _get_auth_client(self, **kwargs):
-        # type: (**Any) -> AadClientBase
-        pass
-
-    def _get_cache_items_for_authority(self, credential_type):
-        # type: (TokenCache.CredentialType) -> List[CacheItem]
-        """yield cache items matching this credential's authority or one of its aliases"""
-
-        items = []
-        for item in self._cache.find(credential_type):
-            environment = item.get("environment")
-            if environment == self._authority or (
-                self._authority == KnownAuthorities.AZURE_PUBLIC_CLOUD and environment in _PUBLIC_CLOUD_ALIASES
-            ):
-                items.append(item)
-        return items
-
-    def _get_accounts_having_matching_refresh_tokens(self):
-        # type: () -> Iterable[CacheItem]
-        """returns an iterable of cached accounts which have a matching refresh token"""
-
-        refresh_tokens = self._get_cache_items_for_authority(TokenCache.CredentialType.REFRESH_TOKEN)
-        all_accounts = self._get_cache_items_for_authority(TokenCache.CredentialType.ACCOUNT)
-
-        accounts = {}
-        for refresh_token in refresh_tokens:
-            home_account_id = refresh_token.get("home_account_id")
-            if not home_account_id:
-                continue
-            for account in all_accounts:
-                # When the token has no family, msal.net falls back to matching client_id,
-                # which won't work for the shared cache because we don't know the IDs of
-                # all contributing apps. It should be unnecessary anyway because the
-                # apps should all belong to the family.
-                if home_account_id == account.get("home_account_id") and "family_id" in refresh_token:
-                    accounts[account["home_account_id"]] = account
-        return accounts.values()
-
-    def _get_account(self, username=None, tenant_id=None):
-        # type: (Optional[str], Optional[str]) -> CacheItem
-        """returns exactly one account which has a refresh token and matches username and/or tenant_id"""
-
-        accounts = self._get_accounts_having_matching_refresh_tokens()
-        if not accounts:
-            # cache is empty or contains no refresh token -> user needs to sign in
-            raise ClientAuthenticationError(message=NO_ACCOUNTS)
-
-        filtered_accounts = _filtered_accounts(accounts, username, tenant_id)
-        if len(filtered_accounts) == 1:
-            return filtered_accounts[0]
-
-        # no, or multiple, accounts after filtering -> choose the best error message
-        cached_accounts = ", ".join(_account_to_string(account) for account in accounts)
-        if username or tenant_id:
-            username_string = " username: {}".format(username) if username else ""
-            tenant_string = " tenant: {}".format(tenant_id) if tenant_id else ""
-            if filtered_accounts:
-                message = MULTIPLE_MATCHING_ACCOUNTS.format(username_string, tenant_string, cached_accounts)
-            else:
-                message = NO_MATCHING_ACCOUNTS.format(username_string, tenant_string, cached_accounts)
-        else:
-            message = MULTIPLE_ACCOUNTS.format(cached_accounts)
-
-        raise ClientAuthenticationError(message=message)
-
-    def _get_refresh_tokens(self, scopes, account):
-        """Yields all an account's cached refresh tokens except those which have a scope (which is unexpected) that
-        isn't a superset of ``scopes``."""
-
-        for token in self._cache.find(
-            TokenCache.CredentialType.REFRESH_TOKEN, query={"home_account_id": account.get("home_account_id")}
-        ):
-            if "target" in token and not all((scope in token["target"] for scope in scopes)):
-                continue
-            yield token
-
-    @staticmethod
-    def supported():
-        # type: () -> bool
-        """Whether the shared token cache is supported on the current platform.
-
-        :rtype: bool
-        """
-        return sys.platform.startswith("win")
 
 
 class SharedTokenCacheCredential(SharedTokenCacheBase):
@@ -210,28 +65,3 @@ class SharedTokenCacheCredential(SharedTokenCacheBase):
     def _get_auth_client(self, **kwargs):
         # type: (**Any) -> AadClientBase
         return AadClient(tenant_id="common", client_id=AZURE_CLI_CLIENT_ID, **kwargs)
-
-
-def _account_to_string(account):
-    username = account.get("username")
-    home_account_id = account.get("home_account_id", "").split(".")
-    tenant_id = home_account_id[-1] if len(home_account_id) == 2 else ""
-    return "(username: {}, tenant: {})".format(username, tenant_id)
-
-
-def _filtered_accounts(accounts, username=None, tenant_id=None):
-    """yield accounts matching username and/or tenant_id"""
-
-    filtered_accounts = []
-    for account in accounts:
-        if username and account.get("username") != username:
-            continue
-        if tenant_id:
-            try:
-                _, tenant = account["home_account_id"].split(".")
-                if tenant_id != tenant:
-                    continue
-            except:  # pylint:disable=bare-except
-                continue
-        filtered_accounts.append(account)
-    return filtered_accounts

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -1,0 +1,95 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import os
+import sys
+
+from azure.core.exceptions import ClientAuthenticationError
+
+from .._authn_client import AuthnClient
+from .._internal import wrap_exceptions
+
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import,ungrouped-imports
+    from typing import Any, Optional
+    import msal_extensions
+    from azure.core.credentials import AccessToken
+    from .._authn_client import AuthnClientBase
+
+
+class SharedTokenCacheCredential(object):
+    """Authenticates using tokens in the local cache shared between Microsoft applications.
+
+    :param str username:
+        Username (typically an email address) of the user to authenticate as. This is used when the local cache
+        contains tokens for multiple identities.
+
+    :keyword str authority: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+        the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
+        defines authorities for other clouds.
+    :keyword str tenant_id: an Azure Active Directory tenant ID. Used to select an account when the cache contains
+        tokens for multiple identities.
+    """
+
+    def __init__(self, username=None, **kwargs):  # pylint:disable=unused-argument
+        # type: (Optional[str], **Any) -> None
+
+        self._username = username
+        self._tenant_id = kwargs.pop("tenant_id", None)
+
+        cache = kwargs.pop("_cache", None)  # for ease of testing
+
+        if not cache and sys.platform.startswith("win") and "LOCALAPPDATA" in os.environ:
+            from msal_extensions.token_cache import WindowsTokenCache
+
+            cache = WindowsTokenCache(cache_location=os.environ["LOCALAPPDATA"] + "/.IdentityService/msal.cache")
+
+            # prevent writing to the shared cache
+            # TODO: seperating deserializing access tokens from caching them would make this cleaner
+            cache.add = lambda *_: None
+
+        if cache:
+            self._client = self._get_auth_client(cache=cache, **kwargs)  # type: Optional[AuthnClientBase]
+        else:
+            self._client = None
+
+    @wrap_exceptions
+    def get_token(self, *scopes, **kwargs):  # pylint:disable=unused-argument
+        # type (*str, **Any) -> AccessToken
+        """Get an access token for `scopes` from the shared cache.
+
+        If no access token is cached, attempt to acquire one using a cached refresh token.
+
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
+        :param str scopes: desired scopes for the token
+        :rtype: :class:`azure.core.credentials.AccessToken`
+        :raises:
+            :class:`azure.core.exceptions.ClientAuthenticationError` when the cache is unavailable or no access token
+            can be acquired from it
+        """
+
+        if not self._client:
+            raise ClientAuthenticationError(message="Shared token cache unavailable")
+
+        return self._client.obtain_token_by_refresh_token(scopes, self._username, self._tenant_id)
+
+    @staticmethod
+    def supported():
+        # type: () -> bool
+        """Whether the shared token cache is supported on the current platform.
+
+        :rtype: bool
+        """
+        return sys.platform.startswith("win")
+
+    @staticmethod
+    def _get_auth_client(**kwargs):
+        # type: (msal_extensions.FileTokenCache) -> AuthnClientBase
+        return AuthnClient(tenant="common", **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user.py
@@ -130,9 +130,9 @@ class SharedTokenCacheCredential(object):
 
         self._username = username
 
-        cache = None
+        cache = kwargs.pop("_cache", None)  # for ease of testing
 
-        if sys.platform.startswith("win") and "LOCALAPPDATA" in os.environ:
+        if not cache and sys.platform.startswith("win") and "LOCALAPPDATA" in os.environ:
             from msal_extensions.token_cache import WindowsTokenCache
 
             cache = WindowsTokenCache(

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user.py
@@ -144,7 +144,7 @@ class SharedTokenCacheCredential(object):
             cache.add = lambda *_: None
 
         if cache:
-            self._client = self._get_auth_client(cache)  # type: Optional[AuthnClientBase]
+            self._client = self._get_auth_client(cache=cache, **kwargs)  # type: Optional[AuthnClientBase]
         else:
             self._client = None
 
@@ -179,9 +179,9 @@ class SharedTokenCacheCredential(object):
         return sys.platform.startswith("win")
 
     @staticmethod
-    def _get_auth_client(cache):
+    def _get_auth_client(**kwargs):
         # type: (msal_extensions.FileTokenCache) -> AuthnClientBase
-        return AuthnClient(tenant="common", cache=cache)
+        return AuthnClient(tenant="common", **kwargs)
 
 
 class UsernamePasswordCredential(PublicClientCredential):

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user.py
@@ -117,18 +117,21 @@ class SharedTokenCacheCredential(object):
     """Authenticates using tokens in the local cache shared between Microsoft applications.
 
     :param str username:
-        Username (typically an email address) of the user to authenticate as. This is required because the local cache
-        may contain tokens for multiple identities.
+        Username (typically an email address) of the user to authenticate as. This is used when the local cache
+        contains tokens for multiple identities.
 
     :keyword str authority: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
-          the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
-          defines authorities for other clouds.
+        the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
+        defines authorities for other clouds.
+    :keyword str tenant_id: an Azure Active Directory tenant ID. Used to select an account when the cache contains
+        tokens for multiple identities.
     """
 
     def __init__(self, username=None, **kwargs):  # pylint:disable=unused-argument
         # type: (Optional[str], **Any) -> None
 
         self._username = username
+        self._tenant_id = kwargs.pop("tenant_id", None)
 
         cache = kwargs.pop("_cache", None)  # for ease of testing
 
@@ -167,7 +170,7 @@ class SharedTokenCacheCredential(object):
         if not self._client:
             raise ClientAuthenticationError(message="Shared token cache unavailable")
 
-        return self._client.obtain_token_by_refresh_token(scopes, self._username)
+        return self._client.obtain_token_by_refresh_token(scopes, self._username, self._tenant_id)
 
     @staticmethod
     def supported():

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user.py
@@ -3,14 +3,11 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from datetime import datetime
-import os
-import sys
 import time
 
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
 
-from .._authn_client import AuthnClient
 from .._internal import PublicClientCredential, wrap_exceptions
 
 try:
@@ -21,8 +18,6 @@ except ImportError:
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
     from typing import Any, Callable, Optional
-    import msal_extensions
-    from .._authn_client import AuthnClientBase
 
 
 class DeviceCodeCredential(PublicClientCredential):
@@ -111,80 +106,6 @@ class DeviceCodeCredential(PublicClientCredential):
 
         token = AccessToken(result["access_token"], now + int(result["expires_in"]))
         return token
-
-
-class SharedTokenCacheCredential(object):
-    """Authenticates using tokens in the local cache shared between Microsoft applications.
-
-    :param str username:
-        Username (typically an email address) of the user to authenticate as. This is used when the local cache
-        contains tokens for multiple identities.
-
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
-        the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
-        defines authorities for other clouds.
-    :keyword str tenant_id: an Azure Active Directory tenant ID. Used to select an account when the cache contains
-        tokens for multiple identities.
-    """
-
-    def __init__(self, username=None, **kwargs):  # pylint:disable=unused-argument
-        # type: (Optional[str], **Any) -> None
-
-        self._username = username
-        self._tenant_id = kwargs.pop("tenant_id", None)
-
-        cache = kwargs.pop("_cache", None)  # for ease of testing
-
-        if not cache and sys.platform.startswith("win") and "LOCALAPPDATA" in os.environ:
-            from msal_extensions.token_cache import WindowsTokenCache
-
-            cache = WindowsTokenCache(
-                cache_location=os.path.join(os.environ["LOCALAPPDATA"], ".IdentityService", "msal.cache")
-            )
-
-            # prevent writing to the shared cache
-            # TODO: seperating deserializing access tokens from caching them would make this cleaner
-            cache.add = lambda *_: None
-
-        if cache:
-            self._client = self._get_auth_client(cache=cache, **kwargs)  # type: Optional[AuthnClientBase]
-        else:
-            self._client = None
-
-    @wrap_exceptions
-    def get_token(self, *scopes, **kwargs):  # pylint:disable=unused-argument
-        # type (*str, **Any) -> AccessToken
-        """Get an access token for `scopes` from the shared cache.
-
-        If no access token is cached, attempt to acquire one using a cached refresh token.
-
-        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
-
-        :param str scopes: desired scopes for the token
-        :rtype: :class:`azure.core.credentials.AccessToken`
-        :raises:
-            :class:`azure.core.exceptions.ClientAuthenticationError` when the cache is unavailable or no access token
-            can be acquired from it
-        """
-
-        if not self._client:
-            raise ClientAuthenticationError(message="Shared token cache unavailable")
-
-        return self._client.obtain_token_by_refresh_token(scopes, self._username, self._tenant_id)
-
-    @staticmethod
-    def supported():
-        # type: () -> bool
-        """Whether the shared token cache is supported on the current platform.
-
-        :rtype: bool
-        """
-        return sys.platform.startswith("win")
-
-    @staticmethod
-    def _get_auth_client(**kwargs):
-        # type: (msal_extensions.FileTokenCache) -> AuthnClientBase
-        return AuthnClient(tenant="common", **kwargs)
 
 
 class UsernamePasswordCredential(PublicClientCredential):

--- a/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
@@ -82,19 +82,19 @@ class AadClientBase(ABC):
         _raise_for_error(response)
 
         # TokenCache.add mutates the response. In particular, it removes tokens.
-        original_response = copy.deepcopy(response)
+        response_copy = copy.deepcopy(response)
 
         self._cache.add(event={"response": response, "scope": scopes}, now=now)
-        if "expires_on" in original_response:
-            expires_on = int(original_response["expires_on"])
-        elif "expires_in" in original_response:
-            expires_on = now + int(original_response["expires_in"])
+        if "expires_on" in response_copy:
+            expires_on = int(response_copy["expires_on"])
+        elif "expires_in" in response_copy:
+            expires_on = now + int(response_copy["expires_in"])
         else:
-            _scrub_secrets(original_response)
+            _scrub_secrets(response_copy)
             raise ClientAuthenticationError(
-                message="Unexpected response from Azure Active Directory: {}".format(original_response)
+                message="Unexpected response from Azure Active Directory: {}".format(response_copy)
             )
-        return AccessToken(original_response["access_token"], expires_on)
+        return AccessToken(response_copy["access_token"], expires_on)
 
     @abc.abstractmethod
     def _get_client_session(self, **kwargs):

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -172,16 +172,10 @@ class SharedTokenCacheBase(ABC):
 
         raise ClientAuthenticationError(message=message)
 
-    def _get_refresh_tokens(self, scopes, account):
-        """Yields all an account's cached refresh tokens except those which have a scope (which is unexpected) that
-        isn't a superset of ``scopes``."""
-
-        for token in self._cache.find(
+    def _get_refresh_tokens(self, account):
+        return self._cache.find(
             TokenCache.CredentialType.REFRESH_TOKEN, query={"home_account_id": account.get("home_account_id")}
-        ):
-            if "target" in token and not all((scope in token["target"] for scope in scopes)):
-                continue
-            yield token
+        )
 
     @staticmethod
     def supported():

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -73,7 +73,7 @@ def _filtered_accounts(accounts, username=None, tenant_id=None):
                 _, tenant = account["home_account_id"].split(".")
                 if tenant_id != tenant:
                     continue
-            except:  # pylint:disable=bare-except
+            except Exception:  # pylint:disable=broad-except
                 continue
         filtered_accounts.append(account)
     return filtered_accounts

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -33,17 +33,20 @@ if TYPE_CHECKING:
 
 MULTIPLE_ACCOUNTS = """Multiple users were discovered in the shared token cache. If using DefaultAzureCredential, set
 the AZURE_USERNAME environment variable to the preferred username. Otherwise,
-specify it when constructing SharedTokenCacheCredential.\nDiscovered accounts: {}"""
+specify it when constructing SharedTokenCacheCredential.
+Discovered accounts: {}"""
 
 MULTIPLE_MATCHING_ACCOUNTS = """Found multiple accounts matching{}{}. If using DefaultAzureCredential, set environment
 variables AZURE_USERNAME and AZURE_TENANT_ID with the preferred username and tenant.
-Otherwise, specify them when constructing SharedTokenCacheCredential.\nDiscovered accounts: {}"""
+Otherwise, specify them when constructing SharedTokenCacheCredential.
+Discovered accounts: {}"""
 
 NO_ACCOUNTS = """The shared cache contains no signed-in accounts. To authenticate with SharedTokenCacheCredential, login
 through developer tooling supporting Azure single sign on"""
 
 NO_MATCHING_ACCOUNTS = """The cache contains no account matching the specified{}{}. To authenticate with
-SharedTokenCacheCredential, login through developer tooling supporting Azure single sign on.\nDiscovered accounts: {}"""
+SharedTokenCacheCredential, login through developer tooling supporting Azure single sign on.
+Discovered accounts: {}"""
 
 NO_TOKEN = """Token acquisition failed for user '{}'. To fix, re-authenticate
 through developer tooling supporting Azure single sign on"""

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -1,0 +1,190 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import abc
+import os
+import sys
+
+
+from msal import TokenCache
+from azure.core.exceptions import ClientAuthenticationError
+from .._constants import KnownAuthorities
+
+try:
+    ABC = abc.ABC
+except AttributeError:  # Python 2.7, abc exists, but not ABC
+    ABC = abc.ABCMeta("ABC", (object,), {"__slots__": ()})  # type: ignore
+
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import,ungrouped-imports
+    from typing import Any, Iterable, List, Mapping, Optional
+    import msal_extensions
+    from azure.core.credentials import AccessToken
+    from .._internal import AadClientBase
+
+    CacheItem = Mapping[str, str]
+
+
+MULTIPLE_ACCOUNTS = """Multiple users were discovered in the shared token cache. If using DefaultAzureCredential, set
+the AZURE_USERNAME environment variable to the preferred username. Otherwise,
+specify it when constructing SharedTokenCacheCredential.\nDiscovered accounts: {}"""
+
+MULTIPLE_MATCHING_ACCOUNTS = """Found multiple accounts matching{}{}. If using DefaultAzureCredential, set environment
+variables AZURE_USERNAME and AZURE_TENANT_ID with the preferred username and tenant.
+Otherwise, specify them when constructing SharedTokenCacheCredential.\nDiscovered accounts: {}"""
+
+NO_ACCOUNTS = """The shared cache contains no signed-in accounts. To authenticate with SharedTokenCacheCredential, login
+through developer tooling supporting Azure single sign on"""
+
+NO_MATCHING_ACCOUNTS = """The cache contains no account matching the specified{}{}. To authenticate with
+SharedTokenCacheCredential, login through developer tooling supporting Azure single sign on.\nDiscovered accounts: {}"""
+
+NO_TOKEN = """Token acquisition failed for user '{}'. To fix, re-authenticate
+through developer tooling supporting Azure single sign on"""
+
+_PUBLIC_CLOUD_ALIASES = {"login.windows.net", "login.microsoft.com", "sts.windows.net"}
+
+
+def _account_to_string(account):
+    username = account.get("username")
+    home_account_id = account.get("home_account_id", "").split(".")
+    tenant_id = home_account_id[-1] if len(home_account_id) == 2 else ""
+    return "(username: {}, tenant: {})".format(username, tenant_id)
+
+
+def _filtered_accounts(accounts, username=None, tenant_id=None):
+    """yield accounts matching username and/or tenant_id"""
+
+    filtered_accounts = []
+    for account in accounts:
+        if username and account.get("username") != username:
+            continue
+        if tenant_id:
+            try:
+                _, tenant = account["home_account_id"].split(".")
+                if tenant_id != tenant:
+                    continue
+            except:  # pylint:disable=bare-except
+                continue
+        filtered_accounts.append(account)
+    return filtered_accounts
+
+
+class SharedTokenCacheBase(ABC):
+    def __init__(self, username=None, **kwargs):  # pylint:disable=unused-argument
+        # type: (Optional[str], **Any) -> None
+
+        self._authority = kwargs.pop("authority", KnownAuthorities.AZURE_PUBLIC_CLOUD)
+        self._username = username
+        self._tenant_id = kwargs.pop("tenant_id", None)
+
+        cache = kwargs.pop("_cache", None)  # for ease of testing
+
+        if not cache and sys.platform.startswith("win") and "LOCALAPPDATA" in os.environ:
+            from msal_extensions.token_cache import WindowsTokenCache
+
+            cache = WindowsTokenCache(
+                cache_location=os.path.join(os.environ["LOCALAPPDATA"], ".IdentityService", "msal.cache")
+            )
+
+            # prevent writing to the shared cache
+            # TODO: seperating deserializing access tokens from caching them would make this cleaner
+            cache.add = lambda *_, **__: None
+
+        if cache:
+            self._cache = cache
+            self._client = self._get_auth_client(cache=cache, **kwargs)  # type: Optional[AadClientBase]
+        else:
+            self._client = None
+
+    @abc.abstractmethod
+    def _get_auth_client(self, **kwargs):
+        # type: (**Any) -> AadClientBase
+        pass
+
+    def _get_cache_items_for_authority(self, credential_type):
+        # type: (TokenCache.CredentialType) -> List[CacheItem]
+        """yield cache items matching this credential's authority or one of its aliases"""
+
+        items = []
+        for item in self._cache.find(credential_type):
+            environment = item.get("environment")
+            if environment == self._authority or (
+                self._authority == KnownAuthorities.AZURE_PUBLIC_CLOUD and environment in _PUBLIC_CLOUD_ALIASES
+            ):
+                items.append(item)
+        return items
+
+    def _get_accounts_having_matching_refresh_tokens(self):
+        # type: () -> Iterable[CacheItem]
+        """returns an iterable of cached accounts which have a matching refresh token"""
+
+        refresh_tokens = self._get_cache_items_for_authority(TokenCache.CredentialType.REFRESH_TOKEN)
+        all_accounts = self._get_cache_items_for_authority(TokenCache.CredentialType.ACCOUNT)
+
+        accounts = {}
+        for refresh_token in refresh_tokens:
+            home_account_id = refresh_token.get("home_account_id")
+            if not home_account_id:
+                continue
+            for account in all_accounts:
+                # When the token has no family, msal.net falls back to matching client_id,
+                # which won't work for the shared cache because we don't know the IDs of
+                # all contributing apps. It should be unnecessary anyway because the
+                # apps should all belong to the family.
+                if home_account_id == account.get("home_account_id") and "family_id" in refresh_token:
+                    accounts[account["home_account_id"]] = account
+        return accounts.values()
+
+    def _get_account(self, username=None, tenant_id=None):
+        # type: (Optional[str], Optional[str]) -> CacheItem
+        """returns exactly one account which has a refresh token and matches username and/or tenant_id"""
+
+        accounts = self._get_accounts_having_matching_refresh_tokens()
+        if not accounts:
+            # cache is empty or contains no refresh token -> user needs to sign in
+            raise ClientAuthenticationError(message=NO_ACCOUNTS)
+
+        filtered_accounts = _filtered_accounts(accounts, username, tenant_id)
+        if len(filtered_accounts) == 1:
+            return filtered_accounts[0]
+
+        # no, or multiple, accounts after filtering -> choose the best error message
+        cached_accounts = ", ".join(_account_to_string(account) for account in accounts)
+        if username or tenant_id:
+            username_string = " username: {}".format(username) if username else ""
+            tenant_string = " tenant: {}".format(tenant_id) if tenant_id else ""
+            if filtered_accounts:
+                message = MULTIPLE_MATCHING_ACCOUNTS.format(username_string, tenant_string, cached_accounts)
+            else:
+                message = NO_MATCHING_ACCOUNTS.format(username_string, tenant_string, cached_accounts)
+        else:
+            message = MULTIPLE_ACCOUNTS.format(cached_accounts)
+
+        raise ClientAuthenticationError(message=message)
+
+    def _get_refresh_tokens(self, scopes, account):
+        """Yields all an account's cached refresh tokens except those which have a scope (which is unexpected) that
+        isn't a superset of ``scopes``."""
+
+        for token in self._cache.find(
+            TokenCache.CredentialType.REFRESH_TOKEN, query={"home_account_id": account.get("home_account_id")}
+        ):
+            if "target" in token and not all((scope in token["target"] for scope in scopes)):
+                continue
+            yield token
+
+    @staticmethod
+    def supported():
+        # type: () -> bool
+        """Whether the shared token cache is supported on the current platform.
+
+        :rtype: bool
+        """
+        return sys.platform.startswith("win")

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -92,7 +92,7 @@ class SharedTokenCacheBase(ABC):
     def __init__(self, username=None, **kwargs):  # pylint:disable=unused-argument
         # type: (Optional[str], **Any) -> None
 
-        self._authority = kwargs.pop("authority", KnownAuthorities.AZURE_PUBLIC_CLOUD)
+        self._authority = kwargs.pop("authority", None) or KnownAuthorities.AZURE_PUBLIC_CLOUD
         self._authority_aliases = KNOWN_ALIASES.get(self._authority) or frozenset((self._authority,))
         self._username = username
         self._tenant_id = kwargs.pop("tenant_id", None)
@@ -112,7 +112,9 @@ class SharedTokenCacheBase(ABC):
 
         if cache:
             self._cache = cache
-            self._client = self._get_auth_client(cache=cache, **kwargs)  # type: Optional[AadClientBase]
+            self._client = self._get_auth_client(
+                authority=self._authority, cache=cache, **kwargs
+            )  # type: Optional[AadClientBase]
         else:
             self._client = None
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/__init__.py
@@ -8,7 +8,7 @@ from .default import DefaultAzureCredential
 from .environment import EnvironmentCredential
 from .managed_identity import ManagedIdentityCredential
 from .client_credential import CertificateCredential, ClientSecretCredential
-from .user import SharedTokenCacheCredential
+from .shared_cache import SharedTokenCacheCredential
 
 
 __all__ = [

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -38,12 +38,19 @@ class DefaultAzureCredential(ChainedTokenCredential):
         Defaults to **False**.
     :keyword bool exclude_shared_token_cache_credential: Whether to exclude the shared token cache. Defaults to
         **False**.
+    :keyword str shared_cache_username: Preferred username for :class:`~azure.identity.SharedTokenCacheCredential`.
+        Defaults to the value of environment variable AZURE_USERNAME, if any.
+    :keyword str shared_cache_tenant_id: Preferred tenant for :class:`~azure.identity.SharedTokenCacheCredential`.
+        Defaults to the value of environment variable AZURE_TENANT_ID, if any.
     """
 
     def __init__(self, **kwargs):
         authority = kwargs.pop("authority", KnownAuthorities.AZURE_PUBLIC_CLOUD)
 
-        username = kwargs.pop("username", os.environ.get(EnvironmentVariables.AZURE_USERNAME))
+        shared_cache_username = kwargs.pop("shared_cache_username", os.environ.get(EnvironmentVariables.AZURE_USERNAME))
+        shared_cache_tenant_id = kwargs.pop(
+            "shared_cache_tenant_id", os.environ.get(EnvironmentVariables.AZURE_TENANT_ID)
+        )
 
         exclude_environment_credential = kwargs.pop("exclude_environment_credential", False)
         exclude_managed_identity_credential = kwargs.pop("exclude_managed_identity_credential", False)
@@ -56,7 +63,11 @@ class DefaultAzureCredential(ChainedTokenCredential):
             credentials.append(ManagedIdentityCredential(**kwargs))
         if not exclude_shared_token_cache_credential and SharedTokenCacheCredential.supported():
             try:
-                credentials.append(SharedTokenCacheCredential(username=username, authority=authority, **kwargs))
+                # username and/or tenant_id are only required when the cache contains tokens for multiple identities
+                shared_cache = SharedTokenCacheCredential(
+                    username=shared_cache_username, tenant_id=shared_cache_tenant_id, authority=authority, **kwargs
+                )
+                credentials.append(shared_cache)
             except Exception as ex:  # pylint:disable=broad-except
                 # transitive dependency pywin32 doesn't support 3.8 (https://github.com/mhammond/pywin32/issues/1431)
                 _LOGGER.info("Shared token cache is unavailable: '%s'", ex)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -45,7 +45,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
     """
 
     def __init__(self, **kwargs):
-        authority = kwargs.pop("authority", KnownAuthorities.AZURE_PUBLIC_CLOUD)
+        authority = kwargs.pop("authority", None) or KnownAuthorities.AZURE_PUBLIC_CLOUD
 
         shared_cache_username = kwargs.pop("shared_cache_username", os.environ.get(EnvironmentVariables.AZURE_USERNAME))
         shared_cache_tenant_id = kwargs.pop(

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -9,7 +9,7 @@ from ..._constants import EnvironmentVariables, KnownAuthorities
 from .chained import ChainedTokenCredential
 from .environment import EnvironmentCredential
 from .managed_identity import ManagedIdentityCredential
-from .user import SharedTokenCacheCredential
+from .shared_cache import SharedTokenCacheCredential
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
@@ -48,7 +48,7 @@ class SharedTokenCacheCredential(SharedTokenCacheBase):
         account = self._get_account(self._username, self._tenant_id)
 
         # try each refresh token, returning the first access token acquired
-        for refresh_token in self._get_refresh_tokens(scopes, account):
+        for refresh_token in self._get_refresh_tokens(account):
             token = await self._client.obtain_token_by_refresh_token(refresh_token, scopes)
             return token
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from azure.core.exceptions import ClientAuthenticationError
 
 from ..._constants import AZURE_CLI_CLIENT_ID
-from ..._credentials.shared_cache import SharedTokenCacheBase, NO_TOKEN
+from ..._internal.shared_token_cache import NO_TOKEN, SharedTokenCacheBase
 from .._internal.aad_client import AadClient
 from .._internal.exception_wrapper import wrap_exceptions
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/user.py
@@ -48,5 +48,5 @@ class SharedTokenCacheCredential(SyncSharedTokenCacheCredential):
         return await self._client.obtain_token_by_refresh_token(scopes, self._username)
 
     @staticmethod
-    def _get_auth_client(cache: "msal_extensions.FileTokenCache") -> "AuthnClientBase":
-        return AsyncAuthnClient(tenant="common", cache=cache)
+    def _get_auth_client(**kwargs: "Any") -> "AuthnClientBase":
+        return AsyncAuthnClient(tenant="common", **kwargs)

--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -56,8 +56,16 @@ def build_aad_response(  # simulate a response from AAD
 
 class Request:
     def __init__(
-        self, url=None, url_substring=None, method=None, required_headers={}, required_data={}, required_params={}
+        self,
+        url=None,
+        authority=None,
+        url_substring=None,
+        method=None,
+        required_headers={},
+        required_data={},
+        required_params={},
     ):
+        self.authority = authority
         self.method = method
         self.url = url
         self.url_substring = url_substring
@@ -66,8 +74,15 @@ class Request:
         self.required_params = required_params
 
     def assert_matches(self, request):
+        # TODO: rewrite this to report all mismatches, and use the parsed url
+        url = six.moves.urllib_parse.urlparse(request.url)
+
         if self.url:
             assert request.url.split("?")[0] == self.url
+        if self.authority:
+            assert url.netloc == self.authority, "Expected authority '{}', actual was '{}".format(
+                self.authority, url.netloc
+            )
         if self.url_substring:
             assert self.url_substring in request.url
         if self.method:

--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -13,7 +13,8 @@ from azure.identity._constants import EnvironmentVariables
 from azure.identity._credentials.managed_identity import ImdsCredential, MsiCredential
 from six.moves.urllib_parse import urlparse
 
-from helpers import mock_response
+from helpers import mock_response, Request, validating_transport
+from test_shared_cache_credential import build_aad_response, get_account_event, populated_cache
 
 try:
     from unittest.mock import Mock, patch
@@ -101,3 +102,102 @@ def test_exclude_options():
     actual = {c.__class__ for c in credential.credentials}
     default = {c.__class__ for c in DefaultAzureCredential().credentials}
     assert actual - default == {InteractiveBrowserCredential}
+
+
+def test_shared_cache_tenant_id():
+    expected_access_token = "expected-access-token"
+    refresh_token_a = "refresh-token-a"
+    refresh_token_b = "refresh-token-b"
+    upn = "spam@eggs"
+    tenant_a = "tenant-a"
+    tenant_b = "tenant-b"
+
+    # two cached accounts, same username, different tenants -> shared_cache_tenant_id should prevail
+    account_a = get_account_event(username=upn, uid="another-guid", utid=tenant_a, refresh_token=refresh_token_a)
+    account_b = get_account_event(username=upn, uid="more-guid", utid=tenant_b, refresh_token=refresh_token_b)
+    cache = populated_cache(account_a, account_b)
+
+    credential = get_credential_for_shared_cache_test(
+        refresh_token_b, expected_access_token, cache, shared_cache_tenant_id=tenant_b
+    )
+    token = credential.get_token("scope")
+    assert token.token == expected_access_token
+
+    # redundantly specifying shared_cache_username makes no difference
+    credential = get_credential_for_shared_cache_test(
+        refresh_token_b, expected_access_token, cache, shared_cache_tenant_id=tenant_b, shared_cache_username=upn
+    )
+    token = credential.get_token("scope")
+    assert token.token == expected_access_token
+
+    # shared_cache_tenant_id should prevail over AZURE_TENANT_ID
+    with patch("os.environ", {EnvironmentVariables.AZURE_TENANT_ID: tenant_a}):
+        credential = get_credential_for_shared_cache_test(
+            refresh_token_b, expected_access_token, cache, shared_cache_tenant_id=tenant_b
+        )
+    token = credential.get_token("scope")
+    assert token.token == expected_access_token
+
+    # AZURE_TENANT_ID should be used when shared_cache_tenant_id isn't specified
+    with patch("os.environ", {EnvironmentVariables.AZURE_TENANT_ID: tenant_b}):
+        credential = get_credential_for_shared_cache_test(refresh_token_b, expected_access_token, cache)
+    token = credential.get_token("scope")
+    assert token.token == expected_access_token
+
+
+def test_shared_cache_username():
+    expected_access_token = "expected-access-token"
+    refresh_token_a = "refresh-token-a"
+    refresh_token_b = "refresh-token-b"
+    upn_a = "spam@eggs"
+    upn_b = "eggs@spam"
+    tenant_id = "the-tenant"
+
+    # two cached accounts, same tenant, different usernames -> shared_cache_username should prevail
+    account_a = get_account_event(username=upn_a, uid="another-guid", utid=tenant_id, refresh_token=refresh_token_a)
+    account_b = get_account_event(username=upn_b, uid="more-guid", utid=tenant_id, refresh_token=refresh_token_b)
+    cache = populated_cache(account_a, account_b)
+
+    credential = get_credential_for_shared_cache_test(
+        refresh_token_a, expected_access_token, cache, shared_cache_username=upn_a
+    )
+    token = credential.get_token("scope")
+    assert token.token == expected_access_token
+
+    # redundantly specifying shared_cache_tenant_id makes no difference
+    credential = get_credential_for_shared_cache_test(
+        refresh_token_a, expected_access_token, cache, shared_cache_tenant_id=tenant_id, shared_cache_username=upn_a
+    )
+    token = credential.get_token("scope")
+    assert token.token == expected_access_token
+
+    # shared_cache_username should prevail over AZURE_USERNAME
+    with patch("os.environ", {EnvironmentVariables.AZURE_USERNAME: upn_b}):
+        credential = get_credential_for_shared_cache_test(
+            refresh_token_a, expected_access_token, cache, shared_cache_username=upn_a
+        )
+    token = credential.get_token("scope")
+    assert token.token == expected_access_token
+
+    # AZURE_USERNAME should be used when shared_cache_username isn't specified
+    with patch("os.environ", {EnvironmentVariables.AZURE_USERNAME: upn_b}):
+        credential = get_credential_for_shared_cache_test(refresh_token_b, expected_access_token, cache)
+    token = credential.get_token("scope")
+    assert token.token == expected_access_token
+
+
+def get_credential_for_shared_cache_test(expected_refresh_token, expected_access_token, cache, **kwargs):
+    exclude_other_credentials = {
+        option: True for option in ("exclude_environment_credential", "exclude_managed_identity_credential")
+    }
+    options = dict(exclude_other_credentials, **kwargs)
+
+    # validating transport will raise if the shared cache credential isn't used, or selects the wrong refresh token
+    transport = validating_transport(
+        requests=[Request(required_data={"refresh_token": expected_refresh_token})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_access_token))],
+    )
+
+    # this credential uses a mock shared cache, so it works on all platforms
+    with patch.object(SharedTokenCacheCredential, "supported"):
+        return DefaultAzureCredential(_cache=cache, transport=transport, **options)

--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -23,8 +23,6 @@ except ImportError:  # python < 3.3
 
 
 def test_default_credential_authority():
-    # TODO need a mock cache to test SharedTokenCacheCredential
-    tenant_id = "expected_tenant"
     expected_access_token = "***"
     response = mock_response(
         json_payload={
@@ -42,16 +40,17 @@ def test_default_credential_authority():
 
         def send(request, **_):
             url = urlparse(request.url)
-            assert url.scheme == "https"
-            assert url.netloc == expected_authority
-            assert url.path.startswith("/" + tenant_id)
+            assert url.scheme == "https", "Unexpected scheme '{}'".format(url.scheme)
+            assert url.netloc == expected_authority, "Expected authority '{}', actual was '{}'".format(
+                expected_authority, url.netloc
+            )
             return response
 
         # environment credential configured with client secret should respect authority
         environment = {
             EnvironmentVariables.AZURE_CLIENT_ID: "client_id",
             EnvironmentVariables.AZURE_CLIENT_SECRET: "secret",
-            EnvironmentVariables.AZURE_TENANT_ID: tenant_id,
+            EnvironmentVariables.AZURE_TENANT_ID: "tenant_id",
         }
         with patch("os.environ", environment):
             transport = Mock(send=send)
@@ -63,6 +62,14 @@ def test_default_credential_authority():
             transport = Mock(send=lambda *_, **__: response)
             access_token, _ = DefaultAzureCredential(authority=authority_kwarg, transport=transport).get_token("scope")
             assert access_token == expected_access_token
+
+        # shared cache credential should respect authority
+        account = get_account_event(username="spam@eggs", uid="guid", utid="tenant", authority=authority_kwarg)
+        cache = populated_cache(account)
+        with patch.object(SharedTokenCacheCredential, "supported"):
+            credential = DefaultAzureCredential(_cache=cache, authority=authority_kwarg, transport=Mock(send=send))
+        access_token, _ = credential.get_token("scope")
+        assert access_token == expected_access_token
 
     # all credentials not representing managed identities should use a specified authority or default to public cloud
     exercise_credentials("authority.com")
@@ -201,3 +208,7 @@ def get_credential_for_shared_cache_test(expected_refresh_token, expected_access
     # this credential uses a mock shared cache, so it works on all platforms
     with patch.object(SharedTokenCacheCredential, "supported"):
         return DefaultAzureCredential(_cache=cache, transport=transport, **options)
+
+
+if __name__ == "__main__":
+    test_default_credential_authority()

--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -208,7 +208,3 @@ def get_credential_for_shared_cache_test(expected_refresh_token, expected_access
     # this credential uses a mock shared cache, so it works on all platforms
     with patch.object(SharedTokenCacheCredential, "supported"):
         return DefaultAzureCredential(_cache=cache, transport=transport, **options)
-
-
-if __name__ == "__main__":
-    test_default_credential_authority()

--- a/sdk/identity/azure-identity/tests/test_default_async.py
+++ b/sdk/identity/azure-identity/tests/test_default_async.py
@@ -13,7 +13,8 @@ from azure.identity.aio._credentials.managed_identity import ImdsCredential, Msi
 from azure.identity._constants import EnvironmentVariables
 import pytest
 
-from helpers import mock_response
+from helpers import async_validating_transport, mock_response, Request
+from test_shared_cache_credential import build_aad_response, get_account_event, populated_cache
 
 
 @pytest.mark.asyncio
@@ -101,3 +102,96 @@ def test_exclude_options():
     if SharedTokenCacheCredential.supported():
         credential = DefaultAzureCredential(exclude_shared_token_cache_credential=True)
         assert_credentials_not_present(credential, SharedTokenCacheCredential)
+
+
+@pytest.mark.asyncio
+async def test_shared_cache_tenant_id():
+    expected_access_token = "expected-access-token"
+    refresh_token_a = "refresh-token-a"
+    refresh_token_b = "refresh-token-b"
+    upn = "spam@eggs"
+    tenant_a = "tenant-a"
+    tenant_b = "tenant-b"
+
+    # two cached accounts, same username, different tenants -> shared_cache_tenant_id should prevail
+    account_a = get_account_event(username=upn, uid="another-guid", utid=tenant_a, refresh_token=refresh_token_a)
+    account_b = get_account_event(username=upn, uid="more-guid", utid=tenant_b, refresh_token=refresh_token_b)
+    cache = populated_cache(account_a, account_b)
+
+    credential = get_credential_for_shared_cache_test(
+        refresh_token_b, expected_access_token, cache, shared_cache_tenant_id=tenant_b
+    )
+    token = await credential.get_token("scope")
+    assert token.token == expected_access_token
+
+    # redundantly specifying shared_cache_username makes no difference
+    credential = get_credential_for_shared_cache_test(
+        refresh_token_b, expected_access_token, cache, shared_cache_tenant_id=tenant_b, shared_cache_username=upn
+    )
+    token = await credential.get_token("scope")
+    assert token.token == expected_access_token
+
+    # shared_cache_tenant_id should prevail over AZURE_TENANT_ID
+    with patch("os.environ", {EnvironmentVariables.AZURE_TENANT_ID: tenant_a}):
+        credential = get_credential_for_shared_cache_test(
+            refresh_token_b, expected_access_token, cache, shared_cache_tenant_id=tenant_b
+        )
+    token = await credential.get_token("scope")
+    assert token.token == expected_access_token
+
+    # AZURE_TENANT_ID should be used when shared_cache_tenant_id isn't specified
+    with patch("os.environ", {EnvironmentVariables.AZURE_TENANT_ID: tenant_b}):
+        credential = get_credential_for_shared_cache_test(refresh_token_b, expected_access_token, cache)
+    token = await credential.get_token("scope")
+    assert token.token == expected_access_token
+
+
+@pytest.mark.asyncio
+async def test_shared_cache_username():
+    expected_access_token = "expected-access-token"
+    refresh_token_a = "refresh-token-a"
+    refresh_token_b = "refresh-token-b"
+    upn_a = "spam@eggs"
+    upn_b = "eggs@spam"
+    tenant_id = "the-tenant"
+
+    # two cached accounts, same tenant, different usernames -> shared_cache_username should prevail
+    account_a = get_account_event(username=upn_a, uid="another-guid", utid=tenant_id, refresh_token=refresh_token_a)
+    account_b = get_account_event(username=upn_b, uid="more-guid", utid=tenant_id, refresh_token=refresh_token_b)
+    cache = populated_cache(account_a, account_b)
+
+    credential = get_credential_for_shared_cache_test(
+        refresh_token_a, expected_access_token, cache, shared_cache_username=upn_a
+    )
+    token = await credential.get_token("scope")
+    assert token.token == expected_access_token
+
+    # shared_cache_username should prevail over AZURE_USERNAME
+    with patch("os.environ", {EnvironmentVariables.AZURE_USERNAME: upn_b}):
+        credential = get_credential_for_shared_cache_test(
+            refresh_token_a, expected_access_token, cache, shared_cache_username=upn_a
+        )
+    token = await credential.get_token("scope")
+    assert token.token == expected_access_token
+
+    # AZURE_USERNAME should be used when shared_cache_username isn't specified
+    with patch("os.environ", {EnvironmentVariables.AZURE_USERNAME: upn_b}):
+        credential = get_credential_for_shared_cache_test(refresh_token_b, expected_access_token, cache)
+    token = await credential.get_token("scope")
+    assert token.token == expected_access_token
+
+
+def get_credential_for_shared_cache_test(expected_refresh_token, expected_access_token, cache, **kwargs):
+    exclude_other_credentials = {
+        option: True for option in ("exclude_environment_credential", "exclude_managed_identity_credential")
+    }
+
+    # validating transport will raise if the shared cache credential isn't used, or selects the wrong refresh token
+    transport = async_validating_transport(
+        requests=[Request(required_data={"refresh_token": expected_refresh_token})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_access_token))],
+    )
+
+    # this credential uses a mock shared cache, so it works on all platforms
+    with patch.object(SharedTokenCacheCredential, "supported", lambda: True):
+        return DefaultAzureCredential(_cache=cache, transport=transport, **exclude_other_credentials, **kwargs)

--- a/sdk/identity/azure-identity/tests/test_interactive_credential.py
+++ b/sdk/identity/azure-identity/tests/test_interactive_credential.py
@@ -40,7 +40,7 @@ def test_interactive_credential(mock_open):
     )
     transport = validating_transport(
         requests=[Request(url_substring=endpoint)] * 3
-        + [Request(url_substring=endpoint, required_data={"refresh_token": expected_refresh_token})],
+        + [Request(authority=authority, url_substring=endpoint, required_data={"refresh_token": expected_refresh_token})],
         responses=[
             discovery_response,  # instance discovery
             discovery_response,  # tenant discovery

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 from azure.core.exceptions import ClientAuthenticationError
 from azure.identity import KnownAuthorities, SharedTokenCacheCredential
-from azure.identity._authn_client import (
+from azure.identity._credentials.shared_cache import (
     MULTIPLE_ACCOUNTS,
     MULTIPLE_MATCHING_ACCOUNTS,
     NO_ACCOUNTS,
@@ -203,3 +203,6 @@ def populated_cache(*accounts):
     for account in accounts:
         cache.add(account)
     return cache
+
+if __name__ == "__main__":
+    test_single_account()

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 from azure.core.exceptions import ClientAuthenticationError
 from azure.identity import KnownAuthorities, SharedTokenCacheCredential
-from azure.identity._credentials.shared_cache import (
+from azure.identity._internal.shared_token_cache import (
     MULTIPLE_ACCOUNTS,
     MULTIPLE_MATCHING_ACCOUNTS,
     NO_ACCOUNTS,

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
@@ -14,9 +14,9 @@ from msal import TokenCache
 import pytest
 
 try:
-    from unittest.mock import Mock, patch
+    from unittest.mock import Mock
 except ImportError:  # python < 3.3
-    from mock import Mock, patch  # type: ignore
+    from mock import Mock  # type: ignore
 
 from helpers import build_aad_response, build_id_token, mock_response, Request, validating_transport
 
@@ -24,9 +24,15 @@ from helpers import build_aad_response, build_id_token, mock_response, Request, 
 def test_empty_cache():
     with pytest.raises(ClientAuthenticationError, match=NO_ACCOUNTS):
         SharedTokenCacheCredential(_cache=TokenCache()).get_token("scope")
+    with pytest.raises(ClientAuthenticationError, match=NO_ACCOUNTS):
+        SharedTokenCacheCredential(_cache=TokenCache(), username="not@cache").get_token("scope")
+    with pytest.raises(ClientAuthenticationError, match=NO_ACCOUNTS):
+        SharedTokenCacheCredential(_cache=TokenCache(), tenant_id="not-cached").get_token("scope")
+    with pytest.raises(ClientAuthenticationError, match=NO_ACCOUNTS):
+        SharedTokenCacheCredential(_cache=TokenCache(), tenant_id="not-cached", username="not@cache").get_token("scope")
 
 
-def test_no_matching_account():
+def test_no_matching_account_for_username():
     """one cached account, username specified, username doesn't match -> credential should raise"""
 
     upn = "spam@eggs"
@@ -42,7 +48,69 @@ def test_no_matching_account():
     assert upn in discovered_accounts and tenant in discovered_accounts
 
 
-def test_single_matching_account():
+def test_no_matching_account_for_tenant():
+    """one cached account, tenant specified, tenant doesn't match -> credential should raise"""
+
+    upn = "spam@eggs"
+    tenant = "some-guid"
+    account = get_account_event(username=upn, uid="uid", utid=tenant, refresh_token="refresh-token")
+    cache = populated_cache(account)
+
+    with pytest.raises(ClientAuthenticationError) as ex:
+        SharedTokenCacheCredential(_cache=cache, tenant_id="not-" + tenant).get_token("scope")
+
+    assert ex.value.message.startswith(NO_MATCHING_ACCOUNTS[: NO_MATCHING_ACCOUNTS.index("{")])
+    discovered_accounts = ex.value.message.splitlines()[-1]
+    assert upn in discovered_accounts and tenant in discovered_accounts
+
+
+def test_no_matching_account_for_tenant_and_username():
+    """one cached account, tenant and username specified, neither match -> credential should raise"""
+
+    upn = "spam@eggs"
+    tenant = "some-guid"
+    account = get_account_event(username=upn, uid="uid", utid=tenant, refresh_token="refresh-token")
+    cache = populated_cache(account)
+
+    with pytest.raises(ClientAuthenticationError) as ex:
+        SharedTokenCacheCredential(_cache=cache, tenant_id="not-" + tenant, username="not" + upn).get_token("scope")
+
+    assert ex.value.message.startswith(NO_MATCHING_ACCOUNTS[: NO_MATCHING_ACCOUNTS.index("{")])
+    discovered_accounts = ex.value.message.splitlines()[-1]
+    assert upn in discovered_accounts and tenant in discovered_accounts
+
+
+def test_no_matching_account_for_tenant_or_username():
+    """two cached accounts, username and tenant specified, one account matches each -> credential should raise"""
+
+    refresh_token_a = "refresh-token-a"
+    refresh_token_b = "refresh-token-b"
+    upn_a = "a@foo"
+    upn_b = "b@foo"
+    tenant_a = "tenant-a"
+    tenant_b = "tenant-b"
+    account_a = get_account_event(username=upn_a, uid="uid_a", utid=tenant_a, refresh_token=refresh_token_a)
+    account_b = get_account_event(username=upn_b, uid="uid_b", utid=tenant_b, refresh_token=refresh_token_b)
+    cache = populated_cache(account_a, account_b)
+
+    transport = Mock(side_effect=Exception())  # credential shouldn't use the network
+
+    credential = SharedTokenCacheCredential(username=upn_a, tenant_id=tenant_b, _cache=cache, transport=transport)
+    with pytest.raises(ClientAuthenticationError) as ex:
+        credential.get_token("scope")
+    assert ex.value.message.startswith(NO_MATCHING_ACCOUNTS[: NO_MATCHING_ACCOUNTS.index("{")])
+    discovered_accounts = ex.value.message.splitlines()[-1]
+    assert all(s in discovered_accounts for s in (upn_a, upn_b, tenant_a, tenant_b))
+
+    credential = SharedTokenCacheCredential(username=upn_b, tenant_id=tenant_a, _cache=cache, transport=transport)
+    with pytest.raises(ClientAuthenticationError) as ex:
+        credential.get_token("scope")
+    assert ex.value.message.startswith(NO_MATCHING_ACCOUNTS[: NO_MATCHING_ACCOUNTS.index("{")])
+    discovered_accounts = ex.value.message.splitlines()[-1]
+    assert all(s in discovered_accounts for s in (upn_a, upn_b, tenant_a, tenant_b))
+
+
+def test_single_account_matching_username():
     """one cached account, username specified, username matches -> credential should auth that account"""
 
     upn = "spam@eggs"
@@ -57,6 +125,45 @@ def test_single_matching_account():
         responses=[mock_response(json_payload=build_aad_response(access_token=expected_token))],
     )
     credential = SharedTokenCacheCredential(_cache=cache, transport=transport, username=upn)
+    token = credential.get_token(scope)
+    assert token.token == expected_token
+
+
+def test_single_account_matching_tenant():
+    """one cached account, tenant specified, tenant matches -> credential should auth that account"""
+
+    tenant_id = "tenant-id"
+    refresh_token = "refresh-token"
+    scope = "scope"
+    account = get_account_event(uid="uid_a", utid=tenant_id, username="spam@eggs", refresh_token=refresh_token)
+    cache = populated_cache(account)
+
+    expected_token = "***"
+    transport = validating_transport(
+        requests=[Request(required_data={"refresh_token": refresh_token, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_token))],
+    )
+    credential = SharedTokenCacheCredential(_cache=cache, transport=transport, tenant_id=tenant_id)
+    token = credential.get_token(scope)
+    assert token.token == expected_token
+
+
+def test_single_account_matching_tenant_and_username():
+    """one cached account, tenant and username specified, both match -> credential should auth that account"""
+
+    upn = "spam@eggs"
+    tenant_id = "tenant-id"
+    refresh_token = "refresh-token"
+    scope = "scope"
+    account = get_account_event(uid="uid_a", utid=tenant_id, username=upn, refresh_token=refresh_token)
+    cache = populated_cache(account)
+
+    expected_token = "***"
+    transport = validating_transport(
+        requests=[Request(required_data={"refresh_token": refresh_token, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_token))],
+    )
+    credential = SharedTokenCacheCredential(_cache=cache, transport=transport, tenant_id=tenant_id, username=upn)
     token = credential.get_token(scope)
     assert token.token == expected_token
 
@@ -86,8 +193,7 @@ def test_no_refresh_token():
     account = get_account_event(uid="uid_a", utid="utid", username="spam@eggs", refresh_token=None)
     cache = populated_cache(account)
 
-    # credential has no refresh token to redeem => it shouldn't use the network
-    transport = Mock(side_effect=Exception())
+    transport = Mock(side_effect=Exception())  # credential shouldn't use the network
 
     credential = SharedTokenCacheCredential(_cache=cache, transport=transport)
     with pytest.raises(ClientAuthenticationError, match=NO_ACCOUNTS):
@@ -98,8 +204,8 @@ def test_no_refresh_token():
         credential.get_token("scope")
 
 
-def test_two_accounts_username_unspecified():
-    """two cached accounts, no username specified -> credential should raise"""
+def test_two_accounts_no_username_or_tenant():
+    """two cached accounts, no username or tenant specified -> credential should raise"""
 
     upn_a = "a@foo"
     upn_b = "b@foo"
@@ -141,18 +247,63 @@ def test_two_accounts_username_specified():
     assert token.token == expected_token
 
 
+def test_two_accounts_tenant_specified():
+    """two cached accounts, tenant specified, one account matches -> credential should auth that account"""
+
+    scope = "scope"
+    expected_refresh_token = "refresh-token-a"
+    upn_a = "a@foo"
+    upn_b = "b@foo"
+    tenant_id = "tenant-id"
+    account_a = get_account_event(username=upn_a, uid="uid_a", utid=tenant_id, refresh_token=expected_refresh_token)
+    account_b = get_account_event(username=upn_b, uid="uid_b", utid="utid", refresh_token="refresh_token_b")
+    cache = populated_cache(account_a, account_b)
+
+    expected_token = "***"
+    transport = validating_transport(
+        requests=[Request(required_data={"refresh_token": expected_refresh_token, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_token))],
+    )
+    credential = SharedTokenCacheCredential(tenant_id=tenant_id, _cache=cache, transport=transport)
+    token = credential.get_token(scope)
+    assert token.token == expected_token
+
+
+def test_two_accounts_tenant_and_username_specified():
+    """two cached accounts, tenant and username specified, one account matches both -> credential should auth that account"""
+
+    scope = "scope"
+    expected_refresh_token = "refresh-token-a"
+    upn_a = "a@foo"
+    upn_b = "b@foo"
+    tenant_id = "tenant-id"
+    account_a = get_account_event(username=upn_a, uid="uid_a", utid=tenant_id, refresh_token=expected_refresh_token)
+    account_b = get_account_event(username=upn_b, uid="uid_b", utid="utid", refresh_token="refresh_token_b")
+    cache = populated_cache(account_a, account_b)
+
+    expected_token = "***"
+    transport = validating_transport(
+        requests=[Request(required_data={"refresh_token": expected_refresh_token, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_token))],
+    )
+    credential = SharedTokenCacheCredential(tenant_id=tenant_id, username=upn_a, _cache=cache, transport=transport)
+    token = credential.get_token(scope)
+    assert token.token == expected_token
+
+
 def test_same_username_different_tenants():
     """two cached accounts, same username, different tenants"""
 
-    expected_access_token = "***"
-    expected_refresh_token = "refresh-token"
+    access_token_a = "access-token-a"
+    access_token_b = "access-token-b"
+    refresh_token_a = "refresh-token-a"
+    refresh_token_b = "refresh-token-b"
 
     upn = "spam@eggs"
     tenant_a = "tenant-a"
     tenant_b = "tenant-b"
-    uid = "some-guid"
-    account_a = get_account_event(username=upn, uid=uid, utid=tenant_a, refresh_token="refresh_token")
-    account_b = get_account_event(username=upn, uid=uid, utid=tenant_b, refresh_token=expected_refresh_token)
+    account_a = get_account_event(username=upn, uid="another-guid", utid=tenant_a, refresh_token=refresh_token_a)
+    account_b = get_account_event(username=upn, uid="more-guid", utid=tenant_b, refresh_token=refresh_token_b)
     cache = populated_cache(account_a, account_b)
 
     # with no tenant specified the credential can't select an identity
@@ -166,16 +317,68 @@ def test_same_username_different_tenants():
     assert discovered_accounts.count(upn) == 2
     assert tenant_a in discovered_accounts and tenant_b in discovered_accounts
 
-    # with username and tenant_id specified, the credential should auth the matching account
-    expected_access_token = "***"
+    # with tenant specified, the credential should auth the matching account
     scope = "scope"
     transport = validating_transport(
-        requests=[Request(required_data={"refresh_token": expected_refresh_token, "scope": scope})],
-        responses=[mock_response(json_payload=build_aad_response(access_token=expected_access_token))],
+        requests=[Request(required_data={"refresh_token": refresh_token_a, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=access_token_a))],
     )
-    credential = SharedTokenCacheCredential(username=upn, tenant_id=tenant_b, _cache=cache, transport=transport)
+    credential = SharedTokenCacheCredential(tenant_id=tenant_a, _cache=cache, transport=transport)
     token = credential.get_token(scope)
-    assert token.token == expected_access_token
+    assert token.token == access_token_a
+
+    transport = validating_transport(
+        requests=[Request(required_data={"refresh_token": refresh_token_b, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=access_token_b))],
+    )
+    credential = SharedTokenCacheCredential(tenant_id=tenant_b, _cache=cache, transport=transport)
+    token = credential.get_token(scope)
+    assert token.token == access_token_b
+
+
+def test_same_tenant_different_usernames():
+    """two cached accounts, same tenant, different usernames"""
+
+    access_token_a = "access-token-a"
+    access_token_b = "access-token-b"
+    refresh_token_a = "refresh-token-a"
+    refresh_token_b = "refresh-token-b"
+
+    upn_a = "spam@eggs"
+    upn_b = "eggs@spam"
+    tenant_id = "the-tenant"
+    account_a = get_account_event(username=upn_a, uid="another-guid", utid=tenant_id, refresh_token=refresh_token_a)
+    account_b = get_account_event(username=upn_b, uid="more-guid", utid=tenant_id, refresh_token=refresh_token_b)
+    cache = populated_cache(account_a, account_b)
+
+    # with no username specified the credential can't select an identity
+    transport = Mock(side_effect=Exception())  # (so it shouldn't use the network)
+    credential = SharedTokenCacheCredential(tenant_id=tenant_id, _cache=cache, transport=transport)
+    with pytest.raises(ClientAuthenticationError) as ex:
+        credential.get_token("scope")
+    # error message should indicate multiple matching accounts, and list discovered accounts
+    assert ex.value.message.startswith(MULTIPLE_MATCHING_ACCOUNTS[: MULTIPLE_MATCHING_ACCOUNTS.index("{")])
+    discovered_accounts = ex.value.message.splitlines()[-1]
+    assert discovered_accounts.count(tenant_id) == 2
+    assert upn_a in discovered_accounts and upn_b in discovered_accounts
+
+    # with a username specified, the credential should auth the matching account
+    scope = "scope"
+    transport = validating_transport(
+        requests=[Request(required_data={"refresh_token": refresh_token_b, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=access_token_a))],
+    )
+    credential = SharedTokenCacheCredential(username=upn_b, _cache=cache, transport=transport)
+    token = credential.get_token(scope)
+    assert token.token == access_token_a
+
+    transport = validating_transport(
+        requests=[Request(required_data={"refresh_token": refresh_token_a, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=access_token_a))],
+    )
+    credential = SharedTokenCacheCredential(username=upn_a, _cache=cache, transport=transport)
+    token = credential.get_token(scope)
+    assert token.token == access_token_a
 
 
 def get_account_event(
@@ -196,7 +399,7 @@ def get_account_event(
             foci="1",
         ),
         "client_id": client_id,
-        "token_endpoint": "https://" + authority + "/some/path",
+        "token_endpoint": "https://" + "/".join((authority, utid, "/path")),
         "scope": scopes or ["scope"],
     }
 

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
@@ -1,0 +1,205 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from azure.core.exceptions import ClientAuthenticationError
+from azure.identity import KnownAuthorities, SharedTokenCacheCredential
+from azure.identity._authn_client import (
+    MULTIPLE_ACCOUNTS,
+    MULTIPLE_MATCHING_ACCOUNTS,
+    NO_ACCOUNTS,
+    NO_MATCHING_ACCOUNTS,
+    NO_TOKEN,
+)
+from msal import TokenCache
+import pytest
+
+try:
+    from unittest.mock import Mock, patch
+except ImportError:  # python < 3.3
+    from mock import Mock, patch  # type: ignore
+
+from helpers import build_aad_response, build_id_token, mock_response, Request, validating_transport
+
+
+def test_empty_cache():
+    with pytest.raises(ClientAuthenticationError, match=NO_ACCOUNTS):
+        SharedTokenCacheCredential(_cache=TokenCache()).get_token("scope")
+
+
+def test_no_matching_account():
+    """one cached account, username specified, username doesn't match -> credential should raise"""
+
+    upn = "spam@eggs"
+    tenant = "some-guid"
+    account = get_account_event(username=upn, uid="uid", utid=tenant)
+    cache = populated_cache(account)
+
+    with pytest.raises(ClientAuthenticationError) as ex:
+        SharedTokenCacheCredential(_cache=cache, username="not" + upn).get_token("scope")
+
+    assert ex.value.message.startswith(NO_MATCHING_ACCOUNTS[: NO_MATCHING_ACCOUNTS.index("{")])
+    discovered_accounts = ex.value.message.splitlines()[-1]
+    assert upn in discovered_accounts and tenant in discovered_accounts
+
+
+def test_single_matching_account():
+    """one cached account, username specified, username matches -> credential should auth that account"""
+
+    upn = "spam@eggs"
+    refresh_token = "refresh-token"
+    scope = "scope"
+    account = get_account_event(uid="uid_a", utid="utid", username=upn, refresh_token=refresh_token)
+    cache = populated_cache(account)
+
+    expected_token = "***"
+    transport = validating_transport(
+        requests=[Request(required_data={"refresh_token": refresh_token, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_token))],
+    )
+    credential = SharedTokenCacheCredential(_cache=cache, transport=transport, username=upn)
+    token = credential.get_token(scope)
+    assert token.token == expected_token
+
+
+def test_single_account():
+    """one cached account, no username specified -> credential should auth that account"""
+
+    refresh_token = "refresh-token"
+    scope = "scope"
+    account = get_account_event(uid="uid_a", utid="utid", username="spam@eggs", refresh_token=refresh_token)
+    cache = populated_cache(account)
+
+    expected_token = "***"
+    transport = validating_transport(
+        requests=[Request(required_data={"refresh_token": refresh_token, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_token))],
+    )
+    credential = SharedTokenCacheCredential(_cache=cache, transport=transport)
+
+    token = credential.get_token(scope)
+    assert token.token == expected_token
+
+
+def test_no_refresh_token():
+    """one cached account, account has no refresh token -> credential should raise"""
+
+    account = get_account_event(uid="uid_a", utid="utid", username="spam@eggs", refresh_token=None)
+    cache = populated_cache(account)
+
+    # credential has no refresh token to redeem => it shouldn't use the network
+    transport = Mock(side_effect=Exception())
+    credential = SharedTokenCacheCredential(_cache=cache, transport=transport)
+
+    with pytest.raises(ClientAuthenticationError) as ex:
+        credential.get_token("scope")
+    assert ex.value.message.startswith(NO_TOKEN[: NO_TOKEN.index("{")])
+
+
+def test_two_accounts_username_unspecified():
+    """two cached accounts, no username specified -> credential should raise"""
+
+    upn_a = "a@foo"
+    upn_b = "b@foo"
+    account_a = get_account_event(username=upn_a, uid="uid_a", utid="utid")
+    account_b = get_account_event(username=upn_b, uid="uid_b", utid="utid")
+    cache = populated_cache(account_a, account_b)
+
+    # credential can't select an identity => it shouldn't use the network
+    transport = Mock(side_effect=Exception())
+
+    # two users in the cache, no username specified -> ClientAuthenticationError
+    credential = SharedTokenCacheCredential(_cache=cache, transport=transport)
+    with pytest.raises(ClientAuthenticationError) as ex:
+        credential.get_token("scope")
+
+    # error message should mention multiple accounts and list usernames in the cache
+    assert upn_a in ex.value.message and upn_b in ex.value.message
+    assert ex.value.message.splitlines()[:-1] == MULTIPLE_ACCOUNTS.splitlines()[:-1]
+
+
+def test_two_accounts_username_specified():
+    """two cached accounts, username specified, one account matches -> credential should auth that account"""
+
+    scope = "scope"
+    expected_refresh_token = "refresh-token-a"
+    upn_a = "a@foo"
+    upn_b = "b@foo"
+    account_a = get_account_event(username=upn_a, uid="uid_a", utid="utid", refresh_token=expected_refresh_token)
+    account_b = get_account_event(username=upn_b, uid="uid_b", utid="utid", refresh_token="refresh_token_b")
+    cache = populated_cache(account_a, account_b)
+
+    expected_token = "***"
+    transport = validating_transport(
+        requests=[Request(required_data={"refresh_token": expected_refresh_token, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_token))],
+    )
+    credential = SharedTokenCacheCredential(username=upn_a, _cache=cache, transport=transport)
+    token = credential.get_token(scope)
+    assert token.token == expected_token
+
+
+def test_same_username_different_tenants():
+    """two cached accounts, same username, different tenants"""
+
+    expected_access_token = "***"
+    expected_refresh_token = "refresh-token"
+
+    upn = "spam@eggs"
+    tenant_a = "tenant-a"
+    tenant_b = "tenant-b"
+    uid = "some-guid"
+    account_a = get_account_event(username=upn, uid=uid, utid=tenant_a, refresh_token="refresh_token")
+    account_b = get_account_event(username=upn, uid=uid, utid=tenant_b, refresh_token=expected_refresh_token)
+    cache = populated_cache(account_a, account_b)
+
+    # with no tenant specified the credential can't select an identity
+    transport = Mock(side_effect=Exception())  # (so it shouldn't use the network)
+    credential = SharedTokenCacheCredential(username=upn, _cache=cache, transport=transport)
+    with pytest.raises(ClientAuthenticationError) as ex:
+        credential.get_token("scope")
+    # error message should indicate multiple matching accounts, and list discovered accounts
+    assert ex.value.message.startswith(MULTIPLE_MATCHING_ACCOUNTS[: MULTIPLE_MATCHING_ACCOUNTS.index("{")])
+    discovered_accounts = ex.value.message.splitlines()[-1]
+    assert discovered_accounts.count(upn) == 2
+    assert tenant_a in discovered_accounts and tenant_b in discovered_accounts
+
+    # with username and tenant_id specified, the credential should auth the matching account
+    expected_access_token = "***"
+    scope = "scope"
+    transport = validating_transport(
+        requests=[Request(required_data={"refresh_token": expected_refresh_token, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_access_token))],
+    )
+    credential = SharedTokenCacheCredential(username=upn, tenant_id=tenant_b, _cache=cache, transport=transport)
+    token = credential.get_token(scope)
+    assert token.token == expected_access_token
+
+
+def get_account_event(
+    username,
+    uid,
+    utid,
+    authority=KnownAuthorities.AZURE_PUBLIC_CLOUD,
+    client_id="client-id",
+    refresh_token="refresh-token",
+    scopes=None,
+):
+    return {
+        "response": build_aad_response(
+            uid=uid,
+            utid=utid,
+            refresh_token=refresh_token,
+            id_token=build_id_token(aud=client_id, preferred_username=username),
+        ),
+        "client_id": client_id,
+        "token_endpoint": "https://" + authority + "/some/path",
+        "scope": scopes or ["scope"],
+    }
+
+
+def populated_cache(*accounts):
+    cache = TokenCache()
+    for account in accounts:
+        cache.add(account)
+    return cache

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
@@ -397,7 +397,7 @@ def test_authority_aliases():
 
         # the token should be acceptable for this authority itself
         transport = validating_transport(
-            requests=[Request(required_data={"refresh_token": expected_refresh_token})],
+            requests=[Request(authority=authority, required_data={"refresh_token": expected_refresh_token})],
             responses=[mock_response(json_payload=build_aad_response(access_token=expected_access_token))],
         )
         credential = SharedTokenCacheCredential(authority=authority, _cache=cache, transport=transport)
@@ -407,7 +407,7 @@ def test_authority_aliases():
         # it should be acceptable for every known alias of this authority
         for alias in KNOWN_ALIASES[authority]:
             transport = validating_transport(
-                requests=[Request(required_data={"refresh_token": expected_refresh_token})],
+                requests=[Request(authority=alias, required_data={"refresh_token": expected_refresh_token})],
                 responses=[mock_response(json_payload=build_aad_response(access_token=expected_access_token))],
             )
             credential = SharedTokenCacheCredential(authority=alias, _cache=cache, transport=transport)
@@ -424,7 +424,7 @@ def test_authority_with_no_known_alias():
     account = get_account_event("spam@eggs", "uid", "tenant", authority=authority, refresh_token=expected_refresh_token)
     cache = populated_cache(account)
     transport = validating_transport(
-        requests=[Request(required_data={"refresh_token": expected_refresh_token})],
+        requests=[Request(authority=authority, required_data={"refresh_token": expected_refresh_token})],
         responses=[mock_response(json_payload=build_aad_response(access_token=expected_access_token))],
     )
     credential = SharedTokenCacheCredential(authority=authority, _cache=cache, transport=transport)
@@ -436,7 +436,7 @@ def get_account_event(
     username,
     uid,
     utid,
-    authority=KnownAuthorities.AZURE_PUBLIC_CLOUD,
+    authority=None,
     client_id="client-id",
     refresh_token="refresh-token",
     scopes=None,
@@ -450,7 +450,7 @@ def get_account_event(
             foci="1",
         ),
         "client_id": client_id,
-        "token_endpoint": "https://" + "/".join((authority, utid, "/path")),
+        "token_endpoint": "https://" + "/".join((authority or KnownAuthorities.AZURE_PUBLIC_CLOUD, utid, "/path")),
         "scope": scopes or ["scope"],
     }
 

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
@@ -18,6 +18,7 @@ from msal import TokenCache
 import pytest
 
 from helpers import async_validating_transport, build_aad_response, build_id_token, mock_response, Request
+from test_shared_cache_credential import get_account_event, populated_cache
 
 
 @pytest.mark.asyncio
@@ -449,34 +450,3 @@ async def test_authority_with_no_known_alias():
     credential = SharedTokenCacheCredential(authority=authority, _cache=cache, transport=transport)
     token = await credential.get_token("scope")
     assert token.token == expected_access_token
-
-
-def get_account_event(
-    username,
-    uid,
-    utid,
-    authority=KnownAuthorities.AZURE_PUBLIC_CLOUD,
-    client_id="client-id",
-    refresh_token="refresh-token",
-    scopes=None,
-):
-    return {
-        "response": build_aad_response(
-            uid=uid,
-            utid=utid,
-            refresh_token=refresh_token,
-            id_token=build_id_token(aud=client_id, preferred_username=username),
-            foci="1",
-        ),
-        "client_id": client_id,
-        "token_endpoint": "https://" + "/".join((authority, utid, "/path")),
-        "scope": scopes or ["scope"],
-    }
-
-
-def populated_cache(*accounts):
-    cache = TokenCache()
-    for account in accounts:
-        cache.add(account)
-    cache.add = lambda *_, **__: None  # prevent anything being added to the cache
-    return cache

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
@@ -416,7 +416,7 @@ async def test_authority_aliases():
 
         # the token should be acceptable for this authority itself
         transport = async_validating_transport(
-            requests=[Request(required_data={"refresh_token": expected_refresh_token})],
+            requests=[Request(authority=authority, required_data={"refresh_token": expected_refresh_token})],
             responses=[mock_response(json_payload=build_aad_response(access_token=expected_access_token))],
         )
         credential = SharedTokenCacheCredential(authority=authority, _cache=cache, transport=transport)
@@ -426,7 +426,7 @@ async def test_authority_aliases():
         # it should also be acceptable for every known alias of this authority
         for alias in KNOWN_ALIASES[authority]:
             transport = async_validating_transport(
-                requests=[Request(required_data={"refresh_token": expected_refresh_token})],
+                requests=[Request(authority=alias, required_data={"refresh_token": expected_refresh_token})],
                 responses=[mock_response(json_payload=build_aad_response(access_token=expected_access_token))],
             )
             credential = SharedTokenCacheCredential(authority=alias, _cache=cache, transport=transport)
@@ -444,7 +444,7 @@ async def test_authority_with_no_known_alias():
     account = get_account_event("spam@eggs", "uid", "tenant", authority=authority, refresh_token=expected_refresh_token)
     cache = populated_cache(account)
     transport = async_validating_transport(
-        requests=[Request(required_data={"refresh_token": expected_refresh_token})],
+        requests=[Request(authority=authority, required_data={"refresh_token": expected_refresh_token})],
         responses=[mock_response(json_payload=build_aad_response(access_token=expected_access_token))],
     )
     credential = SharedTokenCacheCredential(authority=authority, _cache=cache, transport=transport)

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
@@ -1,0 +1,425 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from unittest.mock import Mock
+
+from azure.core.exceptions import ClientAuthenticationError
+from azure.identity import KnownAuthorities
+from azure.identity.aio import SharedTokenCacheCredential
+from azure.identity._credentials.shared_cache import (
+    MULTIPLE_ACCOUNTS,
+    MULTIPLE_MATCHING_ACCOUNTS,
+    NO_ACCOUNTS,
+    NO_MATCHING_ACCOUNTS,
+)
+from msal import TokenCache
+import pytest
+
+from helpers import async_validating_transport, build_aad_response, build_id_token, mock_response, Request
+
+
+@pytest.mark.asyncio
+async def test_empty_cache():
+    with pytest.raises(ClientAuthenticationError, match=NO_ACCOUNTS):
+        await SharedTokenCacheCredential(_cache=TokenCache()).get_token("scope")
+    with pytest.raises(ClientAuthenticationError, match=NO_ACCOUNTS):
+        await SharedTokenCacheCredential(_cache=TokenCache(), username="not@cache").get_token("scope")
+    with pytest.raises(ClientAuthenticationError, match=NO_ACCOUNTS):
+        await SharedTokenCacheCredential(_cache=TokenCache(), tenant_id="not-cached").get_token("scope")
+    with pytest.raises(ClientAuthenticationError, match=NO_ACCOUNTS):
+        await SharedTokenCacheCredential(_cache=TokenCache(), tenant_id="not-cached", username="not@cache").get_token("scope")
+
+
+@pytest.mark.asyncio
+async def test_no_matching_account_for_username():
+    """one cached account, username specified, username doesn't match -> credential should raise"""
+
+    upn = "spam@eggs"
+    tenant = "some-guid"
+    account = get_account_event(username=upn, uid="uid", utid=tenant, refresh_token="refresh-token")
+    cache = populated_cache(account)
+
+    with pytest.raises(ClientAuthenticationError) as ex:
+        await SharedTokenCacheCredential(_cache=cache, username="not" + upn).get_token("scope")
+
+    assert ex.value.message.startswith(NO_MATCHING_ACCOUNTS[: NO_MATCHING_ACCOUNTS.index("{")])
+    discovered_accounts = ex.value.message.splitlines()[-1]
+    assert upn in discovered_accounts and tenant in discovered_accounts
+
+
+@pytest.mark.asyncio
+async def test_no_matching_account_for_tenant():
+    """one cached account, tenant specified, tenant doesn't match -> credential should raise"""
+
+    upn = "spam@eggs"
+    tenant = "some-guid"
+    account = get_account_event(username=upn, uid="uid", utid=tenant, refresh_token="refresh-token")
+    cache = populated_cache(account)
+
+    with pytest.raises(ClientAuthenticationError) as ex:
+        await SharedTokenCacheCredential(_cache=cache, tenant_id="not-" + tenant).get_token("scope")
+
+    assert ex.value.message.startswith(NO_MATCHING_ACCOUNTS[: NO_MATCHING_ACCOUNTS.index("{")])
+    discovered_accounts = ex.value.message.splitlines()[-1]
+    assert upn in discovered_accounts and tenant in discovered_accounts
+
+
+@pytest.mark.asyncio
+async def test_no_matching_account_for_tenant_and_username():
+    """one cached account, tenant and username specified, neither match -> credential should raise"""
+
+    upn = "spam@eggs"
+    tenant = "some-guid"
+    account = get_account_event(username=upn, uid="uid", utid=tenant, refresh_token="refresh-token")
+    cache = populated_cache(account)
+
+    with pytest.raises(ClientAuthenticationError) as ex:
+        await SharedTokenCacheCredential(_cache=cache, tenant_id="not-" + tenant, username="not" + upn).get_token("scope")
+
+    assert ex.value.message.startswith(NO_MATCHING_ACCOUNTS[: NO_MATCHING_ACCOUNTS.index("{")])
+    discovered_accounts = ex.value.message.splitlines()[-1]
+    assert upn in discovered_accounts and tenant in discovered_accounts
+
+
+@pytest.mark.asyncio
+async def test_no_matching_account_for_tenant_or_username():
+    """two cached accounts, username and tenant specified, one account matches each -> credential should raise"""
+
+    refresh_token_a = "refresh-token-a"
+    refresh_token_b = "refresh-token-b"
+    upn_a = "a@foo"
+    upn_b = "b@foo"
+    tenant_a = "tenant-a"
+    tenant_b = "tenant-b"
+    account_a = get_account_event(username=upn_a, uid="uid_a", utid=tenant_a, refresh_token=refresh_token_a)
+    account_b = get_account_event(username=upn_b, uid="uid_b", utid=tenant_b, refresh_token=refresh_token_b)
+    cache = populated_cache(account_a, account_b)
+
+    transport = Mock(side_effect=Exception())  # credential shouldn't use the network
+
+    credential = SharedTokenCacheCredential(username=upn_a, tenant_id=tenant_b, _cache=cache, transport=transport)
+    with pytest.raises(ClientAuthenticationError) as ex:
+        await credential.get_token("scope")
+    assert ex.value.message.startswith(NO_MATCHING_ACCOUNTS[: NO_MATCHING_ACCOUNTS.index("{")])
+    discovered_accounts = ex.value.message.splitlines()[-1]
+    assert all(s in discovered_accounts for s in (upn_a, upn_b, tenant_a, tenant_b))
+
+    credential = SharedTokenCacheCredential(username=upn_b, tenant_id=tenant_a, _cache=cache, transport=transport)
+    with pytest.raises(ClientAuthenticationError) as ex:
+        await credential.get_token("scope")
+    assert ex.value.message.startswith(NO_MATCHING_ACCOUNTS[: NO_MATCHING_ACCOUNTS.index("{")])
+    discovered_accounts = ex.value.message.splitlines()[-1]
+    assert all(s in discovered_accounts for s in (upn_a, upn_b, tenant_a, tenant_b))
+
+
+@pytest.mark.asyncio
+async def test_single_account_matching_username():
+    """one cached account, username specified, username matches -> credential should auth that account"""
+
+    upn = "spam@eggs"
+    refresh_token = "refresh-token"
+    scope = "scope"
+    account = get_account_event(uid="uid_a", utid="utid", username=upn, refresh_token=refresh_token)
+    cache = populated_cache(account)
+
+    expected_token = "***"
+    transport = async_validating_transport(
+        requests=[Request(required_data={"refresh_token": refresh_token, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_token))],
+    )
+    credential = SharedTokenCacheCredential(_cache=cache, transport=transport, username=upn)
+    token = await credential.get_token(scope)
+    assert token.token == expected_token
+
+
+@pytest.mark.asyncio
+async def test_single_account_matching_tenant():
+    """one cached account, tenant specified, tenant matches -> credential should auth that account"""
+
+    tenant_id = "tenant-id"
+    refresh_token = "refresh-token"
+    scope = "scope"
+    account = get_account_event(uid="uid_a", utid=tenant_id, username="spam@eggs", refresh_token=refresh_token)
+    cache = populated_cache(account)
+
+    expected_token = "***"
+    transport = async_validating_transport(
+        requests=[Request(required_data={"refresh_token": refresh_token, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_token))],
+    )
+    credential = SharedTokenCacheCredential(_cache=cache, transport=transport, tenant_id=tenant_id)
+    token = await credential.get_token(scope)
+    assert token.token == expected_token
+
+
+@pytest.mark.asyncio
+async def test_single_account_matching_tenant_and_username():
+    """one cached account, tenant and username specified, both match -> credential should auth that account"""
+
+    upn = "spam@eggs"
+    tenant_id = "tenant-id"
+    refresh_token = "refresh-token"
+    scope = "scope"
+    account = get_account_event(uid="uid_a", utid=tenant_id, username=upn, refresh_token=refresh_token)
+    cache = populated_cache(account)
+
+    expected_token = "***"
+    transport = async_validating_transport(
+        requests=[Request(required_data={"refresh_token": refresh_token, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_token))],
+    )
+    credential = SharedTokenCacheCredential(_cache=cache, transport=transport, tenant_id=tenant_id, username=upn)
+    token = await credential.get_token(scope)
+    assert token.token == expected_token
+
+
+@pytest.mark.asyncio
+async def test_single_account():
+    """one cached account, no username specified -> credential should auth that account"""
+
+    refresh_token = "refresh-token"
+    scope = "scope"
+    account = get_account_event(uid="uid_a", utid="utid", username="spam@eggs", refresh_token=refresh_token)
+    cache = populated_cache(account)
+
+    expected_token = "***"
+    transport = async_validating_transport(
+        requests=[Request(required_data={"refresh_token": refresh_token, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_token))],
+    )
+    credential = SharedTokenCacheCredential(_cache=cache, transport=transport)
+
+    token = await credential.get_token(scope)
+    assert token.token == expected_token
+
+
+@pytest.mark.asyncio
+async def test_no_refresh_token():
+    """one cached account, account has no refresh token -> credential should raise"""
+
+    account = get_account_event(uid="uid_a", utid="utid", username="spam@eggs", refresh_token=None)
+    cache = populated_cache(account)
+
+    transport = Mock(side_effect=Exception())  # credential shouldn't use the network
+
+    credential = SharedTokenCacheCredential(_cache=cache, transport=transport)
+    with pytest.raises(ClientAuthenticationError, match=NO_ACCOUNTS):
+        await credential.get_token("scope")
+
+    credential = SharedTokenCacheCredential(_cache=cache, transport=transport, username="not@cache")
+    with pytest.raises(ClientAuthenticationError, match=NO_ACCOUNTS):
+        await credential.get_token("scope")
+
+
+@pytest.mark.asyncio
+async def test_two_accounts_no_username_or_tenant():
+    """two cached accounts, no username or tenant specified -> credential should raise"""
+
+    upn_a = "a@foo"
+    upn_b = "b@foo"
+    account_a = get_account_event(username=upn_a, uid="uid_a", utid="utid")
+    account_b = get_account_event(username=upn_b, uid="uid_b", utid="utid")
+    cache = populated_cache(account_a, account_b)
+
+    # credential can't select an identity => it shouldn't use the network
+    transport = Mock(side_effect=Exception())
+
+    # two users in the cache, no username specified -> ClientAuthenticationError
+    credential = SharedTokenCacheCredential(_cache=cache, transport=transport)
+    with pytest.raises(ClientAuthenticationError) as ex:
+        await credential.get_token("scope")
+
+    # error message should mention multiple accounts and list usernames in the cache
+    assert upn_a in ex.value.message and upn_b in ex.value.message
+    assert ex.value.message.splitlines()[:-1] == MULTIPLE_ACCOUNTS.splitlines()[:-1]
+
+
+@pytest.mark.asyncio
+async def test_two_accounts_username_specified():
+    """two cached accounts, username specified, one account matches -> credential should auth that account"""
+
+    scope = "scope"
+    expected_refresh_token = "refresh-token-a"
+    upn_a = "a@foo"
+    upn_b = "b@foo"
+    account_a = get_account_event(username=upn_a, uid="uid_a", utid="utid", refresh_token=expected_refresh_token)
+    account_b = get_account_event(username=upn_b, uid="uid_b", utid="utid", refresh_token="refresh_token_b")
+    cache = populated_cache(account_a, account_b)
+
+    expected_token = "***"
+    transport = async_validating_transport(
+        requests=[Request(required_data={"refresh_token": expected_refresh_token, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_token))],
+    )
+    credential = SharedTokenCacheCredential(username=upn_a, _cache=cache, transport=transport)
+    token = await credential.get_token(scope)
+    assert token.token == expected_token
+
+
+@pytest.mark.asyncio
+async def test_two_accounts_tenant_specified():
+    """two cached accounts, tenant specified, one account matches -> credential should auth that account"""
+
+    scope = "scope"
+    expected_refresh_token = "refresh-token-a"
+    upn_a = "a@foo"
+    upn_b = "b@foo"
+    tenant_id = "tenant-id"
+    account_a = get_account_event(username=upn_a, uid="uid_a", utid=tenant_id, refresh_token=expected_refresh_token)
+    account_b = get_account_event(username=upn_b, uid="uid_b", utid="utid", refresh_token="refresh_token_b")
+    cache = populated_cache(account_a, account_b)
+
+    expected_token = "***"
+    transport = async_validating_transport(
+        requests=[Request(required_data={"refresh_token": expected_refresh_token, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_token))],
+    )
+    credential = SharedTokenCacheCredential(tenant_id=tenant_id, _cache=cache, transport=transport)
+    token = await credential.get_token(scope)
+    assert token.token == expected_token
+
+
+@pytest.mark.asyncio
+async def test_two_accounts_tenant_and_username_specified():
+    """two cached accounts, tenant and username specified, one account matches both -> credential should auth that account"""
+
+    scope = "scope"
+    expected_refresh_token = "refresh-token-a"
+    upn_a = "a@foo"
+    upn_b = "b@foo"
+    tenant_id = "tenant-id"
+    account_a = get_account_event(username=upn_a, uid="uid_a", utid=tenant_id, refresh_token=expected_refresh_token)
+    account_b = get_account_event(username=upn_b, uid="uid_b", utid="utid", refresh_token="refresh_token_b")
+    cache = populated_cache(account_a, account_b)
+
+    expected_token = "***"
+    transport = async_validating_transport(
+        requests=[Request(required_data={"refresh_token": expected_refresh_token, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_token))],
+    )
+    credential = SharedTokenCacheCredential(tenant_id=tenant_id, username=upn_a, _cache=cache, transport=transport)
+    token = await credential.get_token(scope)
+    assert token.token == expected_token
+
+
+@pytest.mark.asyncio
+async def test_same_username_different_tenants():
+    """two cached accounts, same username, different tenants"""
+
+    access_token_a = "access-token-a"
+    access_token_b = "access-token-b"
+    refresh_token_a = "refresh-token-a"
+    refresh_token_b = "refresh-token-b"
+
+    upn = "spam@eggs"
+    tenant_a = "tenant-a"
+    tenant_b = "tenant-b"
+    account_a = get_account_event(username=upn, uid="another-guid", utid=tenant_a, refresh_token=refresh_token_a)
+    account_b = get_account_event(username=upn, uid="more-guid", utid=tenant_b, refresh_token=refresh_token_b)
+    cache = populated_cache(account_a, account_b)
+
+    # with no tenant specified the credential can't select an identity
+    transport = Mock(side_effect=Exception())  # (so it shouldn't use the network)
+    credential = SharedTokenCacheCredential(username=upn, _cache=cache, transport=transport)
+    with pytest.raises(ClientAuthenticationError) as ex:
+        await credential.get_token("scope")
+    # error message should indicate multiple matching accounts, and list discovered accounts
+    assert ex.value.message.startswith(MULTIPLE_MATCHING_ACCOUNTS[: MULTIPLE_MATCHING_ACCOUNTS.index("{")])
+    discovered_accounts = ex.value.message.splitlines()[-1]
+    assert discovered_accounts.count(upn) == 2
+    assert tenant_a in discovered_accounts and tenant_b in discovered_accounts
+
+    # with tenant specified, the credential should auth the matching account
+    scope = "scope"
+    transport = async_validating_transport(
+        requests=[Request(required_data={"refresh_token": refresh_token_a, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=access_token_a))],
+    )
+    credential = SharedTokenCacheCredential(tenant_id=tenant_a, _cache=cache, transport=transport)
+    token = await credential.get_token(scope)
+    assert token.token == access_token_a
+
+    transport = async_validating_transport(
+        requests=[Request(required_data={"refresh_token": refresh_token_b, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=access_token_b))],
+    )
+    credential = SharedTokenCacheCredential(tenant_id=tenant_b, _cache=cache, transport=transport)
+    token = await credential.get_token(scope)
+    assert token.token == access_token_b
+
+
+@pytest.mark.asyncio
+async def test_same_tenant_different_usernames():
+    """two cached accounts, same tenant, different usernames"""
+
+    access_token_a = "access-token-a"
+    access_token_b = "access-token-b"
+    refresh_token_a = "refresh-token-a"
+    refresh_token_b = "refresh-token-b"
+
+    upn_a = "spam@eggs"
+    upn_b = "eggs@spam"
+    tenant_id = "the-tenant"
+    account_a = get_account_event(username=upn_a, uid="another-guid", utid=tenant_id, refresh_token=refresh_token_a)
+    account_b = get_account_event(username=upn_b, uid="more-guid", utid=tenant_id, refresh_token=refresh_token_b)
+    cache = populated_cache(account_a, account_b)
+
+    # with no username specified the credential can't select an identity
+    transport = Mock(side_effect=Exception())  # (so it shouldn't use the network)
+    credential = SharedTokenCacheCredential(tenant_id=tenant_id, _cache=cache, transport=transport)
+    with pytest.raises(ClientAuthenticationError) as ex:
+        await credential.get_token("scope")
+    # error message should indicate multiple matching accounts, and list discovered accounts
+    assert ex.value.message.startswith(MULTIPLE_MATCHING_ACCOUNTS[: MULTIPLE_MATCHING_ACCOUNTS.index("{")])
+    discovered_accounts = ex.value.message.splitlines()[-1]
+    assert discovered_accounts.count(tenant_id) == 2
+    assert upn_a in discovered_accounts and upn_b in discovered_accounts
+
+    # with a username specified, the credential should auth the matching account
+    scope = "scope"
+    transport = async_validating_transport(
+        requests=[Request(required_data={"refresh_token": refresh_token_b, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=access_token_a))],
+    )
+    credential = SharedTokenCacheCredential(username=upn_b, _cache=cache, transport=transport)
+    token = await credential.get_token(scope)
+    assert token.token == access_token_a
+
+    transport = async_validating_transport(
+        requests=[Request(required_data={"refresh_token": refresh_token_a, "scope": scope})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=access_token_a))],
+    )
+    credential = SharedTokenCacheCredential(username=upn_a, _cache=cache, transport=transport)
+    token = await credential.get_token(scope)
+    assert token.token == access_token_a
+
+
+def get_account_event(
+    username,
+    uid,
+    utid,
+    authority=KnownAuthorities.AZURE_PUBLIC_CLOUD,
+    client_id="client-id",
+    refresh_token="refresh-token",
+    scopes=None,
+):
+    return {
+        "response": build_aad_response(
+            uid=uid,
+            utid=utid,
+            refresh_token=refresh_token,
+            id_token=build_id_token(aud=client_id, preferred_username=username),
+            foci="1",
+        ),
+        "client_id": client_id,
+        "token_endpoint": "https://" + "/".join((authority, utid, "/path")),
+        "scope": scopes or ["scope"],
+    }
+
+
+def populated_cache(*accounts):
+    cache = TokenCache()
+    for account in accounts:
+        cache.add(account)
+    return cache

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
@@ -8,6 +8,7 @@ from azure.core.exceptions import ClientAuthenticationError
 from azure.identity import KnownAuthorities
 from azure.identity.aio import SharedTokenCacheCredential
 from azure.identity._internal.shared_token_cache import (
+    KNOWN_ALIASES,
     MULTIPLE_ACCOUNTS,
     MULTIPLE_MATCHING_ACCOUNTS,
     NO_ACCOUNTS,
@@ -28,7 +29,8 @@ async def test_empty_cache():
     with pytest.raises(ClientAuthenticationError, match=NO_ACCOUNTS):
         await SharedTokenCacheCredential(_cache=TokenCache(), tenant_id="not-cached").get_token("scope")
     with pytest.raises(ClientAuthenticationError, match=NO_ACCOUNTS):
-        await SharedTokenCacheCredential(_cache=TokenCache(), tenant_id="not-cached", username="not@cache").get_token("scope")
+        credential = SharedTokenCacheCredential(_cache=TokenCache(), tenant_id="not-cached", username="not@cache")
+        await credential.get_token("scope")
 
 
 @pytest.mark.asyncio
@@ -75,7 +77,9 @@ async def test_no_matching_account_for_tenant_and_username():
     cache = populated_cache(account)
 
     with pytest.raises(ClientAuthenticationError) as ex:
-        await SharedTokenCacheCredential(_cache=cache, tenant_id="not-" + tenant, username="not" + upn).get_token("scope")
+        await SharedTokenCacheCredential(_cache=cache, tenant_id="not-" + tenant, username="not" + upn).get_token(
+            "scope"
+        )
 
     assert ex.value.message.startswith(NO_MATCHING_ACCOUNTS[: NO_MATCHING_ACCOUNTS.index("{")])
     discovered_accounts = ex.value.message.splitlines()[-1]
@@ -395,6 +399,58 @@ async def test_same_tenant_different_usernames():
     assert token.token == access_token_a
 
 
+@pytest.mark.asyncio
+async def test_authority_aliases():
+    """the credential should use a refresh token valid for any known alias of its authority"""
+
+    expected_access_token = "access-token"
+
+    for authority in KNOWN_ALIASES:
+        # cache a token for this authority
+        expected_refresh_token = authority.replace(".", "")
+        account = get_account_event(
+            "spam@eggs", "uid", "tenant", authority=authority, refresh_token=expected_refresh_token
+        )
+        cache = populated_cache(account)
+
+        # the token should be acceptable for this authority itself
+        transport = async_validating_transport(
+            requests=[Request(required_data={"refresh_token": expected_refresh_token})],
+            responses=[mock_response(json_payload=build_aad_response(access_token=expected_access_token))],
+        )
+        credential = SharedTokenCacheCredential(authority=authority, _cache=cache, transport=transport)
+        token = await credential.get_token("scope")
+        assert token.token == expected_access_token
+
+        # it should also be acceptable for every known alias of this authority
+        for alias in KNOWN_ALIASES[authority]:
+            transport = async_validating_transport(
+                requests=[Request(required_data={"refresh_token": expected_refresh_token})],
+                responses=[mock_response(json_payload=build_aad_response(access_token=expected_access_token))],
+            )
+            credential = SharedTokenCacheCredential(authority=alias, _cache=cache, transport=transport)
+            token = await credential.get_token("scope")
+            assert token.token == expected_access_token
+
+
+@pytest.mark.asyncio
+async def test_authority_with_no_known_alias():
+    """given an appropriate token, an authority with no known aliases should work"""
+
+    authority = "unknown.authority"
+    expected_access_token = "access-token"
+    expected_refresh_token = "refresh-token"
+    account = get_account_event("spam@eggs", "uid", "tenant", authority=authority, refresh_token=expected_refresh_token)
+    cache = populated_cache(account)
+    transport = async_validating_transport(
+        requests=[Request(required_data={"refresh_token": expected_refresh_token})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=expected_access_token))],
+    )
+    credential = SharedTokenCacheCredential(authority=authority, _cache=cache, transport=transport)
+    token = await credential.get_token("scope")
+    assert token.token == expected_access_token
+
+
 def get_account_event(
     username,
     uid,
@@ -422,4 +478,5 @@ def populated_cache(*accounts):
     cache = TokenCache()
     for account in accounts:
         cache.add(account)
+    cache.add = lambda *_, **__: None  # prevent anything being added to the cache
     return cache

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 from azure.core.exceptions import ClientAuthenticationError
 from azure.identity import KnownAuthorities
 from azure.identity.aio import SharedTokenCacheCredential
-from azure.identity._credentials.shared_cache import (
+from azure.identity._internal.shared_token_cache import (
     MULTIPLE_ACCOUNTS,
     MULTIPLE_MATCHING_ACCOUNTS,
     NO_ACCOUNTS,


### PR DESCRIPTION
This aligns the account selection behavior of `SharedTokenCacheCredential` with what we have for .NET. The credential now attempts to authenticate a cached account matching a specified username and/or tenant (both optional). It ignores accounts not associated with refresh tokens, and treats as identical accounts with the same username, tenant, and environment (AAD authority). Most of this is implicit in our .NET library, whose account filtering begins with [MSAL's](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/3bf2f02aa7c131680d2b14ebc11874826b708071/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs#L495). When filtering results in no, or multiple, accounts, `SharedTokenCacheCredential` raises the same errors as does our .NET library (closes #8181).

Sorry for the large diff. I took the opportunity to move code handling the shared cache out of `AuthnClient` into its own module, to refactor `SharedTokenCacheCredential` to use `AadClient` (a wrapper around MSAL's OAuth client) instead, and to add an offline test suite (closes #8175).