### PR TITLE
Mock text with the proper API in Key Vault

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/tests/certificates_helpers.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/certificates_helpers.py
@@ -39,7 +39,7 @@ class Request:
 def mock_response(status_code=200, headers={}, json_payload=None):
     response = mock.Mock(status_code=status_code, headers=headers)
     if json_payload is not None:
-        response.text = lambda: json.dumps(json_payload)
+        response.text = lambda encoding=None: json.dumps(json_payload)
         response.headers["content-type"] = "application/json"
         response.content_type = ["application/json"]
     return response

--- a/sdk/keyvault/azure-keyvault-keys/tests/keys_helpers.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/keys_helpers.py
@@ -39,7 +39,7 @@ class Request:
 def mock_response(status_code=200, headers={}, json_payload=None):
     response = mock.Mock(status_code=status_code, headers=headers)
     if json_payload is not None:
-        response.text = lambda: json.dumps(json_payload)
+        response.text = lambda encoding=None: json.dumps(json_payload)
         response.headers["content-type"] = "application/json"
         response.content_type = ["application/json"]
     return response


### PR DESCRIPTION
Similarly to #9598, this ensures mocks in Key Vault have the correct API.