### PR TITLE
Auto version increment and change log update failed

### DIFF
--- a/eng/versioning/version_shared.py
+++ b/eng/versioning/version_shared.py
@@ -119,7 +119,7 @@ def set_dev_classifier(setup_py_location, version):
 
 def update_change_log(setup_py_location, version, is_unreleased, replace_version):
     script = os.path.join(root_dir, "eng", "common", "Update-Change-Log.ps1")
-    pkg_root = os.path.join(setup_py_location, "..")
+    pkg_root = os.path.abspath(os.path.join(setup_py_location, ".."))
     commands = [
         "pwsh",
         script,


### PR DESCRIPTION
Fixed issue in finding change log path using path.join. Concatenated relative path doesn't refer to parent folder on Unix machine and caused issue. Updated code to find abspath when generating change log path.