### PR TITLE
[Event Hubs] Eventhubs livetest fix

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_eventprocessor/event_processor.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_eventprocessor/event_processor.py
@@ -143,14 +143,15 @@ class EventProcessor(
         for partition_id in claimed_partitions:
             if partition_id not in self._tasks or self._tasks[partition_id].done():
                 checkpoint = checkpoints.get(partition_id) if checkpoints else None
-                self._tasks[partition_id] = self._loop.create_task(
-                    self._receive(partition_id, checkpoint)
-                )
-                _LOGGER.info(
-                    "EventProcessor %r has claimed partition %r",
-                    self._id,
-                    partition_id
-                )
+                if self._running:
+                    self._tasks[partition_id] = self._loop.create_task(
+                        self._receive(partition_id, checkpoint)
+                    )
+                    _LOGGER.info(
+                        "EventProcessor %r has claimed partition %r",
+                        self._id,
+                        partition_id
+                    )
 
     async def _process_error(
         self, partition_context: PartitionContext, err: Exception
@@ -215,6 +216,20 @@ class EventProcessor(
                 )
             await self._event_handler(partition_context, event)
 
+    async def _close_consumer(self, partition_context):
+        partition_id = partition_context.partition_id
+        try:
+            await self._consumers[partition_id].close()
+            del self._consumers[partition_id]
+            await self._close_partition(
+                partition_context,
+                CloseReason.OWNERSHIP_LOST if self._running else CloseReason.SHUTDOWN,
+            )
+            await self._ownership_manager.release_ownership(partition_id)
+        finally:
+            if partition_id in self._tasks:
+                del self._tasks[partition_id]
+
     async def _receive(
         self, partition_id: str, checkpoint: Optional[Dict[str, Any]] = None
     ) -> None:  # pylint: disable=too-many-statements
@@ -278,15 +293,7 @@ class EventProcessor(
                     await self._process_error(partition_context, error)
                     break
         finally:
-            await self._consumers[partition_id].close()
-            del self._consumers[partition_id]
-            await self._close_partition(
-                partition_context,
-                CloseReason.OWNERSHIP_LOST if self._running else CloseReason.SHUTDOWN,
-            )
-            await self._ownership_manager.release_ownership(partition_id)
-            if partition_id in self._tasks:
-                del self._tasks[partition_id]
+            await asyncio.shield(self._close_consumer(partition_context))
 
     async def start(self) -> None:
         """Start the EventProcessor.

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_properties_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_properties_async.py
@@ -14,9 +14,10 @@ async def test_get_properties(live_eventhub):
     client = EventHubConsumerClient(live_eventhub['hostname'], live_eventhub['event_hub'], '$default',
         EventHubSharedKeyCredential(live_eventhub['key_name'], live_eventhub['access_key'])
     )
-    properties = await client.get_eventhub_properties()
-    assert properties['eventhub_name'] == live_eventhub['event_hub'] and properties['partition_ids'] == ['0', '1']
-    await client.close()
+    async with client:
+        properties = await client.get_eventhub_properties()
+        assert properties['eventhub_name'] == live_eventhub['event_hub'] and properties['partition_ids'] == ['0', '1']
+
 
 @pytest.mark.liveTest
 @pytest.mark.asyncio
@@ -24,9 +25,9 @@ async def test_get_partition_ids(live_eventhub):
     client = EventHubConsumerClient(live_eventhub['hostname'], live_eventhub['event_hub'], '$default',
         EventHubSharedKeyCredential(live_eventhub['key_name'], live_eventhub['access_key'])
     )
-    partition_ids = await client.get_partition_ids()
-    assert partition_ids == ['0', '1']
-    await client.close()
+    async with client:
+        partition_ids = await client.get_partition_ids()
+        assert partition_ids == ['0', '1']
 
 
 @pytest.mark.liveTest
@@ -35,12 +36,12 @@ async def test_get_partition_properties(live_eventhub):
     client = EventHubProducerClient(live_eventhub['hostname'], live_eventhub['event_hub'],
         EventHubSharedKeyCredential(live_eventhub['key_name'], live_eventhub['access_key'])
     )
-    properties = await client.get_partition_properties('0')
-    assert properties['eventhub_name'] == live_eventhub['event_hub'] \
-        and properties['id'] == '0' \
-        and 'beginning_sequence_number' in properties \
-        and 'last_enqueued_sequence_number' in properties \
-        and 'last_enqueued_offset' in properties \
-        and 'last_enqueued_time_utc' in properties \
-        and 'is_empty' in properties
-    await client.close()
+    async with client:
+        properties = await client.get_partition_properties('0')
+        assert properties['eventhub_name'] == live_eventhub['event_hub'] \
+            and properties['id'] == '0' \
+            and 'beginning_sequence_number' in properties \
+            and 'last_enqueued_sequence_number' in properties \
+            and 'last_enqueued_offset' in properties \
+            and 'last_enqueued_time_utc' in properties \
+            and 'is_empty' in properties

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_negative.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_negative.py
@@ -57,11 +57,13 @@ def test_send_batch_with_invalid_key(live_eventhub):
         'invalid',
         live_eventhub['event_hub'])
     client = EventHubProducerClient.from_connection_string(conn_str)
-    with pytest.raises(ConnectError):
-        batch = EventDataBatch()
-        batch.add(EventData("test data"))
-        client.send_batch(batch)
-    client.close()
+    try:
+        with pytest.raises(ConnectError):
+            batch = EventDataBatch()
+            batch.add(EventData("test data"))
+            client.send_batch(batch)
+    finally:
+        client.close()
 
 
 @pytest.mark.liveTest

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_properties.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_properties.py
@@ -13,30 +13,30 @@ from azure.eventhub import EventHubConsumerClient
 def test_get_properties(live_eventhub):
     client = EventHubConsumerClient(live_eventhub['hostname'], live_eventhub['event_hub'], '$default',
                             EventHubSharedKeyCredential(live_eventhub['key_name'], live_eventhub['access_key']))
-    properties = client.get_eventhub_properties()
-    assert properties['eventhub_name'] == live_eventhub['event_hub'] and properties['partition_ids'] == ['0', '1']
-    client.close()
+    with client:
+        properties = client.get_eventhub_properties()
+        assert properties['eventhub_name'] == live_eventhub['event_hub'] and properties['partition_ids'] == ['0', '1']
 
 
 @pytest.mark.liveTest
 def test_get_partition_ids(live_eventhub):
     client = EventHubConsumerClient(live_eventhub['hostname'], live_eventhub['event_hub'], '$default',
                             EventHubSharedKeyCredential(live_eventhub['key_name'], live_eventhub['access_key']))
-    partition_ids = client.get_partition_ids()
-    assert partition_ids == ['0', '1']
-    client.close()
+    with client:
+        partition_ids = client.get_partition_ids()
+        assert partition_ids == ['0', '1']
 
 
 @pytest.mark.liveTest
 def test_get_partition_properties(live_eventhub):
     client = EventHubConsumerClient(live_eventhub['hostname'], live_eventhub['event_hub'], '$default',
                             EventHubSharedKeyCredential(live_eventhub['key_name'], live_eventhub['access_key']))
-    properties = client.get_partition_properties('0')
-    assert properties['eventhub_name'] == live_eventhub['event_hub'] \
-        and properties['id'] == '0' \
-        and 'beginning_sequence_number' in properties \
-        and 'last_enqueued_sequence_number' in properties \
-        and 'last_enqueued_offset' in properties \
-        and 'last_enqueued_time_utc' in properties \
-        and 'is_empty' in properties
-    client.close()
+    with client:
+        properties = client.get_partition_properties('0')
+        assert properties['eventhub_name'] == live_eventhub['event_hub'] \
+            and properties['id'] == '0' \
+            and 'beginning_sequence_number' in properties \
+            and 'last_enqueued_sequence_number' in properties \
+            and 'last_enqueued_offset' in properties \
+            and 'last_enqueued_time_utc' in properties \
+            and 'is_empty' in properties


### PR DESCRIPTION
Use try ... finally or with statement to make sure client is closed if assertion has errors.
This can avoid segmentation fault error.