### PR TITLE
Incorporate DefaultAzureCredential samples into client identity authentication sample for eventhubs.

### DIFF
--- a/sdk/eventhub/azure-eventhub/samples/sync_samples/client_identity_authentication.py
+++ b/sdk/eventhub/azure-eventhub/samples/sync_samples/client_identity_authentication.py
@@ -30,6 +30,9 @@ User with username and password:
     school accounts.
 
 Please refer to azure.identity library for detailed information.
+
+This sample also shows the process of utilizing a different credential object, in this case, DefaultAzureCredential,
+both to demonstrate the ease of adjusting authentication, and to surface another method for doing so.
 """
 
 import os
@@ -40,8 +43,15 @@ from azure.identity import EnvironmentCredential
 fully_qualified_namespace = os.environ['EVENT_HUB_HOSTNAME']
 eventhub_name = os.environ['EVENT_HUB_NAME']
 
-
 credential = EnvironmentCredential()
+
+# Note: One has other options to specify the credential.  For instance, DefaultAzureCredential.
+# Default Azure Credentials attempt a chained set of authentication methods, per documentation here: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/identity/azure-identity
+# For example user to be logged in can be specified by the environment variable AZURE_USERNAME, consumed via the ManagedIdentityCredential
+# Alternately, one can specify the AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_CLIENT_SECRET to use the EnvironmentCredentialClass.
+# The docs above specify all mechanisms which the defaultCredential internally support.
+# credential = DefaultAzureCredential()
+
 producer = EventHubProducerClient(fully_qualified_namespace=fully_qualified_namespace,
                                   eventhub_name=eventhub_name,
                                   credential=credential)


### PR DESCRIPTION
Contains an overhaul of the sample from[ this pr](https://github.com/Azure/azure-sdk-for-python/pull/8190).

incorporates a trivial defaultazurecredential sample and docstring into the identity sample already provided.