### PR TITLE
Cosmos: Fix for test test_create_indexing_policy_with_composite_and_spatial_indexes 

### DIFF
--- a/sdk/cosmos/azure-cosmos/test/crud_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/crud_tests.py
@@ -1885,12 +1885,14 @@ class CRUDTests(unittest.TestCase):
                     "types": [
                         "Point",
                         "LineString",
-                        "Polygon"
+                        "Polygon",
+                        "MultiPolygon"
                     ]
                 },
                 {
                     "path": "/path1/*",
                     "types": [
+                        "Point",
                         "LineString",
                         "Polygon",
                         "MultiPolygon"


### PR DESCRIPTION
The fix is to account for a service change introduced in the emulator version 2.7.1