### PR TITLE
servicebus and textanalytics: add missing live_test_only markers to conftest.py

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/tests/conftest.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/conftest.py
@@ -6,6 +6,8 @@
 # license information.
 # --------------------------------------------------------------------------
 
+import os
+import pytest
 import sys
 
 # fixture needs to be visible from conftest
@@ -21,3 +23,22 @@ def pytest_configure(config):
     config.addinivalue_line(
         "usefixtures", "text_analytics_account"
     )
+    config.addinivalue_line(
+        "markers", "live_test_only: mark test to be a live test only"
+    )
+    config.addinivalue_line(
+        "markers", "playback_test_only: mark test to be a playback test only"
+    )
+
+def pytest_runtest_setup(item):
+    is_live_only_test_marked = bool([mark for mark in item.iter_markers(name="live_test_only")])
+    if is_live_only_test_marked:
+        from devtools_testutils import is_live
+        if not is_live():
+            pytest.skip("live test only")
+
+    is_playback_test_marked = bool([mark for mark in item.iter_markers(name="playback_test_only")])
+    if is_playback_test_marked:
+        from devtools_testutils import is_live
+        if is_live() and os.environ.get('AZURE_SKIP_LIVE_RECORDING', '').lower() == 'true':
+            pytest.skip("playback test only")


### PR DESCRIPTION
These tests need to check if they are running live, but the
markers are not in the respective conftest.py files.
Add them.