### PR TITLE
Improve Page blob upload efficiency

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -280,10 +280,7 @@ class PageBlobChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
     def _is_chunk_empty(self, chunk_data):
         # read until non-zero byte is encountered
         # if reached the end without returning, then chunk_data is all 0's
-        for each_byte in chunk_data:
-            if each_byte not in [0, b"\x00"]:
-                return False
-        return True
+        return (not any(bytearray(chunk_data)))
 
     def _upload_chunk(self, chunk_offset, chunk_data):
         # avoid uploading the empty pages

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -280,7 +280,7 @@ class PageBlobChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
     def _is_chunk_empty(self, chunk_data):
         # read until non-zero byte is encountered
         # if reached the end without returning, then chunk_data is all 0's
-        return (not any(bytearray(chunk_data)))
+        return not any(bytearray(chunk_data))
 
     def _upload_chunk(self, chunk_offset, chunk_data):
         # avoid uploading the empty pages


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-python/issues/9145

Total time taken to upload 10gb page blob
Before: 440 seconds
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
2560  431.393    0.169  431.393    0.169 uploads.py:280(_is_chunk_empty)

After: 120 seconds
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
2561    7.103    0.003    7.103    0.003 {method 'read' of '_io.BufferedReader' objects}

