### PR TITLE
Install azure dev tools and sdk tools as part of CI tools

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -11,3 +11,6 @@ doc-warden==0.5.0
 coverage==4.5.4
 codecov
 beautifulsoup4
+pkginfo
+./tools/azure-devtools
+./tools/azure-sdk-tools

--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -28,8 +28,6 @@ from pkg_resources import parse_version, parse_requirements, Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
-import pkginfo
-
 
 DEV_REQ_FILE = "dev_requirements.txt"
 NEW_DEV_REQ_FILE = "new_dev_requirements.txt"
@@ -385,6 +383,7 @@ def is_required_version_on_pypi(package_name, spec):
     return versions
 
 def find_packages_missing_on_pypi(path):
+    import pkginfo
     requires = []
     if path.endswith(".whl"):
         requires = list(filter(lambda_filter_azure_pkg, pkginfo.get_metadata(path).requires_dist))

--- a/scripts/devops_tasks/test_regression.py
+++ b/scripts/devops_tasks/test_regression.py
@@ -227,9 +227,13 @@ class RegressionTest:
         working_dir = self.context.package_root_path
         temp_dir = self.context.temp_path
 
-        # install dev requirement but skip already installed package which is being tested
+        list_to_exclude = [pkg_to_exclude,]
+        installed_pkgs = [p.split('==')[0] for p in list(freeze.freeze(paths=self.context.venv.lib_paths)) if p.startswith('azure-')]
+        logging.info("Installed azure sdk packages:{}".format(installed_pkgs))
+        list_to_exclude.extend(installed_pkgs)
+        # install dev requirement but skip already installed package which is being tested or present in dev requirement
         filtered_dev_req_path = filter_dev_requirements(
-            dependent_pkg_path, [pkg_to_exclude,], dependent_pkg_path
+            dependent_pkg_path, list_to_exclude, dependent_pkg_path
         )
 
         if filtered_dev_req_path:


### PR DESCRIPTION
ci_tools module is required to check package version on PyPIClient and this check is triggered before starting individual dependent test. Adding dev and sdk tools as part of ci_tools.txt to install them before running regression script.