### PR TITLE
Versioningtoolgracefulreturn

### DIFF
--- a/eng/versioning/version_increment.py
+++ b/eng/versioning/version_increment.py
@@ -10,8 +10,11 @@
 import os
 import argparse
 from packaging.version import parse
+import logging
 
 from version_shared import get_packages, set_version_py, set_dev_classifier, update_change_log
+
+logging.getLogger().setLevel(logging.INFO)
 
 def increment_version(old_version):
     parsed_version = parse(old_version)
@@ -39,12 +42,12 @@ if __name__ == '__main__':
 
     package_name = args.package_name.replace('_', '-')
 
-    packages = get_packages(args)
+    packages = get_packages(args, package_name)
 
     package_map = { pkg[1][0]: pkg for pkg in packages }
 
     if package_name not in package_map:
-        raise ValueError("Package name not found: %s" % package_name)
+        raise ValueError("Package name not found: {}".format(package_name))
 
     target_package = package_map[package_name]
 

--- a/eng/versioning/version_set.py
+++ b/eng/versioning/version_set.py
@@ -1,5 +1,6 @@
 import os
 import argparse
+import logging
 
 from version_shared import get_packages, set_version_py, set_dev_classifier, update_change_log
 
@@ -23,11 +24,12 @@ if __name__ == '__main__':
     package_name = args.package_name.replace('_', '-')
     new_version = args.new_version
 
-    packages = get_packages(args)
+    packages = get_packages(args, package_name)
+
     package_map = { pkg[1][0]: pkg for pkg in packages }
 
     if package_name not in package_map:
-        raise ValueError("Package name not found: %s" % package_name)
+        raise ValueError("Package name not found: {}".format(package_name))
 
     target_package = package_map[package_name]
 

--- a/eng/versioning/version_shared.py
+++ b/eng/versioning/version_shared.py
@@ -12,6 +12,7 @@ import sys
 import os
 from os import path
 import re
+import logging
 from packaging.version import parse
 
 from setup_parser import parse_setup
@@ -27,6 +28,7 @@ VERSION_STRING = 'VERSION = "%s"'
 
 DEV_STATUS_REGEX = r'(classifiers=\[(\s)*)(["\']Development Status :: .*["\'])'
 
+logging.getLogger().setLevel(logging.INFO)
 
 def path_excluded(path):
     return "-nspkg" in path or "tests" in path or "mgmt" in path or is_metapackage(path)
@@ -44,7 +46,7 @@ def get_setup_py_paths(glob_string, base_path):
     return filtered_paths
 
 
-def get_packages(args):
+def get_packages(args, package_name = ""):
     # This function returns list of path to setup.py and setup info like install requires, version for all packages discovered using glob
     # Followiong are the list of arguements expected and parsed by this method
     # service, glob_string
@@ -54,6 +56,11 @@ def get_packages(args):
         target_dir = root_dir
 
     paths = get_setup_py_paths(args.glob_string, target_dir)
+    # Check if package is excluded if a package name param is passed
+    if package_name and not any(filter(lambda x: package_name == os.path.basename(os.path.dirname(x)), paths)):
+        logging.info("Package {} is excluded from version update tool".format(package_name))
+        exit(0)
+
     packages = []
     for setup_path in paths:
         try:


### PR DESCRIPTION
Version increment tool is triggered as part of release pipeline for all packages. If package is not in the supported list of versioning tool, it raises an exception and thus fails CI step. This change is to gracefully exit in such case. For e,g,g Version increment fails if mgmt package is part of build and release pipeline.

e.g. error:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=234582&view=logs&s=db23937b-a773-5b5d-c7b0-8b744d7fdc8f&j=6c82b004-958c-56af-121e-1a39b76f0c26