### PR TITLE
PyPIClient module is failing on Python 2.7 and <Python 3.6 versions

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/code_report.py
+++ b/tools/azure-sdk-tools/packaging_tools/code_report.py
@@ -158,7 +158,7 @@ def main(input_parameter: str, version: Optional[str] = None, no_venv: bool = Fa
             versions = [version]
         else:
             _LOGGER.info(f"Download versions of {package_name} on PyPI")
-            from .pypi import PyPIClient
+            from pypi_tools.pypi import PyPIClient
             client = PyPIClient()
             versions = [str(v) for v in client.get_ordered_versions(package_name)]
             _LOGGER.info(f"Got {versions}")

--- a/tools/azure-sdk-tools/pypi_tools/__init__.py
+++ b/tools/azure-sdk-tools/pypi_tools/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__) # type: ignore

--- a/tools/azure-sdk-tools/pypi_tools/pypi.py
+++ b/tools/azure-sdk-tools/pypi_tools/pypi.py
@@ -11,11 +11,11 @@ def get_pypi_xmlrpc_client():
     return xmlrpc.client.ServerProxy("https://pypi.python.org/pypi", use_datetime=True)
 
 class PyPIClient:
-    def __init__(self, host: str = "https://pypi.org"):
+    def __init__(self, host="https://pypi.org"):
         self._host = host
         self._session = requests.Session()
 
-    def project(self, package_name: str):
+    def project(self, package_name):
         response = self._session.get(
             "{host}/pypi/{project_name}/json".format(
                 host=self._host,
@@ -25,7 +25,7 @@ class PyPIClient:
         response.raise_for_status()
         return response.json()
 
-    def project_release(self, package_name: str, version: str):
+    def project_release(self, package_name, version):
         response = self._session.get(
             "{host}/pypi/{project_name}/{version}/json".format(
                 host=self._host,
@@ -36,7 +36,7 @@ class PyPIClient:
         response.raise_for_status()
         return response.json()
 
-    def get_ordered_versions(self, package_name: str):
+    def get_ordered_versions(self, package_name):
         project = self.project(package_name)
         versions = [
             Version(package_version)
@@ -46,7 +46,7 @@ class PyPIClient:
         versions.sort()
         return versions
 
-    def get_relevant_versions(self, package_name: str):
+    def get_relevant_versions(self, package_name):
         """Return a tuple: (latest release, latest stable)
         If there are different, it means the latest is not a stable
         """


### PR DESCRIPTION
Changes to make PyPIClient Module available on Python 2.7 and Python 3.5

- created new pypi_tools as root module and moved pypi.py into this module
- Updated reference to PyPiClient in code_report.py