### PR TITLE
Minor optimization in RetryPolicy

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py
@@ -84,7 +84,8 @@ class RetryPolicy(HTTPPolicy):
 
     #: Maximum backoff time.
     BACKOFF_MAX = 120
-    _RETRY_CODES = [i for i in range(999) if i not in [i for i in range(500) if i != 408] + [501, 505]]
+    _SAFE_CODES = set(range(506)) - set([408, 500, 502, 503, 504])
+    _RETRY_CODES = set(range(999)) - _SAFE_CODES
 
     def __init__(self, **kwargs):
         self.total_retries = kwargs.pop('retry_total', 10)
@@ -96,7 +97,7 @@ class RetryPolicy(HTTPPolicy):
 
         retry_codes = self._RETRY_CODES
         status_codes = kwargs.pop('retry_on_status_codes', [])
-        self._retry_on_status_codes = set(status_codes + retry_codes)
+        self._retry_on_status_codes = set(status_codes) | retry_codes
         self._method_whitelist = frozenset(['HEAD', 'GET', 'PUT', 'DELETE', 'OPTIONS', 'TRACE'])
         self._respect_retry_after_header = True
         super(RetryPolicy, self).__init__()

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py
@@ -84,6 +84,7 @@ class RetryPolicy(HTTPPolicy):
 
     #: Maximum backoff time.
     BACKOFF_MAX = 120
+    _RETRY_CODES = [i for i in range(999) if i not in [i for i in range(500) if i != 408] + [501, 505]]
 
     def __init__(self, **kwargs):
         self.total_retries = kwargs.pop('retry_total', 10)
@@ -93,8 +94,7 @@ class RetryPolicy(HTTPPolicy):
         self.backoff_factor = kwargs.pop('retry_backoff_factor', 0.8)
         self.backoff_max = kwargs.pop('retry_backoff_max', self.BACKOFF_MAX)
 
-        safe_codes = [i for i in range(500) if i != 408] + [501, 505]
-        retry_codes = [i for i in range(999) if i not in safe_codes]
+        retry_codes = self._RETRY_CODES
         status_codes = kwargs.pop('retry_on_status_codes', [])
         self._retry_on_status_codes = set(status_codes + retry_codes)
         self._method_whitelist = frozenset(['HEAD', 'GET', 'PUT', 'DELETE', 'OPTIONS', 'TRACE'])

--- a/sdk/core/azure-core/tests/test_pipeline.py
+++ b/sdk/core/azure-core/tests/test_pipeline.py
@@ -49,7 +49,8 @@ from azure.core.pipeline import Pipeline
 from azure.core.pipeline.policies import (
     SansIOHTTPPolicy,
     UserAgentPolicy,
-    RedirectPolicy
+    RedirectPolicy,
+    RetryPolicy
 )
 from azure.core.pipeline.transport._base import PipelineClientBase
 from azure.core.pipeline.transport import (
@@ -121,6 +122,13 @@ class TestRequestsTransport(unittest.TestCase):
             with Pipeline(RequestsTransport(), policies=policies) as pipeline:
                 response = pipeline.run(request, connection_timeout=0.000001)
 
+    def test_retry_code_class_variables(self):
+        retry_policy = RetryPolicy()
+        assert retry_policy._RETRY_CODES is not None
+        assert len(retry_policy._RETRY_CODES) == 498
+        assert 408 in retry_policy._RETRY_CODES
+        assert 501 not in retry_policy._RETRY_CODES
+
     def test_basic_requests_separate_session(self):
 
         session = requests.Session()
@@ -138,7 +146,6 @@ class TestRequestsTransport(unittest.TestCase):
         transport.close()
         assert transport.session
         transport.session.close()
-
 
 class TestClientPipelineURLFormatting(unittest.TestCase):
 


### PR DESCRIPTION
retry codes is being computed for every instance.  Downloading a lot of blobs resulted in the following profiling:

```
ncalls  | tottime |  percall  | cumtime |  percall | filename:lineno(function)
2002     7.627      0.004        7.627         0.004          _retry.py:97(<listcomp>)
```