### PR TITLE
Simplify external package requirements for CI and tox env

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -1,0 +1,13 @@
+setuptools
+wheel 
+Jinja2
+packaging
+tox
+tox-monorepo
+pathlib
+twine
+readme-renderer[md]
+doc-warden==0.3.1
+coverage==4.5.4
+codecov
+beautifulsoup4

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -8,6 +8,6 @@ pathlib
 twine
 readme-renderer[md]
 doc-warden==0.3.1
-coverage==4.5.4
+coverage
 codecov
 beautifulsoup4

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -8,6 +8,6 @@ pathlib
 twine
 readme-renderer[md]
 doc-warden==0.3.1
-coverage
+coverage==4.5.4
 codecov
 beautifulsoup4

--- a/eng/pipelines/generate-all-docs.yml
+++ b/eng/pipelines/generate-all-docs.yml
@@ -28,7 +28,7 @@ jobs:
           versionSpec: '$(PythonVersion)'
 
       - script: |
-          pip install wheel setuptools pathlib twine readme-renderer[md] packaging tox tox-monorepo
+          pip install -r eng/ci_tools.txt
         displayName: 'Prep Environment'
 
       - task: PythonScript@0

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -9,8 +9,7 @@ steps:
      versionSpec: '$(PythonVersion)'
 
   - script: |
-     pip install setuptools wheel Jinja2 packaging tox tox-monorepo
-     pip install doc-warden==0.3.1
+     pip install -r eng/ci_tools.txt
      ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/.docsettings.yml
     displayName: 'Verify Readmes'
 

--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -15,7 +15,7 @@ steps:
       versionSpec: '2.7'
 
   - script: |
-      pip install wheel setuptools packaging
+      pip install -r eng/ci_tools.txt
     displayName: 'Prep Py2 Environment'
     
   - template: eng/pipelines/templates/scripts/replace-relative-links.yml@azure-sdk-tools
@@ -37,7 +37,7 @@ steps:
       versionSpec: $(PythonVersion)
 
   - script: |
-      pip install wheel setuptools pathlib twine readme-renderer[md] packaging tox tox-monorepo
+      pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
 
   - template: ../steps/set-dev-build.yml

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -15,7 +15,7 @@ steps:
       versionSpec: '2.7'
 
   - script: |
-      pip install wheel setuptools packaging
+      pip install -r eng/ci_tools.txt
     displayName: 'Prep Py2 Environment'
 
   - task: PythonScript@0
@@ -30,7 +30,7 @@ steps:
       versionSpec: $(PythonVersion)
 
   - script: |
-      pip install wheel setuptools pathlib twine readme-renderer[md] packaging
+      pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
 
   - task: PythonScript@0

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -25,7 +25,7 @@ steps:
       OSName: ${{ parameters.OSName }}
 
   - script: |
-      pip install pathlib twine coverage==4.5.4 codecov beautifulsoup4 tox tox-monorepo packaging
+      pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
     
   - ${{ parameters.BeforeTestSteps }}

--- a/eng/pipelines/templates/steps/run_mypy.yml
+++ b/eng/pipelines/templates/steps/run_mypy.yml
@@ -11,7 +11,7 @@ steps:
      versionSpec: '3.7'
 
   - script: |
-      pip install pathlib tox tox-monorepo packaging
+      pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
 
   - task: PythonScript@0

--- a/eng/pipelines/templates/steps/run_pylint.yml
+++ b/eng/pipelines/templates/steps/run_pylint.yml
@@ -11,7 +11,7 @@ steps:
      versionSpec: '3.7'
 
   - script: |
-      pip install pathlib tox tox-monorepo packaging
+      pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
 
   - task: PythonScript@0

--- a/eng/pipelines/templates/steps/test-nightly.yml
+++ b/eng/pipelines/templates/steps/test-nightly.yml
@@ -25,7 +25,7 @@ steps:
       OSName: ${{ parameters.OSName }}
 
   - script: |
-      pip install pathlib twine codecov beautifulsoup4 tox tox-monorepo packaging
+      pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
 
   - ${{ parameters.BeforeTestSteps }}

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -2,6 +2,6 @@ pytest-custom_exit_code
 pytest-cov
 pytest-xdist
 pytest-asyncio; python_version >= '3.5'
-coverage==4.5.4
+coverage
 ../../../tools/azure-devtools
 ../../../tools/azure-sdk-tools

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -1,0 +1,7 @@
+pytest-custom_exit_code
+pytest-cov
+pytest-xdist
+pytest-asyncio; python_version >= '3.5'
+coverage==4.5.4
+../../../tools/azure-devtools
+../../../tools/azure-sdk-tools

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -2,6 +2,6 @@ pytest-custom_exit_code
 pytest-cov
 pytest-xdist
 pytest-asyncio; python_version >= '3.5'
-coverage
+coverage==4.5.4
 ../../../tools/azure-devtools
 ../../../tools/azure-sdk-tools

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -4,14 +4,8 @@ envlist = whl,sdist
 
 [tools]
 deps =
-  pytest-custom_exit_code
-  pytest-cov
-  pytest-xdist
-  pytest-asyncio; python_version >= '3.5'
-  coverage==4.5.4
-  ../../../tools/azure-devtools
-  ../../../tools/azure-sdk-tools
-
+  -r ../../../eng/test_tools.txt
+  
 
 [coverage:paths]
 source =

--- a/sdk/core/azure-core/dev_requirements.txt
+++ b/sdk/core/azure-core/dev_requirements.txt
@@ -7,3 +7,4 @@ opencensus>=0.6.0
 opencensus-ext-azure>=0.3.1
 opencensus-ext-threading
 mock
+

--- a/sdk/template/azure-template/dev_requirements.txt
+++ b/sdk/template/azure-template/dev_requirements.txt
@@ -1,2 +1,1 @@
 -e ../../../tools/azure-sdk-tools
-


### PR DESCRIPTION
External packages to install are listed in individual yml file and in tox.ini. This can lead to a situation of having incorrect version of package installed if a specific version is pinned and if both places are not updated.

Solution is to have two common requirement files and refer these req files instead of individually listing packages.

ci_tools.txt which has ci required packages
test_tools.txt that has list of packages for test(pytest, pytect-cov etc)
