### PR TITLE
Clear os.environ when patching it

### DIFF
--- a/sdk/identity/azure-identity/tests/test_environment_credential.py
+++ b/sdk/identity/azure-identity/tests/test_environment_credential.py
@@ -23,13 +23,13 @@ ALL_VARIABLES = {
 def test_error_message():
     """get_token should raise CredentialUnavailableError for incomplete configuration, listing any set variables."""
 
-    with mock.patch.dict(os.environ, {}):
+    with mock.patch.dict(os.environ, {}, clear=True):
         with pytest.raises(CredentialUnavailableError) as ex:
             EnvironmentCredential().get_token("scope")
     assert not any(var in ex.value.message for var in ALL_VARIABLES)
 
     for a, b in itertools.combinations(ALL_VARIABLES, 2):  # all credentials require at least 3 variables set
-        with mock.patch.dict(os.environ, {a: "a", b: "b"}):
+        with mock.patch.dict(os.environ, {a: "a", b: "b"}, clear=True):
             with pytest.raises(CredentialUnavailableError) as ex:
                 EnvironmentCredential().get_token("scope")
 

--- a/sdk/identity/azure-identity/tests/test_environment_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_environment_credential_async.py
@@ -16,13 +16,13 @@ from test_environment_credential import ALL_VARIABLES
 async def test_error_message():
     """get_token should raise CredentialUnavailableError for incomplete configuration, listing any set variables."""
 
-    with mock.patch.dict(os.environ, {}):
+    with mock.patch.dict(os.environ, {}, clear=True):
         with pytest.raises(CredentialUnavailableError) as ex:
             await EnvironmentCredential().get_token("scope")
     assert not any(var in ex.value.message for var in ALL_VARIABLES)
 
     for a, b in itertools.combinations(ALL_VARIABLES, 2):  # all credentials require at least 3 variables set
-        with mock.patch.dict(os.environ, {a: "a", b: "b"}):
+        with mock.patch.dict(os.environ, {a: "a", b: "b"}, clear=True):
             with pytest.raises(CredentialUnavailableError) as ex:
                 await EnvironmentCredential().get_token("scope")
 


### PR DESCRIPTION
When running the live test suite, environment variables hold configuration that `EnvironmentCredential` will use, contrary to the expectations of some offline tests patching `os.environ`. This ensures `os.environ` is cleared before those patches are applied.