### PR TITLE
[AutoPR monitor/resource-manager] fix(metricAlert_API): add missing properties to web test metric alert

### DIFF
--- a/sdk/monitor/azure-mgmt-monitor/README.rst
+++ b/sdk/monitor/azure-mgmt-monitor/README.rst
@@ -6,7 +6,7 @@ This is the Microsoft Azure Monitor Client Library.
 Azure Resource Manager (ARM) is the next generation of management APIs that
 replace the old Azure Service Management (ASM).
 
-This package has been tested with Python 2.7, 3.4, 3.5, 3.6 and 3.7.
+This package has been tested with Python 2.7, 3.5, 3.6 and 3.7.
 
 For the older Azure Service Management (ASM) libraries, see
 `azure-servicemanagement-legacy <https://pypi.python.org/pypi/azure-servicemanagement-legacy>`__ library.

--- a/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_03_01/models/__init__.py
+++ b/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_03_01/models/__init__.py
@@ -38,6 +38,7 @@ try:
     from ._models_py3 import SmsReceiver
     from ._models_py3 import VoiceReceiver
     from ._models_py3 import WebhookReceiver
+    from ._models_py3 import WebtestLocationAvailabilityCriteria
 except (SyntaxError, ImportError):
     from ._models import ActionGroupPatchBody
     from ._models import ActionGroupResource
@@ -67,6 +68,7 @@ except (SyntaxError, ImportError):
     from ._models import SmsReceiver
     from ._models import VoiceReceiver
     from ._models import WebhookReceiver
+    from ._models import WebtestLocationAvailabilityCriteria
 from ._paged_models import ActionGroupResourcePaged
 from ._paged_models import MetricAlertResourcePaged
 from ._monitor_management_client_enums import (
@@ -102,6 +104,7 @@ __all__ = [
     'SmsReceiver',
     'VoiceReceiver',
     'WebhookReceiver',
+    'WebtestLocationAvailabilityCriteria',
     'ActionGroupResourcePaged',
     'MetricAlertResourcePaged',
     'ReceiverStatus',

--- a/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_03_01/models/_models.py
+++ b/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_03_01/models/_models.py
@@ -1228,15 +1228,15 @@ class WebhookReceiver(Model):
 
 
 class WebtestLocationAvailabilityCriteria(Model):
-    """Specifies the metric alert criteria for a web test resource.
+    """Specifies the metric alert rule criteria for a web test resource.
 
     All required parameters must be populated in order to send to Azure.
 
     :param web_test_id: Required. The web test Id.
     :type web_test_id: str
-    :param component_id: Required. The component Id.
+    :param component_id: Required. The Application Insights resource Id.
     :type component_id: str
-    :param failed_location_count: Required. Failed location count.
+    :param failed_location_count: Required. The number of failed locations.
     :type failed_location_count: float
     """
 

--- a/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_03_01/models/_models.py
+++ b/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_03_01/models/_models.py
@@ -1225,3 +1225,35 @@ class WebhookReceiver(Model):
         super(WebhookReceiver, self).__init__(**kwargs)
         self.name = kwargs.get('name', None)
         self.service_uri = kwargs.get('service_uri', None)
+
+
+class WebtestLocationAvailabilityCriteria(Model):
+    """Specifies the metric alert criteria for a web test resource.
+
+    All required parameters must be populated in order to send to Azure.
+
+    :param web_test_id: Required. The web test Id.
+    :type web_test_id: str
+    :param component_id: Required. The component Id.
+    :type component_id: str
+    :param failed_location_count: Required. Failed location count.
+    :type failed_location_count: float
+    """
+
+    _validation = {
+        'web_test_id': {'required': True},
+        'component_id': {'required': True},
+        'failed_location_count': {'required': True},
+    }
+
+    _attribute_map = {
+        'web_test_id': {'key': 'webTestId', 'type': 'str'},
+        'component_id': {'key': 'componentId', 'type': 'str'},
+        'failed_location_count': {'key': 'failedLocationCount', 'type': 'float'},
+    }
+
+    def __init__(self, **kwargs):
+        super(WebtestLocationAvailabilityCriteria, self).__init__(**kwargs)
+        self.web_test_id = kwargs.get('web_test_id', None)
+        self.component_id = kwargs.get('component_id', None)
+        self.failed_location_count = kwargs.get('failed_location_count', None)

--- a/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_03_01/models/_models_py3.py
+++ b/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_03_01/models/_models_py3.py
@@ -1225,3 +1225,35 @@ class WebhookReceiver(Model):
         super(WebhookReceiver, self).__init__(**kwargs)
         self.name = name
         self.service_uri = service_uri
+
+
+class WebtestLocationAvailabilityCriteria(Model):
+    """Specifies the metric alert criteria for a web test resource.
+
+    All required parameters must be populated in order to send to Azure.
+
+    :param web_test_id: Required. The web test Id.
+    :type web_test_id: str
+    :param component_id: Required. The component Id.
+    :type component_id: str
+    :param failed_location_count: Required. Failed location count.
+    :type failed_location_count: float
+    """
+
+    _validation = {
+        'web_test_id': {'required': True},
+        'component_id': {'required': True},
+        'failed_location_count': {'required': True},
+    }
+
+    _attribute_map = {
+        'web_test_id': {'key': 'webTestId', 'type': 'str'},
+        'component_id': {'key': 'componentId', 'type': 'str'},
+        'failed_location_count': {'key': 'failedLocationCount', 'type': 'float'},
+    }
+
+    def __init__(self, *, web_test_id: str, component_id: str, failed_location_count: float, **kwargs) -> None:
+        super(WebtestLocationAvailabilityCriteria, self).__init__(**kwargs)
+        self.web_test_id = web_test_id
+        self.component_id = component_id
+        self.failed_location_count = failed_location_count

--- a/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_03_01/models/_models_py3.py
+++ b/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2018_03_01/models/_models_py3.py
@@ -1228,15 +1228,15 @@ class WebhookReceiver(Model):
 
 
 class WebtestLocationAvailabilityCriteria(Model):
-    """Specifies the metric alert criteria for a web test resource.
+    """Specifies the metric alert rule criteria for a web test resource.
 
     All required parameters must be populated in order to send to Azure.
 
     :param web_test_id: Required. The web test Id.
     :type web_test_id: str
-    :param component_id: Required. The component Id.
+    :param component_id: Required. The Application Insights resource Id.
     :type component_id: str
-    :param failed_location_count: Required. Failed location count.
+    :param failed_location_count: Required. The number of failed locations.
     :type failed_location_count: float
     """
 

--- a/sdk/monitor/azure-mgmt-monitor/setup.py
+++ b/sdk/monitor/azure-mgmt-monitor/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/7907