### PR TITLE
Remove enter and exit from async context managers

### DIFF
--- a/sdk/core/azure-core/HISTORY.md
+++ b/sdk/core/azure-core/HISTORY.md
@@ -9,7 +9,12 @@
 - Support fixed retry   #6419
 - Support "retry-after-ms" in response header   #9240
 
-## 1.1.1 (2019-12-03) 
+### Bug fixes
+
+- Removed `__enter__` and `__exit__` from async context managers
+([#9313](https://github.com/Azure/azure-sdk-for-python/pull/9313))
+
+## 1.1.1 (2019-12-03)
 
 ### Bug fixes
 

--- a/sdk/core/azure-core/azure/core/pipeline/_base_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/_base_async.py
@@ -161,13 +161,6 @@ class AsyncPipeline(
         if self._impl_policies:
             self._impl_policies[-1].next = _AsyncTransportRunner(self._transport)
 
-    def __enter__(self):
-        raise TypeError("Use 'async with' instead")
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        # __exit__ should exist in pair with __enter__ but never executed
-        pass  # pragma: no cover
-
     async def __aenter__(self) -> "AsyncPipeline":
         await self._transport.__aenter__()
         return self

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_base_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_base_async.py
@@ -183,10 +183,3 @@ class AsyncHttpTransport(
 
     async def sleep(self, duration):
         await asyncio.sleep(duration)
-
-    def __enter__(self):
-        raise TypeError("Use async with instead")
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        # __exit__ should exist in pair with __enter__ but never executed
-        pass  # pragma: no cover


### PR DESCRIPTION
Per [this comment](https://github.com/Azure/azure-sdk-for-python/pull/9090#discussion_r362668037),  although these methods provide guidance for the "~async~ with" syntax oops, they give a misleading impression that the class is a sync context manager.