### PR TITLE
remove idle timeouts from client, receiver (and async) + eph until underlying UAMQP issues are mitigated.

### DIFF
--- a/sdk/eventhub/azure-eventhubs/HISTORY.rst
+++ b/sdk/eventhub/azure-eventhubs/HISTORY.rst
@@ -9,7 +9,6 @@ Release History
 **Features**
 
 - Updated UAMQP version to 1.2.4
-- Added `idle_timeout` parameter to the `add_receiver` functions and `EPHOptions` for optionally closing idle connections.
 - Added `reconnect_timeout` and `max_reconnect_tries` parameters to `receive` functions for better control of connection behaviour during receive.
 - Added an option `release_partition_on_checkpoint_failure` to `EPHOptions` for `EventProcessorHost` to
   instruct the EventProcessorHost to fail fast on a checkpoint failure and proactively release the partition.

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/async_ops/__init__.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/async_ops/__init__.py
@@ -204,8 +204,7 @@ class EventHubClientAsync(EventHubClient):
 
     def add_async_receiver(
             self, consumer_group, partition, offset=None, prefetch=300,
-            operation=None, keep_alive=30, auto_reconnect=True, loop=None,
-            idle_timeout=None):
+            operation=None, keep_alive=30, auto_reconnect=True, loop=None):
         """
         Add an async receiver to the client for a particular consumer group and partition.
 
@@ -220,9 +219,6 @@ class EventHubClientAsync(EventHubClient):
         :param operation: An optional operation to be appended to the hostname in the source URL.
          The value must start with `/` character.
         :type operation: str
-        :param idle_timeout: An optional timeout in seconds after which the underlying connection
-         will close if there is no further activity.  Default is None.
-        :type idle_timeout: int
         :rtype: ~azure.eventhub.async_ops.receiver_async.ReceiverAsync
 
         Example:
@@ -239,15 +235,13 @@ class EventHubClientAsync(EventHubClient):
             self.address.hostname, path, consumer_group, partition)
         handler = AsyncReceiver(
             self, source_url, offset=offset, prefetch=prefetch,
-            keep_alive=keep_alive, auto_reconnect=auto_reconnect, loop=loop,
-            idle_timeout=idle_timeout)
+            keep_alive=keep_alive, auto_reconnect=auto_reconnect, loop=loop)
         self.clients.append(handler)
         return handler
 
     def add_async_epoch_receiver(
             self, consumer_group, partition, epoch, prefetch=300,
-            operation=None, keep_alive=30, auto_reconnect=True, loop=None,
-            idle_timeout=None):
+            operation=None, keep_alive=30, auto_reconnect=True, loop=None):
         """
         Add an async receiver to the client with an epoch value. Only a single epoch receiver
         can connect to a partition at any given time - additional epoch receivers must have
@@ -281,8 +275,7 @@ class EventHubClientAsync(EventHubClient):
             self.address.hostname, path, consumer_group, partition)
         handler = AsyncReceiver(
             self, source_url, prefetch=prefetch, epoch=epoch,
-            keep_alive=keep_alive, auto_reconnect=auto_reconnect, loop=loop,
-            idle_timeout=idle_timeout)
+            keep_alive=keep_alive, auto_reconnect=auto_reconnect, loop=loop)
         self.clients.append(handler)
         return handler
 

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/async_ops/receiver_async.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/async_ops/receiver_async.py
@@ -34,7 +34,7 @@ class AsyncReceiver(Receiver):
 
     def __init__(  # pylint: disable=super-init-not-called
             self, client, source, offset=None, prefetch=300, epoch=None,
-            keep_alive=None, auto_reconnect=True loop=None):
+            keep_alive=None, auto_reconnect=True, loop=None):
         """
         Instantiate an async receiver.
 

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/async_ops/receiver_async.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/async_ops/receiver_async.py
@@ -34,7 +34,7 @@ class AsyncReceiver(Receiver):
 
     def __init__(  # pylint: disable=super-init-not-called
             self, client, source, offset=None, prefetch=300, epoch=None,
-            keep_alive=None, auto_reconnect=True, idle_timeout=None, loop=None):
+            keep_alive=None, auto_reconnect=True loop=None):
         """
         Instantiate an async receiver.
 
@@ -48,9 +48,6 @@ class AsyncReceiver(Receiver):
         :param epoch: An optional epoch value.
         :type epoch: int
         :param loop: An event loop.
-        :param idle_timeout: An optionl timeout in seconds after which the underlying connection
-         will close if there is no further activity.  Default is None.
-        :type idle_timeout: int
         """
         self.loop = loop or asyncio.get_event_loop()
         self.running = False
@@ -66,7 +63,7 @@ class AsyncReceiver(Receiver):
         self.redirected = None
         self.error = None
         self.properties = None
-        self.idle_timeout = (idle_timeout * 1000) if idle_timeout else None
+        self.idle_timeout = None #TODO: Add this back in when UAMQP bug is fixed. (idle_timeout * 1000) if idle_timeout else None
         partition = self.source.split('/')[-1]
         self.name = "EHReceiver-{}-partition{}".format(uuid.uuid4(), partition)
         source = Source(self.source)
@@ -341,5 +338,5 @@ class AsyncReceiver(Receiver):
             raise TimeoutError("Timeout exceeded when reconnecting receiver")      
         if num_tries > max_reconnect_retries:
             log.warn("Max retries exceeded when reconnecting receiver")    
-            
+
         return data_batch

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/client.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/client.py
@@ -435,7 +435,7 @@ class EventHubClient(object):
 
     def add_receiver(
             self, consumer_group, partition, offset=None, prefetch=300,
-            operation=None, keep_alive=30, auto_reconnect=True, idle_timeout=None):
+            operation=None, keep_alive=30, auto_reconnect=True):
         """
         Add a receiver to the client for a particular consumer group and partition.
 
@@ -450,9 +450,6 @@ class EventHubClient(object):
         :param operation: An optional operation to be appended to the hostname in the source URL.
          The value must start with `/` character.
         :type operation: str
-        :param idle_timeout: An optional timeout in seconds after which the underlying connection
-         will close if there is no further activity.  Default is None.
-        :type idle_timeout: int
         :rtype: ~azure.eventhub.receiver.Receiver
 
         Example:
@@ -469,15 +466,13 @@ class EventHubClient(object):
             self.address.hostname, path, consumer_group, partition)
         handler = Receiver(
             self, source_url, offset=offset, prefetch=prefetch,
-            keep_alive=keep_alive, auto_reconnect=auto_reconnect,
-            idle_timeout=idle_timeout)
+            keep_alive=keep_alive, auto_reconnect=auto_reconnect)
         self.clients.append(handler)
         return handler
 
     def add_epoch_receiver(
             self, consumer_group, partition, epoch, prefetch=300,
-            operation=None, keep_alive=30, auto_reconnect=True,
-            idle_timeout=None):
+            operation=None, keep_alive=30, auto_reconnect=True):
         """
         Add a receiver to the client with an epoch value. Only a single epoch receiver
         can connect to a partition at any given time - additional epoch receivers must have
@@ -495,9 +490,6 @@ class EventHubClient(object):
         :operation: An optional operation to be appended to the hostname in the source URL.
          The value must start with `/` character.
         :type operation: str
-        :param idle_timeout: An optional timeout in seconds after which the underlying connection
-         will close if there is no further activity.  Default is None.
-        :type idle_timeout: int
         :rtype: ~azure.eventhub.receiver.Receiver
 
         Example:
@@ -514,8 +506,7 @@ class EventHubClient(object):
             self.address.hostname, path, consumer_group, partition)
         handler = Receiver(
             self, source_url, prefetch=prefetch, epoch=epoch,
-            keep_alive=keep_alive, auto_reconnect=auto_reconnect,
-            idle_timeout=idle_timeout)
+            keep_alive=keep_alive, auto_reconnect=auto_reconnect)
         self.clients.append(handler)
         return handler
 

--- a/sdk/eventhub/azure-eventhubs/azure/eventhub/receiver.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventhub/receiver.py
@@ -33,8 +33,7 @@ class Receiver(object):
     timeout = 0
     _epoch = b'com.microsoft:epoch'
 
-    def __init__(self, client, source, offset=None, prefetch=300, epoch=None, keep_alive=None, auto_reconnect=True,
-                 idle_timeout=None):
+    def __init__(self, client, source, offset=None, prefetch=300, epoch=None, keep_alive=None, auto_reconnect=True):
         """
         Instantiate a receiver.
 
@@ -47,9 +46,6 @@ class Receiver(object):
         :type prefetch: int
         :param epoch: An optional epoch value.
         :type epoch: int
-        :param idle_timeout: An optionl timeout in seconds after which the underlying connection
-         will close if there is no further activity.  Default is None.
-        :type idle_timeout: int
         """
         self.running = False
         self.client = client
@@ -64,7 +60,7 @@ class Receiver(object):
         self.properties = None
         self.redirected = None
         self.error = None
-        self.idle_timeout = (idle_timeout * 1000) if idle_timeout else None
+        self.idle_timeout = None #TODO: Add this back in when UAMQP bug is fixed. (idle_timeout * 1000) if idle_timeout else None
         partition = self.source.split('/')[-1]
         self.name = "EHReceiver-{}-partition{}".format(uuid.uuid4(), partition)
         source = Source(self.source)

--- a/sdk/eventhub/azure-eventhubs/azure/eventprocessorhost/eh_partition_pump.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventprocessorhost/eh_partition_pump.py
@@ -96,7 +96,6 @@ class EventHubPartitionPump(PartitionPump):
             prefetch=self.host.eph_options.prefetch_count,
             keep_alive=self.host.eph_options.keep_alive_interval,
             auto_reconnect=self.host.eph_options.auto_reconnect_on_error,
-            idle_timeout=self.host.eph_options.connection_idle_timeout,
             loop=self.loop)
         self.partition_receiver = PartitionReceiver(self)
 

--- a/sdk/eventhub/azure-eventhubs/azure/eventprocessorhost/eph.py
+++ b/sdk/eventhub/azure-eventhubs/azure/eventprocessorhost/eph.py
@@ -100,9 +100,6 @@ class EPHOptions:
      from the active partition when a checkpoint is not able to be persisted. This can
      allow parallel scenarios to collide less, but can introduce latency.  Default is False.
     :vartype release_partition_on_checkpoint_failure: bool
-    :ivar connection_idle_timeout: Timeout in seconds after which the underlying connection
-    will close if there is no further activity.  Default is None.
-    :vartype connection_idle_timeout: int
     """
 
     def __init__(self):
@@ -116,4 +113,3 @@ class EPHOptions:
         self.keep_alive_interval = None
         self.auto_reconnect_on_error = True
         self.release_partition_on_checkpoint_failure = False
-        self.connection_idle_timeout = None

--- a/sdk/eventhub/azure-eventhubs/conftest.py
+++ b/sdk/eventhub/azure-eventhubs/conftest.py
@@ -185,6 +185,7 @@ def connstr_receivers(connection_str):
 
 @pytest.fixture()
 def short_idle_connstr_receivers(connection_str):
+    pytest.skip("Note: idle_timeout tests are disabled until underlying UAMQP idle timeout bugs are fixed.")
     client = EventHubClient.from_connection_string(connection_str, debug=False)
     eh_hub_info = client.get_eventhub_info()
     partitions = eh_hub_info["partition_ids"]


### PR DESCRIPTION
Ideally we are adding these in next release, but for now, disable the settings.