### PR TITLE
Enable ChangeLog verification using updated docWarden

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -7,7 +7,7 @@ tox-monorepo
 pathlib
 twine
 readme-renderer[md]
-doc-warden==0.3.1
+doc-warden==0.4.2
 coverage==4.5.4
 codecov
 beautifulsoup4

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -10,8 +10,15 @@ steps:
 
   - script: |
      pip install -r eng/ci_tools.txt
-     ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/.docsettings.yml
-    displayName: 'Verify Readmes'
+     ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/.docsettings.yml -t all
+    displayName: 'Verify Readmes and changelogs'
+    condition: ne(variables['Build.Reason'],'Manual')
+  
+  - script: |
+     pip install -r eng/ci_tools.txt
+     ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/.docsettings.yml -t all -s release
+    displayName: 'Verify Readmes, changelogs and latest release notes'
+    condition: eq(variables['Build.Reason'],'Manual')
 
   - task: PythonScript@0
     displayName: 'Analyze dependencies'


### PR DESCRIPTION
- Switch to the latest version of Doc-Warden
- Verify changelogs (presence and content)
- Verify release note entry on manually queued builds