### PR TITLE
Update pathlib requirement appropriately

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -5,7 +5,7 @@ packaging
 tox
 tox-monorepo
 twine
-importlib-resources-1.0.2
+importlib-resources==1.0.2
 pathlib
 readme-renderer[md]
 doc-warden==0.5.0

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -4,7 +4,7 @@ Jinja2
 packaging
 tox
 tox-monorepo
-pathlib
+pathlib2;python_version<="3.0"
 twine
 readme-renderer[md]
 doc-warden==0.5.0

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -5,6 +5,8 @@ packaging
 tox
 tox-monorepo
 twine
+importlib-resources-1.0.2
+pathlib
 readme-renderer[md]
 doc-warden==0.5.0
 coverage==4.5.4

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -4,7 +4,6 @@ Jinja2
 packaging
 tox
 tox-monorepo
-pathlib2;python_version<="3.0"
 twine
 readme-renderer[md]
 doc-warden==0.5.0


### PR DESCRIPTION
This get's CI to green, but we still don't understand the exact package interaction that is causing this error. `importlib-resources` is a dependency of `virtualenv` (which tox uses on py27 to create the virtual environment), but we don't yet understand why version 1.1.0 is breaking things.

pinning to `importlib-resources==1.0.2` while we continue to dig. In the meantime we can get CI green again.

@lmazuel 
@Azure/azure-sdk-eng 