### PR TITLE
[Event Hubs] fix a bug that owner_level 0 is ignored

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
@@ -105,7 +105,7 @@ class EventHubConsumer(
         partition = self._source.split("/")[-1]
         self._partition = partition
         self._name = "EHConsumer-{}-partition{}".format(uuid.uuid4(), partition)
-        if owner_level:
+        if owner_level is not None:
             self._link_properties[types.AMQPSymbol(EPOCH_SYMBOL)] = types.AMQPLong(
                 int(owner_level)
             )

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_async.py
@@ -99,7 +99,7 @@ class EventHubConsumer(
         partition = self._source.split("/")[-1]
         self._partition = partition
         self._name = "EHReceiver-{}-partition{}".format(uuid.uuid4(), partition)
-        if owner_level:
+        if owner_level is not None:
             self._link_properties[types.AMQPSymbol(EPOCH_SYMBOL)] = types.AMQPLong(
                 int(owner_level)
             )


### PR DESCRIPTION
When owner_level is 0, it's ignored in EventHubConsumer of both sync and async. It shouldn't be ignored.