### PR TITLE
Fix mock of text in storage

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/test_blob_service_stats.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_service_stats.py
@@ -38,11 +38,11 @@ class ServiceStatsTest(StorageTestCase):
 
     @staticmethod
     def override_response_body_with_live_status(response):
-        response.http_response.text = lambda: SERVICE_LIVE_RESP_BODY
+        response.http_response.text = lambda encoding=None: SERVICE_LIVE_RESP_BODY
 
     @staticmethod
     def override_response_body_with_unavailable_status(response):
-        response.http_response.text = lambda: SERVICE_UNAVAILABLE_RESP_BODY
+        response.http_response.text = lambda encoding=None: SERVICE_UNAVAILABLE_RESP_BODY
 
     # --Test cases per service ---------------------------------------
     @GlobalResourceGroupPreparer()

--- a/sdk/storage/azure-storage-blob/tests/test_blob_service_stats_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_service_stats_async.py
@@ -55,11 +55,11 @@ class ServiceStatsTestAsync(AsyncStorageTestCase):
 
     @staticmethod
     def override_response_body_with_live_status(response):
-        response.http_response.text = lambda: SERVICE_LIVE_RESP_BODY
+        response.http_response.text = lambda encoding=None: SERVICE_LIVE_RESP_BODY
 
     @staticmethod
     def override_response_body_with_unavailable_status(response):
-        response.http_response.text = lambda: SERVICE_UNAVAILABLE_RESP_BODY
+        response.http_response.text = lambda encoding=None: SERVICE_UNAVAILABLE_RESP_BODY
 
     # --Test cases per service ---------------------------------------
     @GlobalResourceGroupPreparer()

--- a/sdk/storage/azure-storage-queue/tests/test_queue_service_stats.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_service_stats.py
@@ -37,11 +37,11 @@ class QueueServiceStatsTest(StorageTestCase):
 
     @staticmethod
     def override_response_body_with_unavailable_status(response):
-        response.http_response.text = lambda: SERVICE_UNAVAILABLE_RESP_BODY
+        response.http_response.text = lambda encoding=None: SERVICE_UNAVAILABLE_RESP_BODY
 
     @staticmethod
     def override_response_body_with_live_status(response):
-        response.http_response.text = lambda: SERVICE_LIVE_RESP_BODY
+        response.http_response.text = lambda encoding=None: SERVICE_LIVE_RESP_BODY
 
     # --Test cases per service ---------------------------------------
 

--- a/sdk/storage/azure-storage-queue/tests/test_queue_service_stats_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_service_stats_async.py
@@ -52,11 +52,11 @@ class QueueServiceStatsTestAsync(AsyncStorageTestCase):
 
     @staticmethod
     def override_response_body_with_unavailable_status(response):
-        response.http_response.text = lambda: SERVICE_UNAVAILABLE_RESP_BODY
+        response.http_response.text = lambda encoding=None: SERVICE_UNAVAILABLE_RESP_BODY
 
     @staticmethod
     def override_response_body_with_live_status(response):
-        response.http_response.text = lambda: SERVICE_LIVE_RESP_BODY
+        response.http_response.text = lambda encoding=None: SERVICE_LIVE_RESP_BODY
 
     # --Test cases per service ---------------------------------------
     @GlobalResourceGroupPreparer()


### PR DESCRIPTION
"text" takes an optional parameter encoding. With some recent changes in azure-core, it may be possible that some policies uses this parameter now. This means the mock needs to be closer to the truth than it is currently.