### PR TITLE
Unpin idna to use latest version

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -12,6 +12,5 @@ coverage==4.5.4
 codecov
 beautifulsoup4
 pkginfo
-idna
 ./tools/azure-devtools
 ./tools/azure-sdk-tools

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -12,6 +12,6 @@ coverage==4.5.4
 codecov
 beautifulsoup4
 pkginfo
-idna==2.8
+idna
 ./tools/azure-devtools
 ./tools/azure-sdk-tools

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -3,6 +3,6 @@ pytest-cov
 pytest-xdist
 pytest-asyncio; python_version >= '3.5'
 coverage==4.5.4
-idna==2.8
+idna
 ../../../tools/azure-devtools
 ../../../tools/azure-sdk-tools

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -3,6 +3,5 @@ pytest-cov
 pytest-xdist
 pytest-asyncio; python_version >= '3.5'
 coverage==4.5.4
-idna
 ../../../tools/azure-devtools
 ../../../tools/azure-sdk-tools


### PR DESCRIPTION
idna was pinned to 2.8 due to dependency requirement issue between requests package and azure-common. requests has released a new version which support idna latest version.