### PR TITLE
Add `fail_on_exist` param for resource creation

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/common/mixins.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/common/mixins.py
@@ -87,9 +87,9 @@ class ServiceBusMixin(object):
             dead_lettering_on_message_expiration=dead_lettering_on_message_expiration,
             duplicate_detection_history_time_window=duplicate_detection_history_time_window,
             max_delivery_count=max_delivery_count,
-            enable_batched_operations=enable_batched_operations)
+            enable_batched_operations=enable_batched_operations, fail_on_exist=True)
         try:
-            return self.mgmt_client.create_queue(queue_name, queue=queue_properties, fail_on_exist=True)
+            return self.mgmt_client.create_queue(queue_name, queue=queue_properties, fail_on_exist=fail_on_exist)
         except requests.exceptions.ConnectionError as e:
             raise ServiceBusConnectionError("Namespace: {} not found".format(self.service_namespace), e)
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/common/mixins.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/common/mixins.py
@@ -121,7 +121,7 @@ class ServiceBusMixin(object):
             default_message_time_to_live=None,
             max_size_in_megabytes=None, requires_duplicate_detection=None,
             duplicate_detection_history_time_window=None,
-            enable_batched_operations=None):
+            enable_batched_operations=None, fail_on_exist=True):
         """Create a topic entity.
 
         :param topic_name: The name of the new topic.
@@ -140,6 +140,9 @@ class ServiceBusMixin(object):
         :type duplicate_detection_history_time_window: ~datetime.timedelta
         :param enable_batched_operations:
         :type: enable_batched_operations: bool
+        :param fail_on_exist: Whether to throw an exception if there is already a topic with same name
+         already existed.
+        :type: fail_on_exist: bool
         :raises: ~azure.servicebus.common.errors.ServiceBusConnectionError if the namespace is not found.
         :raises: ~azure.common.AzureConflictHttpError if a topic of the same name already exists.
         """
@@ -150,7 +153,7 @@ class ServiceBusMixin(object):
             duplicate_detection_history_time_window=duplicate_detection_history_time_window,
             enable_batched_operations=enable_batched_operations)
         try:
-            return self.mgmt_client.create_topic(topic_name, topic=topic_properties, fail_on_exist=True)
+            return self.mgmt_client.create_topic(topic_name, topic=topic_properties, fail_on_exist=fail_on_exist)
         except requests.exceptions.ConnectionError as e:
             raise ServiceBusConnectionError("Namespace: {} not found".format(self.service_namespace), e)
 
@@ -180,7 +183,7 @@ class ServiceBusMixin(object):
             default_message_time_to_live=None,
             dead_lettering_on_message_expiration=None,
             dead_lettering_on_filter_evaluation_exceptions=None,
-            enable_batched_operations=None, max_delivery_count=None):
+            enable_batched_operations=None, max_delivery_count=None, fail_on_exist=True):
         """Create a subscription entity.
 
         :param topic_name: The name of the topic under which to create the subscription.
@@ -206,6 +209,9 @@ class ServiceBusMixin(object):
         :type max_delivery_count: int
         :param enable_batched_operations:
         :type: enable_batched_operations: bool
+        :param fail_on_exist: Whether to throw an exception if there is already a subscription with same name
+         already existed.
+        :type: fail_on_exist: bool
         :raises: ~azure.servicebus.common.errors.ServiceBusConnectionError if the namespace is not found.
         :raises: ~azure.common.AzureConflictHttpError if a queue of the same name already exists.
         """
@@ -220,7 +226,7 @@ class ServiceBusMixin(object):
         try:
             return self.mgmt_client.create_subscription(
                 topic_name, subscription_name,
-                subscription=sub_properties, fail_on_exist=True)
+                subscription=sub_properties, fail_on_exist=fail_on_exist)
         except requests.exceptions.ConnectionError as e:
             raise ServiceBusConnectionError("Namespace: {} not found".format(self.service_namespace), e)
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/common/mixins.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/common/mixins.py
@@ -44,7 +44,7 @@ class ServiceBusMixin(object):
             default_message_time_to_live=None,
             dead_lettering_on_message_expiration=False,
             duplicate_detection_history_time_window=None,
-            max_delivery_count=None, enable_batched_operations=None):
+            max_delivery_count=None, enable_batched_operations=None, fail_on_exist=True):
         """Create a queue entity.
 
         :param queue_name: The name of the new queue.
@@ -75,6 +75,9 @@ class ServiceBusMixin(object):
         :type max_delivery_count: int
         :param enable_batched_operations:
         :type: enable_batched_operations: bool
+        :param fail_on_exist: Whether to throw an exception if there is already a queue with same name
+         already existed.
+        :type: fail_on_exist: bool
         :raises: ~azure.servicebus.common.errors.ServiceBusConnectionError if the namespace is not found.
         :raises: ~azure.common.AzureConflictHttpError if a queue of the same name already exists.
         """
@@ -87,7 +90,7 @@ class ServiceBusMixin(object):
             dead_lettering_on_message_expiration=dead_lettering_on_message_expiration,
             duplicate_detection_history_time_window=duplicate_detection_history_time_window,
             max_delivery_count=max_delivery_count,
-            enable_batched_operations=enable_batched_operations, fail_on_exist=True)
+            enable_batched_operations=enable_batched_operations)
         try:
             return self.mgmt_client.create_queue(queue_name, queue=queue_properties, fail_on_exist=fail_on_exist)
         except requests.exceptions.ConnectionError as e:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/common/mixins.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/common/mixins.py
@@ -75,8 +75,7 @@ class ServiceBusMixin(object):
         :type max_delivery_count: int
         :param enable_batched_operations:
         :type: enable_batched_operations: bool
-        :param fail_on_exist: Whether to throw an exception if there is already a queue with same name
-         already existed.
+        :param fail_on_exist: Whether to throw an exception if a queue with the same name already exists.
         :type: fail_on_exist: bool
         :raises: ~azure.servicebus.common.errors.ServiceBusConnectionError if the namespace is not found.
         :raises: ~azure.common.AzureConflictHttpError if a queue of the same name already exists.
@@ -140,8 +139,7 @@ class ServiceBusMixin(object):
         :type duplicate_detection_history_time_window: ~datetime.timedelta
         :param enable_batched_operations:
         :type: enable_batched_operations: bool
-        :param fail_on_exist: Whether to throw an exception if there is already a topic with same name
-         already existed.
+        :param fail_on_exist: Whether to throw an exception if a topic with the same name already exists.
         :type: fail_on_exist: bool
         :raises: ~azure.servicebus.common.errors.ServiceBusConnectionError if the namespace is not found.
         :raises: ~azure.common.AzureConflictHttpError if a topic of the same name already exists.
@@ -209,8 +207,8 @@ class ServiceBusMixin(object):
         :type max_delivery_count: int
         :param enable_batched_operations:
         :type: enable_batched_operations: bool
-        :param fail_on_exist: Whether to throw an exception if there is already a subscription with same name
-         already existed.
+        :param fail_on_exist: Whether to throw an exception if a subscription with the same name already
+         exists.
         :type: fail_on_exist: bool
         :raises: ~azure.servicebus.common.errors.ServiceBusConnectionError if the namespace is not found.
         :raises: ~azure.common.AzureConflictHttpError if a queue of the same name already exists.

--- a/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
@@ -85,7 +85,11 @@ def test_sb_client_queue_conflict_not_fail_on_exist(live_servicebus_config, stan
         shared_access_key_value=live_servicebus_config['access_key'],
         debug=False)
 
-    client.create_queue(standard_queue, fail_on_exist=False)
+    with pytest.raises(AzureConflictHttpError):
+        client.create_queue(standard_queue, fail_on_exist=True)
+
+    resuslt = client.create_queue(standard_queue, fail_on_exist=False)
+    assert resuslt is False
 
 @pytest.mark.liveTest
 def test_sb_client_topic_conflict_not_fail_on_exist(live_servicebus_config, standard_topic):
@@ -96,7 +100,11 @@ def test_sb_client_topic_conflict_not_fail_on_exist(live_servicebus_config, stan
         shared_access_key_value=live_servicebus_config['access_key'],
         debug=False)
 
-    client.create_topic(standard_topic, fail_on_exist=False)
+    with pytest.raises(AzureConflictHttpError):
+        client.create_topic(standard_topic, fail_on_exist=True)
+
+    result = client.create_topic(standard_topic, fail_on_exist=False)
+    assert result is False
 
 @pytest.mark.liveTest
 def test_sb_client_subscription_conflict_not_fail_on_exist(live_servicebus_config, standard_subscription):
@@ -107,7 +115,11 @@ def test_sb_client_subscription_conflict_not_fail_on_exist(live_servicebus_confi
         shared_access_key_value=live_servicebus_config['access_key'],
         debug=False)
 
-    client.create_subscription(standard_subscription, fail_on_exist=False)
+    with pytest.raises(AzureConflictHttpError):
+        client.create_subscription(standard_subscription, fail_on_exist=True)
+
+    result = client.create_subscription(standard_subscription, fail_on_exist=False)
+    assert result is False
 
 @pytest.mark.liveTest
 def test_sb_client_entity_delete(live_servicebus_config, standard_queue):

--- a/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
@@ -88,8 +88,8 @@ def test_sb_client_queue_conflict_not_fail_on_exist(live_servicebus_config, stan
     with pytest.raises(AzureConflictHttpError):
         client.create_queue(standard_queue, fail_on_exist=True)
 
-    resuslt = client.create_queue(standard_queue, fail_on_exist=False)
-    assert resuslt is False
+    result = client.create_queue(standard_queue, fail_on_exist=False)
+    assert result is False
 
 @pytest.mark.liveTest
 def test_sb_client_topic_conflict_not_fail_on_exist(live_servicebus_config, standard_topic):
@@ -115,10 +115,11 @@ def test_sb_client_subscription_conflict_not_fail_on_exist(live_servicebus_confi
         shared_access_key_value=live_servicebus_config['access_key'],
         debug=False)
 
+    topic_name, subscription_name = standard_subscription
     with pytest.raises(AzureConflictHttpError):
-        client.create_subscription(standard_subscription, fail_on_exist=True)
+        client.create_subscription(topic_name, subscription_name, fail_on_exist=True)
 
-    result = client.create_subscription(standard_subscription, fail_on_exist=False)
+    result = client.create_subscription(topic_name, subscription_name, fail_on_exist=False)
     assert result is False
 
 @pytest.mark.liveTest

--- a/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
@@ -77,6 +77,39 @@ def test_sb_client_entity_conflict(live_servicebus_config, standard_queue):
         client.create_queue(standard_queue, lock_duration=300)
 
 @pytest.mark.liveTest
+def test_sb_client_queue_conflict_not_fail_on_exist(live_servicebus_config, standard_queue):
+
+    client = ServiceBusClient(
+        service_namespace=live_servicebus_config['hostname'],
+        shared_access_key_name=live_servicebus_config['key_name'],
+        shared_access_key_value=live_servicebus_config['access_key'],
+        debug=False)
+
+    client.create_queue(standard_queue, fail_on_exist=False)
+
+@pytest.mark.liveTest
+def test_sb_client_topic_conflict_not_fail_on_exist(live_servicebus_config, standard_topic):
+
+    client = ServiceBusClient(
+        service_namespace=live_servicebus_config['hostname'],
+        shared_access_key_name=live_servicebus_config['key_name'],
+        shared_access_key_value=live_servicebus_config['access_key'],
+        debug=False)
+
+    client.create_topic(standard_topic, fail_on_exist=False)
+
+@pytest.mark.liveTest
+def test_sb_client_subscription_conflict_not_fail_on_exist(live_servicebus_config, standard_subscription):
+
+    client = ServiceBusClient(
+        service_namespace=live_servicebus_config['hostname'],
+        shared_access_key_name=live_servicebus_config['key_name'],
+        shared_access_key_value=live_servicebus_config['access_key'],
+        debug=False)
+
+    client.create_subscription(standard_subscription, fail_on_exist=False)
+
+@pytest.mark.liveTest
 def test_sb_client_entity_delete(live_servicebus_config, standard_queue):
 
     client = ServiceBusClient(


### PR DESCRIPTION
To give an option to make this operation idempotent, so users can create disregarding if there is a queue with same name already exists.