### PR TITLE
[EventHubs] EventHubConsumerClient IotHub Connection String Redirect Support

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
@@ -219,6 +219,7 @@ class ClientBase(object):  # pylint:disable=too-many-instance-attributes
             self._address.hostname, self.eventhub_name
         )
         self._auth_uri = "sb://{}{}".format(self._address.hostname, self._address.path)
+        self._redirected = True
 
     def _create_auth(self):
         # type: () -> authentication.JWTTokenAuth

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_constants.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_constants.py
@@ -39,3 +39,5 @@ NO_RETRY_ERRORS = (
     b"com.microsoft:precondition-failed",
     b"com.microsoft:argument-error",
 )
+
+IOTHUB_ENTITY_PATH = "messages/events"

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_constants.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_constants.py
@@ -20,6 +20,7 @@ PROP_RUNTIME_INFO_RETRIEVAL_TIME_UTC = b"runtime_info_retrieval_time_utc"
 EPOCH_SYMBOL = b"com.microsoft:epoch"
 TIMEOUT_SYMBOL = b"com.microsoft:timeout"
 RECEIVER_RUNTIME_METRIC_SYMBOL = b"com.microsoft:enable-receiver-runtime-metric"
+REDIRECT_SYMBOL = b"amqp:link:redirect"
 
 MAX_USER_AGENT_LENGTH = 512
 ALL_PARTITIONS = "all-partitions"

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
@@ -79,7 +79,6 @@ class EventHubConsumer(
             "track_last_enqueued_event_properties", False
         )
         idle_timeout = kwargs.get("idle_timeout", None)
-        is_iothub = kwargs.get("is_iothub", False)
 
         self.running = False
         self.closed = False
@@ -123,11 +122,6 @@ class EventHubConsumer(
             track_last_enqueued_event_properties
         )
         self._last_received_event = None  # type: Optional[EventData]
-        if is_iothub:
-            symbol_array = [types.AMQPSymbol(REDIRECT_SYMBOL)]
-            self._connection_desired_capabilities = utils.data_factory(types.AMQPArray(symbol_array))
-        else:
-            self._connection_desired_capabilities = None
 
     def _create_handler(self, auth):
         # type: (JWTTokenAuth) -> None
@@ -159,8 +153,7 @@ class EventHubConsumer(
             receive_settle_mode=uamqp.constants.ReceiverSettleMode.ReceiveAndDelete,
             auto_complete=False,
             properties=properties,
-            desired_capabilities=desired_capabilities,
-            connection_desired_capabilities=self._connection_desired_capabilities
+            desired_capabilities=desired_capabilities
         )
 
         self._handler._streaming_receive = True  # pylint:disable=protected-access

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_utils.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_utils.py
@@ -11,7 +11,10 @@ import datetime
 import calendar
 import logging
 from typing import TYPE_CHECKING, Type, Optional, Dict, Union, Any
-
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
 import six
 
 from uamqp import types


### PR DESCRIPTION
Related issue: https://github.com/Azure/azure-sdk-for-python/issues/9224
Re-implementation of what Track1 code does.

To fully implement the redirect feature as the spec describes, further efforts is needed in uamqp-c and uamqp-python library.

1) Client must put `amqp:link:redirect` into the `desired_capabilities` of the connection `OPEN` frame, which means we may need to add attribute `desired_capabilities` to the connection class in C/Cython/Python.

2) Redirect can take place during mgmt request (e.g. `get_eventhub_properties`), currently the sender link and receiver link is encapsulated in the class `MgmtOperation` and it doesn't provide the ability to intercept `DETACH` frame which contains redirect information.