### PR TITLE
Disable import CI test and run when a variable is set

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -115,7 +115,7 @@ jobs:
         }
 
         if ('$(Run.ImportTest)' -eq 'true') {
-          $toxenvvar = "whl,sdist"
+          $toxenvvar = "whl,sdist,depends"
         }
         echo "##vso[task.setvariable variable=toxenv]$toxenvvar"
       displayName: "Set Tox Environment"

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -111,9 +111,11 @@ jobs:
     - pwsh: |
         $toxenvvar = "whl,sdist"
         if (('$(Build.Reason)' -eq 'Schedule') -and ('$(System.TeamProject)' -eq 'internal')) {
-          if ('$(Skip.ImportTest)' -ne 'true') {
-            $toxenvvar = "whl,sdist,depends"
-          }
+          $toxenvvar = "whl,sdist"
+        }
+
+        if ('$(Run.ImportTest)' -eq 'true') {
+          $toxenvvar = "whl,sdist"
         }
         echo "##vso[task.setvariable variable=toxenv]$toxenvvar"
       displayName: "Set Tox Environment"


### PR DESCRIPTION
Import test was enabled and this has caused build failure storm due to parallel runs and few random issues. Disabling this test for scheduled CI runs and running it only when a variable is set.