### PR TITLE
Default to UTF-8 when processing text response.

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/transport/_requests_basic.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_requests_basic.py
@@ -66,11 +66,6 @@ class _RequestsTransportResponseBase(_HttpResponseBase):
     def body(self):
         return self.internal_response.content
 
-    def text(self, encoding=None):
-        if encoding:
-            self.internal_response.encoding = encoding
-        return self.internal_response.text
-
 
 class StreamDownloadGenerator(object):
     """Generator for streaming response data.

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_list_blobs_no_bom.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_list_blobs_no_bom.yaml
@@ -17,7 +17,7 @@ interactions:
       x-ms-version:
       - '2019-02-02'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/containerc01c0c5d?restype=container
+    uri: https://storagename.blob.core.windows.net/container21fb0f36?restype=container
   response:
     body:
       string: ''
@@ -61,7 +61,7 @@ interactions:
       x-ms-version:
       - '2019-02-02'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/containerc01c0c5d/blob1
+    uri: https://storagename.blob.core.windows.net/container21fb0f36/blob1
   response:
     body:
       string: ''
@@ -111,7 +111,7 @@ interactions:
       x-ms-version:
       - '2019-02-02'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/containerc01c0c5d/blob2
+    uri: https://storagename.blob.core.windows.net/container21fb0f36/blob2
   response:
     body:
       string: ''
@@ -161,7 +161,7 @@ interactions:
       x-ms-version:
       - '2019-02-02'
     method: PUT
-    uri: https://storagename.blob.core.windows.net/containerc01c0c5d/blob3%C3%A9
+    uri: https://storagename.blob.core.windows.net/container21fb0f36/blob3%C3%A9
   response:
     body:
       string: ''
@@ -203,11 +203,11 @@ interactions:
       x-ms-version:
       - '2019-02-02'
     method: GET
-    uri: https://storagename.blob.core.windows.net/containerc01c0c5d?restype=container&comp=list
+    uri: https://storagename.blob.core.windows.net/container21fb0f36?restype=container&comp=list
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"containerc01c0c5d\"><Blobs><Blob><Name>blob1</Name><Properties><Creation-Time>Fri,
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
+        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"container21fb0f36\"><Blobs><Blob><Name>blob1</Name><Properties><Creation-Time>Fri,
         25 Oct 2019 17:59:35 GMT</Creation-Time><Last-Modified>Fri, 25 Oct 2019 17:59:35
         GMT</Last-Modified><Etag>0x8D7597518BC14A5</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control


### PR DESCRIPTION
When calling requests.Response.text() an encoding should be provided.
Otherwise, requests uses the chardet library to guess the encoding. If
the body starts with the BOM character (U+FEFF), chardet will guess
UTF-8. However, if the BOM character is missing, chardet will default to
ISO-8859-1. Decoding the body ourselves as UTF-8 avoids this issue.
    
The patch removes the _RequestsTransportResponseBase.text() method, as
the _HttpResponseBase implementation is correct -- it calls self.body()
and subsequently decodes the string as UTF-8.