### PR TITLE
[textanalytics] renames TextAnalyticsAPIKeyCredential to TextAnalyticsApiKeyCredential

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/README.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/README.md
@@ -76,21 +76,21 @@ az cognitiveservices account show --name "resource-name" --resource-group "resou
 ```
 
 #### Types of credentials
-The `credential` parameter may be provided as a `TextAnalyticsAPIKeyCredential` or as a token from Azure Active Directory.
+The `credential` parameter may be provided as a `TextAnalyticsApiKeyCredential` or as a token from Azure Active Directory.
 See the full details regarding [authentication](https://docs.microsoft.com/azure/cognitive-services/authentication) of 
 cognitive services.
 
 1. To use an [API key](https://docs.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account?tabs=multiservice%2Cwindows#get-the-keys-for-your-resource), 
-   pass the key as a string into an instance of `TextAnalyticsAPIKeyCredential("<api_key>")`. 
+   pass the key as a string into an instance of `TextAnalyticsApiKeyCredential("<api_key>")`. 
    The API key can be found in the Azure Portal or by running the following Azure CLI command:
 
     ```az cognitiveservices account keys list --name "resource-name" --resource-group "resource-group-name"```
     
     Use the key as the credential parameter to authenticate the client:
     ```python
-    from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
+    from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
     
-    credential = TextAnalyticsAPIKeyCredential("<api_key>")
+    credential = TextAnalyticsApiKeyCredential("<api_key>")
     text = TextAnalyticsClient(endpoint="https://westus2.api.cognitive.microsoft.com/", credential=credential)
     ```
 
@@ -137,9 +137,9 @@ The endpoint and credential are passed in with the desired text and other option
 [single_analyze_sentiment()](https://aka.ms/azsdk-python-textanalytics-singleanalyzesentiment):
 
 ```python
-from azure.ai.textanalytics import single_analyze_sentiment, TextAnalyticsAPIKeyCredential
+from azure.ai.textanalytics import single_analyze_sentiment, TextAnalyticsApiKeyCredential
 
-credential = TextAnalyticsAPIKeyCredential("<api_key>")
+credential = TextAnalyticsApiKeyCredential("<api_key>")
 text = "I did not like the restaurant. The food was too spicy."
 
 result = single_analyze_sentiment(endpoint=endpoint, credential=credential, input_text=text, language="en")
@@ -189,9 +189,9 @@ The following section provides several code snippets covering some of the most c
 Analyze sentiment in a batch of documents.
 
 ```python
-from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
+from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
     
-text_analytics_client = TextAnalyticsClient(endpoint, TextAnalyticsAPIKeyCredential(key))
+text_analytics_client = TextAnalyticsClient(endpoint, TextAnalyticsApiKeyCredential(key))
 
 documents = [
     "I did not like the restaurant. The food was too spicy.",
@@ -217,9 +217,9 @@ Please refer to the service documentation for a conceptual discussion of [sentim
 Recognize entities in a batch of documents.
 
 ```python
-from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
+from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
     
-text_analytics_client = TextAnalyticsClient(endpoint, TextAnalyticsAPIKeyCredential(key))
+text_analytics_client = TextAnalyticsClient(endpoint, TextAnalyticsApiKeyCredential(key))
 
 documents = [
     "Microsoft was founded by Bill Gates and Paul Allen.",
@@ -243,9 +243,9 @@ and [supported types](https://docs.microsoft.com/azure/cognitive-services/text-a
 Recognize PII entities in a batch of documents.
 
 ```python
-from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
+from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
     
-text_analytics_client = TextAnalyticsClient(endpoint, TextAnalyticsAPIKeyCredential(key))
+text_analytics_client = TextAnalyticsClient(endpoint, TextAnalyticsApiKeyCredential(key))
 
 documents = [
     "The employee's SSN is 555-55-5555.",
@@ -267,9 +267,9 @@ Please refer to the service documentation for [supported PII entity types](https
 Recognize linked entities in a batch of documents.
 
 ```python
-from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
+from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
     
-text_analytics_client = TextAnalyticsClient(endpoint, TextAnalyticsAPIKeyCredential(key))
+text_analytics_client = TextAnalyticsClient(endpoint, TextAnalyticsApiKeyCredential(key))
 
 documents = [
     "Microsoft was founded by Bill Gates and Paul Allen.",
@@ -297,9 +297,9 @@ and [supported types](https://docs.microsoft.com/azure/cognitive-services/text-a
 Extract key phrases in a batch of documents.
 
 ```python
-from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
+from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
     
-text_analytics_client = TextAnalyticsClient(endpoint, TextAnalyticsAPIKeyCredential(key))
+text_analytics_client = TextAnalyticsClient(endpoint, TextAnalyticsApiKeyCredential(key))
 
 documents = [
     "Redmond is a city in King County, Washington, United States, located 15 miles east of Seattle.",
@@ -320,9 +320,9 @@ Please refer to the service documentation for a conceptual discussion of [key ph
 Detect language in a batch of documents.
 
 ```python
-from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
+from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
     
-text_analytics_client = TextAnalyticsClient(endpoint, TextAnalyticsAPIKeyCredential(key))
+text_analytics_client = TextAnalyticsClient(endpoint, TextAnalyticsApiKeyCredential(key))
 
 documents = [
     "This is written in English.",

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/__init__.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/__init__.py
@@ -30,7 +30,7 @@ from ._models import (
     SentenceSentiment,
     SentimentConfidenceScorePerLabel
 )
-from ._credential import TextAnalyticsAPIKeyCredential
+from ._credential import TextAnalyticsApiKeyCredential
 
 __all__ = [
     'TextAnalyticsClient',
@@ -59,7 +59,7 @@ __all__ = [
     'TextDocumentBatchStatistics',
     'SentenceSentiment',
     'SentimentConfidenceScorePerLabel',
-    'TextAnalyticsAPIKeyCredential'
+    'TextAnalyticsApiKeyCredential'
 ]
 
 __version__ = VERSION
@@ -82,10 +82,10 @@ def single_detect_language(
     :param str endpoint: Supported Cognitive Services endpoints (protocol and
         hostname, for example: https://westus2.api.cognitive.microsoft.com).
     :param credential: Credentials needed for the client to connect to Azure.
-        This can be the an instance of TextAnalyticsAPIKeyCredential if using a
-        cognitive services/text analytics subscription key or a token credential
+        This can be the an instance of TextAnalyticsApiKeyCredential if using a
+        cognitive services/text analytics API key or a token credential
         from azure.identity.
-    :type credential: ~azure.ai.textanalytics.TextAnalyticsAPIKeyCredential or
+    :type credential: ~azure.ai.textanalytics.TextAnalyticsApiKeyCredential or
         ~azure.core.credentials.TokenCredential
     :param str input_text: The single string to detect language from.
     :param str country_hint: The country hint for the text. Accepts two
@@ -142,10 +142,10 @@ def single_recognize_entities(
     :param str endpoint: Supported Cognitive Services endpoints (protocol and
         hostname, for example: https://westus2.api.cognitive.microsoft.com).
     :param credential: Credentials needed for the client to connect to Azure.
-        This can be the an instance of TextAnalyticsAPIKeyCredential if using a
-        cognitive services/text analytics subscription key or a token credential
+        This can be the an instance of TextAnalyticsApiKeyCredential if using a
+        cognitive services/text analytics API key or a token credential
         from azure.identity.
-    :type credential: ~azure.ai.textanalytics.TextAnalyticsAPIKeyCredential or
+    :type credential: ~azure.ai.textanalytics.TextAnalyticsApiKeyCredential or
         ~azure.core.credentials.TokenCredential
     :param str input_text: The single string to recognize entities from.
     :param str language: This is the 2 letter ISO 639-1 representation
@@ -202,10 +202,10 @@ def single_recognize_pii_entities(
     :param str endpoint: Supported Cognitive Services endpoints (protocol and
         hostname, for example: https://westus2.api.cognitive.microsoft.com).
     :param credential: Credentials needed for the client to connect to Azure.
-        This can be the an instance of TextAnalyticsAPIKeyCredential if using a
-        cognitive services/text analytics subscription key or a token credential
+        This can be the an instance of TextAnalyticsApiKeyCredential if using a
+        cognitive services/text analytics API key or a token credential
         from azure.identity.
-    :type credential: ~azure.ai.textanalytics.TextAnalyticsAPIKeyCredential or
+    :type credential: ~azure.ai.textanalytics.TextAnalyticsApiKeyCredential or
         ~azure.core.credentials.TokenCredential
     :param str input_text: The single string to recognize entities from.
     :param str language: This is the 2 letter ISO 639-1 representation
@@ -262,10 +262,10 @@ def single_recognize_linked_entities(
     :param str endpoint: Supported Cognitive Services endpoints (protocol and
         hostname, for example: https://westus2.api.cognitive.microsoft.com).
     :param credential: Credentials needed for the client to connect to Azure.
-        This can be the an instance of TextAnalyticsAPIKeyCredential if using a
-        cognitive services/text analytics subscription key or a token credential
+        This can be the an instance of TextAnalyticsApiKeyCredential if using a
+        cognitive services/text analytics API key or a token credential
         from azure.identity.
-    :type credential: ~azure.ai.textanalytics.TextAnalyticsAPIKeyCredential or
+    :type credential: ~azure.ai.textanalytics.TextAnalyticsApiKeyCredential or
         ~azure.core.credentials.TokenCredential
     :param str input_text: The single string to recognize entities from.
     :param str language: This is the 2 letter ISO 639-1 representation
@@ -321,10 +321,10 @@ def single_extract_key_phrases(
     :param str endpoint: Supported Cognitive Services endpoints (protocol and
         hostname, for example: https://westus2.api.cognitive.microsoft.com).
     :param credential: Credentials needed for the client to connect to Azure.
-        This can be the an instance of TextAnalyticsAPIKeyCredential if using a
-        cognitive services/text analytics subscription key or a token credential
+        This can be the an instance of TextAnalyticsApiKeyCredential if using a
+        cognitive services/text analytics API key or a token credential
         from azure.identity.
-    :type credential: ~azure.ai.textanalytics.TextAnalyticsAPIKeyCredential or
+    :type credential: ~azure.ai.textanalytics.TextAnalyticsApiKeyCredential or
         ~azure.core.credentials.TokenCredential
     :param str input_text: The single string to extract key phrases from.
     :param str language: This is the 2 letter ISO 639-1 representation
@@ -381,10 +381,10 @@ def single_analyze_sentiment(
     :param str endpoint: Supported Cognitive Services endpoints (protocol and
         hostname, for example: https://westus2.api.cognitive.microsoft.com).
     :param credential: Credentials needed for the client to connect to Azure.
-        This can be the an instance of TextAnalyticsAPIKeyCredential if using a
-        cognitive services/text analytics subscription key or a token credential
+        This can be the an instance of TextAnalyticsApiKeyCredential if using a
+        cognitive services/text analytics API key or a token credential
         from azure.identity.
-    :type credential: ~azure.ai.textanalytics.TextAnalyticsAPIKeyCredential or
+    :type credential: ~azure.ai.textanalytics.TextAnalyticsApiKeyCredential or
         ~azure.core.credentials.TokenCredential
     :param str input_text: The single string to analyze sentiment from.
     :param str language: This is the 2 letter ISO 639-1 representation

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_base_client.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_base_client.py
@@ -20,7 +20,7 @@ from azure.core.pipeline.policies import (
     HttpLoggingPolicy,
 )
 from ._policies import CognitiveServicesCredentialPolicy, TextAnalyticsResponseHook
-from ._credential import TextAnalyticsAPIKeyCredential
+from ._credential import TextAnalyticsApiKeyCredential
 from ._user_agent import USER_AGENT
 
 
@@ -36,10 +36,10 @@ class TextAnalyticsClientBase(object):
             credential_policy = BearerTokenCredentialPolicy(
                 credential, "https://cognitiveservices.azure.com/.default"
             )
-        elif isinstance(credential, TextAnalyticsAPIKeyCredential):
+        elif isinstance(credential, TextAnalyticsApiKeyCredential):
             credential_policy = CognitiveServicesCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError("Unsupported credential: {}. Use an instance of TextAnalyticsAPIKeyCredential "
+            raise TypeError("Unsupported credential: {}. Use an instance of TextAnalyticsApiKeyCredential "
                             "or a token credential from azure.identity".format(type(credential)))
 
         config = self._create_configuration(**kwargs)

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_credential.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_credential.py
@@ -7,31 +7,31 @@
 import six
 
 
-class TextAnalyticsAPIKeyCredential(object):
+class TextAnalyticsApiKeyCredential(object):
     """Credential type used for authenticating the client
-    with a subscription key.
+    with an API key.
 
-    :param str subscription_key: The subscription key to your Text Analytics
+    :param str api_key: The API key to your Text Analytics
         or Cognitive Services account.
     """
-    def __init__(self, subscription_key):
-        if not isinstance(subscription_key, six.string_types):
-            raise TypeError("Please provide the subscription key as a string.")
-        self._subscription_key = subscription_key
+    def __init__(self, api_key):
+        if not isinstance(api_key, six.string_types):
+            raise TypeError("Please provide the API key as a string.")
+        self._api_key = api_key
 
     @property
-    def subscription_key(self):
-        """Returns the current value of subscription key.
+    def api_key(self):
+        """Returns the current value of the API key.
         """
-        return self._subscription_key
+        return self._api_key
 
     def update_key(self, key):
-        """Update the subscription key.
+        """Update the API key.
 
-        This is intended to be used when you've regenerated your service subscription key
+        This is intended to be used when you've regenerated your service API key
         and want to update long-lived clients.
 
-        :param str key: The subscription key to your Text Analytics
+        :param str key: The API key to your Text Analytics
             or Cognitive Services account.
         """
-        self._subscription_key = key
+        self._api_key = key

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_policies.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_policies.py
@@ -17,7 +17,7 @@ class CognitiveServicesCredentialPolicy(SansIOHTTPPolicy):
     def on_request(self, request):
         request.http_request.headers[
             "Ocp-Apim-Subscription-Key"
-        ] = self.credential.subscription_key
+        ] = self.credential.api_key
         request.http_request.headers["X-BingApis-SDK-Client"] = "Python-SDK"
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
@@ -54,10 +54,10 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
     :param str endpoint: Supported Cognitive Services or Text Analytics resource
         endpoints (protocol and hostname, for example: https://westus2.api.cognitive.microsoft.com).
     :param credential: Credentials needed for the client to connect to Azure.
-        This can be the an instance of TextAnalyticsAPIKeyCredential if using a
-        cognitive services/text analytics subscription key or a token credential
+        This can be the an instance of TextAnalyticsApiKeyCredential if using a
+        cognitive services/text analytics API key or a token credential
         from azure.identity.
-    :type credential: ~azure.ai.textanalytics.TextAnalyticsAPIKeyCredential or
+    :type credential: ~azure.ai.textanalytics.TextAnalyticsApiKeyCredential or
         ~azure.core.credentials.TokenCredential
     :keyword str default_country_hint: Sets the default country_hint to use for all operations.
         Defaults to "US". If you don't want to use a country hint, pass the empty string "".
@@ -71,7 +71,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             :end-before: [END create_ta_client_with_key]
             :language: python
             :dedent: 8
-            :caption: Creating the TextAnalyticsClient with endpoint and subscription key.
+            :caption: Creating the TextAnalyticsClient with endpoint and API key.
 
         .. literalinclude:: ../samples/sample_authentication.py
             :start-after: [START create_ta_client_with_aad]

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/__init__.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/__init__.py
@@ -44,10 +44,10 @@ async def single_detect_language(
     :param str endpoint: Supported Cognitive Services endpoints (protocol and
         hostname, for example: https://westus2.api.cognitive.microsoft.com).
     :param credential: Credentials needed for the client to connect to Azure.
-        This can be the an instance of TextAnalyticsAPIKeyCredential if using a
-        cognitive services/text analytics subscription key or a token credential
+        This can be the an instance of TextAnalyticsApiKeyCredential if using a
+        cognitive services/text analytics API key or a token credential
         from azure.identity.
-    :type credential: ~azure.ai.textanalytics.TextAnalyticsAPIKeyCredential or
+    :type credential: ~azure.ai.textanalytics.TextAnalyticsApiKeyCredential or
         ~azure.core.credentials.TokenCredential
     :param str input_text: The single string to detect language from.
     :param str country_hint: The country hint for the text. Accepts two
@@ -103,10 +103,10 @@ async def single_recognize_entities(
     :param str endpoint: Supported Cognitive Services endpoints (protocol and
         hostname, for example: https://westus2.api.cognitive.microsoft.com).
     :param credential: Credentials needed for the client to connect to Azure.
-        This can be the an instance of TextAnalyticsAPIKeyCredential if using a
-        cognitive services/text analytics subscription key or a token credential
+        This can be the an instance of TextAnalyticsApiKeyCredential if using a
+        cognitive services/text analytics API key or a token credential
         from azure.identity.
-    :type credential: ~azure.ai.textanalytics.TextAnalyticsAPIKeyCredential or
+    :type credential: ~azure.ai.textanalytics.TextAnalyticsApiKeyCredential or
         ~azure.core.credentials.TokenCredential
     :param str input_text: The single string to recognize entities from.
     :param str language: This is the 2 letter ISO 639-1 representation
@@ -162,10 +162,10 @@ async def single_recognize_pii_entities(
     :param str endpoint: Supported Cognitive Services endpoints (protocol and
         hostname, for example: https://westus2.api.cognitive.microsoft.com).
     :param credential: Credentials needed for the client to connect to Azure.
-        This can be the an instance of TextAnalyticsAPIKeyCredential if using a
-        cognitive services/text analytics subscription key or a token credential
+        This can be the an instance of TextAnalyticsApiKeyCredential if using a
+        cognitive services/text analytics API key or a token credential
         from azure.identity.
-    :type credential: ~azure.ai.textanalytics.TextAnalyticsAPIKeyCredential or
+    :type credential: ~azure.ai.textanalytics.TextAnalyticsApiKeyCredential or
         ~azure.core.credentials.TokenCredential
     :param str input_text: The single string to recognize entities from.
     :param str language: This is the 2 letter ISO 639-1 representation
@@ -221,10 +221,10 @@ async def single_recognize_linked_entities(
     :param str endpoint: Supported Cognitive Services endpoints (protocol and
         hostname, for example: https://westus2.api.cognitive.microsoft.com).
     :param credential: Credentials needed for the client to connect to Azure.
-        This can be the an instance of TextAnalyticsAPIKeyCredential if using a
-        cognitive services/text analytics subscription key or a token credential
+        This can be the an instance of TextAnalyticsApiKeyCredential if using a
+        cognitive services/text analytics API key or a token credential
         from azure.identity.
-    :type credential: ~azure.ai.textanalytics.TextAnalyticsAPIKeyCredential or
+    :type credential: ~azure.ai.textanalytics.TextAnalyticsApiKeyCredential or
         ~azure.core.credentials.TokenCredential
     :param str input_text: The single string to recognize entities from.
     :param str language: This is the 2 letter ISO 639-1 representation
@@ -279,10 +279,10 @@ async def single_extract_key_phrases(
     :param str endpoint: Supported Cognitive Services endpoints (protocol and
         hostname, for example: https://westus2.api.cognitive.microsoft.com).
     :param credential: Credentials needed for the client to connect to Azure.
-        This can be the an instance of TextAnalyticsAPIKeyCredential if using a
-        cognitive services/text analytics subscription key or a token credential
+        This can be the an instance of TextAnalyticsApiKeyCredential if using a
+        cognitive services/text analytics API key or a token credential
         from azure.identity.
-    :type credential: ~azure.ai.textanalytics.TextAnalyticsAPIKeyCredential or
+    :type credential: ~azure.ai.textanalytics.TextAnalyticsApiKeyCredential or
         ~azure.core.credentials.TokenCredential
     :param str input_text: The single string to extract key phrases from.
     :param str language: This is the 2 letter ISO 639-1 representation
@@ -338,10 +338,10 @@ async def single_analyze_sentiment(
     :param str endpoint: Supported Cognitive Services endpoints (protocol and
         hostname, for example: https://westus2.api.cognitive.microsoft.com).
     :param credential: Credentials needed for the client to connect to Azure.
-        This can be the an instance of TextAnalyticsAPIKeyCredential if using a
-        cognitive services/text analytics subscription key or a token credential
+        This can be the an instance of TextAnalyticsApiKeyCredential if using a
+        cognitive services/text analytics API key or a token credential
         from azure.identity.
-    :type credential: ~azure.ai.textanalytics.TextAnalyticsAPIKeyCredential or
+    :type credential: ~azure.ai.textanalytics.TextAnalyticsApiKeyCredential or
         ~azure.core.credentials.TokenCredential
     :param str input_text: The single string to analyze sentiment from.
     :param str language: This is the 2 letter ISO 639-1 representation

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_base_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_base_client_async.py
@@ -18,7 +18,7 @@ from azure.core.pipeline.policies import (
     HttpLoggingPolicy,
     DistributedTracingPolicy
 )
-from .._credential import TextAnalyticsAPIKeyCredential
+from .._credential import TextAnalyticsApiKeyCredential
 from .._policies import CognitiveServicesCredentialPolicy
 from ._policies_async import AsyncTextAnalyticsResponseHook
 from .._user_agent import USER_AGENT
@@ -37,10 +37,10 @@ class AsyncTextAnalyticsClientBase(object):
             credential_policy = AsyncBearerTokenCredentialPolicy(
                 credential, "https://cognitiveservices.azure.com/.default"
             )
-        elif isinstance(credential, TextAnalyticsAPIKeyCredential):
+        elif isinstance(credential, TextAnalyticsApiKeyCredential):
             credential_policy = CognitiveServicesCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError("Unsupported credential: {}. Use an instance of TextAnalyticsAPIKeyCredential "
+            raise TypeError("Unsupported credential: {}. Use an instance of TextAnalyticsApiKeyCredential "
                             "or a token credential from azure.identity".format(type(credential)))
 
         config = self._create_configuration(**kwargs)

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
@@ -51,10 +51,10 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
     :param str endpoint: Supported Cognitive Services or Text Analytics resource
         endpoints (protocol and hostname, for example: https://westus2.api.cognitive.microsoft.com).
     :param credential: Credentials needed for the client to connect to Azure.
-        This can be the an instance of TextAnalyticsAPIKeyCredential if using a
-        cognitive services/text analytics subscription key or a token credential
+        This can be the an instance of TextAnalyticsApiKeyCredential if using a
+        cognitive services/text analytics API key or a token credential
         from azure.identity.
-    :type credential: ~azure.ai.textanalytics.TextAnalyticsAPIKeyCredential
+    :type credential: ~azure.ai.textanalytics.TextAnalyticsApiKeyCredential
         or ~azure.core.credentials.TokenCredential
     :keyword str default_country_hint: Sets the default country_hint to use for all operations.
         Defaults to "US". If you don't want to use a country hint, pass the empty string "".
@@ -68,7 +68,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             :end-before: [END create_ta_client_with_key_async]
             :language: python
             :dedent: 8
-            :caption: Creating the TextAnalyticsClient with endpoint and subscription key.
+            :caption: Creating the TextAnalyticsClient with endpoint and API key.
 
         .. literalinclude:: ../samples/async_samples/sample_authentication_async.py
             :start-after: [START create_ta_client_with_aad_async]

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_analyze_sentiment_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_analyze_sentiment_async.py
@@ -86,8 +86,8 @@ class AnalyzeSentimentSampleAsync(object):
     async def analyze_sentiment_async(self):
         # [START batch_analyze_sentiment_async]
         from azure.ai.textanalytics.aio import TextAnalyticsClient
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
         documents = [
             "I had the best day of my life.",
             "This was a waste of my time. The speaker put me to sleep.",
@@ -129,8 +129,8 @@ class AnalyzeSentimentSampleAsync(object):
         with the text.
         """
         from azure.ai.textanalytics.aio import TextAnalyticsClient
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
 
         documents = [
             {"id": "0", "language": "en", "text": "I had the best day of my life."},

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_authentication_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_authentication_async.py
@@ -13,7 +13,7 @@ DESCRIPTION:
     This sample demonstrates how to authenticate with the text analytics service.
 
     There are two supported methods of authentication:
-    1) Use a cognitive services subscription key with TextAnalyticsAPIKeyCredential
+    1) Use a cognitive services/text analytics API key with TextAnalyticsApiKeyCredential
     2) Use a token credential to authenticate with Azure Active Directory
 
     See more details about authentication here:
@@ -24,7 +24,7 @@ USAGE:
 
     Set the environment variables with your own values before running the sample:
     1) AZURE_TEXT_ANALYTICS_ENDPOINT - the endpoint to your cognitive services resource.
-    2) AZURE_TEXT_ANALYTICS_KEY - your text analytics subscription key
+    2) AZURE_TEXT_ANALYTICS_KEY - your cognitive services/text analytics API key
     3) AZURE_CLIENT_ID - the client ID of your active directory application.
     4) AZURE_TENANT_ID - the tenant ID of your active directory application.
     5) AZURE_CLIENT_SECRET - the secret of your active directory application.
@@ -39,11 +39,11 @@ class AuthenticationSampleAsync(object):
     async def authentication_with_subscription_key_async(self):
         # [START create_ta_client_with_key_async]
         from azure.ai.textanalytics.aio import TextAnalyticsClient
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
         endpoint = os.getenv("AZURE_TEXT_ANALYTICS_ENDPOINT")
         key = os.getenv("AZURE_TEXT_ANALYTICS_KEY")
 
-        text_analytics_client = TextAnalyticsClient(endpoint, TextAnalyticsAPIKeyCredential(key))
+        text_analytics_client = TextAnalyticsClient(endpoint, TextAnalyticsApiKeyCredential(key))
         # [END create_ta_client_with_key_async]
 
         doc = ["I need to take my cat to the veterinarian."]

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_authentication_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_authentication_async.py
@@ -36,7 +36,7 @@ import asyncio
 
 class AuthenticationSampleAsync(object):
 
-    async def authentication_with_subscription_key_async(self):
+    async def authentication_with_api_key_credential_async(self):
         # [START create_ta_client_with_key_async]
         from azure.ai.textanalytics.aio import TextAnalyticsClient
         from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
@@ -77,7 +77,7 @@ class AuthenticationSampleAsync(object):
 
 async def main():
     sample = AuthenticationSampleAsync()
-    await sample.authentication_with_subscription_key_async()
+    await sample.authentication_with_api_key_credential_async()
     await sample.authentication_with_azure_active_directory_async()
 
 if __name__ == '__main__':

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_detect_languages_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_detect_languages_async.py
@@ -59,8 +59,8 @@ class DetectLanguagesSampleAsync(object):
     async def detect_languages_async(self):
         # [START batch_detect_languages_async]
         from azure.ai.textanalytics.aio import TextAnalyticsClient
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
         documents = [
             "This document is written in English.",
             "Este es un document escrito en Español.",
@@ -90,8 +90,8 @@ class DetectLanguagesSampleAsync(object):
         with the text.
         """
         from azure.ai.textanalytics.aio import TextAnalyticsClient
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
 
         documents = [
             {"id": "0", "country_hint": "US", "text": "This is a document written in English."},

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_extract_key_phrases_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_extract_key_phrases_async.py
@@ -37,8 +37,8 @@ class ExtractKeyPhrasesSampleAsync(object):
     async def extract_key_phrases_async(self):
         # [START batch_extract_key_phrases_async]
         from azure.ai.textanalytics.aio import TextAnalyticsClient
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
         documents = [
             "Redmond is a city in King County, Washington, United States, located 15 miles east of Seattle.",
             "I need to take my cat to the veterinarian.",
@@ -64,8 +64,8 @@ class ExtractKeyPhrasesSampleAsync(object):
         with the text.
         """
         from azure.ai.textanalytics.aio import TextAnalyticsClient
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
 
         documents = [
             {"id": "0", "language": "en",

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_entities_async.py
@@ -47,8 +47,8 @@ class RecognizeEntitiesSampleAsync(object):
     async def recognize_entities_async(self):
         # [START batch_recognize_entities_async]
         from azure.ai.textanalytics.aio import TextAnalyticsClient
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
         documents = [
             "Microsoft was founded by Bill Gates and Paul Allen.",
             "I had a wonderful trip to Seattle last week.",
@@ -76,8 +76,8 @@ class RecognizeEntitiesSampleAsync(object):
         with the text.
         """
         from azure.ai.textanalytics.aio import TextAnalyticsClient
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
 
         documents = [
             {"id": "0", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen."},

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_linked_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_linked_entities_async.py
@@ -109,8 +109,8 @@ class RecognizeLinkedEntitiesSampleAsync(object):
     async def recognize_linked_entities_async(self):
         # [START batch_recognize_linked_entities_async]
         from azure.ai.textanalytics.aio import TextAnalyticsClient
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
         documents = [
             "Microsoft moved its headquarters to Bellevue, Washington in January 1979.",
             "Steve Ballmer stepped down as CEO of Microsoft and was succeeded by Satya Nadella.",
@@ -144,8 +144,8 @@ class RecognizeLinkedEntitiesSampleAsync(object):
         with the text.
         """
         from azure.ai.textanalytics.aio import TextAnalyticsClient
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
 
         documents = [
             {"id": "0", "language": "en", "text": "Microsoft moved its headquarters to Bellevue, Washington in January 1979."},

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_pii_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_pii_entities_async.py
@@ -48,8 +48,8 @@ class RecognizePiiEntitiesSampleAsync(object):
     async def recognize_pii_entities_async(self):
         # [START batch_recognize_pii_entities_async]
         from azure.ai.textanalytics.aio import TextAnalyticsClient
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
         documents = [
             "The employee's SSN is 555-55-5555.",
             "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check.",
@@ -78,8 +78,8 @@ class RecognizePiiEntitiesSampleAsync(object):
         with the text.
         """
         from azure.ai.textanalytics.aio import TextAnalyticsClient
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
 
         documents = [
             {"id": "0", "language": "en", "text": "The employee's SSN is 555-55-5555."},

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_single_analyze_sentiment_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_single_analyze_sentiment_async.py
@@ -56,14 +56,14 @@ class SingleAnalyzeSentimentSampleAsync(object):
     async def analyze_sentiment_async(self):
         # [START single_analyze_sentiment_async]
         from azure.ai.textanalytics.aio import single_analyze_sentiment
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
 
         text = "I visited the restaurant last week. The portions were very generous. However, I did not like what " \
                "I ordered."
 
         result = await single_analyze_sentiment(
             endpoint=self.endpoint,
-            credential=TextAnalyticsAPIKeyCredential(self.key),
+            credential=TextAnalyticsApiKeyCredential(self.key),
             input_text=text,
             language="en"
         )

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_single_detect_language_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_single_detect_language_async.py
@@ -44,13 +44,13 @@ class SingleDetectLanguageSampleAsync(object):
     async def detect_language_async(self):
         # [START single_detect_language_async]
         from azure.ai.textanalytics.aio import single_detect_language
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
 
         text = "I need to take my cat to the veterinarian."
 
         result = await single_detect_language(
             endpoint=self.endpoint,
-            credential=TextAnalyticsAPIKeyCredential(self.key),
+            credential=TextAnalyticsApiKeyCredential(self.key),
             input_text=text,
             country_hint="US",
             show_stats=True

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_single_extract_key_phrases_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_single_extract_key_phrases_async.py
@@ -47,13 +47,13 @@ class SingleExtractKeyPhrasesSampleAsync(object):
     async def extract_key_phrases_async(self):
         # [START single_extract_key_phrases_async]
         from azure.ai.textanalytics.aio import single_extract_key_phrases
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
 
         text = "Redmond is a city in King County, Washington, United States, located 15 miles east of Seattle."
 
         result = await single_extract_key_phrases(
             endpoint=self.endpoint,
-            credential=TextAnalyticsAPIKeyCredential(self.key),
+            credential=TextAnalyticsApiKeyCredential(self.key),
             input_text=text,
             language="en"
         )

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_single_recognize_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_single_recognize_entities_async.py
@@ -61,14 +61,14 @@ class SingleRecognizeEntitiesSampleAsync(object):
     async def recognize_entities_async(self):
         # [START single_recognize_entities_async]
         from azure.ai.textanalytics.aio import single_recognize_entities
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
 
         text = "Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975," \
                " to develop and sell BASIC interpreters for the Altair 8800."
 
         result = await single_recognize_entities(
             endpoint=self.endpoint,
-            credential=TextAnalyticsAPIKeyCredential(self.key),
+            credential=TextAnalyticsApiKeyCredential(self.key),
             input_text=text,
             language="en"
         )

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_single_recognize_linked_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_single_recognize_linked_entities_async.py
@@ -74,14 +74,14 @@ class SingleRecognizeLinkedEntitiesSampleAsync(object):
     async def recognize_linked_entities_async(self):
         # [START single_recognize_linked_entities_async]
         from azure.ai.textanalytics.aio import single_recognize_linked_entities
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
 
         text = "Easter Island, a Chilean territory, is a remote volcanic island in Polynesia. " \
                "Its native name is Rapa Nui."
 
         result = await single_recognize_linked_entities(
             endpoint=self.endpoint,
-            credential=TextAnalyticsAPIKeyCredential(self.key),
+            credential=TextAnalyticsApiKeyCredential(self.key),
             input_text=text,
             language="en"
         )

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_single_recognize_pii_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_single_recognize_pii_entities_async.py
@@ -47,13 +47,13 @@ class SingleRecognizePiiEntitiesSampleAsync(object):
     async def recognize_pii_entities_async(self):
         # [START single_recognize_pii_entities_async]
         from azure.ai.textanalytics.aio import single_recognize_pii_entities
-        from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
+        from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
 
         text = "The employee's ABA number is 111000025 and his SSN is 555-55-5555."
 
         result = await single_recognize_pii_entities(
             endpoint=self.endpoint,
-            credential=TextAnalyticsAPIKeyCredential(self.key),
+            credential=TextAnalyticsApiKeyCredential(self.key),
             input_text=text,
             language="en"
         )

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_analyze_sentiment.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_analyze_sentiment.py
@@ -84,8 +84,8 @@ class AnalyzeSentimentSample(object):
 
     def analyze_sentiment(self):
         # [START batch_analyze_sentiment]
-        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
         documents = [
             "I had the best day of my life.",
             "This was a waste of my time. The speaker put me to sleep.",
@@ -124,8 +124,8 @@ class AnalyzeSentimentSample(object):
         using a list[TextDocumentInput] and supplying your own IDs and language hints along
         with the text.
         """
-        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
 
         documents = [
             {"id": "0", "language": "en", "text": "I had the best day of my life."},

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_authentication.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_authentication.py
@@ -35,7 +35,7 @@ import os
 
 class AuthenticationSample(object):
 
-    def authentication_with_subscription_key(self):
+    def authentication_with_api_key_credential(self):
         # [START create_ta_client_with_key]
         from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
         endpoint = os.getenv("AZURE_TEXT_ANALYTICS_ENDPOINT")
@@ -73,5 +73,5 @@ class AuthenticationSample(object):
 
 if __name__ == '__main__':
     sample = AuthenticationSample()
-    sample.authentication_with_subscription_key()
+    sample.authentication_with_api_key_credential()
     sample.authentication_with_azure_active_directory()

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_authentication.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_authentication.py
@@ -13,7 +13,7 @@ DESCRIPTION:
     This sample demonstrates how to authenticate with the text analytics service.
 
     There are two supported methods of authentication:
-    1) Use a cognitive services subscription key with TextAnalyticsAPIKeyCredential
+    1) Use a cognitive services/text analytics API key with TextAnalyticsApiKeyCredential
     2) Use a token credential to authenticate with Azure Active Directory
 
     See more details about authentication here:
@@ -23,8 +23,8 @@ USAGE:
     python sample_authentication.py
 
     Set the environment variables with your own values before running the sample:
-    1) AZURE_TEXT_ANALYTICS_ENDPOINT - the endpoint to your cognitive services resource.
-    2) AZURE_TEXT_ANALYTICS_KEY - your text analytics subscription key
+    1) AZURE_TEXT_ANALYTICS_ENDPOINT - the endpoint to your cognitive services/text analytics resource.
+    2) AZURE_TEXT_ANALYTICS_KEY - your text analytics API key
     3) AZURE_CLIENT_ID - the client ID of your active directory application.
     4) AZURE_TENANT_ID - the tenant ID of your active directory application.
     5) AZURE_CLIENT_SECRET - the secret of your active directory application.
@@ -37,11 +37,11 @@ class AuthenticationSample(object):
 
     def authentication_with_subscription_key(self):
         # [START create_ta_client_with_key]
-        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
+        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
         endpoint = os.getenv("AZURE_TEXT_ANALYTICS_ENDPOINT")
         key = os.getenv("AZURE_TEXT_ANALYTICS_KEY")
 
-        text_analytics_client = TextAnalyticsClient(endpoint, TextAnalyticsAPIKeyCredential(key))
+        text_analytics_client = TextAnalyticsClient(endpoint, TextAnalyticsApiKeyCredential(key))
         # [END create_ta_client_with_key]
 
         doc = ["I need to take my cat to the veterinarian."]

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_detect_languages.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_detect_languages.py
@@ -57,8 +57,8 @@ class DetectLanguagesSample(object):
 
     def detect_languages(self):
         # [START batch_detect_languages]
-        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
         documents = [
             "This document is written in English.",
             "Este es un document escrito en Español.",
@@ -87,8 +87,8 @@ class DetectLanguagesSample(object):
         using a list[DetectLanguageInput] and supplying your own IDs and country hints along
         with the text.
         """
-        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
 
         documents = [
             {"id": "0", "country_hint": "US", "text": "This is a document written in English."},

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_extract_key_phrases.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_extract_key_phrases.py
@@ -35,8 +35,8 @@ class ExtractKeyPhrasesSample(object):
 
     def extract_key_phrases(self):
         # [START batch_extract_key_phrases]
-        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
         documents = [
             "Redmond is a city in King County, Washington, United States, located 15 miles east of Seattle.",
             "I need to take my cat to the veterinarian.",
@@ -59,8 +59,8 @@ class ExtractKeyPhrasesSample(object):
         using a list[TextDocumentInput] and supplying your own IDs and language hints along
         with the text.
         """
-        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
 
         documents = [
             {"id": "0", "language": "en",

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_entities.py
@@ -44,8 +44,8 @@ class RecognizeEntitiesSample(object):
 
     def recognize_entities(self):
         # [START batch_recognize_entities]
-        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
         documents = [
             "Microsoft was founded by Bill Gates and Paul Allen.",
             "I had a wonderful trip to Seattle last week.",
@@ -70,8 +70,8 @@ class RecognizeEntitiesSample(object):
         using a list[TextDocumentInput] and supplying your own IDs and language hints along
         with the text.
         """
-        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
 
         documents = [
             {"id": "0", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen."},

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_linked_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_linked_entities.py
@@ -107,8 +107,8 @@ class RecognizeLinkedEntitiesSample(object):
 
     def recognize_linked_entities(self):
         # [START batch_recognize_linked_entities]
-        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
         documents = [
             "Microsoft moved its headquarters to Bellevue, Washington in January 1979.",
             "Steve Ballmer stepped down as CEO of Microsoft and was succeeded by Satya Nadella.",
@@ -139,8 +139,8 @@ class RecognizeLinkedEntitiesSample(object):
         using a list[TextDocumentInput] and supplying your own IDs and language hints along
         with the text.
         """
-        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
 
         documents = [
             {"id": "0", "language": "en", "text": "Microsoft moved its headquarters to Bellevue, Washington in January 1979."},

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_pii_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_pii_entities.py
@@ -46,8 +46,8 @@ class RecognizePiiEntitiesSample(object):
 
     def recognize_pii_entities(self):
         # [START batch_recognize_pii_entities]
-        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
         documents = [
             "The employee's SSN is 555-55-5555.",
             "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check.",
@@ -73,8 +73,8 @@ class RecognizePiiEntitiesSample(object):
         using a list[TextDocumentInput] and supplying your own IDs and language hints along
         with the text.
         """
-        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
-        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsAPIKeyCredential(self.key))
+        from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
+        text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
 
         documents = [
             {"id": "0", "language": "en", "text": "The employee's SSN is 555-55-5555."},

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_single_analyze_sentiment.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_single_analyze_sentiment.py
@@ -55,14 +55,14 @@ class SingleAnalyzeSentimentSample(object):
 
     def analyze_sentiment(self):
         # [START single_analyze_sentiment]
-        from azure.ai.textanalytics import single_analyze_sentiment, TextAnalyticsAPIKeyCredential
+        from azure.ai.textanalytics import single_analyze_sentiment, TextAnalyticsApiKeyCredential
 
         text = "I visited the restaurant last week. The portions were very generous. However, I did not like what " \
                "I ordered."
 
         result = single_analyze_sentiment(
             endpoint=self.endpoint,
-            credential=TextAnalyticsAPIKeyCredential(self.key),
+            credential=TextAnalyticsApiKeyCredential(self.key),
             input_text=text,
             language="en"
         )

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_single_detect_language.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_single_detect_language.py
@@ -42,13 +42,13 @@ class SingleDetectLanguageSample(object):
 
     def detect_language(self):
         # [START single_detect_language]
-        from azure.ai.textanalytics import single_detect_language, TextAnalyticsAPIKeyCredential
+        from azure.ai.textanalytics import single_detect_language, TextAnalyticsApiKeyCredential
 
         text = "I need to take my cat to the veterinarian."
 
         result = single_detect_language(
             endpoint=self.endpoint,
-            credential=TextAnalyticsAPIKeyCredential(self.key),
+            credential=TextAnalyticsApiKeyCredential(self.key),
             input_text=text,
             country_hint="US",
             show_stats=True

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_single_extract_key_phrases.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_single_extract_key_phrases.py
@@ -45,13 +45,13 @@ class SingleExtractKeyPhrasesSample(object):
 
     def extract_key_phrases(self):
         # [START single_extract_key_phrases]
-        from azure.ai.textanalytics import single_extract_key_phrases, TextAnalyticsAPIKeyCredential
+        from azure.ai.textanalytics import single_extract_key_phrases, TextAnalyticsApiKeyCredential
 
         text = "Redmond is a city in King County, Washington, United States, located 15 miles east of Seattle."
 
         result = single_extract_key_phrases(
             endpoint=self.endpoint,
-            credential=TextAnalyticsAPIKeyCredential(self.key),
+            credential=TextAnalyticsApiKeyCredential(self.key),
             input_text=text,
             language="en"
         )

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_single_recognize_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_single_recognize_entities.py
@@ -59,14 +59,14 @@ class SingleRecognizeEntitiesSample(object):
 
     def recognize_entities(self):
         # [START single_recognize_entities]
-        from azure.ai.textanalytics import single_recognize_entities, TextAnalyticsAPIKeyCredential
+        from azure.ai.textanalytics import single_recognize_entities, TextAnalyticsApiKeyCredential
 
         text = "Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975," \
                " to develop and sell BASIC interpreters for the Altair 8800."
 
         result = single_recognize_entities(
             endpoint=self.endpoint,
-            credential=TextAnalyticsAPIKeyCredential(self.key),
+            credential=TextAnalyticsApiKeyCredential(self.key),
             input_text=text,
             language="en"
         )

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_single_recognize_linked_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_single_recognize_linked_entities.py
@@ -72,14 +72,14 @@ class SingleRecognizeLinkedEntitiesSample(object):
 
     def recognize_linked_entities(self):
         # [START single_recognize_linked_entities]
-        from azure.ai.textanalytics import single_recognize_linked_entities, TextAnalyticsAPIKeyCredential
+        from azure.ai.textanalytics import single_recognize_linked_entities, TextAnalyticsApiKeyCredential
 
         text = "Easter Island, a Chilean territory, is a remote volcanic island in Polynesia. " \
                "Its native name is Rapa Nui."
 
         result = single_recognize_linked_entities(
             endpoint=self.endpoint,
-            credential=TextAnalyticsAPIKeyCredential(self.key),
+            credential=TextAnalyticsApiKeyCredential(self.key),
             input_text=text,
             language="en"
         )

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_single_recognize_pii_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_single_recognize_pii_entities.py
@@ -45,13 +45,13 @@ class SingleRecognizePiiEntitiesSample(object):
 
     def recognize_pii_entities(self):
         # [START single_recognize_pii_entities]
-        from azure.ai.textanalytics import single_recognize_pii_entities, TextAnalyticsAPIKeyCredential
+        from azure.ai.textanalytics import single_recognize_pii_entities, TextAnalyticsApiKeyCredential
 
         text = "The employee's ABA number is 111000025 and his SSN is 555-55-5555."
 
         result = single_recognize_pii_entities(
             endpoint=self.endpoint,
-            credential=TextAnalyticsAPIKeyCredential(self.key),
+            credential=TextAnalyticsApiKeyCredential(self.key),
             input_text=text,
             language="en"
         )

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_batch.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_batch.py
@@ -13,7 +13,7 @@ from azure.ai.textanalytics import (
     TextAnalyticsClient,
     DetectLanguageInput,
     TextDocumentInput,
-    TextAnalyticsAPIKeyCredential
+    TextAnalyticsApiKeyCredential
 )
 from testcase import TextAnalyticsTest, GlobalTextAnalyticsAccountPreparer
 
@@ -35,7 +35,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_successful_detect_language(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "text": "I should take my cat to the veterinarian."},
                 {"id": "2", "text": "Este es un document escrito en Español."},
@@ -60,7 +60,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_some_errors_detect_language(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "country_hint": "United States", "text": "I should take my cat to the veterinarian."},
                 {"id": "2", "text": "Este es un document escrito en Español."},
@@ -76,7 +76,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_all_errors_detect_language(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
         text = ""
         for _ in range(5121):
             text += "x"
@@ -93,7 +93,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_successful_recognize_entities(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975."},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen el 4 de abril de 1975."},
@@ -113,7 +113,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_some_errors_recognize_entities(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975."},
                 {"id": "2", "language": "Spanish", "text": "Hola"},
@@ -126,7 +126,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_all_errors_recognize_entities(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "text": ""},
                 {"id": "2", "language": "Spanish", "text": "Hola"},
@@ -139,7 +139,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_successful_recognize_pii_entities(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "text": "My SSN is 555-55-5555."},
                 {"id": "2", "text": "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check."},
@@ -164,7 +164,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_some_errors_recognize_pii_entities(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "es", "text": "hola"},
                 {"id": "2", "text": ""},
@@ -177,7 +177,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_all_errors_recognize_pii_entities(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "es", "text": "hola"},
                 {"id": "2", "text": ""}]
@@ -188,7 +188,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_successful_recognize_linked_entities(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
@@ -208,7 +208,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_some_errors_recognize_linked_entities(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "text": ""},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
@@ -219,7 +219,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_all_errors_recognize_linked_entities(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "text": ""},
                 {"id": "2", "language": "Spanish", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
@@ -230,7 +230,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_successful_extract_key_phrases(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
@@ -245,7 +245,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_some_errors_extract_key_phrases(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "English", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
@@ -256,7 +256,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_all_errors_extract_key_phrases(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "English", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": ""}]
@@ -267,7 +267,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_successful_analyze_sentiment(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
                 {"id": "2", "language": "en", "text": "I did not like the hotel we stayed it. It was too expensive."},
@@ -285,7 +285,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_some_errors_analyze_sentiment(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "en", "text": ""},
                 {"id": "2", "language": "english", "text": "I did not like the hotel we stayed it. It was too expensive."},
@@ -297,7 +297,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_all_errors_analyze_sentiment(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "en", "text": ""},
                 {"id": "2", "language": "english", "text": "I did not like the hotel we stayed it. It was too expensive."},
@@ -310,7 +310,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_validate_input_string(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [
             u"I should take my cat to the veterinarian.",
@@ -329,7 +329,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_validate_language_input(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [
             DetectLanguageInput(id="1", text="I should take my cat to the veterinarian."),
@@ -346,7 +346,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_validate_multilanguage_input(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [
             TextDocumentInput(id="1", text="Microsoft was founded by Bill Gates and Paul Allen."),
@@ -361,7 +361,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_mixing_inputs(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
         docs = [
             {"id": "1", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
             TextDocumentInput(id="2", text="I did not like the hotel we stayed it. It was too expensive."),
@@ -372,7 +372,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_out_of_order_ids(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
@@ -387,7 +387,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_show_stats_and_model_version(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(response):
             self.assertIsNotNone(response.model_version)
@@ -412,7 +412,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_batch_size_over_limit(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [u"hello world"] * 1050
         with self.assertRaises(HttpResponseError):
@@ -420,7 +420,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_country_hint(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
@@ -437,7 +437,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_dont_use_country_hint(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             country_str = "\"countryHint\": \"\""
@@ -454,7 +454,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_per_item_dont_use_country_hint(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             country_str = "\"countryHint\": \"\""
@@ -473,7 +473,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_country_hint_and_obj_input(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
@@ -490,7 +490,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_country_hint_and_dict_input(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
@@ -505,7 +505,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_country_hint_and_obj_per_item_hints(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
@@ -525,7 +525,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_country_hint_and_dict_per_item_hints(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
@@ -543,7 +543,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_language_hint(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             language_str = "\"language\": \"fr\""
@@ -560,7 +560,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_dont_use_language_hint(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             language_str = "\"language\": \"\""
@@ -577,7 +577,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_per_item_dont_use_language_hint(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             language_str = "\"language\": \"\""
@@ -596,7 +596,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_language_hint_and_obj_input(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             language_str = "\"language\": \"de\""
@@ -613,7 +613,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_language_hint_and_dict_input(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             language_str = "\"language\": \"es\""
@@ -628,7 +628,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_language_hint_and_obj_per_item_hints(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             language_str = "\"language\": \"es\""
@@ -648,7 +648,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_language_hint_and_dict_per_item_hints(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             language_str = "\"language\": \"es\""
@@ -667,7 +667,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_bad_document_input(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = "This is the wrong type"
 
@@ -676,7 +676,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_client_passed_default_country_hint(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key), default_country_hint="CA")
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key), default_country_hint="CA")
 
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
@@ -698,7 +698,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_client_passed_default_language_hint(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key), default_language="es")
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key), default_language="es")
 
         def callback(resp):
             language_str = "\"language\": \"es\""
@@ -720,7 +720,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_rotate_subscription_key(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        credential = TextAnalyticsAPIKeyCredential(text_analytics_account_key)
+        credential = TextAnalyticsApiKeyCredential(text_analytics_account_key)
         text_analytics = TextAnalyticsClient(text_analytics_account, credential)
 
         docs = [{"id": "1", "text": "I will go to the park."},
@@ -740,7 +740,7 @@ class BatchTextAnalyticsTest(TextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_user_agent(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             self.assertIn("azsdk-python-azure-ai-textanalytics/{} Python/{} ({})".format(

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_batch_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_batch_async.py
@@ -15,7 +15,7 @@ from azure.ai.textanalytics import (
     VERSION,
     DetectLanguageInput,
     TextDocumentInput,
-    TextAnalyticsAPIKeyCredential
+    TextAnalyticsApiKeyCredential
 )
 
 from testcase import GlobalTextAnalyticsAccountPreparer
@@ -52,7 +52,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_successful_detect_language_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "text": "I should take my cat to the veterinarian."},
                 {"id": "2", "text": "Este es un document escrito en Español."},
@@ -69,7 +69,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_some_errors_detect_language_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "country_hint": "United States", "text": "I should take my cat to the veterinarian."},
                 {"id": "2", "text": "Este es un document escrito en Español."},
@@ -86,7 +86,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_all_errors_detect_language_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
         text = ""
         for _ in range(5121):
             text += "x"
@@ -104,7 +104,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_successful_recognize_entities_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975."},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen el 4 de abril de 1975."},
@@ -117,7 +117,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_some_errors_recognize_entities_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975."},
                 {"id": "2", "language": "Spanish", "text": "Hola"},
@@ -131,7 +131,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_all_errors_recognize_entities_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "text": ""},
                 {"id": "2", "language": "Spanish", "text": "Hola"},
@@ -145,7 +145,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_successful_recognize_pii_entities_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "text": "My SSN is 555-55-5555."},
                 {"id": "2", "text": "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check."},
@@ -162,7 +162,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_some_errors_recognize_pii_entities_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "es", "text": "hola"},
                 {"id": "2", "text": ""},
@@ -176,7 +176,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_all_errors_recognize_pii_entities_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "es", "text": "hola"},
                 {"id": "2", "text": ""}]
@@ -188,7 +188,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_successful_recognize_linked_entities_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
@@ -200,7 +200,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_some_errors_recognize_linked_entities_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "text": ""},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
@@ -212,7 +212,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_all_errors_recognize_linked_entities_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "text": ""},
                 {"id": "2", "language": "Spanish", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
@@ -224,7 +224,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_successful_extract_key_phrases_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
@@ -238,7 +238,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_some_errors_extract_key_phrases_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "English", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": "Microsoft fue fundado por Bill Gates y Paul Allen"}]
@@ -250,7 +250,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_all_errors_extract_key_phrases_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "English", "text": "Microsoft was founded by Bill Gates and Paul Allen"},
                 {"id": "2", "language": "es", "text": ""}]
@@ -262,7 +262,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_successful_analyze_sentiment_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "en", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
                 {"id": "2", "language": "en", "text": "I did not like the hotel we stayed it. It was too expensive."},
@@ -276,7 +276,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_some_errors_analyze_sentiment_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "en", "text": ""},
                 {"id": "2", "language": "english", "text": "I did not like the hotel we stayed it. It was too expensive."},
@@ -289,7 +289,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_all_errors_analyze_sentiment_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "1", "language": "en", "text": ""},
                 {"id": "2", "language": "english", "text": "I did not like the hotel we stayed it. It was too expensive."},
@@ -303,7 +303,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_validate_input_string_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [
             "I should take my cat to the veterinarian.",
@@ -323,7 +323,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_validate_language_input_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [
             DetectLanguageInput(id="1", text="I should take my cat to the veterinarian."),
@@ -341,7 +341,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_validate_multilanguage_input_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [
             TextDocumentInput(id="1", text="Microsoft was founded by Bill Gates and Paul Allen."),
@@ -357,7 +357,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_mixing_inputs_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
         docs = [
             {"id": "1", "text": "Microsoft was founded by Bill Gates and Paul Allen."},
             TextDocumentInput(id="2", text="I did not like the hotel we stayed it. It was too expensive."),
@@ -369,7 +369,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_out_of_order_ids_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = [{"id": "56", "text": ":)"},
                 {"id": "0", "text": ":("},
@@ -385,7 +385,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_show_stats_and_model_version_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(response):
             self.assertIsNotNone(response.model_version)
@@ -411,7 +411,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_batch_size_over_limit_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = ["hello world"] * 1050
         with self.assertRaises(HttpResponseError):
@@ -420,7 +420,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_whole_batch_country_hint_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
@@ -438,7 +438,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_whole_batch_dont_use_country_hint_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             country_str = "\"countryHint\": \"\""
@@ -456,7 +456,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_per_item_dont_use_country_hint_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             country_str = "\"countryHint\": \"\""
@@ -476,7 +476,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_whole_batch_country_hint_and_obj_input_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
@@ -494,7 +494,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_whole_batch_country_hint_and_dict_input_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
@@ -510,7 +510,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_whole_batch_country_hint_and_obj_per_item_hints_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
@@ -531,7 +531,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_whole_batch_country_hint_and_dict_per_item_hints_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
@@ -550,7 +550,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_whole_batch_language_hint_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             language_str = "\"language\": \"fr\""
@@ -568,7 +568,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_whole_batch_dont_use_language_hint_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             language_str = "\"language\": \"\""
@@ -586,7 +586,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_per_item_dont_use_language_hint_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             language_str = "\"language\": \"\""
@@ -606,7 +606,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_whole_batch_language_hint_and_obj_input_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             language_str = "\"language\": \"de\""
@@ -624,7 +624,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_whole_batch_language_hint_and_dict_input_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             language_str = "\"language\": \"es\""
@@ -640,7 +640,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_whole_batch_language_hint_and_obj_per_item_hints_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             language_str = "\"language\": \"es\""
@@ -661,7 +661,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_whole_batch_language_hint_and_dict_per_item_hints_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             language_str = "\"language\": \"es\""
@@ -681,7 +681,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_bad_document_input_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         docs = "This is the wrong type"
 
@@ -691,7 +691,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_client_passed_default_country_hint_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key), default_country_hint="CA")
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key), default_country_hint="CA")
 
         def callback(resp):
             country_str = "\"countryHint\": \"CA\""
@@ -714,7 +714,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_client_passed_default_language_hint_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key), default_language="es")
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key), default_language="es")
 
         def callback(resp):
             language_str = "\"language\": \"es\""
@@ -737,7 +737,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_rotate_subscription_key_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        credential = TextAnalyticsAPIKeyCredential(text_analytics_account_key)
+        credential = TextAnalyticsApiKeyCredential(text_analytics_account_key)
         text_analytics = TextAnalyticsClient(text_analytics_account, credential)
 
         docs = [{"id": "1", "text": "I will go to the park."},
@@ -758,7 +758,7 @@ class BatchTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
     async def test_user_agent_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         def callback(resp):
             self.assertIn("azsdk-python-azure-ai-textanalytics/{} Python/{} ({})".format(

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_single.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_single.py
@@ -12,7 +12,7 @@ from azure.ai.textanalytics import (
     single_recognize_linked_entities,
     single_analyze_sentiment,
     single_extract_key_phrases,
-    TextAnalyticsAPIKeyCredential
+    TextAnalyticsApiKeyCredential
 )
 
 from testcase import TextAnalyticsTest, GlobalTextAnalyticsAccountPreparer
@@ -26,7 +26,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
     def test_successful_single_language_detection(self, resource_group, location, text_analytics_account, text_analytics_account_key):
         response = single_detect_language(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="This is written in English.",
             country_hint="US"
         )
@@ -40,7 +40,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = single_detect_language(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(""),
+                credential=TextAnalyticsApiKeyCredential(""),
                 input_text="This is written in English.",
             )
 
@@ -49,7 +49,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = single_detect_language(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential("xxxxxxxxxxxx"),
+                credential=TextAnalyticsApiKeyCredential("xxxxxxxxxxxx"),
                 input_text="This is written in English.",
             )
 
@@ -88,7 +88,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError) as err:
             response = single_detect_language(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text=text,
             )
 
@@ -97,7 +97,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_detect_language(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="",
             )
 
@@ -106,7 +106,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(TypeError):
             response = single_detect_language(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text={"id": "1", "text": "hello world"}
             )
 
@@ -115,7 +115,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_detect_language(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="This is written in English.",
                 country_hint="United States"
             )
@@ -125,7 +125,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_detect_language(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 country_hint="US",
                 model_version="old"
@@ -139,7 +139,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
 
         response = single_detect_language(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Este es un document escrito en Español.",
             show_stats=True,
             model_version="latest",
@@ -155,7 +155,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
 
         response = single_detect_language(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Este es un document escrito en Español.",
             country_hint="",
             response_hook=callback
@@ -170,7 +170,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
 
         response = single_detect_language(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Este es un document escrito en Español.",
             country_hint="CA",
             response_hook=callback
@@ -185,7 +185,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
 
         response = single_detect_language(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Este es un document escrito en Español.",
             response_hook=callback
         )
@@ -196,7 +196,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
     def test_successful_single_recognize_entities(self, resource_group, location, text_analytics_account, text_analytics_account_key):
         response = single_recognize_entities(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Microsoft was founded by Bill Gates.",
             language="en"
         )
@@ -214,7 +214,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = single_recognize_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(""),
+                credential=TextAnalyticsApiKeyCredential(""),
                 input_text="Microsoft was founded by Bill Gates.",
             )
 
@@ -223,7 +223,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = single_recognize_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential("xxxxxxxxxxxx"),
+                credential=TextAnalyticsApiKeyCredential("xxxxxxxxxxxx"),
                 input_text="Microsoft was founded by Bill Gates.",
             )
 
@@ -262,7 +262,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_recognize_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text=text,
             )
 
@@ -271,7 +271,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_recognize_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="",
             )
 
@@ -280,7 +280,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(TypeError):
             response = single_recognize_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text={"id": "1", "text": "hello world"}
             )
 
@@ -289,7 +289,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_recognize_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 language="English"
             )
@@ -299,7 +299,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_recognize_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 language="en",
                 model_version="old"
@@ -313,7 +313,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
 
         response = single_recognize_entities(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Microsoft was founded by Bill Gates.",
             show_stats=True,
             model_version="latest",
@@ -326,7 +326,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
     def test_successful_single_recognize_pii_entities(self, resource_group, location, text_analytics_account, text_analytics_account_key):
         response = single_recognize_pii_entities(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="My SSN is 555-55-5555",
             language="en"
         )
@@ -343,7 +343,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = single_recognize_pii_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(""),
+                credential=TextAnalyticsApiKeyCredential(""),
                 input_text="My SSN is 555-55-5555",
             )
 
@@ -352,7 +352,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = single_recognize_pii_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential("xxxxxxxxxxxx"),
+                credential=TextAnalyticsApiKeyCredential("xxxxxxxxxxxx"),
                 input_text="My SSN is 555-55-5555",
             )
 
@@ -391,7 +391,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_recognize_pii_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text=text,
             )
 
@@ -400,7 +400,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_recognize_pii_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="",
             )
 
@@ -409,7 +409,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(TypeError):
             response = single_recognize_pii_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text={"id": "1", "text": "hello world"}
             )
 
@@ -418,7 +418,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_recognize_pii_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="My SSN is 555-55-5555",
                 language="English"
             )
@@ -428,7 +428,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_recognize_pii_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 language="en",
                 model_version="old"
@@ -442,7 +442,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
 
         response = single_recognize_pii_entities(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="My SSN is 555-55-5555",
             show_stats=True,
             model_version="latest",
@@ -455,7 +455,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
     def test_successful_single_recognize_linked_entities(self, resource_group, location, text_analytics_account, text_analytics_account_key):
         response = single_recognize_linked_entities(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Microsoft was founded by Bill Gates.",
             language="en"
         )
@@ -474,7 +474,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = single_recognize_linked_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(""),
+                credential=TextAnalyticsApiKeyCredential(""),
                 input_text="Microsoft was founded by Bill Gates.",
             )
 
@@ -483,7 +483,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = single_recognize_linked_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential("xxxxxxxxxxxx"),
+                credential=TextAnalyticsApiKeyCredential("xxxxxxxxxxxx"),
                 input_text="Microsoft was founded by Bill Gates.",
             )
 
@@ -522,7 +522,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_recognize_linked_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text=text,
             )
 
@@ -531,7 +531,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_recognize_linked_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="",
             )
 
@@ -540,7 +540,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(TypeError):
             response = single_recognize_linked_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text={"id": "1", "text": "hello world"}
             )
 
@@ -549,7 +549,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_recognize_linked_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 language="English"
             )
@@ -559,7 +559,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_recognize_linked_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 language="en",
                 model_version="old"
@@ -573,7 +573,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
 
         response = single_recognize_linked_entities(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Microsoft was founded by Bill Gates.",
             show_stats=True,
             model_version="latest",
@@ -586,7 +586,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
     def test_successful_single_extract_key_phrases(self, resource_group, location, text_analytics_account, text_analytics_account_key):
         response = single_extract_key_phrases(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Microsoft was founded by Bill Gates.",
             language="en"
         )
@@ -599,7 +599,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = single_extract_key_phrases(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(""),
+                credential=TextAnalyticsApiKeyCredential(""),
                 input_text="Microsoft was founded by Bill Gates.",
             )
 
@@ -608,7 +608,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = single_extract_key_phrases(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential("xxxxxxxxxxxx"),
+                credential=TextAnalyticsApiKeyCredential("xxxxxxxxxxxx"),
                 input_text="Microsoft was founded by Bill Gates.",
             )
 
@@ -647,7 +647,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_extract_key_phrases(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text=text,
             )
 
@@ -656,7 +656,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_extract_key_phrases(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="",
             )
 
@@ -665,7 +665,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(TypeError):
             response = single_extract_key_phrases(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text={"id": "1", "text": "hello world"}
             )
 
@@ -674,7 +674,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_extract_key_phrases(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 language="English"
             )
@@ -684,7 +684,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_extract_key_phrases(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 language="en",
                 model_version="old"
@@ -698,7 +698,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
 
         response = single_extract_key_phrases(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Microsoft was founded by Bill Gates.",
             show_stats=True,
             model_version="latest",
@@ -711,7 +711,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
     def test_successful_single_analyze_sentiment(self, resource_group, location, text_analytics_account, text_analytics_account_key):
         response = single_analyze_sentiment(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="I was unhappy with the food at the restaurant.",
             language="en"
         )
@@ -726,7 +726,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = single_analyze_sentiment(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(""),
+                credential=TextAnalyticsApiKeyCredential(""),
                 input_text="I was unhappy with the food at the restaurant.",
             )
 
@@ -735,7 +735,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = single_analyze_sentiment(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential("xxxxxxxxxxxx"),
+                credential=TextAnalyticsApiKeyCredential("xxxxxxxxxxxx"),
                 input_text="I was unhappy with the food at the restaurant.",
             )
 
@@ -774,7 +774,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_analyze_sentiment(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text=text,
             )
 
@@ -783,7 +783,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_analyze_sentiment(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="",
             )
 
@@ -792,7 +792,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(TypeError):
             response = single_analyze_sentiment(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text={"id": "1", "text": "hello world"}
             )
 
@@ -801,7 +801,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_analyze_sentiment(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="I was unhappy with the food at the restaurant.",
                 language="English"
             )
@@ -811,7 +811,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = single_analyze_sentiment(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 language="en",
                 model_version="old"
@@ -825,7 +825,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
 
         response = single_analyze_sentiment(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="I was unhappy with the food at the restaurant.",
             show_stats=True,
             model_version="latest",
@@ -841,7 +841,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
 
         response = single_analyze_sentiment(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Este es un document escrito en Español.",
             language="",
             response_hook=callback
@@ -856,7 +856,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
 
         response = single_analyze_sentiment(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Este es un document escrito en Español.",
             language="es",
             response_hook=callback
@@ -871,7 +871,7 @@ class SingleTextAnalyticsTest(TextAnalyticsTest):
 
         response = single_analyze_sentiment(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Este es un document escrito en Español.",
             response_hook=callback
         )

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_single_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_single_async.py
@@ -15,7 +15,7 @@ from azure.ai.textanalytics.aio import (
     single_analyze_sentiment,
     single_extract_key_phrases
 )
-from azure.ai.textanalytics import TextAnalyticsAPIKeyCredential
+from azure.ai.textanalytics import TextAnalyticsApiKeyCredential
 
 from testcase import GlobalTextAnalyticsAccountPreparer
 from asynctestcase import AsyncTextAnalyticsTest
@@ -41,7 +41,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     async def test_successful_single_language_detection_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
         response = await single_detect_language(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="This is written in English.",
             country_hint="US"
         )
@@ -56,7 +56,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = await single_detect_language(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(""),
+                credential=TextAnalyticsApiKeyCredential(""),
                 input_text="This is written in English.",
             )
 
@@ -66,7 +66,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = await single_detect_language(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential("xxxxxxxxxxxx"),
+                credential=TextAnalyticsApiKeyCredential("xxxxxxxxxxxx"),
                 input_text="This is written in English.",
             )
 
@@ -109,7 +109,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError) as err:
             response = await single_detect_language(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text=text,
             )
 
@@ -119,7 +119,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_detect_language(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="",
             )
 
@@ -129,7 +129,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(TypeError):
             response = await single_detect_language(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text={"id": "1", "text": "hello world"}
             )
 
@@ -139,7 +139,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_detect_language(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="This is written in English.",
                 country_hint="United States"
             )
@@ -150,7 +150,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_detect_language(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 country_hint="US",
                 model_version="old"
@@ -165,7 +165,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
 
         response = await single_detect_language(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Este es un document escrito en Español.",
             show_stats=True,
             model_version="latest",
@@ -182,7 +182,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
 
         response = await single_detect_language(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Este es un document escrito en Español.",
             country_hint="",
             response_hook=callback
@@ -198,7 +198,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
 
         response = await single_detect_language(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Este es un document escrito en Español.",
             country_hint="CA",
             response_hook=callback
@@ -214,7 +214,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
 
         response = await single_detect_language(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Este es un document escrito en Español.",
             response_hook=callback
         )
@@ -226,7 +226,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     async def test_successful_single_recognize_entities_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
         response = await single_recognize_entities(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Microsoft was founded by Bill Gates.",
             language="en"
         )
@@ -245,7 +245,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = await single_recognize_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(""),
+                credential=TextAnalyticsApiKeyCredential(""),
                 input_text="Microsoft was founded by Bill Gates.",
             )
 
@@ -255,7 +255,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = await single_recognize_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential("xxxxxxxxxxxx"),
+                credential=TextAnalyticsApiKeyCredential("xxxxxxxxxxxx"),
                 input_text="Microsoft was founded by Bill Gates.",
             )
 
@@ -298,7 +298,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_recognize_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text=text,
             )
 
@@ -308,7 +308,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_recognize_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="",
             )
 
@@ -318,7 +318,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(TypeError):
             response = await single_recognize_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text={"id": "1", "text": "hello world"}
             )
 
@@ -328,7 +328,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_recognize_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 language="English"
             )
@@ -339,7 +339,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_recognize_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 language="en",
                 model_version="old"
@@ -354,7 +354,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
 
         response = await single_recognize_entities(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Microsoft was founded by Bill Gates.",
             show_stats=True,
             model_version="latest",
@@ -368,7 +368,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     async def test_successful_single_recognize_pii_entities_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
         response = await single_recognize_pii_entities(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="My SSN is 555-55-5555",
             language="en"
         )
@@ -386,7 +386,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = await single_recognize_pii_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(""),
+                credential=TextAnalyticsApiKeyCredential(""),
                 input_text="My SSN is 555-55-5555",
             )
 
@@ -396,7 +396,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = await single_recognize_pii_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential("xxxxxxxxxxxx"),
+                credential=TextAnalyticsApiKeyCredential("xxxxxxxxxxxx"),
                 input_text="My SSN is 555-55-5555",
             )
 
@@ -439,7 +439,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_recognize_pii_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text=text,
             )
 
@@ -449,7 +449,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_recognize_pii_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="",
             )
 
@@ -459,7 +459,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(TypeError):
             response = await single_recognize_pii_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text={"id": "1", "text": "hello world"}
             )
 
@@ -469,7 +469,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_recognize_pii_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="My SSN is 555-55-5555",
                 language="English"
             )
@@ -480,7 +480,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_recognize_pii_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 language="en",
                 model_version="old"
@@ -495,7 +495,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
 
         response = await single_recognize_pii_entities(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="My SSN is 555-55-5555",
             show_stats=True,
             model_version="latest",
@@ -509,7 +509,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     async def test_successful_single_recognize_linked_entities_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
         response = await single_recognize_linked_entities(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Microsoft was founded by Bill Gates.",
             language="en"
         )
@@ -529,7 +529,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = await single_recognize_linked_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(""),
+                credential=TextAnalyticsApiKeyCredential(""),
                 input_text="Microsoft was founded by Bill Gates.",
             )
 
@@ -539,7 +539,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = await single_recognize_linked_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential("xxxxxxxxxxxx"),
+                credential=TextAnalyticsApiKeyCredential("xxxxxxxxxxxx"),
                 input_text="Microsoft was founded by Bill Gates.",
             )
 
@@ -582,7 +582,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_recognize_linked_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text=text,
             )
 
@@ -592,7 +592,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_recognize_linked_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="",
             )
 
@@ -602,7 +602,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(TypeError):
             response = await single_recognize_linked_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text={"id": "1", "text": "hello world"}
             )
 
@@ -612,7 +612,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_recognize_linked_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 language="English"
             )
@@ -623,7 +623,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_recognize_linked_entities(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 language="en",
                 model_version="old"
@@ -638,7 +638,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
 
         response = await single_recognize_linked_entities(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Microsoft was founded by Bill Gates.",
             show_stats=True,
             model_version="latest",
@@ -652,7 +652,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     async def test_successful_single_extract_key_phrases_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
         response = await single_extract_key_phrases(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Microsoft was founded by Bill Gates.",
             language="en"
         )
@@ -666,7 +666,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = await single_extract_key_phrases(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(""),
+                credential=TextAnalyticsApiKeyCredential(""),
                 input_text="Microsoft was founded by Bill Gates.",
             )
 
@@ -676,7 +676,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = await single_extract_key_phrases(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential("xxxxxxxxxxxx"),
+                credential=TextAnalyticsApiKeyCredential("xxxxxxxxxxxx"),
                 input_text="Microsoft was founded by Bill Gates.",
             )
 
@@ -719,7 +719,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_extract_key_phrases(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text=text,
             )
 
@@ -729,7 +729,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_extract_key_phrases(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="",
             )
 
@@ -739,7 +739,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(TypeError):
             response = await single_extract_key_phrases(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text={"id": "1", "text": "hello world"}
             )
 
@@ -749,7 +749,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_extract_key_phrases(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 language="English"
             )
@@ -760,7 +760,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_extract_key_phrases(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 language="en",
                 model_version="old"
@@ -775,7 +775,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
 
         response = await single_extract_key_phrases(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Microsoft was founded by Bill Gates.",
             show_stats=True,
             model_version="latest",
@@ -789,7 +789,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
     async def test_successful_single_analyze_sentiment_async(self, resource_group, location, text_analytics_account, text_analytics_account_key):
         response = await single_analyze_sentiment(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="I was unhappy with the food at the restaurant.",
             language="en"
         )
@@ -805,7 +805,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = await single_analyze_sentiment(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(""),
+                credential=TextAnalyticsApiKeyCredential(""),
                 input_text="I was unhappy with the food at the restaurant.",
             )
 
@@ -815,7 +815,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(ClientAuthenticationError):
             response = await single_analyze_sentiment(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential("xxxxxxxxxxxx"),
+                credential=TextAnalyticsApiKeyCredential("xxxxxxxxxxxx"),
                 input_text="I was unhappy with the food at the restaurant.",
             )
 
@@ -858,7 +858,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_analyze_sentiment(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text=text,
             )
 
@@ -868,7 +868,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_analyze_sentiment(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="",
             )
 
@@ -878,7 +878,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(TypeError):
             response = await single_analyze_sentiment(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text={"id": "1", "text": "hello world"}
             )
 
@@ -888,7 +888,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_analyze_sentiment(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="I was unhappy with the food at the restaurant.",
                 language="English"
             )
@@ -899,7 +899,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await single_analyze_sentiment(
                 endpoint=text_analytics_account,
-                credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+                credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
                 input_text="Microsoft was founded by Bill Gates.",
                 language="en",
                 model_version="old"
@@ -914,7 +914,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
 
         response = await single_analyze_sentiment(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="I was unhappy with the food at the restaurant.",
             show_stats=True,
             model_version="latest",
@@ -931,7 +931,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
 
         response = await single_analyze_sentiment(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Este es un document escrito en Español.",
             language="",
             response_hook=callback
@@ -947,7 +947,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
 
         response = await single_analyze_sentiment(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Este es un document escrito en Español.",
             language="es",
             response_hook=callback
@@ -963,7 +963,7 @@ class SingleTextAnalyticsTestAsync(AsyncTextAnalyticsTest):
 
         response = await single_analyze_sentiment(
             endpoint=text_analytics_account,
-            credential=TextAnalyticsAPIKeyCredential(text_analytics_account_key),
+            credential=TextAnalyticsApiKeyCredential(text_analytics_account_key),
             input_text="Este es un document escrito en Español.",
             response_hook=callback
         )

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_text_analytics.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_text_analytics.py
@@ -5,7 +5,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsAPIKeyCredential
+from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
 from azure.ai.textanalytics import _models
 from testcase import GlobalTextAnalyticsAccountPreparer
 from testcase import TextAnalyticsTest as TestAnalyticsTestCase
@@ -15,7 +15,7 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_detect_language(self, resource_group, location, text_analytics_account, text_analytics_account_key):
-        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsAPIKeyCredential(text_analytics_account_key))
+        text_analytics = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key))
 
         response = text_analytics.detect_languages(
             inputs=[{


### PR DESCRIPTION
Also fixes docs to refer to key as API key instead of subscription key.