### PR TITLE
azure-storage-blob - Allow Multiple Test Runs Simultaneously

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/test_append_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_append_blob.py
@@ -926,7 +926,7 @@ class StorageAppendBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'from_path_chunked_upload.temp.dat'
+        FILE_PATH = 'from_path_chunked_upload.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -949,7 +949,7 @@ class StorageAppendBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'progress_chunked_upload.temp.dat'
+        FILE_PATH = 'progress_chunked_upload.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -984,7 +984,7 @@ class StorageAppendBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'stream_chunked_upload.temp.dat'
+        FILE_PATH = 'stream_chunked_upload.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1006,7 +1006,7 @@ class StorageAppendBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'upload_known_size.temp.dat'
+        FILE_PATH = 'upload_known_size.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
         blob_size = len(data) - 66
@@ -1027,7 +1027,7 @@ class StorageAppendBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'upload_unk_size.temp.dat'
+        FILE_PATH = 'upload_unk_size.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1047,7 +1047,7 @@ class StorageAppendBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'multiple_appends.temp.dat'
+        FILE_PATH = 'multiple_appends.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream1:
             stream1.write(data)
         with open(FILE_PATH, 'wb') as stream2:
@@ -1071,7 +1071,7 @@ class StorageAppendBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'upload_with_count.temp.dat'
+        FILE_PATH = 'upload_with_count.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1093,7 +1093,7 @@ class StorageAppendBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'upload_with_count_parallel.temp.dat'
+        FILE_PATH = 'upload_with_count_parallel.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 

--- a/sdk/storage/azure-storage-blob/tests/test_append_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_append_blob.py
@@ -12,6 +12,7 @@ from os import (
     remove,
 )
 import unittest
+import uuid
 from datetime import datetime, timedelta
 
 from azure.core import MatchConditions
@@ -926,7 +927,7 @@ class StorageAppendBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'from_path_chunked_upload.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'from_path_chunked_upload.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -949,7 +950,7 @@ class StorageAppendBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'progress_chunked_upload.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'progress_chunked_upload.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -984,7 +985,7 @@ class StorageAppendBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'stream_chunked_upload.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'stream_chunked_upload.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1006,7 +1007,7 @@ class StorageAppendBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'upload_known_size.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'upload_known_size.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
         blob_size = len(data) - 66
@@ -1027,7 +1028,7 @@ class StorageAppendBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'upload_unk_size.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'upload_unk_size.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1047,7 +1048,7 @@ class StorageAppendBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'multiple_appends.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'multiple_appends.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream1:
             stream1.write(data)
         with open(FILE_PATH, 'wb') as stream2:
@@ -1071,7 +1072,7 @@ class StorageAppendBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'upload_with_count.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'upload_with_count.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1093,7 +1094,7 @@ class StorageAppendBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'upload_with_count_parallel.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'upload_with_count_parallel.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 

--- a/sdk/storage/azure-storage-blob/tests/test_append_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_append_blob_async.py
@@ -15,6 +15,7 @@ from os import (
     remove,
 )
 import unittest
+import uuid
 
 from azure.core import MatchConditions
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError, ResourceModifiedError
@@ -34,7 +35,7 @@ from _shared.asynctestcase import AsyncStorageTestCase
 
 # ------------------------------------------------------------------------------
 TEST_BLOB_PREFIX = 'blob'
-FILE_PATH = 'blob_input.temp.{}.dat.format(str(uuid.uuid4()))'
+FILE_PATH = 'blob_input.temp.{}.dat'.format(str(uuid.uuid4()))
 LARGE_BLOB_SIZE = 64 * 1024
 
 
@@ -1020,7 +1021,7 @@ class StorageAppendBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'path_chunked_upload_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'path_chunked_upload_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1045,7 +1046,7 @@ class StorageAppendBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'progress_chnked_upload_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'progress_chnked_upload_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1082,7 +1083,7 @@ class StorageAppendBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'stream_chunked_upload_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'stream_chunked_upload_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1107,7 +1108,7 @@ class StorageAppendBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'chnkd_upld_knwn_size_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'chnkd_upld_knwn_size_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
         blob_size = len(data) - 66
@@ -1131,7 +1132,7 @@ class StorageAppendBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'nonseek_chnked_upld_unk_size_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'nonseek_chnked_upld_unk_size_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1153,7 +1154,7 @@ class StorageAppendBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'stream_with_multiple_appends_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'stream_with_multiple_appends_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream1:
             stream1.write(data)
         with open(FILE_PATH, 'wb') as stream2:
@@ -1179,7 +1180,7 @@ class StorageAppendBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'hnked_upload_w_count_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'hnked_upload_w_count_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1204,7 +1205,7 @@ class StorageAppendBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'upload_w_count_parallel_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'upload_w_count_parallel_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 

--- a/sdk/storage/azure-storage-blob/tests/test_append_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_append_blob_async.py
@@ -34,7 +34,7 @@ from _shared.asynctestcase import AsyncStorageTestCase
 
 # ------------------------------------------------------------------------------
 TEST_BLOB_PREFIX = 'blob'
-FILE_PATH = 'blob_input.temp.dat'
+FILE_PATH = 'blob_input.temp.{}.dat.format(str(uuid.uuid4()))'
 LARGE_BLOB_SIZE = 64 * 1024
 
 
@@ -1020,7 +1020,7 @@ class StorageAppendBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'path_chunked_upload_async.temp.dat'
+        FILE_PATH = 'path_chunked_upload_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1045,7 +1045,7 @@ class StorageAppendBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'progress_chnked_upload_async.temp.dat'
+        FILE_PATH = 'progress_chnked_upload_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1082,7 +1082,7 @@ class StorageAppendBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'stream_chunked_upload_async.temp.dat'
+        FILE_PATH = 'stream_chunked_upload_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1107,7 +1107,7 @@ class StorageAppendBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'chnkd_upld_knwn_size_async.temp.dat'
+        FILE_PATH = 'chnkd_upld_knwn_size_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
         blob_size = len(data) - 66
@@ -1131,7 +1131,7 @@ class StorageAppendBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'nonseek_chnked_upld_unk_size_async.temp.dat'
+        FILE_PATH = 'nonseek_chnked_upld_unk_size_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1153,7 +1153,7 @@ class StorageAppendBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'stream_with_multiple_appends_async.temp.dat'
+        FILE_PATH = 'stream_with_multiple_appends_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream1:
             stream1.write(data)
         with open(FILE_PATH, 'wb') as stream2:
@@ -1179,7 +1179,7 @@ class StorageAppendBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'hnked_upload_w_count_async.temp.dat'
+        FILE_PATH = 'hnked_upload_w_count_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1204,7 +1204,7 @@ class StorageAppendBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'upload_w_count_parallel_async.temp.dat'
+        FILE_PATH = 'upload_w_count_parallel_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob.py
@@ -8,6 +8,7 @@
 import os
 import unittest
 import pytest
+import uuid
 
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from azure.storage.blob import (
@@ -574,7 +575,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_input.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'create_blob_from_input.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -595,7 +596,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(100)
-        FILE_PATH = 'create_blob_from_path_non_par.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'create_blob_from_path_non_par.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -617,7 +618,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(100)
-        FILE_PATH = '_path_non_parallel_with_standard_blob.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = '_path_non_parallel_with_standard_blob.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
         blob_tier = StandardBlobTier.Cool
@@ -639,7 +640,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_path_with_progr.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'create_blob_from_path_with_progr.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -668,7 +669,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'blob_from_path_with_properties.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_from_path_with_properties.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -695,7 +696,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'blob_from_stream_chunked_up.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_from_stream_chunked_up.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -720,7 +721,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
         blob_size = len(data) - 66
-        FILE_PATH = 'stream_nonseek_chunk_upld_knwn_size.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'stream_nonseek_chunk_upld_knwn_size.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -742,7 +743,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'stream_nonseek_chunk_upld.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'stream_nonseek_chunk_upld.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -764,7 +765,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'stream_with_progress_chunked.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'stream_with_progress_chunked.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -793,7 +794,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'chunked_upload_with_count.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'chunked_upload_with_count.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -815,7 +816,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'from_stream_chunk_upload_with_cntandrops.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'from_stream_chunk_upload_with_cntandrops.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -843,7 +844,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'chnked_upload_with_properti.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'chnked_upload_with_properti.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -871,7 +872,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'blob_from_stream_chunked_upload.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_from_stream_chunked_upload.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
         blob_tier = StandardBlobTier.Cool

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob.py
@@ -574,7 +574,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_input.temp.dat'
+        FILE_PATH = 'create_blob_from_input.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -595,7 +595,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(100)
-        FILE_PATH = 'create_blob_from_path_non_par.temp.dat'
+        FILE_PATH = 'create_blob_from_path_non_par.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -617,7 +617,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(100)
-        FILE_PATH = '_path_non_parallel_with_standard_blob.temp.dat'
+        FILE_PATH = '_path_non_parallel_with_standard_blob.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
         blob_tier = StandardBlobTier.Cool
@@ -639,7 +639,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_path_with_progr.temp.dat'
+        FILE_PATH = 'create_blob_from_path_with_progr.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -668,7 +668,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'blob_from_path_with_properties.temp.dat'
+        FILE_PATH = 'blob_from_path_with_properties.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -695,7 +695,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'blob_from_stream_chunked_up.temp.dat'
+        FILE_PATH = 'blob_from_stream_chunked_up.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -720,7 +720,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
         blob_size = len(data) - 66
-        FILE_PATH = 'stream_nonseek_chunk_upld_knwn_size.temp.dat'
+        FILE_PATH = 'stream_nonseek_chunk_upld_knwn_size.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -742,7 +742,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'stream_nonseek_chunk_upld.temp.dat'
+        FILE_PATH = 'stream_nonseek_chunk_upld.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -764,7 +764,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'stream_with_progress_chunked.temp.dat'
+        FILE_PATH = 'stream_with_progress_chunked.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -793,7 +793,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'chunked_upload_with_count.temp.dat'
+        FILE_PATH = 'chunked_upload_with_count.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -815,7 +815,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'from_stream_chunk_upload_with_cntandrops.temp.dat'
+        FILE_PATH = 'from_stream_chunk_upload_with_cntandrops.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -843,7 +843,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'chnked_upload_with_properti.temp.dat'
+        FILE_PATH = 'chnked_upload_with_properti.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -871,7 +871,7 @@ class StorageBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'blob_from_stream_chunked_upload.temp.dat'
+        FILE_PATH = 'blob_from_stream_chunked_upload.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
         blob_tier = StandardBlobTier.Cool

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob_async.py
@@ -9,6 +9,7 @@ import os
 import unittest
 import pytest
 import asyncio
+import uuid
 
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from azure.core.pipeline.transport import AioHttpTransport
@@ -642,7 +643,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_path.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'create_blob_from_path.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -665,7 +666,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(100)
-        FILE_PATH = 'from_path_non_parallel.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'from_path_non_parallel.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -687,7 +688,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         await self._setup(storage_account.name, storage_account_key)
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
-        FILE_PATH = 'non_parallel_with_standard_blob_tier.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'non_parallel_with_standard_blob_tier.temp.{}.dat'.format(str(uuid.uuid4()))
         data = self.get_random_bytes(100)
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
@@ -712,7 +713,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'blob_from_path_with_progressasync.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_from_path_with_progressasync.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -743,7 +744,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_path_with_propertiesasync.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'create_blob_from_path_with_propertiesasync.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -772,7 +773,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_stream_chunked_uploadasync.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'create_blob_from_stream_chunked_uploadasync.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -799,7 +800,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
         blob_size = len(data) - 66
-        FILE_PATH = 'create_frm_stream_nonseek_chunk_upload_knwn_sizeasync.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'create_frm_stream_nonseek_chunk_upload_knwn_sizeasync.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -823,7 +824,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'strm_nonseek_chunk_upld_unkwn_size_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'strm_nonseek_chunk_upld_unkwn_size_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -847,7 +848,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'from_stream_with_progress_chunked_upload.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'from_stream_with_progress_chunked_upload.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -878,7 +879,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'blob_from_stream_chunked_upload_with.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_from_stream_chunked_upload_with.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -902,7 +903,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = '_frm_stream_chu_upld_with_count.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = '_frm_stream_chu_upld_with_count.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -932,7 +933,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = '_from_stream_chunked_upload_with_propert.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = '_from_stream_chunked_upload_with_propert.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -961,7 +962,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'tream_chunked_upload_with_properti.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'tream_chunked_upload_with_properti.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
         blob_tier = StandardBlobTier.Cool

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob_async.py
@@ -642,7 +642,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_path.temp.dat'
+        FILE_PATH = 'create_blob_from_path.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -665,7 +665,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(100)
-        FILE_PATH = 'from_path_non_parallel.temp.dat'
+        FILE_PATH = 'from_path_non_parallel.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -687,7 +687,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         await self._setup(storage_account.name, storage_account_key)
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
-        FILE_PATH = 'non_parallel_with_standard_blob_tier.temp.dat'
+        FILE_PATH = 'non_parallel_with_standard_blob_tier.temp.{}.dat.format(str(uuid.uuid4()))'
         data = self.get_random_bytes(100)
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
@@ -712,7 +712,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'blob_from_path_with_progressasync.temp.dat'
+        FILE_PATH = 'blob_from_path_with_progressasync.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -743,7 +743,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_path_with_propertiesasync.temp.dat'
+        FILE_PATH = 'create_blob_from_path_with_propertiesasync.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -772,7 +772,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_stream_chunked_uploadasync.temp.dat'
+        FILE_PATH = 'create_blob_from_stream_chunked_uploadasync.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -799,7 +799,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
         blob_size = len(data) - 66
-        FILE_PATH = 'create_frm_stream_nonseek_chunk_upload_knwn_sizeasync.temp.dat'
+        FILE_PATH = 'create_frm_stream_nonseek_chunk_upload_knwn_sizeasync.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -823,7 +823,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'strm_nonseek_chunk_upld_unkwn_size_async.temp.dat'
+        FILE_PATH = 'strm_nonseek_chunk_upld_unkwn_size_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -847,7 +847,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'from_stream_with_progress_chunked_upload.temp.dat'
+        FILE_PATH = 'from_stream_with_progress_chunked_upload.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -878,7 +878,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'blob_from_stream_chunked_upload_with.temp.dat'
+        FILE_PATH = 'blob_from_stream_chunked_upload_with.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -902,7 +902,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = '_frm_stream_chu_upld_with_count.temp.dat'
+        FILE_PATH = '_frm_stream_chu_upld_with_count.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -932,7 +932,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = '_from_stream_chunked_upload_with_propert.temp.dat'
+        FILE_PATH = '_from_stream_chunked_upload_with_propert.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -961,7 +961,7 @@ class StorageBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'tream_chunked_upload_with_properti.temp.dat'
+        FILE_PATH = 'tream_chunked_upload_with_properti.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
         blob_tier = StandardBlobTier.Cool

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -10,6 +10,7 @@ import pytest
 import requests
 import time
 import unittest
+import uuid
 import os
 from datetime import datetime, timedelta
 
@@ -1721,7 +1722,7 @@ class StorageCommonBlobTest(StorageTestCase):
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         blob = BlobClient.from_blob_url(source_blob.url, credential=sas_token)
-        FILE_PATH = 'download_to_file_with_sas.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'download_to_file_with_sas.temp.{}.dat'.format(str(uuid.uuid4()))
 
         # Act
         download_blob_from_url(blob.url, FILE_PATH)
@@ -1741,7 +1742,7 @@ class StorageCommonBlobTest(StorageTestCase):
         self._setup_remote(rmt.name, rmt_key)
         self._create_remote_container()
         source_blob = self._create_remote_block_blob(blob_data=data)
-        FILE_PATH = 'to_file_with_credential.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'to_file_with_credential.temp.{}.dat'.format(str(uuid.uuid4()))
         # Act
         download_blob_from_url(
             source_blob.url, FILE_PATH,
@@ -1762,7 +1763,7 @@ class StorageCommonBlobTest(StorageTestCase):
         self._setup_remote(rmt.name, rmt_key)
         self._create_remote_container()
         source_blob = self._create_remote_block_blob(blob_data=data)
-        FILE_PATH = 'download_to_stream_with_credential.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'download_to_stream_with_credential.temp.{}.dat'.format(str(uuid.uuid4()))
         # Act
         with open(FILE_PATH, 'wb') as stream:
             download_blob_from_url(
@@ -1785,7 +1786,7 @@ class StorageCommonBlobTest(StorageTestCase):
         self._setup_remote(rmt.name, rmt_key)
         self._create_remote_container()
         source_blob = self._create_remote_block_blob(blob_data=data)
-        FILE_PATH = 'file_with_existing_file.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'file_with_existing_file.temp.{}.dat'.format(str(uuid.uuid4()))
         # Act
         download_blob_from_url(
             source_blob.url, FILE_PATH,
@@ -1809,7 +1810,7 @@ class StorageCommonBlobTest(StorageTestCase):
         self._setup_remote(rmt.name, rmt_key)
         self._create_remote_container()
         source_blob = self._create_remote_block_blob(blob_data=data)
-        FILE_PATH = 'file_with_existing_file_overwrite.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'file_with_existing_file_overwrite.temp.{}.dat'.format(str(uuid.uuid4()))
         # Act
         download_blob_from_url(
             source_blob.url, FILE_PATH,
@@ -1942,7 +1943,7 @@ class StorageCommonBlobTest(StorageTestCase):
     @GlobalStorageAccountPreparer()
     def test_upload_to_url_file_with_credential(self, resource_group, location, storage_account, storage_account_key):
         # SAS URL is calculated from storage key, so this test runs live only
-        FILE_PATH = 'upload_to_url_file_with_credential.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'upload_to_url_file_with_credential.temp.{}.dat'.format(str(uuid.uuid4()))
         self._setup(storage_account.name, storage_account_key)
         data = b'12345678' * 1024 * 1024
         with open(FILE_PATH, 'wb') as stream:

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -1721,7 +1721,7 @@ class StorageCommonBlobTest(StorageTestCase):
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
         blob = BlobClient.from_blob_url(source_blob.url, credential=sas_token)
-        FILE_PATH = 'download_to_file_with_sas.temp.dat'
+        FILE_PATH = 'download_to_file_with_sas.temp.{}.dat.format(str(uuid.uuid4()))'
 
         # Act
         download_blob_from_url(blob.url, FILE_PATH)
@@ -1741,7 +1741,7 @@ class StorageCommonBlobTest(StorageTestCase):
         self._setup_remote(rmt.name, rmt_key)
         self._create_remote_container()
         source_blob = self._create_remote_block_blob(blob_data=data)
-        FILE_PATH = 'to_file_with_credential.temp.dat'
+        FILE_PATH = 'to_file_with_credential.temp.{}.dat.format(str(uuid.uuid4()))'
         # Act
         download_blob_from_url(
             source_blob.url, FILE_PATH,
@@ -1762,7 +1762,7 @@ class StorageCommonBlobTest(StorageTestCase):
         self._setup_remote(rmt.name, rmt_key)
         self._create_remote_container()
         source_blob = self._create_remote_block_blob(blob_data=data)
-        FILE_PATH = 'download_to_stream_with_credential.temp.dat'
+        FILE_PATH = 'download_to_stream_with_credential.temp.{}.dat.format(str(uuid.uuid4()))'
         # Act
         with open(FILE_PATH, 'wb') as stream:
             download_blob_from_url(
@@ -1785,7 +1785,7 @@ class StorageCommonBlobTest(StorageTestCase):
         self._setup_remote(rmt.name, rmt_key)
         self._create_remote_container()
         source_blob = self._create_remote_block_blob(blob_data=data)
-        FILE_PATH = 'file_with_existing_file.temp.dat'
+        FILE_PATH = 'file_with_existing_file.temp.{}.dat.format(str(uuid.uuid4()))'
         # Act
         download_blob_from_url(
             source_blob.url, FILE_PATH,
@@ -1809,7 +1809,7 @@ class StorageCommonBlobTest(StorageTestCase):
         self._setup_remote(rmt.name, rmt_key)
         self._create_remote_container()
         source_blob = self._create_remote_block_blob(blob_data=data)
-        FILE_PATH = 'file_with_existing_file_overwrite.temp.dat'
+        FILE_PATH = 'file_with_existing_file_overwrite.temp.{}.dat.format(str(uuid.uuid4()))'
         # Act
         download_blob_from_url(
             source_blob.url, FILE_PATH,
@@ -1942,7 +1942,7 @@ class StorageCommonBlobTest(StorageTestCase):
     @GlobalStorageAccountPreparer()
     def test_upload_to_url_file_with_credential(self, resource_group, location, storage_account, storage_account_key):
         # SAS URL is calculated from storage key, so this test runs live only
-        FILE_PATH = 'upload_to_url_file_with_credential.temp.dat'
+        FILE_PATH = 'upload_to_url_file_with_credential.temp.{}.dat.format(str(uuid.uuid4()))'
         self._setup(storage_account.name, storage_account_key)
         data = b'12345678' * 1024 * 1024
         with open(FILE_PATH, 'wb') as stream:

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -13,6 +13,7 @@ import requests
 import time
 import unittest
 import os
+import uuid
 from datetime import datetime, timedelta
 
 from azure.core.exceptions import (
@@ -1803,7 +1804,7 @@ class StorageCommonBlobTestAsync(AsyncStorageTestCase):
             permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
-        FILE_PATH = '_to_file_with_sas.async.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = '_to_file_with_sas.async.{}.dat'.format(str(uuid.uuid4()))
         blob = BlobClient.from_blob_url(source_blob.url, credential=sas_token)
 
         # Act
@@ -1826,7 +1827,7 @@ class StorageCommonBlobTestAsync(AsyncStorageTestCase):
         await self._setup_remote(rmt.name, rmt_key)
         await self._create_remote_container()
         source_blob = await self._create_remote_block_blob(blob_data=data)
-        FILE_PATH = 'to_file_with_credential.async.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'to_file_with_credential.async.{}.dat'.format(str(uuid.uuid4()))
         # Act
         await download_blob_from_url(
             source_blob.url, FILE_PATH,
@@ -1850,7 +1851,7 @@ class StorageCommonBlobTestAsync(AsyncStorageTestCase):
         await self._setup_remote(rmt.name, rmt_key)
         await self._create_remote_container()
         source_blob = await self._create_remote_block_blob(blob_data=data)
-        FILE_PATH = 'to_stream_with_credential.async.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'to_stream_with_credential.async.{}.dat'.format(str(uuid.uuid4()))
         # Act
         with open(FILE_PATH, 'wb') as stream:
             await download_blob_from_url(
@@ -1875,7 +1876,7 @@ class StorageCommonBlobTestAsync(AsyncStorageTestCase):
         await self._setup_remote(rmt.name, rmt_key)
         await self._create_remote_container()
         source_blob = await self._create_remote_block_blob(blob_data=data)
-        FILE_PATH = 'with_existing_file.async.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'with_existing_file.async.{}.dat'.format(str(uuid.uuid4()))
         # Act
         await download_blob_from_url(
             source_blob.url, FILE_PATH,
@@ -1901,7 +1902,7 @@ class StorageCommonBlobTestAsync(AsyncStorageTestCase):
         await self._setup_remote(rmt.name, rmt_key)
         await self._create_remote_container()
         source_blob = await self._create_remote_block_blob(blob_data=data)
-        FILE_PATH = 'existing_file_overwrite.async.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'existing_file_overwrite.async.{}.dat'.format(str(uuid.uuid4()))
         # Act
         await download_blob_from_url(
             source_blob.url, FILE_PATH,
@@ -2048,7 +2049,7 @@ class StorageCommonBlobTestAsync(AsyncStorageTestCase):
         # Arrange
         await self._setup(storage_account.name, storage_account_key)
         data = b'12345678' * 1024 * 1024
-        FILE_PATH = 'url_file_with_credential.async.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'url_file_with_credential.async.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
         blob_name = self._get_blob_reference()

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -1803,7 +1803,7 @@ class StorageCommonBlobTestAsync(AsyncStorageTestCase):
             permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1),
         )
-        FILE_PATH = '_to_file_with_sas.async.dat'
+        FILE_PATH = '_to_file_with_sas.async.{}.dat.format(str(uuid.uuid4()))'
         blob = BlobClient.from_blob_url(source_blob.url, credential=sas_token)
 
         # Act
@@ -1826,7 +1826,7 @@ class StorageCommonBlobTestAsync(AsyncStorageTestCase):
         await self._setup_remote(rmt.name, rmt_key)
         await self._create_remote_container()
         source_blob = await self._create_remote_block_blob(blob_data=data)
-        FILE_PATH = 'to_file_with_credential.async.dat'
+        FILE_PATH = 'to_file_with_credential.async.{}.dat.format(str(uuid.uuid4()))'
         # Act
         await download_blob_from_url(
             source_blob.url, FILE_PATH,
@@ -1850,7 +1850,7 @@ class StorageCommonBlobTestAsync(AsyncStorageTestCase):
         await self._setup_remote(rmt.name, rmt_key)
         await self._create_remote_container()
         source_blob = await self._create_remote_block_blob(blob_data=data)
-        FILE_PATH = 'to_stream_with_credential.async.dat'
+        FILE_PATH = 'to_stream_with_credential.async.{}.dat.format(str(uuid.uuid4()))'
         # Act
         with open(FILE_PATH, 'wb') as stream:
             await download_blob_from_url(
@@ -1875,7 +1875,7 @@ class StorageCommonBlobTestAsync(AsyncStorageTestCase):
         await self._setup_remote(rmt.name, rmt_key)
         await self._create_remote_container()
         source_blob = await self._create_remote_block_blob(blob_data=data)
-        FILE_PATH = 'with_existing_file.async.dat'
+        FILE_PATH = 'with_existing_file.async.{}.dat.format(str(uuid.uuid4()))'
         # Act
         await download_blob_from_url(
             source_blob.url, FILE_PATH,
@@ -1901,7 +1901,7 @@ class StorageCommonBlobTestAsync(AsyncStorageTestCase):
         await self._setup_remote(rmt.name, rmt_key)
         await self._create_remote_container()
         source_blob = await self._create_remote_block_blob(blob_data=data)
-        FILE_PATH = 'existing_file_overwrite.async.dat'
+        FILE_PATH = 'existing_file_overwrite.async.{}.dat.format(str(uuid.uuid4()))'
         # Act
         await download_blob_from_url(
             source_blob.url, FILE_PATH,
@@ -2048,7 +2048,7 @@ class StorageCommonBlobTestAsync(AsyncStorageTestCase):
         # Arrange
         await self._setup(storage_account.name, storage_account_key)
         data = b'12345678' * 1024 * 1024
-        FILE_PATH = 'url_file_with_credential.async.dat'
+        FILE_PATH = 'url_file_with_credential.async.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
         blob_name = self._get_blob_reference()

--- a/sdk/storage/azure-storage-blob/tests/test_get_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_get_blob.py
@@ -296,7 +296,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'get_blob_to_streamm.temp.dat'
+        FILE_PATH = 'get_blob_to_streamm.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(max_concurrency=2)
             read_bytes = downloader.readinto(stream)
@@ -323,7 +323,7 @@ class StorageGetBlobTest(StorageTestCase):
             progress.append((current, total))
 
         # Act
-        FILE_PATH = 'blob_to_stream_with_progress.temp.dat'
+        FILE_PATH = 'blob_to_stream_with_progress.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(raw_response_hook=callback, max_concurrency=2)
             read_bytes = downloader.readinto(stream)
@@ -351,7 +351,7 @@ class StorageGetBlobTest(StorageTestCase):
             progress.append((current, total))
 
         # Act
-        FILE_PATH = 'stream_non_parallel.temp.dat'
+        FILE_PATH = 'stream_non_parallel.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(raw_response_hook=callback, max_concurrency=1)
             read_bytes = downloader.readinto(stream)
@@ -385,7 +385,7 @@ class StorageGetBlobTest(StorageTestCase):
 
 
         # Act
-        FILE_PATH = 'blob_to_stream_small.temp.dat'
+        FILE_PATH = 'blob_to_stream_small.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(raw_response_hook=callback, max_concurrency=2)
             read_bytes = downloader.readinto(stream)
@@ -411,7 +411,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'get_blob_to_path.temp.dat'
+        FILE_PATH = 'get_blob_to_path.temp.{}.dat.format(str(uuid.uuid4()))'
         end_range = self.config.max_single_get_size
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=1, length=end_range - 1, max_concurrency=2)
@@ -441,7 +441,7 @@ class StorageGetBlobTest(StorageTestCase):
         # Act
         start_range = 3
         end_range = self.config.max_single_get_size + 1024
-        FILE_PATH = 'blob_to_path_with_progress.temp.dat'
+        FILE_PATH = 'blob_to_path_with_progress.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(
                 offset=start_range,
@@ -468,7 +468,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'blob_to_path_small.temp.dat'
+        FILE_PATH = 'blob_to_path_small.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=1, length=4, max_concurrency=2)
             read_bytes = downloader.readinto(stream)
@@ -486,7 +486,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'blob_to_path_non_parallel.temp.dat'
+        FILE_PATH = 'blob_to_path_non_parallel.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=1, length=3, max_concurrency=1)
             read_bytes = downloader.readinto(stream)
@@ -512,7 +512,7 @@ class StorageGetBlobTest(StorageTestCase):
 
         # Act
         end_range = 2 * self.config.max_single_get_size
-        FILE_PATH = 'path_invalid_range_parallel.temp.dat'
+        FILE_PATH = 'path_invalid_range_parallel.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=1, length=end_range, max_concurrency=2)
             read_bytes = downloader.readinto(stream)
@@ -538,7 +538,7 @@ class StorageGetBlobTest(StorageTestCase):
 
         # Act
         end_range = 2 * self.config.max_single_get_size
-        FILE_PATH = 'invalid_range_non_parallel.temp.dat'
+        FILE_PATH = 'invalid_range_non_parallel.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=1, length=end_range, max_concurrency=2)
             read_bytes = downloader.readinto(stream)
@@ -708,7 +708,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'get_blob_non_seekable.temp.dat'
+        FILE_PATH = 'get_blob_non_seekable.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             non_seekable_stream = StorageGetBlobTest.NonSeekableFile(stream)
             downloader = blob.download_blob(max_concurrency=1)
@@ -730,7 +730,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'get_blob_non_seekable.temp.dat'
+        FILE_PATH = 'get_blob_non_seekable.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             non_seekable_stream = StorageGetBlobTest.NonSeekableFile(stream)
 
@@ -755,7 +755,7 @@ class StorageGetBlobTest(StorageTestCase):
             progress.append((current, total))
 
         # Act
-        FILE_PATH = 'blob_to_stream_exact_get_size.temp.dat'
+        FILE_PATH = 'blob_to_stream_exact_get_size.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(raw_response_hook=callback, max_concurrency=2)
             properties = downloader.readinto(stream)
@@ -837,7 +837,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'stream_with_md5.temp.dat'
+        FILE_PATH = 'stream_with_md5.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(validate_content=True, max_concurrency=2)
             read_bytes = downloader.readinto(stream)
@@ -875,7 +875,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob.set_http_headers(props.content_settings)
 
         # Act
-        FILE_PATH = 'blob_range_to_stream_with_overall_md5.temp.dat'
+        FILE_PATH = 'blob_range_to_stream_with_overall_md5.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=0, length=1024, validate_content=True, max_concurrency=2)
             read_bytes = downloader.readinto(stream)

--- a/sdk/storage/azure-storage-blob/tests/test_get_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_get_blob.py
@@ -8,6 +8,7 @@
 import pytest
 import base64
 import unittest
+import uuid
 from os import path, remove, sys, urandom
 from azure.core.exceptions import HttpResponseError
 from devtools_testutils import ResourceGroupPreparer, StorageAccountPreparer
@@ -296,7 +297,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'get_blob_to_streamm.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'get_blob_to_streamm.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(max_concurrency=2)
             read_bytes = downloader.readinto(stream)
@@ -323,7 +324,7 @@ class StorageGetBlobTest(StorageTestCase):
             progress.append((current, total))
 
         # Act
-        FILE_PATH = 'blob_to_stream_with_progress.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_to_stream_with_progress.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(raw_response_hook=callback, max_concurrency=2)
             read_bytes = downloader.readinto(stream)
@@ -351,7 +352,7 @@ class StorageGetBlobTest(StorageTestCase):
             progress.append((current, total))
 
         # Act
-        FILE_PATH = 'stream_non_parallel.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'stream_non_parallel.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(raw_response_hook=callback, max_concurrency=1)
             read_bytes = downloader.readinto(stream)
@@ -385,7 +386,7 @@ class StorageGetBlobTest(StorageTestCase):
 
 
         # Act
-        FILE_PATH = 'blob_to_stream_small.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_to_stream_small.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(raw_response_hook=callback, max_concurrency=2)
             read_bytes = downloader.readinto(stream)
@@ -411,7 +412,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'get_blob_to_path.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'get_blob_to_path.temp.{}.dat'.format(str(uuid.uuid4()))
         end_range = self.config.max_single_get_size
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=1, length=end_range - 1, max_concurrency=2)
@@ -441,7 +442,7 @@ class StorageGetBlobTest(StorageTestCase):
         # Act
         start_range = 3
         end_range = self.config.max_single_get_size + 1024
-        FILE_PATH = 'blob_to_path_with_progress.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_to_path_with_progress.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(
                 offset=start_range,
@@ -468,7 +469,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'blob_to_path_small.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_to_path_small.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=1, length=4, max_concurrency=2)
             read_bytes = downloader.readinto(stream)
@@ -486,7 +487,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'blob_to_path_non_parallel.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_to_path_non_parallel.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=1, length=3, max_concurrency=1)
             read_bytes = downloader.readinto(stream)
@@ -512,7 +513,7 @@ class StorageGetBlobTest(StorageTestCase):
 
         # Act
         end_range = 2 * self.config.max_single_get_size
-        FILE_PATH = 'path_invalid_range_parallel.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'path_invalid_range_parallel.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=1, length=end_range, max_concurrency=2)
             read_bytes = downloader.readinto(stream)
@@ -538,7 +539,7 @@ class StorageGetBlobTest(StorageTestCase):
 
         # Act
         end_range = 2 * self.config.max_single_get_size
-        FILE_PATH = 'invalid_range_non_parallel.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'invalid_range_non_parallel.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=1, length=end_range, max_concurrency=2)
             read_bytes = downloader.readinto(stream)
@@ -708,7 +709,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'get_blob_non_seekable.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'get_blob_non_seekable.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             non_seekable_stream = StorageGetBlobTest.NonSeekableFile(stream)
             downloader = blob.download_blob(max_concurrency=1)
@@ -730,7 +731,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'get_blob_non_seekable.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'get_blob_non_seekable.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             non_seekable_stream = StorageGetBlobTest.NonSeekableFile(stream)
 
@@ -755,7 +756,7 @@ class StorageGetBlobTest(StorageTestCase):
             progress.append((current, total))
 
         # Act
-        FILE_PATH = 'blob_to_stream_exact_get_size.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_to_stream_exact_get_size.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(raw_response_hook=callback, max_concurrency=2)
             properties = downloader.readinto(stream)
@@ -837,7 +838,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'stream_with_md5.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'stream_with_md5.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(validate_content=True, max_concurrency=2)
             read_bytes = downloader.readinto(stream)
@@ -875,7 +876,7 @@ class StorageGetBlobTest(StorageTestCase):
         blob.set_http_headers(props.content_settings)
 
         # Act
-        FILE_PATH = 'blob_range_to_stream_with_overall_md5.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_range_to_stream_with_overall_md5.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = blob.download_blob(offset=0, length=1024, validate_content=True, max_concurrency=2)
             read_bytes = downloader.readinto(stream)

--- a/sdk/storage/azure-storage-blob/tests/test_get_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_get_blob_async.py
@@ -333,7 +333,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'get_blob_to_stream_async.temp.dat'
+        FILE_PATH = 'get_blob_to_stream_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(max_concurrency=2)
             read_bytes = await downloader.readinto(stream)
@@ -362,7 +362,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
             progress.append((current, total))
 
         # Act
-        FILE_PATH = 'blob_to_stream_with_progress_async.temp.dat'
+        FILE_PATH = 'blob_to_stream_with_progress_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(raw_response_hook=callback, max_concurrency=2)
             read_bytes = await downloader.readinto(stream)
@@ -392,7 +392,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
             progress.append((current, total))
 
         # Act
-        FILE_PATH = 'blob_to_stream_non_parallel_async.temp.dat'
+        FILE_PATH = 'blob_to_stream_non_parallel_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(raw_response_hook=callback, max_concurrency=1)
             read_bytes = await downloader.readinto(stream)
@@ -428,7 +428,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
 
 
         # Act
-        FILE_PATH = 'blob_to_stream_small_async.temp.dat'
+        FILE_PATH = 'blob_to_stream_small_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(raw_response_hook=callback, max_concurrency=2)
             read_bytes = await downloader.readinto(stream)
@@ -457,7 +457,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
 
         # Act
         end_range = self.config.max_single_get_size
-        FILE_PATH = 'ranged_get_blob_to_path_async.temp.dat'
+        FILE_PATH = 'ranged_get_blob_to_path_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=1, length=end_range-1, max_concurrency=2)
             read_bytes = await downloader.readinto(stream)
@@ -488,7 +488,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         # Act
         start_range = 3
         end_range = self.config.max_single_get_size + 1024
-        FILE_PATH = 'get_blob_to_path_with_progress_async.temp.dat'
+        FILE_PATH = 'get_blob_to_path_with_progress_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(
                 offset=start_range,
@@ -517,7 +517,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'get_blob_to_path_small_asyncc.temp.dat'
+        FILE_PATH = 'get_blob_to_path_small_asyncc.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=1, length=4, max_concurrency=2)
             read_bytes = await downloader.readinto(stream)
@@ -537,7 +537,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'granged_get_blob_to_path_non_parallel_async.temp.dat'
+        FILE_PATH = 'granged_get_blob_to_path_non_parallel_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=1, length=3, max_concurrency=1)
             read_bytes = await downloader.readinto(stream)
@@ -564,7 +564,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         await blob.upload_blob(blob_data)
 
         # Act
-        FILE_PATH = 'path_invalid_range_parallel_async.temp.dat'
+        FILE_PATH = 'path_invalid_range_parallel_async.temp.{}.dat.format(str(uuid.uuid4()))'
         end_range = 2 * self.config.max_single_get_size
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=1, length=end_range, max_concurrency=2)
@@ -593,7 +593,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
 
         # Act
         end_range = 2 * self.config.max_single_get_size
-        FILE_PATH = 'path_invalid_range_non_parallel_asy.temp.dat'
+        FILE_PATH = 'path_invalid_range_non_parallel_asy.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=1, length=end_range, max_concurrency=2)
             read_bytes = await downloader.readinto(stream)
@@ -776,7 +776,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'get_blob_non_seekable_async.temp.dat'
+        FILE_PATH = 'get_blob_non_seekable_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             non_seekable_stream = StorageGetBlobTestAsync.NonSeekableFile(stream)
             downloader = await blob.download_blob(max_concurrency=1)
@@ -800,7 +800,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'et_blob_non_seekable_parallel_asyn.temp.dat'
+        FILE_PATH = 'et_blob_non_seekable_parallel_asyn.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             non_seekable_stream = StorageGetBlobTestAsync.NonSeekableFile(stream)
 
@@ -827,7 +827,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
             progress.append((current, total))
 
         # Act
-        FILE_PATH = 'stream_exact_get_size_async.temp.dat'
+        FILE_PATH = 'stream_exact_get_size_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(raw_response_hook=callback, max_concurrency=2)
             properties = await downloader.readinto(stream)
@@ -915,7 +915,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'lob_to_stream_with_md5_asyncc.temp.dat'
+        FILE_PATH = 'lob_to_stream_with_md5_asyncc.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(validate_content=True, max_concurrency=2)
             read_bytes = await downloader.readinto(stream)
@@ -957,7 +957,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         await blob.set_http_headers(props.content_settings)
 
         # Act
-        FILE_PATH = 'range_to_stream_with_overall_md5_async.temp.dat'
+        FILE_PATH = 'range_to_stream_with_overall_md5_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=0, length=1024, validate_content=True, max_concurrency=2)
             read_bytes = await downloader.readinto(stream)

--- a/sdk/storage/azure-storage-blob/tests/test_get_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_get_blob_async.py
@@ -10,6 +10,7 @@ import base64
 from os import path, remove, sys, urandom
 import unittest
 import asyncio
+import uuid
 
 from azure.core.exceptions import HttpResponseError
 from azure.core.pipeline.transport import AioHttpTransport
@@ -333,7 +334,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'get_blob_to_stream_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'get_blob_to_stream_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(max_concurrency=2)
             read_bytes = await downloader.readinto(stream)
@@ -362,7 +363,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
             progress.append((current, total))
 
         # Act
-        FILE_PATH = 'blob_to_stream_with_progress_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_to_stream_with_progress_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(raw_response_hook=callback, max_concurrency=2)
             read_bytes = await downloader.readinto(stream)
@@ -392,7 +393,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
             progress.append((current, total))
 
         # Act
-        FILE_PATH = 'blob_to_stream_non_parallel_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_to_stream_non_parallel_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(raw_response_hook=callback, max_concurrency=1)
             read_bytes = await downloader.readinto(stream)
@@ -428,7 +429,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
 
 
         # Act
-        FILE_PATH = 'blob_to_stream_small_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_to_stream_small_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(raw_response_hook=callback, max_concurrency=2)
             read_bytes = await downloader.readinto(stream)
@@ -457,7 +458,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
 
         # Act
         end_range = self.config.max_single_get_size
-        FILE_PATH = 'ranged_get_blob_to_path_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'ranged_get_blob_to_path_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=1, length=end_range-1, max_concurrency=2)
             read_bytes = await downloader.readinto(stream)
@@ -488,7 +489,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         # Act
         start_range = 3
         end_range = self.config.max_single_get_size + 1024
-        FILE_PATH = 'get_blob_to_path_with_progress_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'get_blob_to_path_with_progress_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(
                 offset=start_range,
@@ -517,7 +518,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'get_blob_to_path_small_asyncc.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'get_blob_to_path_small_asyncc.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=1, length=4, max_concurrency=2)
             read_bytes = await downloader.readinto(stream)
@@ -537,7 +538,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'granged_get_blob_to_path_non_parallel_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'granged_get_blob_to_path_non_parallel_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=1, length=3, max_concurrency=1)
             read_bytes = await downloader.readinto(stream)
@@ -564,7 +565,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         await blob.upload_blob(blob_data)
 
         # Act
-        FILE_PATH = 'path_invalid_range_parallel_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'path_invalid_range_parallel_async.temp.{}.dat'.format(str(uuid.uuid4()))
         end_range = 2 * self.config.max_single_get_size
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=1, length=end_range, max_concurrency=2)
@@ -593,7 +594,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
 
         # Act
         end_range = 2 * self.config.max_single_get_size
-        FILE_PATH = 'path_invalid_range_non_parallel_asy.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'path_invalid_range_non_parallel_asy.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=1, length=end_range, max_concurrency=2)
             read_bytes = await downloader.readinto(stream)
@@ -776,7 +777,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'get_blob_non_seekable_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'get_blob_non_seekable_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             non_seekable_stream = StorageGetBlobTestAsync.NonSeekableFile(stream)
             downloader = await blob.download_blob(max_concurrency=1)
@@ -800,7 +801,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'et_blob_non_seekable_parallel_asyn.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'et_blob_non_seekable_parallel_asyn.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             non_seekable_stream = StorageGetBlobTestAsync.NonSeekableFile(stream)
 
@@ -827,7 +828,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
             progress.append((current, total))
 
         # Act
-        FILE_PATH = 'stream_exact_get_size_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'stream_exact_get_size_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(raw_response_hook=callback, max_concurrency=2)
             properties = await downloader.readinto(stream)
@@ -915,7 +916,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         blob = self.bsc.get_blob_client(self.container_name, self.byte_blob)
 
         # Act
-        FILE_PATH = 'lob_to_stream_with_md5_asyncc.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'lob_to_stream_with_md5_asyncc.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(validate_content=True, max_concurrency=2)
             read_bytes = await downloader.readinto(stream)
@@ -957,7 +958,7 @@ class StorageGetBlobTestAsync(AsyncStorageTestCase):
         await blob.set_http_headers(props.content_settings)
 
         # Act
-        FILE_PATH = 'range_to_stream_with_overall_md5_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'range_to_stream_with_overall_md5_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             downloader = await blob.download_blob(offset=0, length=1024, validate_content=True, max_concurrency=2)
             read_bytes = await downloader.readinto(stream)

--- a/sdk/storage/azure-storage-blob/tests/test_large_block_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_large_block_blob.py
@@ -11,6 +11,7 @@ import pytest
 from os import path, remove, sys, urandom
 import platform
 import unittest
+import uuid
 from devtools_testutils import ResourceGroupPreparer, StorageAccountPreparer
 from azure.storage.blob import (
     BlobServiceClient,
@@ -151,7 +152,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'large_blob_from_path.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'large_blob_from_path.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -242,7 +243,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'blob_from_path_with_properties.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_from_path_with_properties.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -269,7 +270,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'blob_from_stream_chunked_upload.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_from_stream_chunked_upload.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -290,7 +291,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'stream_w_progress_chnkd_upload.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'stream_w_progress_chnkd_upload.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -318,7 +319,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'chunked_upload_with_count.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'chunked_upload_with_count.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -340,7 +341,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'plod_w_count_n_props.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'plod_w_count_n_props.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -369,7 +370,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'creat_lrg_blob.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'creat_lrg_blob.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 

--- a/sdk/storage/azure-storage-blob/tests/test_large_block_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_large_block_blob.py
@@ -151,7 +151,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'large_blob_from_path.temp.dat'
+        FILE_PATH = 'large_blob_from_path.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -242,7 +242,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'blob_from_path_with_properties.temp.dat'
+        FILE_PATH = 'blob_from_path_with_properties.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -269,7 +269,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'blob_from_stream_chunked_upload.temp.dat'
+        FILE_PATH = 'blob_from_stream_chunked_upload.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -290,7 +290,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'stream_w_progress_chnkd_upload.temp.dat'
+        FILE_PATH = 'stream_w_progress_chnkd_upload.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -318,7 +318,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'chunked_upload_with_count.temp.dat'
+        FILE_PATH = 'chunked_upload_with_count.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -340,7 +340,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'plod_w_count_n_props.temp.dat'
+        FILE_PATH = 'plod_w_count_n_props.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -369,7 +369,7 @@ class StorageLargeBlockBlobTest(StorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'creat_lrg_blob.temp.dat'
+        FILE_PATH = 'creat_lrg_blob.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 

--- a/sdk/storage/azure-storage-blob/tests/test_large_block_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_large_block_blob_async.py
@@ -11,6 +11,7 @@ import asyncio
 
 from os import path, remove, sys, urandom
 import unittest
+import uuid
 
 from azure.core.pipeline.transport import AioHttpTransport
 from multidict import CIMultiDict, CIMultiDictProxy
@@ -182,7 +183,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'create_large_blob_from_path_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'create_large_blob_from_path_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -207,7 +208,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'reate_large_blob_from_path_with_md5_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'reate_large_blob_from_path_with_md5_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -231,7 +232,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(self.get_random_bytes(100))
-        FILE_PATH = 'large_blob_from_path_non_parallel_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'large_blob_from_path_non_parallel_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -255,7 +256,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         await self._setup(storage_account.name, storage_account_key)
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
-        FILE_PATH = 'large_blob_from_path_with_progress_asyn.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'large_blob_from_path_with_progress_asyn.temp.{}.dat'.format(str(uuid.uuid4()))
         data = bytearray(urandom(LARGE_BLOB_SIZE))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
@@ -289,7 +290,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'large_blob_from_path_with_properties_asy.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'large_blob_from_path_with_properties_asy.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -320,7 +321,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'frm_stream_chnkd_upload_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'frm_stream_chnkd_upload_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -345,7 +346,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'frm_strm_w_prgrss_chnkduplod_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'frm_strm_w_prgrss_chnkduplod_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -378,7 +379,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = '_lrgblob_frm_strm_chnkd_uplod_w_cnt_.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = '_lrgblob_frm_strm_chnkd_uplod_w_cnt_.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -404,7 +405,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'frm_stream_chnk_upload_w_cntnprops_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'frm_stream_chnk_upload_w_cntnprops_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -437,7 +438,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'from_stream_chunk_upld_with_props_async.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'from_stream_chunk_upld_with_props_async.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 

--- a/sdk/storage/azure-storage-blob/tests/test_large_block_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_large_block_blob_async.py
@@ -182,7 +182,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'create_large_blob_from_path_async.temp.dat'
+        FILE_PATH = 'create_large_blob_from_path_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -207,7 +207,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'reate_large_blob_from_path_with_md5_async.temp.dat'
+        FILE_PATH = 'reate_large_blob_from_path_with_md5_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -231,7 +231,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(self.get_random_bytes(100))
-        FILE_PATH = 'large_blob_from_path_non_parallel_async.temp.dat'
+        FILE_PATH = 'large_blob_from_path_non_parallel_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -255,7 +255,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         await self._setup(storage_account.name, storage_account_key)
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
-        FILE_PATH = 'large_blob_from_path_with_progress_asyn.temp.dat'
+        FILE_PATH = 'large_blob_from_path_with_progress_asyn.temp.{}.dat.format(str(uuid.uuid4()))'
         data = bytearray(urandom(LARGE_BLOB_SIZE))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
@@ -289,7 +289,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'large_blob_from_path_with_properties_asy.temp.dat'
+        FILE_PATH = 'large_blob_from_path_with_properties_asy.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -320,7 +320,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'frm_stream_chnkd_upload_async.temp.dat'
+        FILE_PATH = 'frm_stream_chnkd_upload_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -345,7 +345,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'frm_strm_w_prgrss_chnkduplod_async.temp.dat'
+        FILE_PATH = 'frm_strm_w_prgrss_chnkduplod_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -378,7 +378,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = '_lrgblob_frm_strm_chnkd_uplod_w_cnt_.temp.dat'
+        FILE_PATH = '_lrgblob_frm_strm_chnkd_uplod_w_cnt_.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -404,7 +404,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'frm_stream_chnk_upload_w_cntnprops_async.temp.dat'
+        FILE_PATH = 'frm_stream_chnk_upload_w_cntnprops_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -437,7 +437,7 @@ class StorageLargeBlockBlobTestAsync(AsyncStorageTestCase):
         blob_name = self._get_blob_reference()
         blob = self.bsc.get_blob_client(self.container_name, blob_name)
         data = bytearray(urandom(LARGE_BLOB_SIZE))
-        FILE_PATH = 'from_stream_chunk_upld_with_props_async.temp.dat'
+        FILE_PATH = 'from_stream_chunk_upld_with_props_async.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob.py
@@ -1210,7 +1210,7 @@ class StoragePageBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_path.temp.dat'
+        FILE_PATH = 'create_blob_from_path.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1234,7 +1234,7 @@ class StoragePageBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_path_with_progress.temp.dat'
+        FILE_PATH = 'create_blob_from_path_with_progress.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1263,7 +1263,7 @@ class StoragePageBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'st_create_blob_from_stream.temp.dat'
+        FILE_PATH = 'st_create_blob_from_stream.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1291,7 +1291,7 @@ class StoragePageBlobTest(StorageTestCase):
         data = bytearray(LARGE_BLOB_SIZE)
         data[512: 1024] = self.get_random_bytes(512)
         data[8192: 8196] = self.get_random_bytes(4)
-        FILE_PATH = 'create_blob_from_stream_with_empty_pages.temp.dat'
+        FILE_PATH = 'create_blob_from_stream_with_empty_pages.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1323,7 +1323,7 @@ class StoragePageBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_stream_non_seekable.temp.dat'
+        FILE_PATH = 'create_blob_from_stream_non_seekable.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1350,7 +1350,7 @@ class StoragePageBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_stream_with_proge.temp.dat'
+        FILE_PATH = 'create_blob_from_stream_with_proge.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1381,7 +1381,7 @@ class StoragePageBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_stream_trun.temp.dat'
+        FILE_PATH = 'create_blob_from_stream_trun.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1403,7 +1403,7 @@ class StoragePageBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = '_blob_from_stream_with_progress_trunca.temp.dat'
+        FILE_PATH = '_blob_from_stream_with_progress_trunca.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1536,7 +1536,7 @@ class StoragePageBlobTest(StorageTestCase):
             # test create_blob_from_path API
             blob3 = self._get_blob_reference(bsc)
             pblob3 = pbs.get_blob_client(container_name, blob3.blob_name)
-            FILE_PATH = '_blob_tier_on_create.temp.dat'
+            FILE_PATH = '_blob_tier_on_create.temp.{}.dat.format(str(uuid.uuid4()))'
             with open(FILE_PATH, 'wb') as stream:
                 stream.write(byte_data)
             with open(FILE_PATH, 'rb') as stream:

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob.py
@@ -10,6 +10,7 @@ import pytest
 import pytest
 import os
 import unittest
+import uuid
 from datetime import datetime, timedelta
 from azure.core import MatchConditions
 from azure.core.exceptions import HttpResponseError, ResourceExistsError, ResourceModifiedError
@@ -1210,7 +1211,7 @@ class StoragePageBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_path.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'create_blob_from_path.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1234,7 +1235,7 @@ class StoragePageBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_path_with_progress.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'create_blob_from_path_with_progress.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1263,7 +1264,7 @@ class StoragePageBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'st_create_blob_from_stream.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'st_create_blob_from_stream.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1291,7 +1292,7 @@ class StoragePageBlobTest(StorageTestCase):
         data = bytearray(LARGE_BLOB_SIZE)
         data[512: 1024] = self.get_random_bytes(512)
         data[8192: 8196] = self.get_random_bytes(4)
-        FILE_PATH = 'create_blob_from_stream_with_empty_pages.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'create_blob_from_stream_with_empty_pages.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1323,7 +1324,7 @@ class StoragePageBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_stream_non_seekable.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'create_blob_from_stream_non_seekable.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1350,7 +1351,7 @@ class StoragePageBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_stream_with_proge.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'create_blob_from_stream_with_proge.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1381,7 +1382,7 @@ class StoragePageBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_stream_trun.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'create_blob_from_stream_trun.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1403,7 +1404,7 @@ class StoragePageBlobTest(StorageTestCase):
         self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = '_blob_from_stream_with_progress_trunca.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = '_blob_from_stream_with_progress_trunca.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1536,7 +1537,7 @@ class StoragePageBlobTest(StorageTestCase):
             # test create_blob_from_path API
             blob3 = self._get_blob_reference(bsc)
             pblob3 = pbs.get_blob_client(container_name, blob3.blob_name)
-            FILE_PATH = '_blob_tier_on_create.temp.{}.dat.format(str(uuid.uuid4()))'
+            FILE_PATH = '_blob_tier_on_create.temp.{}.dat'.format(str(uuid.uuid4()))
             with open(FILE_PATH, 'wb') as stream:
                 stream.write(byte_data)
             with open(FILE_PATH, 'rb') as stream:

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
@@ -1256,7 +1256,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_p.temp.dat'
+        FILE_PATH = 'create_blob_from_p.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1281,7 +1281,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_path_with_p.temp.dat'
+        FILE_PATH = 'create_blob_from_path_with_p.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1311,7 +1311,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = '_create_blob_from_s.temp.dat'
+        FILE_PATH = '_create_blob_from_s.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1340,7 +1340,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
         data = bytearray(LARGE_BLOB_SIZE)
         data[512: 1024] = self.get_random_bytes(512)
         data[8192: 8196] = self.get_random_bytes(4)
-        FILE_PATH = '_with_empty_pages.temp.dat'
+        FILE_PATH = '_with_empty_pages.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1374,7 +1374,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'blob_from_stream_non_see.temp.dat'
+        FILE_PATH = 'blob_from_stream_non_see.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1402,7 +1402,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'rom_stream_with_progress.temp.dat'
+        FILE_PATH = 'rom_stream_with_progress.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1434,7 +1434,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = '_create_blob_from_stream_trunc.temp.dat'
+        FILE_PATH = '_create_blob_from_stream_trunc.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1457,7 +1457,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'from_stream_with_progress_truncated.temp.dat'
+        FILE_PATH = 'from_stream_with_progress_truncated.temp.{}.dat.format(str(uuid.uuid4()))'
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1598,7 +1598,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
             # test create_blob_from_path API
             blob3 = self._get_blob_reference(bsc)
             pblob3 = pbs.get_blob_client(container_name, blob3.blob_name)
-            FILE_PATH = 'test_blob_tier_on_creat.temp.dat'
+            FILE_PATH = 'test_blob_tier_on_creat.temp.{}.dat.format(str(uuid.uuid4()))'
             with open(FILE_PATH, 'wb') as stream:
                 stream.write(byte_data)
             with open(FILE_PATH, 'rb') as stream:

--- a/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_page_blob_async.py
@@ -10,6 +10,7 @@ import pytest
 import asyncio
 import os
 import unittest
+import uuid
 from datetime import datetime, timedelta
 
 from azure.core import MatchConditions
@@ -1256,7 +1257,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_p.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'create_blob_from_p.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1281,7 +1282,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'create_blob_from_path_with_p.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'create_blob_from_path_with_p.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1311,7 +1312,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = '_create_blob_from_s.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = '_create_blob_from_s.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1340,7 +1341,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
         data = bytearray(LARGE_BLOB_SIZE)
         data[512: 1024] = self.get_random_bytes(512)
         data[8192: 8196] = self.get_random_bytes(4)
-        FILE_PATH = '_with_empty_pages.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = '_with_empty_pages.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1374,7 +1375,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'blob_from_stream_non_see.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'blob_from_stream_non_see.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1402,7 +1403,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'rom_stream_with_progress.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'rom_stream_with_progress.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1434,7 +1435,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = '_create_blob_from_stream_trunc.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = '_create_blob_from_stream_trunc.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1457,7 +1458,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
         await self._setup(bsc)
         blob = self._get_blob_reference(bsc)
         data = self.get_random_bytes(LARGE_BLOB_SIZE)
-        FILE_PATH = 'from_stream_with_progress_truncated.temp.{}.dat.format(str(uuid.uuid4()))'
+        FILE_PATH = 'from_stream_with_progress_truncated.temp.{}.dat'.format(str(uuid.uuid4()))
         with open(FILE_PATH, 'wb') as stream:
             stream.write(data)
 
@@ -1598,7 +1599,7 @@ class StoragePageBlobTestAsync(AsyncStorageTestCase):
             # test create_blob_from_path API
             blob3 = self._get_blob_reference(bsc)
             pblob3 = pbs.get_blob_client(container_name, blob3.blob_name)
-            FILE_PATH = 'test_blob_tier_on_creat.temp.{}.dat.format(str(uuid.uuid4()))'
+            FILE_PATH = 'test_blob_tier_on_creat.temp.{}.dat'.format(str(uuid.uuid4()))
             with open(FILE_PATH, 'wb') as stream:
                 stream.write(byte_data)
             with open(FILE_PATH, 'rb') as stream:


### PR DESCRIPTION
@rakshith91 This is the PR for the changes I was talking to you about this afternoon. Can you take a look?

If both `whl` and `sdist` environments are running tests, there is a possibility that one will finish before the other and clean up the local files that will be used to test upload. 

This PR avoids that.