### PR TITLE
Replace 'is' with ==

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
@@ -112,7 +112,7 @@ def test_scope():
             raise ValueError("unexpected request")
 
         def get_token(*scopes):
-            assert len(scopes) is 1
+            assert len(scopes) == 1
             assert scopes[0] == expected_scope
             return AccessToken(expected_token, 0)
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
@@ -65,7 +65,7 @@ async def test_scope():
             raise ValueError("unexpected request")
 
         async def get_token(*scopes):
-            assert len(scopes) is 1
+            assert len(scopes) == 1
             assert scopes[0] == expected_scope
             return AccessToken(expected_token, 0)
 


### PR DESCRIPTION
The safety of comparing small integers with 'is' depends on the interpreter's implementation, so we ought to prefer ==.

Closes #9525 