### PR TITLE
also install pkginfo

### DIFF
--- a/eng/pipelines/smoke-test.yml
+++ b/eng/pipelines/smoke-test.yml
@@ -40,8 +40,8 @@ jobs:
       - script: pip --version
         displayName: pip --version
 
-      - script: pip install packaging
-        displayName: Install packaging requirements
+      - script: pip install packaging pkginfo
+        displayName: Install requirements for dev tools
 
       - script: pip install -r ./common/smoketest/requirements.txt
         displayName: "Install requirements.txt"


### PR DESCRIPTION
A dependency change for dev scripts last night was not accounted for. This quick fix unblocks the pipeline, but a longer term fix should be considered: https://github.com/Azure/azure-sdk-for-python/issues/9837