### PR TITLE
Verify JSON attributes in Key Vault test playback

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/tests/_shared/json_attribute_matcher.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/_shared/json_attribute_matcher.py
@@ -1,0 +1,18 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import json
+
+import six
+
+_has_json_body = lambda req: req.body and "json" in req.headers.get("Content-Type", "")
+
+
+def json_attribute_matcher(r1, r2):
+    """Tests whether two vcr.py requests have JSON content with identical attributes (ignoring values)."""
+
+    if _has_json_body(r1) and _has_json_body(r2):
+        c1 = json.loads(six.ensure_str(r1.body))
+        c2 = json.loads(six.ensure_str(r2.body))
+        assert sorted(c1.keys()) == sorted(c2.keys())

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_merge_certificate.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_merge_certificate.py
@@ -9,6 +9,7 @@ from azure.keyvault.certificates import CertificateClient, CertificatePolicy, We
 from devtools_testutils import ResourceGroupPreparer, KeyVaultPreparer
 from OpenSSL import crypto
 
+from _shared.json_attribute_matcher import json_attribute_matcher
 from _shared.preparer import KeyVaultClientPreparer
 from _shared.test_case import KeyVaultTestCase
 
@@ -16,6 +17,7 @@ from _shared.test_case import KeyVaultTestCase
 class MergeCertificateTest(KeyVaultTestCase):
     def __init__(self, *args, **kwargs):
         kwargs["match_body"] = False
+        kwargs["custom_request_matchers"] = [json_attribute_matcher]
         super(MergeCertificateTest, self).__init__(*args, **kwargs)
 
     @ResourceGroupPreparer(random_name_enabled=True)

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_merge_certificate_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_merge_certificate_async.py
@@ -10,13 +10,14 @@ from azure.keyvault.certificates.aio import CertificateClient
 from devtools_testutils import ResourceGroupPreparer, KeyVaultPreparer
 from OpenSSL import crypto
 
+from _shared.json_attribute_matcher import json_attribute_matcher
 from _shared.preparer_async import KeyVaultClientPreparer
 from _shared.test_case_async import KeyVaultTestCase
 
 
 class MergeCertificateTest(KeyVaultTestCase):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, match_body=False, **kwargs)
+        super().__init__(*args, match_body=False, custom_request_matchers=[json_attribute_matcher], **kwargs)
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @KeyVaultPreparer()

--- a/sdk/keyvault/azure-keyvault-keys/tests/_shared/json_attribute_matcher.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/_shared/json_attribute_matcher.py
@@ -1,0 +1,18 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import json
+
+import six
+
+_has_json_body = lambda req: req.body and "json" in req.headers.get("Content-Type", "")
+
+
+def json_attribute_matcher(r1, r2):
+    """Tests whether two vcr.py requests have JSON content with identical attributes (ignoring values)."""
+
+    if _has_json_body(r1) and _has_json_body(r2):
+        c1 = json.loads(six.ensure_str(r1.body))
+        c2 = json.loads(six.ensure_str(r2.body))
+        assert sorted(c1.keys()) == sorted(c2.keys())

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.test_ec_verify_local.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.test_ec_verify_local.yaml
@@ -13,9 +13,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256K/create?api-version=7.0
+    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256/create?api-version=7.0
   response:
     body:
       string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
@@ -28,7 +28,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:55:31 GMT
+      - Wed, 22 Jan 2020 19:14:50 GMT
       expires:
       - '-1'
       pragma:
@@ -45,122 +45,18 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.160.72;act_addr_fam=InterNetwork;
+      - addr=131.107.174.21;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.883
+      - 1.1.0.891
       x-powered-by:
       - ASP.NET
     status:
       code: 401
       message: Unauthorized
 - request:
-    body: '{"crv": "P-256K", "kty": "EC"}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json; charset=utf-8
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
-    method: POST
-    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256K/create?api-version=7.0
-  response:
-    body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-256K/6397463338f24025b5530c635c510309","kty":"EC","key_ops":["sign","verify"],"crv":"P-256K","x":"bx5K8MlF1XitYiLeedO6Z54wOmACJrFwpGnVWy_VtfI","y":"O61BSPcFwOfgCjqinp1H_HIn7lrvzS1u0roYAGX2o5U"},"attributes":{"enabled":true,"created":1575676531,"updated":1575676531,"recoveryLevel":"Purgeable"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '375'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 06 Dec 2019 23:55:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - addr=131.107.160.72;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - westus
-      x-ms-keyvault-service-version:
-      - 1.1.0.883
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"alg": "ES256K", "value": "vgZc0NQUb6WMKX___V2JntcFRO_vszKwSAj7R2rL1zg"}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '73'
-      Content-Type:
-      - application/json; charset=utf-8
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
-    method: POST
-    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256K/6397463338f24025b5530c635c510309/sign?api-version=7.0
-  response:
-    body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-256K/6397463338f24025b5530c635c510309","value":"fk-T34xxHkdc2-kuD5LDC5wBe2xZiBt_4i-LuHPJb_UXVoPSikV8RHxbrS7uukc8awMqXqCkmAc5FSxwlmbTqQ"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '210'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 06 Dec 2019 23:55:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - addr=131.107.160.72;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - westus
-      x-ms-keyvault-service-version:
-      - 1.1.0.883
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"crv": "P-521", "kty": "EC"}'
+    body: '{"kty": "EC", "crv": "P-256"}'
     headers:
       Accept:
       - application/json
@@ -173,220 +69,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
-    method: POST
-    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-521/create?api-version=7.0
-  response:
-    body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-521/57ee99325df845fba26f82830692f58c","kty":"EC","key_ops":["sign","verify"],"crv":"P-521","x":"ATaD7vLWkAsDPrUQle_VgOsvF1xVqMAqYZ_EExMs_T48XdU5l4yI1suDNzRByYwX3ZT9c4YHKiKr1BjYjTG7S_Dm","y":"AQVPutWhj0kymRrcwz53PCDymsVIoyko8_Ft9rlyZ-aSegAQRtsxl_abLN7JpARKi4YnB078vYwXFhCUuP2cLaoe"},"attributes":{"enabled":true,"created":1575676532,"updated":1575676532,"recoveryLevel":"Purgeable"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '463'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 06 Dec 2019 23:55:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - addr=131.107.160.72;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - westus
-      x-ms-keyvault-service-version:
-      - 1.1.0.883
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"alg": "ES512", "value": "zZyL-eOHDnnq34aZaWgBMobx4x2Pm3mPRo4eqnRmLK6sE0jsXZFOFhMXaTcvILQxovTsMMh9JupeojYCnDvfrQ"}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '115'
-      Content-Type:
-      - application/json; charset=utf-8
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
-    method: POST
-    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-521/57ee99325df845fba26f82830692f58c/sign?api-version=7.0
-  response:
-    body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-521/57ee99325df845fba26f82830692f58c","value":"AbkdpwEqGpA7ocW9t-EOw7da70RCpDfN25GqDE6xj74CWgaanwPeUBpyMoCjB8IEfqOW9du0ui-Z7DPOPVhqU6wVAQunYSuISY7KgfovFriYK1g_bFzuADpwdcLkxfdiiZWpBze6FdwZuttUV5OIuwoZaYh56nXPdGha1QgBJiRIzemA"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '299'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 06 Dec 2019 23:55:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - addr=131.107.160.72;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - westus
-      x-ms-keyvault-service-version:
-      - 1.1.0.883
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"crv": "P-384", "kty": "EC"}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '29'
-      Content-Type:
-      - application/json; charset=utf-8
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
-    method: POST
-    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-384/create?api-version=7.0
-  response:
-    body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-384/0bd7a280508a460d9c44e3aa5069eeae","kty":"EC","key_ops":["sign","verify"],"crv":"P-384","x":"ZhwKFGLIRt5oSKbhOBqh6yCn6X9DVMa8itz4A1odhTJq2b5rLuFij8KEpxdLIQp5","y":"lsNzH-K5QB4FN7tvABv0CX9ymiPFViaW9kHMZraCMX6DhN5ekfDKi5od6GlwggLt"},"attributes":{"enabled":true,"created":1575676532,"updated":1575676532,"recoveryLevel":"Purgeable"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '415'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 06 Dec 2019 23:55:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - addr=131.107.160.72;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - westus
-      x-ms-keyvault-service-version:
-      - 1.1.0.883
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"alg": "ES384", "value": "OnZY76NXJ8_MBkjnc9b9RiaL5OYscmrTal040wQuLFlRrnLvJFecIvZl2KjXqwVB"}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '93'
-      Content-Type:
-      - application/json; charset=utf-8
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
-    method: POST
-    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-384/0bd7a280508a460d9c44e3aa5069eeae/sign?api-version=7.0
-  response:
-    body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-384/0bd7a280508a460d9c44e3aa5069eeae","value":"bHTN15GzLXXt01VFmDkPtcwJjIlOlvCq6ndtE1_F6tHVddfNoHVmS8B5CRt7Lxk0and9XyEMcYnCFpwZULj_y5ZtXvQblIDmAgVVrH9IxqONkr7SVdiraIJ-ocrKIwRx"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '251'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 06 Dec 2019 23:55:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000;includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-network-info:
-      - addr=131.107.160.72;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - westus
-      x-ms-keyvault-service-version:
-      - 1.1.0.883
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"crv": "P-256", "kty": "EC"}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '29'
-      Content-Type:
-      - application/json; charset=utf-8
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256/create?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-256/4840c48d5f174fb195be48c443fff0e4","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"X8gB2vY29QYaYeflDGgYxm9j_6I7eEuqC46tt1nZCXk","y":"ljMmJXGOo8O4xzG1_neNItIZ29CEmU5QhGZ5tF6rHxk"},"attributes":{"enabled":true,"created":1575676532,"updated":1575676532,"recoveryLevel":"Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-256/8790e36e9659494e9571616f271de8ba","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"ZOV0wkSxEFNJDCM5VqXho1fRdHQKa_vBZKsLrMluPEM","y":"fprVETOwkDHgTUBxSLD0XWxdiNqd1Zq8nkPSD9nic08"},"attributes":{"enabled":true,"created":1579720491,"updated":1579720491,"recoveryLevel":"Purgeable"}}'
     headers:
       cache-control:
       - no-cache
@@ -395,7 +83,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:55:32 GMT
+      - Wed, 22 Jan 2020 19:14:50 GMT
       expires:
       - '-1'
       pragma:
@@ -409,11 +97,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.160.72;act_addr_fam=InterNetwork;
+      - addr=131.107.174.21;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.883
+      - 1.1.0.891
       x-powered-by:
       - ASP.NET
     status:
@@ -433,12 +121,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256/4840c48d5f174fb195be48c443fff0e4/sign?api-version=7.0
+    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256/8790e36e9659494e9571616f271de8ba/sign?api-version=7.0
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-256/4840c48d5f174fb195be48c443fff0e4","value":"AZXzjONpkLq1iV70KWU_N8TVUy-YA-mEfom452R-9wWUao4j0FQ3CuwVCb6KA9Jv7-w4CULOMwt5HSpDADQ43A"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-256/8790e36e9659494e9571616f271de8ba","value":"ppPFyGmSYvinkIWaZ-oo4ucGYJ-81NSiJUnfANogH7pAop2sKL3dzqOhJTJT7M7XymY0oSElqtIf6em-lmahuQ"}'
     headers:
       cache-control:
       - no-cache
@@ -447,7 +135,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:55:32 GMT
+      - Wed, 22 Jan 2020 19:14:50 GMT
       expires:
       - '-1'
       pragma:
@@ -461,11 +149,323 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.160.72;act_addr_fam=InterNetwork;
+      - addr=131.107.174.21;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.883
+      - 1.1.0.891
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "EC", "crv": "P-256K"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256K/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-256K/9baba6a2776e4a7487b19747614bf91f","kty":"EC","key_ops":["sign","verify"],"crv":"P-256K","x":"yzPxzqweo3nq6IPzOF7nTRY-XKW2iMyWnrjiPQnGmXQ","y":"qTJwSgFYfC4QdRlz55usJo0chHgxO3xZGQdxjX92XVc"},"attributes":{"enabled":true,"created":1579720491,"updated":1579720491,"recoveryLevel":"Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '375'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Jan 2020 19:14:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=131.107.174.21;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.891
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "ES256K", "value": "vgZc0NQUb6WMKX___V2JntcFRO_vszKwSAj7R2rL1zg"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256K/9baba6a2776e4a7487b19747614bf91f/sign?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-256K/9baba6a2776e4a7487b19747614bf91f","value":"K7McIuZ5zMSct49LvB8YavfYcDmyRtPy6m1EF-NoaB2zdOy0DkHKtCsMowz-VHCdfIUGxNQFQeZiqE0Ng5_Jsw"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Jan 2020 19:14:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=131.107.174.21;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.891
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "EC", "crv": "P-384"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '29'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-384/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-384/71216ab2fae7463fa073be63efe50d42","kty":"EC","key_ops":["sign","verify"],"crv":"P-384","x":"NvtmnQhICToJEMa6y5UimWTgXB9dSzx_uzeLmnLbe_2JqhJUFAz7jwssncBDL6dG","y":"Jb09pcPx8gkg4ORJPDix0Ll2jffg4qfAlDjXyK95sd2OKi7daXuRBtjRNZ7zgRxP"},"attributes":{"enabled":true,"created":1579720491,"updated":1579720491,"recoveryLevel":"Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '415'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Jan 2020 19:14:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=131.107.174.21;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.891
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "ES384", "value": "OnZY76NXJ8_MBkjnc9b9RiaL5OYscmrTal040wQuLFlRrnLvJFecIvZl2KjXqwVB"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-384/71216ab2fae7463fa073be63efe50d42/sign?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-384/71216ab2fae7463fa073be63efe50d42","value":"AwxqSLABmB6yy_wNdk8eTrkMSKStbzozL8pCagIDlLlVthYpMLFvCjXl1CnnYjNLeXE3p-GdUAswlhhtlUjdRRRFZ4NSdmcB96gtmWbqOkZuYUBUBqouqEJ85N3V2Fkp"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '251'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Jan 2020 19:14:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=131.107.174.21;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.891
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kty": "EC", "crv": "P-521"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '29'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-521/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-521/a75d649e3f9344e79da1dcbad7f6240d","kty":"EC","key_ops":["sign","verify"],"crv":"P-521","x":"AVhP5Des3kGiI7IW0xUpBxzSkWHu9AdriOpdkyjhDVCPa-52AczeP558paXSSoikSY_EEufyiZhjJpXCJ6sXX3Nd","y":"AeasI9OFsH9fbo6wbwy1jCeH-9lVPPkclVInllNRjeye8DAWTUTT4yhPuPurqzjMgTrNhunsU3qQfOebvA8-VDCe"},"attributes":{"enabled":true,"created":1579720492,"updated":1579720492,"recoveryLevel":"Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '463'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Jan 2020 19:14:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=131.107.174.21;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.891
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"alg": "ES512", "value": "zZyL-eOHDnnq34aZaWgBMobx4x2Pm3mPRo4eqnRmLK6sE0jsXZFOFhMXaTcvILQxovTsMMh9JupeojYCnDvfrQ"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '115'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-521/a75d649e3f9344e79da1dcbad7f6240d/sign?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-521/a75d649e3f9344e79da1dcbad7f6240d","value":"AHvYuiDYcVYKiOGyOusm4UUDIibltMzIpsuSS_dMlSAqkZoi6V6tQOdzmUlHGbnGbDUgu8dxnIRgKWJSoDcTG4YBAYRA-ogShVHQ17Xlp0jS7AQXu0sECQMVlkfID5DWMNZ-Ss_CjnCPFrLT_O0czzT1FzH9LW9xuz0RUmApi4I3Pl3I"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '299'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Jan 2020 19:14:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=131.107.174.21;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.891
       x-powered-by:
       - ASP.NET
     status:

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.test_ec_verify_local.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.test_ec_verify_local.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256K/create?api-version=7.0
+    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256/create?api-version=7.0
   response:
     body:
       string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
@@ -20,7 +20,7 @@ interactions:
       cache-control: no-cache
       content-length: '87'
       content-type: application/json; charset=utf-8
-      date: Fri, 06 Dec 2019 23:55:30 GMT
+      date: Wed, 22 Jan 2020 23:02:34 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-IIS/10.0
@@ -29,107 +29,16 @@ interactions:
         resource="https://vault.azure.net"
       x-aspnet-version: 4.0.30319
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.160.72;act_addr_fam=InterNetwork;
+      x-ms-keyvault-network-info: addr=131.107.174.21;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.1.0.883
+      x-ms-keyvault-service-version: 1.1.0.891
       x-powered-by: ASP.NET
     status:
       code: 401
       message: Unauthorized
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - qrmwkyoyo3oxytjbd4gzfavz.vault.azure.net
-        - /keys/ec-verify-P-256K/create
-        - api-version=7.0
-        - ''
+    url: https://bpkne4fbj6xagkn5kplxnkzo.vault.azure.net/keys/ec-verify-P-256/create?api-version=7.0
 - request:
-    body: '{"crv": "P-256K", "kty": "EC"}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json; charset=utf-8
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
-    method: POST
-    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256K/create?api-version=7.0
-  response:
-    body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-256K/709574017e6e4f75b78dce9b918572e7","kty":"EC","key_ops":["sign","verify"],"crv":"P-256K","x":"wx1PGA5pZOclX77ymUS4xUVFP0BItGz5JsIKNsL-BlA","y":"m71ylotMQRt9G9TvHKpAVGGl0ZPp5TvPfULZ4mRBozE"},"attributes":{"enabled":true,"created":1575676531,"updated":1575676531,"recoveryLevel":"Purgeable"}}'
-    headers:
-      cache-control: no-cache
-      content-length: '375'
-      content-type: application/json; charset=utf-8
-      date: Fri, 06 Dec 2019 23:55:31 GMT
-      expires: '-1'
-      pragma: no-cache
-      server: Microsoft-IIS/10.0
-      strict-transport-security: max-age=31536000;includeSubDomains
-      x-aspnet-version: 4.0.30319
-      x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.160.72;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.1.0.883
-      x-powered-by: ASP.NET
-    status:
-      code: 200
-      message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - qrmwkyoyo3oxytjbd4gzfavz.vault.azure.net
-        - /keys/ec-verify-P-256K/create
-        - api-version=7.0
-        - ''
-- request:
-    body: '{"alg": "ES256K", "value": "vgZc0NQUb6WMKX___V2JntcFRO_vszKwSAj7R2rL1zg"}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '73'
-      Content-Type:
-      - application/json; charset=utf-8
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
-    method: POST
-    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256K/709574017e6e4f75b78dce9b918572e7/sign?api-version=7.0
-  response:
-    body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-256K/709574017e6e4f75b78dce9b918572e7","value":"wpy7AE8Hf7QFhH41Yx-X7smUyhmPvEFgASxv5JAMsTNfq0N-XEMuZUIM4dISVK_89BLYiI-ftk2viM1BItU_Gg"}'
-    headers:
-      cache-control: no-cache
-      content-length: '210'
-      content-type: application/json; charset=utf-8
-      date: Fri, 06 Dec 2019 23:55:31 GMT
-      expires: '-1'
-      pragma: no-cache
-      server: Microsoft-IIS/10.0
-      strict-transport-security: max-age=31536000;includeSubDomains
-      x-aspnet-version: 4.0.30319
-      x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.160.72;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.1.0.883
-      x-powered-by: ASP.NET
-    status:
-      code: 200
-      message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - qrmwkyoyo3oxytjbd4gzfavz.vault.azure.net
-        - /keys/ec-verify-P-256K/709574017e6e4f75b78dce9b918572e7/sign
-        - api-version=7.0
-        - ''
-- request:
-    body: '{"crv": "P-521", "kty": "EC"}'
+    body: '{"kty": "EC", "crv": "P-256"}'
     headers:
       Accept:
       - application/json
@@ -138,206 +47,31 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
-    method: POST
-    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-521/create?api-version=7.0
-  response:
-    body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-521/b4406d2e9880467792cb21f149ddf2eb","kty":"EC","key_ops":["sign","verify"],"crv":"P-521","x":"AS4c-TA9nFr0tQCLlMDzL2NIeMOScN0EJjDjb5_dyM9v1S08E0Ys7YEZXEOpiWXdXz544UdnoFHuTOT1oCt9V_Av","y":"ARUND_s52UzPAlGi-ZZbZGHLBNSd9PASihq__uE6qVqy5QkvElBfQ8TWZJ0XMV883_F1Nc4PffnEYcPK3M7b6MnK"},"attributes":{"enabled":true,"created":1575676532,"updated":1575676532,"recoveryLevel":"Purgeable"}}'
-    headers:
-      cache-control: no-cache
-      content-length: '463'
-      content-type: application/json; charset=utf-8
-      date: Fri, 06 Dec 2019 23:55:31 GMT
-      expires: '-1'
-      pragma: no-cache
-      server: Microsoft-IIS/10.0
-      strict-transport-security: max-age=31536000;includeSubDomains
-      x-aspnet-version: 4.0.30319
-      x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.160.72;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.1.0.883
-      x-powered-by: ASP.NET
-    status:
-      code: 200
-      message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - qrmwkyoyo3oxytjbd4gzfavz.vault.azure.net
-        - /keys/ec-verify-P-521/create
-        - api-version=7.0
-        - ''
-- request:
-    body: '{"alg": "ES512", "value": "zZyL-eOHDnnq34aZaWgBMobx4x2Pm3mPRo4eqnRmLK6sE0jsXZFOFhMXaTcvILQxovTsMMh9JupeojYCnDvfrQ"}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '115'
-      Content-Type:
-      - application/json; charset=utf-8
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
-    method: POST
-    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-521/b4406d2e9880467792cb21f149ddf2eb/sign?api-version=7.0
-  response:
-    body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-521/b4406d2e9880467792cb21f149ddf2eb","value":"AZG-vYKBLNQ9-ONomBgLX8VbaoMIAD1KrTB4LvmQjDr0PHSTZKRgnnKZxnrV8dWUGSOaHazGu8f4NAkme_jmMIa1AOwcDJdqepkcgFVrqRH8hOFPJfY6_9TKH7jHMMMOFXutjTxegKDOLmPoQZh475nuZw_wzK3HgQvVHS7ezymRAHM1"}'
-    headers:
-      cache-control: no-cache
-      content-length: '299'
-      content-type: application/json; charset=utf-8
-      date: Fri, 06 Dec 2019 23:55:32 GMT
-      expires: '-1'
-      pragma: no-cache
-      server: Microsoft-IIS/10.0
-      strict-transport-security: max-age=31536000;includeSubDomains
-      x-aspnet-version: 4.0.30319
-      x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.160.72;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.1.0.883
-      x-powered-by: ASP.NET
-    status:
-      code: 200
-      message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - qrmwkyoyo3oxytjbd4gzfavz.vault.azure.net
-        - /keys/ec-verify-P-521/b4406d2e9880467792cb21f149ddf2eb/sign
-        - api-version=7.0
-        - ''
-- request:
-    body: '{"crv": "P-384", "kty": "EC"}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '29'
-      Content-Type:
-      - application/json; charset=utf-8
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
-    method: POST
-    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-384/create?api-version=7.0
-  response:
-    body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-384/f6febd50f16041d380f0acd73baae856","kty":"EC","key_ops":["sign","verify"],"crv":"P-384","x":"YVSg9Ua1Cq9RANc0Y-FsHAIte0p9JzC-wM5pltWhihjVn8ZS9Vr74GGyhPkg8aUu","y":"tH_nGhq4AgwEyb8ScEf0cptVDtBiu_6TTQO3L6knnR3ZtmBVytHygRMxZ_pDx1o2"},"attributes":{"enabled":true,"created":1575676532,"updated":1575676532,"recoveryLevel":"Purgeable"}}'
-    headers:
-      cache-control: no-cache
-      content-length: '415'
-      content-type: application/json; charset=utf-8
-      date: Fri, 06 Dec 2019 23:55:31 GMT
-      expires: '-1'
-      pragma: no-cache
-      server: Microsoft-IIS/10.0
-      strict-transport-security: max-age=31536000;includeSubDomains
-      x-aspnet-version: 4.0.30319
-      x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.160.72;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.1.0.883
-      x-powered-by: ASP.NET
-    status:
-      code: 200
-      message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - qrmwkyoyo3oxytjbd4gzfavz.vault.azure.net
-        - /keys/ec-verify-P-384/create
-        - api-version=7.0
-        - ''
-- request:
-    body: '{"alg": "ES384", "value": "OnZY76NXJ8_MBkjnc9b9RiaL5OYscmrTal040wQuLFlRrnLvJFecIvZl2KjXqwVB"}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '93'
-      Content-Type:
-      - application/json; charset=utf-8
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
-    method: POST
-    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-384/f6febd50f16041d380f0acd73baae856/sign?api-version=7.0
-  response:
-    body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-384/f6febd50f16041d380f0acd73baae856","value":"adgO3fnCmFehADAzQ4BX6LEqvLsYeo-tpLMpaiMKiwtkNAX73O6MgOupIW1cgE4sgwJM-QqEtScqyxsBawSZaMhraIePP-VkwDsJBe5WmgMhBKIdaoaCBfLTClR7dkFV"}'
-    headers:
-      cache-control: no-cache
-      content-length: '251'
-      content-type: application/json; charset=utf-8
-      date: Fri, 06 Dec 2019 23:55:32 GMT
-      expires: '-1'
-      pragma: no-cache
-      server: Microsoft-IIS/10.0
-      strict-transport-security: max-age=31536000;includeSubDomains
-      x-aspnet-version: 4.0.30319
-      x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.160.72;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.1.0.883
-      x-powered-by: ASP.NET
-    status:
-      code: 200
-      message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - qrmwkyoyo3oxytjbd4gzfavz.vault.azure.net
-        - /keys/ec-verify-P-384/f6febd50f16041d380f0acd73baae856/sign
-        - api-version=7.0
-        - ''
-- request:
-    body: '{"crv": "P-256", "kty": "EC"}'
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '29'
-      Content-Type:
-      - application/json; charset=utf-8
-      User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
     method: POST
     uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256/create?api-version=7.0
   response:
     body:
-      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-256/233994f8bdb249a6b0b5e085623f758f","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"IpxHcWDQC6PUku4h_QtWHP34wMz_jc6acTi55dd3Iy8","y":"CZi-6tqQXE7MtiYEfCS-vbZirJF3M40NX2AqsNEY2HU"},"attributes":{"enabled":true,"created":1575676532,"updated":1575676532,"recoveryLevel":"Purgeable"}}'
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-256/5f45347fbb4b4b6faca835a743876196","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"nPz6Sg0p6QhUOyh9AOHA-garbQjYPsdba30BuXKbY1U","y":"jgPyADec_lLws6PwXatJ5ATpeECAy7L31n-b6vfaT7Y"},"attributes":{"enabled":true,"created":1579734155,"updated":1579734155,"recoveryLevel":"Purgeable"}}'
     headers:
       cache-control: no-cache
       content-length: '373'
       content-type: application/json; charset=utf-8
-      date: Fri, 06 Dec 2019 23:55:32 GMT
+      date: Wed, 22 Jan 2020 23:02:35 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-IIS/10.0
       strict-transport-security: max-age=31536000;includeSubDomains
       x-aspnet-version: 4.0.30319
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.160.72;act_addr_fam=InterNetwork;
+      x-ms-keyvault-network-info: addr=131.107.174.21;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.1.0.883
+      x-ms-keyvault-service-version: 1.1.0.891
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - qrmwkyoyo3oxytjbd4gzfavz.vault.azure.net
-        - /keys/ec-verify-P-256/create
-        - api-version=7.0
-        - ''
+    url: https://bpkne4fbj6xagkn5kplxnkzo.vault.azure.net/keys/ec-verify-P-256/create?api-version=7.0
 - request:
     body: '{"alg": "ES256", "value": "vgZc0NQUb6WMKX___V2JntcFRO_vszKwSAj7R2rL1zg"}'
     headers:
@@ -348,36 +82,239 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.5.4 (Windows-10-10.0.18362-SP0)
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
     method: POST
-    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256/233994f8bdb249a6b0b5e085623f758f/sign?api-version=7.0
+    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256/5f45347fbb4b4b6faca835a743876196/sign?api-version=7.0
   response:
     body:
-      string: '{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-256/233994f8bdb249a6b0b5e085623f758f","value":"naEo5m-amp2lJhhQun1ZFHlijGjoeCfgzGJ3kSbDoFPRIK8aC5OQIpJhhddsrvY9GUWFIut8Dq5HkzZ5_yIuQA"}'
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-256/5f45347fbb4b4b6faca835a743876196","value":"BmDdrahLHI15kO3ss0WruiwRF4e37xta2Sz-Hgt_rxCI-JheoHGSfYpsOZDmxNZcjyB4BfDoSzs2NB4tsirK4A"}'
     headers:
       cache-control: no-cache
       content-length: '209'
       content-type: application/json; charset=utf-8
-      date: Fri, 06 Dec 2019 23:55:32 GMT
+      date: Wed, 22 Jan 2020 23:02:35 GMT
       expires: '-1'
       pragma: no-cache
       server: Microsoft-IIS/10.0
       strict-transport-security: max-age=31536000;includeSubDomains
       x-aspnet-version: 4.0.30319
       x-content-type-options: nosniff
-      x-ms-keyvault-network-info: addr=131.107.160.72;act_addr_fam=InterNetwork;
+      x-ms-keyvault-network-info: addr=131.107.174.21;act_addr_fam=InterNetwork;
       x-ms-keyvault-region: westus
-      x-ms-keyvault-service-version: 1.1.0.883
+      x-ms-keyvault-service-version: 1.1.0.891
       x-powered-by: ASP.NET
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - qrmwkyoyo3oxytjbd4gzfavz.vault.azure.net
-        - /keys/ec-verify-P-256/233994f8bdb249a6b0b5e085623f758f/sign
-        - api-version=7.0
-        - ''
+    url: https://bpkne4fbj6xagkn5kplxnkzo.vault.azure.net/keys/ec-verify-P-256/5f45347fbb4b4b6faca835a743876196/sign?api-version=7.0
+- request:
+    body: '{"kty": "EC", "crv": "P-256K"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256K/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-256K/32aa946ea40841768fbf7f45bbd11c22","kty":"EC","key_ops":["sign","verify"],"crv":"P-256K","x":"YFD8XabrFd-itdGKR0J4vaj69qPkSQ5hO8qjZMYXzgE","y":"z2UEh1vy_JGAHzcgE8PKdBRVjxVdBrW4QCxc1A83g_I"},"attributes":{"enabled":true,"created":1579734155,"updated":1579734155,"recoveryLevel":"Purgeable"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '375'
+      content-type: application/json; charset=utf-8
+      date: Wed, 22 Jan 2020 23:02:35 GMT
+      expires: '-1'
+      pragma: no-cache
+      server: Microsoft-IIS/10.0
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-aspnet-version: 4.0.30319
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: addr=131.107.174.21;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.1.0.891
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://bpkne4fbj6xagkn5kplxnkzo.vault.azure.net/keys/ec-verify-P-256K/create?api-version=7.0
+- request:
+    body: '{"alg": "ES256K", "value": "vgZc0NQUb6WMKX___V2JntcFRO_vszKwSAj7R2rL1zg"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-256K/32aa946ea40841768fbf7f45bbd11c22/sign?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-256K/32aa946ea40841768fbf7f45bbd11c22","value":"J3Dgodd-wKn49g5A2nUFV5AUhfVh9fhARTbZtNkK7bQ6arUFBg39t3mtM4CecIICymINf9LwQ36dnls79M-aoA"}'
+    headers:
+      cache-control: no-cache
+      content-length: '210'
+      content-type: application/json; charset=utf-8
+      date: Wed, 22 Jan 2020 23:02:35 GMT
+      expires: '-1'
+      pragma: no-cache
+      server: Microsoft-IIS/10.0
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-aspnet-version: 4.0.30319
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: addr=131.107.174.21;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.1.0.891
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://bpkne4fbj6xagkn5kplxnkzo.vault.azure.net/keys/ec-verify-P-256K/32aa946ea40841768fbf7f45bbd11c22/sign?api-version=7.0
+- request:
+    body: '{"kty": "EC", "crv": "P-384"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '29'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-384/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-384/821081dd416e4dc095af12b61fb1e616","kty":"EC","key_ops":["sign","verify"],"crv":"P-384","x":"-5__0c8g4W-6Xopt1uAB972OEbpHhKW1bol8JrKKz0yVYFMcpNFcuGVG6s_voU_c","y":"XLyQdItNQkYjcm9ho3texyP3wJumvvQ3-xnwvjdcn1ghTq029BbVbc78JpUap8He"},"attributes":{"enabled":true,"created":1579734156,"updated":1579734156,"recoveryLevel":"Purgeable"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '415'
+      content-type: application/json; charset=utf-8
+      date: Wed, 22 Jan 2020 23:02:35 GMT
+      expires: '-1'
+      pragma: no-cache
+      server: Microsoft-IIS/10.0
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-aspnet-version: 4.0.30319
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: addr=131.107.174.21;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.1.0.891
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://bpkne4fbj6xagkn5kplxnkzo.vault.azure.net/keys/ec-verify-P-384/create?api-version=7.0
+- request:
+    body: '{"alg": "ES384", "value": "OnZY76NXJ8_MBkjnc9b9RiaL5OYscmrTal040wQuLFlRrnLvJFecIvZl2KjXqwVB"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-384/821081dd416e4dc095af12b61fb1e616/sign?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-384/821081dd416e4dc095af12b61fb1e616","value":"R3jk4DuuFEQhnrFBdn5tWTqkJT5S9cK_rc6awgoosa3bqSjbAUAct79cRrcLnTusBGg4SWFaT_oni7zfnNbKI2bXZ9M_nVpo-V3APxKYZYuhX3ScOzSaW3Bg1fgIgBrj"}'
+    headers:
+      cache-control: no-cache
+      content-length: '251'
+      content-type: application/json; charset=utf-8
+      date: Wed, 22 Jan 2020 23:02:36 GMT
+      expires: '-1'
+      pragma: no-cache
+      server: Microsoft-IIS/10.0
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-aspnet-version: 4.0.30319
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: addr=131.107.174.21;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.1.0.891
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://bpkne4fbj6xagkn5kplxnkzo.vault.azure.net/keys/ec-verify-P-384/821081dd416e4dc095af12b61fb1e616/sign?api-version=7.0
+- request:
+    body: '{"kty": "EC", "crv": "P-521"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '29'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-521/create?api-version=7.0
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-521/572a62c11a8544ee9d159629ad54e3c3","kty":"EC","key_ops":["sign","verify"],"crv":"P-521","x":"AGQWayLgz45lEsgEF52H_sbyH8DmpjcKOdxS01HZ0DrEwROns9pDxJAytUmU9XozuBymjLV_1WsAHrF4jVAnQiGI","y":"AfNq_pfAmhtYylwkHQ3e_Wi-PikTIwJms9n-nPEKv1zx33g9KDyY5wwRCyf7WqKISYVU5jDWTiMuAdi3x-1rWMn6"},"attributes":{"enabled":true,"created":1579734156,"updated":1579734156,"recoveryLevel":"Purgeable"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '463'
+      content-type: application/json; charset=utf-8
+      date: Wed, 22 Jan 2020 23:02:36 GMT
+      expires: '-1'
+      pragma: no-cache
+      server: Microsoft-IIS/10.0
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-aspnet-version: 4.0.30319
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: addr=131.107.174.21;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.1.0.891
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://bpkne4fbj6xagkn5kplxnkzo.vault.azure.net/keys/ec-verify-P-521/create?api-version=7.0
+- request:
+    body: '{"alg": "ES512", "value": "zZyL-eOHDnnq34aZaWgBMobx4x2Pm3mPRo4eqnRmLK6sE0jsXZFOFhMXaTcvILQxovTsMMh9JupeojYCnDvfrQ"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '115'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.1.0b1 Python/3.8.0 (Windows-10-10.0.18362-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/ec-verify-P-521/572a62c11a8544ee9d159629ad54e3c3/sign?api-version=7.0
+  response:
+    body:
+      string: '{"kid":"https://vaultname.vault.azure.net/keys/ec-verify-P-521/572a62c11a8544ee9d159629ad54e3c3","value":"AJHRHWBrb8AWfVXPcwv7E_2vv3rpA51_6OR0t1PghnjAd1TSSeIPLCPRoz1TgcpRb7w6tzneG0xNMT2_sAOSCJsxANnc30P3Ikq4KHBtXURa9YDpJZSJvki-cOHDG9FLqqGea0pB7KPDfMFKo7aMcW6BugGFuc3bgVW1faViWGdGPlr9"}'
+    headers:
+      cache-control: no-cache
+      content-length: '299'
+      content-type: application/json; charset=utf-8
+      date: Wed, 22 Jan 2020 23:02:36 GMT
+      expires: '-1'
+      pragma: no-cache
+      server: Microsoft-IIS/10.0
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-aspnet-version: 4.0.30319
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: addr=131.107.174.21;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.1.0.891
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://bpkne4fbj6xagkn5kplxnkzo.vault.azure.net/keys/ec-verify-P-521/572a62c11a8544ee9d159629ad54e3c3/sign?api-version=7.0
 version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -13,6 +13,7 @@ from azure.keyvault.keys.crypto import CryptographyClient, EncryptionAlgorithm, 
 from azure.mgmt.keyvault.models import KeyPermissions, Permissions
 from devtools_testutils import ResourceGroupPreparer, KeyVaultPreparer
 
+from _shared.json_attribute_matcher import json_attribute_matcher
 from _shared.test_case import KeyVaultTestCase
 from crypto_client_preparer import CryptoClientPreparer
 
@@ -23,6 +24,7 @@ NO_GET = Permissions(keys=[p.value for p in KeyPermissions if p.value != "get"])
 class CryptoClientTests(KeyVaultTestCase):
     def __init__(self, *args, **kwargs):
         kwargs["match_body"] = False
+        kwargs["custom_request_matchers"] = [json_attribute_matcher]
         super(CryptoClientTests, self).__init__(*args, **kwargs)
 
     plaintext = b"5063e6aaa845f150200547944fd199679c98ed6f99da0a0b2dafeaf1f4684496fd532c1c229968cb9dee44957fcef7ccef59ceda0b362e56bcd78fd3faee5781c623c0bb22b35beabde0664fd30e0e824aba3dd1b0afffc4a3d955ede20cf6a854d52cfd"
@@ -216,7 +218,7 @@ class CryptoClientTests(KeyVaultTestCase):
             KeyCurveName.p_521: (SignatureAlgorithm.es512, hashlib.sha512),
         }
 
-        for curve, (signature_algorithm, hash_function) in matrix.items():
+        for curve, (signature_algorithm, hash_function) in sorted(matrix.items()):
             key = key_client.create_ec_key("ec-verify-{}".format(curve.value), curve=curve)
             crypto_client = CryptographyClient(key, credential)
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -12,6 +12,7 @@ from azure.keyvault.keys.aio import KeyClient
 from azure.keyvault.keys.crypto.aio import CryptographyClient, EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
 from azure.mgmt.keyvault.models import KeyPermissions, Permissions
 from devtools_testutils import ResourceGroupPreparer, KeyVaultPreparer
+from _shared.json_attribute_matcher import json_attribute_matcher
 from _shared.test_case_async import KeyVaultTestCase
 
 from crypto_client_preparer_async import CryptoClientPreparer
@@ -22,8 +23,7 @@ NO_GET = Permissions(keys=[p.value for p in KeyPermissions if p.value != "get"])
 
 class CryptoClientTests(KeyVaultTestCase):
     def __init__(self, *args, **kwargs):
-        kwargs["match_body"] = False
-        super(CryptoClientTests, self).__init__(*args, **kwargs)
+        super().__init__(*args, match_body=False, custom_request_matchers=[json_attribute_matcher], **kwargs)
 
     plaintext = b"5063e6aaa845f150200547944fd199679c98ed6f99da0a0b2dafeaf1f4684496fd532c1c229968cb9dee44957fcef7ccef59ceda0b362e56bcd78fd3faee5781c623c0bb22b35beabde0664fd30e0e824aba3dd1b0afffc4a3d955ede20cf6a854d52cfd"
 
@@ -227,7 +227,7 @@ class CryptoClientTests(KeyVaultTestCase):
             KeyCurveName.p_521: (SignatureAlgorithm.es512, hashlib.sha512),
         }
 
-        for curve, (signature_algorithm, hash_function) in matrix.items():
+        for curve, (signature_algorithm, hash_function) in sorted(matrix.items()):
             key = await key_client.create_ec_key("ec-verify-{}".format(curve.value), curve=curve)
             crypto_client = CryptographyClient(key, credential)
 

--- a/sdk/keyvault/azure-keyvault-secrets/tests/_shared/json_attribute_matcher.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/_shared/json_attribute_matcher.py
@@ -1,0 +1,18 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import json
+
+import six
+
+_has_json_body = lambda req: req.body and "json" in req.headers.get("Content-Type", "")
+
+
+def json_attribute_matcher(r1, r2):
+    """Tests whether two vcr.py requests have JSON content with identical attributes (ignoring values)."""
+
+    if _has_json_body(r1) and _has_json_body(r2):
+        c1 = json.loads(six.ensure_str(r1.body))
+        c2 = json.loads(six.ensure_str(r2.body))
+        assert sorted(c1.keys()) == sorted(c2.keys())


### PR DESCRIPTION
Some Key Vault tests send requests with non-determinstic content. This content should be considered in request matching during playback but is not, because vcr.py's JSON matcher is too strict: it asserts attributes and values are identical. So, this PR adds a custom matcher which compares only attributes, ignoring their values. Closes #8838 