### PR TITLE
Remove parallel spinner for tox logs. Allow eventhub to run in serial

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -4,6 +4,7 @@ parameters:
   TestMarkArgument: ''
   BuildTargetingString: 'azure-*'
   TestTimeoutInMinutes: 0
+  ToxEnvParallel: '--tenvparallel'
   TestMatrix:
     Linux_Python27:
       OSName: 'Linux'
@@ -117,7 +118,7 @@ jobs:
         PythonVersion: $(PythonVersion)
         BuildTargetingString: ${{ parameters.BuildTargetingString }}
         ToxTestEnv: 'whl,sdist'
-        ToxEnvParallel: '--tenvparallel'
+        ToxEnvParallel: ${{ parameters.ToxEnvParallel }}
         BeforeTestSteps: 
           - task: DownloadPipelineArtifact@0
             inputs:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -1,6 +1,7 @@
 parameters:
   Artifacts: []
   ServiceDirectory: not-specified
+  ToxEnvParallel: '--tenvparallel'
   
 stages:
   - stage: Build
@@ -8,6 +9,7 @@ stages:
     - template: ../jobs/archetype-sdk-client.yml
       parameters:
         ServiceDirectory: ${{parameters.ServiceDirectory}}
+        ToxEnvParallel: ${{parameters.ToxEnvParallel}}
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:

--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -282,6 +282,7 @@ def prep_and_run_tox(targeted_packages, parsed_args, options_array=[]):
 
         if in_ci():
             replace_dev_reqs(destination_dev_req)
+            os.environ["TOX_PARALLEL_NO_SPINNER"] = "1"
 
         if parsed_args.tox_env:
             tox_execution_array.extend(["-e", parsed_args.tox_env])

--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -41,6 +41,7 @@ stages:
 - template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: eventhub
+    ToxEnvParallel: ' '
     Artifacts:
     - name: azure_eventhub
       safeName: azureeventhub


### PR DESCRIPTION
QoL and necessary for eventhub release today.

@YijunXieMS 
@Azure/azure-sdk-eng 