### PR TITLE
Remove explicit version tag from automation

### DIFF
--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapistorageprod.blob.core.windows.net/sdkautomation/prod/schemas/swagger_to_sdk_config.schema.json",
   "meta": {
     "autorest_options": {
+      "version": "V2",
       "use": "@microsoft.azure/autorest.python@~4.0.71",
       "python": "",
       "python-mode": "update",

--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -2,7 +2,6 @@
   "$schema": "https://openapistorageprod.blob.core.windows.net/sdkautomation/prod/schemas/swagger_to_sdk_config.schema.json",
   "meta": {
     "autorest_options": {
-      "version": "preview",
       "use": "@microsoft.azure/autorest.python@~4.0.71",
       "python": "",
       "python-mode": "update",


### PR DESCRIPTION
In order to not mess up autorest v3 CLI detection of needed core