### PR TITLE
[EventHubs] Update products in sample readme

### DIFF
--- a/sdk/eventhub/azure-eventhub/samples/README.md
+++ b/sdk/eventhub/azure-eventhub/samples/README.md
@@ -4,7 +4,7 @@ languages:
   - python
 products:
   - azure
-  - azure-eventhub
+  - azure-event-hubs
 urlFragment: eventhub-samples
 ---
 


### PR DESCRIPTION
should be `azure-event-hubs` for product, mentioned in https://review.docs.microsoft.com/en-us/new-hope/information-architecture/metadata/taxonomies?branch=master#product