### PR TITLE
Add user-agent to credential pipelines

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -14,14 +14,16 @@ from azure.core.exceptions import ClientAuthenticationError
 from azure.core.pipeline import Pipeline
 from azure.core.pipeline.policies import (
     ContentDecodePolicy,
+    DistributedTracingPolicy,
     HttpLoggingPolicy,
     NetworkTraceLoggingPolicy,
     ProxyPolicy,
     RetryPolicy,
-    DistributedTracingPolicy,
+    UserAgentPolicy,
 )
 from azure.core.pipeline.transport import RequestsTransport, HttpRequest
 from ._constants import AZURE_CLI_CLIENT_ID, KnownAuthorities
+from ._internal.user_agent import USER_AGENT
 
 try:
     ABC = abc.ABC
@@ -177,6 +179,7 @@ class AuthnClient(AuthnClientBase):
         config = config or self._create_config(**kwargs)
         policies = policies or [
             ContentDecodePolicy(),
+            config.user_agent_policy,
             config.proxy_policy,
             config.retry_policy,
             config.logging_policy,
@@ -211,4 +214,5 @@ class AuthnClient(AuthnClientBase):
         config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
         config.retry_policy = RetryPolicy(**kwargs)
         config.proxy_policy = ProxyPolicy(**kwargs)
+        config.user_agent_policy = UserAgentPolicy(base_user_agent=USER_AGENT, **kwargs)
         return config

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -14,10 +14,12 @@ from azure.core.pipeline.policies import (
     HttpLoggingPolicy,
     NetworkTraceLoggingPolicy,
     RetryPolicy,
+    UserAgentPolicy,
 )
 
 from .._authn_client import AuthnClient
 from .._constants import Endpoints, EnvironmentVariables
+from .._internal.user_agent import USER_AGENT
 
 try:
     from typing import TYPE_CHECKING
@@ -72,6 +74,7 @@ class _ManagedIdentityBase(object):
         policies = [
             ContentDecodePolicy(),
             config.headers_policy,
+            config.user_agent_policy,
             config.retry_policy,
             config.logging_policy,
             DistributedTracingPolicy(**kwargs),
@@ -96,6 +99,7 @@ class _ManagedIdentityBase(object):
         # Metadata header is required by IMDS and in Cloud Shell; App Service ignores it
         config.headers_policy = HeadersPolicy(base_headers={"Metadata": "true"}, **kwargs)
         config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
+        config.user_agent_policy = UserAgentPolicy(base_user_agent=USER_AGENT, **kwargs)
 
         return config
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
@@ -16,8 +16,11 @@ from azure.core.pipeline.policies import (
     NetworkTraceLoggingPolicy,
     ProxyPolicy,
     RetryPolicy,
+    UserAgentPolicy,
 )
 from azure.core.pipeline.transport import HttpRequest, RequestsTransport
+
+from .user_agent import USER_AGENT
 
 try:
     from unittest import mock
@@ -80,12 +83,14 @@ class MsalTransportAdapter(object):
         config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
         config.retry_policy = RetryPolicy(**kwargs)
         config.proxy_policy = ProxyPolicy(**kwargs)
+        config.user_agent_policy = UserAgentPolicy(base_user_agent=USER_AGENT, **kwargs)
         return config
 
     def _build_pipeline(self, config=None, policies=None, transport=None, **kwargs):
         config = config or self._create_config(**kwargs)
         policies = policies or [
             ContentDecodePolicy(),
+            config.user_agent_policy,
             config.proxy_policy,
             config.retry_policy,
             config.logging_policy,

--- a/sdk/identity/azure-identity/azure/identity/_internal/user_agent.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/user_agent.py
@@ -1,0 +1,9 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import platform
+
+from .._version import VERSION
+
+USER_AGENT = "azsdk-python-identity/{} Python/{} ({})".format(VERSION, platform.python_version(), platform.platform())

--- a/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
@@ -15,10 +15,12 @@ from azure.core.pipeline.policies import (
     HttpLoggingPolicy,
     NetworkTraceLoggingPolicy,
     ProxyPolicy,
+    UserAgentPolicy,
 )
 from azure.core.pipeline.transport import AioHttpTransport
 
 from .._authn_client import AuthnClientBase
+from .._internal.user_agent import USER_AGENT
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Iterable, Mapping, Optional
@@ -40,6 +42,7 @@ class AsyncAuthnClient(AuthnClientBase):  # pylint:disable=async-client-bad-name
         config = config or self._create_config(**kwargs)
         policies = policies or [
             ContentDecodePolicy(),
+            config.user_agent_policy,
             config.proxy_policy,
             config.retry_policy,
             config.logging_policy,
@@ -72,4 +75,5 @@ class AsyncAuthnClient(AuthnClientBase):  # pylint:disable=async-client-bad-name
         config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
         config.retry_policy = AsyncRetryPolicy(**kwargs)
         config.proxy_policy = ProxyPolicy(**kwargs)
+        config.user_agent_policy = UserAgentPolicy(base_user_agent=USER_AGENT, **kwargs)
         return config

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/msal_transport_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/msal_transport_adapter.py
@@ -16,10 +16,12 @@ from azure.core.pipeline.policies import (
     HttpLoggingPolicy,
     NetworkTraceLoggingPolicy,
     ProxyPolicy,
+    UserAgentPolicy,
 )
 from azure.core.pipeline.transport import AioHttpTransport, HttpRequest
 
-from azure.identity._internal import MsalTransportResponse
+from ..._internal import MsalTransportResponse
+from ..._internal.user_agent import USER_AGENT
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import
@@ -41,6 +43,7 @@ class MsalTransportAdapter:
 
         config = config or self._create_config(**kwargs)
         policies = policies or [
+            config.user_agent_policy,
             config.proxy_policy,
             config.retry_policy,
             config.logging_policy,
@@ -118,4 +121,5 @@ class MsalTransportAdapter:
         config.proxy_policy = ProxyPolicy(**kwargs)
         config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
         config.retry_policy = AsyncRetryPolicy(**kwargs)
+        config.user_agent_policy = UserAgentPolicy(base_user_agent=USER_AGENT, **kwargs)
         return config

--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -92,7 +92,10 @@ class Request:
         for param, expected_value in self.required_params.items():
             assert request.query.get(param) == expected_value
         for header, expected_value in self.required_headers.items():
-            assert request.headers.get(header) == expected_value
+            actual = request.headers.get(header)
+            assert actual == expected_value, "expected header '{}: {}', actual value was '{}'".format(
+                header, expected_value, actual
+            )
         for field, expected_value in self.required_data.items():
             assert request.body.get(field) == expected_value
 

--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -93,9 +93,13 @@ class Request:
             assert request.query.get(param) == expected_value
         for header, expected_value in self.required_headers.items():
             actual = request.headers.get(header)
-            assert actual == expected_value, "expected header '{}: {}', actual value was '{}'".format(
-                header, expected_value, actual
-            )
+            if header.lower() == "user-agent":
+                # UserAgentPolicy appends the value of $AZURE_HTTP_USER_AGENT, which is set in pipelines.
+                assert expected_value in actual
+            else:
+                assert actual == expected_value, "expected header '{}: {}', actual value was '{}'".format(
+                    header, expected_value, actual
+                )
         for field, expected_value in self.required_data.items():
             assert request.body.get(field) == expected_value
 

--- a/sdk/identity/azure-identity/tests/test_auth_code.py
+++ b/sdk/identity/azure-identity/tests/test_auth_code.py
@@ -5,8 +5,9 @@
 from azure.core.credentials import AccessToken
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.identity import AuthorizationCodeCredential
+from azure.identity._internal.user_agent import USER_AGENT
 
-from helpers import build_aad_response, mock_response
+from helpers import build_aad_response, mock_response, Request, validating_transport
 
 try:
     from unittest.mock import Mock
@@ -27,6 +28,19 @@ def test_policies_configurable():
     credential.get_token("scope")
 
     assert policy.on_request.called
+
+
+def test_user_agent():
+    transport = validating_transport(
+        requests=[Request(required_headers={"User-Agent": USER_AGENT})],
+        responses=[mock_response(json_payload=build_aad_response(access_token="**"))],
+    )
+
+    credential = AuthorizationCodeCredential(
+        "tenant-id", "client-id", "auth-code", "http://localhost", transport=transport
+    )
+
+    credential.get_token("scope")
 
 
 def test_auth_code_credential():

--- a/sdk/identity/azure-identity/tests/test_authn_client.py
+++ b/sdk/identity/azure-identity/tests/test_authn_client.py
@@ -15,7 +15,8 @@ except ImportError:  # python < 3.3
 from azure.core.credentials import AccessToken
 from azure.identity._authn_client import AuthnClient
 from six.moves.urllib_parse import urlparse
-from helpers import mock_response
+
+from helpers import mock_response, Request
 
 
 def test_authn_client_deserialization():

--- a/sdk/identity/azure-identity/tests/test_authn_client.py
+++ b/sdk/identity/azure-identity/tests/test_authn_client.py
@@ -15,8 +15,7 @@ except ImportError:  # python < 3.3
 from azure.core.credentials import AccessToken
 from azure.identity._authn_client import AuthnClient
 from six.moves.urllib_parse import urlparse
-
-from helpers import mock_response, Request
+from helpers import mock_response
 
 
 def test_authn_client_deserialization():

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential.py
@@ -7,6 +7,8 @@ import time
 from azure.core.credentials import AccessToken
 from azure.core.pipeline.policies import ContentDecodePolicy, SansIOHTTPPolicy
 from azure.identity import ClientSecretCredential
+from azure.identity._internal.user_agent import USER_AGENT
+
 from helpers import build_aad_response, mock_response, Request, validating_transport
 
 try:
@@ -28,6 +30,17 @@ def test_policies_configurable():
     credential.get_token("scope")
 
     assert policy.on_request.called
+
+
+def test_user_agent():
+    transport = validating_transport(
+        requests=[Request(required_headers={"User-Agent": USER_AGENT})],
+        responses=[mock_response(json_payload=build_aad_response(access_token="**"))],
+    )
+
+    credential = ClientSecretCredential("tenant-id", "client-id", "client-secret", transport=transport)
+
+    credential.get_token("scope")
 
 
 def test_client_secret_credential():

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential_async.py
@@ -8,7 +8,9 @@ from unittest.mock import Mock
 
 from azure.core.credentials import AccessToken
 from azure.core.pipeline.policies import ContentDecodePolicy, SansIOHTTPPolicy
+from azure.identity._internal.user_agent import USER_AGENT
 from azure.identity.aio import ClientSecretCredential
+
 from helpers import async_validating_transport, build_aad_response, mock_response, Request
 
 import pytest
@@ -28,6 +30,18 @@ async def test_policies_configurable():
     await credential.get_token("scope")
 
     assert policy.on_request.called
+
+
+@pytest.mark.asyncio
+async def test_user_agent():
+    transport = async_validating_transport(
+        requests=[Request(required_headers={"User-Agent": USER_AGENT})],
+        responses=[mock_response(json_payload=build_aad_response(access_token="**"))],
+    )
+
+    credential = ClientSecretCredential("tenant-id", "client-id", "client-secret", transport=transport)
+
+    await credential.get_token("scope")
 
 
 @pytest.mark.asyncio

--- a/sdk/identity/azure-identity/tests/test_managed_identity.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity.py
@@ -12,7 +12,7 @@ except ImportError:  # python < 3.3
 from azure.core.credentials import AccessToken
 from azure.identity import ManagedIdentityCredential
 from azure.identity._constants import Endpoints, EnvironmentVariables
-
+from azure.identity._internal.user_agent import USER_AGENT
 
 from helpers import validating_transport, mock_response, Request
 
@@ -27,7 +27,12 @@ def test_cloud_shell():
     scope = "scope"
     transport = validating_transport(
         requests=[
-            Request(url, method="POST", required_headers={"Metadata": "true"}, required_data={"resource": scope})
+            Request(
+                url,
+                method="POST",
+                required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
+                required_data={"resource": scope},
+            )
         ],
         responses=[
             mock_response(
@@ -62,7 +67,7 @@ def test_cloud_shell_user_assigned_identity():
             Request(
                 url,
                 method="POST",
-                required_headers={"Metadata": "true"},
+                required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
                 required_data={"client_id": client_id, "resource": scope},
             )
         ],
@@ -99,7 +104,7 @@ def test_app_service():
             Request(
                 url,
                 method="GET",
-                required_headers={"Metadata": "true", "secret": secret},
+                required_headers={"Metadata": "true", "secret": secret, "User-Agent": USER_AGENT},
                 required_params={"api-version": "2017-09-01", "resource": scope},
             )
         ],
@@ -135,7 +140,7 @@ def test_app_service_user_assigned_identity():
             Request(
                 url,
                 method="GET",
-                required_headers={"Metadata": "true", "secret": secret},
+                required_headers={"Metadata": "true", "secret": secret, "User-Agent": USER_AGENT},
                 required_params={"api-version": "2017-09-01", "clientid": client_id, "resource": scope},
             )
         ],
@@ -168,7 +173,7 @@ def test_imds():
             Request(
                 url,
                 method="GET",
-                required_headers={"Metadata": "true"},
+                required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
                 required_params={"api-version": "2018-02-01", "resource": scope},
             ),
         ],
@@ -206,7 +211,7 @@ def test_imds_user_assigned_identity():
             Request(
                 url,
                 method="GET",
-                required_headers={"Metadata": "true"},
+                required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
                 required_params={"api-version": "2018-02-01", "client_id": client_id, "resource": scope},
             ),
         ],

--- a/sdk/identity/azure-identity/tests/test_managed_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity_async.py
@@ -8,6 +8,8 @@ from unittest import mock
 from azure.core.credentials import AccessToken
 from azure.identity.aio import ManagedIdentityCredential
 from azure.identity._constants import Endpoints, EnvironmentVariables
+from azure.identity._internal.user_agent import USER_AGENT
+
 import pytest
 
 from helpers import async_validating_transport, mock_response, Request
@@ -24,7 +26,12 @@ async def test_cloud_shell():
     scope = "scope"
     transport = async_validating_transport(
         requests=[
-            Request(url, method="POST", required_headers={"Metadata": "true"}, required_data={"resource": scope})
+            Request(
+                url,
+                method="POST",
+                required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
+                required_data={"resource": scope},
+            )
         ],
         responses=[
             mock_response(
@@ -60,7 +67,7 @@ async def test_cloud_shell_user_assigned_identity():
             Request(
                 url,
                 method="POST",
-                required_headers={"Metadata": "true"},
+                required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
                 required_data={"client_id": client_id, "resource": scope},
             )
         ],
@@ -98,7 +105,7 @@ async def test_app_service():
             Request(
                 url,
                 method="GET",
-                required_headers={"Metadata": "true", "secret": secret},
+                required_headers={"Metadata": "true", "secret": secret, "User-Agent": USER_AGENT},
                 required_params={"api-version": "2017-09-01", "resource": scope},
             )
         ],
@@ -135,7 +142,7 @@ async def test_app_service_user_assigned_identity():
             Request(
                 url,
                 method="GET",
-                required_headers={"Metadata": "true", "secret": secret},
+                required_headers={"Metadata": "true", "secret": secret, "User-Agent": USER_AGENT},
                 required_params={"api-version": "2017-09-01", "clientid": client_id, "resource": scope},
             )
         ],
@@ -169,7 +176,7 @@ async def test_imds():
             Request(
                 url,
                 method="GET",
-                required_headers={"Metadata": "true"},
+                required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
                 required_params={"api-version": "2018-02-01", "resource": scope},
             ),
         ],
@@ -208,7 +215,7 @@ async def test_imds_user_assigned_identity():
             Request(
                 url,
                 method="GET",
-                required_headers={"Metadata": "true"},
+                required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
                 required_params={"api-version": "2018-02-01", "client_id": client_id, "resource": scope},
             ),
         ],

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
@@ -12,6 +12,7 @@ from azure.identity._internal.shared_token_cache import (
     NO_ACCOUNTS,
     NO_MATCHING_ACCOUNTS,
 )
+from azure.identity._internal.user_agent import USER_AGENT
 from msal import TokenCache
 import pytest
 
@@ -38,6 +39,19 @@ def test_policies_configurable():
     credential.get_token("scope")
 
     assert policy.on_request.called
+
+
+def test_user_agent():
+    transport = validating_transport(
+        requests=[Request(required_headers={"User-Agent": USER_AGENT})],
+        responses=[mock_response(json_payload=build_aad_response(access_token="**"))],
+    )
+
+    credential = SharedTokenCacheCredential(
+        _cache=populated_cache(get_account_event("test@user", "uid", "utid")), transport=transport
+    )
+
+    credential.get_token("scope")
 
 
 def test_empty_cache():

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
@@ -15,6 +15,7 @@ from azure.identity._internal.shared_token_cache import (
     NO_ACCOUNTS,
     NO_MATCHING_ACCOUNTS,
 )
+from azure.identity._internal.user_agent import USER_AGENT
 from msal import TokenCache
 import pytest
 
@@ -38,6 +39,20 @@ async def test_policies_configurable():
     await credential.get_token("scope")
 
     assert policy.on_request.called
+
+
+@pytest.mark.asyncio
+async def test_user_agent():
+    transport = async_validating_transport(
+        requests=[Request(required_headers={"User-Agent": USER_AGENT})],
+        responses=[mock_response(json_payload=build_aad_response(access_token="**"))],
+    )
+
+    credential = SharedTokenCacheCredential(
+        _cache=populated_cache(get_account_event("test@user", "uid", "utid")), transport=transport
+    )
+
+    await credential.get_token("scope")
 
 
 @pytest.mark.asyncio

--- a/sdk/identity/azure-identity/tests/test_username_password_credential.py
+++ b/sdk/identity/azure-identity/tests/test_username_password_credential.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 from azure.core.pipeline.policies import ContentDecodePolicy, SansIOHTTPPolicy
 from azure.identity import UsernamePasswordCredential
+from azure.identity._internal.user_agent import USER_AGENT
 from helpers import build_aad_response, get_discovery_response, mock_response, Request, validating_transport
 
 try:
@@ -24,6 +25,17 @@ def test_policies_configurable():
     credential.get_token("scope")
 
     assert policy.on_request.called
+
+
+def test_user_agent():
+    transport = validating_transport(
+        requests=[Request()] * 2 + [Request(required_headers={"User-Agent": USER_AGENT})],
+        responses=[get_discovery_response()] * 2 + [mock_response(json_payload=build_aad_response(access_token="**"))],
+    )
+
+    credential = UsernamePasswordCredential("client-id", "username", "password", transport=transport)
+
+    credential.get_token("scope")
 
 
 def test_username_password_credential():


### PR DESCRIPTION
Closes #9014 by ensuring credentials' requests include a user-agent, e.g. 'azsdk-python-identity/1.1.1 Python/3.7.2 (Windows-10-10.0.18362-SP0)'.