### PR TITLE
Single Variable to Identify Test-Mode

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -29,6 +29,9 @@ parameters:
       OSVmImage: 'ubuntu-16.04'
       PythonVersion: '3.8'
 
+variables:
+  AZURE_RUN_MODE: 'Live' #Record, Playback
+
 jobs:
   - job: ${{ parameters.JobName }}
     variables:

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -29,9 +29,6 @@ parameters:
       OSVmImage: 'ubuntu-16.04'
       PythonVersion: '3.8'
 
-variables:
-  AZURE_RUN_MODE: 'Live' #Record, Playback
-
 jobs:
   - job: ${{ parameters.JobName }}
     variables:
@@ -53,7 +50,9 @@ jobs:
           BuildTargetingString: ${{ parameters.BuildTargetingString }}
           ServiceDirectory: ${{ parameters.ServiceDirectory }}
           CoverageArg: $(CoverageArg)
-          EnvVars: ${{ parameters.EnvVars }}
+          EnvVars:
+            AZURE_RUN_MODE: 'Live' #Record, Playback
+            ${{ insert }}: ${{ parameters.EnvVars }}
           BeforeTestSteps: ${{ parameters.BeforeTestSteps }}
           PythonVersion: $(PythonVersion)
           OSName: $(OSName)


### PR DESCRIPTION
Context: @KieranBrantnerMagee is preparing generic preparers for the Python tests. The issue here is, given that they're _generic_ he can't rely on the `is_live` logic that is currently individually implemented for each package. Usually the `is_live` value is determined by the presence of a specific variable that has been defined by the dev. This obviously doesn't work so well in a generic case. This should enable Kieran to move that PR forward.

This PR adds a default variable to enable the generic preparers to recognize what the livetest mode is.

`AZURE_RUN_MODE` will be set to `Live` in the case of a livetest run. If it's non-existent or set to something other than `Live`, run in playback. 

@Azure/azure-sdk-eng 

@praveenkuttappan when you see this (and if you're good with it) please just merge it. 

 