### PR TITLE
[textanalytics] Response hook inherits from SansIOHTTPPolicy

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `AnalyzeSentimentResult` and `SentenceSentiment` attribute `sentiment_scores` has been renamed to `confidence_scores`
 - `LinkedEntity` attribute `id` has been renamed to `data_source_entity_id`
 - Parameters `country_hint` and `language` are now passed as keyword arguments
+- The keyword argument `response_hook` has been renamed to `raw_response_hook`
 
 **New features**
 - Pass `country_hint="none"` to not use the default country hint of `"US"`.

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_base_client.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_base_client.py
@@ -19,7 +19,7 @@ from azure.core.pipeline.policies import (
     DistributedTracingPolicy,
     HttpLoggingPolicy,
 )
-from ._policies import CognitiveServicesCredentialPolicy, TextAnalyticsResponseHook
+from ._policies import CognitiveServicesCredentialPolicy, TextAnalyticsResponseHookPolicy
 from ._user_agent import USER_AGENT
 
 
@@ -55,7 +55,7 @@ class TextAnalyticsClientBase(object):
             config.retry_policy,
             credential_policy,
             config.logging_policy,
-            TextAnalyticsResponseHook(**kwargs),
+            TextAnalyticsResponseHookPolicy(**kwargs),
             DistributedTracingPolicy(**kwargs),
             HttpLoggingPolicy(**kwargs),
         ]

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_policies.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_policies.py
@@ -5,7 +5,7 @@
 # ------------------------------------
 
 from azure.core.pipeline.policies import ContentDecodePolicy
-from azure.core.pipeline.policies import SansIOHTTPPolicy, HTTPPolicy
+from azure.core.pipeline.policies import SansIOHTTPPolicy
 from ._models import TextDocumentBatchStatistics
 
 
@@ -40,21 +40,3 @@ class TextAnalyticsResponseHookPolicy(SansIOHTTPPolicy):
             response.model_version = model_version
             response.raw_response = data
             self._response_callback(response)
-            # return response
-
-    #
-    # def send(self, request):
-    #     response_callback = request.context.options.pop("response_hook", self._response_callback)
-    #     if response_callback:
-    #         response = self.next.send(request)
-    #         data = ContentDecodePolicy.deserialize_from_http_generics(response.http_response)
-    #         statistics = data.get("statistics", None)
-    #         model_version = data.get("modelVersion", None)
-    #
-    #         batch_statistics = TextDocumentBatchStatistics._from_generated(statistics)  # pylint: disable=protected-access
-    #         response.statistics = batch_statistics
-    #         response.model_version = model_version
-    #         response.raw_response = data
-    #         response_callback(response)
-    #         return response
-    #     return self.next.send(request)

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_policies.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_policies.py
@@ -21,15 +21,16 @@ class CognitiveServicesCredentialPolicy(SansIOHTTPPolicy):
         request.http_request.headers["X-BingApis-SDK-Client"] = "Python-SDK"
 
 
-class TextAnalyticsResponseHook(HTTPPolicy):
+class TextAnalyticsResponseHookPolicy(SansIOHTTPPolicy):
     def __init__(self, **kwargs):
         self._response_callback = kwargs.get("response_hook")
-        super(TextAnalyticsResponseHook, self).__init__()
+        super(TextAnalyticsResponseHookPolicy, self).__init__()
 
-    def send(self, request):
-        response_callback = request.context.options.pop("response_hook", self._response_callback)
-        if response_callback:
-            response = self.next.send(request)
+    def on_request(self, request):
+        self._response_callback = request.context.options.pop("response_hook", self._response_callback)
+
+    def on_response(self, request, response):
+        if self._response_callback:
             data = ContentDecodePolicy.deserialize_from_http_generics(response.http_response)
             statistics = data.get("statistics", None)
             model_version = data.get("modelVersion", None)
@@ -38,6 +39,22 @@ class TextAnalyticsResponseHook(HTTPPolicy):
             response.statistics = batch_statistics
             response.model_version = model_version
             response.raw_response = data
-            response_callback(response)
-            return response
-        return self.next.send(request)
+            self._response_callback(response)
+            # return response
+
+    #
+    # def send(self, request):
+    #     response_callback = request.context.options.pop("response_hook", self._response_callback)
+    #     if response_callback:
+    #         response = self.next.send(request)
+    #         data = ContentDecodePolicy.deserialize_from_http_generics(response.http_response)
+    #         statistics = data.get("statistics", None)
+    #         model_version = data.get("modelVersion", None)
+    #
+    #         batch_statistics = TextDocumentBatchStatistics._from_generated(statistics)  # pylint: disable=protected-access
+    #         response.statistics = batch_statistics
+    #         response.model_version = model_version
+    #         response.raw_response = data
+    #         response_callback(response)
+    #         return response
+    #     return self.next.send(request)

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_policies.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_policies.py
@@ -23,11 +23,11 @@ class CognitiveServicesCredentialPolicy(SansIOHTTPPolicy):
 
 class TextAnalyticsResponseHookPolicy(SansIOHTTPPolicy):
     def __init__(self, **kwargs):
-        self._response_callback = kwargs.get("response_hook")
+        self._response_callback = kwargs.get("raw_response_hook")
         super(TextAnalyticsResponseHookPolicy, self).__init__()
 
     def on_request(self, request):
-        self._response_callback = request.context.options.pop("response_hook", self._response_callback)
+        self._response_callback = request.context.options.pop("raw_response_hook", self._response_callback)
 
     def on_response(self, request, response):
         if self._response_callback:

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_base_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_base_client_async.py
@@ -19,7 +19,7 @@ from azure.core.pipeline.policies import (
     DistributedTracingPolicy
 )
 from .._policies import CognitiveServicesCredentialPolicy
-from ._policies_async import AsyncTextAnalyticsResponseHook
+from ._policies_async import AsyncTextAnalyticsResponseHookPolicy
 from .._user_agent import USER_AGENT
 
 
@@ -60,7 +60,7 @@ class AsyncTextAnalyticsClientBase(object):
             AsyncRetryPolicy(**kwargs),
             credential_policy,
             config.logging_policy,
-            AsyncTextAnalyticsResponseHook(**kwargs),
+            AsyncTextAnalyticsResponseHookPolicy(**kwargs),
             DistributedTracingPolicy(**kwargs),
             HttpLoggingPolicy(**kwargs)
         ]

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_policies_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_policies_async.py
@@ -13,11 +13,11 @@ from .._models import TextDocumentBatchStatistics
 class AsyncTextAnalyticsResponseHookPolicy(SansIOHTTPPolicy):
 
     def __init__(self, **kwargs):
-        self._response_callback = kwargs.get('response_hook')
+        self._response_callback = kwargs.get('raw_response_hook')
         super(AsyncTextAnalyticsResponseHookPolicy, self).__init__()
 
     async def on_request(self, request):
-        self._response_callback = request.context.options.pop("response_hook", self._response_callback)
+        self._response_callback = request.context.options.pop("raw_response_hook", self._response_callback)
 
     async def on_response(self, request, response):
         if self._response_callback:

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_policies_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_policies_async.py
@@ -10,11 +10,11 @@ from azure.core.pipeline.policies import AsyncHTTPPolicy
 from .._models import TextDocumentBatchStatistics
 
 
-class AsyncTextAnalyticsResponseHook(AsyncHTTPPolicy):
+class AsyncTextAnalyticsResponseHookPolicy(AsyncHTTPPolicy):
 
     def __init__(self, **kwargs):
         self._response_callback = kwargs.get('response_hook')
-        super(AsyncTextAnalyticsResponseHook, self).__init__()
+        super(AsyncTextAnalyticsResponseHookPolicy, self).__init__()
 
     async def send(self, request):
         response_callback = request.context.options.pop("response_hook", self._response_callback)

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_policies_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_policies_async.py
@@ -6,20 +6,21 @@
 
 import asyncio
 from azure.core.pipeline.policies import ContentDecodePolicy
-from azure.core.pipeline.policies import AsyncHTTPPolicy
+from azure.core.pipeline.policies import SansIOHTTPPolicy
 from .._models import TextDocumentBatchStatistics
 
 
-class AsyncTextAnalyticsResponseHookPolicy(AsyncHTTPPolicy):
+class AsyncTextAnalyticsResponseHookPolicy(SansIOHTTPPolicy):
 
     def __init__(self, **kwargs):
         self._response_callback = kwargs.get('response_hook')
         super(AsyncTextAnalyticsResponseHookPolicy, self).__init__()
 
-    async def send(self, request):
-        response_callback = request.context.options.pop("response_hook", self._response_callback)
-        if response_callback:
-            response = await self.next.send(request)
+    async def on_request(self, request):
+        self._response_callback = request.context.options.pop("response_hook", self._response_callback)
+
+    async def on_response(self, request, response):
+        if self._response_callback:
             data = ContentDecodePolicy.deserialize_from_http_generics(response.http_response)
             statistics = data.get("statistics", None)
             model_version = data.get("modelVersion", None)
@@ -28,9 +29,7 @@ class AsyncTextAnalyticsResponseHookPolicy(AsyncHTTPPolicy):
             response.statistics = batch_statistics
             response.model_version = model_version
             response.raw_response = data
-            if asyncio.iscoroutine(response_callback):
-                await response_callback(response)
+            if asyncio.iscoroutine(self._response_callback):
+                await self._response_callback(response)
             else:
-                response_callback(response)
-            return response
-        return await self.next.send(request)
+                self._response_callback(response)

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_analyze_sentiment_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_analyze_sentiment_async.py
@@ -100,7 +100,7 @@ class AnalyzeSentimentSampleAsync(object):
                 documents,
                 show_stats=True,
                 model_version="latest",
-                response_hook=callback
+                raw_response_hook=callback
             )
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_detect_language_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_detect_language_async.py
@@ -87,7 +87,7 @@ class DetectLanguageSampleAsync(object):
                 documents,
                 show_stats=True,
                 model_version="latest",
-                response_hook=callback
+                raw_response_hook=callback
             )
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_extract_key_phrases_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_extract_key_phrases_async.py
@@ -81,7 +81,7 @@ class ExtractKeyPhrasesSampleAsync(object):
                 documents,
                 show_stats=True,
                 model_version="latest",
-                response_hook=callback
+                raw_response_hook=callback
             )
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_entities_async.py
@@ -82,7 +82,7 @@ class RecognizeEntitiesSampleAsync(object):
                 documents,
                 show_stats=True,
                 model_version="latest",
-                response_hook=callback
+                raw_response_hook=callback
             )
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_linked_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_linked_entities_async.py
@@ -90,7 +90,7 @@ class RecognizeLinkedEntitiesSampleAsync(object):
                 documents,
                 show_stats=True,
                 model_version="latest",
-                response_hook=callback
+                raw_response_hook=callback
             )
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_pii_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_pii_entities_async.py
@@ -83,7 +83,7 @@ class RecognizePiiEntitiesSampleAsync(object):
                 documents,
                 show_stats=True,
                 model_version="latest",
-                response_hook=callback
+                raw_response_hook=callback
             )
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_analyze_sentiment.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_analyze_sentiment.py
@@ -34,35 +34,34 @@ class AnalyzeSentimentSample(object):
         from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
         text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
         documents = [
-            "🥨. I'm having a great day!",
+            "I had the best day of my life.",
             "This was a waste of my time. The speaker put me to sleep.",
             "No tengo dinero ni nada que dar...",
             "L'hôtel n'était pas très confortable. L'éclairage était trop sombre."
         ]
 
         result = text_analytics_client.analyze_sentiment(documents)
-        print(result)
         docs = [doc for doc in result if not doc.is_error]
 
-        # for idx, doc in enumerate(docs):
-        #     print("Document text: {}".format(documents[idx]))
-        #     print("Overall sentiment: {}".format(doc.sentiment))
-        # # [END batch_analyze_sentiment]
-        #     print("Overall confidence scores: positive={0:.3f}; neutral={1:.3f}; negative={2:.3f} \n".format(
-        #         doc.confidence_scores.positive,
-        #         doc.confidence_scores.neutral,
-        #         doc.confidence_scores.negative,
-        #     ))
-        #     for idx, sentence in enumerate(doc.sentences):
-        #         print("Sentence {} sentiment: {}".format(idx+1, sentence.sentiment))
-        #         print("Sentence confidence scores: positive={0:.3f}; neutral={1:.3f}; negative={2:.3f}".format(
-        #             sentence.confidence_scores.positive,
-        #             sentence.confidence_scores.neutral,
-        #             sentence.confidence_scores.negative,
-        #         ))
-        #         print("Offset: {}".format(sentence.offset))
-        #         print("Length: {}\n".format(sentence.length))
-        #     print("------------------------------------")
+        for idx, doc in enumerate(docs):
+            print("Document text: {}".format(documents[idx]))
+            print("Overall sentiment: {}".format(doc.sentiment))
+        # [END batch_analyze_sentiment]
+            print("Overall confidence scores: positive={0:.3f}; neutral={1:.3f}; negative={2:.3f} \n".format(
+                doc.confidence_scores.positive,
+                doc.confidence_scores.neutral,
+                doc.confidence_scores.negative,
+            ))
+            for idx, sentence in enumerate(doc.sentences):
+                print("Sentence {} sentiment: {}".format(idx+1, sentence.sentiment))
+                print("Sentence confidence scores: positive={0:.3f}; neutral={1:.3f}; negative={2:.3f}".format(
+                    sentence.confidence_scores.positive,
+                    sentence.confidence_scores.neutral,
+                    sentence.confidence_scores.negative,
+                ))
+                print("Offset: {}".format(sentence.offset))
+                print("Length: {}\n".format(sentence.length))
+            print("------------------------------------")
 
     def alternative_scenario_analyze_sentiment(self):
         """This sample demonstrates how to retrieve batch statistics, the

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_analyze_sentiment.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_analyze_sentiment.py
@@ -34,34 +34,35 @@ class AnalyzeSentimentSample(object):
         from azure.ai.textanalytics import TextAnalyticsClient, TextAnalyticsApiKeyCredential
         text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=TextAnalyticsApiKeyCredential(self.key))
         documents = [
-            "I had the best day of my life.",
+            "🥨. I'm having a great day!",
             "This was a waste of my time. The speaker put me to sleep.",
             "No tengo dinero ni nada que dar...",
             "L'hôtel n'était pas très confortable. L'éclairage était trop sombre."
         ]
 
         result = text_analytics_client.analyze_sentiment(documents)
+        print(result)
         docs = [doc for doc in result if not doc.is_error]
 
-        for idx, doc in enumerate(docs):
-            print("Document text: {}".format(documents[idx]))
-            print("Overall sentiment: {}".format(doc.sentiment))
-        # [END batch_analyze_sentiment]
-            print("Overall confidence scores: positive={0:.3f}; neutral={1:.3f}; negative={2:.3f} \n".format(
-                doc.confidence_scores.positive,
-                doc.confidence_scores.neutral,
-                doc.confidence_scores.negative,
-            ))
-            for idx, sentence in enumerate(doc.sentences):
-                print("Sentence {} sentiment: {}".format(idx+1, sentence.sentiment))
-                print("Sentence confidence scores: positive={0:.3f}; neutral={1:.3f}; negative={2:.3f}".format(
-                    sentence.confidence_scores.positive,
-                    sentence.confidence_scores.neutral,
-                    sentence.confidence_scores.negative,
-                ))
-                print("Offset: {}".format(sentence.offset))
-                print("Length: {}\n".format(sentence.length))
-            print("------------------------------------")
+        # for idx, doc in enumerate(docs):
+        #     print("Document text: {}".format(documents[idx]))
+        #     print("Overall sentiment: {}".format(doc.sentiment))
+        # # [END batch_analyze_sentiment]
+        #     print("Overall confidence scores: positive={0:.3f}; neutral={1:.3f}; negative={2:.3f} \n".format(
+        #         doc.confidence_scores.positive,
+        #         doc.confidence_scores.neutral,
+        #         doc.confidence_scores.negative,
+        #     ))
+        #     for idx, sentence in enumerate(doc.sentences):
+        #         print("Sentence {} sentiment: {}".format(idx+1, sentence.sentiment))
+        #         print("Sentence confidence scores: positive={0:.3f}; neutral={1:.3f}; negative={2:.3f}".format(
+        #             sentence.confidence_scores.positive,
+        #             sentence.confidence_scores.neutral,
+        #             sentence.confidence_scores.negative,
+        #         ))
+        #         print("Offset: {}".format(sentence.offset))
+        #         print("Length: {}\n".format(sentence.length))
+        #     print("------------------------------------")
 
     def alternative_scenario_analyze_sentiment(self):
         """This sample demonstrates how to retrieve batch statistics, the
@@ -94,7 +95,7 @@ class AnalyzeSentimentSample(object):
             documents,
             show_stats=True,
             model_version="latest",
-            response_hook=callback
+            raw_response_hook=callback
         )
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_detect_language.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_detect_language.py
@@ -83,7 +83,7 @@ class DetectLanguageSample(object):
             documents,
             show_stats=True,
             model_version="latest",
-            response_hook=callback
+            raw_response_hook=callback
         )
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_extract_key_phrases.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_extract_key_phrases.py
@@ -75,7 +75,7 @@ class ExtractKeyPhrasesSample(object):
             documents,
             show_stats=True,
             model_version="latest",
-            response_hook=callback
+            raw_response_hook=callback
         )
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_entities.py
@@ -76,7 +76,7 @@ class RecognizeEntitiesSample(object):
             documents,
             show_stats=True,
             model_version="latest",
-            response_hook=callback
+            raw_response_hook=callback
         )
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_linked_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_linked_entities.py
@@ -84,7 +84,7 @@ class RecognizeLinkedEntitiesSample(object):
             documents,
             show_stats=True,
             model_version="latest",
-            response_hook=callback
+            raw_response_hook=callback
         )
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_pii_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_pii_entities.py
@@ -77,7 +77,7 @@ class RecognizePiiEntitiesSample(object):
             documents,
             show_stats=True,
             model_version="latest",
-            response_hook=callback
+            raw_response_hook=callback
         )
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_batch.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_batch.py
@@ -578,7 +578,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
             docs,
             show_stats=True,
             model_version="latest",
-            response_hook=callback
+            raw_response_hook=callback
         )
 
     @GlobalTextAnalyticsAccountPreparer()
@@ -604,7 +604,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
             u"The restaurant was not as good as I hoped."
         ]
 
-        response = text_analytics.detect_language(docs, country_hint="CA", response_hook=callback)
+        response = text_analytics.detect_language(docs, country_hint="CA", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_dont_use_country_hint(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -621,7 +621,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
             u"The restaurant was not as good as I hoped."
         ]
 
-        response = text_analytics.detect_language(docs, country_hint="", response_hook=callback)
+        response = text_analytics.detect_language(docs, country_hint="", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_per_item_dont_use_country_hint(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -640,7 +640,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
                 {"id": "2", "country_hint": "", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = text_analytics.detect_language(docs, response_hook=callback)
+        response = text_analytics.detect_language(docs, raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_country_hint_and_obj_input(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -657,7 +657,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
             DetectLanguageInput(id="3", text="猫は幸せ"),
         ]
 
-        response = text_analytics.detect_language(docs, country_hint="CA", response_hook=callback)
+        response = text_analytics.detect_language(docs, country_hint="CA", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_country_hint_and_dict_input(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -672,7 +672,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
                 {"id": "2", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = text_analytics.detect_language(docs, country_hint="CA", response_hook=callback)
+        response = text_analytics.detect_language(docs, country_hint="CA", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_country_hint_and_obj_per_item_hints(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -692,7 +692,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
             DetectLanguageInput(id="3", text="猫は幸せ"),
         ]
 
-        response = text_analytics.detect_language(docs, country_hint="US", response_hook=callback)
+        response = text_analytics.detect_language(docs, country_hint="US", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_country_hint_and_dict_per_item_hints(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -710,7 +710,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
                 {"id": "2", "country_hint": "US", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = text_analytics.detect_language(docs, country_hint="CA", response_hook=callback)
+        response = text_analytics.detect_language(docs, country_hint="CA", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_language_hint(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -727,7 +727,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
             u"The restaurant was not as good as I hoped."
         ]
 
-        response = text_analytics.analyze_sentiment(docs, language="fr", response_hook=callback)
+        response = text_analytics.analyze_sentiment(docs, language="fr", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_dont_use_language_hint(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -744,7 +744,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
             u"The restaurant was not as good as I hoped."
         ]
 
-        response = text_analytics.analyze_sentiment(docs, language="", response_hook=callback)
+        response = text_analytics.analyze_sentiment(docs, language="", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_per_item_dont_use_language_hint(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -763,7 +763,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
                 {"id": "2", "language": "", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = text_analytics.analyze_sentiment(docs, response_hook=callback)
+        response = text_analytics.analyze_sentiment(docs, raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_language_hint_and_obj_input(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -780,7 +780,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
             TextDocumentInput(id="3", text="猫は幸せ"),
         ]
 
-        response = text_analytics.analyze_sentiment(docs, language="de", response_hook=callback)
+        response = text_analytics.analyze_sentiment(docs, language="de", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_language_hint_and_dict_input(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -795,7 +795,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
                 {"id": "2", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = text_analytics.analyze_sentiment(docs, language="es", response_hook=callback)
+        response = text_analytics.analyze_sentiment(docs, language="es", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_language_hint_and_obj_per_item_hints(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -815,7 +815,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
             TextDocumentInput(id="3", text="猫は幸せ"),
         ]
 
-        response = text_analytics.analyze_sentiment(docs, language="en", response_hook=callback)
+        response = text_analytics.analyze_sentiment(docs, language="en", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_whole_batch_language_hint_and_dict_per_item_hints(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -834,7 +834,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
                 {"id": "2", "language": "es", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = text_analytics.analyze_sentiment(docs, language="en", response_hook=callback)
+        response = text_analytics.analyze_sentiment(docs, language="en", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_bad_document_input(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -863,9 +863,9 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
                 {"id": "2", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = text_analytics.detect_language(docs, response_hook=callback)
-        response = text_analytics.detect_language(docs, country_hint="DE", response_hook=callback_2)
-        response = text_analytics.detect_language(docs, response_hook=callback)
+        response = text_analytics.detect_language(docs, raw_response_hook=callback)
+        response = text_analytics.detect_language(docs, country_hint="DE", raw_response_hook=callback_2)
+        response = text_analytics.detect_language(docs, raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_client_passed_default_language_hint(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -885,9 +885,9 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
                 {"id": "2", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = text_analytics.analyze_sentiment(docs, response_hook=callback)
-        response = text_analytics.analyze_sentiment(docs, language="en", response_hook=callback_2)
-        response = text_analytics.analyze_sentiment(docs, response_hook=callback)
+        response = text_analytics.analyze_sentiment(docs, raw_response_hook=callback)
+        response = text_analytics.analyze_sentiment(docs, language="en", raw_response_hook=callback_2)
+        response = text_analytics.analyze_sentiment(docs, raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_rotate_subscription_key(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -923,7 +923,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
                 {"id": "2", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = text_analytics.analyze_sentiment(docs, response_hook=callback)
+        response = text_analytics.analyze_sentiment(docs, raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_document_attribute_error(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -1030,14 +1030,14 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
             self.assertEqual(country, 1)
 
         # test dict
-        result = text_analytics.detect_language(documents, response_hook=callback)
+        result = text_analytics.detect_language(documents, raw_response_hook=callback)
         # test DetectLanguageInput
-        result2 = text_analytics.detect_language(documents2, response_hook=callback)
+        result2 = text_analytics.detect_language(documents2, raw_response_hook=callback)
         # test per-operation
-        result3 = text_analytics.detect_language(inputs=["this is written in english"], country_hint="none", response_hook=callback)
+        result3 = text_analytics.detect_language(inputs=["this is written in english"], country_hint="none", raw_response_hook=callback)
         # test client default
         new_client = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key), default_country_hint="none")
-        result4 = new_client.detect_language(inputs=["this is written in english"], response_hook=callback)
+        result4 = new_client.detect_language(inputs=["this is written in english"], raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_keyword_arguments(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -1066,7 +1066,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
             model_version="latest",
             show_stats=True,
             country_hint="ES",
-            response_hook=callback
+            raw_response_hook=callback
         )
 
         res = text_analytics.recognize_entities(
@@ -1074,7 +1074,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
             model_version="latest",
             show_stats=True,
             language="es",
-            response_hook=callback2
+            raw_response_hook=callback2
         )
 
         res = text_analytics.recognize_linked_entities(
@@ -1082,7 +1082,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
             model_version="latest",
             show_stats=True,
             language="es",
-            response_hook=callback2
+            raw_response_hook=callback2
         )
 
         res = text_analytics.recognize_pii_entities(
@@ -1090,7 +1090,7 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
             model_version="latest",
             show_stats=True,
             language="en",
-            response_hook=callback3
+            raw_response_hook=callback3
         )
 
         res = text_analytics.analyze_sentiment(
@@ -1098,5 +1098,5 @@ class TestBatchTextAnalytics(TextAnalyticsTest):
             model_version="latest",
             show_stats=True,
             language="es",
-            response_hook=callback2
+            raw_response_hook=callback2
         )

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_batch_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_batch_async.py
@@ -640,7 +640,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
             docs,
             show_stats=True,
             model_version="latest",
-            response_hook=callback
+            raw_response_hook=callback
         )
 
     @GlobalTextAnalyticsAccountPreparer()
@@ -668,7 +668,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
             u"The restaurant was not as good as I hoped."
         ]
 
-        response = await text_analytics.detect_language(docs, country_hint="CA", response_hook=callback)
+        response = await text_analytics.detect_language(docs, country_hint="CA", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -686,7 +686,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
             u"The restaurant was not as good as I hoped."
         ]
 
-        response = await text_analytics.detect_language(docs, country_hint="", response_hook=callback)
+        response = await text_analytics.detect_language(docs, country_hint="", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -706,7 +706,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
                 {"id": "2", "country_hint": "", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = await text_analytics.detect_language(docs, response_hook=callback)
+        response = await text_analytics.detect_language(docs, raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -724,7 +724,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
             DetectLanguageInput(id="3", text="猫は幸せ"),
         ]
 
-        response = await text_analytics.detect_language(docs, country_hint="CA", response_hook=callback)
+        response = await text_analytics.detect_language(docs, country_hint="CA", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -740,7 +740,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
                 {"id": "2", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = await text_analytics.detect_language(docs, country_hint="CA", response_hook=callback)
+        response = await text_analytics.detect_language(docs, country_hint="CA", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -761,7 +761,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
             DetectLanguageInput(id="3", text="猫は幸せ"),
         ]
 
-        response = await text_analytics.detect_language(docs, country_hint="US", response_hook=callback)
+        response = await text_analytics.detect_language(docs, country_hint="US", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -780,7 +780,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
                 {"id": "2", "country_hint": "US", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = await text_analytics.detect_language(docs, country_hint="CA", response_hook=callback)
+        response = await text_analytics.detect_language(docs, country_hint="CA", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -798,7 +798,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
             u"The restaurant was not as good as I hoped."
         ]
 
-        response = await text_analytics.analyze_sentiment(docs, language="fr", response_hook=callback)
+        response = await text_analytics.analyze_sentiment(docs, language="fr", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -816,7 +816,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
             u"The restaurant was not as good as I hoped."
         ]
 
-        response = await text_analytics.analyze_sentiment(docs, language="", response_hook=callback)
+        response = await text_analytics.analyze_sentiment(docs, language="", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -836,7 +836,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
                 {"id": "2", "language": "", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = await text_analytics.analyze_sentiment(docs, response_hook=callback)
+        response = await text_analytics.analyze_sentiment(docs, raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -854,7 +854,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
             TextDocumentInput(id="3", text="猫は幸せ"),
         ]
 
-        response = await text_analytics.analyze_sentiment(docs, language="de", response_hook=callback)
+        response = await text_analytics.analyze_sentiment(docs, language="de", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -870,7 +870,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
                 {"id": "2", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = await text_analytics.analyze_sentiment(docs, language="es", response_hook=callback)
+        response = await text_analytics.analyze_sentiment(docs, language="es", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -891,7 +891,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
             TextDocumentInput(id="3", text="猫は幸せ"),
         ]
 
-        response = await text_analytics.analyze_sentiment(docs, language="en", response_hook=callback)
+        response = await text_analytics.analyze_sentiment(docs, language="en", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -911,7 +911,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
                 {"id": "2", "language": "es", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = await text_analytics.analyze_sentiment(docs, language="en", response_hook=callback)
+        response = await text_analytics.analyze_sentiment(docs, language="en", raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -942,9 +942,9 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
                 {"id": "2", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = await text_analytics.detect_language(docs, response_hook=callback)
-        response = await text_analytics.detect_language(docs, country_hint="DE", response_hook=callback_2)
-        response = await text_analytics.detect_language(docs, response_hook=callback)
+        response = await text_analytics.detect_language(docs, raw_response_hook=callback)
+        response = await text_analytics.detect_language(docs, country_hint="DE", raw_response_hook=callback_2)
+        response = await text_analytics.detect_language(docs, raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -965,9 +965,9 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
                 {"id": "2", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = await text_analytics.analyze_sentiment(docs, response_hook=callback)
-        response = await text_analytics.analyze_sentiment(docs, language="en", response_hook=callback_2)
-        response = await text_analytics.analyze_sentiment(docs, response_hook=callback)
+        response = await text_analytics.analyze_sentiment(docs, raw_response_hook=callback)
+        response = await text_analytics.analyze_sentiment(docs, language="en", raw_response_hook=callback_2)
+        response = await text_analytics.analyze_sentiment(docs, raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -1005,7 +1005,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
                 {"id": "2", "text": "I did not like the hotel we stayed it."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = await text_analytics.analyze_sentiment(docs, response_hook=callback)
+        response = await text_analytics.analyze_sentiment(docs, raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -1116,14 +1116,14 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
             self.assertEqual(country, 1)
 
         # test dict
-        result = await text_analytics.detect_language(documents, response_hook=callback)
+        result = await text_analytics.detect_language(documents, raw_response_hook=callback)
         # test DetectLanguageInput
-        result2 = await text_analytics.detect_language(documents2, response_hook=callback)
+        result2 = await text_analytics.detect_language(documents2, raw_response_hook=callback)
         # test per-operation
-        result3 = await text_analytics.detect_language(inputs=["this is written in english"], country_hint="none", response_hook=callback)
+        result3 = await text_analytics.detect_language(inputs=["this is written in english"], country_hint="none", raw_response_hook=callback)
         # test client default
         new_client = TextAnalyticsClient(text_analytics_account, TextAnalyticsApiKeyCredential(text_analytics_account_key), default_country_hint="none")
-        result4 = await new_client.detect_language(inputs=["this is written in english"], response_hook=callback)
+        result4 = await new_client.detect_language(inputs=["this is written in english"], raw_response_hook=callback)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -1153,7 +1153,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
             model_version="latest",
             show_stats=True,
             country_hint="ES",
-            response_hook=callback
+            raw_response_hook=callback
         )
 
         res = await text_analytics.recognize_entities(
@@ -1161,7 +1161,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
             model_version="latest",
             show_stats=True,
             language="es",
-            response_hook=callback2
+            raw_response_hook=callback2
         )
 
         res = await text_analytics.recognize_linked_entities(
@@ -1169,7 +1169,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
             model_version="latest",
             show_stats=True,
             language="es",
-            response_hook=callback2
+            raw_response_hook=callback2
         )
 
         res = await text_analytics.recognize_pii_entities(
@@ -1177,7 +1177,7 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
             model_version="latest",
             show_stats=True,
             language="en",
-            response_hook=callback3
+            raw_response_hook=callback3
         )
 
         res = await text_analytics.analyze_sentiment(
@@ -1185,5 +1185,5 @@ class TestBatchTextAnalyticsAsync(AsyncTextAnalyticsTest):
             model_version="latest",
             show_stats=True,
             language="es",
-            response_hook=callback2
+            raw_response_hook=callback2
         )


### PR DESCRIPTION
Resolves #9967 

* Fixes text analytics response hook (sync/async) to inherit from `SansIOHTTPPolicy`
* Renames from `TextAnalyticsResponseHook` to `TextAnalyticsResponseHookPolicy`
* Renames keyword argument to `raw_response_hook` to be consistent with azure-core