### PR TITLE
Verify CertificateCredential signatures

### DIFF
--- a/sdk/identity/azure-identity/tests/test_certificate_credential.py
+++ b/sdk/identity/azure-identity/tests/test_certificate_credential.py
@@ -8,6 +8,10 @@ import os
 from azure.core.pipeline.policies import ContentDecodePolicy, SansIOHTTPPolicy
 from azure.identity import CertificateCredential
 from azure.identity._internal.user_agent import USER_AGENT
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
 from six.moves.urllib_parse import urlparse
 
 from helpers import build_aad_response, urlsafeb64_decode, mock_response, Request, validating_transport
@@ -52,10 +56,10 @@ def test_request_url():
     access_token = "***"
 
     def validate_url(url):
-        scheme, netloc, path, _, _, _ = urlparse(url)
-        assert scheme == "https"
-        assert netloc == authority
-        assert path.startswith("/" + tenant_id)
+        parsed = urlparse(url)
+        assert parsed.scheme == "https"
+        assert parsed.netloc == authority
+        assert parsed.path.startswith("/" + tenant_id)
 
     def mock_send(request, **kwargs):
         validate_url(request.url)
@@ -69,21 +73,44 @@ def test_request_url():
 def test_request_body():
     access_token = "***"
     authority = "authority.com"
+    client_id = "client-id"
+    expected_scope = "scope"
     tenant_id = "tenant"
 
-    def validate_url(url):
-        scheme, netloc, path, _, _, _ = urlparse(url)
-        assert scheme == "https"
-        assert netloc == authority
-        assert path.startswith("/" + tenant_id)
-
     def mock_send(request, **kwargs):
-        jwt = request.body["client_assertion"]
-        header, payload, signature = (urlsafeb64_decode(s) for s in jwt.split("."))
-        claims = json.loads(payload.decode("utf-8"))
-        validate_url(claims["aud"])
+        assert request.body["grant_type"] == "client_credentials"
+        assert request.body["scope"] == expected_scope
+
+        with open(CERT_PATH, "rb") as cert_file:
+            validate_jwt(request, client_id, cert_file.read())
+
         return mock_response(json_payload={"token_type": "Bearer", "expires_in": 42, "access_token": access_token})
 
-    cred = CertificateCredential(tenant_id, "client_id", CERT_PATH, transport=Mock(send=mock_send), authority=authority)
-    token = cred.get_token("scope")
+    cred = CertificateCredential(tenant_id, client_id, CERT_PATH, transport=Mock(send=mock_send), authority=authority)
+    token = cred.get_token(expected_scope)
+
     assert token.token == access_token
+
+
+def validate_jwt(request, client_id, pem_bytes):
+    """Validate the request meets AAD's expectations for a client credential grant using a certificate, as documented
+    at https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-certificate-credentials
+    """
+
+    cert = x509.load_pem_x509_certificate(pem_bytes, default_backend())
+
+    # jwt is of the form 'header.payload.signature'; 'signature' is 'header.payload' signed with cert's private key
+    jwt = request.body["client_assertion"]
+    header, payload, signature = (urlsafeb64_decode(s) for s in jwt.split("."))
+    signed_part = jwt[: jwt.rfind(".")]
+    claims = json.loads(payload.decode("utf-8"))
+
+    deserialized_header = json.loads(header.decode("utf-8"))
+    assert deserialized_header["alg"] == "RS256"
+    assert deserialized_header["typ"] == "JWT"
+    assert urlsafeb64_decode(deserialized_header["x5t"]) == cert.fingerprint(hashes.SHA1())
+
+    assert claims["aud"] == request.url
+    assert claims["iss"] == claims["sub"] == client_id
+
+    cert.public_key().verify(signature, signed_part.encode("utf-8"), padding.PKCS1v15(), hashes.SHA256())


### PR DESCRIPTION
Validates `CertificateCredential` request bodies, particularly their JWT signatures. Closes #8354 