### PR TITLE
Plumb ServiceDirectory parameter variable through release pipelines

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -21,6 +21,7 @@ stages:
     - template: pipelines/stages/archetype-python-release.yml@azure-sdk-build-tools
       parameters:
         DependsOn: Build
+        ServiceDirectory: ${{parameters.ServiceDirectory}}
         Artifacts: ${{parameters.Artifacts}}
         ArtifactName: packages
         DocArtifact: documentation

--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -53,5 +53,6 @@ stages:
     - template: pipelines/stages/archetype-python-release.yml@azure-sdk-build-tools
       parameters:
         DependsOn: Build
+        ServiceDirectory: ${{parameters.ServiceDirectory}}
         Artifacts: ${{parameters.Artifacts}}
         ArtifactName: packages


### PR DESCRIPTION
I just made the same change for JS. The problem here is that the ServiceDirectory parameter from the ci.yml wasn't fully plumbed through to the archetype-python-release.yml which never needed it until now.