### PR TITLE
Prevent raising KeyVaultErrorException

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/exceptions.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/exceptions.py
@@ -5,33 +5,52 @@
 import functools
 from typing import TYPE_CHECKING
 
-from azure.core.exceptions import DecodeError, ResourceExistsError, ResourceNotFoundError
+from azure.core.exceptions import DecodeError, HttpResponseError, ResourceExistsError, ResourceNotFoundError
 from azure.core.pipeline.policies import ContentDecodePolicy
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
-    from typing import Type
-    from azure.core.exceptions import AzureError
+    from typing import Optional, Type
     from azure.core.pipeline.transport import HttpResponse
 
 
-def get_exception_for_key_vault_error(cls, response):
-    # type: (Type[AzureError], HttpResponse) -> AzureError
+def _get_exception_for_key_vault_error(cls, response):
+    # type: (Type[HttpResponseError], HttpResponse) -> HttpResponseError
+    """Construct cls (HttpResponseError or subclass thereof) with Key Vault's error message."""
+
     try:
         body = ContentDecodePolicy.deserialize_from_http_generics(response)
-        message = "({}) {}".format(body["error"]["code"], body["error"]["message"])
+        message = "({}) {}".format(body["error"]["code"], body["error"]["message"])  # type: Optional[str]
     except (DecodeError, KeyError):
-        # Key Vault error response bodies have the expected shape and should be deserializable.
+        # Key Vault error response bodies should have the expected shape and be deserializable.
         # If we somehow land here, we'll take HttpResponse's default message.
         message = None
 
     return cls(message=message, response=response)
 
 
+# errors map to HttpResponseError...
+_default = functools.partial(_get_exception_for_key_vault_error, HttpResponseError)
+
+# ...unless this mapping specifies another type
 _code_to_core_error = {404: ResourceNotFoundError, 409: ResourceExistsError}
 
+
+class _ErrorMap(dict):
+    """A dict whose 'get' method returns a default value.
+
+    defaultdict would be preferable but defaultdict.get returns None for keys having no value
+    (azure.core.exceptions.map_error calls error_map.get)
+    """
+
+    def get(self, key):
+        return super(_ErrorMap, self).get(key) or _default
+
+
 # map status codes to callables returning appropriate azure-core errors
-error_map = {
-    status_code: functools.partial(get_exception_for_key_vault_error, cls)
-    for status_code, cls in _code_to_core_error.items()
-}
+error_map = _ErrorMap(
+    {
+        status_code: functools.partial(_get_exception_for_key_vault_error, cls)
+        for status_code, cls in _code_to_core_error.items()
+    }
+)

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/exceptions.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/exceptions.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from collections import defaultdict
 import functools
 from typing import TYPE_CHECKING
 
@@ -36,19 +37,19 @@ _default = functools.partial(_get_exception_for_key_vault_error, HttpResponseErr
 _code_to_core_error = {404: ResourceNotFoundError, 409: ResourceExistsError}
 
 
-class _ErrorMap(dict):
+class _ErrorMap(defaultdict):
     """A dict whose 'get' method returns a default value.
 
     defaultdict would be preferable but defaultdict.get returns None for keys having no value
     (azure.core.exceptions.map_error calls error_map.get)
     """
 
-    def get(self, key):
-        return super(_ErrorMap, self).get(key) or _default
+    def get(self, key, value=None):  # pylint:disable=unused-argument
+        return self[key]
 
 
 # map status codes to callables returning appropriate azure-core errors
-error_map = _ErrorMap(
+error_map = _ErrorMap(lambda: _default,
     {
         status_code: functools.partial(_get_exception_for_key_vault_error, cls)
         for status_code, cls in _code_to_core_error.items()

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
@@ -96,6 +96,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
             certificate_policy=policy._to_certificate_policy_bundle(),
             certificate_attributes=attributes,
             tags=tags,
+            error_map=_error_map,
             **kwargs
         )
 
@@ -144,7 +145,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
     @distributed_trace_async
     async def get_certificate_version(
         self, certificate_name: str, version: str, **kwargs: "Any"
-        ) -> KeyVaultCertificate:
+    ) -> KeyVaultCertificate:
         """Gets a specific version of a certificate without returning its management policy.
 
         Requires certificates/get permission. To get the latest version of the certificate,
@@ -257,7 +258,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         await self._client.purge_deleted_certificate(
-            vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
+            vault_base_url=self.vault_url, certificate_name=certificate_name, error_map=_error_map, **kwargs
         )
 
     @distributed_trace_async
@@ -285,7 +286,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         if polling_interval is None:
             polling_interval = 2
         recovered_cert_bundle = await self._client.recover_deleted_certificate(
-            vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
+            vault_base_url=self.vault_url, certificate_name=certificate_name, error_map=_error_map, **kwargs
         )
         recovered_certificate = KeyVaultCertificate._from_certificate_bundle(recovered_cert_bundle)
         command = partial(self.get_certificate, certificate_name=certificate_name, **kwargs)
@@ -337,6 +338,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
             password=password,
             certificate_policy=CertificatePolicy._to_certificate_policy_bundle(policy),
             certificate_attributes=attributes,
+            error_map=_error_map,
             **kwargs
         )
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
@@ -353,7 +355,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = await self._client.get_certificate_policy(
-            vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
+            vault_base_url=self.vault_url, certificate_name=certificate_name, error_map=_error_map, **kwargs
         )
         return CertificatePolicy._from_certificate_policy_bundle(certificate_policy_bundle=bundle)
 
@@ -376,6 +378,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
             vault_base_url=self.vault_url,
             certificate_name=certificate_name,
             certificate_policy=policy._to_certificate_policy_bundle(),
+            error_map=_error_map,
             **kwargs
         )
         return CertificatePolicy._from_certificate_policy_bundle(certificate_policy_bundle=bundle)
@@ -416,6 +419,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
             certificate_name=certificate_name,
             certificate_version=version or "",
             certificate_attributes=attributes,
+            error_map=_error_map,
             **kwargs
         )
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
@@ -471,7 +475,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
                 :dedent: 8
         """
         bundle = await self._client.restore_certificate(
-            vault_base_url=self.vault_url, certificate_bundle_backup=backup, **kwargs
+            vault_base_url=self.vault_url, certificate_bundle_backup=backup, error_map=_error_map, **kwargs
         )
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
@@ -569,9 +573,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def set_contacts(
-        self, contacts: Iterable[CertificateContact], **kwargs: "Any"
-    ) -> List[CertificateContact]:
+    async def set_contacts(self, contacts: Iterable[CertificateContact], **kwargs: "Any") -> List[CertificateContact]:
         # pylint:disable=unsubscriptable-object
 
         # disabled unsubscriptable-object because of pylint bug referenced here:
@@ -595,6 +597,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         contacts = await self._client.set_certificate_contacts(
             vault_base_url=self.vault_url,
             contact_list=[c._to_certificate_contacts_item() for c in contacts],
+            error_map=_error_map,
             **kwargs
         )
         return [CertificateContact._from_certificate_contacts_item(contact_item=item) for item in contacts.contact_list]
@@ -619,7 +622,9 @@ class CertificateClient(AsyncKeyVaultClientBase):
                 :caption: Get contacts
                 :dedent: 8
         """
-        contacts = await self._client.get_certificate_contacts(vault_base_url=self._vault_url, **kwargs)
+        contacts = await self._client.get_certificate_contacts(
+            vault_base_url=self._vault_url, error_map=_error_map, **kwargs
+        )
         return [CertificateContact._from_certificate_contacts_item(contact_item=item) for item in contacts.contact_list]
 
     @distributed_trace_async
@@ -642,7 +647,9 @@ class CertificateClient(AsyncKeyVaultClientBase):
                 :caption: Delete contacts
                 :dedent: 8
         """
-        contacts = await self._client.delete_certificate_contacts(vault_base_url=self.vault_url, **kwargs)
+        contacts = await self._client.delete_certificate_contacts(
+            vault_base_url=self.vault_url, error_map=_error_map, **kwargs
+        )
         return [CertificateContact._from_certificate_contacts_item(contact_item=item) for item in contacts.contact_list]
 
     @distributed_trace_async
@@ -690,7 +697,11 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = await self._client.update_certificate_operation(
-            vault_base_url=self.vault_url, certificate_name=certificate_name, cancellation_requested=True, **kwargs
+            vault_base_url=self.vault_url,
+            certificate_name=certificate_name,
+            cancellation_requested=True,
+            error_map=_error_map,
+            **kwargs
         )
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
 
@@ -728,6 +739,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
             certificate_name=certificate_name,
             x509_certificates=x509_certificates,
             certificate_attributes=attributes,
+            error_map=_error_map,
             **kwargs
         )
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
@@ -757,9 +769,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace_async
-    async def create_issuer(
-        self, issuer_name: str, provider: str, **kwargs: "Any"
-    ) -> CertificateIssuer:
+    async def create_issuer(self, issuer_name: str, provider: str, **kwargs: "Any") -> CertificateIssuer:
         """Sets the specified certificate issuer. Requires certificates/setissuers permission.
 
         :param str issuer_name: The name of the issuer.
@@ -823,6 +833,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
             credentials=issuer_credentials,
             organization_details=organization_details,
             attributes=issuer_attributes,
+            error_map=_error_map,
             **kwargs
         )
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
@@ -885,6 +896,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
             credentials=issuer_credentials,
             organization_details=organization_details,
             attributes=issuer_attributes,
+            error_map=_error_map,
             **kwargs
         )
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
@@ -909,7 +921,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
                 :dedent: 8
         """
         issuer_bundle = await self._client.delete_certificate_issuer(
-            vault_base_url=self.vault_url, issuer_name=issuer_name, **kwargs
+            vault_base_url=self.vault_url, issuer_name=issuer_name, error_map=_error_map, **kwargs
         )
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/exceptions.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/exceptions.py
@@ -5,33 +5,52 @@
 import functools
 from typing import TYPE_CHECKING
 
-from azure.core.exceptions import DecodeError, ResourceExistsError, ResourceNotFoundError
+from azure.core.exceptions import DecodeError, HttpResponseError, ResourceExistsError, ResourceNotFoundError
 from azure.core.pipeline.policies import ContentDecodePolicy
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
-    from typing import Type
-    from azure.core.exceptions import AzureError
+    from typing import Optional, Type
     from azure.core.pipeline.transport import HttpResponse
 
 
-def get_exception_for_key_vault_error(cls, response):
-    # type: (Type[AzureError], HttpResponse) -> AzureError
+def _get_exception_for_key_vault_error(cls, response):
+    # type: (Type[HttpResponseError], HttpResponse) -> HttpResponseError
+    """Construct cls (HttpResponseError or subclass thereof) with Key Vault's error message."""
+
     try:
         body = ContentDecodePolicy.deserialize_from_http_generics(response)
-        message = "({}) {}".format(body["error"]["code"], body["error"]["message"])
+        message = "({}) {}".format(body["error"]["code"], body["error"]["message"])  # type: Optional[str]
     except (DecodeError, KeyError):
-        # Key Vault error response bodies have the expected shape and should be deserializable.
+        # Key Vault error response bodies should have the expected shape and be deserializable.
         # If we somehow land here, we'll take HttpResponse's default message.
         message = None
 
     return cls(message=message, response=response)
 
 
+# errors map to HttpResponseError...
+_default = functools.partial(_get_exception_for_key_vault_error, HttpResponseError)
+
+# ...unless this mapping specifies another type
 _code_to_core_error = {404: ResourceNotFoundError, 409: ResourceExistsError}
 
+
+class _ErrorMap(dict):
+    """A dict whose 'get' method returns a default value.
+
+    defaultdict would be preferable but defaultdict.get returns None for keys having no value
+    (azure.core.exceptions.map_error calls error_map.get)
+    """
+
+    def get(self, key):
+        return super(_ErrorMap, self).get(key) or _default
+
+
 # map status codes to callables returning appropriate azure-core errors
-error_map = {
-    status_code: functools.partial(get_exception_for_key_vault_error, cls)
-    for status_code, cls in _code_to_core_error.items()
-}
+error_map = _ErrorMap(
+    {
+        status_code: functools.partial(_get_exception_for_key_vault_error, cls)
+        for status_code, cls in _code_to_core_error.items()
+    }
+)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/exceptions.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/exceptions.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from collections import defaultdict
 import functools
 from typing import TYPE_CHECKING
 
@@ -36,19 +37,19 @@ _default = functools.partial(_get_exception_for_key_vault_error, HttpResponseErr
 _code_to_core_error = {404: ResourceNotFoundError, 409: ResourceExistsError}
 
 
-class _ErrorMap(dict):
+class _ErrorMap(defaultdict):
     """A dict whose 'get' method returns a default value.
 
     defaultdict would be preferable but defaultdict.get returns None for keys having no value
     (azure.core.exceptions.map_error calls error_map.get)
     """
 
-    def get(self, key):
-        return super(_ErrorMap, self).get(key) or _default
+    def get(self, key, value=None):  # pylint:disable=unused-argument
+        return self[key]
 
 
 # map status codes to callables returning appropriate azure-core errors
-error_map = _ErrorMap(
+error_map = _ErrorMap(lambda: _default,
     {
         status_code: functools.partial(_get_exception_for_key_vault_error, cls)
         for status_code, cls in _code_to_core_error.items()

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -92,6 +92,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             key_size=kwargs.pop("size", None),
             key_attributes=attributes,
             key_ops=kwargs.pop("key_operations", None),
+            error_map=_error_map,
             **kwargs,
         )
         return KeyVaultKey._from_key_bundle(bundle)
@@ -265,6 +266,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             self.vault_url,
             maxresults=kwargs.pop("max_page_size", None),
             cls=lambda objs: [DeletedKey._from_deleted_key_item(x) for x in objs],
+            error_map=_error_map,
             **kwargs,
         )
 
@@ -287,6 +289,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             self.vault_url,
             maxresults=kwargs.pop("max_page_size", None),
             cls=lambda objs: [KeyProperties._from_key_item(x) for x in objs],
+            error_map=_error_map,
             **kwargs,
         )
 
@@ -311,6 +314,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             name,
             maxresults=kwargs.pop("max_page_size", None),
             cls=lambda objs: [KeyProperties._from_key_item(x) for x in objs],
+            error_map=_error_map,
             **kwargs,
         )
 
@@ -338,7 +342,7 @@ class KeyClient(AsyncKeyVaultClientBase):
                 await key_client.purge_deleted_key("key-name")
 
         """
-        await self._client.purge_deleted_key(self.vault_url, name, **kwargs)
+        await self._client.purge_deleted_key(self.vault_url, name, error_map=_error_map, **kwargs)
 
     @distributed_trace_async
     async def recover_deleted_key(self, name: str, **kwargs: "Any") -> KeyVaultKey:
@@ -365,7 +369,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         if polling_interval is None:
             polling_interval = 2
         recovered_key = KeyVaultKey._from_key_bundle(
-            await self._client.recover_deleted_key(self.vault_url, name, **kwargs)
+            await self._client.recover_deleted_key(self.vault_url, name, error_map=_error_map, **kwargs)
         )
         command = partial(self.get_key, name=name, **kwargs)
 
@@ -502,6 +506,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             key=key._to_generated_model(),
             key_attributes=attributes,
             hsm=kwargs.pop("hardware_protected", None),
+            error_map=_error_map,
             **kwargs
         )
         return KeyVaultKey._from_key_bundle(bundle)

--- a/sdk/keyvault/azure-keyvault-keys/tests/keys_helpers.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/keys_helpers.py
@@ -36,12 +36,12 @@ class Request:
             assert request.body.get(field) == expected_value
 
 
-def mock_response(status_code=200, headers={}, json_payload=None):
-    response = mock.Mock(status_code=status_code, headers=headers)
+def mock_response(status_code=200, headers=None, json_payload=None):
+    response = mock.Mock(status_code=status_code, headers=headers or {})
     if json_payload is not None:
         response.text = lambda encoding=None: json.dumps(json_payload)
         response.headers["content-type"] = "application/json"
-        response.content_type = ["application/json"]
+        response.content_type = "application/json"
     return response
 
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_exceptions.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_exceptions.py
@@ -1,0 +1,27 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from azure.core.exceptions import HttpResponseError, map_error
+from azure.keyvault.keys._shared.exceptions import error_map
+import pytest
+
+from keys_helpers import mock_response
+
+
+def test_error_map():
+    """error_map should map all error codes to a subclass of HttpResponseError"""
+
+    error_code = "oops"
+    error_message = "something went wrong"
+    error_body = {"error": {"code": error_code, "message": error_message}}  # Key Vault error responses look like this
+
+    for status_code in range(400, 600):
+        response = mock_response(status_code=status_code, json_payload=error_body)
+
+        with pytest.raises(HttpResponseError) as ex:
+            map_error(status_code, response, error_map)
+
+        # the concrete error should include error information returned by Key Vault
+        assert error_code in ex.value.message
+        assert error_message in ex.value.message

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/exceptions.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/exceptions.py
@@ -5,33 +5,52 @@
 import functools
 from typing import TYPE_CHECKING
 
-from azure.core.exceptions import DecodeError, ResourceExistsError, ResourceNotFoundError
+from azure.core.exceptions import DecodeError, HttpResponseError, ResourceExistsError, ResourceNotFoundError
 from azure.core.pipeline.policies import ContentDecodePolicy
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
-    from typing import Type
-    from azure.core.exceptions import AzureError
+    from typing import Optional, Type
     from azure.core.pipeline.transport import HttpResponse
 
 
-def get_exception_for_key_vault_error(cls, response):
-    # type: (Type[AzureError], HttpResponse) -> AzureError
+def _get_exception_for_key_vault_error(cls, response):
+    # type: (Type[HttpResponseError], HttpResponse) -> HttpResponseError
+    """Construct cls (HttpResponseError or subclass thereof) with Key Vault's error message."""
+
     try:
         body = ContentDecodePolicy.deserialize_from_http_generics(response)
-        message = "({}) {}".format(body["error"]["code"], body["error"]["message"])
+        message = "({}) {}".format(body["error"]["code"], body["error"]["message"])  # type: Optional[str]
     except (DecodeError, KeyError):
-        # Key Vault error response bodies have the expected shape and should be deserializable.
+        # Key Vault error response bodies should have the expected shape and be deserializable.
         # If we somehow land here, we'll take HttpResponse's default message.
         message = None
 
     return cls(message=message, response=response)
 
 
+# errors map to HttpResponseError...
+_default = functools.partial(_get_exception_for_key_vault_error, HttpResponseError)
+
+# ...unless this mapping specifies another type
 _code_to_core_error = {404: ResourceNotFoundError, 409: ResourceExistsError}
 
+
+class _ErrorMap(dict):
+    """A dict whose 'get' method returns a default value.
+
+    defaultdict would be preferable but defaultdict.get returns None for keys having no value
+    (azure.core.exceptions.map_error calls error_map.get)
+    """
+
+    def get(self, key):
+        return super(_ErrorMap, self).get(key) or _default
+
+
 # map status codes to callables returning appropriate azure-core errors
-error_map = {
-    status_code: functools.partial(get_exception_for_key_vault_error, cls)
-    for status_code, cls in _code_to_core_error.items()
-}
+error_map = _ErrorMap(
+    {
+        status_code: functools.partial(_get_exception_for_key_vault_error, cls)
+        for status_code, cls in _code_to_core_error.items()
+    }
+)

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/exceptions.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/exceptions.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from collections import defaultdict
 import functools
 from typing import TYPE_CHECKING
 
@@ -36,19 +37,19 @@ _default = functools.partial(_get_exception_for_key_vault_error, HttpResponseErr
 _code_to_core_error = {404: ResourceNotFoundError, 409: ResourceExistsError}
 
 
-class _ErrorMap(dict):
+class _ErrorMap(defaultdict):
     """A dict whose 'get' method returns a default value.
 
     defaultdict would be preferable but defaultdict.get returns None for keys having no value
     (azure.core.exceptions.map_error calls error_map.get)
     """
 
-    def get(self, key):
-        return super(_ErrorMap, self).get(key) or _default
+    def get(self, key, value=None):  # pylint:disable=unused-argument
+        return self[key]
 
 
 # map status codes to callables returning appropriate azure-core errors
-error_map = _ErrorMap(
+error_map = _ErrorMap(lambda: _default,
     {
         status_code: functools.partial(_get_exception_for_key_vault_error, cls)
         for status_code, cls in _code_to_core_error.items()

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
@@ -93,7 +93,9 @@ class SecretClient(AsyncKeyVaultClientBase):
             )
         else:
             attributes = None
-        bundle = await self._client.set_secret(self.vault_url, name, value, secret_attributes=attributes, **kwargs)
+        bundle = await self._client.set_secret(
+            self.vault_url, name, value, secret_attributes=attributes, error_map=_error_map, **kwargs
+        )
         return KeyVaultSecret._from_secret_bundle(bundle)
 
     @distributed_trace_async
@@ -340,7 +342,7 @@ class SecretClient(AsyncKeyVaultClientBase):
                 await secret_client.purge_deleted_secret("secret-name")
 
         """
-        await self._client.purge_deleted_secret(self.vault_url, name, **kwargs)
+        await self._client.purge_deleted_secret(self.vault_url, name, error_map=_error_map, **kwargs)
 
     @distributed_trace_async
     async def recover_deleted_secret(self, name: str, **kwargs: "Any") -> SecretProperties:
@@ -367,7 +369,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         if polling_interval is None:
             polling_interval = 2
         recovered_secret = SecretProperties._from_secret_bundle(
-            await self._client.recover_deleted_secret(self.vault_url, name, **kwargs)
+            await self._client.recover_deleted_secret(self.vault_url, name, error_map=_error_map, **kwargs)
         )
         command = partial(self.get_secret, name=name, **kwargs)
 


### PR DESCRIPTION
When the generated Key Vault client receives a response with an unexpected status code, it calls azure-core's `map_error`. If `map_error` doesn't raise, the generated client raises `KeyVaultErrorException`, a generated class.

This change ensures the generated error is never raised, i.e. it ensures `map_error` always finds something else to raise. All calls to the generated client's methods pass an error map mapping all error status codes to something, defaulting to `HttpResponseError`.

Closes #9690