### PR TITLE
Update core test to properly execute on py2.7

### DIFF
--- a/sdk/core/azure-core/tests/test_universal_pipeline.py
+++ b/sdk/core/azure-core/tests/test_universal_pipeline.py
@@ -269,7 +269,7 @@ def test_raw_deserializer():
     raw_deserializer.on_request(request)
     raw_deserializer.on_response(request, response)
     result = response.context["deserialized_data"]
-    assert result == "é"
+    assert result == u"é"
     assert response.context["response_encoding"] == "utf-8"
     del request.context['response_encoding']
 
@@ -279,7 +279,7 @@ def test_raw_deserializer():
     raw_deserializer.on_request(request)
     raw_deserializer.on_response(request, response)
     result = response.context["deserialized_data"]
-    assert result == "é"
+    assert result == u"é"
     assert response.context["response_encoding"] == "utf-8"
     del request.context['response_encoding']
 
@@ -289,7 +289,7 @@ def test_raw_deserializer():
     raw_deserializer.on_request(request)
     raw_deserializer.on_response(request, response)
     result = response.context["deserialized_data"]
-    assert result == "é"
+    assert result == u"é"
     assert response.context["response_encoding"] == "utf-8-sig"
     del request.context['response_encoding']
 


### PR DESCRIPTION
@lmazuel this is the issue that I wanted to discuss with you yesterday. Essentially, a test has been failing because py2.7 can't successfully interpret the right side of the comparison. However, when it attempts to OUTPUT the failing test, `tox` itself attempts to wrap the test output in a `str()` call, which ITSELF fails. The primary issue here is that the tox invocation DOESN'T melt on that inability to output!

I'll preface any further discussion with 

> yes I am positive this is occurring just here. We aren't silently throwing tests away in other random places. Verified on the `python - all` runs.

This is what _should_ happen when [tox sees this.](https://github.com/tox-dev/tox/issues/1369)
This is what IS happening:

![image](https://user-images.githubusercontent.com/45376673/75387001-7be2f980-5897-11ea-8ce1-8e08f8bc9167.png)

What happens in both a tox local run as well as a default pytest run:

![image](https://user-images.githubusercontent.com/45376673/75386262-37a32980-5896-11ea-82fc-40f0e95726c1.png)
[Build Link for Above](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=271888&view=ms.vss-test-web.build-test-results-tab&runId=9112768&paneView=debug&resultId=100234)

So the left side is absolutely what we expect, and this is just an inability to parse the right side of the comparison. 

I believe this is strictly a bug in how tox is collecting the output during parallel runs, and I'm currently working on a minimum repro. Once I get the repro I'll submit a PR to `tox/tox-dev`. 

Regardless of what we choose for `tox` to resolve going forward, I'm filing an issue for work that should catch issues like this in the future. This kind of error scares me.

@Azure/azure-sdk-eng 



