### PR TITLE
Test for azure-keyvault-* 4.0.0 regression in azure-core

### DIFF
--- a/sdk/core/azure-core/tests/test_authentication.py
+++ b/sdk/core/azure-core/tests/test_authentication.py
@@ -84,7 +84,7 @@ def test_bearer_policy_enforces_tls():
 
 @pytest.mark.skipif(azure.core.__version__ >= "2", reason="this test applies only to azure-core 1.x")
 def test_key_vault_regression():
-    """Test behavior azure-keyvault-* 4.0.0 requires from azure-core 1.x. This test must pass until azure-core 2.0."""
+    """Test for regression affecting azure-keyvault-* 4.0.0. This test must pass, unmodified, for all 1.x versions."""
 
     from azure.core.pipeline.policies._authentication import _BearerTokenCredentialPolicyBase
 


### PR DESCRIPTION
This test validates `_BearerTokenCredentialPolicyBase` has the API azure-keyvault-* 4.0.0 expects. It passes with all currently released versions of azure-core except 1.2.0.