### PR TITLE
Allow requests to opt out of HTTPS enforcement

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -37,9 +37,10 @@ class _BearerTokenCredentialPolicyBase(object):
         self._token = None  # type: Optional[AccessToken]
 
     @staticmethod
-    def _enforce_tls(request):
+    def _enforce_https(request):
         # type: (PipelineRequest) -> None
-        if not request.http_request.url.lower().startswith("https"):
+        enforce_https = request.context.options.pop("enforce_https", True)
+        if enforce_https and not request.http_request.url.lower().startswith("https"):
             raise ServiceRequestError(
                 "Bearer token authentication is not permitted for non-TLS protected (non-https) URLs."
             )
@@ -76,7 +77,7 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, SansIOHTTPPo
         :param request: The pipeline request object
         :type request: ~azure.core.pipeline.PipelineRequest
         """
-        self._enforce_tls(request)
+        self._enforce_https(request)
 
         if self._need_new_token:
             self._token = self._credential.get_token(*self._scopes)

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -30,7 +30,7 @@ class AsyncBearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, SansIOH
         :type request: ~azure.core.pipeline.PipelineRequest
         :raises: :class:`~azure.core.exceptions.ServiceRequestError`
         """
-        self._enforce_tls(request)
+        self._enforce_https(request)
 
         with self._lock:
             if self._need_new_token:

--- a/sdk/core/azure-core/tests/azure_core_asynctests/test_authentication.py
+++ b/sdk/core/azure-core/tests/azure_core_asynctests/test_authentication.py
@@ -67,7 +67,10 @@ async def test_bearer_policy_token_caching():
         return expected_token
 
     credential = Mock(get_token=get_token)
-    policies = [AsyncBearerTokenCredentialPolicy(credential, "scope"), Mock(send=Mock(get_completed_future()))]
+    policies = [
+        AsyncBearerTokenCredentialPolicy(credential, "scope"),
+        Mock(send=Mock(return_value=get_completed_future())),
+    ]
     pipeline = AsyncPipeline(transport=Mock, policies=policies)
 
     await pipeline.run(HttpRequest("GET", "https://spam.eggs"))

--- a/sdk/core/azure-core/tests/azure_core_asynctests/test_authentication.py
+++ b/sdk/core/azure-core/tests/azure_core_asynctests/test_authentication.py
@@ -8,9 +8,9 @@ import time
 from unittest.mock import Mock
 
 from azure.core.credentials import AccessToken
-from azure.core.exceptions import ServiceRequestError
+from azure.core.exceptions import AzureError, ServiceRequestError
 from azure.core.pipeline import AsyncPipeline
-from azure.core.pipeline.policies import AsyncBearerTokenCredentialPolicy
+from azure.core.pipeline.policies import AsyncBearerTokenCredentialPolicy, SansIOHTTPPolicy
 from azure.core.pipeline.transport import HttpRequest
 import pytest
 
@@ -116,3 +116,41 @@ async def test_bearer_policy_optionally_enforces_https():
     await pipeline.run(HttpRequest("GET", "https://secure"), enforce_https=False)
     await pipeline.run(HttpRequest("GET", "https://secure"), enforce_https=True)
     await pipeline.run(HttpRequest("GET", "https://secure"))
+
+
+@pytest.mark.asyncio
+async def test_preserves_enforce_https_opt_out():
+    """The policy should use request context to preserve an opt out from https enforcement"""
+
+    class ContextValidator(SansIOHTTPPolicy):
+        def on_request(self, request):
+            assert "enforce_https" in request.context, "'enforce_https' is not in the request's context"
+
+    get_token = get_completed_future(AccessToken("***", 42))
+    credential = Mock(get_token=lambda *_, **__: get_token)
+    policies = [AsyncBearerTokenCredentialPolicy(credential, "scope"), ContextValidator()]
+    pipeline = AsyncPipeline(transport=Mock(send=lambda *_, **__: get_completed_future()), policies=policies)
+
+    await pipeline.run(HttpRequest("GET", "http://not.secure"), enforce_https=False)
+
+
+@pytest.mark.asyncio
+async def test_context_unmodified_by_default():
+    """When no options for the policy accompany a request, the policy shouldn't add anything to the request context"""
+
+    class ContextValidator(SansIOHTTPPolicy):
+        def on_request(self, request):
+            assert not any(request.context), "the policy shouldn't add to the request's context"
+
+    get_token = get_completed_future(AccessToken("***", 42))
+    credential = Mock(get_token=lambda *_, **__: get_token)
+    policies = [AsyncBearerTokenCredentialPolicy(credential, "scope"), ContextValidator()]
+    pipeline = AsyncPipeline(transport=Mock(send=lambda *_, **__: get_completed_future()), policies=policies)
+
+    await pipeline.run(HttpRequest("GET", "https://secure"))
+
+
+def get_completed_future(result=None):
+    fut = asyncio.Future()
+    fut.set_result(result)
+    return fut


### PR DESCRIPTION
Our logic for authenticating a multipart request currently fails because preparing one entails passing requests with schemeless URLs to `BearerTokenCredentialPolicy`, which duly raises because these URLs don't start with "https".

As a workaround for this and other cases in which enforcing HTTPS is unnecessary or undesirable, this change allows individual requests to opt out of https enforcement via an `enforce_https` context option (i.e. a keyword argument to `pipeline.run`).