### PR TITLE
[Event Hubs] Remove sync EventHubConsumer.receive( ) retry

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
@@ -196,8 +196,6 @@ class EventHubConsumer(
 
     def receive(self):
         # type: () -> None
-        retried_times = 0
-
         try:
             if self._open():
                 self._handler.do_work()  # type: ignore


### PR DESCRIPTION
It potentially causes something bad happening in uamqp to crash Python.
Being verified with long running test.