### PR TITLE
Add azure-search-nspkg

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -104,6 +104,7 @@ known_content_issues:
   - ['sdk/core/azure-mgmt-nspkg/README.rst', 'nspkg and common']
   - ['sdk/core/azure-nspkg/README.rst', 'nspkg and common']
   - ['sdk/keyvault/azure-keyvault-nspkg/README.md', 'nspkg and common']
+  - ['sdk/search/azure-search-nspkg/README.md', 'nspkg and common']
   - ['sdk/storage/azure-storage-blob/samples/README.md', 'nspkg and common']
   - ['sdk/storage/azure-storage-file-datalake/samples/README.md', 'nspkg and common']
   - ['sdk/storage/azure-storage-file-share/samples/README.md', 'nspkg and common']

--- a/sdk/search/azure-search-nspkg/MANIFEST.in
+++ b/sdk/search/azure-search-nspkg/MANIFEST.in
@@ -1,0 +1,3 @@
+include *.md
+include azure/__init__.py
+include azure/search/__init__.py

--- a/sdk/search/azure-search-nspkg/README.md
+++ b/sdk/search/azure-search-nspkg/README.md
@@ -1,0 +1,16 @@
+# Microsoft Azure SDK for Python
+
+This is the Microsoft Azure Cognitive Search namespace package.
+
+This package is not intended to be installed directly by the end user.
+
+Since version 3.0, this is Python 2 package only, Python 3.x SDKs will use `PEP420 <https://www.python.org/dev/peps/pep-0420/>` as namespace package strategy.
+To avoid issues with package servers that does not support `python_requires`, a Python 3 package is installed but is empty.
+
+It provides the necessary files for other packages to extend the azure.search namespace.
+
+If you are looking to install the Azure client libraries, see the
+`azure <https://pypi.python.org/pypi/azure>`__ bundle package.
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-python%2Fsdk%2Ftextanalytics%2Fazure-ai-nspkg%2FREADME.png)

--- a/sdk/search/azure-search-nspkg/azure/__init__.py
+++ b/sdk/search/azure-search-nspkg/azure/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/sdk/search/azure-search-nspkg/azure/search/__init__.py
+++ b/sdk/search/azure-search-nspkg/azure/search/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/sdk/search/azure-search-nspkg/sdk_packaging.toml
+++ b/sdk/search/azure-search-nspkg/sdk_packaging.toml
@@ -1,0 +1,2 @@
+[packaging]
+auto_update = false

--- a/sdk/search/azure-search-nspkg/setup.py
+++ b/sdk/search/azure-search-nspkg/setup.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+import sys
+from setuptools import setup
+
+# azure v0.x is not compatible with this package
+# azure v0.x used to have a __version__ attribute (newer versions don't)
+try:
+    import azure
+    try:
+        ver = azure.__version__
+        raise Exception(
+            'This package is incompatible with azure=={}. '.format(ver) +
+            'Uninstall it with "pip uninstall azure".'
+        )
+    except AttributeError:
+        pass
+except ImportError:
+    pass
+
+PACKAGES = []
+# Do an empty package on Python 3 and not python_requires, since not everybody is ready
+# https://github.com/Azure/azure-sdk-for-python/issues/3447
+# https://github.com/Azure/azure-sdk-for-python/issues/3481
+if sys.version_info[0] < 3:
+    PACKAGES = ['azure.search']
+
+setup(
+    name='azure-search-nspkg',
+    version='1.0.0',
+    description='Microsoft Azure Cognitive Search Namespace Package [Internal]',
+    long_description=open('README.md', 'r').read(),
+    license='MIT License',
+    author='Microsoft Corporation',
+    author_email='azpysdkhelp@microsoft.com',
+    url='https://github.com/Azure/azure-sdk-for-python',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'License :: OSI Approved :: MIT License',
+    ],
+    zip_safe=False,
+    packages=PACKAGES,
+    install_requires=[
+        'azure-nspkg>=3.0.0',
+    ]
+)

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -82,6 +82,7 @@ azure-mgmt-trafficmanager~=0.50.0
 azure-mgmt-web~=0.35.0
 azure-nspkg
 azure-keyvault-nspkg
+azure-search-nspkg
 azure-security-nspkg
 azure-servicebus~=0.21.1
 azure-servicefabric~=6.3.0.0


### PR DESCRIPTION
This adds an nspkg for azure-search up ahead of the full Azure search work (changes in this PR require trigger all pipelines, so merging ahead will prevent a large CI burden on the main PR).