### PR TITLE
Improve live managed identity tests

### DIFF
--- a/sdk/identity/azure-identity/conftest.py
+++ b/sdk/identity/azure-identity/conftest.py
@@ -8,8 +8,8 @@ import sys
 import pytest
 from azure.identity._constants import AZURE_CLI_CLIENT_ID, EnvironmentVariables
 
-# Ignore async tests on unsupported platforms
-if sys.version_info < (3, 5):
+
+if sys.version_info < (3, 5, 3):
     collect_ignore_glob = ["*_async.py"]
 
 
@@ -93,8 +93,3 @@ def live_user_details():
         pytest.skip("To test username/password authentication, set $AZURE_USERNAME, $AZURE_PASSWORD, $USER_TENANT")
     else:
         return user_details
-
-
-@pytest.fixture()
-def managed_identity_id():
-    return os.environ.get("MANAGED_IDENTITY_ID")

--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -58,53 +58,72 @@ def build_aad_response(  # simulate a response from AAD
 class Request:
     def __init__(
         self,
+        base_url=None,
         url=None,
         authority=None,
         url_substring=None,
         method=None,
-        required_headers={},
-        required_data={},
-        required_params={},
+        required_headers=None,
+        required_data=None,
+        required_params=None,
     ):
         self.authority = authority
+        self.base_url = base_url
         self.method = method
         self.url = url
         self.url_substring = url_substring
-        self.required_headers = required_headers
-        self.required_data = required_data
-        self.required_params = required_params
+        self.required_headers = required_headers or {}
+        self.required_data = required_data or {}
+        self.required_params = required_params or {}
 
     def assert_matches(self, request):
-        # TODO: rewrite this to report all mismatches, and use the parsed url
-        url = six.moves.urllib_parse.urlparse(request.url)
+        discrepancies = []
 
-        if self.url:
-            assert request.url.split("?")[0] == self.url
-        if self.authority:
-            assert url.netloc == self.authority, "Expected authority '{}', actual was '{}".format(
-                self.authority, url.netloc
-            )
-        if self.url_substring:
-            assert self.url_substring in request.url
-        if self.method:
-            assert request.method == self.method
+        def add_discrepancy(name, expected, actual):
+            discrepancies.append("{}:\n\t expected: {}\n\t   actual: {}".format(name, expected, actual))
+
+        if self.base_url and self.base_url != request.url.split("?")[0]:
+            add_discrepancy('base url', self.base_url, request.url)
+
+        if self.url and self.url != request.url:
+            add_discrepancy("url", self.url, request.url)
+
+        if self.url_substring and self.url_substring not in request.url:
+            add_discrepancy("url substring", self.url_substring, request.url)
+
+        parsed = six.moves.urllib_parse.urlparse(request.url)
+        if self.authority and parsed.netloc != self.authority:
+            add_discrepancy("authority", self.authority, parsed.netloc)
+
+        if self.method and request.method != self.method:
+            add_discrepancy("method", self.method, request.method)
+
         for param, expected_value in self.required_params.items():
-            assert request.query.get(param) == expected_value
+            actual_value = request.query.get(param)
+            if actual_value != expected_value:
+                add_discrepancy(param, expected_value, actual_value)
+
         for header, expected_value in self.required_headers.items():
-            actual = request.headers.get(header)
+            actual_value = request.headers.get(header)
+
+            # UserAgentPolicy appends the value of $AZURE_HTTP_USER_AGENT, which is set in
+            # pipelines, so we accept a user agent which merely contains the expected value
             if header.lower() == "user-agent":
-                # UserAgentPolicy appends the value of $AZURE_HTTP_USER_AGENT, which is set in pipelines.
-                assert expected_value in actual
-            else:
-                assert actual == expected_value, "expected header '{}: {}', actual value was '{}'".format(
-                    header, expected_value, actual
-                )
+                if expected_value not in actual_value:
+                    add_discrepancy("user-agent", "contains " + expected_value, actual_value)
+            elif actual_value != expected_value:
+                add_discrepancy(header, expected_value, actual_value)
+
         for field, expected_value in self.required_data.items():
-            assert request.body.get(field) == expected_value
+            actual_value = request.body.get(field)
+            if actual_value != expected_value:
+                add_discrepancy("form field", expected_value, actual_value)
+
+        assert not discrepancies, "Unexpected request\n\t" + "\n\t".join(discrepancies)
 
 
-def mock_response(status_code=200, headers={}, json_payload=None):
-    response = mock.Mock(status_code=status_code, headers=headers)
+def mock_response(status_code=200, headers=None, json_payload=None):
+    response = mock.Mock(status_code=status_code, headers=headers or {})
     if json_payload is not None:
         response.text = lambda: json.dumps(json_payload)
         response.headers["content-type"] = "application/json"
@@ -124,7 +143,7 @@ def validating_transport(requests, responses):
     sessions = zip(requests, responses)
     sessions = (s for s in sessions)  # 2.7's zip returns a list, and nesting a generator doesn't break it for 3.x
 
-    def validate_request(request, **kwargs):
+    def validate_request(request, **_):
         try:
             expected_request, response = next(sessions)
         except StopIteration:

--- a/sdk/identity/azure-identity/tests/managed-identity-live/Dockerfile
+++ b/sdk/identity/azure-identity/tests/managed-identity-live/Dockerfile
@@ -1,0 +1,21 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+ARG PYTHON_VERSION=2.7
+
+# docker can't tell when the repo has changed and will therefore cache this layer
+FROM alpine/git as repo
+RUN git clone https://github.com/chlowell/azure-sdk-for-python --single-branch --branch live-managed-id --depth 1 /azure-sdk-for-python
+
+
+FROM python:${PYTHON_VERSION}-slim
+
+COPY --from=repo /azure-sdk-for-python/sdk/identity /sdk/identity
+COPY --from=repo /azure-sdk-for-python/sdk/core/azure-core /sdk/core/azure-core
+COPY --from=repo /azure-sdk-for-python/sdk/keyvault/azure-keyvault-secrets /sdk/keyvault/azure-keyvault-secrets
+
+WORKDIR /sdk/identity/azure-identity/tests/managed-identity-live
+RUN pip install --no-cache-dir -r requirements.txt
+
+CMD [ "pytest", "-rs", "-v", "--log-level=DEBUG" ]

--- a/sdk/identity/azure-identity/tests/managed-identity-live/conftest.py
+++ b/sdk/identity/azure-identity/tests/managed-identity-live/conftest.py
@@ -1,0 +1,36 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import os
+import sys
+
+import pytest
+
+if sys.version_info < (3, 5, 3):
+    collect_ignore_glob = ["*_async.py"]
+
+AZURE_IDENTITY_TEST_VAULT_URL = "AZURE_IDENTITY_TEST_VAULT_URL"
+AZURE_IDENTITY_TEST_MANAGED_IDENTITY_CLIENT_ID = "AZURE_IDENTITY_TEST_MANAGED_IDENTITY_CLIENT_ID"
+
+
+@pytest.fixture()
+def live_managed_identity_config():
+    """Live managed identity tests interact with a service to verify the credential acquires a valid access token.
+
+    These tests use the Key Vault Secrets API. They therefore require azure-keyvault-secrets and the URL of a Key Vault
+    in $AZURE_IDENTITY_TEST_VAULT_URL. They also use the value of $AZURE_IDENTITY_TEST_MANAGED_IDENTITY_CLIENT_ID to
+    (optionally) test user-assigned managed identity; that value should be the client ID of an Azure Managed Identity.
+    """
+
+    try:
+        import azure.keyvault.secrets
+
+        return {
+            "vault_url": os.environ[AZURE_IDENTITY_TEST_VAULT_URL],
+            "client_id": os.environ.get(AZURE_IDENTITY_TEST_MANAGED_IDENTITY_CLIENT_ID),
+        }
+    except ImportError:
+        pytest.skip("this test requires azure-keyvault-secrets")
+    except KeyError:
+        pytest.skip("this test requires a Key Vault URL in $" + AZURE_IDENTITY_TEST_VAULT_URL)

--- a/sdk/identity/azure-identity/tests/managed-identity-live/requirements.txt
+++ b/sdk/identity/azure-identity/tests/managed-identity-live/requirements.txt
@@ -1,0 +1,6 @@
+../../../../core/azure-core
+../..
+../../../../keyvault/azure-keyvault-secrets
+pytest
+pytest-asyncio;python_full_version>="3.5.3"
+aiohttp;python_full_version>="3.5.3"

--- a/sdk/identity/azure-identity/tests/managed-identity-live/test_managed_identity_live.py
+++ b/sdk/identity/azure-identity/tests/managed-identity-live/test_managed_identity_live.py
@@ -1,0 +1,20 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from azure.identity import ManagedIdentityCredential
+
+try:
+    from azure.keyvault.secrets import SecretClient
+except ImportError:
+    # prevent pytest discovery failing before it can skip the test
+    pass
+
+
+def test_managed_identity_live(live_managed_identity_config):
+    credential = ManagedIdentityCredential(client_id=live_managed_identity_config["client_id"])
+
+    # do something with Key Vault to verify the credential can get a valid token
+    client = SecretClient(live_managed_identity_config["vault_url"], credential, logging_enable=True)
+    secret = client.set_secret("managed-identity-test-secret", "value")
+    client.begin_delete_secret(secret.name)

--- a/sdk/identity/azure-identity/tests/managed-identity-live/test_managed_identity_live_async.py
+++ b/sdk/identity/azure-identity/tests/managed-identity-live/test_managed_identity_live_async.py
@@ -1,0 +1,24 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from azure.identity.aio import ManagedIdentityCredential
+
+import pytest
+
+try:
+    from azure.keyvault.secrets.aio import SecretClient
+except ImportError:
+    # prevent pytest discovery failing before it can skip the test
+    pass
+
+
+
+@pytest.mark.asyncio
+async def test_managed_identity_live(live_managed_identity_config):
+    credential = ManagedIdentityCredential(client_id=live_managed_identity_config["client_id"])
+
+    # do something with Key Vault to verify the credential can get a valid token
+    client = SecretClient(live_managed_identity_config["vault_url"], credential, logging_enable=True)
+    secret = await client.set_secret("managed-identity-test-secret", "value")
+    await client.delete_secret(secret.name)

--- a/sdk/identity/azure-identity/tests/test_live.py
+++ b/sdk/identity/azure-identity/tests/test_live.py
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-import os
-
 import pytest
 
 from azure.identity import (
@@ -13,11 +11,9 @@ from azure.identity import (
     DeviceCodeCredential,
     KnownAuthorities,
     InteractiveBrowserCredential,
-    ManagedIdentityCredential,
     UsernamePasswordCredential,
 )
-from azure.identity._constants import AZURE_CLI_CLIENT_ID, EnvironmentVariables
-from azure.identity._credentials.managed_identity import ImdsCredential, MsiCredential
+from azure.identity._constants import AZURE_CLI_CLIENT_ID
 from azure.identity._internal import ConfidentialClientCredential
 
 ARM_SCOPE = "https://management.azure.com/.default"
@@ -59,33 +55,6 @@ def test_confidential_client_credential(live_service_principal):
         tenant_id=live_service_principal["tenant_id"],
     )
     get_token(credential)
-
-
-@pytest.mark.skipif("TEST_IMDS" not in os.environ, reason="To test IMDS authentication, set $TEST_IMDS with any value")
-def test_imds_credential(managed_identity_id):
-    get_token(ImdsCredential())
-    if managed_identity_id:
-        get_token(ImdsCredential(client_id=managed_identity_id))
-
-
-@pytest.mark.skipif(
-    EnvironmentVariables.MSI_ENDPOINT not in os.environ or EnvironmentVariables.MSI_SECRET in os.environ,
-    reason="Legacy MSI unavailable",
-)
-def test_msi_legacy(managed_identity_id):
-    get_token(MsiCredential())
-    if managed_identity_id:
-        get_token(ImdsCredential(client_id=managed_identity_id))
-
-
-@pytest.mark.skipif(
-    EnvironmentVariables.MSI_ENDPOINT not in os.environ or EnvironmentVariables.MSI_SECRET not in os.environ,
-    reason="App Service MSI unavailable",
-)
-def test_msi_app_service(managed_identity_id):
-    get_token(MsiCredential())
-    if managed_identity_id:
-        get_token(ImdsCredential(client_id=managed_identity_id))
 
 
 def test_username_password_auth(live_user_details):

--- a/sdk/identity/azure-identity/tests/test_live_async.py
+++ b/sdk/identity/azure-identity/tests/test_live_async.py
@@ -2,13 +2,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-import os
-
 import pytest
 
-from azure.identity._constants import EnvironmentVariables
 from azure.identity.aio import DefaultAzureCredential, CertificateCredential, ClientSecretCredential
-from azure.identity.aio._credentials.managed_identity import ImdsCredential, MsiCredential
 
 ARM_SCOPE = "https://management.azure.com/.default"
 
@@ -42,27 +38,3 @@ async def test_client_secret_credential(live_service_principal):
 async def test_default_credential(live_service_principal):
     credential = DefaultAzureCredential()
     await get_token(credential)
-
-
-@pytest.mark.skipif("TEST_IMDS" not in os.environ, reason="To test IMDS authentication, set $TEST_IMDS with any value")
-@pytest.mark.asyncio
-async def test_imds_credential():
-    await get_token(ImdsCredential())
-
-
-@pytest.mark.skipif(
-    EnvironmentVariables.MSI_ENDPOINT not in os.environ or EnvironmentVariables.MSI_SECRET in os.environ,
-    reason="Legacy MSI unavailable",
-)
-@pytest.mark.asyncio
-async def test_msi_legacy():
-    await get_token(MsiCredential())
-
-
-@pytest.mark.skipif(
-    EnvironmentVariables.MSI_ENDPOINT not in os.environ or EnvironmentVariables.MSI_SECRET not in os.environ,
-    reason="App Service MSI unavailable",
-)
-@pytest.mark.asyncio
-async def test_msi_app_service():
-    await get_token(MsiCredential())

--- a/sdk/identity/azure-identity/tests/test_managed_identity.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity.py
@@ -23,12 +23,12 @@ def test_cloud_shell():
     access_token = "****"
     expires_on = 42
     expected_token = AccessToken(access_token, expires_on)
-    url = "http://localhost:42/token"
+    endpoint = "http://localhost:42/token"
     scope = "scope"
     transport = validating_transport(
         requests=[
             Request(
-                url,
+                base_url=endpoint,
                 method="POST",
                 required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
                 required_data={"resource": scope},
@@ -48,7 +48,7 @@ def test_cloud_shell():
         ],
     )
 
-    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url}):
+    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: endpoint}):
         token = ManagedIdentityCredential(transport=transport).get_token(scope)
         assert token == expected_token
 
@@ -60,12 +60,12 @@ def test_cloud_shell_user_assigned_identity():
     expires_on = 42
     client_id = "some-guid"
     expected_token = AccessToken(access_token, expires_on)
-    url = "http://localhost:42/token"
+    endpoint = "http://localhost:42/token"
     scope = "scope"
     transport = validating_transport(
         requests=[
             Request(
-                url,
+                base_url=endpoint,
                 method="POST",
                 required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
                 required_data={"client_id": client_id, "resource": scope},
@@ -85,7 +85,7 @@ def test_cloud_shell_user_assigned_identity():
         ],
     )
 
-    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url}):
+    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: endpoint}):
         token = ManagedIdentityCredential(client_id=client_id, transport=transport).get_token(scope)
         assert token == expected_token
 
@@ -96,13 +96,13 @@ def test_app_service():
     access_token = "****"
     expires_on = 42
     expected_token = AccessToken(access_token, expires_on)
-    url = "http://localhost:42/token"
+    endpoint = "http://localhost:42/token"
     secret = "expected-secret"
     scope = "scope"
     transport = validating_transport(
         requests=[
             Request(
-                url,
+                base_url=endpoint,
                 method="GET",
                 required_headers={"Metadata": "true", "secret": secret, "User-Agent": USER_AGENT},
                 required_params={"api-version": "2017-09-01", "resource": scope},
@@ -120,7 +120,9 @@ def test_app_service():
         ],
     )
 
-    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url, EnvironmentVariables.MSI_SECRET: secret}):
+    with mock.patch(
+        "os.environ", {EnvironmentVariables.MSI_ENDPOINT: endpoint, EnvironmentVariables.MSI_SECRET: secret}
+    ):
         token = ManagedIdentityCredential(transport=transport).get_token(scope)
         assert token == expected_token
 
@@ -132,13 +134,13 @@ def test_app_service_user_assigned_identity():
     expires_on = 42
     client_id = "some-guid"
     expected_token = AccessToken(access_token, expires_on)
-    url = "http://localhost:42/token"
+    endpoint = "http://localhost:42/token"
     secret = "expected-secret"
     scope = "scope"
     transport = validating_transport(
         requests=[
             Request(
-                url,
+                base_url=endpoint,
                 method="GET",
                 required_headers={"Metadata": "true", "secret": secret, "User-Agent": USER_AGENT},
                 required_params={"api-version": "2017-09-01", "clientid": client_id, "resource": scope},
@@ -156,7 +158,9 @@ def test_app_service_user_assigned_identity():
         ],
     )
 
-    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url, EnvironmentVariables.MSI_SECRET: secret}):
+    with mock.patch(
+        "os.environ", {EnvironmentVariables.MSI_ENDPOINT: endpoint, EnvironmentVariables.MSI_SECRET: secret}
+    ):
         token = ManagedIdentityCredential(client_id=client_id, transport=transport).get_token(scope)
         assert token == expected_token
 
@@ -165,13 +169,12 @@ def test_imds():
     access_token = "****"
     expires_on = 42
     expected_token = AccessToken(access_token, expires_on)
-    url = Endpoints.IMDS
     scope = "scope"
     transport = validating_transport(
         requests=[
-            Request(url),  # first request should be availability probe => match only the URL
+            Request(url=Endpoints.IMDS),  # first request should be availability probe => match only the URL
             Request(
-                url,
+                base_url=Endpoints.IMDS,
                 method="GET",
                 required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
                 required_params={"api-version": "2018-02-01", "resource": scope},
@@ -202,14 +205,14 @@ def test_imds_user_assigned_identity():
     access_token = "****"
     expires_on = 42
     expected_token = AccessToken(access_token, expires_on)
-    url = Endpoints.IMDS
+    endpoint = Endpoints.IMDS
     scope = "scope"
     client_id = "some-guid"
     transport = validating_transport(
         requests=[
-            Request(url),  # first request should be availability probe => match only the URL
+            Request(base_url=endpoint),  # first request should be availability probe => match only the URL
             Request(
-                url,
+                base_url=endpoint,
                 method="GET",
                 required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
                 required_params={"api-version": "2018-02-01", "client_id": client_id, "resource": scope},

--- a/sdk/identity/azure-identity/tests/test_managed_identity.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity.py
@@ -197,7 +197,9 @@ def test_imds():
         ],
     )
 
-    token = ManagedIdentityCredential(transport=transport).get_token(scope)
+    # ensure e.g. $MSI_ENDPOINT isn't set, so we get ImdsCredential
+    with mock.patch.dict("os.environ", clear=True):
+        token = ManagedIdentityCredential(transport=transport).get_token(scope)
     assert token == expected_token
 
 
@@ -236,5 +238,7 @@ def test_imds_user_assigned_identity():
         ],
     )
 
-    token = ManagedIdentityCredential(client_id=client_id, transport=transport).get_token(scope)
+    # ensure e.g. $MSI_ENDPOINT isn't set, so we get ImdsCredential
+    with mock.patch.dict("os.environ", clear=True):
+        token = ManagedIdentityCredential(client_id=client_id, transport=transport).get_token(scope)
     assert token == expected_token

--- a/sdk/identity/azure-identity/tests/test_managed_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity_async.py
@@ -23,12 +23,12 @@ async def test_cloud_shell():
     access_token = "****"
     expires_on = 42
     expected_token = AccessToken(access_token, expires_on)
-    url = "http://localhost:42/token"
+    endpoint = "http://localhost:42/token"
     scope = "scope"
     transport = async_validating_transport(
         requests=[
             Request(
-                url,
+                base_url=endpoint,
                 method="POST",
                 required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
                 required_data={"resource": scope},
@@ -48,7 +48,7 @@ async def test_cloud_shell():
         ],
     )
 
-    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url}):
+    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: endpoint}):
         token = await ManagedIdentityCredential(transport=transport).get_token(scope)
         assert token == expected_token
 
@@ -61,12 +61,12 @@ async def test_cloud_shell_user_assigned_identity():
     expires_on = 42
     client_id = "some-guid"
     expected_token = AccessToken(access_token, expires_on)
-    url = "http://localhost:42/token"
+    endpoint = "http://localhost:42/token"
     scope = "scope"
     transport = async_validating_transport(
         requests=[
             Request(
-                url,
+                base_url=endpoint,
                 method="POST",
                 required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
                 required_data={"client_id": client_id, "resource": scope},
@@ -86,7 +86,7 @@ async def test_cloud_shell_user_assigned_identity():
         ],
     )
 
-    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url}):
+    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: endpoint}):
         token = await ManagedIdentityCredential(client_id=client_id, transport=transport).get_token(scope)
         assert token == expected_token
 
@@ -98,13 +98,13 @@ async def test_app_service():
     access_token = "****"
     expires_on = 42
     expected_token = AccessToken(access_token, expires_on)
-    url = "http://localhost:42/token"
+    endpoint = "http://localhost:42/token"
     secret = "expected-secret"
     scope = "scope"
     transport = async_validating_transport(
         requests=[
             Request(
-                url,
+                base_url=endpoint,
                 method="GET",
                 required_headers={"Metadata": "true", "secret": secret, "User-Agent": USER_AGENT},
                 required_params={"api-version": "2017-09-01", "resource": scope},
@@ -122,7 +122,9 @@ async def test_app_service():
         ],
     )
 
-    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url, EnvironmentVariables.MSI_SECRET: secret}):
+    with mock.patch(
+        "os.environ", {EnvironmentVariables.MSI_ENDPOINT: endpoint, EnvironmentVariables.MSI_SECRET: secret}
+    ):
         token = await ManagedIdentityCredential(transport=transport).get_token(scope)
         assert token == expected_token
 
@@ -135,13 +137,13 @@ async def test_app_service_user_assigned_identity():
     expires_on = 42
     client_id = "some-guid"
     expected_token = AccessToken(access_token, expires_on)
-    url = "http://localhost:42/token"
+    endpoint = "http://localhost:42/token"
     secret = "expected-secret"
     scope = "scope"
     transport = async_validating_transport(
         requests=[
             Request(
-                url,
+                base_url=endpoint,
                 method="GET",
                 required_headers={"Metadata": "true", "secret": secret, "User-Agent": USER_AGENT},
                 required_params={"api-version": "2017-09-01", "clientid": client_id, "resource": scope},
@@ -159,7 +161,9 @@ async def test_app_service_user_assigned_identity():
         ],
     )
 
-    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url, EnvironmentVariables.MSI_SECRET: secret}):
+    with mock.patch(
+        "os.environ", {EnvironmentVariables.MSI_ENDPOINT: endpoint, EnvironmentVariables.MSI_SECRET: secret}
+    ):
         token = await ManagedIdentityCredential(client_id=client_id, transport=transport).get_token(scope)
         assert token == expected_token
 
@@ -169,13 +173,12 @@ async def test_imds():
     access_token = "****"
     expires_on = 42
     expected_token = AccessToken(access_token, expires_on)
-    url = Endpoints.IMDS
     scope = "scope"
     transport = async_validating_transport(
         requests=[
-            Request(url),  # first request should be availability probe => match only the URL
+            Request(url=Endpoints.IMDS),  # first request should be availability probe => match only the URL
             Request(
-                url,
+                base_url=Endpoints.IMDS,
                 method="GET",
                 required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
                 required_params={"api-version": "2018-02-01", "resource": scope},
@@ -212,9 +215,9 @@ async def test_imds_user_assigned_identity():
     client_id = "some-guid"
     transport = async_validating_transport(
         requests=[
-            Request(url),  # first request should be availability probe => match only the URL
+            Request(base_url=url),  # first request should be availability probe => match only the URL
             Request(
-                url,
+                base_url=url,
                 method="GET",
                 required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
                 required_params={"api-version": "2018-02-01", "client_id": client_id, "resource": scope},

--- a/sdk/identity/azure-identity/tests/test_managed_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity_async.py
@@ -201,7 +201,9 @@ async def test_imds():
         ],
     )
 
-    token = await ManagedIdentityCredential(transport=transport).get_token(scope)
+    # ensure e.g. $MSI_ENDPOINT isn't set, so we get ImdsCredential
+    with mock.patch.dict("os.environ", clear=True):
+        token = await ManagedIdentityCredential(transport=transport).get_token(scope)
     assert token == expected_token
 
 
@@ -241,5 +243,7 @@ async def test_imds_user_assigned_identity():
         ],
     )
 
-    token = await ManagedIdentityCredential(client_id=client_id, transport=transport).get_token(scope)
+    # ensure e.g. $MSI_ENDPOINT isn't set, so we get ImdsCredential
+    with mock.patch.dict("os.environ", clear=True):
+        token = await ManagedIdentityCredential(client_id=client_id, transport=transport).get_token(scope)
     assert token == expected_token


### PR DESCRIPTION
Adding live managed identity tests which use Key Vault to verify credentials acquire valid tokens. These new tests will be skipped in normal runs unless a couple of unwieldy environment variables unlikely to be set accidentally have values. This also includes a Dockerfile so the new tests can be run in a container, allowing them to execute in AKS and ACI.