### PR TITLE
Add proxy policy to credential pipelines

### DIFF
--- a/sdk/identity/azure-identity/HISTORY.md
+++ b/sdk/identity/azure-identity/HISTORY.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+- All credential pipelines include `ProxyPolicy`
+([#8945](https://github.com/Azure/azure-sdk-for-python/pull/8945))
+
+
 # 2019-11-27 1.1.0
 
 - Constructing `DefaultAzureCredential` no longer raises `ImportError` on Python

--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -177,6 +177,7 @@ class AuthnClient(AuthnClientBase):
         config = config or self._create_config(**kwargs)
         policies = policies or [
             ContentDecodePolicy(),
+            config.proxy_policy,
             config.retry_policy,
             config.logging_policy,
             DistributedTracingPolicy(**kwargs),

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
@@ -86,6 +86,7 @@ class MsalTransportAdapter(object):
         config = config or self._create_config(**kwargs)
         policies = policies or [
             ContentDecodePolicy(),
+            config.proxy_policy,
             config.retry_policy,
             config.logging_policy,
             DistributedTracingPolicy(**kwargs),

--- a/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
@@ -43,6 +43,7 @@ class AsyncAuthnClient(AuthnClientBase):  # pylint:disable=async-client-bad-name
         config = config or self._create_config(**kwargs)
         policies = policies or [
             ContentDecodePolicy(),
+            config.proxy_policy,
             config.retry_policy,
             config.logging_policy,
             DistributedTracingPolicy(**kwargs),

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/msal_transport_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/msal_transport_adapter.py
@@ -15,6 +15,7 @@ from azure.core.pipeline.policies import (
     DistributedTracingPolicy,
     HttpLoggingPolicy,
     NetworkTraceLoggingPolicy,
+    ProxyPolicy,
 )
 from azure.core.pipeline.transport import AioHttpTransport, HttpRequest
 
@@ -40,6 +41,7 @@ class MsalTransportAdapter:
 
         config = config or self._create_config(**kwargs)
         policies = policies or [
+            config.proxy_policy,
             config.retry_policy,
             config.logging_policy,
             DistributedTracingPolicy(**kwargs),
@@ -113,6 +115,7 @@ class MsalTransportAdapter:
     @staticmethod
     def _create_config(**kwargs: "Any") -> Configuration:
         config = Configuration(**kwargs)
+        config.proxy_policy = ProxyPolicy(**kwargs)
         config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
         config.retry_policy = AsyncRetryPolicy(**kwargs)
         return config

--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -4,8 +4,10 @@
 # ------------------------------------
 import base64
 import json
-import six
 import time
+
+from azure.core.pipeline.policies import SansIOHTTPPolicy
+import six
 
 try:
     from unittest import mock
@@ -102,6 +104,11 @@ def mock_response(status_code=200, headers={}, json_payload=None):
         response.headers["content-type"] = "application/json"
         response.content_type = "application/json"
     return response
+
+
+def get_discovery_response(endpoint="https://a/b"):
+    aad_metadata_endpoint_names = ("authorization_endpoint", "token_endpoint", "tenant_discovery_endpoint")
+    return mock_response(json_payload={name: endpoint for name in aad_metadata_endpoint_names})
 
 
 def validating_transport(requests, responses):

--- a/sdk/identity/azure-identity/tests/test_auth_code.py
+++ b/sdk/identity/azure-identity/tests/test_auth_code.py
@@ -17,13 +17,11 @@ except ImportError:  # python < 3.3
 def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
 
+    def send(*_, **__):
+        return mock_response(json_payload=build_aad_response(access_token="**"))
+
     credential = AuthorizationCodeCredential(
-        "tenant-id",
-        "client-id",
-        "auth-code",
-        "http://localhost",
-        policies=[policy],
-        transport=Mock(send=lambda *_, **__: mock_response(json_payload=build_aad_response(access_token="**"))),
+        "tenant-id", "client-id", "auth-code", "http://localhost", policies=[policy], transport=Mock(send=send)
     )
 
     credential.get_token("scope")

--- a/sdk/identity/azure-identity/tests/test_auth_code.py
+++ b/sdk/identity/azure-identity/tests/test_auth_code.py
@@ -3,12 +3,32 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from azure.core.credentials import AccessToken
+from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.identity import AuthorizationCodeCredential
+
+from helpers import build_aad_response, mock_response
 
 try:
     from unittest.mock import Mock
 except ImportError:  # python < 3.3
     from mock import Mock  # type: ignore
+
+
+def test_policies_configurable():
+    policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
+
+    credential = AuthorizationCodeCredential(
+        "tenant-id",
+        "client-id",
+        "auth-code",
+        "http://localhost",
+        policies=[policy],
+        transport=Mock(send=lambda *_, **__: mock_response(json_payload=build_aad_response(access_token="**"))),
+    )
+
+    credential.get_token("scope")
+
+    assert policy.on_request.called
 
 
 def test_auth_code_credential():

--- a/sdk/identity/azure-identity/tests/test_certificate_credential.py
+++ b/sdk/identity/azure-identity/tests/test_certificate_credential.py
@@ -5,9 +5,10 @@
 import json
 import os
 
+from azure.core.pipeline.policies import ContentDecodePolicy, SansIOHTTPPolicy
 from azure.identity import CertificateCredential
 from six.moves.urllib_parse import urlparse
-from helpers import urlsafeb64_decode, mock_response
+from helpers import build_aad_response, urlsafeb64_decode, mock_response
 
 try:
     from unittest.mock import Mock, patch
@@ -15,6 +16,22 @@ except ImportError:  # python < 3.3
     from mock import Mock, patch  # type: ignore
 
 CERT_PATH = os.path.join(os.path.dirname(__file__), "certificate.pem")
+
+
+def test_policies_configurable():
+    policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
+
+    credential = CertificateCredential(
+        "tenant-id",
+        "client-id",
+        CERT_PATH,
+        policies=[ContentDecodePolicy(), policy],
+        transport=Mock(send=lambda *_, **__: mock_response(json_payload=build_aad_response(access_token="**"))),
+    )
+
+    credential.get_token("scope")
+
+    assert policy.on_request.called
 
 
 def test_request_url():

--- a/sdk/identity/azure-identity/tests/test_certificate_credential.py
+++ b/sdk/identity/azure-identity/tests/test_certificate_credential.py
@@ -21,12 +21,11 @@ CERT_PATH = os.path.join(os.path.dirname(__file__), "certificate.pem")
 def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
 
+    def send(*_, **__):
+        return mock_response(json_payload=build_aad_response(access_token="**"))
+
     credential = CertificateCredential(
-        "tenant-id",
-        "client-id",
-        CERT_PATH,
-        policies=[ContentDecodePolicy(), policy],
-        transport=Mock(send=lambda *_, **__: mock_response(json_payload=build_aad_response(access_token="**"))),
+        "tenant-id", "client-id", CERT_PATH, policies=[ContentDecodePolicy(), policy], transport=Mock(send=send)
     )
 
     credential.get_token("scope")

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential.py
@@ -18,12 +18,11 @@ except ImportError:  # python < 3.3
 def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
 
+    def send(*_, **__):
+        return mock_response(json_payload=build_aad_response(access_token="**"))
+
     credential = ClientSecretCredential(
-        "tenant-id",
-        "client-id",
-        "client-secret",
-        policies=[ContentDecodePolicy(), policy],
-        transport=Mock(send=lambda *_, **__: mock_response(json_payload=build_aad_response(access_token="**"))),
+        "tenant-id", "client-id", "client-secret", policies=[ContentDecodePolicy(), policy], transport=Mock(send=send)
     )
 
     credential.get_token("scope")

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential.py
@@ -2,9 +2,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import time
+
+from azure.core.credentials import AccessToken
 from azure.core.pipeline.policies import ContentDecodePolicy, SansIOHTTPPolicy
 from azure.identity import ClientSecretCredential
-from helpers import build_aad_response, mock_response
+from helpers import build_aad_response, mock_response, Request, validating_transport
 
 try:
     from unittest.mock import Mock
@@ -26,3 +29,65 @@ def test_policies_configurable():
     credential.get_token("scope")
 
     assert policy.on_request.called
+
+
+def test_client_secret_credential():
+    client_id = "fake-client-id"
+    secret = "fake-client-secret"
+    tenant_id = "fake-tenant-id"
+    access_token = "***"
+
+    transport = validating_transport(
+        requests=[Request(url_substring=tenant_id, required_data={"client_id": client_id, "client_secret": secret})],
+        responses=[
+            mock_response(
+                json_payload={
+                    "token_type": "Bearer",
+                    "expires_in": 42,
+                    "ext_expires_in": 42,
+                    "access_token": access_token,
+                }
+            )
+        ],
+    )
+
+    token = ClientSecretCredential(tenant_id, client_id, secret, transport=transport).get_token("scope")
+
+    # not validating expires_on because doing so requires monkeypatching time, and this is tested elsewhere
+    assert token.token == access_token
+
+
+def test_cache():
+    expired = "this token's expired"
+    now = int(time.time())
+    expired_on = now - 3600
+    expired_token = AccessToken(expired, expired_on)
+    token_payload = {
+        "access_token": expired,
+        "expires_in": 0,
+        "ext_expires_in": 0,
+        "expires_on": expired_on,
+        "not_before": now,
+        "token_type": "Bearer",
+    }
+    mock_send = Mock(return_value=mock_response(json_payload=token_payload))
+    scope = "scope"
+
+    credential = ClientSecretCredential(
+        tenant_id="some-guid", client_id="client_id", client_secret="secret", transport=Mock(send=mock_send)
+    )
+
+    # get_token initially returns the expired token because the credential
+    # doesn't check whether tokens it receives from the service have expired
+    token = credential.get_token(scope)
+    assert token == expired_token
+
+    access_token = "new token"
+    token_payload["access_token"] = access_token
+    token_payload["expires_on"] = now + 3600
+    valid_token = AccessToken(access_token, now + 3600)
+
+    # second call should observe the cached token has expired, and request another
+    token = credential.get_token(scope)
+    assert token == valid_token
+    assert mock_send.call_count == 2

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential.py
@@ -1,0 +1,28 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from azure.core.pipeline.policies import ContentDecodePolicy, SansIOHTTPPolicy
+from azure.identity import ClientSecretCredential
+from helpers import build_aad_response, mock_response
+
+try:
+    from unittest.mock import Mock
+except ImportError:  # python < 3.3
+    from mock import Mock  # type: ignore
+
+
+def test_policies_configurable():
+    policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
+
+    credential = ClientSecretCredential(
+        "tenant-id",
+        "client-id",
+        "client-secret",
+        policies=[ContentDecodePolicy(), policy],
+        transport=Mock(send=lambda *_, **__: mock_response(json_payload=build_aad_response(access_token="**"))),
+    )
+
+    credential.get_token("scope")
+
+    assert policy.on_request.called

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential_async.py
@@ -2,16 +2,16 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import asyncio
+import time
+from unittest.mock import Mock
+
+from azure.core.credentials import AccessToken
 from azure.core.pipeline.policies import ContentDecodePolicy, SansIOHTTPPolicy
 from azure.identity.aio import ClientSecretCredential
-from helpers import build_aad_response, mock_response
+from helpers import async_validating_transport, build_aad_response, mock_response, Request
 
 import pytest
-
-try:
-    from unittest.mock import Mock
-except ImportError:  # python < 3.3
-    from mock import Mock  # type: ignore
 
 
 @pytest.mark.asyncio
@@ -28,3 +28,68 @@ async def test_policies_configurable():
     await credential.get_token("scope")
 
     assert policy.on_request.called
+
+
+@pytest.mark.asyncio
+async def test_client_secret_credential():
+    client_id = "fake-client-id"
+    secret = "fake-client-secret"
+    tenant_id = "fake-tenant-id"
+    access_token = "***"
+
+    transport = async_validating_transport(
+        requests=[Request(url_substring=tenant_id, required_data={"client_id": client_id, "client_secret": secret})],
+        responses=[
+            mock_response(
+                json_payload={
+                    "token_type": "Bearer",
+                    "expires_in": 42,
+                    "ext_expires_in": 42,
+                    "access_token": access_token,
+                }
+            )
+        ],
+    )
+
+    token = await ClientSecretCredential(
+        tenant_id=tenant_id, client_id=client_id, client_secret=secret, transport=transport
+    ).get_token("scope")
+
+    # not validating expires_on because doing so requires monkeypatching time, and this is tested elsewhere
+    assert token.token == access_token
+
+
+@pytest.mark.asyncio
+async def test_cache():
+    expired = "this token's expired"
+    now = int(time.time())
+    expired_on = now - 3600
+    expired_token = AccessToken(expired, expired_on)
+    token_payload = {
+        "access_token": expired,
+        "expires_in": 0,
+        "ext_expires_in": 0,
+        "expires_on": expired_on,
+        "not_before": now,
+        "token_type": "Bearer",
+    }
+    mock_send = Mock(return_value=mock_response(json_payload=token_payload))
+    transport = Mock(send=asyncio.coroutine(mock_send))
+    scope = "scope"
+
+    credential = ClientSecretCredential("tenant-id", "client-id", "secret", transport=transport)
+
+    # get_token initially returns the expired token because the credential
+    # doesn't check whether tokens it receives from the service have expired
+    token = await credential.get_token(scope)
+    assert token == expired_token
+
+    access_token = "new token"
+    token_payload["access_token"] = access_token
+    token_payload["expires_on"] = now + 3600
+    valid_token = AccessToken(access_token, now + 3600)
+
+    # second call should observe the cached token has expired, and request another
+    token = await credential.get_token(scope)
+    assert token == valid_token
+    assert mock_send.call_count == 2

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential_async.py
@@ -1,0 +1,30 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from azure.core.pipeline.policies import ContentDecodePolicy, SansIOHTTPPolicy
+from azure.identity.aio import ClientSecretCredential
+from helpers import build_aad_response, mock_response
+
+import pytest
+
+try:
+    from unittest.mock import Mock
+except ImportError:  # python < 3.3
+    from mock import Mock  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_policies_configurable():
+    policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
+
+    async def send(*_, **__):
+        return mock_response(json_payload=build_aad_response(access_token="**"))
+
+    credential = ClientSecretCredential(
+        "tenant-id", "client-id", "client-secret", policies=[ContentDecodePolicy(), policy], transport=Mock(send=send)
+    )
+
+    await credential.get_token("scope")
+
+    assert policy.on_request.called

--- a/sdk/identity/azure-identity/tests/test_device_code_credential.py
+++ b/sdk/identity/azure-identity/tests/test_device_code_credential.py
@@ -1,0 +1,41 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from azure.core.pipeline.policies import ContentDecodePolicy, SansIOHTTPPolicy
+from azure.identity import DeviceCodeCredential
+from helpers import build_aad_response, get_discovery_response, mock_response, Request, validating_transport
+
+try:
+    from unittest.mock import Mock
+except ImportError:  # python < 3.3
+    from mock import Mock  # type: ignore
+
+
+def test_policies_configurable():
+    policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
+
+    transport = validating_transport(
+        requests=[Request()] * 3,
+        responses=[
+            # expected requests: discover tenant, start device code flow, poll for completion
+            get_discovery_response(),
+            mock_response(
+                json_payload={
+                    "device_code": "_",
+                    "user_code": "user-code",
+                    "verification_uri": "verification-uri",
+                    "expires_in": 42,
+                }
+            ),
+            mock_response(json_payload=dict(build_aad_response(access_token="**"), scope="scope")),
+        ],
+    )
+
+    credential = DeviceCodeCredential(
+        client_id="client-id", prompt_callback=Mock(), policies=[policy], transport=transport
+    )
+
+    credential.get_token("scope")
+
+    assert policy.on_request.called

--- a/sdk/identity/azure-identity/tests/test_device_code_credential.py
+++ b/sdk/identity/azure-identity/tests/test_device_code_credential.py
@@ -2,8 +2,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from azure.core.pipeline.policies import ContentDecodePolicy, SansIOHTTPPolicy
+import datetime
+
+from azure.core.exceptions import ClientAuthenticationError
+from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.identity import DeviceCodeCredential
+import pytest
+
 from helpers import build_aad_response, get_discovery_response, mock_response, Request, validating_transport
 
 try:
@@ -39,3 +44,76 @@ def test_policies_configurable():
     credential.get_token("scope")
 
     assert policy.on_request.called
+
+
+def test_device_code_credential():
+    expected_token = "access-token"
+    user_code = "user-code"
+    verification_uri = "verification-uri"
+    expires_in = 42
+
+    transport = validating_transport(
+        requests=[Request()] * 3,  # not validating requests because they're formed by MSAL
+        responses=[
+            # expected requests: discover tenant, start device code flow, poll for completion
+            mock_response(json_payload={"authorization_endpoint": "https://a/b", "token_endpoint": "https://a/b"}),
+            mock_response(
+                json_payload={
+                    "device_code": "_",
+                    "user_code": user_code,
+                    "verification_uri": verification_uri,
+                    "expires_in": expires_in,
+                }
+            ),
+            mock_response(
+                json_payload={
+                    "access_token": expected_token,
+                    "expires_in": expires_in,
+                    "scope": "scope",
+                    "token_type": "Bearer",
+                    "refresh_token": "_",
+                }
+            ),
+        ],
+    )
+
+    callback = Mock()
+    credential = DeviceCodeCredential(
+        client_id="_", prompt_callback=callback, transport=transport, instance_discovery=False
+    )
+
+    now = datetime.datetime.utcnow()
+    token = credential.get_token("scope")
+    assert token.token == expected_token
+
+    # prompt_callback should have been called as documented
+    assert callback.call_count == 1
+    uri, code, expires_on = callback.call_args[0]
+    assert uri == verification_uri
+    assert code == user_code
+
+    # validating expires_on exactly would require depending on internals of the credential and
+    # patching time, so we'll be satisfied if expires_on is a datetime at least expires_in
+    # seconds later than our call to get_token
+    assert isinstance(expires_on, datetime.datetime)
+    assert expires_on - now >= datetime.timedelta(seconds=expires_in)
+
+
+def test_timeout():
+    transport = validating_transport(
+        requests=[Request()] * 3,  # not validating requests because they're formed by MSAL
+        responses=[
+            # expected requests: discover tenant, start device code flow, poll for completion
+            mock_response(json_payload={"authorization_endpoint": "https://a/b", "token_endpoint": "https://a/b"}),
+            mock_response(json_payload={"device_code": "_", "user_code": "_", "verification_uri": "_"}),
+            mock_response(json_payload={"error": "authorization_pending"}),
+        ],
+    )
+
+    credential = DeviceCodeCredential(
+        client_id="_", prompt_callback=Mock(), transport=transport, timeout=0.01, instance_discovery=False
+    )
+
+    with pytest.raises(ClientAuthenticationError) as ex:
+        credential.get_token("scope")
+    assert "timed out" in ex.value.message.lower()

--- a/sdk/identity/azure-identity/tests/test_identity.py
+++ b/sdk/identity/azure-identity/tests/test_identity.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-import datetime
 import functools
 import json
 import time
@@ -14,82 +13,12 @@ except ImportError:  # python < 3.3
 
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
-from azure.identity import (
-    ChainedTokenCredential,
-    ClientSecretCredential,
-    DefaultAzureCredential,
-    DeviceCodeCredential,
-    EnvironmentCredential,
-    ManagedIdentityCredential,
-    UsernamePasswordCredential,
-)
+from azure.identity import ChainedTokenCredential, ClientSecretCredential, DefaultAzureCredential, EnvironmentCredential
 from azure.identity._credentials.managed_identity import ImdsCredential
 from azure.identity._constants import EnvironmentVariables
 import pytest
 
 from helpers import mock_response, Request, validating_transport
-
-
-def test_client_secret_credential_cache():
-    expired = "this token's expired"
-    now = int(time.time())
-    expired_on = now - 3600
-    expired_token = AccessToken(expired, expired_on)
-    token_payload = {
-        "access_token": expired,
-        "expires_in": 0,
-        "ext_expires_in": 0,
-        "expires_on": expired_on,
-        "not_before": now,
-        "token_type": "Bearer",
-    }
-    mock_send = Mock(return_value=mock_response(json_payload=token_payload))
-    scope = "scope"
-
-    credential = ClientSecretCredential(
-        tenant_id="some-guid", client_id="client_id", client_secret="secret", transport=Mock(send=mock_send)
-    )
-
-    # get_token initially returns the expired token because the credential
-    # doesn't check whether tokens it receives from the service have expired
-    token = credential.get_token(scope)
-    assert token == expired_token
-
-    access_token = "new token"
-    token_payload["access_token"] = access_token
-    token_payload["expires_on"] = now + 3600
-    valid_token = AccessToken(access_token, now + 3600)
-
-    # second call should observe the cached token has expired, and request another
-    token = credential.get_token(scope)
-    assert token == valid_token
-    assert mock_send.call_count == 2
-
-
-def test_client_secret_credential():
-    client_id = "fake-client-id"
-    secret = "fake-client-secret"
-    tenant_id = "fake-tenant-id"
-    access_token = "***"
-
-    transport = validating_transport(
-        requests=[Request(url_substring=tenant_id, required_data={"client_id": client_id, "client_secret": secret})],
-        responses=[
-            mock_response(
-                json_payload={
-                    "token_type": "Bearer",
-                    "expires_in": 42,
-                    "ext_expires_in": 42,
-                    "access_token": access_token,
-                }
-            )
-        ],
-    )
-
-    token = ClientSecretCredential(tenant_id, client_id, secret, transport=transport).get_token("scope")
-
-    # not validating expires_on because doing so requires monkeypatching time, and this is tested elsewhere
-    assert token.token == access_token
 
 
 def test_client_secret_environment_credential():
@@ -253,111 +182,6 @@ def test_default_credential_shared_cache_use(mock_credential):
     assert mock_credential.call_count == 1
     assert mock_credential.supported.call_count == 1
     mock_credential.supported.reset_mock()
-
-def test_device_code_credential():
-    expected_token = "access-token"
-    user_code = "user-code"
-    verification_uri = "verification-uri"
-    expires_in = 42
-
-    transport = validating_transport(
-        requests=[Request()] * 3,  # not validating requests because they're formed by MSAL
-        responses=[
-            # expected requests: discover tenant, start device code flow, poll for completion
-            mock_response(json_payload={"authorization_endpoint": "https://a/b", "token_endpoint": "https://a/b"}),
-            mock_response(
-                json_payload={
-                    "device_code": "_",
-                    "user_code": user_code,
-                    "verification_uri": verification_uri,
-                    "expires_in": expires_in,
-                }
-            ),
-            mock_response(
-                json_payload={
-                    "access_token": expected_token,
-                    "expires_in": expires_in,
-                    "scope": "scope",
-                    "token_type": "Bearer",
-                    "refresh_token": "_",
-                }
-            ),
-        ],
-    )
-
-    callback = Mock()
-    credential = DeviceCodeCredential(
-        client_id="_", prompt_callback=callback, transport=transport, instance_discovery=False
-    )
-
-    now = datetime.datetime.utcnow()
-    token = credential.get_token("scope")
-    assert token.token == expected_token
-
-    # prompt_callback should have been called as documented
-    assert callback.call_count == 1
-    uri, code, expires_on = callback.call_args[0]
-    assert uri == verification_uri
-    assert code == user_code
-
-    # validating expires_on exactly would require depending on internals of the credential and
-    # patching time, so we'll be satisfied if expires_on is a datetime at least expires_in
-    # seconds later than our call to get_token
-    assert isinstance(expires_on, datetime.datetime)
-    assert expires_on - now >= datetime.timedelta(seconds=expires_in)
-
-
-def test_device_code_credential_timeout():
-    transport = validating_transport(
-        requests=[Request()] * 3,  # not validating requests because they're formed by MSAL
-        responses=[
-            # expected requests: discover tenant, start device code flow, poll for completion
-            mock_response(json_payload={"authorization_endpoint": "https://a/b", "token_endpoint": "https://a/b"}),
-            mock_response(json_payload={"device_code": "_", "user_code": "_", "verification_uri": "_"}),
-            mock_response(json_payload={"error": "authorization_pending"}),
-        ],
-    )
-
-    credential = DeviceCodeCredential(
-        client_id="_", prompt_callback=Mock(), transport=transport, timeout=0.01, instance_discovery=False
-    )
-
-    with pytest.raises(ClientAuthenticationError) as ex:
-        credential.get_token("scope")
-    assert "timed out" in ex.value.message.lower()
-
-
-def test_username_password_credential():
-    expected_token = "access-token"
-    transport = validating_transport(
-        requests=[Request()] * 3,  # not validating requests because they're formed by MSAL
-        responses=[
-            # tenant discovery
-            mock_response(json_payload={"authorization_endpoint": "https://a/b", "token_endpoint": "https://a/b"}),
-            # user realm discovery, interests MSAL only when the response body contains account_type == "Federated"
-            mock_response(json_payload={}),
-            # token request
-            mock_response(
-                json_payload={
-                    "access_token": expected_token,
-                    "expires_in": 42,
-                    "token_type": "Bearer",
-                    "ext_expires_in": 42,
-                }
-            ),
-        ],
-    )
-
-    credential = UsernamePasswordCredential(
-        client_id="some-guid",
-        username="user@azure",
-        password="secret_password",
-        transport=transport,
-        instance_discovery=False,  # kwargs are passed to MSAL; this one prevents an AAD verification request
-    )
-
-    token = credential.get_token("scope")
-    assert token.token == expected_token
 
 
 def test_username_password_environment_credential():

--- a/sdk/identity/azure-identity/tests/test_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_identity_async.py
@@ -7,7 +7,6 @@ import json
 import os
 import time
 from unittest.mock import Mock, patch
-import uuid
 
 import pytest
 from azure.core.credentials import AccessToken
@@ -23,71 +22,6 @@ from azure.identity.aio._credentials.managed_identity import ImdsCredential
 from azure.identity._constants import EnvironmentVariables
 
 from helpers import mock_response, Request, async_validating_transport
-
-
-@pytest.mark.asyncio
-async def test_client_secret_credential_cache():
-    expired = "this token's expired"
-    now = int(time.time())
-    expired_on = now - 3600
-    expired_token = AccessToken(expired, expired_on)
-    token_payload = {
-        "access_token": expired,
-        "expires_in": 0,
-        "ext_expires_in": 0,
-        "expires_on": expired_on,
-        "not_before": now,
-        "token_type": "Bearer",
-    }
-    mock_send = Mock(return_value=mock_response(json_payload=token_payload))
-    transport = Mock(send=asyncio.coroutine(mock_send))
-    scope = "scope"
-
-    credential = ClientSecretCredential("tenant-id", "client-id", "secret", transport=transport)
-
-    # get_token initially returns the expired token because the credential
-    # doesn't check whether tokens it receives from the service have expired
-    token = await credential.get_token(scope)
-    assert token == expired_token
-
-    access_token = "new token"
-    token_payload["access_token"] = access_token
-    token_payload["expires_on"] = now + 3600
-    valid_token = AccessToken(access_token, now + 3600)
-
-    # second call should observe the cached token has expired, and request another
-    token = await credential.get_token(scope)
-    assert token == valid_token
-    assert mock_send.call_count == 2
-
-
-@pytest.mark.asyncio
-async def test_client_secret_credential():
-    client_id = "fake-client-id"
-    secret = "fake-client-secret"
-    tenant_id = "fake-tenant-id"
-    access_token = "***"
-
-    transport = async_validating_transport(
-        requests=[Request(url_substring=tenant_id, required_data={"client_id": client_id, "client_secret": secret})],
-        responses=[
-            mock_response(
-                json_payload={
-                    "token_type": "Bearer",
-                    "expires_in": 42,
-                    "ext_expires_in": 42,
-                    "access_token": access_token,
-                }
-            )
-        ],
-    )
-
-    token = await ClientSecretCredential(
-        tenant_id=tenant_id, client_id=client_id, client_secret=secret, transport=transport
-    ).get_token("scope")
-
-    # not validating expires_on because doing so requires monkeypatching time, and this is tested elsewhere
-    assert token.token == access_token
 
 
 @pytest.mark.asyncio

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
@@ -26,10 +26,13 @@ from helpers import build_aad_response, build_id_token, mock_response, Request, 
 def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
 
+    def send(*_, **__):
+        return mock_response(json_payload=build_aad_response(access_token="**"))
+
     credential = SharedTokenCacheCredential(
         _cache=populated_cache(get_account_event("test@user", "uid", "utid")),
         policies=[policy],
-        transport=Mock(send=lambda *_, **__: mock_response(json_payload=build_aad_response(access_token="**"))),
+        transport=Mock(send=send),
     )
 
     credential.get_token("scope")

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from azure.core.exceptions import ClientAuthenticationError
+from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.identity import KnownAuthorities, SharedTokenCacheCredential
 from azure.identity._internal.shared_token_cache import (
     KNOWN_ALIASES,
@@ -20,6 +21,20 @@ except ImportError:  # python < 3.3
     from mock import Mock  # type: ignore
 
 from helpers import build_aad_response, build_id_token, mock_response, Request, validating_transport
+
+
+def test_policies_configurable():
+    policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
+
+    credential = SharedTokenCacheCredential(
+        _cache=populated_cache(get_account_event("test@user", "uid", "utid")),
+        policies=[policy],
+        transport=Mock(send=lambda *_, **__: mock_response(json_payload=build_aad_response(access_token="**"))),
+    )
+
+    credential.get_token("scope")
+
+    assert policy.on_request.called
 
 
 def test_empty_cache():
@@ -433,13 +448,7 @@ def test_authority_with_no_known_alias():
 
 
 def get_account_event(
-    username,
-    uid,
-    utid,
-    authority=None,
-    client_id="client-id",
-    refresh_token="refresh-token",
-    scopes=None,
+    username, uid, utid, authority=None, client_id="client-id", refresh_token="refresh-token", scopes=None
 ):
     return {
         "response": build_aad_response(

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
@@ -5,6 +5,7 @@
 from unittest.mock import Mock
 
 from azure.core.exceptions import ClientAuthenticationError
+from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.identity import KnownAuthorities
 from azure.identity.aio import SharedTokenCacheCredential
 from azure.identity._internal.shared_token_cache import (
@@ -19,6 +20,24 @@ import pytest
 
 from helpers import async_validating_transport, build_aad_response, build_id_token, mock_response, Request
 from test_shared_cache_credential import get_account_event, populated_cache
+
+
+@pytest.mark.asyncio
+async def test_policies_configurable():
+    policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
+
+    async def send(*_, **__):
+        return mock_response(json_payload=build_aad_response(access_token="**"))
+
+    credential = SharedTokenCacheCredential(
+        _cache=populated_cache(get_account_event("test@user", "uid", "utid")),
+        policies=[policy],
+        transport=Mock(send=send),
+    )
+
+    await credential.get_token("scope")
+
+    assert policy.on_request.called
 
 
 @pytest.mark.asyncio

--- a/sdk/identity/azure-identity/tests/test_username_password_credential.py
+++ b/sdk/identity/azure-identity/tests/test_username_password_credential.py
@@ -1,0 +1,26 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from azure.core.pipeline.policies import ContentDecodePolicy, SansIOHTTPPolicy
+from azure.identity import UsernamePasswordCredential
+from helpers import build_aad_response, get_discovery_response, mock_response, Request, validating_transport
+
+try:
+    from unittest.mock import Mock
+except ImportError:  # python < 3.3
+    from mock import Mock  # type: ignore
+
+
+def test_policies_configurable():
+    policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
+
+    transport = validating_transport(
+        requests=[Request()] * 3,
+        responses=[get_discovery_response()] * 2 + [mock_response(json_payload=build_aad_response(access_token="**"))],
+    )
+    credential = UsernamePasswordCredential("client-id", "username", "password", policies=[policy], transport=transport)
+
+    credential.get_token("scope")
+
+    assert policy.on_request.called


### PR DESCRIPTION
Primary purpose here is to ensure `ProxyPolicy` is added to all default pipelines. While I was at it I added tests verifying credential constructors respect the 'policies' keyword argument.