### PR TITLE
Make certain the job will fail if there are test failures recorded

### DIFF
--- a/eng/pipelines/templates/jobs/tests-nightly-python.yml
+++ b/eng/pipelines/templates/jobs/tests-nightly-python.yml
@@ -47,3 +47,4 @@ jobs:
         inputs:
           testResultsFiles: '**/junit/test-results.xml'
           testRunTitle: '$(OSName) Python $(PythonVersion)'
+          failTaskOnFailedTests: true

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -52,6 +52,7 @@ steps:
     inputs:
       testResultsFiles: '**/*test*.xml'
       testRunTitle: '${{ parameters.OSName }} Python ${{ parameters.PythonVersion }}'
+      failTaskOnFailedTests: true
   
   - template: publish-coverage.yml
     parameters: 


### PR DESCRIPTION
Related to #10007 uncaught error. This will ensure that failing tests will also fail the test upload step (after uploading!).