### PR TITLE
Adding placeholder to list any third party licenses

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,7 @@
+This file list any third-party libraries or other resources that may be
+distributed under licenses different than the Azure SDK for Python software.
+
+In the event that we accidentally failed to list a required notice, please
+bring it to our attention by opening an issue.
+
+The attached notices are provided for information only.


### PR DESCRIPTION
This is a place holder file to list licenses in the event python sdk need to redistribute 3rd party source code.