### PR TITLE
Mock text with the proper API in identity

### DIFF
--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -125,7 +125,7 @@ class Request:
 def mock_response(status_code=200, headers=None, json_payload=None):
     response = mock.Mock(status_code=status_code, headers=headers or {})
     if json_payload is not None:
-        response.text = lambda: json.dumps(json_payload)
+        response.text = lambda encoding=None: json.dumps(json_payload)
         response.headers["content-type"] = "application/json"
         response.content_type = "application/json"
     return response

--- a/sdk/identity/azure-identity/tests/test_authn_client.py
+++ b/sdk/identity/azure-identity/tests/test_authn_client.py
@@ -26,45 +26,40 @@ def test_authn_client_deserialization():
     expected_access_token = AccessToken(access_token, expires_on)
     scope = "scope"
 
-    mock_response = Mock(headers={"content-type": "application/json"}, status_code=200, content_type="application/json")
-    mock_send = Mock(return_value=mock_response)
-
     # response with expires_on only
-    mock_response.text = lambda: json.dumps(
-        {"access_token": access_token, "expires_on": expires_on, "token_type": "Bearer", "resource": scope}
-    )
+    token_payload = {"access_token": access_token, "expires_on": expires_on, "token_type": "Bearer", "resource": scope}
+    mock_send = Mock(return_value=mock_response(json_payload=token_payload))
     token = AuthnClient(endpoint="http://foo", transport=Mock(send=mock_send)).request_token(scope)
     assert token == expected_access_token
 
     # response with expires_on only and it's a datetime string (App Service MSI)
-    mock_response.text = lambda: json.dumps(
-        {
-            "access_token": access_token,
-            "expires_on": "01/01/1970 00:00:{} +00:00".format(now + expires_in),
-            "token_type": "Bearer",
-            "resource": scope,
-        }
-    )
+    token_payload = {
+        "access_token": access_token,
+        "expires_on": "01/01/1970 00:00:{} +00:00".format(now + expires_in),
+        "token_type": "Bearer",
+        "resource": scope,
+    }
     token = AuthnClient(endpoint="http://foo", transport=Mock(send=mock_send)).request_token(scope)
     assert token == expected_access_token
 
     # response with string expires_in and expires_on (IMDS, Cloud Shell)
-    mock_response.text = lambda: json.dumps(
-        {
-            "access_token": access_token,
-            "expires_in": str(expires_in),
-            "expires_on": str(expires_on),
-            "token_type": "Bearer",
-            "resource": scope,
-        }
-    )
+    token_payload = {
+        "access_token": access_token,
+        "expires_in": str(expires_in),
+        "expires_on": str(expires_on),
+        "token_type": "Bearer",
+        "resource": scope,
+    }
     token = AuthnClient(endpoint="http://foo", transport=Mock(send=mock_send)).request_token(scope)
     assert token == expected_access_token
 
     # response with int expires_in (AAD)
-    mock_response.text = lambda: json.dumps(
-        {"access_token": access_token, "expires_in": expires_in, "token_type": "Bearer", "ext_expires_in": expires_in}
-    )
+    token_payload = {
+        "access_token": access_token,
+        "expires_in": expires_in,
+        "token_type": "Bearer",
+        "ext_expires_in": expires_in,
+    }
     with patch("azure.identity._authn_client.time.time") as mock_time:
         mock_time.return_value = now
         token = AuthnClient(endpoint="http://foo", transport=Mock(send=mock_send)).request_token(scope)
@@ -80,13 +75,11 @@ def test_caching_when_only_expires_in_set():
     expires_on = now + expires_in
     expected_token = AccessToken(access_token, expires_on)
 
-    mock_response = Mock(
-        text=lambda encoding=None: json.dumps({"access_token": access_token, "expires_in": expires_in, "token_type": "Bearer"}),
-        headers={"content-type": "application/json"},
-        status_code=200,
-        content_type="application/json",
+    mock_send = Mock(
+        return_value=mock_response(
+            json_payload={"access_token": access_token, "expires_in": expires_in, "token_type": "Bearer"}
+        )
     )
-    mock_send = Mock(return_value=mock_response)
 
     client = AuthnClient(endpoint="http://foo", transport=Mock(send=mock_send))
     with patch("azure.identity._authn_client.time.time") as mock_time:
@@ -102,11 +95,15 @@ def test_caching_when_only_expires_in_set():
 def test_expires_in_strings():
     expected_token = "token"
 
-    mock_response = Mock(headers={"content-type": "application/json"}, status_code=200, content_type="application/json")
-    mock_send = Mock(return_value=mock_response)
-
-    mock_response.text = lambda: json.dumps(
-        {"access_token": expected_token, "expires_in": "42", "ext_expires_in": "42", "token_type": "Bearer"}
+    mock_send = Mock(
+        return_value=mock_response(
+            json_payload={
+                "access_token": expected_token,
+                "expires_in": "42",
+                "ext_expires_in": "42",
+                "token_type": "Bearer",
+            }
+        )
     )
 
     now = int(time.time())
@@ -124,13 +121,7 @@ def test_cache_expiry():
     expires_on = now + expires_in
     expected_token = AccessToken(access_token, expires_on)
     token_payload = {"access_token": access_token, "expires_in": expires_in, "token_type": "Bearer"}
-    mock_response = Mock(
-        text=lambda encoding=None: json.dumps(token_payload),
-        headers={"content-type": "application/json"},
-        status_code=200,
-        content_type="application/json",
-    )
-    mock_send = Mock(return_value=mock_response)
+    mock_send = Mock(return_value=mock_response(json_payload=token_payload))
 
     client = AuthnClient(endpoint="http://foo", transport=Mock(send=mock_send))
     with patch("azure.identity._authn_client.time.time") as mock_time:

--- a/sdk/identity/azure-identity/tests/test_authn_client.py
+++ b/sdk/identity/azure-identity/tests/test_authn_client.py
@@ -81,7 +81,7 @@ def test_caching_when_only_expires_in_set():
     expected_token = AccessToken(access_token, expires_on)
 
     mock_response = Mock(
-        text=lambda: json.dumps({"access_token": access_token, "expires_in": expires_in, "token_type": "Bearer"}),
+        text=lambda encoding=None: json.dumps({"access_token": access_token, "expires_in": expires_in, "token_type": "Bearer"}),
         headers={"content-type": "application/json"},
         status_code=200,
         content_type="application/json",
@@ -125,7 +125,7 @@ def test_cache_expiry():
     expected_token = AccessToken(access_token, expires_on)
     token_payload = {"access_token": access_token, "expires_in": expires_in, "token_type": "Bearer"}
     mock_response = Mock(
-        text=lambda: json.dumps(token_payload),
+        text=lambda encoding=None: json.dumps(token_payload),
         headers={"content-type": "application/json"},
         status_code=200,
         content_type="application/json",

--- a/sdk/identity/azure-identity/tests/test_identity.py
+++ b/sdk/identity/azure-identity/tests/test_identity.py
@@ -116,7 +116,7 @@ def test_imds_credential_cache():
     }
 
     mock_response = Mock(
-        text=lambda: json.dumps(token_payload),
+        text=lambda encoding=None: json.dumps(token_payload),
         headers={"content-type": "application/json"},
         status_code=200,
         content_type="application/json",
@@ -145,7 +145,7 @@ def test_imds_credential_cache():
 
 def test_imds_credential_retries():
     mock_response = Mock(
-        text=lambda: b"{}",
+        text=lambda encoding=None: b"{}",
         headers={"content-type": "application/json", "Retry-After": "0"},
         content_type="application/json",
     )

--- a/sdk/identity/azure-identity/tests/test_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_identity_async.py
@@ -123,7 +123,7 @@ async def test_imds_credential_cache():
     }
 
     mock_response = Mock(
-        text=lambda: json.dumps(token_payload),
+        text=lambda encoding=None: json.dumps(token_payload),
         headers={"content-type": "application/json"},
         status_code=200,
         content_type="application/json",
@@ -153,7 +153,7 @@ async def test_imds_credential_cache():
 @pytest.mark.asyncio
 async def test_imds_credential_retries():
     mock_response = Mock(
-        text=lambda: b"{}",
+        text=lambda encoding=None: b"{}",
         headers={"content-type": "application/json", "Retry-After": "0"},
         content_type="application/json",
     )


### PR DESCRIPTION
"text" takes an optional parameter encoding. With some recent changes in azure-core, it may be possible that some policies uses this parameter now. This means the mock needs to be closer to the truth than it is currently.
Doing this identity-only PR on purpose