### PR TITLE
Regression test should not fail if required package is not available

### DIFF
--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -394,6 +394,7 @@ def find_packages_missing_on_pypi(path):
 
     # parse pkg name and spec
     pkg_spec_dict = dict(parse_require(req) for req in requires)
+    logging.info("Package requirement: {}".format(pkg_spec_dict))
     # find if version is available on pypi
     missing_packages = ["{0}{1}".format(pkg, pkg_spec_dict[pkg]) for pkg in pkg_spec_dict.keys() if not is_required_version_on_pypi(pkg, pkg_spec_dict[pkg])]
     if missing_packages:

--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -62,14 +62,14 @@ omit_regression = (
 )
 omit_docs = lambda x: "nspkg" not in x and os.path.basename(x) not in META_PACKAGES
 omit_build = lambda x: x # Dummy lambda to match omit type
+lambda_filter_azure_pkg = lambda x: x.startswith("azure") and "-nspkg" not in x
+
 # dict of filter type and filter function
 omit_funct_dict = {
     "Build": omit_build,
     "Docs": omit_docs,
     "Regression": omit_regression,
 }
-
-lambda_filter_azure_pkg = lambda x: x.startswith("azure") and "-nspkg" not in x
 
 def log_file(file_location, is_error=False):
     with open(file_location, "r") as file:

--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -388,7 +388,7 @@ def find_packages_missing_on_pypi(path):
     requires = []
     client = PyPIClient()
     if path.endswith(".whl"):
-        requires = [ r for r in pkginfo.get_metadata(path).requires_dist if r.startswith('azure') and "-nspkg" not in r]
+        requires = list(filter(lambda_filter_azure_pkg, pkginfo.get_metadata(path).requires_dist))
     else:
         _, _, _, requires = parse_setup(path)
 

--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -28,6 +28,8 @@ from pkg_resources import parse_version, parse_requirements, Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
+import pkginfo
+from pypi_tools.pypi import PyPIClient
 from pip._internal.operations import freeze
 
 DEV_REQ_FILE = "dev_requirements.txt"
@@ -67,6 +69,7 @@ omit_funct_dict = {
     "Regression": omit_regression,
 }
 
+lambda_filter_azure_pkg = lambda x: x.startswith("azure") and "-nspkg" not in x
 
 def log_file(file_location, is_error=False):
     with open(file_location, "r") as file:
@@ -323,11 +326,7 @@ def parse_require(req):
     spec = SpecifierSet(str(req_object).replace(pkg_name, ""))
     return [pkg_name, spec]
 
-
-# This method installs package from a pre-built whl
-def install_package_from_whl(
-    package_name, version, whl_directory, working_dir, python_sym_link=sys.executable
-):
+def find_whl(package_name, version, whl_directory):
     if not os.path.exists(whl_directory):
         logging.error("Whl directory is incorrect")
         exit(1)
@@ -343,10 +342,15 @@ def install_package_from_whl(
         )
         exit(1)
 
-    package_whl_path = paths[0]
+    return paths[0]
+
+# This method installs package from a pre-built whl
+def install_package_from_whl(
+    package_whl_path, working_dir, python_sym_link=sys.executable
+):
     commands = [python_sym_link, "-m", "pip", "install", package_whl_path]
     run_check_call(commands, working_dir)
-    logging.info("Installed package {}".format(package_name))
+    logging.info("Installed package from {}".format(package_whl_path))
 
 
 def filter_dev_requirements(pkg_root_path, packages_to_exclude, dest_dir):
@@ -374,4 +378,25 @@ def filter_dev_requirements(pkg_root_path, packages_to_exclude, dest_dir):
         dev_req_file.writelines(requirements)
 
     return new_dev_req_path
-    
+
+def is_required_version_on_pypi(package_name, spec):
+    client = PyPIClient()
+    versions = [str(v) for v in client.get_ordered_versions(package_name) if str(v) in spec]
+    return versions
+
+def find_packages_missing_on_pypi(path):
+    requires = []
+    client = PyPIClient()
+    if path.endswith(".whl"):
+        requires = [ r for r in pkginfo.get_metadata(path).requires_dist if r.startswith('azure') and "-nspkg" not in r]
+    else:
+        _, _, _, requires = parse_setup(path)
+
+    # parse pkg name and spec
+    pkg_spec_dict = dict(parse_require(req) for req in requires)
+    # find if version is available on pypi
+    missing_packages = ["{0}{1}".format(pkg, pkg_spec_dict[pkg]) for pkg in pkg_spec_dict.keys() if not is_required_version_on_pypi(pkg, pkg_spec_dict[pkg])]
+    if missing_packages:
+        logging.error("Packages not found on PyPI: {}".format(missing_packages))
+    return missing_packages
+

--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -29,8 +29,7 @@ from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 import pkginfo
-from pypi_tools.pypi import PyPIClient
-from pip._internal.operations import freeze
+
 
 DEV_REQ_FILE = "dev_requirements.txt"
 NEW_DEV_REQ_FILE = "new_dev_requirements.txt"
@@ -380,13 +379,13 @@ def filter_dev_requirements(pkg_root_path, packages_to_exclude, dest_dir):
     return new_dev_req_path
 
 def is_required_version_on_pypi(package_name, spec):
+    from pypi_tools.pypi import PyPIClient
     client = PyPIClient()
     versions = [str(v) for v in client.get_ordered_versions(package_name) if str(v) in spec]
     return versions
 
 def find_packages_missing_on_pypi(path):
     requires = []
-    client = PyPIClient()
     if path.endswith(".whl"):
         requires = list(filter(lambda_filter_azure_pkg, pkginfo.get_metadata(path).requires_dist))
     else:

--- a/scripts/devops_tasks/git_helper.py
+++ b/scripts/devops_tasks/git_helper.py
@@ -80,8 +80,7 @@ def git_checkout_tag(tag_name, working_dir):
 # This method checkouts a given tag of sdk repo
 def git_checkout_branch(branch_name, working_dir):
     # fetch tags
-    run_check_call(["git", "fetch", "origin", "'{0}':'{1}'".format(branch_name, branch_name)], working_dir)
-
+    run_check_call(["git", "fetch", "origin", branch_name], working_dir)
     logging.info("checkout git repo with branch {}".format(branch_name))
     commands = ["git", "checkout", branch_name]
     run_check_call(commands, working_dir)

--- a/scripts/devops_tasks/git_helper.py
+++ b/scripts/devops_tasks/git_helper.py
@@ -67,14 +67,25 @@ def get_release_tag(dep_pkg_name, isLatest):
 
 
 # This method checkouts a given tag of sdk repo
-def checkout_code_repo(tag_name, working_dir):
+def git_checkout_tag(tag_name, working_dir):
     # fetch tags
-    run_check_call(["git", "fetch", "--all", "--tags"], working_dir)
+    run_check_call(["git", "fetch", "origin", "tag", tag_name], working_dir)
 
     logging.info("checkout git repo with tag {}".format(tag_name))
     commands = ["git", "checkout", "tags/{}".format(tag_name)]
     run_check_call(commands, working_dir)
     logging.info("Code with tag {} is checked out successfully".format(tag_name))
+
+
+# This method checkouts a given tag of sdk repo
+def git_checkout_branch(branch_name, working_dir):
+    # fetch tags
+    run_check_call(["git", "fetch", "origin", "'{0}':'{1}'".format(branch_name, branch_name)], working_dir)
+
+    logging.info("checkout git repo with branch {}".format(branch_name))
+    commands = ["git", "checkout", branch_name]
+    run_check_call(commands, working_dir)
+    logging.info("Repo with branch name {} is checked out successfully".format(branch_name))
 
 
 def clone_repo(dest_dir, repo_url):

--- a/scripts/devops_tasks/git_helper.py
+++ b/scripts/devops_tasks/git_helper.py
@@ -81,6 +81,7 @@ def git_checkout_tag(tag_name, working_dir):
 def git_checkout_branch(branch_name, working_dir):
     # fetch tags
     run_check_call(["git", "fetch", "origin", branch_name], working_dir)
+    run_check_call(["git", "branch", branch_name, "FETCH_HEAD"], working_dir)
     logging.info("checkout git repo with branch {}".format(branch_name))
     commands = ["git", "checkout", branch_name]
     run_check_call(commands, working_dir)

--- a/scripts/devops_tasks/test_regression.py
+++ b/scripts/devops_tasks/test_regression.py
@@ -326,7 +326,7 @@ def run_main(args):
         )
 
     # find package dependency map for azure sdk
-    pkg_dependency = find_package_dependency('azure-identity', code_repo_root)
+    pkg_dependency = find_package_dependency(AZURE_GLOB_STRING, code_repo_root)
 
     # Create regression text context. One context object will be reused for all packages
     context = RegressionContext(

--- a/scripts/devops_tasks/test_regression.py
+++ b/scripts/devops_tasks/test_regression.py
@@ -19,7 +19,9 @@ from common_tasks import (
     run_check_call,
     parse_require,
     install_package_from_whl,
-    filter_dev_requirements
+    filter_dev_requirements,
+    find_packages_missing_on_pypi,
+    find_wheel
 )
 from git_helper import get_release_tag, checkout_code_repo, clone_repo
 from pip._internal.operations import freeze
@@ -171,10 +173,13 @@ class RegressionTest:
                 self.context.package_root_path,
             )
             # Install pre-built whl for current package
+            whl_path = find_wheel(self.context.package_name, self.context.pkg_version, self.context.whl_directory)
+            if find_packages_missing_on_pypi(whl_path):
+                logging.error("Required packages are not available on PyPI. Skipping test for current package")
+                return
+
             install_package_from_whl(
-                self.context.package_name,
-                self.context.pkg_version,
-                self.context.whl_directory,
+                whl_path,
                 self.context.temp_path,
                 self.context.venv.python_executable,
             )

--- a/scripts/devops_tasks/test_regression.py
+++ b/scripts/devops_tasks/test_regression.py
@@ -159,7 +159,7 @@ class RegressionTest:
             git_checkout_branch(test_branch_name, dep_pkg_path)
         except:
             # If git checkout failed for "tests" branch then checkout branch with release tag
-            logging.info("Failed to checkout branch {}. Checking out release tagged git repo".format(test_branch_name))            
+            logging.info("Failed to checkout branch {}. Checking out release tagged git repo".format(test_branch_name))
             git_checkout_tag(release_tag, dep_pkg_path)
 
         try:

--- a/scripts/devops_tasks/test_regression.py
+++ b/scripts/devops_tasks/test_regression.py
@@ -151,7 +151,7 @@ class RegressionTest:
         dep_pkg_name, version, _, _ = parse_setup(dep_pkg_path)
         release_tag = get_release_tag(dep_pkg_name, self.context.is_latest_depend_test)
         if not release_tag:
-            logging.error("Release tag is not avaiable. Skipping package {} from test".format(dep_pkg_name))
+            logging.error("Release tag is not available. Skipping package {} from test".format(dep_pkg_name))
             return
 
         test_branch_name = "{0}_tests".format(release_tag)


### PR DESCRIPTION
If a required package is not available on PyPI, Regression Test currently fails. Test should exit gracefully if error is due to a missing required package on PyPI.