### PR TITLE
Update _custom_search_client.py

### DIFF
--- a/sdk/cognitiveservices/azure-cognitiveservices-search-customsearch/azure/cognitiveservices/search/customsearch/_custom_search_client.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-customsearch/azure/cognitiveservices/search/customsearch/_custom_search_client.py
@@ -33,6 +33,14 @@ class CustomSearchClient(SDKClient):
     :param credentials: Subscription credentials which uniquely identify
      client subscription.
     :type credentials: None
+    
+    Ex : 
+    from azure.cognitiveservices.search.customsearch import CustomSearchClient
+    from msrest.authentication import CognitiveServicesCredentials
+    
+    sub_key = "your subscription key"
+    client = CustomSearchClient('https://sampleurl.cognitiveservices.azure.com/bingcustomsearch/v7.0', CognitiveServicesCredentials(sub_key)) 
+    
     """
 
     def __init__(


### PR DESCRIPTION
Added an Example for usage of customsearch class. It was required as in v0.3.0 there is addition of a parameter (endpoint) so if we change the order of parameters during calling customsearch class, its a bit confusing to solve the error.