### PR TITLE
Removed invalid artifact name from ci.yml for azure support service

### DIFF
--- a/sdk/support/ci.yml
+++ b/sdk/support/ci.yml
@@ -42,5 +42,3 @@ stages:
     Artifacts:
     - name: azure_mgmt_support
       safeName: azuremgmtsupport
-    - name: support
-      safeName: support


### PR DESCRIPTION
CI is failing for azure service due to invalid entry in ci.yml. "Support" is added as an artifact but there is no such artifact.