### PR TITLE
unpin coverage version

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -8,7 +8,7 @@ pathlib
 twine
 readme-renderer[md]
 doc-warden==0.5.0
-coverage==4.5.4
+coverage
 codecov
 beautifulsoup4
 pkginfo

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -2,6 +2,6 @@ pytest-custom_exit_code
 pytest-cov
 pytest-xdist
 pytest-asyncio; python_version >= '3.5'
-coverage==4.5.4
+coverage
 ../../../tools/azure-devtools
 ../../../tools/azure-sdk-tools


### PR DESCRIPTION
Coverage package is now pinned to 4.5.4. Version 5.0.0 and higher is causing issue in generating coverage report.