### PR TITLE
Storage operations within checkpoint manager did not utilize the blob_prefix.

### DIFF
--- a/sdk/eventhub/azure-eventhubs/HISTORY.rst
+++ b/sdk/eventhub/azure-eventhubs/HISTORY.rst
@@ -3,8 +3,20 @@
 Release History
 ===============
 
+1.3.4 (TBD)
+-----------
+
+**Features**
+
+- Add new parameter to AzureStorageCheckpointLeaseManager, use_consumer_group_as_directory, to control consumer_group pathing in concert with storage_blob_prefix.
+
+**BugFixes**
+
+- Ensures storage_blob_prefix within AzureStorageCheckpointLeaseManager is actually applied.
+
+
 1.3.3 (2019-12-4)
-------------------
+-----------------
 
 **Features**
 

--- a/sdk/eventhub/azure-eventhubs/azure/eventprocessorhost/azure_storage_checkpoint_manager.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventprocessorhost/azure_storage_checkpoint_manager.py
@@ -37,7 +37,10 @@ class AzureStorageCheckpointLeaseManager(AbstractCheckpointManager, AbstractLeas
      will be used.
     :param str lease_container_name: The name of the container that will be used to store
      leases. If it does not already exist it will be created. Default value is 'eph-leases'.
-    :param str storage_blob_prefix: A string to prefix the lease storage path, default empty.
+     Leases are named via internal partition_ids, locations can be modified via
+     storage_blob_prefix and use_consumer_group_as_directory.
+    :param str storage_blob_prefix: If populated, prepends a prefix when constructing
+     the location that leases are stored within the lease_container. Default None.
     :param int lease_renew_interval: The interval in seconds at which EPH will attempt to
      renew the lease of a particular partition. Default value is 10.
     :param int lease_duration: The duration in seconds of a lease on a partition.
@@ -50,8 +53,10 @@ class AzureStorageCheckpointLeaseManager(AbstractCheckpointManager, AbstractLeas
     :param str connection_string: If specified, this will override all other endpoint parameters.
      See http://azure.microsoft.com/en-us/documentation/articles/storage-configure-connection-string/
      for the connection string format.
-    :param bool use_consumer_group_as_directory: If true, uses the consumer group when constructing
-     the lease storage path, as such:  <consumer_group>/<partition_id>. Default False.
+    :param bool use_consumer_group_as_directory: If true, includes the consumer group as part of the
+     location we use to store leases within the container, as such:  <consumer_group>/<partition_id>, 
+     otherwise leases are simply named by their partition_id.  Default False.
+     If storage_blob_prefix is provided this prefix will be prepended in either case.
     """
 
     def __init__(self, storage_account_name=None, storage_account_key=None, lease_container_name="eph-leases",

--- a/sdk/eventhub/azure-eventhubs/azure/eventprocessorhost/azure_storage_checkpoint_manager.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventprocessorhost/azure_storage_checkpoint_manager.py
@@ -41,6 +41,7 @@ class AzureStorageCheckpointLeaseManager(AbstractCheckpointManager, AbstractLeas
      storage_blob_prefix and use_consumer_group_as_directory.
     :param str storage_blob_prefix: If populated, prepends a prefix when constructing
      the location that leases are stored within the lease_container. Default None.
+     If consumer_group_as_directory is also provided, it is unified as such <prefix><group>/<id>.
     :param int lease_renew_interval: The interval in seconds at which EPH will attempt to
      renew the lease of a particular partition. Default value is 10.
     :param int lease_duration: The duration in seconds of a lease on a partition.

--- a/sdk/eventhub/azure-eventhubs/conftest.py
+++ b/sdk/eventhub/azure-eventhubs/conftest.py
@@ -219,6 +219,25 @@ def connstr_senders(connection_str):
 
 
 @pytest.fixture()
+def storage_clm_with_prefix(eph):
+    try:
+        container = str(uuid.uuid4())
+        storage_clm = AzureStorageCheckpointLeaseManager(
+            os.environ['AZURE_STORAGE_ACCOUNT'],
+            os.environ['AZURE_STORAGE_ACCESS_KEY'],
+            container,
+            storage_blob_prefix="testprefix" + str(uuid.uuid4()))
+    except KeyError:
+        pytest.skip("Live Storage configuration not found.")
+    try:
+        storage_clm.initialize(eph)
+        storage_clm.storage_client.create_container(container)
+        yield storage_clm
+    finally:
+        storage_clm.storage_client.delete_container(container)
+
+
+@pytest.fixture()
 def storage_clm(eph):
     try:
         container = str(uuid.uuid4())

--- a/sdk/eventhub/azure-eventhubs/tests/asynctests/test_checkpoint_manager.py
+++ b/sdk/eventhub/azure-eventhubs/tests/asynctests/test_checkpoint_manager.py
@@ -74,6 +74,34 @@ def test_delete_lease(storage_clm):
 
 
 @pytest.mark.liveTest
+def test_lease_with_path_prefix(storage_clm_with_prefix):
+    """
+    Test creating a lease with a blob prefix
+    """
+    loop = asyncio.get_event_loop()
+    local_checkpoint = loop.run_until_complete(storage_clm_with_prefix.create_checkpoint_if_not_exists_async("1"))
+    assert local_checkpoint.partition_id == "1"
+    assert local_checkpoint.offset == "-1"
+    lease = loop.run_until_complete(storage_clm_with_prefix.get_lease_async("1"))
+    
+    path_parts = storage_clm_with_prefix._get_lease_blob_path("0").split('/')
+    assert "testprefix" in path_parts[0]
+    assert "$default" in path_parts[0]
+    assert len(path_parts) == 2
+    assert path_parts[-1] == "0"
+
+
+@pytest.mark.liveTest
+def test_lease_without_path_prefix(storage_clm):
+    """
+    Test creating a lease with a blob prefix
+    """
+    path_parts = storage_clm._get_lease_blob_path("0").split('/')
+    assert len(path_parts) == 1
+    assert path_parts[0] == "0"
+
+
+@pytest.mark.liveTest
 def test_checkpointing(storage_clm):
     """
     Test checkpointing

--- a/sdk/eventhub/azure-eventhubs/tests/asynctests/test_checkpoint_manager.py
+++ b/sdk/eventhub/azure-eventhubs/tests/asynctests/test_checkpoint_manager.py
@@ -86,6 +86,42 @@ def test_lease_with_path_prefix(storage_clm_with_prefix):
     
     path_parts = storage_clm_with_prefix._get_lease_blob_path("0").split('/')
     assert "testprefix" in path_parts[0]
+    assert "$default" not in path_parts[0]
+    assert len(path_parts) == 1
+    assert path_parts[-1][-1] == "0"
+
+
+@pytest.mark.liveTest
+def test_lease_with_path_prefix_and_consumer_dir(storage_clm_with_prefix_and_consumer_dir):
+    """
+    Test creating a lease with a blob prefix
+    """
+    loop = asyncio.get_event_loop()
+    local_checkpoint = loop.run_until_complete(storage_clm_with_prefix_and_consumer_dir.create_checkpoint_if_not_exists_async("1"))
+    assert local_checkpoint.partition_id == "1"
+    assert local_checkpoint.offset == "-1"
+    lease = loop.run_until_complete(storage_clm_with_prefix_and_consumer_dir.get_lease_async("1"))
+    
+    path_parts = storage_clm_with_prefix_and_consumer_dir._get_lease_blob_path("0").split('/')
+    assert "testprefix" in path_parts[0]
+    assert "$default" in path_parts[0]
+    assert len(path_parts) == 2
+    assert path_parts[-1] == "0"
+
+
+@pytest.mark.liveTest
+def test_lease_with_consumer_dir(storage_clm_with_consumer_dir):
+    """
+    Test creating a lease with a blob prefix
+    """
+    loop = asyncio.get_event_loop()
+    local_checkpoint = loop.run_until_complete(storage_clm_with_consumer_dir.create_checkpoint_if_not_exists_async("1"))
+    assert local_checkpoint.partition_id == "1"
+    assert local_checkpoint.offset == "-1"
+    lease = loop.run_until_complete(storage_clm_with_consumer_dir.get_lease_async("1"))
+    
+    path_parts = storage_clm_with_consumer_dir._get_lease_blob_path("0").split('/')
+    assert "testprefix" not in path_parts[0]
     assert "$default" in path_parts[0]
     assert len(path_parts) == 2
     assert path_parts[-1] == "0"


### PR DESCRIPTION
Adds functionality such that if the prefix is defined, it is used.  lease path previously would simply be <container>/<consumer> even if prefix was defined, will now be <container>/<prefix><consumer>/<partition>

Adds unit tests to validate this as well.

NOTES:
- This will need to be validated in Track2 as well.  This is a note to myself to ensure I've done so or created an issue to track this task, before I merge this. (Posted here in case someone can say "it's fine" that I can check this off)
- There are two nitpicks I'd call out as well.
1. The logic looks like it initially wanted the non-prefix case to render as <container>/<consumer group>/<partition>  However due to the bug in question, it's only <container>/<partition>.  For backwards compatibility, I have NOT changed this to include the consumer group, otherwise users who did not define the prefix would suddenly find their lease checkpoint paths "missing"
2. VERY pedantically, I've put the blob_path generation within the trys, but not pushed the full path to all of the error logs (many still only detail the partition).  Shout if others would prefer a different semantic.