### PR TITLE
Pin idna version to 2.8 until new release of requests package 

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -12,5 +12,6 @@ coverage==4.5.4
 codecov
 beautifulsoup4
 pkginfo
+idna==2.8
 ./tools/azure-devtools
 ./tools/azure-sdk-tools

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -3,5 +3,6 @@ pytest-cov
 pytest-xdist
 pytest-asyncio; python_version >= '3.5'
 coverage==4.5.4
+idna==2.8
 ../../../tools/azure-devtools
 ../../../tools/azure-sdk-tools


### PR DESCRIPTION
idna 2.8 is required by current request package and idna 2.9 is installed by yarl which is required by vcrpy.

idna(2.9) <-- yarl <-- vcrpy
idna(2.8) <-- requests(2.22.0) 