### PR TITLE
Update doc strings to reflect accurate perm option

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
@@ -69,7 +69,7 @@ class BlobSharedAccessSignature(SharedAccessSignature):
         :param BlobSasPermissions permission:
             The permissions associated with the shared access signature. The
             user is restricted to operations allowed by the permissions.
-            Permissions must be ordered read, write, delete, list.
+            Permissions must be ordered read, add, create, write, delete.
             Required unless an id is given referencing a stored access policy
             which contains this field. This field must be omitted if it has been
             specified in an associated stored access policy.
@@ -501,7 +501,7 @@ def generate_blob_sas(
     :param permission:
         The permissions associated with the shared access signature. The
         user is restricted to operations allowed by the permissions.
-        Permissions must be ordered read, write, delete, list.
+        Permissions must be ordered read, add, create, write, delete.
         Required unless an id is given referencing a stored access policy
         which contains this field. This field must be omitted if it has been
         specified in an associated stored access policy.

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
@@ -220,7 +220,7 @@ def generate_directory_sas(
     :param permission:
         The permissions associated with the shared access signature. The
         user is restricted to operations allowed by the permissions.
-        Permissions must be ordered read, write, delete, list.
+        Permissions must be ordered read, add, create, write, delete.
         Required unless an id is given referencing a stored access policy
         which contains this field. This field must be omitted if it has been
         specified in an associated stored access policy.
@@ -316,7 +316,7 @@ def generate_file_sas(
     :param permission:
         The permissions associated with the shared access signature. The
         user is restricted to operations allowed by the permissions.
-        Permissions must be ordered read, write, delete, list.
+        Permissions must be ordered read, add, create, write, delete.
         Required unless an id is given referencing a stored access policy
         which contains this field. This field must be omitted if it has been
         specified in an associated stored access policy.

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
@@ -59,7 +59,7 @@ class FileSharedAccessSignature(SharedAccessSignature):
         :param ~azure.storage.fileshare.FileSasPermissions permission:
             The permissions associated with the shared access signature. The
             user is restricted to operations allowed by the permissions.
-            Permissions must be ordered read, create, write, delete, list.
+            Permissions must be ordered read, create, write, delete.
             Required unless an id is given referencing a stored access policy
             which contains this field. This field must be omitted if it has been
             specified in an associated stored access policy.
@@ -137,7 +137,7 @@ class FileSharedAccessSignature(SharedAccessSignature):
         :param ShareSasPermissions permission:
             The permissions associated with the shared access signature. The
             user is restricted to operations allowed by the permissions.
-            Permissions must be ordered read, create, write, delete, list.
+            Permissions must be ordered read, write, delete, list.
             Required unless an id is given referencing a stored access policy
             which contains this field. This field must be omitted if it has been
             specified in an associated stored access policy.
@@ -334,7 +334,7 @@ def generate_share_sas(
     :param ~azure.storage.fileshare.ShareSasPermissions permission:
         The permissions associated with the shared access signature. The
         user is restricted to operations allowed by the permissions.
-        Permissions must be ordered read, create, write, delete, list.
+        Permissions must be ordered read, write, delete, list.
         Required unless an id is given referencing a stored access policy
         which contains this field. This field must be omitted if it has been
         specified in an associated stored access policy.
@@ -425,7 +425,7 @@ def generate_file_sas(
     :param ~azure.storage.fileshare.FileSasPermissions permission:
         The permissions associated with the shared access signature. The
         user is restricted to operations allowed by the permissions.
-        Permissions must be ordered read, write, delete, list.
+        Permissions must be ordered read, create, write, delete.
         Required unless an id is given referencing a stored access policy
         which contains this field. This field must be omitted if it has been
         specified in an associated stored access policy.


### PR DESCRIPTION
Resolves #8784 

Note that the datalake tests are failing with tox so I wasn't able to fullly test, but given that these are only doc strings we should be ok.  See issue: #8789 

