### PR TITLE
Bearer token authorization requires TLS

### DIFF
--- a/sdk/core/azure-core/HISTORY.md
+++ b/sdk/core/azure-core/HISTORY.md
@@ -3,7 +3,7 @@
 
 -------------------
 ## Version 1.1.1 Unreleased
-- Bearer token authorization requires TLS
+- Bearer token authorization requires HTTPS
 
 ## 2019-11-25 Version 1.1.0
 

--- a/sdk/core/azure-core/HISTORY.md
+++ b/sdk/core/azure-core/HISTORY.md
@@ -3,6 +3,7 @@
 
 -------------------
 ## Version 1.1.1 Unreleased
+- Bearer token authorization requires TLS
 
 ## 2019-11-25 Version 1.1.0
 

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -39,7 +39,7 @@ class _BearerTokenCredentialPolicyBase(object):
     @staticmethod
     def _enforce_tls(request):
         # type: (PipelineRequest) -> None
-        if not request.http_request.url.startswith("https"):
+        if not request.http_request.url.lower().startswith("https"):
             raise ServiceRequestError(
                 "Bearer token authentication is not permitted for non-TLS protected (non-https) URLs."
             )
@@ -66,6 +66,7 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, SansIOHTTPPo
     :param credential: The credential.
     :type credential: ~azure.core.TokenCredential
     :param str scopes: Lets you specify the type of access needed.
+    :raises: :class:`~azure.core.exceptions.ServiceRequestError`
     """
 
     def on_request(self, request):

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -29,6 +29,8 @@ class AsyncBearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, SansIOH
         :param request: The pipeline request object to be modified.
         :type request: ~azure.core.pipeline.PipelineRequest
         """
+        self._enforce_tls(request)
+
         with self._lock:
             if self._need_new_token:
                 self._token = await self._credential.get_token(*self._scopes)  # type: ignore

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -28,6 +28,7 @@ class AsyncBearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, SansIOH
 
         :param request: The pipeline request object to be modified.
         :type request: ~azure.core.pipeline.PipelineRequest
+        :raises: :class:`~azure.core.exceptions.ServiceRequestError`
         """
         self._enforce_tls(request)
 


### PR DESCRIPTION
This changes `BearerTokenCredentialPolicy` and its async equivalent to raise `ServiceRequestError` when given a request to a non-https URL. I chose `ServiceRequestError` because we document it as indicating an error concerning a request that hasn't been sent.