### PR TITLE
Implemented ManagedIdentityCredential with composition (#9302)

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -42,6 +42,7 @@ class ManagedIdentityCredential(object):
     """
 
     def __init__(self, **kwargs):
+        # type: (**Any) -> None
         self._credential = None
         if os.environ.get(EnvironmentVariables.MSI_ENDPOINT):
             self._credential = MsiCredential(**kwargs)
@@ -49,6 +50,7 @@ class ManagedIdentityCredential(object):
             self._credential = ImdsCredential(**kwargs)
 
     def get_token(self, *scopes, **kwargs):
+        # type: (*str, **Any) -> AccessToken
         """Request an access token for `scopes`.
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -33,7 +33,8 @@ if TYPE_CHECKING:
 
 
 class ManagedIdentityCredential(object):
-    """Authenticates with an Azure managed identity in any hosting environment which supports managed identities.
+    """
+    Authenticates with an Azure managed identity in any hosting environment which supports managed identities.
 
     See the Azure Active Directory documentation for more information about managed identities:
     https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
@@ -42,16 +43,13 @@ class ManagedIdentityCredential(object):
     """
 
     def __init__(self, **kwargs):
-        # type: (**Any) -> None
         self._credential = None
         if os.environ.get(EnvironmentVariables.MSI_ENDPOINT):
             self._credential = MsiCredential(**kwargs)
-        self._credential = ImdsCredential(**kwargs)
+        else:
+            self._credential = ImdsCredential(**kwargs)
 
-    def get_token(
-        self, *scopes, **kwargs
-    ):  # pylint:disable=unused-argument,no-self-use
-        # type: (*str, **Any) -> AccessToken
+    def get_token(self, *scopes, **kwargs):
         """Request an access token for `scopes`.
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
@@ -60,10 +58,9 @@ class ManagedIdentityCredential(object):
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.identity.CredentialUnavailableError: managed identity isn't available in the hosting environment
         """
+
         if not self._credential:
-            raise CredentialUnavailableError(
-                message="managed identity isn't available in the hosting environment"
-            )
+            raise CredentialUnavailableError(message="No Managed identity endpoint found.")
         return self._credential.get_token(*scopes, **kwargs)
 
 
@@ -83,9 +80,7 @@ class _ManagedIdentityBase(object):
             DistributedTracingPolicy(**kwargs),
             HttpLoggingPolicy(**kwargs),
         ]
-        self._client = client_cls(
-            endpoint=endpoint, config=config, policies=policies, **kwargs
-        )
+        self._client = client_cls(endpoint=endpoint, config=config, policies=policies, **kwargs)
 
     @staticmethod
     def _create_config(**kwargs):
@@ -97,16 +92,12 @@ class _ManagedIdentityBase(object):
 
         # retry is the only IO policy, so its class is a kwarg to increase async code sharing
         retry_policy = kwargs.pop("retry_policy", RetryPolicy)  # type: ignore
-        args = (
-            kwargs.copy()
-        )  # combine kwargs and default retry settings in a Python 2-compatible way
+        args = kwargs.copy()  # combine kwargs and default retry settings in a Python 2-compatible way
         args.update(_ManagedIdentityBase._retry_settings)  # type: ignore
         config.retry_policy = retry_policy(**args)  # type: ignore
 
         # Metadata header is required by IMDS and in Cloud Shell; App Service ignores it
-        config.headers_policy = HeadersPolicy(
-            base_headers={"Metadata": "true"}, **kwargs
-        )
+        config.headers_policy = HeadersPolicy(base_headers={"Metadata": "true"}, **kwargs)
         config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
         config.user_agent_policy = UserAgentPolicy(base_user_agent=USER_AGENT, **kwargs)
 
@@ -132,9 +123,7 @@ class ImdsCredential(_ManagedIdentityBase):
 
     def __init__(self, **kwargs):
         # type: (**Any) -> None
-        super(ImdsCredential, self).__init__(
-            endpoint=Endpoints.IMDS, client_cls=AuthnClient, **kwargs
-        )
+        super(ImdsCredential, self).__init__(endpoint=Endpoints.IMDS, client_cls=AuthnClient, **kwargs)
         self._endpoint_available = None  # type: Optional[bool]
 
     def get_token(self, *scopes, **kwargs):  # pylint:disable=unused-argument
@@ -150,9 +139,7 @@ class ImdsCredential(_ManagedIdentityBase):
             # we send a request it would immediately reject (missing a required header),
             # setting a short timeout.
             try:
-                self._client.request_token(
-                    scopes, method="GET", connection_timeout=0.3, retry_total=0
-                )
+                self._client.request_token(scopes, method="GET", connection_timeout=0.3, retry_total=0)
                 self._endpoint_available = True
             except HttpResponseError:
                 # received a response, choked on it
@@ -189,9 +176,7 @@ class MsiCredential(_ManagedIdentityBase):
         # type: (**Any) -> None
         self._endpoint = os.environ.get(EnvironmentVariables.MSI_ENDPOINT)
         if self._endpoint:
-            super(MsiCredential, self).__init__(
-                endpoint=self._endpoint, client_cls=AuthnClient, **kwargs
-            )
+            super(MsiCredential, self).__init__(endpoint=self._endpoint, client_cls=AuthnClient, **kwargs)
 
     def get_token(self, *scopes, **kwargs):  # pylint:disable=unused-argument
         # type: (*str, **Any) -> AccessToken
@@ -216,9 +201,7 @@ class MsiCredential(_ManagedIdentityBase):
             secret = os.environ.get(EnvironmentVariables.MSI_SECRET)
             if secret:
                 # MSI_ENDPOINT and MSI_SECRET set -> App Service
-                token = self._request_app_service_token(
-                    scopes=scopes, resource=resource, secret=secret
-                )
+                token = self._request_app_service_token(scopes=scopes, resource=resource, secret=secret)
             else:
                 # only MSI_ENDPOINT set -> legacy-style MSI (Cloud Shell)
                 token = self._request_legacy_token(scopes=scopes, resource=resource)
@@ -228,9 +211,7 @@ class MsiCredential(_ManagedIdentityBase):
         params = {"api-version": "2017-09-01", "resource": resource}
         if self._client_id:
             params["clientid"] = self._client_id
-        return self._client.request_token(
-            scopes, method="GET", headers={"secret": secret}, params=params
-        )
+        return self._client.request_token(scopes, method="GET", headers={"secret": secret}, params=params)
 
     def _request_legacy_token(self, scopes, resource):
         form_data = {"resource": resource}

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -33,8 +33,7 @@ if TYPE_CHECKING:
 
 
 class ManagedIdentityCredential(object):
-    """
-    Authenticates with an Azure managed identity in any hosting environment which supports managed identities.
+    """Authenticates with an Azure managed identity in any hosting environment which supports managed identities.
 
     See the Azure Active Directory documentation for more information about managed identities:
     https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
@@ -60,7 +59,7 @@ class ManagedIdentityCredential(object):
         """
 
         if not self._credential:
-            raise CredentialUnavailableError(message="No Managed identity endpoint found.")
+            raise CredentialUnavailableError(message="No managed identity endpoint found.")
         return self._credential.get_token(*scopes, **kwargs)
 
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -40,17 +40,15 @@ class ManagedIdentityCredential(object):
 
     :keyword str client_id: ID of a user-assigned identity. Leave unspecified to use a system-assigned identity.
     """
-
-    def __new__(cls, **kwargs):
-        if os.environ.get(EnvironmentVariables.MSI_ENDPOINT):
-            return MsiCredential(**kwargs)
-        return ImdsCredential(**kwargs)
-
+    
     # the below methods are never called, because ManagedIdentityCredential can't be instantiated;
     # they exist so tooling gets accurate signatures for Imds- and MsiCredential
     def __init__(self, **kwargs):
         # type: (**Any) -> None
-        pass
+        self._credential = None
+        if os.environ.get(EnvironmentVariables.MSI_ENDPOINT):
+            self._credential = MsiCredential(**kwargs)
+        self._credential = ImdsCredential(**kwargs)
 
     def get_token(self, *scopes, **kwargs):  # pylint:disable=unused-argument,no-self-use
         # type: (*str, **Any) -> AccessToken
@@ -62,7 +60,9 @@ class ManagedIdentityCredential(object):
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.identity.CredentialUnavailableError: managed identity isn't available in the hosting environment
         """
-        return AccessToken()
+        if not self._credential:
+            raise CredentialUnavailableError(message="managed identity isn't available in the hosting environment")
+        return self._credential.get_token(*scopes, **kwargs)
 
 
 class _ManagedIdentityBase(object):

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from azure.core.configuration import Configuration
 
 
-class ManagedIdentityCredential(object):
+class ManagedIdentityCredential(AsyncCredentialBase):
     """Authenticates with an Azure managed identity in any hosting environment which supports managed identities.
 
     See the Azure Active Directory documentation for more information about managed identities:
@@ -31,7 +31,7 @@ class ManagedIdentityCredential(object):
     """
 
     def __init__(self, **kwargs: "Any") -> None:
-        self._credential = None
+        self._credential = None  # type: (**Any) -> None
         if os.environ.get(EnvironmentVariables.MSI_ENDPOINT):
             self._credential = MsiCredential(**kwargs)
         else:
@@ -42,12 +42,15 @@ class ManagedIdentityCredential(object):
             await self._credential.__aenter__()
         return self
 
-    async def __aexit__(self, *args):
+    async def close(self):
         """Close the credential's transport session."""
         if self._credential:
             await self._credential.__aexit__()
 
-    async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":  # pylint:disable=unused-argument
+    async def get_token(
+        self, *scopes: str, **kwargs: "Any"
+    ) -> "AccessToken":  # pylint:disable=unused-argument,no-self-use
+        # type: (*str,**Any) -> AccessToken
         """Asynchronously request an access token for `scopes`.
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
@@ -57,7 +60,7 @@ class ManagedIdentityCredential(object):
         :raises ~azure.identity.CredentialUnavailableError: managed identity isn't available in the hosting environment
         """
         if not self._credential:
-            raise CredentialUnavailableError(message="No managed identity endpoints found")
+            raise CredentialUnavailableError(message="No managed identity endpoint found.")
         return await self._credential.get_token(*scopes, **kwargs)
 
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -58,7 +58,7 @@ class ManagedIdentityCredential(object):
         """
         if not self._credential:
             raise CredentialUnavailableError(message="No managed identity endpoints found")
-        return self._credential.get_token(*scopes, **kwargs)
+        return await self._credential.get_token(*scopes, **kwargs)
 
 
 class _AsyncManagedIdentityBase(_ManagedIdentityBase, AsyncCredentialBase):

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -31,7 +31,7 @@ class ManagedIdentityCredential(AsyncCredentialBase):
     """
 
     def __init__(self, **kwargs: "Any") -> None:
-        self._credential = None  # type: (**Any) -> None
+        self._credential = None
         if os.environ.get(EnvironmentVariables.MSI_ENDPOINT):
             self._credential = MsiCredential(**kwargs)
         else:
@@ -47,10 +47,7 @@ class ManagedIdentityCredential(AsyncCredentialBase):
         if self._credential:
             await self._credential.__aexit__()
 
-    async def get_token(
-        self, *scopes: str, **kwargs: "Any"
-    ) -> "AccessToken":  # pylint:disable=unused-argument,no-self-use
-        # type: (*str,**Any) -> AccessToken
+    async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":
         """Asynchronously request an access token for `scopes`.
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -61,7 +61,7 @@ class ManagedIdentityCredential(object):
         """
         if not self._credential:
             raise CredentialUnavailableError(message="No managed identity endpoints found")
-        return self._credential.get_token()
+        return self._credential.get_token(*scopes, **kwargs)
 
 
 class _AsyncManagedIdentityBase(_ManagedIdentityBase, AsyncCredentialBase):

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -43,9 +43,6 @@ class ManagedIdentityCredential(object):
         return self
 
     async def __aexit__(self, *args):
-        pass
-
-    async def close(self):
         """Close the credential's transport session."""
         if self._credential:
             await self._credential.__aexit__()

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -30,24 +30,25 @@ class ManagedIdentityCredential(object):
     :keyword str client_id: ID of a user-assigned identity. Leave unspecified to use a system-assigned identity.
     """
 
-    def __new__(cls, *args, **kwargs):
-        if os.environ.get(EnvironmentVariables.MSI_ENDPOINT):
-            return MsiCredential(*args, **kwargs)
-        return ImdsCredential(*args, **kwargs)
-
-    # the below methods are never called, because ManagedIdentityCredential can't be instantiated;
-    # they exist so tooling gets accurate signatures for Imds- and MsiCredential
     def __init__(self, **kwargs: "Any") -> None:
-        pass
+        self._credential = None
+        if os.environ.get(EnvironmentVariables.MSI_ENDPOINT):
+            self._credential = MsiCredential(**kwargs)
+        else:
+            self._credential = ImdsCredential(**kwargs)
 
     async def __aenter__(self):
-        pass
+        if self._credential:
+            await self._credential.__aenter__()
+        return self
 
     async def __aexit__(self, *args):
         pass
 
     async def close(self):
         """Close the credential's transport session."""
+        if self._credential:
+            await self._credential.__aexit__()
 
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":  # pylint:disable=unused-argument
         """Asynchronously request an access token for `scopes`.
@@ -58,7 +59,9 @@ class ManagedIdentityCredential(object):
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.identity.CredentialUnavailableError: managed identity isn't available in the hosting environment
         """
-        return AccessToken()
+        if not self._credential:
+            raise CredentialUnavailableError(message="No managed identity endpoints found")
+        return self._credential.get_token()
 
 
 class _AsyncManagedIdentityBase(_ManagedIdentityBase, AsyncCredentialBase):

--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -93,12 +93,12 @@ def test_exclude_options():
         assert actual <= default  # n.b. we know actual is non-empty
         assert default - actual <= excluded
 
-    # with no environment variables set, ManagedIdentityCredential = ImdsCredential
+    # with no environment variables set, ManagedIdentityCredential holds an instance of  ImdsCredential
     with patch("os.environ", {}):
         credential = DefaultAzureCredential(exclude_managed_identity_credential=True)
         assert_credentials_not_present(credential, ManagedIdentityCredential)
 
-    # with $MSI_ENDPOINT set, ManagedIdentityCredential = MsiCredential
+    # with $MSI_ENDPOINT set, ManagedIdentityCredential holds an instance of MsiCredential
     with patch("os.environ", {"MSI_ENDPOINT": "spam"}):
         credential = DefaultAzureCredential(exclude_managed_identity_credential=True)
         assert_credentials_not_present(credential, ManagedIdentityCredential)

--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -11,7 +11,7 @@ from azure.identity import (
     SharedTokenCacheCredential,
 )
 from azure.identity._constants import EnvironmentVariables
-from azure.identity._credentials.managed_identity import ImdsCredential, MsiCredential
+from azure.identity._credentials.managed_identity import ImdsCredential, MsiCredential, ManagedIdentityCredential
 from six.moves.urllib_parse import urlparse
 
 from helpers import mock_response, Request, validating_transport

--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -11,7 +11,7 @@ from azure.identity import (
     SharedTokenCacheCredential,
 )
 from azure.identity._constants import EnvironmentVariables
-from azure.identity._credentials.managed_identity import ImdsCredential, MsiCredential, ManagedIdentityCredential
+from azure.identity._credentials.managed_identity import ManagedIdentityCredential
 from six.moves.urllib_parse import urlparse
 
 from helpers import mock_response, Request, validating_transport

--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -93,15 +93,9 @@ def test_exclude_options():
         assert actual <= default  # n.b. we know actual is non-empty
         assert default - actual <= excluded
 
-    # with no environment variables set, ManagedIdentityCredential holds an instance of  ImdsCredential
-    with patch("os.environ", {}):
-        credential = DefaultAzureCredential(exclude_managed_identity_credential=True)
-        assert_credentials_not_present(credential, ManagedIdentityCredential)
-
-    # with $MSI_ENDPOINT set, ManagedIdentityCredential holds an instance of MsiCredential
-    with patch("os.environ", {"MSI_ENDPOINT": "spam"}):
-        credential = DefaultAzureCredential(exclude_managed_identity_credential=True)
-        assert_credentials_not_present(credential, ManagedIdentityCredential)
+    # when exclude_managed_identity_credential is set to True, check if ManagedIdentityCredential instance is not present
+    credential = DefaultAzureCredential(exclude_managed_identity_credential=True)
+    assert_credentials_not_present(credential, ManagedIdentityCredential)
 
     if SharedTokenCacheCredential.supported():
         credential = DefaultAzureCredential(exclude_shared_token_cache_credential=True)

--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -96,12 +96,12 @@ def test_exclude_options():
     # with no environment variables set, ManagedIdentityCredential = ImdsCredential
     with patch("os.environ", {}):
         credential = DefaultAzureCredential(exclude_managed_identity_credential=True)
-        assert_credentials_not_present(credential, ImdsCredential, MsiCredential)
+        assert_credentials_not_present(credential, ManagedIdentityCredential)
 
     # with $MSI_ENDPOINT set, ManagedIdentityCredential = MsiCredential
     with patch("os.environ", {"MSI_ENDPOINT": "spam"}):
         credential = DefaultAzureCredential(exclude_managed_identity_credential=True)
-        assert_credentials_not_present(credential, ImdsCredential, MsiCredential)
+        assert_credentials_not_present(credential, ManagedIdentityCredential)
 
     if SharedTokenCacheCredential.supported():
         credential = DefaultAzureCredential(exclude_shared_token_cache_credential=True)

--- a/sdk/identity/azure-identity/tests/test_default_async.py
+++ b/sdk/identity/azure-identity/tests/test_default_async.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 
 from azure.identity import KnownAuthorities
 from azure.identity.aio import DefaultAzureCredential, SharedTokenCacheCredential
-from azure.identity.aio._credentials.managed_identity import ImdsCredential, MsiCredential, ManagedIdentityCredential
+from azure.identity.aio._credentials.managed_identity import ManagedIdentityCredential
 from azure.identity._constants import EnvironmentVariables
 import pytest
 
@@ -98,12 +98,12 @@ def test_exclude_options():
         assert actual <= default  # n.b. we know actual is non-empty
         assert default - actual <= excluded
 
-    # with no environment variables set, ManagedIdentityCredential = ImdsCredential
+    # with no environment variables set, ManagedIdentityCredential holds an instance of  ImdsCredential
     with patch("os.environ", {}):
         credential = DefaultAzureCredential(exclude_managed_identity_credential=True)
         assert_credentials_not_present(credential, ManagedIdentityCredential)
 
-    # with $MSI_ENDPOINT set, ManagedIdentityCredential = MsiCredential
+    # with $MSI_ENDPOINT set, ManagedIdentityCredential holds an instance of MsiCredential
     with patch("os.environ", {"MSI_ENDPOINT": "spam"}):
         credential = DefaultAzureCredential(exclude_managed_identity_credential=True)
         assert_credentials_not_present(credential, ManagedIdentityCredential)

--- a/sdk/identity/azure-identity/tests/test_default_async.py
+++ b/sdk/identity/azure-identity/tests/test_default_async.py
@@ -98,15 +98,9 @@ def test_exclude_options():
         assert actual <= default  # n.b. we know actual is non-empty
         assert default - actual <= excluded
 
-    # with no environment variables set, ManagedIdentityCredential holds an instance of  ImdsCredential
-    with patch("os.environ", {}):
-        credential = DefaultAzureCredential(exclude_managed_identity_credential=True)
-        assert_credentials_not_present(credential, ManagedIdentityCredential)
-
-    # with $MSI_ENDPOINT set, ManagedIdentityCredential holds an instance of MsiCredential
-    with patch("os.environ", {"MSI_ENDPOINT": "spam"}):
-        credential = DefaultAzureCredential(exclude_managed_identity_credential=True)
-        assert_credentials_not_present(credential, ManagedIdentityCredential)
+    # when exclude_managed_identity_credential is set to True, check if ManagedIdentityCredential instance is not present
+    credential = DefaultAzureCredential(exclude_managed_identity_credential=True)
+    assert_credentials_not_present(credential, ManagedIdentityCredential)
 
     if SharedTokenCacheCredential.supported():
         credential = DefaultAzureCredential(exclude_shared_token_cache_credential=True)

--- a/sdk/identity/azure-identity/tests/test_default_async.py
+++ b/sdk/identity/azure-identity/tests/test_default_async.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 
 from azure.identity import KnownAuthorities
 from azure.identity.aio import DefaultAzureCredential, SharedTokenCacheCredential
-from azure.identity.aio._credentials.managed_identity import ImdsCredential, MsiCredential
+from azure.identity.aio._credentials.managed_identity import ImdsCredential, MsiCredential, ManagedIdentityCredential
 from azure.identity._constants import EnvironmentVariables
 import pytest
 
@@ -101,12 +101,12 @@ def test_exclude_options():
     # with no environment variables set, ManagedIdentityCredential = ImdsCredential
     with patch("os.environ", {}):
         credential = DefaultAzureCredential(exclude_managed_identity_credential=True)
-        assert_credentials_not_present(credential, ImdsCredential, MsiCredential)
+        assert_credentials_not_present(credential, ManagedIdentityCredential)
 
     # with $MSI_ENDPOINT set, ManagedIdentityCredential = MsiCredential
     with patch("os.environ", {"MSI_ENDPOINT": "spam"}):
         credential = DefaultAzureCredential(exclude_managed_identity_credential=True)
-        assert_credentials_not_present(credential, ImdsCredential, MsiCredential)
+        assert_credentials_not_present(credential, ManagedIdentityCredential)
 
     if SharedTokenCacheCredential.supported():
         credential = DefaultAzureCredential(exclude_shared_token_cache_credential=True)


### PR DESCRIPTION
Implemented `ManagedIdentityCredential` using composistion to hold an instance of `ImdsCredential` or `MsiCredential`. #9302 