### PR TITLE
Adopt vcrpy 3.0.0

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/_shared/asynctestcase.py
+++ b/sdk/storage/azure-storage-blob/tests/_shared/asynctestcase.py
@@ -8,6 +8,7 @@
 import asyncio
 import functools
 
+from azure_devtools.scenario_tests.patches import mock_in_unit_test
 from azure_devtools.scenario_tests.utilities import trim_kwargs_from_test_function
 
 from azure.core.credentials import AccessToken
@@ -27,7 +28,38 @@ class AsyncFakeTokenCredential(object):
         return self.token
 
 
+def patch_play_responses(unit_test):
+    """Fixes a bug affecting blob tests by applying https://github.com/kevin1024/vcrpy/pull/511 to vcrpy 3.0.0"""
+
+    try:
+        from vcr.stubs.aiohttp_stubs import _serialize_headers, build_response, Request, URL
+    except ImportError:
+        # return a do-nothing patch when importing from vcr fails
+        return lambda _: None
+
+    def fixed_play_responses(cassette, vcr_request):
+        history = []
+        vcr_response = cassette.play_response(vcr_request)
+        response = build_response(vcr_request, vcr_response, history)
+        while 300 <= response.status <= 399:
+            if "location" not in response.headers:
+                break
+            next_url = URL(response.url).with_path(response.headers["location"])
+            vcr_request = Request("GET", str(next_url), None, _serialize_headers(response.request_info.headers))
+            vcr_request = cassette.find_requests_with_most_matches(vcr_request)[0][0]
+            history.append(response)
+            vcr_response = cassette.play_response(vcr_request)
+            response = build_response(vcr_request, vcr_response, history)
+        return response
+
+    return mock_in_unit_test(unit_test, "vcr.stubs.aiohttp_stubs.play_responses", fixed_play_responses)
+
+
 class AsyncStorageTestCase(StorageTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.replay_patches.append(patch_play_responses)
+
     @staticmethod
     def await_prepared_test(test_fn):
         """Synchronous wrapper for async test methods. Used to avoid making changes

--- a/sdk/storage/azure-storage-file-share/tests/_shared/asynctestcase.py
+++ b/sdk/storage/azure-storage-file-share/tests/_shared/asynctestcase.py
@@ -8,6 +8,7 @@
 import asyncio
 import functools
 
+from azure_devtools.scenario_tests.patches import mock_in_unit_test
 from azure_devtools.scenario_tests.utilities import trim_kwargs_from_test_function
 
 from azure.core.credentials import AccessToken
@@ -27,7 +28,38 @@ class AsyncFakeTokenCredential(object):
         return self.token
 
 
+def patch_play_responses(unit_test):
+    """Fixes a bug affecting blob tests by applying https://github.com/kevin1024/vcrpy/pull/511 to vcrpy 3.0.0"""
+
+    try:
+        from vcr.stubs.aiohttp_stubs import _serialize_headers, build_response, Request, URL
+    except ImportError:
+        # return a do-nothing patch when importing from vcr fails
+        return lambda _: None
+
+    def fixed_play_responses(cassette, vcr_request):
+        history = []
+        vcr_response = cassette.play_response(vcr_request)
+        response = build_response(vcr_request, vcr_response, history)
+        while 300 <= response.status <= 399:
+            if "location" not in response.headers:
+                break
+            next_url = URL(response.url).with_path(response.headers["location"])
+            vcr_request = Request("GET", str(next_url), None, _serialize_headers(response.request_info.headers))
+            vcr_request = cassette.find_requests_with_most_matches(vcr_request)[0][0]
+            history.append(response)
+            vcr_response = cassette.play_response(vcr_request)
+            response = build_response(vcr_request, vcr_response, history)
+        return response
+
+    return mock_in_unit_test(unit_test, "vcr.stubs.aiohttp_stubs.play_responses", fixed_play_responses)
+
+
 class AsyncStorageTestCase(StorageTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.replay_patches.append(patch_play_responses)
+
     @staticmethod
     def await_prepared_test(test_fn):
         """Synchronous wrapper for async test methods. Used to avoid making changes

--- a/sdk/storage/azure-storage-queue/tests/_shared/asynctestcase.py
+++ b/sdk/storage/azure-storage-queue/tests/_shared/asynctestcase.py
@@ -8,6 +8,7 @@
 import asyncio
 import functools
 
+from azure_devtools.scenario_tests.patches import mock_in_unit_test
 from azure_devtools.scenario_tests.utilities import trim_kwargs_from_test_function
 
 from azure.core.credentials import AccessToken
@@ -27,7 +28,38 @@ class AsyncFakeTokenCredential(object):
         return self.token
 
 
+def patch_play_responses(unit_test):
+    """Fixes a bug affecting blob tests by applying https://github.com/kevin1024/vcrpy/pull/511 to vcrpy 3.0.0"""
+
+    try:
+        from vcr.stubs.aiohttp_stubs import _serialize_headers, build_response, Request, URL
+    except ImportError:
+        # return a do-nothing patch when importing from vcr fails
+        return lambda _: None
+
+    def fixed_play_responses(cassette, vcr_request):
+        history = []
+        vcr_response = cassette.play_response(vcr_request)
+        response = build_response(vcr_request, vcr_response, history)
+        while 300 <= response.status <= 399:
+            if "location" not in response.headers:
+                break
+            next_url = URL(response.url).with_path(response.headers["location"])
+            vcr_request = Request("GET", str(next_url), None, _serialize_headers(response.request_info.headers))
+            vcr_request = cassette.find_requests_with_most_matches(vcr_request)[0][0]
+            history.append(response)
+            vcr_response = cassette.play_response(vcr_request)
+            response = build_response(vcr_request, vcr_response, history)
+        return response
+
+    return mock_in_unit_test(unit_test, "vcr.stubs.aiohttp_stubs.play_responses", fixed_play_responses)
+
+
 class AsyncStorageTestCase(StorageTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.replay_patches.append(patch_play_responses)
+
     @staticmethod
     def await_prepared_test(test_fn):
         """Synchronous wrapper for async test methods. Used to avoid making changes

--- a/tools/azure-devtools/setup.py
+++ b/tools/azure-devtools/setup.py
@@ -29,7 +29,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'ConfigArgParse>=0.12.0',
     'six>=1.10.0',
-    'vcrpy>=1.11.0,<2.1.0',
+    'vcrpy==3.0.0'
 ]
 
 with io.open('README.rst', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
This adopts vcrpy 3.0.0 in azure-devtools to acquire a fix (kevin1024/vcrpy#495) for a bug affecting Key Vault tests. However, that fix introduces a bug affecting Storage Blob tests. That bug is fixed by kevin1024/vcrpy#511, which I expect will eventually be released. In the meantime, this PR includes that fix as a patch applied during blob and queue playback tests. Queue tests don't need this patch; I copied it there only to maintain identical `tests/_shared`.

I haven't found another test broken by the upgrade. As for why I propose to adopt vcrpy 3.0.0 rather than the latest 4.x: 4.x doesn't support Python 2.7.