### PR TITLE
Downgrade coverage package to fix pipelines due to coverage issue

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -25,7 +25,7 @@ steps:
       OSName: ${{ parameters.OSName }}
 
   - script: |
-      pip install pathlib twine codecov beautifulsoup4 tox tox-monorepo packaging
+      pip install pathlib twine coverage==4.5.4 codecov beautifulsoup4 tox tox-monorepo packaging
     displayName: 'Prep Environment'
     
   - ${{ parameters.BeforeTestSteps }}

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -9,6 +9,7 @@ deps =
   pytest-xdist
   pytest-asyncio; python_version >= '3.5'
   coverage==4.5.4
+  pytest==5.3.1
   ../../../tools/azure-devtools
   ../../../tools/azure-sdk-tools
 

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -8,7 +8,7 @@ deps =
   pytest-cov
   pytest-xdist
   pytest-asyncio; python_version >= '3.5'
-  coverage
+  coverage==4.5.4
   ../../../tools/azure-devtools
   ../../../tools/azure-sdk-tools
 

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -8,7 +8,7 @@ deps =
   pytest-cov
   pytest-xdist
   pytest-asyncio; python_version >= '3.5'
-  coverage
+  coverage==4.5.4
   ../../../tools/azure-devtools
   ../../../tools/azure-sdk-tools
 
@@ -42,6 +42,7 @@ deps = {[base]deps}
 changedir = {toxinidir}
 commands = 
     {envbindir}/python {toxinidir}/../../../eng/tox/create_wheel_and_install.py -d {distdir} -p {toxinidir}
+    pip freeze
     pytest \
       {[testenv]default_pytest_params} \
       {posargs} \
@@ -81,6 +82,7 @@ changedir = {toxinidir}
 deps = 
   {[base]deps}
 commands =
+    pip freeze
     pytest \
       {posargs} \
       {toxinidir}

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -8,8 +8,7 @@ deps =
   pytest-cov
   pytest-xdist
   pytest-asyncio; python_version >= '3.5'
-  coverage==4.5.4
-  pytest<=5.3.1
+  coverage
   ../../../tools/azure-devtools
   ../../../tools/azure-sdk-tools
 

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -9,7 +9,7 @@ deps =
   pytest-xdist
   pytest-asyncio; python_version >= '3.5'
   coverage==4.5.4
-  pytest==5.3.1
+  pytest<=5.3.1
   ../../../tools/azure-devtools
   ../../../tools/azure-sdk-tools
 


### PR DESCRIPTION
Coverage has released a new package 5.0 and this has broken our test pipelines due to coverage issue.
Quick fix is to pin coverage version to 4.5.4