### PR TITLE
Simplify and speed up Key Vault test playback

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/tests/certificates_async_preparer.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/certificates_async_preparer.py
@@ -34,4 +34,7 @@ class AsyncVaultClientPreparer(VaultClientPreparer):
             credential = EnvironmentCredential()
         else:
             credential = Mock(get_token=asyncio.coroutine(lambda _: AccessToken("fake-token", 0)))
-        return VaultClient(vault_uri, credential, transport=AiohttpTestTransport(), **self.client_kwargs)
+
+        return VaultClient(
+            vault_uri, credential, transport=AiohttpTestTransport(), is_live=self.is_live, **self.client_kwargs
+        )

--- a/sdk/keyvault/azure-keyvault-certificates/tests/certificates_async_preparer.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/certificates_async_preparer.py
@@ -29,12 +29,10 @@ class AiohttpTestTransport(AioHttpTransport):
 
 
 class NoSleepTransport(AiohttpTestTransport):
+    """Prevents the transport from sleeping, e.g. to observe a Retry-After header"""
+
     async def sleep(self, _):
-        """Prevent sleeping between retries. (RetryPolicy doesn't expose configuration to ignore Retry-After headers.)
-        """
-        f = asyncio.Future()
-        f.set_result(None)
-        return f
+        return
 
 
 class AsyncVaultClientPreparer(VaultClientPreparer):

--- a/sdk/keyvault/azure-keyvault-certificates/tests/certificates_preparer.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/certificates_preparer.py
@@ -17,9 +17,9 @@ from certificates_vault_client import VaultClient
 
 
 class NoSleepTransport(RequestsTransport):
+    """Prevents the transport from sleeping, e.g. to observe a Retry-After header"""
+
     def sleep(self, _):
-        """Prevent sleeping between retries. (RetryPolicy doesn't expose configuration to ignore Retry-After headers.)
-        """
         return
 
 
@@ -32,7 +32,7 @@ class VaultClientPreparer(AzureMgmtPreparer):
         disable_recording=True,
         playback_fake_resource=None,
         client_kwargs=None,
-        random_name_enabled=True
+        random_name_enabled=True,
     ):
         super(VaultClientPreparer, self).__init__(
             name_prefix,
@@ -40,7 +40,7 @@ class VaultClientPreparer(AzureMgmtPreparer):
             disable_recording=disable_recording,
             playback_fake_resource=playback_fake_resource,
             client_kwargs=client_kwargs,
-            random_name_enabled=random_name_enabled
+            random_name_enabled=random_name_enabled,
         )
         self.parameter_name = parameter_name
 

--- a/sdk/keyvault/azure-keyvault-certificates/tests/certificates_preparer.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/certificates_preparer.py
@@ -45,4 +45,4 @@ class VaultClientPreparer(AzureMgmtPreparer):
             credential = EnvironmentCredential()
         else:
             credential = Mock(get_token=lambda _: AccessToken("fake-token", 0))
-        return VaultClient(vault_uri, credential, **self.client_kwargs)
+        return VaultClient(vault_uri, credential, is_live=self.is_live, **self.client_kwargs)

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client_async.py
@@ -25,7 +25,7 @@ from azure.keyvault.certificates import (
     LifetimeAction,
     WellKnownIssuerNames,
     CertificateIssuer,
-    IssuerProperties
+    IssuerProperties,
 )
 from azure.keyvault.certificates._shared import parse_vault_id
 from devtools_testutils import ResourceGroupPreparer, KeyVaultPreparer
@@ -41,13 +41,16 @@ class RetryAfterReplacer(RecordingProcessor):
             response["headers"]["retry-after"] = "0"
         return response
 
+
 # used for logging tests
 class MockHandler(logging.Handler):
     def __init__(self):
         super(MockHandler, self).__init__()
         self.messages = []
+
     def emit(self, record):
         self.messages.append(record)
+
 
 class CertificateClientTests(KeyVaultTestCase):
     FILTER_HEADERS = [
@@ -76,14 +79,9 @@ class CertificateClientTests(KeyVaultTestCase):
             reuse_key=False,
             content_type="application/x-pkcs12",
             validity_in_months=12,
-            key_usage=["digitalSignature", "keyEncipherment"]
+            key_usage=["digitalSignature", "keyEncipherment"],
         )
-        return await client.import_certificate(
-            cert_name,
-            cert_content,
-            policy=cert_policy,
-            password=cert_password,
-        )
+        return await client.import_certificate(cert_name, cert_content, policy=cert_policy, password=cert_password)
 
     def _validate_certificate_operation(self, pending_cert_operation, vault, cert_name, original_cert_policy):
         self.assertIsNotNone(pending_cert_operation)
@@ -140,7 +138,9 @@ class CertificateClientTests(KeyVaultTestCase):
             if cert.id in a.keys():
                 del a[cert.id]
             else:
-                assert False, "Returned certificate with id {} not found in list of original certificates".format(cert.id)
+                assert False, "Returned certificate with id {} not found in list of original certificates".format(
+                    cert.id
+                )
         self.assertEqual(len(a), 0)
 
     def _validate_certificate_contacts(self, a, b):
@@ -151,12 +151,7 @@ class CertificateClientTests(KeyVaultTestCase):
             self.assertEqual(a_entry.phone, b_entry.phone)
 
     def _admin_contact_equal(self, a, b):
-        return (
-            a.first_name == b.first_name
-            and a.last_name == b.last_name
-            and a.email == b.email
-            and a.phone == b.phone
-        )
+        return a.first_name == b.first_name and a.last_name == b.last_name and a.email == b.email and a.phone == b.phone
 
     def _validate_certificate_issuer(self, a, b):
         self.assertEqual(a.provider, b.provider)
@@ -183,9 +178,7 @@ class CertificateClientTests(KeyVaultTestCase):
         self.assertIsNotNone(vault_client)
         client = vault_client.certificates
         cert_name = self.get_resource_name("cert")
-        lifetime_actions = [
-            LifetimeAction(lifetime_percentage=80, action=CertificatePolicyAction.auto_renew)
-        ]
+        lifetime_actions = [LifetimeAction(lifetime_percentage=80, action=CertificatePolicyAction.auto_renew)]
         cert_policy = CertificatePolicy(
             issuer_name="Self",
             subject="CN=DefaultPolicy",
@@ -196,18 +189,13 @@ class CertificateClientTests(KeyVaultTestCase):
             content_type=CertificateContentType.pkcs12,
             lifetime_actions=lifetime_actions,
             validity_in_months=12,
-            key_usage=[KeyUsageType.digital_signature, KeyUsageType.key_encipherment]
+            key_usage=[KeyUsageType.digital_signature, KeyUsageType.key_encipherment],
         )
 
-        polling_interval = 0 if self.is_playback() else None
         # create certificate
-        cert = await client.create_certificate(
-            certificate_name=cert_name, policy=CertificatePolicy.get_default(), _polling_interval=polling_interval
-        )
+        cert = await client.create_certificate(certificate_name=cert_name, policy=CertificatePolicy.get_default())
 
-        self._validate_certificate_bundle(
-            cert=cert, cert_name=cert_name, cert_policy=cert_policy
-        )
+        self._validate_certificate_bundle(cert=cert, cert_name=cert_name, cert_policy=cert_policy)
 
         self.assertEqual(
             (await client.get_certificate_operation(certificate_name=cert_name)).status.lower(), "completed"
@@ -215,33 +203,23 @@ class CertificateClientTests(KeyVaultTestCase):
 
         # get certificate
         cert = await client.get_certificate(certificate_name=cert_name)
-        self._validate_certificate_bundle(
-            cert=cert, cert_name=cert_name, cert_policy=cert_policy
-        )
+        self._validate_certificate_bundle(cert=cert, cert_name=cert_name, cert_policy=cert_policy)
 
         # update certificate
         tags = {"tag1": "updated_value1"}
-        cert_bundle = await client.update_certificate_properties(
-            cert_name, tags=tags
-        )
-        self._validate_certificate_bundle(
-            cert=cert_bundle, cert_name=cert_name, cert_policy=cert_policy
-        )
+        cert_bundle = await client.update_certificate_properties(cert_name, tags=tags)
+        self._validate_certificate_bundle(cert=cert_bundle, cert_name=cert_name, cert_policy=cert_policy)
         self.assertEqual(tags, cert_bundle.properties.tags)
         self.assertEqual(cert.id, cert_bundle.id)
         self.assertNotEqual(cert.properties.updated_on, cert_bundle.properties.updated_on)
 
         # delete certificate
-        deleted_cert_bundle = await client.delete_certificate(certificate_name=cert_name, _polling_interval=polling_interval)
-        self._validate_certificate_bundle(
-            cert=deleted_cert_bundle, cert_name=cert_name, cert_policy=cert_policy
-        )
+        deleted_cert_bundle = await client.delete_certificate(certificate_name=cert_name)
+        self._validate_certificate_bundle(cert=deleted_cert_bundle, cert_name=cert_name, cert_policy=cert_policy)
 
         # get certificate returns not found
         try:
-            await client.get_certificate_version(
-                cert_name, deleted_cert_bundle.properties.version
-            )
+            await client.get_certificate_version(cert_name, deleted_cert_bundle.properties.version)
             self.fail("Get should fail")
         except Exception as ex:
             if not hasattr(ex, "message") or "not found" not in ex.message.lower():
@@ -297,15 +275,7 @@ class CertificateClientTests(KeyVaultTestCase):
             try:
                 cert_bundle = await self._import_common_certificate(client=client, cert_name=cert_name)
                 parsed_id = parse_vault_id(url=cert_bundle.id)
-                cid = (
-                    parsed_id.vault_url
-                    + "/"
-                    + parsed_id.collection
-                    + "/"
-                    + parsed_id.name
-                    + "/"
-                    + parsed_id.version
-                )
+                cid = parsed_id.vault_url + "/" + parsed_id.collection + "/" + parsed_id.name + "/" + parsed_id.version
                 expected[cid.strip("/")] = cert_bundle
             except Exception as ex:
                 if hasattr(ex, "message") and "Throttled" in ex.message:
@@ -318,9 +288,11 @@ class CertificateClientTests(KeyVaultTestCase):
         # list certificate versions
         await self._validate_certificate_list(
             expected,
-            (client.list_properties_of_certificate_versions(
-                certificate_name=cert_name, max_page_size=max_certificates - 1
-            ))
+            (
+                client.list_properties_of_certificate_versions(
+                    certificate_name=cert_name, max_page_size=max_certificates - 1
+                )
+            ),
         )
 
     @ResourceGroupPreparer(random_name_enabled=True)
@@ -375,11 +347,9 @@ class CertificateClientTests(KeyVaultTestCase):
             cert_name = self.get_resource_name("certprg{}".format(str(i)))
             certs[cert_name] = await self._import_common_certificate(client=client, cert_name=cert_name)
 
-        polling_interval = 0 if self.is_playback() else None
-
         # delete all certificates
         for cert_name in certs.keys():
-            await client.delete_certificate(certificate_name=cert_name, _polling_interval=polling_interval)
+            await client.delete_certificate(certificate_name=cert_name)
 
         # validate all our deleted certificates are returned by list_deleted_certificates
         deleted_certificates = client.list_deleted_certificates()
@@ -390,9 +360,7 @@ class CertificateClientTests(KeyVaultTestCase):
 
         # recover select certificates
         for certificate_name in [c for c in certs.keys() if c.startswith("certrec")]:
-            await client.recover_deleted_certificate(
-                certificate_name=certificate_name, _polling_interval=polling_interval
-            )
+            await client.recover_deleted_certificate(certificate_name=certificate_name)
 
         # purge select certificates
         for certificate_name in [c for c in certs.keys() if c.startswith("certprg")]:
@@ -426,14 +394,9 @@ class CertificateClientTests(KeyVaultTestCase):
 
         cert_name = "asyncCanceledDeletedCert"
         cert_policy = CertificatePolicy.get_default()
-        polling_interval = 0 if self.is_playback() else None
 
         # create certificate
-        await client.create_certificate(
-            certificate_name=cert_name,
-            policy=cert_policy,
-            _polling_interval=polling_interval
-        )
+        await client.create_certificate(certificate_name=cert_name, policy=cert_policy)
 
         # cancel certificate operation
         cancel_operation = await client.cancel_certificate_operation(cert_name)
@@ -453,7 +416,6 @@ class CertificateClientTests(KeyVaultTestCase):
                 break
             await asyncio.sleep(10)
         self.assertTrue(cancelled)
-
 
         retrieved_operation = await client.get_certificate_operation(certificate_name=cert_name)
         self.assertTrue(hasattr(retrieved_operation, "cancellation_requested"))
@@ -483,7 +445,7 @@ class CertificateClientTests(KeyVaultTestCase):
                 raise ex
 
         # delete cancelled certificate
-        await client.delete_certificate(cert_name, _polling_interval=polling_interval)
+        await client.delete_certificate(cert_name)
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @KeyVaultPreparer()
@@ -500,26 +462,17 @@ class CertificateClientTests(KeyVaultTestCase):
             key_type=KeyType.rsa,
             key_size=2048,
             reuse_key=True,
-            enhanced_key_usage=["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],
+            enhanced_key_usage=["1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.2"],
             key_usage=[KeyUsageType.decipher_only],
             content_type=CertificateContentType.pkcs12,
             validity_in_months=12,
-            lifetime_actions=[LifetimeAction(
-                action=CertificatePolicyAction.email_contacts,
-                lifetime_percentage=98
-            )],
+            lifetime_actions=[LifetimeAction(action=CertificatePolicyAction.email_contacts, lifetime_percentage=98)],
             certificate_transparency=False,
-            san_dns_names=["sdk.azure-int.net"]
+            san_dns_names=["sdk.azure-int.net"],
         )
-
-        polling_interval = 0 if self.is_playback() else None
 
         # get certificate policy
-        await client.create_certificate(
-            cert_name,
-            cert_policy,
-            _polling_interval=polling_interval
-        )
+        await client.create_certificate(cert_name, cert_policy)
 
         returned_policy = await client.get_certificate_policy(certificate_name=cert_name)
 
@@ -542,14 +495,8 @@ class CertificateClientTests(KeyVaultTestCase):
         client = vault_client.certificates
         cert_name = "unknownIssuerCert"
 
-        polling_interval = 0 if self.is_playback() else None
-
         # get pending certificate signing request
-        await client.create_certificate(
-            certificate_name=cert_name,
-            policy=CertificatePolicy.get_default(),
-            _polling_interval=polling_interval
-        )
+        await client.create_certificate(certificate_name=cert_name, policy=CertificatePolicy.get_default())
         operation = await client.get_certificate_operation(certificate_name=cert_name)
         pending_version_csr = operation.csr
         self.assertEqual((await client.get_certificate_operation(certificate_name=cert_name)).csr, pending_version_csr)
@@ -565,26 +512,18 @@ class CertificateClientTests(KeyVaultTestCase):
         policy = CertificatePolicy.get_default()
         policy._san_user_principal_names = ["john.doe@domain.com"]
 
-        polling_interval = 0 if self.is_playback() else None
-
         # create certificate
-        await client.create_certificate(
-            certificate_name=cert_name,
-            policy=policy,
-            _polling_interval=polling_interval
-        )
+        await client.create_certificate(certificate_name=cert_name, policy=policy)
 
         # create a backup
         certificate_backup = await client.backup_certificate(certificate_name=cert_name)
 
         # delete the certificate
-        await client.delete_certificate(certificate_name=cert_name, _polling_interval=polling_interval)
+        await client.delete_certificate(certificate_name=cert_name)
 
         # restore certificate
         restored_certificate = await client.restore_certificate_backup(backup=certificate_backup)
-        self._validate_certificate_bundle(
-            cert=restored_certificate, cert_name=cert_name, cert_policy=policy
-        )
+        self._validate_certificate_bundle(cert=restored_certificate, cert_name=cert_name, cert_policy=policy)
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @KeyVaultPreparer()
@@ -599,9 +538,7 @@ class CertificateClientTests(KeyVaultTestCase):
         client = vault_client.certificates
         cert_name = "mergeCertificate"
         cert_policy = CertificatePolicy(
-            issuer_name=WellKnownIssuerNames.unknown,
-            subject="CN=MyCert",
-            certificate_transparency=False
+            issuer_name=WellKnownIssuerNames.unknown, subject="CN=MyCert", certificate_transparency=False
         )
 
         dirname = os.path.dirname(os.path.abspath(__file__))
@@ -611,14 +548,8 @@ class CertificateClientTests(KeyVaultTestCase):
         with open(os.path.abspath(os.path.join(dirname, "ca.crt")), "rt") as f:
             ca_cert = crypto.load_certificate(crypto.FILETYPE_PEM, f.read())
 
-        polling_interval = 0 if self.is_playback() else None
-
         # the poller will stop immediately because the issuer is `Unknown`
-        await client.create_certificate(
-            certificate_name=cert_name,
-            policy=cert_policy,
-            _polling_interval=polling_interval
-        )
+        await client.create_certificate(certificate_name=cert_name, policy=cert_policy)
 
         certificate_operation = await client.get_certificate_operation(certificate_name=cert_name)
 
@@ -664,7 +595,7 @@ class CertificateClientTests(KeyVaultTestCase):
             provider="Test",
             account_id="keyvaultuser",
             admin_contacts=admin_contacts,
-            issuer_id=client.vault_url + "/certificates/issuers/" + issuer_name
+            issuer_id=client.vault_url + "/certificates/issuers/" + issuer_name,
         )
 
         self._validate_certificate_issuer(expected, issuer)
@@ -709,7 +640,7 @@ class CertificateClientTests(KeyVaultTestCase):
             provider="Test",
             account_id="keyvaultuser",
             admin_contacts=admin_contacts,
-            issuer_id=client.vault_url + "/certificates/issuers/" + issuer_name
+            issuer_id=client.vault_url + "/certificates/issuers/" + issuer_name,
         )
         issuer = await client.update_issuer(issuer_name, admin_contacts=admin_contacts)
         self._validate_certificate_issuer(expected, issuer)
@@ -727,23 +658,23 @@ class CertificateClientTests(KeyVaultTestCase):
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @KeyVaultPreparer()
-    @AsyncVaultClientPreparer(client_kwargs={'logging_enable': True})
+    @AsyncVaultClientPreparer(client_kwargs={"logging_enable": True})
     @AsyncKeyVaultTestCase.await_prepared_test
     async def test_logging_enabled(self, vault_client, **kwargs):
         client = vault_client.certificates
         mock_handler = MockHandler()
 
-        logger = logging.getLogger('azure')
+        logger = logging.getLogger("azure")
         logger.addHandler(mock_handler)
         logger.setLevel(logging.DEBUG)
 
         await client.create_issuer(issuer_name="cert-name", provider="Test")
 
         for message in mock_handler.messages:
-            if message.levelname == 'DEBUG' and message.funcName == 'on_request':
+            if message.levelname == "DEBUG" and message.funcName == "on_request":
                 try:
                     body = json.loads(message.message)
-                    if body['provider'] == 'Test':
+                    if body["provider"] == "Test":
                         return
                 except (ValueError, KeyError):
                     # this means the message is not JSON or has no kty property
@@ -759,14 +690,14 @@ class CertificateClientTests(KeyVaultTestCase):
         client = vault_client.certificates
         mock_handler = MockHandler()
 
-        logger = logging.getLogger('azure')
+        logger = logging.getLogger("azure")
         logger.addHandler(mock_handler)
         logger.setLevel(logging.DEBUG)
 
         await client.create_issuer(issuer_name="cert-name", provider="Test")
 
         for message in mock_handler.messages:
-            if message.levelname == 'DEBUG' and message.funcName == 'on_request':
+            if message.levelname == "DEBUG" and message.funcName == "on_request":
                 try:
                     body = json.loads(message.message)
                     assert body["provider"] != "Test", "Client request body was logged"

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates.py
@@ -199,7 +199,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         polling_interval = 0 if self.is_playback() else None
         cert_name = "cert-name"
         certificate_client.begin_create_certificate(
-            certificate_name=cert_name, policy=cert_policy, _polling_interval=polling_interval
+            certificate_name=cert_name, policy=cert_policy
         ).wait()
 
         # [START backup_certificate]
@@ -213,7 +213,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         # [END backup_certificate]
 
         certificate_client.begin_delete_certificate(
-            certificate_name=cert_name, _polling_interval=polling_interval
+            certificate_name=cert_name
         ).wait()
 
         # [START restore_certificate]
@@ -250,11 +250,11 @@ class TestExamplesKeyVault(KeyVaultTestCase):
 
         polling_interval = 0 if self.is_playback() else None
         certificate_client.begin_create_certificate(
-            certificate_name=cert_name, policy=cert_policy, _polling_interval=polling_interval
+            certificate_name=cert_name, policy=cert_policy
         ).wait()
 
         certificate_client.begin_delete_certificate(
-            certificate_name=cert_name, _polling_interval=polling_interval
+            certificate_name=cert_name
         ).wait()
         # [START get_deleted_certificate]
 

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates_async.py
@@ -31,7 +31,6 @@ def test_create_certificate():
 
 
 class TestExamplesKeyVault(AsyncKeyVaultTestCase):
-
     @ResourceGroupPreparer(random_name_enabled=True)
     @KeyVaultPreparer(enable_soft_delete=True)
     @AsyncVaultClientPreparer()
@@ -56,9 +55,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         )
         cert_name = "cert-name"
 
-        certificate = await certificate_client.create_certificate(
-            certificate_name=cert_name, policy=cert_policy
-        )
+        certificate = await certificate_client.create_certificate(certificate_name=cert_name, policy=cert_policy)
 
         print(certificate.id)
         print(certificate.name)
@@ -124,15 +121,10 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
             validity_in_months=24,
         )
 
-        polling_interval = 0 if self.is_playback() else None
-
         create_certificate_pollers = []
         for i in range(4):
             create_certificate_pollers.append(
-                certificate_client.create_certificate(
-                    certificate_name="certificate{}".format(i),
-                    policy=cert_policy,
-                    _polling_interval=polling_interval)
+                certificate_client.create_certificate(certificate_name="certificate{}".format(i), policy=cert_policy)
             )
 
         for poller in create_certificate_pollers:
@@ -197,11 +189,8 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         )
 
         cert_name = "cert-name"
-        polling_interval = 0 if self.is_playback() else None
         create_certificate_poller = certificate_client.create_certificate(
-            certificate_name=cert_name,
-            policy=cert_policy,
-            _polling_interval=polling_interval
+            certificate_name=cert_name, policy=cert_policy
         )
 
         await create_certificate_poller
@@ -216,9 +205,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
 
         # [END backup_certificate]
 
-        await certificate_client.delete_certificate(
-            certificate_name=cert_name, _polling_interval=polling_interval
-        )
+        await certificate_client.delete_certificate(certificate_name=cert_name)
 
         # [START restore_certificate]
 
@@ -251,17 +238,12 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         )
 
         cert_name = "cert-name"
-        polling_interval = 0 if self.is_playback() else None
         create_certificate_poller = certificate_client.create_certificate(
-            certificate_name=cert_name,
-            policy=cert_policy,
-            _polling_interval=polling_interval
+            certificate_name=cert_name, policy=cert_policy
         )
         await create_certificate_poller
 
-        await certificate_client.delete_certificate(
-            certificate_name=cert_name, _polling_interval=polling_interval
-        )
+        await certificate_client.delete_certificate(certificate_name=cert_name)
 
         # [START get_deleted_certificate]
 
@@ -342,7 +324,11 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         ]
 
         issuer = await certificate_client.create_issuer(
-            issuer_name="issuer1", provider="Test", account_id="keyvaultuser", admin_contacts=admin_contacts, enabled=True
+            issuer_name="issuer1",
+            provider="Test",
+            account_id="keyvaultuser",
+            admin_contacts=admin_contacts,
+            enabled=True,
         )
 
         print(issuer.name)
@@ -373,7 +359,9 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
 
         # [END get_issuer]
 
-        await certificate_client.create_issuer(issuer_name="issuer2", provider="Test", account_id="keyvaultuser", enabled=True)
+        await certificate_client.create_issuer(
+            issuer_name="issuer2", provider="Test", account_id="keyvaultuser", enabled=True
+        )
 
         # [START list_properties_of_issuers]
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/keys_async_preparer.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/keys_async_preparer.py
@@ -34,4 +34,6 @@ class AsyncVaultClientPreparer(VaultClientPreparer):
             credential = EnvironmentCredential()
         else:
             credential = Mock(get_token=asyncio.coroutine(lambda _: AccessToken("fake-token", 0)))
-        return VaultClient(vault_uri, credential, transport=AiohttpTestTransport(), **self.client_kwargs)
+        return VaultClient(
+            vault_uri, credential, transport=AiohttpTestTransport(), is_live=self.is_live, **self.client_kwargs
+        )

--- a/sdk/keyvault/azure-keyvault-keys/tests/keys_preparer.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/keys_preparer.py
@@ -45,4 +45,4 @@ class VaultClientPreparer(AzureMgmtPreparer):
             credential = EnvironmentCredential()
         else:
             credential = Mock(get_token=lambda _: AccessToken("fake-token", 0))
-        return VaultClient(vault_uri, credential, **self.client_kwargs)
+        return VaultClient(vault_uri, credential, is_live=self.is_live, **self.client_kwargs)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -171,8 +171,7 @@ class KeyClientTests(KeyVaultTestCase):
         self._update_key_properties(client, created_rsa_key)
 
         # delete the new key
-        polling_interval = 0 if self.is_playback() else 2
-        deleted_key_poller = client.begin_delete_key(created_rsa_key.name, _polling_interval=polling_interval)
+        deleted_key_poller = client.begin_delete_key(created_rsa_key.name)
         deleted_key = deleted_key_poller.result()
         self.assertIsNotNone(deleted_key)
         self.assertEqual(created_rsa_key.key_type, deleted_key.key_type)
@@ -206,8 +205,7 @@ class KeyClientTests(KeyVaultTestCase):
         self.assertIsNotNone(key_backup, "key_backup")
 
         # delete key
-        polling_interval = 0 if self.is_playback() else 2
-        client.begin_delete_key(created_bundle.name, _polling_interval=polling_interval).wait()
+        client.begin_delete_key(created_bundle.name).wait()
 
         # restore key
         restored = client.restore_key_backup(key_backup)
@@ -281,9 +279,8 @@ class KeyClientTests(KeyVaultTestCase):
             expected[key_name] = client.create_key(key_name, "RSA")
 
         # delete them
-        polling_interval = 0 if self.is_playback() else 2
         for key_name in expected.keys():
-            client.begin_delete_key(key_name, _polling_interval=polling_interval).wait()
+            client.begin_delete_key(key_name).wait()
 
         # validate list deleted keys with attributes
         for deleted_key in client.list_deleted_keys():
@@ -312,9 +309,8 @@ class KeyClientTests(KeyVaultTestCase):
             keys[key_name] = client.create_key(key_name, "RSA")
 
         # delete them
-        polling_interval = 0 if self.is_playback() else 2
         for key_name in keys.keys():
-            client.begin_delete_key(key_name, _polling_interval=polling_interval).wait()
+            client.begin_delete_key(key_name).wait()
 
         # validate the deleted keys are returned by list_deleted_keys
         deleted = [s.name for s in client.list_deleted_keys()]
@@ -322,7 +318,7 @@ class KeyClientTests(KeyVaultTestCase):
 
         # recover the keys
         for key_name in keys.keys():
-            recovered_key = client.begin_recover_deleted_key(key_name, _polling_interval=polling_interval).result()
+            recovered_key = client.begin_recover_deleted_key(key_name).result()
             expected_key = keys[key_name]
             self._assert_key_attributes_equal(expected_key.properties, recovered_key.properties)
 
@@ -339,9 +335,8 @@ class KeyClientTests(KeyVaultTestCase):
             client.create_key(name, "RSA")
 
         # delete them
-        polling_interval = 0 if self.is_playback() else 2
         for key_name in key_names:
-            client.begin_delete_key(key_name, _polling_interval=polling_interval).wait()
+            client.begin_delete_key(key_name).wait()
 
         # validate all our deleted keys are returned by list_deleted_keys
         deleted = [k.name for k in client.list_deleted_keys()]

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -199,8 +199,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         await self._update_key_properties(client, created_rsa_key)
 
         # delete the new key
-        polling_interval = 0 if self.is_playback() else 2
-        deleted_key = await client.delete_key(created_rsa_key.name, _polling_interval=polling_interval)
+        deleted_key = await client.delete_key(created_rsa_key.name)
         self.assertIsNotNone(deleted_key)
         self._assert_jwks_equal(created_rsa_key.key, deleted_key.key)
         self.assertEqual(deleted_key.id, created_rsa_key.id)
@@ -282,9 +281,8 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
             expected[key_name] = await client.create_key(key_name, key_type)
 
         # delete all keys
-        polling_interval = 0 if self.is_playback() else 2
         for key_name in expected.keys():
-            await client.delete_key(key_name, _polling_interval=polling_interval)
+            await client.delete_key(key_name)
 
         # validate list deleted keys with attributes
         async for deleted_key in client.list_deleted_keys():
@@ -318,8 +316,7 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
         self.assertIsNotNone(key_backup, "key_backup")
 
         # delete key
-        polling_interval = 0 if self.is_playback() else 2
-        await client.delete_key(created_bundle.name, _polling_interval=polling_interval)
+        await client.delete_key(created_bundle.name)
         # can add test case to see if we do get_deleted should return error
 
         # restore key
@@ -342,13 +339,12 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
             keys[key_name] = await client.create_key(key_name, "RSA")
 
         # delete them
-        polling_interval = 0 if self.is_playback() else 2
         for key_name in keys.keys():
-            await client.delete_key(key_name, _polling_interval=polling_interval)
+            await client.delete_key(key_name)
 
         # recover them
         for key_name in keys.keys():
-            recovered_key = await client.recover_deleted_key(key_name, _polling_interval=polling_interval)
+            recovered_key = await client.recover_deleted_key(key_name)
             expected_key = keys[key_name]
             self._assert_key_attributes_equal(expected_key.properties, recovered_key.properties)
 
@@ -376,9 +372,8 @@ class KeyVaultKeyTest(AsyncKeyVaultTestCase):
             keys[key_name] = await client.create_key(key_name, "RSA")
 
         # delete them
-        polling_interval = 0 if self.is_playback() else 2
         for key_name in keys.keys():
-            await client.delete_key(key_name, _polling_interval=polling_interval)
+            await client.delete_key(key_name)
 
         # purge them
         for key_name in keys.keys():

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -196,9 +196,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
 
         # [END backup_key]
 
-        polling_interval = 0 if self.is_playback() else 2
-
-        key_client.begin_delete_key(key_name, _polling_interval=polling_interval).wait()
+        key_client.begin_delete_key(key_name).wait()
 
         # [START restore_key_backup]
 
@@ -215,8 +213,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     def test_example_keys_recover(self, vault_client, **kwargs):
         key_client = vault_client.keys
         created_key = key_client.create_key("key-name", "RSA")
-        polling_interval = 0 if self.is_playback() else 2
-        key_client.begin_delete_key(created_key.name, _polling_interval=polling_interval).wait()
+        key_client.begin_delete_key(created_key.name).wait()
         # [START get_deleted_key]
 
         # get a deleted key (requires soft-delete enabled for the vault)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -192,9 +192,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
 
         # [END backup_key]
 
-        polling_interval = 0 if self.is_playback() else 2
-
-        await key_client.delete_key(key_name, _polling_interval=polling_interval)
+        await key_client.delete_key(key_name)
 
         # [START restore_key_backup]
 
@@ -214,8 +212,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
         key_client = vault_client.keys
         created_key = await key_client.create_key("key-name", "RSA")
 
-        polling_interval = 0 if self.is_playback() else 2
-        await key_client.delete_key(created_key.name, _polling_interval=polling_interval)
+        await key_client.delete_key(created_key.name)
 
         # [START get_deleted_key]
 

--- a/sdk/keyvault/azure-keyvault-secrets/tests/secrets_async_preparer.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/secrets_async_preparer.py
@@ -34,4 +34,7 @@ class AsyncVaultClientPreparer(VaultClientPreparer):
             credential = EnvironmentCredential()
         else:
             credential = Mock(get_token=asyncio.coroutine(lambda _: AccessToken("fake-token", 0)))
-        return VaultClient(vault_uri, credential, transport=AiohttpTestTransport(), **self.client_kwargs)
+
+        return VaultClient(
+            vault_uri, credential, transport=AiohttpTestTransport(), is_live=self.is_live, **self.client_kwargs
+        )

--- a/sdk/keyvault/azure-keyvault-secrets/tests/secrets_preparer.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/secrets_preparer.py
@@ -49,4 +49,4 @@ class VaultClientPreparer(AzureMgmtPreparer):
             credential = EnvironmentCredential()
         else:
             credential = Mock(get_token=lambda _: AccessToken("fake-token", 0))
-        return VaultClient(vault_uri, credential, **self.client_kwargs)
+        return VaultClient(vault_uri, credential, is_live=self.is_live, **self.client_kwargs)

--- a/sdk/keyvault/azure-keyvault-secrets/tests/secrets_vault_client_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/secrets_vault_client_async.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import functools
 from typing import Any, Callable, Mapping, TYPE_CHECKING
 from azure.core.configuration import Configuration
 from azure.core.pipeline import AsyncPipeline
@@ -29,12 +30,17 @@ class VaultClient(AsyncKeyVaultClientBase):
         credential: "TokenCredential",
         transport: HttpTransport = None,
         api_version: str = None,
+        is_live: bool = True,
         **kwargs: Any
     ) -> None:
-        super(VaultClient, self).__init__(
-            vault_url, credential, transport=transport, api_version=api_version, **kwargs
-        )
+        super(VaultClient, self).__init__(vault_url, credential, transport=transport, api_version=api_version, **kwargs)
         self._secrets = SecretClient(self.vault_url, credential, generated_client=self._client, **kwargs)
+        if not is_live:
+            # ensure pollers don't sleep during playback
+            self._secrets.delete_secret = functools.partial(self._secrets.delete_secret, _polling_interval=0)
+            self._secrets.recover_deleted_secret = functools.partial(
+                self._secrets.recover_deleted_secret, _polling_interval=0
+            )
 
     @property
     def secrets(self):

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
@@ -166,8 +166,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         print(secret_backup)
 
         # [END backup_secret]
-        polling_interval = 0 if self.is_playback() else 2
-        secret_client.begin_delete_secret("secret-name", _polling_interval=polling_interval).wait()
+        secret_client.begin_delete_secret("secret-name").wait()
         # [START restore_secret_backup]
 
         # restores a backed up secret
@@ -183,8 +182,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     def test_example_secrets_recover(self, vault_client, **kwargs):
         secret_client = vault_client.secrets
         created_secret = secret_client.set_secret("secret-name", "secret-value")
-        polling_interval = 0 if self.is_playback() else 2
-        secret_client.begin_delete_secret(created_secret.name, _polling_interval=polling_interval).wait()
+        secret_client.begin_delete_secret(created_secret.name).wait()
 
         # [START get_deleted_secret]
         # gets a deleted secret (requires soft-delete enabled for the vault)

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
@@ -165,8 +165,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
 
         # [END backup_secret]
 
-        polling_interval = 0 if self.is_playback() else 2
-        await secret_client.delete_secret(created_secret.name, _polling_interval=polling_interval)
+        await secret_client.delete_secret(created_secret.name)
 
         # [START restore_secret_backup]
 
@@ -184,8 +183,7 @@ class TestExamplesKeyVault(AsyncKeyVaultTestCase):
     async def test_example_secrets_recover(self, vault_client, **kwargs):
         secret_client = vault_client.secrets
         created_secret = await secret_client.set_secret("secret-name", "secret-value")
-        polling_interval = 0 if self.is_playback() else 2
-        await secret_client.delete_secret(created_secret.name, _polling_interval=polling_interval)
+        await secret_client.delete_secret(created_secret.name)
 
         # [START get_deleted_secret]
         # gets a deleted secret (requires soft-delete enabled for the vault)

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
@@ -125,8 +125,7 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
         updated = await _update_secret(created)
 
         # delete secret
-        polling_interval = 0 if self.is_playback() else 2
-        deleted = await client.delete_secret(updated.name, _polling_interval=polling_interval)
+        deleted = await client.delete_secret(updated.name)
         self.assertIsNotNone(deleted)
 
     @ResourceGroupPreparer(random_name_enabled=True)
@@ -168,10 +167,10 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
             secret_name = "secret{}".format(i)
             secret_value = "value{}".format(i)
             expected[secret_name] = await client.set_secret(secret_name, secret_value)
-        polling_interval = 0 if self.is_playback() else 2
+
         # delete them
         for secret_name in expected.keys():
-            await client.delete_secret(secret_name, _polling_interval=polling_interval)
+            await client.delete_secret(secret_name)
 
         # validate list deleted secrets with attributes
         async for deleted_secret in client.list_deleted_secrets():
@@ -230,8 +229,7 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
         self.assertIsNotNone(secret_backup, "secret_backup")
 
         # delete secret
-        polling_interval = 0 if self.is_playback() else 2
-        await client.delete_secret(created_bundle.name, _polling_interval=polling_interval)
+        await client.delete_secret(created_bundle.name)
 
         # restore secret
         restored = await client.restore_secret_backup(secret_backup)
@@ -255,9 +253,8 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
             secrets[secret_name] = await client.set_secret(secret_name, secret_value)
 
         # delete all secrets
-        polling_interval = 0 if self.is_playback() else 2
         for secret_name in secrets.keys():
-            await client.delete_secret(secret_name, _polling_interval=polling_interval)
+            await client.delete_secret(secret_name)
 
         # validate all our deleted secrets are returned by list_deleted_secrets
         async for deleted_secret in client.list_deleted_secrets():
@@ -265,7 +262,7 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
 
         # recover select secrets
         for secret_name in secrets.keys():
-            await client.recover_deleted_secret(secret_name, _polling_interval=polling_interval)
+            await client.recover_deleted_secret(secret_name)
 
         # validate the recovered secrets exist
         await self._poll_until_no_exception(
@@ -289,9 +286,8 @@ class KeyVaultSecretTest(AsyncKeyVaultTestCase):
             secrets[secret_name] = await client.set_secret(secret_name, secret_value)
 
         # delete all secrets
-        polling_interval = 0 if self.is_playback() else 2
         for secret_name in secrets.keys():
-            await client.delete_secret(secret_name, _polling_interval=polling_interval)
+            await client.delete_secret(secret_name)
 
         # validate all our deleted secrets are returned by list_deleted_secrets
         async for deleted_secret in client.list_deleted_secrets():

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
@@ -129,8 +129,7 @@ class SecretClientTests(KeyVaultTestCase):
         updated = _update_secret(created)
 
         # delete secret
-        polling_interval = 0 if self.is_playback() else 2
-        deleted = client.begin_delete_secret(updated.name, _polling_interval=polling_interval).result()
+        deleted = client.begin_delete_secret(updated.name).result()
         self.assertIsNotNone(deleted)
 
     @ResourceGroupPreparer(random_name_enabled=True)
@@ -203,9 +202,8 @@ class SecretClientTests(KeyVaultTestCase):
             expected[secret_name] = client.set_secret(secret_name, secret_value)
 
         # delete them
-        polling_interval = 0 if self.is_playback() else 2
         for secret_name in expected.keys():
-            client.begin_delete_secret(secret_name, _polling_interval=polling_interval).wait()
+            client.begin_delete_secret(secret_name).wait()
 
         # validate list deleted secrets with attributes
         for deleted_secret in client.list_deleted_secrets():
@@ -232,8 +230,7 @@ class SecretClientTests(KeyVaultTestCase):
         self.assertIsNotNone(secret_backup, "secret_backup")
 
         # delete secret
-        polling_interval = 0 if self.is_playback() else 2
-        client.begin_delete_secret(created_bundle.name, _polling_interval=polling_interval).wait()
+        client.begin_delete_secret(created_bundle.name).wait()
 
         # restore secret
         restored = client.restore_secret_backup(secret_backup)
@@ -254,10 +251,9 @@ class SecretClientTests(KeyVaultTestCase):
             secret_value = "value{}".format(i)
             secrets[secret_name] = client.set_secret(secret_name, secret_value)
 
-        polling_interval = 0 if self.is_playback() else 2
         # delete all secrets
         for secret_name in secrets.keys():
-            client.begin_delete_secret(secret_name, _polling_interval=polling_interval).wait()
+            client.begin_delete_secret(secret_name).wait()
 
         # validate all our deleted secrets are returned by list_deleted_secrets
         deleted = [s.name for s in client.list_deleted_secrets()]
@@ -265,7 +261,7 @@ class SecretClientTests(KeyVaultTestCase):
 
         # recover select secrets
         for secret_name in secrets.keys():
-            client.begin_recover_deleted_secret(secret_name, _polling_interval=polling_interval).wait()
+            client.begin_recover_deleted_secret(secret_name).wait()
 
         # validate the recovered secrets exist
         for secret_name in secrets.keys():
@@ -288,9 +284,8 @@ class SecretClientTests(KeyVaultTestCase):
             secrets[secret_name] = client.set_secret(secret_name, secret_value)
 
         # delete all secrets
-        polling_interval = 0 if self.is_playback() else 2
         for secret_name in secrets.keys():
-            client.begin_delete_secret(secret_name, _polling_interval=polling_interval).wait()
+            client.begin_delete_secret(secret_name).wait()
 
         # validate all our deleted secrets are returned by list_deleted_secrets
         deleted = [s.name for s in client.list_deleted_secrets()]


### PR DESCRIPTION
Client methods which return pollers accept a `_polling_interval` keyword argument which we use in tests to prevent sleeping between polls, i.e. wasting time, during playback. The first commit here has `VaultClient` wrap these methods during playback such that every invocation receives `_polling_interval=0`. The second commit removes usage of the argument from individual test cases (and is noisy due to formatting with `black`; *you probably want to ignore this commit*).

While working on this I observed certificates tests are slow because some Key Vault responses include Retry-After headers. `RetryPolicy` exposes no configuration for ignoring these, and so during playback, always respects them. The third commit here solves this problem by introducing a transport whose `sleep` method is a no-op.