### PR TITLE
[Event Hubs] Add batch receiving

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
@@ -121,7 +121,6 @@ class EventHubConsumer(
         self._track_last_enqueued_event_properties = (
             track_last_enqueued_event_properties
         )
-        self._bufferred_events = deque()  # type: Deque[EventData]
         self._last_received_event = None  # type: Optional[EventData]
 
     def _create_handler(self, auth):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_eventprocessor/_eventprocessor_mixin.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_eventprocessor/_eventprocessor_mixin.py
@@ -79,6 +79,7 @@ class EventProcessorMixin(object):
         initial_event_position,  # type: Union[str, int, datetime]
         initial_event_position_inclusive,  # type: bool
         on_event_received,  # type: Callable[[EventData], None]
+        batch=False,
         **kwargs  # type: Any
     ):
         # type: (...) -> Union[EventHubConsumer, EventHubConsumerAsync]
@@ -87,6 +88,7 @@ class EventProcessorMixin(object):
             partition_id,
             initial_event_position,
             on_event_received,  # type: ignore
+            batch=batch,
             event_position_inclusive=initial_event_position_inclusive,
             owner_level=self._owner_level,
             track_last_enqueued_event_properties=self._track_last_enqueued_event_properties,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_eventprocessor/event_processor.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_eventprocessor/event_processor.py
@@ -49,6 +49,7 @@ class EventProcessor(
         eventhub_client,  # type: EventHubConsumerClient
         consumer_group,  # type: str
         on_event,  # type: Callable[[PartitionContext, EventData], None]
+        batch=False,
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -60,6 +61,7 @@ class EventProcessor(
         )
         self._eventhub_name = eventhub_client.eventhub_name
         self._event_handler = on_event
+        self._batch = batch
         self._partition_id = kwargs.get("partition_id", None)  # type: Optional[str]
         self._error_handler = kwargs.get(
             "on_error", None
@@ -182,6 +184,7 @@ class EventProcessor(
                             initial_event_position,
                             event_postition_inclusive,
                             event_received_callback,
+                            batch=self._batch
                         ),
                     )
                     if self._partition_initialize_handler:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_client_async.py
@@ -388,6 +388,32 @@ class EventHubConsumerClient(ClientBaseAsync):
                 except KeyError:
                     pass
 
+    async def receive_batch(
+        self,
+        on_event_batch: Callable[["PartitionContext", List["EventData"]], Awaitable[None]],
+        max_batch_size: int,
+        max_wait_time: float,
+        *,
+        partition_id: Optional[str] = None,
+        owner_level: Optional[int] = None,
+        prefetch: int = 300,
+        track_last_enqueued_event_properties: bool = False,
+        starting_position: Optional[
+            Union[str, int, datetime.datetime, Dict[str, Any]]
+        ] = None,
+        starting_position_inclusive: Union[bool, Dict[str, bool]] = False,
+        on_error: Optional[
+            Callable[["PartitionContext", Exception], Awaitable[None]]
+        ] = None,
+        on_partition_initialize: Optional[
+            Callable[["PartitionContext"], Awaitable[None]]
+        ] = None,
+        on_partition_close: Optional[
+            Callable[["PartitionContext", "CloseReason"], Awaitable[None]]
+        ] = None
+    ) -> None:
+        pass
+
     async def get_eventhub_properties(self) -> Dict[str, Any]:
         """Get properties of the Event Hub.
 


### PR DESCRIPTION
This draft PR is a proof of concept PR for receiving batch.
Add method receive_batch() to EventHubConsumerClient sync. The new method is the same as method receive( ) except that it accept on_events callback instead of on_event.

Please focus on the internal implementation. The final API is to be discussed with architects and feature crew. If this implementation is accepted, the async will do the same thing.