### PR TITLE
Remove Dependency on pypi azure-devtools from azure-sdk-tools

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -9,6 +9,8 @@ deps =
   pytest-xdist
   pytest-asyncio; python_version >= '3.5'
   coverage
+  ../../../tools/azure-devtools
+  ../../../tools/azure-sdk-tools
 
 
 [coverage:paths]
@@ -22,12 +24,6 @@ deps =
   -rdev_requirements.txt
   {[tools]deps}
 
-
-[devtools]
-deps =
-  ../../../tools/azure-devtools
-  ../../../tools/azure-sdk-tools
-  {[tools]deps}
 
 [testenv]
 default_pytest_params = --junitxml={toxinidir}/test-junit-{envname}.xml --verbose --durations=10 --ignore=azure
@@ -162,7 +158,7 @@ commands =
 [testenv:devtest]
 pre-deps =
   wheel
-deps = {[devtools]deps}
+deps = {[tools]deps}
 changedir = {toxinidir}
 commands = 
     {envbindir}/python {toxinidir}/../../../eng/tox/create_wheel_and_install.py \

--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -258,7 +258,7 @@ def prep_and_run_tox(targeted_packages, parsed_args, options_array=[]):
         if not os.path.exists(destination_dev_req):
             logging.info("No dev_requirements present.")
             with open(destination_dev_req, "w+") as file:
-                file.write("-e ../../../tools/azure-sdk-tools")
+                file.write("\n")
 
         if parsed_args.tox_env:
             tox_execution_array.extend(["-e", parsed_args.tox_env])

--- a/tools/azure-sdk-tools/setup.py
+++ b/tools/azure-sdk-tools/setup.py
@@ -11,7 +11,6 @@ DEPENDENCIES = [
     'Jinja2',
     'pytoml',
     'json-delta>=2.0',
-    'azure-devtools[ci_tools]>=1.1.0',
     # Tests
     'pytest-cov',
     'pytest>=3.5.1',


### PR DESCRIPTION
Timeline for issue with azure-keyvault.

1. Packages run in alphabetical order
2. this makes `azure-keyvault` run _first_ in the `keyvault` service folder
3. a package with no dev_requirements will take a dependency on `azure-sdk-tools`. 
4. `azure-sdk-tools` took a dependency on `azure-devtools[ci_tools]`
5. Since `azure-keyvault` would install `azure-sdk-tools` as a dev dependency, and `azure-devtools` isn't explicitly noted anywhere else, we're getting the `pypi` version.

Simplest fix here is to take Laurent's suggestion and remove the `azure-sdk-tools` -> `azure-devtools` dep, then explicitly keep the correct order in the tox `tools` setting.
