### PR TITLE
Parse App Service MSI responses on Windows

### DIFF
--- a/sdk/identity/azure-identity/HISTORY.md
+++ b/sdk/identity/azure-identity/HISTORY.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 1.2.1b1 (Unreleased)
+
+- Correctly parse token expiration time on Windows App Service
+([#9393](https://github.com/Azure/azure-sdk-for-python/issues/9393))
+
 ## 1.2.0 (2020-01-14)
 
 - All credential pipelines include `ProxyPolicy`

--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -138,12 +138,13 @@ class AuthnClientBase(ABC):
         """
 
         # parse the string minus the timezone offset
-        date_string = expires_on[: -len(" +00:00")]
-        for format_string in ("%m/%d/%Y %H:%M:%S", "%m/%d/%Y %I:%M:%S %p"):  # (Linux, Windows)
-            try:
-                return time.strptime(date_string, format_string)
-            except ValueError:
-                pass
+        if expires_on.endswith(" +00:00"):
+            date_string = expires_on[: -len(" +00:00")]
+            for format_string in ("%m/%d/%Y %H:%M:%S", "%m/%d/%Y %I:%M:%S %p"):  # (Linux, Windows)
+                try:
+                    return time.strptime(date_string, format_string)
+                except ValueError:
+                    pass
 
         raise ValueError("'{}' doesn't match the expected format".format(expires_on))
 

--- a/sdk/identity/azure-identity/tests/test_managed_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity_async.py
@@ -15,6 +15,8 @@ import pytest
 from helpers import mock_response, Request
 from helpers_async import async_validating_transport
 
+MANAGED_IDENTITY_ENVIRON = "azure.identity.aio._credentials.managed_identity.os.environ"
+
 
 @pytest.mark.asyncio
 async def test_cloud_shell():
@@ -125,6 +127,61 @@ async def test_app_service():
     with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: url, EnvironmentVariables.MSI_SECRET: secret}):
         token = await ManagedIdentityCredential(transport=transport).get_token(scope)
         assert token == expected_token
+
+
+@pytest.mark.asyncio
+async def test_app_service_2017_09_01():
+    """test parsing of App Service MSI 2017-09-01's eccentric platform-dependent expires_on strings"""
+
+    access_token = "****"
+    expires_on = 42
+    expected_token = AccessToken(access_token, expires_on)
+    url = "http://localhost:42/token"
+    secret = "expected-secret"
+    scope = "scope"
+
+    transport = async_validating_transport(
+        requests=[
+            Request(
+                url,
+                method="GET",
+                required_headers={"Metadata": "true", "secret": secret, "User-Agent": USER_AGENT},
+                required_params={"api-version": "2017-09-01", "resource": scope},
+            )
+        ]
+        * 2,
+        responses=[
+            mock_response(
+                json_payload={
+                    "access_token": access_token,
+                    "expires_on": "01/01/1970 00:00:{} +00:00".format(expires_on),  # linux format
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            ),
+            mock_response(
+                json_payload={
+                    "access_token": access_token,
+                    "expires_on": "1/1/1970 12:00:{} AM +00:00".format(expires_on),  # windows format
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            ),
+        ],
+    )
+
+    with mock.patch.dict(
+        MANAGED_IDENTITY_ENVIRON,
+        {EnvironmentVariables.MSI_ENDPOINT: url, EnvironmentVariables.MSI_SECRET: secret},
+        clear=True,
+    ):
+        token = await ManagedIdentityCredential(transport=transport).get_token(scope)
+        assert token == expected_token
+        assert token.expires_on == expires_on
+
+        token = await ManagedIdentityCredential(transport=transport).get_token(scope)
+        assert token == expected_token
+        assert token.expires_on == expires_on
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
App Service MSI version 2017-09-01 (the latest) returns token expiration times as platform-dependent datetime strings. `ManagedIdentityCredential` currently works on Linux but not Windows. This adds support for the Windows format.

Fixes #9393