### PR TITLE
Run doc generation and test using non-dev version

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -124,11 +124,6 @@ jobs:
               artifactName: 'artifacts' 
               targetPath: $(Build.ArtifactStagingDirectory)
 
-          - template: ../steps/set-dev-build.yml
-            parameters:
-              ServiceDirectory: ${{ parameters.ServiceDirectory }}
-              BuildTargetingString: ${{ parameters.BuildTargetingString }}
-
   - job: 'RunMyPy'
     condition: and(succeededOrFailed(), ne(variables['Skip.MyPy'], 'true'))
     displayName: 'Run MyPy'

--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -40,11 +40,6 @@ steps:
       pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
 
-  - template: ../steps/set-dev-build.yml
-    parameters:
-      ServiceDirectory: ${{ parameters.ServiceDirectory }}
-      BuildTargetingString: ${{ parameters.BuildTargetingString }}
-
   - task: PythonScript@0
     displayName: 'Generate Packages'
     inputs:
@@ -63,6 +58,18 @@ steps:
         "${{ parameters.BuildTargetingString }}" 
         --service="${{ parameters.ServiceDirectory }}" 
         --toxenv=sphinx
+
+  - template: ../steps/set-dev-build.yml
+    parameters:
+      ServiceDirectory: ${{ parameters.ServiceDirectory }}
+      BuildTargetingString: ${{ parameters.BuildTargetingString }}
+
+  - task: PythonScript@0
+    displayName: 'Generate Dev Build Packages'
+    condition: Succeeded()
+    inputs:
+      scriptPath: 'scripts/devops_tasks/build_packages.py'
+      arguments: '-d "$(Build.ArtifactStagingDirectory)" "${{ parameters.BuildTargetingString }}" --service=${{parameters.ServiceDirectory}}'
 
   - ${{ parameters.BeforePublishSteps }}
 

--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -66,7 +66,7 @@ steps:
 
   - task: PythonScript@0
     displayName: 'Generate Dev Build Packages'
-    condition: Succeeded()
+    condition: succeeded()
     inputs:
       scriptPath: 'scripts/devops_tasks/build_packages.py'
       arguments: '-d "$(Build.ArtifactStagingDirectory)" "${{ parameters.BuildTargetingString }}" --service=${{parameters.ServiceDirectory}}'

--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -66,7 +66,7 @@ steps:
 
   - task: PythonScript@0
     displayName: 'Generate Dev Build Packages'
-    condition: succeeded()
+    condition: eq(variables['SetDevVersion'],'true')
     inputs:
       scriptPath: 'scripts/devops_tasks/build_packages.py'
       arguments: '-d "$(Build.ArtifactStagingDirectory)" "${{ parameters.BuildTargetingString }}" --service=${{parameters.ServiceDirectory}}'

--- a/sdk/eventhub/azure-eventhub/dev_requirements.txt
+++ b/sdk/eventhub/azure-eventhub/dev_requirements.txt
@@ -7,3 +7,4 @@ docutils>=0.14
 pygments>=2.2.0
 behave==1.2.6
 wheel
+


### PR DESCRIPTION
Currently scheduled nightly CI runs doc generation and test on dev build version. This is causing an issue when dependent package version is not yet available on PyPI and package needs future GA version or higher as per install requires. for e.g. scheduled CI for eventhub is failing now since version is changed to 5.0.0 and it is not yet released. dev version of this package 5.0.0.devxxxxxxxxxxx is lower than 5.0.0. eventhub-checkpointstore has a requirement of >= 5.0.0 which will not be satisfied if version is updated to dev in the repo.

Solution: Update the version temporarily only when building dev build package. Test and doc gen should run on non-dev version.

