### PR TITLE
Support matching content in playback

### DIFF
--- a/tools/azure-devtools/setup.py
+++ b/tools/azure-devtools/setup.py
@@ -9,7 +9,7 @@ import io
 from setuptools import setup
 
 
-VERSION = "1.1.1"
+VERSION = "1.2.1"
 
 
 CLASSIFIERS = [

--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/base.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/base.py
@@ -86,7 +86,8 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
 
     def __init__(self,  # pylint: disable=too-many-arguments
                  method_name, config_file=None, recording_dir=None, recording_name=None, recording_processors=None,
-                 replay_processors=None, recording_patches=None, replay_patches=None):
+                 replay_processors=None, recording_patches=None, replay_patches=None, match_body=False,
+                 custom_request_matchers=None):
         super(ReplayableTest, self).__init__(method_name)
 
         self.recording_processors = recording_processors or []
@@ -112,6 +113,11 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
             filter_headers=self.FILTER_HEADERS
         )
         self.vcr.register_matcher('query', self._custom_request_query_matcher)
+        if match_body:
+            self.vcr.match_on += ('body',)
+        for matcher in custom_request_matchers or []:
+            self.vcr.register_matcher(matcher.__name__, matcher)
+            self.vcr.match_on += (matcher.__name__,)
 
         self.recording_file = os.path.join(
             recording_dir,

--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/tests/test_replayable_test.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/tests/test_replayable_test.py
@@ -1,0 +1,47 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from azure_devtools.scenario_tests.base import ReplayableTest
+
+import pytest
+
+try:
+    from unittest import mock
+except ImportError:  # python < 3.3
+    import mock  # type: ignore
+
+VCR = ReplayableTest.__module__ + ".vcr.VCR"
+
+
+def test_default_match_configuration():
+    """ReplayableTest should default to VCR's default matching configuration"""
+
+    with mock.patch(VCR) as mock_vcr:
+        ReplayableTest("__init__")
+
+    assert not any("match_on" in call.kwargs for call in mock_vcr.call_args_list)
+
+
+@pytest.mark.parametrize("opt_in", (True, False, None))
+def test_match_body(opt_in):
+    """match_body should control opting in to vcr.py's in-box body matching, and default to False"""
+
+    mock_vcr = mock.Mock(match_on=())
+    with mock.patch(VCR, lambda *_, **__: mock_vcr):
+        ReplayableTest("__init__", match_body=opt_in)
+
+    assert ("body" in mock_vcr.match_on) == (opt_in == True)
+
+
+def test_custom_request_matchers():
+    """custom request matchers should be registered with vcr.py and added to the default matchers"""
+
+    matcher = mock.Mock(__name__="mock matcher")
+
+    mock_vcr = mock.Mock(match_on=())
+    with mock.patch(VCR, lambda *_, **__: mock_vcr):
+        ReplayableTest("__init__", custom_request_matchers=[matcher])
+
+    assert mock.call(matcher.__name__, matcher) in mock_vcr.register_matcher.call_args_list
+    assert matcher.__name__ in mock_vcr.match_on

--- a/tools/azure-sdk-tools/devtools_testutils/azure_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/azure_testcase.py
@@ -63,7 +63,8 @@ class AzureTestCase(ReplayableTest):
     def __init__(self, method_name, config_file=None,
                  recording_dir=None, recording_name=None,
                  recording_processors=None, replay_processors=None,
-                 recording_patches=None, replay_patches=None):
+                 recording_patches=None, replay_patches=None,
+                 **kwargs):
         self.working_folder = os.path.dirname(__file__)
         self.qualified_test_name = get_qualified_method_name(self, method_name)
         self._fake_settings, self._real_settings = self._load_settings()
@@ -80,6 +81,7 @@ class AzureTestCase(ReplayableTest):
             replay_processors=replay_processors or self._get_replay_processors(),
             recording_patches=recording_patches,
             replay_patches=replay_patches,
+            **kwargs
         )
 
     @property

--- a/tools/azure-sdk-tools/devtools_testutils/mgmt_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/mgmt_testcase.py
@@ -52,7 +52,7 @@ class AzureMgmtTestCase(AzureTestCase):
     def __init__(self, method_name, config_file=None,
                  recording_dir=None, recording_name=None,
                  recording_processors=None, replay_processors=None,
-                 recording_patches=None, replay_patches=None):
+                 recording_patches=None, replay_patches=None, **kwargs):
         self.region = 'westus'
         super(AzureMgmtTestCase, self).__init__(
             method_name,
@@ -63,6 +63,7 @@ class AzureMgmtTestCase(AzureTestCase):
             replay_processors=replay_processors,
             recording_patches=recording_patches,
             replay_patches=replay_patches,
+            **kwargs
         )
 
     def _setup_scrubber(self):


### PR DESCRIPTION
Our tests currently don't consider request content when playing back recordings, allowing some bugs to pass CI. VCR.py has a built-in matcher which adequately handles most JSON. It's disabled by default, and today `ReplayableTest` accepts VCR.py's default matcher configuration.

This PR adds a couple keyword arguments to allow changing this behavior:
- `custom_request_matchers` allows registering custom matchers to run on every test
  - this will be necessary for cases not covered by VCR.py's body matcher, for example nondeterministic content
- `match_body` allows a test class to opt in to VCR.py's body matching. This should arguably be opt-out instead, however making it so would break some tests today.
  - the original problem could be solved with `custom_request_matchers` alone, with more verbosity; thoughts?