### PR TITLE
[Event Hubs] set timeout of fixture uamqp.ReceiveClient to 0

### DIFF
--- a/sdk/eventhub/azure-eventhub/conftest.py
+++ b/sdk/eventhub/azure-eventhub/conftest.py
@@ -184,7 +184,7 @@ def connstr_receivers(connection_str, live_eventhub_config):
             live_eventhub_config['event_hub'],
             live_eventhub_config['consumer_group'],
             p)
-        receiver = uamqp.ReceiveClient(source, auth=sas_auth, debug=False, timeout=5000, prefetch=500)
+        receiver = uamqp.ReceiveClient(source, auth=sas_auth, debug=False, timeout=0, prefetch=500)
         receiver.open()
         receivers.append(receiver)
     yield connection_str, receivers


### PR DESCRIPTION
Original setting is 5 seconds. Some test methods wait more than 5 seconds so the receive client may be closed and used to receive the previously sent events. This may result in wrong assertion. Setting it to 0 to keep it without a timeout. Test code will explicitly close the receive client.