### PR TITLE
Set tox environment list dynamically

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -93,7 +93,7 @@ jobs:
     timeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
     variables:
     - template: ../variables/globals.yml
-
+    
     dependsOn:
        - 'Build'
 
@@ -107,7 +107,15 @@ jobs:
     pool:
       vmImage: '$(OSVmImage)'
 
-    steps:
+    steps:    
+    - pwsh: |
+        $toxenvvar = "whl,sdist"
+        if (('$(Build.Reason)' -eq 'Schedule') -and ('$(System.TeamProject)' -eq 'internal')) {
+          $toxenvvar = "whl,sdist"
+        }
+        echo "##vso[task.setvariable variable=toxenv]$toxenvvar"
+      displayName: "Set Tox Environment"
+
     - template: ../steps/build-test.yml
       parameters:
         ServiceDirectory: ${{ parameters.ServiceDirectory }}
@@ -117,7 +125,7 @@ jobs:
         CoverageArg: $(CoverageArg)
         PythonVersion: $(PythonVersion)
         BuildTargetingString: ${{ parameters.BuildTargetingString }}
-        ToxTestEnv: 'whl,sdist'
+        ToxTestEnv: $(toxenv)
         ToxEnvParallel: ${{ parameters.ToxEnvParallel }}
         BeforeTestSteps: 
           - task: DownloadPipelineArtifact@0


### PR DESCRIPTION
This change is to set tox env name dynamically based on the environment. This is a pre step to enable latest and minimum dependency test based on pipeline type.( for e.g. internal pipeline vs public)