### PR TITLE
[Event Hubs] Checkpoint store setup tentatively restores to use eventhubs b6 before release

### DIFF
--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/setup.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/setup.py
@@ -67,7 +67,7 @@ setup(
     python_requires=">=3.5.3",
     install_requires=[
         'azure-storage-blob<13.0.0,>=12.0.0',
-        'azure-eventhub<6.0.0,>=5.0.0',
+        'azure-eventhub<6.0.0,>=5.0.0b6',
         'aiohttp<4.0,>=3.0',
     ],
     extras_require={

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob/setup.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob/setup.py
@@ -68,7 +68,7 @@ setup(
     packages=find_packages(exclude=exclude_packages),
     install_requires=[
         'azure-storage-blob<13.0.0,>=12.0.0',
-        'azure-eventhub<6.0.0,>=5.0.0',
+        'azure-eventhub<6.0.0,>=5.0.0b6',
     ],
     extras_require={
 

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -10,7 +10,7 @@ azure-common~=1.1
 azure-core<2.0.0,>=1.0.0
 azure-cosmosdb-table~=1.0
 azure-datalake-store~=0.0.18
-azure-eventhub<6.0.0,>=5.0.0
+azure-eventhub<6.0.0,>=5.0.0b6
 azure-eventgrid~=1.1
 azure-graphrbac~=0.40.0
 azure-keyvault==4.0.0b5


### PR DESCRIPTION
Restore azure-eventhub-checkpointstore and -aio to use eventhub 5.0.0b6 to avoid nightly CI build error.
On the release day, it will be changed to 5.0.0.