### PR TITLE
Enable long path for Windows test

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -27,7 +27,7 @@ steps:
   - pwsh: |
       Set-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem -Name LongPathsEnabled -Value 1
     displayName: "Enable Long File Path"
-    condition: eq(${{ parameters.OSName }}, "Windows")
+    condition: eq(variables['OSName'], "Windows")
 
   - script: |
       pip install pathlib twine codecov beautifulsoup4 tox tox-monorepo packaging

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -24,6 +24,11 @@ steps:
     parameters:
       OSName: ${{ parameters.OSName }}
 
+  - pwsh: |
+      Set-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem -Name LongPathsEnabled -Value 1
+    displayName: "Enable Long File Path"
+    condition: eq(${{ parameters.OSName }}, "Windows")
+
   - script: |
       pip install pathlib twine codecov beautifulsoup4 tox tox-monorepo packaging
     displayName: 'Prep Environment'

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -26,8 +26,8 @@ steps:
 
   - pwsh: |
       Set-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem -Name LongPathsEnabled -Value 1
-    displayName: "Enable Long File Path"
-    condition: eq(variables['OSName'], "Windows")
+    displayName: 'Enable Long File Path'
+    condition: eq(variables['OSName'], 'Windows')
 
   - script: |
       pip install pathlib twine codecov beautifulsoup4 tox tox-monorepo packaging

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -42,6 +42,7 @@ deps = {[base]deps}
 changedir = {toxinidir}
 commands = 
     {envbindir}/python {toxinidir}/../../../eng/tox/create_wheel_and_install.py -d {distdir} -p {toxinidir}
+    pip freeze
     pytest \
       {[testenv]default_pytest_params} \
       {posargs} \
@@ -81,6 +82,7 @@ changedir = {toxinidir}
 deps = 
   {[base]deps}
 commands =
+    pip freeze
     pytest \
       {posargs} \
       {toxinidir}

--- a/sdk/cognitiveservices/azure-cognitiveservices-language-textanalytics/dev_requirements.txt
+++ b/sdk/cognitiveservices/azure-cognitiveservices-language-textanalytics/dev_requirements.txt
@@ -2,3 +2,4 @@
 -e ../azure-mgmt-cognitiveservices
 ../../core/azure-core
 aiohttp>=3.0; python_version >= '3.5'
+


### PR DESCRIPTION
Cognitive services is failing to test with dev build version due to path name for few files exceeding 260 chars. This fix is to enable long path name on windows host.

Additional fix is to record list of packages installed as part of every test to aid in debugging when test fails suddenly due to new dependent external package.