### PR TITLE
Distinguish credential unavailability from failure

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Correctly parse token expiration time on Windows App Service
 ([#9393](https://github.com/Azure/azure-sdk-for-python/issues/9393))
+- Credentials raise `CredentialUnavailableError` when they can't attempt to
+authenticate due to missing data or state
+([#9372](https://github.com/Azure/azure-sdk-for-python/pull/9372))
+
 
 ## 1.2.0 (2020-01-14)
 

--- a/sdk/identity/azure-identity/azure/identity/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/__init__.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 """Credentials for Azure SDK clients."""
 
+from ._exceptions import CredentialUnavailableError
 from ._constants import KnownAuthorities
 from ._credentials import (
     AuthorizationCodeCredential,
@@ -25,6 +26,7 @@ __all__ = [
     "CertificateCredential",
     "ChainedTokenCredential",
     "ClientSecretCredential",
+    "CredentialUnavailableError",
     "DefaultAzureCredential",
     "DeviceCodeCredential",
     "EnvironmentCredential",
@@ -36,4 +38,5 @@ __all__ = [
 ]
 
 from ._version import VERSION
+
 __version__ = VERSION

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -2,8 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-
-from azure.core.exceptions import ClientAuthenticationError
+from .. import CredentialUnavailableError
 from .._constants import AZURE_CLI_CLIENT_ID
 from .._internal import AadClient, wrap_exceptions
 from .._internal.shared_token_cache import NO_TOKEN, SharedTokenCacheBase
@@ -45,13 +44,13 @@ class SharedTokenCacheCredential(SharedTokenCacheBase):
 
         :param str scopes: desired scopes for the token
         :rtype: :class:`azure.core.credentials.AccessToken`
-        :raises:
-            :class:`azure.core.exceptions.ClientAuthenticationError` when the cache is unavailable or no access token
-            can be acquired from it
+        :raises ~azure.identity.CredentialUnavailableError: the cache is unavailable or contains insufficient user
+            information
+        :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed
         """
 
         if not self._client:
-            raise ClientAuthenticationError(message="Shared token cache unavailable")
+            raise CredentialUnavailableError(message="Shared token cache unavailable")
 
         account = self._get_account(self._username, self._tenant_id)
 
@@ -60,7 +59,7 @@ class SharedTokenCacheCredential(SharedTokenCacheBase):
             token = self._client.obtain_token_by_refresh_token(refresh_token, scopes)
             return token
 
-        raise ClientAuthenticationError(message=NO_TOKEN.format(account.get("username")))
+        raise CredentialUnavailableError(message=NO_TOKEN.format(account.get("username")))
 
     def _get_auth_client(self, **kwargs):
         # type: (**Any) -> AadClientBase

--- a/sdk/identity/azure-identity/azure/identity/_exceptions.py
+++ b/sdk/identity/azure-identity/azure/identity/_exceptions.py
@@ -1,0 +1,9 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from azure.core.exceptions import ClientAuthenticationError
+
+
+class CredentialUnavailableError(ClientAuthenticationError):
+    """The credential did not attempt to authenticate because required data or state is unavailable."""

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
@@ -3,8 +3,8 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from typing import TYPE_CHECKING
-from azure.core.exceptions import ClientAuthenticationError
 
+from ... import CredentialUnavailableError
 from ..._constants import AZURE_CLI_CLIENT_ID
 from ..._internal.shared_token_cache import NO_TOKEN, SharedTokenCacheBase
 from .._internal.aad_client import AadClient
@@ -23,6 +23,12 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncCredentialBase):
     :param str username:
         Username (typically an email address) of the user to authenticate as. This is required because the local cache
         may contain tokens for multiple identities.
+
+    :keyword str authority: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+        the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.KnownAuthorities`
+        defines authorities for other clouds.
+    :keyword str tenant_id: an Azure Active Directory tenant ID. Used to select an account when the cache contains
+        tokens for multiple identities.
     """
 
     async def __aenter__(self):
@@ -40,22 +46,19 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncCredentialBase):
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":  # pylint:disable=unused-argument
         """Get an access token for `scopes` from the shared cache.
 
-        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
-
         If no access token is cached, attempt to acquire one using a cached refresh token.
+
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
         :param str scopes: desired scopes for the token
         :rtype: :class:`azure.core.credentials.AccessToken`
-        :raises ~azure.core.exceptions.ClientAuthenticationError: when the cache is unavailable or no access token
-            can be acquired from it
-
-        :keyword str authority: Authority of an Azure Active Directory endpoint, for example
-              'login.microsoftonline.com', the authority for Azure Public Cloud (which is the default).
-              :class:`~azure.identity.KnownAuthorities` defines authorities for other clouds.
+        :raises ~azure.identity.CredentialUnavailableError: the cache is unavailable or contains insufficient user
+            information
+        :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed
         """
 
         if not self._client:
-            raise ClientAuthenticationError(message="Shared token cache unavailable")
+            raise CredentialUnavailableError(message="Shared token cache unavailable")
 
         account = self._get_account(self._username, self._tenant_id)
 
@@ -64,8 +67,7 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncCredentialBase):
             token = await self._client.obtain_token_by_refresh_token(refresh_token, scopes)
             return token
 
-        raise ClientAuthenticationError(message=NO_TOKEN.format(account.get("username")))
+        raise CredentialUnavailableError(message=NO_TOKEN.format(account.get("username")))
 
-    @staticmethod
-    def _get_auth_client(**kwargs: "Any") -> "AadClientBase":
+    def _get_auth_client(self, **kwargs: "Any") -> "AadClientBase":
         return AadClient(tenant_id="common", client_id=AZURE_CLI_CLIENT_ID, **kwargs)

--- a/sdk/identity/azure-identity/tests/test_environment_credential.py
+++ b/sdk/identity/azure-identity/tests/test_environment_credential.py
@@ -1,0 +1,39 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import itertools
+import os
+
+from azure.identity import CredentialUnavailableError, EnvironmentCredential
+from azure.identity._constants import EnvironmentVariables
+import pytest
+
+from helpers import mock
+
+
+ALL_VARIABLES = {
+    _
+    for _ in EnvironmentVariables.CLIENT_SECRET_VARS
+    + EnvironmentVariables.CERT_VARS
+    + EnvironmentVariables.USERNAME_PASSWORD_VARS
+}
+
+
+def test_error_message():
+    """get_token should raise CredentialUnavailableError for incomplete configuration, listing any set variables."""
+
+    with mock.patch.dict(os.environ, {}):
+        with pytest.raises(CredentialUnavailableError) as ex:
+            EnvironmentCredential().get_token("scope")
+    assert not any(var in ex.value.message for var in ALL_VARIABLES)
+
+    for a, b in itertools.combinations(ALL_VARIABLES, 2):  # all credentials require at least 3 variables set
+        with mock.patch.dict(os.environ, {a: "a", b: "b"}):
+            with pytest.raises(CredentialUnavailableError) as ex:
+                EnvironmentCredential().get_token("scope")
+
+        # error message should contain only the set variables
+        message = ex.value.message
+        assert a in message and b in message
+        assert not any(var in message for var in ALL_VARIABLES if var != a and var != b)

--- a/sdk/identity/azure-identity/tests/test_environment_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_environment_credential_async.py
@@ -1,0 +1,32 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import itertools
+import os
+
+from azure.identity import CredentialUnavailableError, EnvironmentCredential
+import pytest
+
+from helpers import mock
+from test_environment_credential import ALL_VARIABLES
+
+
+@pytest.mark.asyncio
+async def test_error_message():
+    """get_token should raise CredentialUnavailableError for incomplete configuration, listing any set variables."""
+
+    with mock.patch.dict(os.environ, {}):
+        with pytest.raises(CredentialUnavailableError) as ex:
+            await EnvironmentCredential().get_token("scope")
+    assert not any(var in ex.value.message for var in ALL_VARIABLES)
+
+    for a, b in itertools.combinations(ALL_VARIABLES, 2):  # all credentials require at least 3 variables set
+        with mock.patch.dict(os.environ, {a: "a", b: "b"}):
+            with pytest.raises(CredentialUnavailableError) as ex:
+                await EnvironmentCredential().get_token("scope")
+
+        # error message should contain only the set variables
+        message = ex.value.message
+        assert a in message and b in message
+        assert not any(var in message for var in ALL_VARIABLES if var != a and var != b)


### PR DESCRIPTION
This adds `CredentialUnavailableError` to indicate a credential didn't attempt to authenticate because it lacks required data or state. For example, `EnvironmentCredential` raises it when environment configuration is incomplete, and `SharedTokenCacheCredential` raises it when the shared cache isn't present. Credentials previously raised `ClientAuthenticationError` in such cases. That exception now indicates a credential attempted to authenticate but failed due to an unexpected error.

`ChainedTokenCredential` (and `DefaultAzureCredential`) uses this to make authentication more predictable. When one of its credentials raises, `ChainedTokenCredential` only tries the next credential when the raised exception is `CredentialUnavailableError`. This prevents unexpected authentication. For example, if environment variables specify a service principal with an invalid secret, `DefaultAzureCredential` won't continue on to managed identity after authenticating as that principal fails.

Closes #8166