### PR TITLE
Publish test results even if build is canceled

### DIFF
--- a/eng/pipelines/templates/jobs/tests-nightly-python.yml
+++ b/eng/pipelines/templates/jobs/tests-nightly-python.yml
@@ -43,7 +43,7 @@ jobs:
         continueOnError: true
 
       - task: PublishTestResults@2
-        condition: succeededOrFailed()
+        condition: always()
         inputs:
           testResultsFiles: '**/junit/test-results.xml'
           testRunTitle: '$(OSName) Python $(PythonVersion)'

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -44,7 +44,7 @@ steps:
     env: ${{ parameters.EnvVars }}
 
   - task: PublishTestResults@2
-    condition: succeededOrFailed()
+    condition: always()
     inputs:
       testResultsFiles: '**/*test*.xml'
       testRunTitle: '${{ parameters.OSName }} Python ${{ parameters.PythonVersion }}'

--- a/eng/pipelines/templates/steps/test-nightly.yml
+++ b/eng/pipelines/templates/steps/test-nightly.yml
@@ -44,7 +44,7 @@ steps:
     env: ${{ parameters.EnvVars }}
 
   - task: PublishTestResults@2
-    condition: succeededOrFailed()
+    condition: always()
     inputs:
       testResultsFiles: '**/*test*.xml'
       testRunTitle: '${{ parameters.OSName }} Python ${{ parameters.PythonVersion }}'


### PR DESCRIPTION
- If build is canceled due to agent timeout, some tests results may have already been generated and should still be published