### PR TITLE
Skip build and egg info folders from pytest collection lookup

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -21,8 +21,8 @@ deps =
 
 
 [testenv]
-ignore_args=--ignore=azure --ignore=build --ignore=.eggs
-default_pytest_params = --junitxml={toxinidir}/test-junit-{envname}.xml --verbose --durations=10 {[testenv]ignore_args}
+ignore_args=--ignore=.tox --ignore=build --ignore=.eggs
+default_pytest_params = --junitxml={toxinidir}/test-junit-{envname}.xml --verbose --durations=10 --ignore=azure {[testenv]ignore_args}
 parallel_show_output =True
 pre-deps =
   wheel
@@ -43,7 +43,6 @@ commands =
     {envbindir}/python -m pip freeze
     pytest \
       {[testenv]default_pytest_params} \
-      --ignore=.tox \
       {posargs} \
       {toxinidir}
 
@@ -90,7 +89,7 @@ commands =
     pytest \
       {posargs} \
       --no-cov \
-      --ignore=.tox \
+      {[testenv]ignore_args} \
       {toxinidir}
 
 

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -21,7 +21,8 @@ deps =
 
 
 [testenv]
-default_pytest_params = --junitxml={toxinidir}/test-junit-{envname}.xml --verbose --durations=10 --ignore=azure
+ignore_args=--ignore=azure --ignore=build --ignore=.eggs
+default_pytest_params = --junitxml={toxinidir}/test-junit-{envname}.xml --verbose --durations=10 {[testenv]ignore_args}
 parallel_show_output =True
 pre-deps =
   wheel

--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -332,6 +332,9 @@ def prep_and_run_tox(targeted_packages, parsed_args, options_array=[]):
         coverage_commands = create_code_coverage_params(parsed_args, package_name)
         local_options_array.extend(coverage_commands)
 
+        pkg_egg_info_name = "{}.egg-info".format(package_name.replace("-", "_"))
+        local_options_array.extend(["--ignore", pkg_egg_info_name])
+
         # if we are targeting only packages that are management plane, it is a possibility
         # that no tests running is an acceptable situation
         # we explicitly handle this here.


### PR DESCRIPTION
pytest lookup all directories within package root directory to collect tests. Build and egg-info folders are modified when packages are getting built and this causes files not accessible issues when one test builds package(which essentially deletes or creates files) while another test lookup these folders to collect test