### PR TITLE
Prevent unecessary Key Vault poller sleeping

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_polling.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_polling.py
@@ -32,7 +32,8 @@ class CreateCertificatePoller(PollingMethod):
         try:
             while not self.finished():
                 self._update_status()
-                time.sleep(self._polling_interval)
+                if not self.finished():
+                    time.sleep(self._polling_interval)
             if self._pending_certificate_op.status.lower() == "completed":
                 self._resource = self._get_certificate_command()
             else:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/_polling.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/_polling.py
@@ -12,7 +12,7 @@ from azure.core.polling import PollingMethod, LROPoller, NoPolling
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 
 try:
-    from urlparse import urlparse # type: ignore # pylint: disable=unused-import
+    from urlparse import urlparse  # type: ignore # pylint: disable=unused-import
 except ImportError:
     from urllib.parse import urlparse
 
@@ -61,8 +61,8 @@ class KeyVaultOperationPoller(LROPoller):
         if not self._polling_method.finished():
             self._done = threading.Event()
             self._thread = threading.Thread(
-                target=with_current_context(self._start),
-                name="KeyVaultOperationPoller({})".format(uuid.uuid4()))
+                target=with_current_context(self._start), name="KeyVaultOperationPoller({})".format(uuid.uuid4())
+            )
             self._thread.daemon = True
             self._thread.start()
 
@@ -72,29 +72,41 @@ class KeyVaultOperationPoller(LROPoller):
         try:
             # Let's handle possible None in forgiveness here
             raise self._exception  # type: ignore
-        except TypeError: # Was None
+        except TypeError:  # Was None
             pass
 
-class RecoverDeletedPollingMethod(PollingMethod):
-    def __init__(self, command, final_resource, initial_status, finished_status, interval=2):
+
+class DeleteRecoverPollingMethod(PollingMethod):
+    """Poller for deleting resources, and recovering deleted resources, in vaults with soft-delete enabled.
+
+    This works by polling for the existence of the deleted or recovered resource. When a resource is deleted, Key Vault
+    immediately removes it from its collection. However, the resource will not immediately appear in the deleted
+    collection. Key Vault will therefore respond 404 to GET requests for the deleted resource; when it responds 2xx
+    or 403, the resource exists in the deleted collection, i.e. its deletion is complete.
+
+    Similarly, while recovering a deleted resource, Key Vault will respond 404 to GET requests for the non-deleted
+    resource; when it responds 2xx or 403, the resource exists in the non-deleted collection, i.e. its rec+
+    (403 indicates completion of these operations because Key Vault responds 403 when a resource exists but the client
+    lacks permission to access it.)
+    """
+    def __init__(self, command, final_resource, finished, interval=2):
         self._command = command
         self._resource = final_resource
         self._polling_interval = interval
-        self._status = initial_status
-        self._finished_status = finished_status
+        self._finished = finished
 
     def _update_status(self):
         # type: () -> None
         try:
             self._command()
-            self._status = self._finished_status
+            self._finished = True
         except ResourceNotFoundError:
             pass
         except HttpResponseError as e:
             # If we are polling on get_deleted_* and we don't have get permissions, we will get
             # ResourceNotFoundError until the resource is recovered, at which point we'll get a 403.
             if e.status_code == 403:
-                self._status = self._finished_status
+                self._finished = True
             else:
                 raise
 
@@ -106,14 +118,15 @@ class RecoverDeletedPollingMethod(PollingMethod):
         try:
             while not self.finished():
                 self._update_status()
-                time.sleep(self._polling_interval)
+                if not self.finished():
+                    time.sleep(self._polling_interval)
         except Exception as e:
             logger.warning(str(e))
             raise
 
     def finished(self):
         # type: () -> bool
-        return self._status == self._finished_status
+        return self._finished
 
     def resource(self):
         # type: () -> Any
@@ -121,20 +134,4 @@ class RecoverDeletedPollingMethod(PollingMethod):
 
     def status(self):
         # type: () -> str
-        return self._status
-
-
-class DeletePollingMethod(RecoverDeletedPollingMethod):
-    def __init__(self, command, final_resource, initial_status, finished_status, sd_disabled, interval=2):
-        self._sd_disabled = sd_disabled
-        super(DeletePollingMethod, self).__init__(
-            command=command,
-            final_resource=final_resource,
-            initial_status=initial_status,
-            finished_status=finished_status,
-            interval=interval
-        )
-
-    def finished(self):
-        # type: () -> bool
-        return self._sd_disabled or self._status == self._finished_status
+        return "finished" if self._finished else "polling"

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/_polling_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/_polling_async.py
@@ -9,61 +9,66 @@ from typing import TYPE_CHECKING
 
 from azure.core.polling import AsyncPollingMethod
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
+
 if TYPE_CHECKING:
     # pylint:disable=ungrouped-imports
     from typing import Any, Callable, Union
 
 logger = logging.getLogger(__name__)
 
-class RecoverDeletedAsyncPollingMethod(AsyncPollingMethod):
-    def __init__(self, initial_status, finished_status, interval=2):
-        self._command = None
-        self._resource = None
+
+class AsyncDeleteRecoverPollingMethod(AsyncPollingMethod):
+    """Poller for deleting resources, and recovering deleted resources, in vaults with soft-delete enabled.
+
+    This works by polling for the existence of the deleted or recovered resource. When a resource is deleted, Key Vault
+    immediately removes it from its collection. However, the resource will not immediately appear in the deleted
+    collection. Key Vault will therefore respond 404 to GET requests for the deleted resource; when it responds 2xx
+    or 403, the resource exists in the deleted collection, i.e. its deletion is complete.
+
+    Similarly, while recovering a deleted resource, Key Vault will respond 404 to GET requests for the non-deleted
+    resource; when it responds 2xx or 403, the resource exists in the non-deleted collection, i.e. its rec+
+    (403 indicates completion of these operations because Key Vault responds 403 when a resource exists but the client
+    lacks permission to access it.)
+    """
+
+    def __init__(self, command, final_resource, finished, interval=2):
+        self._command = command
+        self._resource = final_resource
         self._polling_interval = interval
-        self._status = initial_status
-        self._finished_status = finished_status
+        self._finished = finished
+
+    def initialize(self, client, initial_response, deserialization_callback):
+        pass
 
     async def _update_status(self) -> None:
         try:
             await self._command()
-            self._status = self._finished_status
+            self._finished = True
         except ResourceNotFoundError:
             pass
         except HttpResponseError as e:
             # If we are polling on get_deleted_* and we don't have get permissions, we will get
             # ResourceNotFoundError until the resource is recovered, at which point we'll get a 403.
             if e.status_code == 403:
-                self._status = self._finished_status
+                self._finished = True
             else:
                 raise
-
-    def initialize(self, client: "Any", initial_response: str, _: "Callable") -> None:
-        self._command = client
-        self._resource = initial_response
 
     async def run(self) -> None:
         try:
             while not self.finished():
                 await self._update_status()
-                await asyncio.sleep(self._polling_interval)
+                if not self.finished():
+                    await asyncio.sleep(self._polling_interval)
         except Exception as e:
             logger.warning(str(e))
             raise
 
     def finished(self) -> bool:
-        return self._status == self._finished_status
+        return self._finished
 
     def resource(self) -> "Any":
         return self._resource
 
     def status(self) -> str:
-        return self._status
-
-
-class DeleteAsyncPollingMethod(RecoverDeletedAsyncPollingMethod):
-    def __init__(self, initial_status, finished_status, sd_disabled, interval=2):
-        self._sd_disabled = sd_disabled
-        super(DeleteAsyncPollingMethod, self).__init__(initial_status, finished_status, interval)
-
-    def finished(self) -> bool:
-        return self._sd_disabled or self._status == self._finished_status
+        return "finished" if self._finished else "polling"

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
@@ -23,7 +23,7 @@ from .. import (
 )
 from ._polling_async import CreateCertificatePollerAsync
 from .._shared import AsyncKeyVaultClientBase
-from .._shared._polling_async import DeleteAsyncPollingMethod, RecoverDeletedAsyncPollingMethod
+from .._shared._polling_async import AsyncDeleteRecoverPollingMethod
 from .._shared.exceptions import error_map as _error_map
 
 
@@ -204,13 +204,17 @@ class CertificateClient(AsyncKeyVaultClientBase):
             vault_base_url=self.vault_url, certificate_name=certificate_name, error_map=_error_map, **kwargs
         )
         deleted_certificate = DeletedCertificate._from_deleted_certificate_bundle(deleted_cert_bundle)
-        sd_disabled = deleted_certificate.recovery_id is None
-        command = partial(self.get_deleted_certificate, certificate_name=certificate_name, **kwargs)
 
-        delete_certificate_poller = DeleteAsyncPollingMethod(
-            initial_status="deleting", finished_status="deleted", sd_disabled=sd_disabled, interval=polling_interval
+        polling_method = AsyncDeleteRecoverPollingMethod(
+            # no recovery ID means soft-delete is disabled, in which case we initialize the poller as finished
+            finished=deleted_certificate.recovery_id is None,
+            command=partial(self.get_deleted_certificate, certificate_name=certificate_name, **kwargs),
+            final_resource=deleted_certificate,
+            interval=polling_interval,
         )
-        return await async_poller(command, deleted_certificate, None, delete_certificate_poller)
+        await polling_method.run()
+
+        return polling_method.resource()
 
     @distributed_trace_async
     async def get_deleted_certificate(self, certificate_name: str, **kwargs: "Any") -> DeletedCertificate:
@@ -289,12 +293,14 @@ class CertificateClient(AsyncKeyVaultClientBase):
             vault_base_url=self.vault_url, certificate_name=certificate_name, error_map=_error_map, **kwargs
         )
         recovered_certificate = KeyVaultCertificate._from_certificate_bundle(recovered_cert_bundle)
-        command = partial(self.get_certificate, certificate_name=certificate_name, **kwargs)
 
-        recover_cert_poller = RecoverDeletedAsyncPollingMethod(
-            initial_status="recovering", finished_status="recovered", interval=polling_interval
+        command = partial(self.get_certificate, certificate_name=certificate_name, **kwargs)
+        polling_method = AsyncDeleteRecoverPollingMethod(
+            command=command, final_resource=recovered_certificate, finished=False, interval=polling_interval
         )
-        return await async_poller(command, recovered_certificate, None, recover_cert_poller)
+        await polling_method.run()
+
+        return polling_method.resource()
 
     @distributed_trace_async
     async def import_certificate(

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_polling_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_polling_async.py
@@ -32,7 +32,8 @@ class CreateCertificatePollerAsync(AsyncPollingMethod):
         try:
             while not self.finished():
                 await self._update_status()
-                await asyncio.sleep(self._polling_interval)
+                if not self.finished():
+                    await asyncio.sleep(self._polling_interval)
             if self._pending_certificate_op.status.lower() == "completed":
                 self._resource = await self._get_certificate_command()
             else:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/_polling.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/_polling.py
@@ -12,7 +12,7 @@ from azure.core.polling import PollingMethod, LROPoller, NoPolling
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 
 try:
-    from urlparse import urlparse # type: ignore # pylint: disable=unused-import
+    from urlparse import urlparse  # type: ignore # pylint: disable=unused-import
 except ImportError:
     from urllib.parse import urlparse
 
@@ -61,8 +61,8 @@ class KeyVaultOperationPoller(LROPoller):
         if not self._polling_method.finished():
             self._done = threading.Event()
             self._thread = threading.Thread(
-                target=with_current_context(self._start),
-                name="KeyVaultOperationPoller({})".format(uuid.uuid4()))
+                target=with_current_context(self._start), name="KeyVaultOperationPoller({})".format(uuid.uuid4())
+            )
             self._thread.daemon = True
             self._thread.start()
 
@@ -72,29 +72,41 @@ class KeyVaultOperationPoller(LROPoller):
         try:
             # Let's handle possible None in forgiveness here
             raise self._exception  # type: ignore
-        except TypeError: # Was None
+        except TypeError:  # Was None
             pass
 
-class RecoverDeletedPollingMethod(PollingMethod):
-    def __init__(self, command, final_resource, initial_status, finished_status, interval=2):
+
+class DeleteRecoverPollingMethod(PollingMethod):
+    """Poller for deleting resources, and recovering deleted resources, in vaults with soft-delete enabled.
+
+    This works by polling for the existence of the deleted or recovered resource. When a resource is deleted, Key Vault
+    immediately removes it from its collection. However, the resource will not immediately appear in the deleted
+    collection. Key Vault will therefore respond 404 to GET requests for the deleted resource; when it responds 2xx
+    or 403, the resource exists in the deleted collection, i.e. its deletion is complete.
+
+    Similarly, while recovering a deleted resource, Key Vault will respond 404 to GET requests for the non-deleted
+    resource; when it responds 2xx or 403, the resource exists in the non-deleted collection, i.e. its rec+
+    (403 indicates completion of these operations because Key Vault responds 403 when a resource exists but the client
+    lacks permission to access it.)
+    """
+    def __init__(self, command, final_resource, finished, interval=2):
         self._command = command
         self._resource = final_resource
         self._polling_interval = interval
-        self._status = initial_status
-        self._finished_status = finished_status
+        self._finished = finished
 
     def _update_status(self):
         # type: () -> None
         try:
             self._command()
-            self._status = self._finished_status
+            self._finished = True
         except ResourceNotFoundError:
             pass
         except HttpResponseError as e:
             # If we are polling on get_deleted_* and we don't have get permissions, we will get
             # ResourceNotFoundError until the resource is recovered, at which point we'll get a 403.
             if e.status_code == 403:
-                self._status = self._finished_status
+                self._finished = True
             else:
                 raise
 
@@ -106,14 +118,15 @@ class RecoverDeletedPollingMethod(PollingMethod):
         try:
             while not self.finished():
                 self._update_status()
-                time.sleep(self._polling_interval)
+                if not self.finished():
+                    time.sleep(self._polling_interval)
         except Exception as e:
             logger.warning(str(e))
             raise
 
     def finished(self):
         # type: () -> bool
-        return self._status == self._finished_status
+        return self._finished
 
     def resource(self):
         # type: () -> Any
@@ -121,20 +134,4 @@ class RecoverDeletedPollingMethod(PollingMethod):
 
     def status(self):
         # type: () -> str
-        return self._status
-
-
-class DeletePollingMethod(RecoverDeletedPollingMethod):
-    def __init__(self, command, final_resource, initial_status, finished_status, sd_disabled, interval=2):
-        self._sd_disabled = sd_disabled
-        super(DeletePollingMethod, self).__init__(
-            command=command,
-            final_resource=final_resource,
-            initial_status=initial_status,
-            finished_status=finished_status,
-            interval=interval
-        )
-
-    def finished(self):
-        # type: () -> bool
-        return self._sd_disabled or self._status == self._finished_status
+        return "finished" if self._finished else "polling"

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/_polling_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/_polling_async.py
@@ -9,61 +9,66 @@ from typing import TYPE_CHECKING
 
 from azure.core.polling import AsyncPollingMethod
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
+
 if TYPE_CHECKING:
     # pylint:disable=ungrouped-imports
     from typing import Any, Callable, Union
 
 logger = logging.getLogger(__name__)
 
-class RecoverDeletedAsyncPollingMethod(AsyncPollingMethod):
-    def __init__(self, initial_status, finished_status, interval=2):
-        self._command = None
-        self._resource = None
+
+class AsyncDeleteRecoverPollingMethod(AsyncPollingMethod):
+    """Poller for deleting resources, and recovering deleted resources, in vaults with soft-delete enabled.
+
+    This works by polling for the existence of the deleted or recovered resource. When a resource is deleted, Key Vault
+    immediately removes it from its collection. However, the resource will not immediately appear in the deleted
+    collection. Key Vault will therefore respond 404 to GET requests for the deleted resource; when it responds 2xx
+    or 403, the resource exists in the deleted collection, i.e. its deletion is complete.
+
+    Similarly, while recovering a deleted resource, Key Vault will respond 404 to GET requests for the non-deleted
+    resource; when it responds 2xx or 403, the resource exists in the non-deleted collection, i.e. its rec+
+    (403 indicates completion of these operations because Key Vault responds 403 when a resource exists but the client
+    lacks permission to access it.)
+    """
+
+    def __init__(self, command, final_resource, finished, interval=2):
+        self._command = command
+        self._resource = final_resource
         self._polling_interval = interval
-        self._status = initial_status
-        self._finished_status = finished_status
+        self._finished = finished
+
+    def initialize(self, client, initial_response, deserialization_callback):
+        pass
 
     async def _update_status(self) -> None:
         try:
             await self._command()
-            self._status = self._finished_status
+            self._finished = True
         except ResourceNotFoundError:
             pass
         except HttpResponseError as e:
             # If we are polling on get_deleted_* and we don't have get permissions, we will get
             # ResourceNotFoundError until the resource is recovered, at which point we'll get a 403.
             if e.status_code == 403:
-                self._status = self._finished_status
+                self._finished = True
             else:
                 raise
-
-    def initialize(self, client: "Any", initial_response: str, _: "Callable") -> None:
-        self._command = client
-        self._resource = initial_response
 
     async def run(self) -> None:
         try:
             while not self.finished():
                 await self._update_status()
-                await asyncio.sleep(self._polling_interval)
+                if not self.finished():
+                    await asyncio.sleep(self._polling_interval)
         except Exception as e:
             logger.warning(str(e))
             raise
 
     def finished(self) -> bool:
-        return self._status == self._finished_status
+        return self._finished
 
     def resource(self) -> "Any":
         return self._resource
 
     def status(self) -> str:
-        return self._status
-
-
-class DeleteAsyncPollingMethod(RecoverDeletedAsyncPollingMethod):
-    def __init__(self, initial_status, finished_status, sd_disabled, interval=2):
-        self._sd_disabled = sd_disabled
-        super(DeleteAsyncPollingMethod, self).__init__(initial_status, finished_status, interval)
-
-    def finished(self) -> bool:
-        return self._sd_disabled or self._status == self._finished_status
+        return "finished" if self._finished else "polling"

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
@@ -8,7 +8,7 @@ from azure.core.tracing.decorator import distributed_trace
 from ._models import KeyVaultSecret, DeletedSecret, SecretProperties
 from ._shared import KeyVaultClientBase
 from ._shared.exceptions import error_map as _error_map
-from ._shared._polling import RecoverDeletedPollingMethod, KeyVaultOperationPoller
+from ._shared._polling import KeyVaultPollingMethod, KeyVaultOperationPoller
 
 try:
     from typing import TYPE_CHECKING
@@ -306,7 +306,7 @@ class SecretClient(KeyVaultClientBase):
         )
 
         command = partial(self.get_deleted_secret, name=name, **kwargs)
-        delete_secret_polling_method = RecoverDeletedPollingMethod(
+        delete_secret_polling_method = KeyVaultPollingMethod(
             # no recovery ID means soft-delete is disabled, in which case we initialize the poller as finished
             finished=deleted_secret.recovery_id is None,
             command=command,
@@ -431,7 +431,7 @@ class SecretClient(KeyVaultClientBase):
         )
 
         command = partial(self.get_secret, name=name, **kwargs)
-        polling_method = RecoverDeletedPollingMethod(
+        polling_method = KeyVaultPollingMethod(
             finished=False, command=command, final_resource=recovered_secret, interval=polling_interval,
         )
         return KeyVaultOperationPoller(polling_method)

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
@@ -8,7 +8,7 @@ from azure.core.tracing.decorator import distributed_trace
 from ._models import KeyVaultSecret, DeletedSecret, SecretProperties
 from ._shared import KeyVaultClientBase
 from ._shared.exceptions import error_map as _error_map
-from ._shared._polling import DeletePollingMethod, RecoverDeletedPollingMethod, KeyVaultOperationPoller
+from ._shared._polling import RecoverDeletedPollingMethod, KeyVaultOperationPoller
 
 try:
     from typing import TYPE_CHECKING
@@ -304,14 +304,13 @@ class SecretClient(KeyVaultClientBase):
         deleted_secret = DeletedSecret._from_deleted_secret_bundle(
             self._client.delete_secret(self.vault_url, name, error_map=_error_map, **kwargs)
         )
-        sd_disabled = deleted_secret.recovery_id is None
+
         command = partial(self.get_deleted_secret, name=name, **kwargs)
-        delete_secret_polling_method = DeletePollingMethod(
+        delete_secret_polling_method = RecoverDeletedPollingMethod(
+            # no recovery ID means soft-delete is disabled, in which case we initialize the poller as finished
+            finished=deleted_secret.recovery_id is None,
             command=command,
             final_resource=deleted_secret,
-            initial_status="deleting",
-            finished_status="deleted",
-            sd_disabled=sd_disabled,
             interval=polling_interval,
         )
         return KeyVaultOperationPoller(delete_secret_polling_method)
@@ -430,12 +429,9 @@ class SecretClient(KeyVaultClientBase):
         recovered_secret = SecretProperties._from_secret_bundle(
             self._client.recover_deleted_secret(self.vault_url, name, error_map=_error_map, **kwargs)
         )
+
         command = partial(self.get_secret, name=name, **kwargs)
-        recover_secret_polling_method = RecoverDeletedPollingMethod(
-            command=command,
-            final_resource=recovered_secret,
-            initial_status="recovering",
-            finished_status="recovered",
-            interval=polling_interval,
+        polling_method = RecoverDeletedPollingMethod(
+            finished=False, command=command, final_resource=recovered_secret, interval=polling_interval,
         )
-        return KeyVaultOperationPoller(recover_secret_polling_method)
+        return KeyVaultOperationPoller(polling_method)

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling.py
@@ -106,7 +106,8 @@ class RecoverDeletedPollingMethod(PollingMethod):
         try:
             while not self.finished():
                 self._update_status()
-                time.sleep(self._polling_interval)
+                if not self.finished():
+                    time.sleep(self._polling_interval)
         except Exception as e:
             logger.warning(str(e))
             raise

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling.py
@@ -12,7 +12,7 @@ from azure.core.polling import PollingMethod, LROPoller, NoPolling
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 
 try:
-    from urlparse import urlparse # type: ignore # pylint: disable=unused-import
+    from urlparse import urlparse  # type: ignore # pylint: disable=unused-import
 except ImportError:
     from urllib.parse import urlparse
 
@@ -61,8 +61,8 @@ class KeyVaultOperationPoller(LROPoller):
         if not self._polling_method.finished():
             self._done = threading.Event()
             self._thread = threading.Thread(
-                target=with_current_context(self._start),
-                name="KeyVaultOperationPoller({})".format(uuid.uuid4()))
+                target=with_current_context(self._start), name="KeyVaultOperationPoller({})".format(uuid.uuid4())
+            )
             self._thread.daemon = True
             self._thread.start()
 
@@ -72,10 +72,17 @@ class KeyVaultOperationPoller(LROPoller):
         try:
             # Let's handle possible None in forgiveness here
             raise self._exception  # type: ignore
-        except TypeError: # Was None
+        except TypeError:  # Was None
             pass
 
-class RecoverDeletedPollingMethod(PollingMethod):
+
+class KeyVaultPollingMethod(PollingMethod):
+    """Poll with GET requests until one succeeds.
+
+    This allows waiting for Key Vault to delete, or recover, a resource, by polling for the existence of the deleted
+    or recovered resource, respectively.
+    """
+
     def __init__(self, command, final_resource, finished, interval=2):
         self._command = command
         self._resource = final_resource

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling.py
@@ -76,13 +76,19 @@ class KeyVaultOperationPoller(LROPoller):
             pass
 
 
-class KeyVaultPollingMethod(PollingMethod):
-    """Poll with GET requests until one succeeds.
+class DeleteRecoverPollingMethod(PollingMethod):
+    """Poller for deleting resources, and recovering deleted resources, in vaults with soft-delete enabled.
 
-    This allows waiting for Key Vault to delete, or recover, a resource, by polling for the existence of the deleted
-    or recovered resource, respectively.
+    This works by polling for the existence of the deleted or recovered resource. When a resource is deleted, Key Vault
+    immediately removes it from its collection. However, the resource will not immediately appear in the deleted
+    collection. Key Vault will therefore respond 404 to GET requests for the deleted resource; when it responds 2xx
+    or 403, the resource exists in the deleted collection, i.e. its deletion is complete.
+
+    Similarly, while recovering a deleted resource, Key Vault will respond 404 to GET requests for the non-deleted
+    resource; when it responds 2xx or 403, the resource exists in the non-deleted collection, i.e. its rec+
+    (403 indicates completion of these operations because Key Vault responds 403 when a resource exists but the client
+    lacks permission to access it.)
     """
-
     def __init__(self, command, final_resource, finished, interval=2):
         self._command = command
         self._resource = final_resource

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling_async.py
@@ -45,7 +45,8 @@ class RecoverDeletedAsyncPollingMethod(AsyncPollingMethod):
         try:
             while not self.finished():
                 await self._update_status()
-                await asyncio.sleep(self._polling_interval)
+                if not self.finished():
+                    await asyncio.sleep(self._polling_interval)
         except Exception as e:
             logger.warning(str(e))
             raise

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling_async.py
@@ -17,11 +17,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class AsyncKeyVaultPollingMethod(AsyncPollingMethod):
-    """Poll with GET requests until one succeeds.
+class AsyncDeleteRecoverPollingMethod(AsyncPollingMethod):
+    """Poller for deleting resources, and recovering deleted resources, in vaults with soft-delete enabled.
 
-    This allows waiting for Key Vault to delete, or recover, a resource, by polling for the existence of the deleted
-    or recovered resource, respectively.
+    This works by polling for the existence of the deleted or recovered resource. When a resource is deleted, Key Vault
+    immediately removes it from its collection. However, the resource will not immediately appear in the deleted
+    collection. Key Vault will therefore respond 404 to GET requests for the deleted resource; when it responds 2xx
+    or 403, the resource exists in the deleted collection, i.e. its deletion is complete.
+
+    Similarly, while recovering a deleted resource, Key Vault will respond 404 to GET requests for the non-deleted
+    resource; when it responds 2xx or 403, the resource exists in the non-deleted collection, i.e. its rec+
+    (403 indicates completion of these operations because Key Vault responds 403 when a resource exists but the client
+    lacks permission to access it.)
     """
 
     def __init__(self, command, final_resource, finished, interval=2):

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling_async.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-class RecoverDeletedAsyncPollingMethod(AsyncPollingMethod):
+class AsyncKeyVaultPollingMethod(AsyncPollingMethod):
     def __init__(self, finished, interval=2):
         self._command = None
         self._resource = None

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
@@ -12,7 +12,7 @@ from azure.core.polling import async_poller
 from .._models import KeyVaultSecret, DeletedSecret, SecretProperties
 from .._shared import AsyncKeyVaultClientBase
 from .._shared.exceptions import error_map as _error_map
-from .._shared._polling_async import RecoverDeletedAsyncPollingMethod
+from .._shared._polling_async import AsyncKeyVaultPollingMethod
 
 
 class SecretClient(AsyncKeyVaultClientBase):
@@ -267,7 +267,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         )
 
         command = partial(self.get_deleted_secret, name=name, **kwargs)
-        delete_secret_poller = RecoverDeletedAsyncPollingMethod(
+        delete_secret_poller = AsyncKeyVaultPollingMethod(
             # no recovery ID means soft-delete is disabled, in which case we initialize the poller as finished
             finished=deleted_secret.recovery_id is None,
             interval=polling_interval,
@@ -375,6 +375,6 @@ class SecretClient(AsyncKeyVaultClientBase):
         )
 
         command = partial(self.get_secret, name=name, **kwargs)
-        polling_method = RecoverDeletedAsyncPollingMethod(finished=False, interval=polling_interval)
+        polling_method = AsyncKeyVaultPollingMethod(finished=False, interval=polling_interval)
 
         return await async_poller(command, recovered_secret, None, polling_method)

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
@@ -270,6 +270,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         delete_secret_poller = AsyncKeyVaultPollingMethod(
             # no recovery ID means soft-delete is disabled, in which case we initialize the poller as finished
             finished=deleted_secret.recovery_id is None,
+            command=partial(self.get_deleted_secret, name=name, **kwargs),
+            final_resource=deleted_secret,
             interval=polling_interval,
         )
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
@@ -11,7 +11,7 @@ from azure.core.tracing.decorator_async import distributed_trace_async
 from .._models import KeyVaultSecret, DeletedSecret, SecretProperties
 from .._shared import AsyncKeyVaultClientBase
 from .._shared.exceptions import error_map as _error_map
-from .._shared._polling_async import AsyncKeyVaultPollingMethod
+from .._shared._polling_async import AsyncDeleteRecoverPollingMethod
 
 
 class SecretClient(AsyncKeyVaultClientBase):
@@ -261,7 +261,7 @@ class SecretClient(AsyncKeyVaultClientBase):
             await self._client.delete_secret(self.vault_url, name, error_map=_error_map, **kwargs)
         )
 
-        polling_method = AsyncKeyVaultPollingMethod(
+        polling_method = AsyncDeleteRecoverPollingMethod(
             # no recovery ID means soft-delete is disabled, in which case we initialize the poller as finished
             command=partial(self.get_deleted_secret, name=name, **kwargs),
             final_resource=deleted_secret,
@@ -372,7 +372,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         )
 
         command = partial(self.get_secret, name=name, **kwargs)
-        polling_method = AsyncKeyVaultPollingMethod(
+        polling_method = AsyncDeleteRecoverPollingMethod(
             command=command, final_resource=recovered_secret, finished=False, interval=polling_interval
         )
         await polling_method.run()

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
@@ -87,9 +87,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         not_before = kwargs.pop("not_before", None)
         expires_on = kwargs.pop("expires_on", None)
         if enabled is not None or not_before is not None or expires_on is not None:
-            attributes = self._models.SecretAttributes(
-                enabled=enabled, not_before=not_before, expires=expires_on
-            )
+            attributes = self._models.SecretAttributes(enabled=enabled, not_before=not_before, expires=expires_on)
         else:
             attributes = None
         bundle = await self._client.set_secret(
@@ -131,9 +129,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         not_before = kwargs.pop("not_before", None)
         expires_on = kwargs.pop("expires_on", None)
         if enabled is not None or not_before is not None or expires_on is not None:
-            attributes = self._models.SecretAttributes(
-                enabled=enabled, not_before=not_before, expires=expires_on
-            )
+            attributes = self._models.SecretAttributes(enabled=enabled, not_before=not_before, expires=expires_on)
         else:
             attributes = None
         bundle = await self._client.update_secret(

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
@@ -12,7 +12,7 @@ from azure.core.polling import async_poller
 from .._models import KeyVaultSecret, DeletedSecret, SecretProperties
 from .._shared import AsyncKeyVaultClientBase
 from .._shared.exceptions import error_map as _error_map
-from .._shared._polling_async import DeleteAsyncPollingMethod, RecoverDeletedAsyncPollingMethod
+from .._shared._polling_async import RecoverDeletedAsyncPollingMethod
 
 
 class SecretClient(AsyncKeyVaultClientBase):
@@ -265,12 +265,14 @@ class SecretClient(AsyncKeyVaultClientBase):
         deleted_secret = DeletedSecret._from_deleted_secret_bundle(
             await self._client.delete_secret(self.vault_url, name, error_map=_error_map, **kwargs)
         )
-        sd_disabled = deleted_secret.recovery_id is None
-        command = partial(self.get_deleted_secret, name=name, **kwargs)
 
-        delete_secret_poller = DeleteAsyncPollingMethod(
-            initial_status="deleting", finished_status="deleted", sd_disabled=sd_disabled, interval=polling_interval
+        command = partial(self.get_deleted_secret, name=name, **kwargs)
+        delete_secret_poller = RecoverDeletedAsyncPollingMethod(
+            # no recovery ID means soft-delete is disabled, in which case we initialize the poller as finished
+            finished=deleted_secret.recovery_id is None,
+            interval=polling_interval,
         )
+
         return await async_poller(command, deleted_secret, None, delete_secret_poller)
 
     @distributed_trace_async
@@ -371,9 +373,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         recovered_secret = SecretProperties._from_secret_bundle(
             await self._client.recover_deleted_secret(self.vault_url, name, error_map=_error_map, **kwargs)
         )
-        command = partial(self.get_secret, name=name, **kwargs)
 
-        recover_secret_poller = RecoverDeletedAsyncPollingMethod(
-            initial_status="recovering", finished_status="recovered", interval=polling_interval
-        )
-        return await async_poller(command, recovered_secret, None, recover_secret_poller)
+        command = partial(self.get_secret, name=name, **kwargs)
+        polling_method = RecoverDeletedAsyncPollingMethod(finished=False, interval=polling_interval)
+
+        return await async_poller(command, recovered_secret, None, polling_method)

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_polling_method.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_polling_method.py
@@ -1,0 +1,130 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
+from azure.keyvault.secrets._shared._polling import DeleteRecoverPollingMethod
+import pytest
+
+from _shared.helpers import mock, mock_response
+
+SLEEP = DeleteRecoverPollingMethod.__module__ + ".time.sleep"
+
+raise_exception = lambda message: mock.Mock(side_effect=Exception(message))
+
+
+def test_initialized_finished():
+    """When the polling method is initialized as finished, it shouldn't invoke the command or sleep"""
+
+    command = raise_exception("polling method shouldn't invoke the command")
+    polling_method = DeleteRecoverPollingMethod(command, final_resource=None, finished=True)
+
+    assert polling_method.finished()
+
+    with mock.patch(SLEEP, raise_exception("the polling method shouldn't sleep")):
+        polling_method.run()
+
+
+def test_continues_polling_when_resource_not_found():
+    class _command:
+        calls = 0
+        operation_complete = False
+
+    def command():
+        """Simulate service responding 404 a few times before 2xx"""
+
+        assert not _command.operation_complete, "polling method shouldn't invoke the command after completion"
+
+        if _command.calls < 3:
+            _command.calls += 1
+            raise ResourceNotFoundError()
+
+        _command.operation_complete = True
+
+    polling_method = DeleteRecoverPollingMethod(command, final_resource=None, finished=False)
+
+    with mock.patch(SLEEP) as sleep:
+        polling_method.run()
+
+    assert sleep.call_count == _command.calls
+
+
+def test_run_idempotence():
+    """After the polling method completes, calling 'run' again shouldn't change state or invoke the command"""
+
+    max_calls = 3
+
+    class _command:
+        calls = 0
+        operation_complete = False
+
+    def command():
+        """Simulate service responding 404 a few times before 2xx"""
+
+        assert not _command.operation_complete, "polling method shouldn't invoke the command after completion"
+
+        if _command.calls < max_calls:
+            _command.calls += 1
+            raise ResourceNotFoundError()
+
+        _command.operation_complete = True
+
+    resource = object()
+    polling_method = DeleteRecoverPollingMethod(command, final_resource=resource, finished=False)
+    assert not polling_method.finished()
+
+    with mock.patch(SLEEP) as sleep:
+        # when run is first called, the polling method should invoke the command until it indicates completion
+        polling_method.run()
+    assert _command.calls == max_calls
+    assert sleep.call_count == _command.calls
+
+    # invoking run again should not change the resource or finished status, invoke the command, or sleep
+    with mock.patch(SLEEP, raise_exception("polling method shouldn't sleep when 'run' is called after completion")):
+        for _ in range(4):
+            assert polling_method.resource() is resource
+            assert polling_method.finished()
+            polling_method.run()
+
+
+def test_final_resource():
+    """The polling method should always expose the final resource"""
+
+    resource = object()
+
+    assert DeleteRecoverPollingMethod(command=None, final_resource=resource, finished=True).resource() is resource
+
+    command = mock.Mock()
+    polling_method = DeleteRecoverPollingMethod(command, final_resource=resource, finished=False)
+
+    assert polling_method.resource() is resource
+    polling_method.run()
+    assert polling_method.resource() is resource
+
+
+def test_terminal_first_response():
+    """The polling method shouldn't sleep when Key Vault's first response indicates the operation is complete"""
+
+    command = mock.Mock()
+    polling_method = DeleteRecoverPollingMethod(command, final_resource=None, finished=False)
+
+    with mock.patch(SLEEP, raise_exception("polling method shouldn't sleep after the operation completes")):
+        polling_method.run()
+
+    assert command.call_count == 1
+    assert polling_method.finished()
+
+
+def test_propagates_unexpected_error():
+    """The polling method should raise when Key Vault responds with an unexpected error"""
+
+    response = mock_response(status_code=418, json_payload={"error": {"code": 418, "message": "I'm a teapot."}})
+    error = HttpResponseError(response=response)
+    command = mock.Mock(side_effect=error)
+    polling_method = DeleteRecoverPollingMethod(command, final_resource=None, finished=False)
+
+    with mock.patch(SLEEP, raise_exception("polling method shouldn't sleep after an unexpected error")):
+        with pytest.raises(HttpResponseError):
+            polling_method.run()
+
+    assert command.call_count == 1

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_polling_method_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_polling_method_async.py
@@ -1,0 +1,140 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
+from azure.keyvault.secrets._shared._polling_async import AsyncDeleteRecoverPollingMethod
+import pytest
+
+from _shared.helpers import mock, mock_response
+from _shared.helpers_async import get_completed_future
+
+SLEEP = AsyncDeleteRecoverPollingMethod.__module__ + ".asyncio.sleep"
+
+raise_exception = lambda message: mock.Mock(side_effect=Exception(message))
+
+
+@pytest.mark.asyncio
+async def test_initialized_finished():
+    """When the polling method is initialized as finished, it shouldn't invoke the command or sleep"""
+
+    command = raise_exception("polling method shouldn't invoke the command")
+    polling_method = AsyncDeleteRecoverPollingMethod(command, final_resource=None, finished=True)
+
+    assert polling_method.finished()
+
+    with mock.patch(SLEEP, raise_exception("the polling method shouldn't sleep")):
+        await polling_method.run()
+
+
+@pytest.mark.asyncio
+async def test_continues_polling_when_resource_not_found():
+    class _command:
+        calls = 0
+        operation_complete = False
+
+    async def command():
+        """Simulate service responding 404 a few times before 2xx"""
+
+        assert not _command.operation_complete, "polling method shouldn't invoke the command after completion"
+
+        if _command.calls < 3:
+            _command.calls += 1
+            raise ResourceNotFoundError()
+
+        _command.operation_complete = True
+
+    polling_method = AsyncDeleteRecoverPollingMethod(command, final_resource=None, finished=False)
+
+    sleep = mock.Mock(return_value=get_completed_future())
+    with mock.patch(SLEEP, sleep):
+        await polling_method.run()
+
+    assert sleep.call_count == _command.calls
+
+
+@pytest.mark.asyncio
+async def test_run_idempotence():
+    """After the polling method completes, calling 'run' again shouldn't change state or invoke the command"""
+
+    max_calls = 3
+
+    class _command:
+        calls = 0
+        operation_complete = False
+
+    async def command():
+        """Simulate service responding 404 a few times before 2xx"""
+
+        assert not _command.operation_complete, "polling method shouldn't invoke the command after completion"
+
+        if _command.calls < max_calls:
+            _command.calls += 1
+            raise ResourceNotFoundError()
+
+        _command.operation_complete = True
+
+    resource = object()
+    polling_method = AsyncDeleteRecoverPollingMethod(command, final_resource=resource, finished=False)
+    assert not polling_method.finished()
+
+    sleep = mock.Mock(return_value=get_completed_future())
+    with mock.patch(SLEEP, sleep):
+        # when run is first called, the polling method should invoke the command until it indicates completion
+        await polling_method.run()
+    assert _command.calls == max_calls
+    assert sleep.call_count == _command.calls
+
+    # invoking run again should not change the resource or finished status, invoke the command, or sleep
+    with mock.patch(SLEEP, raise_exception("polling method shouldn't sleep when 'run' is called after completion")):
+        for _ in range(4):
+            assert polling_method.resource() is resource
+            assert polling_method.finished()
+            await polling_method.run()
+
+
+@pytest.mark.asyncio
+async def test_final_resource():
+    """The polling method should always expose the final resource"""
+
+    resource = object()
+
+    assert AsyncDeleteRecoverPollingMethod(command=None, final_resource=resource, finished=True).resource() is resource
+
+    response = mock.Mock(status_code=403)
+    command = mock.Mock(side_effect=HttpResponseError(response=response))
+    polling_method = AsyncDeleteRecoverPollingMethod(command, final_resource=resource, finished=False)
+
+    assert polling_method.resource() is resource
+    await polling_method.run()
+    assert polling_method.resource() is resource
+
+
+@pytest.mark.asyncio
+async def test_terminal_first_response():
+    """The polling method shouldn't sleep when Key Vault's first response indicates the operation is complete"""
+
+    command = mock.Mock(return_value=get_completed_future())
+    polling_method = AsyncDeleteRecoverPollingMethod(command, final_resource=None, finished=False)
+
+    with mock.patch(SLEEP, raise_exception("polling method shouldn't sleep after the operation completes")):
+        await polling_method.run()
+
+    assert command.call_count == 1
+    assert polling_method.finished()
+
+
+@pytest.mark.asyncio
+async def test_propagates_unexpected_error():
+    """The polling method should raise when Key Vault responds with an unexpected error"""
+
+    response = mock_response(status_code=418, json_payload={"error": {"code": 418, "message": "I'm a teapot."}})
+    error = HttpResponseError(response=response)
+    command = mock.Mock(side_effect=error)
+    polling_method = AsyncDeleteRecoverPollingMethod(command, final_resource=None, finished=False)
+
+    with mock.patch(SLEEP, raise_exception("polling method shouldn't sleep after an unexpected error")):
+        with pytest.raises(HttpResponseError):
+            await polling_method.run()
+
+    assert command.call_count == 1


### PR DESCRIPTION
Polling methods currently sleep after every poll, even the one that completes the operation. This PR eliminates that unnecessary sleep, refactors the pollers to be somewhat simpler, and adds test coverage of them.