### PR TITLE
Fix to install dev tools from test repo inside virtual env

### DIFF
--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -53,7 +53,8 @@ REGRESSION_EXCLUDED_PACKAGES = [
 
 omit_regression = (
     lambda x: "nspkg" not in x
-    and not any([pkg_id in x for pkg_id in MANAGEMENT_PACKAGE_IDENTIFIERS])
+    and "mgmt" not in x
+    and os.path.basename(x) not in MANAGEMENT_PACKAGE_IDENTIFIERS
     and os.path.basename(x) not in META_PACKAGES
     and os.path.basename(x) not in REGRESSION_EXCLUDED_PACKAGES
 )

--- a/scripts/devops_tasks/git_helper.py
+++ b/scripts/devops_tasks/git_helper.py
@@ -81,7 +81,10 @@ def git_checkout_tag(tag_name, working_dir):
 def git_checkout_branch(branch_name, working_dir):
     # fetch tags
     run_check_call(["git", "fetch", "origin", branch_name], working_dir)
-    run_check_call(["git", "branch", branch_name, "FETCH_HEAD"], working_dir)
+    try:
+        run_check_call(["git", "branch", branch_name, "FETCH_HEAD"], working_dir)
+    except:
+        logging.error("Failed to create branch. But this can happen if a branch already exists so ignoring this error")
     logging.info("checkout git repo with branch {}".format(branch_name))
     commands = ["git", "checkout", branch_name]
     run_check_call(commands, working_dir)

--- a/scripts/devops_tasks/test_regression.py
+++ b/scripts/devops_tasks/test_regression.py
@@ -88,18 +88,6 @@ class RegressionContext:
     def initialize(self, dep_pkg_root_path):
         self.dep_pkg_root_path = dep_pkg_root_path
         self.venv.clear_venv()
-        # install test tools requirements outside virtual environment to access pypi_tools package
-        run_check_call(
-            [
-                sys.executable,
-                "-m",
-                "pip",
-                "install",
-                "-r",
-                test_tools_req_file,
-            ],
-            self.package_root_path
-        )
 
     def deinitialize(self, dep_pkg_root_path):
         # This function can be used to reset code repo to master branch
@@ -173,8 +161,9 @@ class RegressionTest:
                     "-r",
                     test_tools_req_file,
                 ],
-                self.context.package_root_path,
+                dep_pkg_path
             )
+
             # Install pre-built whl for current package
             install_package_from_whl(
                 self.whl_path,


### PR DESCRIPTION
Latest version of Azure dev tools was installed to run test for already released packages and this has caused an issue due to new kwargs passed from test resource creation logic in latest dev tools and test failed with an unknown kwarg error. 

Fix is to install dev tools from the repo checked out to run tests for released package versions.