### PR TITLE
Randomized replayable names for service bus management tests

### DIFF
--- a/sdk/servicebus/azure-mgmt-servicebus/tests/recordings/test_azure_mgmt_servicebus_namespace.test_sb_namespace_curd.yaml
+++ b/sdk/servicebus/azure-mgmt-servicebus/tests/recordings/test_azure_mgmt_servicebus_namespace.test_sb_namespace_curd.yaml
@@ -3,1563 +3,995 @@ interactions:
     body: '{"location": "westus", "tags": {"tag1": "value1", "tag2": "value2"}, "sku":
       {"name": "Standard"}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['97']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '97'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace?api-version=2017-04-01
   response:
-    body: {string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace","name":"testingpythontestcasenamespace","type":"Microsoft.ServiceBus/Namespaces","location":"West
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasenamespace","createdAt":"2018-04-21T00:27:30.67Z","updatedAt":"2018-04-21T00:27:30.67Z","serviceBusEndpoint":"https://testingpythontestcasenamespace.servicebus.windows.net:443/","status":"Activating"}}'}
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace","name":"testingpythontestcasenamespace","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasenamespace","createdAt":"2020-03-03T01:15:52.967Z","updatedAt":"2020-03-03T01:15:52.967Z","serviceBusEndpoint":"https://testingpythontestcasenamespace.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['717']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:27:31 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '719'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:15:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace?api-version=2017-04-01
   response:
-    body: {string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace","name":"testingpythontestcasenamespace","type":"Microsoft.ServiceBus/Namespaces","location":"West
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasenamespace","createdAt":"2018-04-21T00:27:30.67Z","updatedAt":"2018-04-21T00:27:54.417Z","serviceBusEndpoint":"https://testingpythontestcasenamespace.servicebus.windows.net:443/","status":"Active"}}'}
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace","name":"testingpythontestcasenamespace","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasenamespace","createdAt":"2020-03-03T01:15:52.967Z","updatedAt":"2020-03-03T01:15:52.967Z","serviceBusEndpoint":"https://testingpythontestcasenamespace.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['716']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:28:00 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '719'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:16:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace?api-version=2017-04-01
   response:
-    body: {string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace","name":"testingpythontestcasenamespace","type":"Microsoft.ServiceBus/Namespaces","location":"West
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasenamespace","createdAt":"2018-04-21T00:27:30.67Z","updatedAt":"2018-04-21T00:27:54.417Z","serviceBusEndpoint":"https://testingpythontestcasenamespace.servicebus.windows.net:443/","status":"Active"}}'}
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace","name":"testingpythontestcasenamespace","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasenamespace","createdAt":"2020-03-03T01:15:52.967Z","updatedAt":"2020-03-03T01:16:36.24Z","serviceBusEndpoint":"https://testingpythontestcasenamespace.servicebus.windows.net:443/","status":"Active"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['716']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:28:01 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '716'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:16:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace?api-version=2017-04-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace","name":"testingpythontestcasenamespace","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasenamespace","createdAt":"2020-03-03T01:15:52.967Z","updatedAt":"2020-03-03T01:16:36.24Z","serviceBusEndpoint":"https://testingpythontestcasenamespace.servicebus.windows.net:443/","status":"Active"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '716'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:16:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces?api-version=2017-04-01
   response:
-    body: {string: '{"value":[{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace","name":"testingpythontestcasenamespace","type":"Microsoft.ServiceBus/Namespaces","location":"West
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasenamespace","createdAt":"2018-04-21T00:27:30.67Z","updatedAt":"2018-04-21T00:27:54.417Z","serviceBusEndpoint":"https://testingpythontestcasenamespace.servicebus.windows.net:443/","status":"Active"}}]}'}
+    body:
+      string: '{"value":[{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace","name":"testingpythontestcasenamespace","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasenamespace","createdAt":"2020-03-03T01:15:52.967Z","updatedAt":"2020-03-03T01:16:36.24Z","serviceBusEndpoint":"https://testingpythontestcasenamespace.servicebus.windows.net:443/","status":"Active"}}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['728']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:28:02 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '728'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:16:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceBus/namespaces?api-version=2017-04-01
   response:
-    body: {string: "{\"value\":[{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-WestEurope/providers/Microsoft.ServiceBus/namespaces/quicktest-sbe2\"\
-        ,\"name\":\"quicktest-sbe2\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West Europe\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:quicktest-sbe2\"\
-        ,\"createdAt\":\"2015-10-01T17:49:41.35Z\",\"updatedAt\":\"2017-08-09T20:15:07.987Z\"\
-        ,\"serviceBusEndpoint\":\"https://quicktest-sbe2.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RapscallionResources/providers/Microsoft.ServiceBus/namespaces/MassiveSB\"\
-        ,\"name\":\"MassiveSB\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"location\"\
-        :\"Central US\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"\
-        ,\"metricId\":\"00000000-0000-0000-0000-000000000000:massivesb\",\"createdAt\"\
-        :\"2016-10-31T21:03:32.36Z\",\"updatedAt\":\"2017-08-17T21:35:02.51Z\",\"\
-        serviceBusEndpoint\":\"https://MassiveSB.servicebus.windows.net:443/\",\"\
-        status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-CentralUS/providers/Microsoft.ServiceBus/namespaces/rrama-dm2-011-createlatency\"\
-        ,\"name\":\"rrama-dm2-011-createlatency\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:rrama-dm2-011-createlatency\"\
-        ,\"createdAt\":\"2017-08-16T16:59:51.647Z\",\"updatedAt\":\"2017-08-17T21:58:31.533Z\"\
-        ,\"serviceBusEndpoint\":\"https://rrama-dm2-011-createlatency.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-SoutheastAsia/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-southeast-asia\"\
-        ,\"name\":\"sbgm-testns-prod-southeast-asia\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Southeast Asia\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-southeast-asia\"\
-        ,\"createdAt\":\"2015-06-16T21:25:43.823Z\",\"updatedAt\":\"2017-08-22T17:14:36.883Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-southeast-asia.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ardsouza-resourcemovetest-group2/providers/Microsoft.ServiceBus/namespaces/ardsouza-5-11-movetest-SBNamespace\"\
-        ,\"name\":\"ardsouza-5-11-movetest-SBNamespace\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:ardsouza-5-11-movetest-sbnamespace\"\
-        ,\"createdAt\":\"2017-05-11T23:04:08.75Z\",\"updatedAt\":\"2017-08-25T02:17:31.693Z\"\
-        ,\"serviceBusEndpoint\":\"https://ardsouza-5-11-movetest-SBNamespace.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vinsutestgrp/providers/Microsoft.ServiceBus/namespaces/testvinsustd928\"\
-        ,\"name\":\"testvinsustd928\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Brazil South\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testvinsustd928\"\
-        ,\"createdAt\":\"2015-09-29T01:56:34.36Z\",\"updatedAt\":\"2017-08-15T23:15:17.073Z\"\
-        ,\"serviceBusEndpoint\":\"https://testvinsustd928.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ARM-ManagementClient-Testing-RG/providers/Microsoft.ServiceBus/namespaces/ardsouza-12-9\"\
-        ,\"name\":\"ardsouza-12-9\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"South Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:ardsouza-12-9\"\
-        ,\"createdAt\":\"2017-12-09T22:36:39.203Z\",\"updatedAt\":\"2017-12-09T22:39:28.777Z\"\
-        ,\"serviceBusEndpoint\":\"https://ardsouza-12-9.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Premium\",\"tier\":\"Premium\"\
-        ,\"capacity\":4},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/newVinsu/providers/Microsoft.ServiceBus/namespaces/testvinsuWatsonIssue\"\
-        ,\"name\":\"testvinsuWatsonIssue\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testvinsuwatsonissue\"\
-        ,\"createdAt\":\"2016-10-31T19:32:04.88Z\",\"updatedAt\":\"2016-10-31T19:32:52.853Z\"\
-        ,\"serviceBusEndpoint\":\"https://testvinsuWatsonIssue.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-EventHub-CentralUS/providers/Microsoft.ServiceBus/namespaces/rrama-ind-premrepro\"\
-        ,\"name\":\"rrama-ind-premrepro\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"South India\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:rrama-ind-premrepro\"\
-        ,\"createdAt\":\"2017-06-21T17:18:26.42Z\",\"updatedAt\":\"2017-08-15T18:51:09.393Z\"\
-        ,\"serviceBusEndpoint\":\"https://rrama-ind-premrepro.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Premium\",\"tier\":\"Premium\"\
-        ,\"capacity\":1},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/binzytest/providers/Microsoft.ServiceBus/namespaces/msatestns2\"\
-        ,\"name\":\"msatestns2\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"location\"\
-        :\"West Central US\",\"tags\":{},\"properties\":{\"provisioningState\":\"\
-        Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:msatestns2\"\
-        ,\"createdAt\":\"2017-09-15T23:36:00.15Z\",\"updatedAt\":\"2017-09-15T23:37:19.307Z\"\
-        ,\"serviceBusEndpoint\":\"https://msatestns2.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/\xE4\
-        group/providers/Microsoft.ServiceBus/namespaces/slacktype\",\"name\":\"slacktype\"\
-        ,\"type\":\"Microsoft.ServiceBus/Namespaces\",\"location\":\"Central US\"\
-        ,\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\",\"metricId\"\
-        :\"00000000-0000-0000-0000-000000000000:slacktype\",\"createdAt\":\"2017-04-06T17:33:55.433Z\"\
-        ,\"updatedAt\":\"2017-08-17T21:49:43.89Z\",\"serviceBusEndpoint\":\"https://slacktype.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vijayjavaclient/providers/Microsoft.ServiceBus/namespaces/vijayjavaclient\"\
-        ,\"name\":\"vijayjavaclient\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:vijayjavaclient\"\
-        ,\"createdAt\":\"2016-10-19T21:43:01.853Z\",\"updatedAt\":\"2017-08-17T21:28:49.553Z\"\
-        ,\"serviceBusEndpoint\":\"https://vijayjavaclient.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-1921-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-1921-ns\"\
-        ,\"name\":\"sb-dotnet-av-1921-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-1921-ns\"\
-        ,\"createdAt\":\"2017-08-03T01:36:14.313Z\",\"updatedAt\":\"2017-08-03T01:36:41.58Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-1921-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-1971-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-1971-ns\"\
-        ,\"name\":\"sb-dotnet-av-1971-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-1971-ns\"\
-        ,\"createdAt\":\"2017-08-03T17:15:33.937Z\",\"updatedAt\":\"2017-08-03T17:15:56.47Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-1971-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-1431-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-1431-ns\"\
-        ,\"name\":\"sb-dotnet-av-1431-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-1431-ns\"\
-        ,\"createdAt\":\"2017-07-19T23:50:49.357Z\",\"updatedAt\":\"2017-07-19T23:51:15.73Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-1431-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Premium\",\"tier\":\"Premium\"\
-        ,\"capacity\":1},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/alitest/providers/Microsoft.ServiceBus/namespaces/sbusns-secondary-ali\"\
-        ,\"name\":\"sbusns-secondary-ali\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbusns-secondary-ali\"\
-        ,\"createdAt\":\"2018-02-28T19:56:20.963Z\",\"updatedAt\":\"2018-03-13T16:53:12.613Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbusns-secondary-ali.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-NorthCentralUS/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-north-central-us\"\
-        ,\"name\":\"sbgm-testns-prod-north-central-us\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"North Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-north-central-us\"\
-        ,\"createdAt\":\"2015-06-16T21:20:53.3Z\",\"updatedAt\":\"2017-01-12T23:23:59.237Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-north-central-us.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-5211-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-5211-ns\"\
-        ,\"name\":\"sb-dotnet-av-5211-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-5211-ns\"\
-        ,\"createdAt\":\"2018-04-20T00:38:10.65Z\",\"updatedAt\":\"2018-04-20T00:38:34.013Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-5211-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-AustraliaSoutheast/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-australia-southeast\"\
-        ,\"name\":\"sbgm-testns-prod-australia-southeast\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Australia Southeast\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-australia-southeast\"\
-        ,\"createdAt\":\"2015-06-16T21:21:04.137Z\",\"updatedAt\":\"2017-08-15T22:01:28.533Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-australia-southeast.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-NorthEurope/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-north-europe\"\
-        ,\"name\":\"sbgm-testns-prod-north-europe\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"North Europe\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-north-europe\"\
-        ,\"createdAt\":\"2015-06-16T21:23:19.077Z\",\"updatedAt\":\"2017-08-24T22:23:51.167Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-north-europe.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-AustraliaEast/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-5384\"\
-        ,\"name\":\"sdk-Namespace-5384\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Australia East\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sdk-namespace-5384\"\
-        ,\"createdAt\":\"2017-08-09T03:38:18.78Z\",\"updatedAt\":\"2017-08-17T20:51:01.44Z\"\
-        ,\"serviceBusEndpoint\":\"https://sdk-Namespace-5384.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RapscallionResources/providers/Microsoft.ServiceBus/namespaces/BlockFrancoWriteFromThisNamespace\"\
-        ,\"name\":\"BlockFrancoWriteFromThisNamespace\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:blockfrancowritefromthisnamespace\"\
-        ,\"createdAt\":\"2017-10-26T21:24:20.907Z\",\"updatedAt\":\"2017-10-26T21:24:48.63Z\"\
-        ,\"serviceBusEndpoint\":\"https://BlockFrancoWriteFromThisNamespace.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-WestEurope/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-west-europe\"\
-        ,\"name\":\"sbgm-testns-prod-west-europe\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West Europe\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-west-europe\"\
-        ,\"createdAt\":\"2015-06-16T21:24:15.37Z\",\"updatedAt\":\"2017-08-09T19:47:10.35Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-west-europe.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-811-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-811-ns\"\
-        ,\"name\":\"sb-dotnet-av-811-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-811-ns\"\
-        ,\"createdAt\":\"2017-07-01T06:59:45.367Z\",\"updatedAt\":\"2017-07-01T07:00:13.087Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-811-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/ardsouza-crudtest-2-11-2018\"\
-        ,\"name\":\"ardsouza-crudtest-2-11-2018\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"South Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:ardsouza-crudtest-2-11-2018\"\
-        ,\"createdAt\":\"2018-02-12T00:21:08.58Z\",\"updatedAt\":\"2018-02-12T00:21:32.967Z\"\
-        ,\"serviceBusEndpoint\":\"https://ardsouza-crudtest-2-11-2018.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-EastUS/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-east-us\"\
-        ,\"name\":\"sbgm-testns-prod-east-us\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"East US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-east-us\"\
-        ,\"createdAt\":\"2015-06-16T21:18:41.58Z\",\"updatedAt\":\"2017-01-12T23:23:42.847Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-east-us.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-JapanWest/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-japan-west\"\
-        ,\"name\":\"sbgm-testns-prod-japan-west\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Japan West\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-japan-west\"\
-        ,\"createdAt\":\"2015-06-16T21:28:52.083Z\",\"updatedAt\":\"2017-08-17T23:51:22.437Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-japan-west.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4702-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4702-ns\"\
-        ,\"name\":\"sb-dotnet-av-4702-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4702-ns\"\
-        ,\"createdAt\":\"2018-01-11T01:52:58.307Z\",\"updatedAt\":\"2018-01-11T01:53:25.38Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4702-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-5231-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-5231-ns\"\
-        ,\"name\":\"sb-dotnet-av-5231-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-5231-ns\"\
-        ,\"createdAt\":\"2018-04-20T01:50:05.41Z\",\"updatedAt\":\"2018-04-20T01:50:30.14Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-5231-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/binzytest/providers/Microsoft.ServiceBus/namespaces/rrama-ns-8-23\"\
-        ,\"name\":\"rrama-ns-8-23\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\":\"\
-        Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:rrama-ns-8-23\"\
-        ,\"createdAt\":\"2016-08-23T20:48:45.577Z\",\"updatedAt\":\"2017-08-25T01:17:00.177Z\"\
-        ,\"serviceBusEndpoint\":\"https://rrama-ns-8-23.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/nemakam/providers/Microsoft.ServiceBus/namespaces/nemakamtest1\"\
-        ,\"name\":\"nemakamtest1\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"West US 2\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:nemakamtest1\"\
-        ,\"createdAt\":\"2017-01-03T23:45:59.5Z\",\"updatedAt\":\"2017-08-17T22:03:35.653Z\"\
-        ,\"serviceBusEndpoint\":\"https://nemakamtest1.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-NorthEurope/providers/Microsoft.ServiceBus/namespaces/quicktest-sbe\"\
-        ,\"name\":\"quicktest-sbe\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"North Europe\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:quicktest-sbe\"\
-        ,\"createdAt\":\"2015-10-01T17:47:51.28Z\",\"updatedAt\":\"2017-01-12T23:24:44.033Z\"\
-        ,\"serviceBusEndpoint\":\"https://quicktest-sbe.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-JapanEast/providers/Microsoft.ServiceBus/namespaces/testvinsukw918\"\
-        ,\"name\":\"testvinsukw918\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Japan East\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testvinsukw918\"\
-        ,\"createdAt\":\"2015-09-18T20:49:16.85Z\",\"updatedAt\":\"2017-08-16T03:43:27.323Z\"\
-        ,\"serviceBusEndpoint\":\"https://testvinsukw918.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-AustraliaEast/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2690\"\
-        ,\"name\":\"sdk-Namespace-2690\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Australia East\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sdk-namespace-2690\"\
-        ,\"createdAt\":\"2017-08-09T23:33:00.2Z\",\"updatedAt\":\"2017-08-17T20:52:24.153Z\"\
-        ,\"serviceBusEndpoint\":\"https://sdk-Namespace-2690.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/newVinsu/providers/Microsoft.ServiceBus/namespaces/vinsuamqpsqlperftest314\"\
-        ,\"name\":\"vinsuamqpsqlperftest314\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"North Europe\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:vinsuamqpsqlperftest314\"\
-        ,\"createdAt\":\"2017-03-14T17:40:15.657Z\",\"updatedAt\":\"2017-08-23T20:01:51.8Z\"\
-        ,\"serviceBusEndpoint\":\"https://vinsuamqpsqlperftest314.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4411-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4411-ns\"\
-        ,\"name\":\"sb-dotnet-av-4411-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4411-ns\"\
-        ,\"createdAt\":\"2017-12-15T00:12:31.82Z\",\"updatedAt\":\"2017-12-15T00:12:55.42Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4411-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-2352-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-2352-ns\"\
-        ,\"name\":\"sb-dotnet-av-2352-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-2352-ns\"\
-        ,\"createdAt\":\"2017-08-11T16:10:27.7Z\",\"updatedAt\":\"2017-08-11T16:10:53.8Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-2352-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/binzytest/providers/Microsoft.ServiceBus/namespaces/testpartition\"\
-        ,\"name\":\"testpartition\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\":\"\
-        Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testpartition\"\
-        ,\"createdAt\":\"2016-10-19T00:19:15.623Z\",\"updatedAt\":\"2017-08-25T01:33:48.217Z\"\
-        ,\"serviceBusEndpoint\":\"https://testpartition.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-781-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-781-ns\"\
-        ,\"name\":\"sb-dotnet-av-781-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-781-ns\"\
-        ,\"createdAt\":\"2017-06-30T21:53:15.56Z\",\"updatedAt\":\"2017-06-30T21:53:38.45Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-781-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-5131-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-5131-ns\"\
-        ,\"name\":\"sb-dotnet-av-5131-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-5131-ns\"\
-        ,\"createdAt\":\"2018-04-02T23:14:14.907Z\",\"updatedAt\":\"2018-04-02T23:14:38.003Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-5131-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RichardTestGroup/providers/Microsoft.ServiceBus/namespaces/aaa-001\"\
-        ,\"name\":\"aaa-001\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"location\"\
-        :\"West US\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"\
-        ,\"metricId\":\"00000000-0000-0000-0000-000000000000:aaa-001\",\"createdAt\"\
-        :\"2017-05-11T19:42:23.74Z\",\"updatedAt\":\"2017-08-25T02:17:30.693Z\",\"\
-        serviceBusEndpoint\":\"https://aaa-001.servicebus.windows.net:443/\",\"status\"\
-        :\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"},\"id\"\
-        :\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-2221-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-2221-ns\"\
-        ,\"name\":\"sb-dotnet-av-2221-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-2221-ns\"\
-        ,\"createdAt\":\"2017-08-10T06:08:29.383Z\",\"updatedAt\":\"2017-08-10T06:08:56.89Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-2221-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AAA-Default-ServiceBus-NewRegions-Testing/providers/Microsoft.ServiceBus/namespaces/Ardsouza-Canada-EastTest\"\
-        ,\"name\":\"Ardsouza-Canada-EastTest\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Canada East\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:ardsouza-canada-easttest\"\
-        ,\"createdAt\":\"2017-05-02T19:38:28.617Z\",\"updatedAt\":\"2017-08-22T16:57:53.587Z\"\
-        ,\"serviceBusEndpoint\":\"https://Ardsouza-Canada-EastTest.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-3291-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-3291-ns\"\
-        ,\"name\":\"sb-dotnet-av-3291-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-3291-ns\"\
-        ,\"createdAt\":\"2017-09-16T00:15:22.96Z\",\"updatedAt\":\"2017-09-16T00:15:47.757Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-3291-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-WestUS/providers/Microsoft.ServiceBus/namespaces/TestingthePwr2017\"\
-        ,\"name\":\"TestingthePwr2017\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testingthepwr2017\"\
-        ,\"createdAt\":\"2017-07-23T23:34:02.043Z\",\"updatedAt\":\"2017-07-23T23:34:27.567Z\"\
-        ,\"serviceBusEndpoint\":\"https://TestingthePwr2017.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-91-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-91-ns\"\
-        ,\"name\":\"sb-dotnet-av-91-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-91-ns\"\
-        ,\"createdAt\":\"2017-06-02T21:53:09.447Z\",\"updatedAt\":\"2017-06-02T21:53:31.99Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-91-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-WestUS/providers/Microsoft.ServiceBus/namespaces/TestingRCPwr201711\"\
-        ,\"name\":\"TestingRCPwr201711\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testingrcpwr201711\"\
-        ,\"createdAt\":\"2017-08-08T17:09:26.94Z\",\"updatedAt\":\"2017-08-08T17:11:13.497Z\"\
-        ,\"serviceBusEndpoint\":\"https://TestingRCPwr201711.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vinsutest15/providers/Microsoft.ServiceBus/namespaces/vinsuafterSendFix\"\
-        ,\"name\":\"vinsuafterSendFix\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:vinsuaftersendfix\"\
-        ,\"createdAt\":\"2017-01-21T02:37:11.79Z\",\"updatedAt\":\"2017-08-25T01:49:28.46Z\"\
-        ,\"serviceBusEndpoint\":\"https://vinsuafterSendFix.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4381-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4381-ns\"\
-        ,\"name\":\"sb-dotnet-av-4381-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4381-ns\"\
-        ,\"createdAt\":\"2017-12-14T20:48:32.503Z\",\"updatedAt\":\"2017-12-14T20:48:57.247Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4381-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-CentralIndia/providers/Microsoft.ServiceBus/namespaces/rrama-upgradetest\"\
-        ,\"name\":\"rrama-upgradetest\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:rrama-upgradetest\"\
-        ,\"createdAt\":\"2017-06-02T00:29:37.667Z\",\"updatedAt\":\"2017-06-02T00:29:59.72Z\"\
-        ,\"serviceBusEndpoint\":\"https://rrama-upgradetest.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-2201-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-2201-ns\"\
-        ,\"name\":\"sb-dotnet-av-2201-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-2201-ns\"\
-        ,\"createdAt\":\"2017-08-10T04:30:13.05Z\",\"updatedAt\":\"2017-08-10T04:30:38.317Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-2201-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Basic\",\"tier\":\"Basic\"},\"\
-        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vinsutest/providers/Microsoft.ServiceBus/namespaces/partOnBasic\"\
-        ,\"name\":\"partOnBasic\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"East US\",\"tags\":{},\"properties\":{\"provisioningState\":\"\
-        Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:partonbasic\"\
-        ,\"createdAt\":\"2016-12-14T22:59:00.21Z\",\"updatedAt\":\"2017-08-25T16:57:09.9Z\"\
-        ,\"serviceBusEndpoint\":\"https://partOnBasic.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4342-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4342-ns\"\
-        ,\"name\":\"sb-dotnet-av-4342-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4342-ns\"\
-        ,\"createdAt\":\"2017-12-14T00:31:45.843Z\",\"updatedAt\":\"2017-12-14T00:32:13.4Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4342-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-292-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-292-ns\"\
-        ,\"name\":\"sb-dotnet-av-292-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-292-ns\"\
-        ,\"createdAt\":\"2017-06-15T23:33:08.713Z\",\"updatedAt\":\"2017-06-15T23:33:29.027Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-292-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-3201-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-3201-ns\"\
-        ,\"name\":\"sb-dotnet-av-3201-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-3201-ns\"\
-        ,\"createdAt\":\"2017-09-14T22:09:43.817Z\",\"updatedAt\":\"2017-09-14T22:10:06.693Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-3201-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-AustraliaEast/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2455\"\
-        ,\"name\":\"sdk-Namespace-2455\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Australia East\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sdk-namespace-2455\"\
-        ,\"createdAt\":\"2017-08-16T00:31:53.02Z\",\"updatedAt\":\"2017-08-17T20:55:39.073Z\"\
-        ,\"serviceBusEndpoint\":\"https://sdk-Namespace-2455.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AkkaTesting/providers/Microsoft.ServiceBus/namespaces/abhigarg-testns1\"\
-        ,\"name\":\"abhigarg-testns1\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"North Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:abhigarg-testns1\"\
-        ,\"createdAt\":\"2018-03-01T00:20:01.927Z\",\"updatedAt\":\"2018-03-01T00:20:30.91Z\"\
-        ,\"serviceBusEndpoint\":\"https://abhigarg-testns1.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mysamplesvtest/providers/Microsoft.ServiceBus/namespaces/sampleeh\"\
-        ,\"name\":\"sampleeh\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"location\"\
-        :\"Central US\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"\
-        ,\"metricId\":\"00000000-0000-0000-0000-000000000000:sampleeh\",\"createdAt\"\
-        :\"2016-08-08T17:00:25.86Z\",\"updatedAt\":\"2017-08-17T21:25:15.643Z\",\"\
-        serviceBusEndpoint\":\"https://sampleeh.servicebus.windows.net:443/\",\"status\"\
-        :\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"},\"id\"\
-        :\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4781-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4781-ns\"\
-        ,\"name\":\"sb-dotnet-av-4781-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4781-ns\"\
-        ,\"createdAt\":\"2018-02-13T01:49:53.82Z\",\"updatedAt\":\"2018-02-13T01:50:20.427Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4781-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-CentralIndia/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-central-india\"\
-        ,\"name\":\"sbgm-testns-prod-central-india\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Central India\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Created\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-central-india\"\
-        ,\"createdAt\":\"2015-09-25T18:52:18.553Z\",\"updatedAt\":\"2017-01-12T23:24:34.61Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-central-india.servicebus.windows.net:443/\"\
-        ,\"status\":\"Activating\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4631-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4631-ns\"\
-        ,\"name\":\"sb-dotnet-av-4631-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4631-ns\"\
-        ,\"createdAt\":\"2017-12-15T20:10:07.88Z\",\"updatedAt\":\"2017-12-15T20:10:32.637Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4631-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-2291-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-2291-ns\"\
-        ,\"name\":\"sb-dotnet-av-2291-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-2291-ns\"\
-        ,\"createdAt\":\"2017-08-11T02:37:27.16Z\",\"updatedAt\":\"2017-08-11T02:37:51.697Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-2291-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4571-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4571-ns\"\
-        ,\"name\":\"sb-dotnet-av-4571-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4571-ns\"\
-        ,\"createdAt\":\"2017-12-15T11:40:40.7Z\",\"updatedAt\":\"2017-12-15T11:41:08.183Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4571-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Basic\",\"tier\":\"Basic\"},\"\
-        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vinsutestgrp/providers/Microsoft.ServiceBus/namespaces/testvinsubasic924\"\
-        ,\"name\":\"testvinsubasic924\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"North Europe\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testvinsubasic924\"\
-        ,\"createdAt\":\"2015-09-25T00:43:22.303Z\",\"updatedAt\":\"2015-09-25T00:43:28.823Z\"\
-        ,\"serviceBusEndpoint\":\"https://testvinsubasic924.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Premium\",\"tier\":\"Premium\"\
-        ,\"capacity\":1},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vinaytest/providers/Microsoft.ServiceBus/namespaces/testvinsuprem928\"\
-        ,\"name\":\"testvinsuprem928\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testvinsuprem928\"\
-        ,\"createdAt\":\"2015-09-29T02:00:30.503Z\",\"updatedAt\":\"2018-02-02T19:11:10.453Z\"\
-        ,\"serviceBusEndpoint\":\"https://testvinsuprem928.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Basic\",\"tier\":\"Basic\"},\"\
-        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vinaytest/providers/Microsoft.ServiceBus/namespaces/testvinsubasic928\"\
-        ,\"name\":\"testvinsubasic928\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"East Asia\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testvinsubasic928\"\
-        ,\"createdAt\":\"2015-09-29T01:58:45.487Z\",\"updatedAt\":\"2017-08-03T01:18:41.713Z\"\
-        ,\"serviceBusEndpoint\":\"https://testvinsubasic928.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-EastUS/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-sn1\"\
-        ,\"name\":\"sbgm-testns-prod-sn1\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"East US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-sn1\"\
-        ,\"createdAt\":\"2015-06-16T21:18:20.947Z\",\"updatedAt\":\"2017-01-12T23:23:42.847Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-sn1.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ARM-ManagementClient-Testing-RG/providers/Microsoft.ServiceBus/namespaces/ardsouza-testNS-4-28-5\"\
-        ,\"name\":\"ardsouza-testNS-4-28-5\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:ardsouza-testns-4-28-5\"\
-        ,\"createdAt\":\"2017-04-29T03:05:38.65Z\",\"updatedAt\":\"2017-08-25T02:11:28.32Z\"\
-        ,\"serviceBusEndpoint\":\"https://ardsouza-testNS-4-28-5.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Basic\",\"tier\":\"Basic\"},\"\
-        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ARM-ManagementClient-Testing-RG/providers/Microsoft.ServiceBus/namespaces/ardsouza-testNS-4-28-4\"\
-        ,\"name\":\"ardsouza-testNS-4-28-4\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:ardsouza-testns-4-28-4\"\
-        ,\"createdAt\":\"2017-04-29T02:35:09.907Z\",\"updatedAt\":\"2017-08-25T02:16:57.767Z\"\
-        ,\"serviceBusEndpoint\":\"https://ardsouza-testNS-4-28-4.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Basic\",\"tier\":\"Basic\"},\"\
-        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ARM-ManagementClient-Testing-RG/providers/Microsoft.ServiceBus/namespaces/ardsouza-testNS-4-28-3\"\
-        ,\"name\":\"ardsouza-testNS-4-28-3\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:ardsouza-testns-4-28-3\"\
-        ,\"createdAt\":\"2017-04-29T02:22:27.973Z\",\"updatedAt\":\"2017-08-25T02:11:02.937Z\"\
-        ,\"serviceBusEndpoint\":\"https://ardsouza-testNS-4-28-3.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Basic\",\"tier\":\"Basic\"},\"\
-        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ARM-ManagementClient-Testing-RG/providers/Microsoft.ServiceBus/namespaces/ardsouza-testNS-4-28-2\"\
-        ,\"name\":\"ardsouza-testNS-4-28-2\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:ardsouza-testns-4-28-2\"\
-        ,\"createdAt\":\"2017-04-29T02:16:41.393Z\",\"updatedAt\":\"2017-08-25T02:11:28.07Z\"\
-        ,\"serviceBusEndpoint\":\"https://ardsouza-testNS-4-28-2.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vijayjavaclienttests/providers/Microsoft.ServiceBus/namespaces/vijayaadtest\"\
-        ,\"name\":\"vijayaadtest\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"East US 2\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:vijayaadtest\"\
-        ,\"createdAt\":\"2017-12-15T02:02:38.617Z\",\"updatedAt\":\"2017-12-15T02:03:05.287Z\"\
-        ,\"serviceBusEndpoint\":\"https://vijayaadtest.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4812-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4812-ns\"\
-        ,\"name\":\"sb-dotnet-av-4812-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4812-ns\"\
-        ,\"createdAt\":\"2018-02-13T04:40:11.337Z\",\"updatedAt\":\"2018-02-13T04:40:37.177Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4812-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/alitest/providers/Microsoft.ServiceBus/namespaces/alitestsb-1\"\
-        ,\"name\":\"alitestsb-1\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"South Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:alitestsb-1\"\
-        ,\"createdAt\":\"2017-12-07T23:18:52.473Z\",\"updatedAt\":\"2017-12-07T23:20:10.82Z\"\
-        ,\"serviceBusEndpoint\":\"https://alitestsb-1.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/alitest/providers/Microsoft.ServiceBus/namespaces/alitestsb\"\
-        ,\"name\":\"alitestsb\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"location\"\
-        :\"East US 2\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"\
-        ,\"metricId\":\"00000000-0000-0000-0000-000000000000:alitestsb\",\"createdAt\"\
-        :\"2017-11-20T18:24:43.903Z\",\"updatedAt\":\"2017-11-20T18:25:17.637Z\",\"\
-        serviceBusEndpoint\":\"https://alitestsb.servicebus.windows.net:443/\",\"\
-        status\":\"Active\"}},{\"sku\":{\"name\":\"Premium\",\"tier\":\"Premium\"\
-        ,\"capacity\":1},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/binzytest/providers/Microsoft.ServiceBus/namespaces/binzy-premium\"\
-        ,\"name\":\"binzy-premium\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\":\"\
-        Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:binzy-premium\"\
-        ,\"createdAt\":\"2016-10-03T23:06:39.077Z\",\"updatedAt\":\"2017-12-15T23:59:13.023Z\"\
-        ,\"serviceBusEndpoint\":\"https://binzy-premium.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Premium\",\"tier\":\"Premium\"\
-        ,\"capacity\":1},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vijaypremiumjavaclienttests/providers/Microsoft.ServiceBus/namespaces/vijaypremiumjavaclienttests\"\
-        ,\"name\":\"vijaypremiumjavaclienttests\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Australia East\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:vijaypremiumjavaclienttests\"\
-        ,\"createdAt\":\"2017-07-11T22:26:21.55Z\",\"updatedAt\":\"2017-07-11T22:27:49.84Z\"\
-        ,\"serviceBusEndpoint\":\"https://vijaypremiumjavaclienttests.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-761-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-761-ns\"\
-        ,\"name\":\"sb-dotnet-av-761-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-761-ns\"\
-        ,\"createdAt\":\"2017-06-30T07:56:03.837Z\",\"updatedAt\":\"2017-06-30T07:56:26.197Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-761-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Premium\",\"tier\":\"Premium\"\
-        ,\"capacity\":1},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/EventHubGeoDRResourceGroup/providers/Microsoft.ServiceBus/namespaces/sb-geodr-scus-1ardsouza-3-13-2018\"\
-        ,\"name\":\"sb-geodr-scus-1ardsouza-3-13-2018\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"South Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-geodr-scus-1ardsouza-3-13-2018\"\
-        ,\"createdAt\":\"2018-03-13T17:04:46.317Z\",\"updatedAt\":\"2018-03-13T17:16:44.78Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-geodr-scus-1ardsouza-3-13-2018.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-EventHub-BrazilSouth/providers/Microsoft.ServiceBus/namespaces/sampletestns\"\
-        ,\"name\":\"sampletestns\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\":\"\
-        Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sampletestns\"\
-        ,\"createdAt\":\"2017-05-12T17:00:21.603Z\",\"updatedAt\":\"2017-08-25T02:21:02.64Z\"\
-        ,\"serviceBusEndpoint\":\"https://sampletestns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-3131-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-3131-ns\"\
-        ,\"name\":\"sb-dotnet-av-3131-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-3131-ns\"\
-        ,\"createdAt\":\"2017-09-14T21:32:21.263Z\",\"updatedAt\":\"2017-09-14T21:32:46.933Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-3131-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-3191-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-3191-ns\"\
-        ,\"name\":\"sb-dotnet-av-3191-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-3191-ns\"\
-        ,\"createdAt\":\"2017-09-14T22:07:59.72Z\",\"updatedAt\":\"2017-09-14T22:08:22.42Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-3191-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TestResourceGroup/providers/Microsoft.ServiceBus/namespaces/ardsouza-12-10-test\"\
-        ,\"name\":\"ardsouza-12-10-test\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:ardsouza-12-10-test\"\
-        ,\"createdAt\":\"2017-12-10T17:35:47.113Z\",\"updatedAt\":\"2017-12-10T17:36:28.713Z\"\
-        ,\"serviceBusEndpoint\":\"https://ardsouza-12-10-test.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/clemensrbactestmessaging\"\
-        ,\"name\":\"clemensrbactestmessaging\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"South Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:clemensrbactestmessaging\"\
-        ,\"createdAt\":\"2017-11-30T18:11:30.993Z\",\"updatedAt\":\"2017-12-13T17:38:29.58Z\"\
-        ,\"serviceBusEndpoint\":\"https://clemensrbactestmessaging.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-5101-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-5101-ns\"\
-        ,\"name\":\"sb-dotnet-av-5101-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-5101-ns\"\
-        ,\"createdAt\":\"2018-03-30T00:12:33.793Z\",\"updatedAt\":\"2018-03-30T00:12:56.787Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-5101-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-WestUS/providers/Microsoft.ServiceBus/namespaces/TEstingServicebusNamespace\"\
-        ,\"name\":\"TEstingServicebusNamespace\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testingservicebusnamespace\"\
-        ,\"createdAt\":\"2017-07-20T00:33:46.673Z\",\"updatedAt\":\"2017-07-20T00:34:12.827Z\"\
-        ,\"serviceBusEndpoint\":\"https://TEstingServicebusNamespace.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-WestUS/providers/Microsoft.ServiceBus/namespaces/TestingArmTeplateAuto\"\
-        ,\"name\":\"TestingArmTeplateAuto\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testingarmteplateauto\"\
-        ,\"createdAt\":\"2018-01-12T23:08:32.84Z\",\"updatedAt\":\"2018-01-12T23:16:12.38Z\"\
-        ,\"serviceBusEndpoint\":\"https://TestingArmTeplateAuto.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-AustraliaEast/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-1055\"\
-        ,\"name\":\"sdk-Namespace-1055\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Australia East\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sdk-namespace-1055\"\
-        ,\"createdAt\":\"2017-08-16T00:39:00.04Z\",\"updatedAt\":\"2017-08-17T20:49:59.757Z\"\
-        ,\"serviceBusEndpoint\":\"https://sdk-Namespace-1055.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Basic\",\"tier\":\"Basic\"},\"\
-        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ARM-ManagementClient-Testing-RG/providers/Microsoft.ServiceBus/namespaces/ardsouza-testNS-4-28\"\
-        ,\"name\":\"ardsouza-testNS-4-28\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:ardsouza-testns-4-28\"\
-        ,\"createdAt\":\"2017-04-29T02:07:09.213Z\",\"updatedAt\":\"2017-08-25T02:16:57.05Z\"\
-        ,\"serviceBusEndpoint\":\"https://ardsouza-testNS-4-28.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/newVinsu/providers/Microsoft.ServiceBus/namespaces/testdotnetcoreissue122\"\
-        ,\"name\":\"testdotnetcoreissue122\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"North Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testdotnetcoreissue122\"\
-        ,\"createdAt\":\"2017-12-02T22:44:49.697Z\",\"updatedAt\":\"2017-12-02T22:45:43.703Z\"\
-        ,\"serviceBusEndpoint\":\"https://testdotnetcoreissue122.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vijayjavaclienttests/providers/Microsoft.ServiceBus/namespaces/vijayjavaclienttests\"\
-        ,\"name\":\"vijayjavaclienttests\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:vijayjavaclienttests\"\
-        ,\"createdAt\":\"2017-05-26T19:42:19.41Z\",\"updatedAt\":\"2017-08-17T21:51:34.353Z\"\
-        ,\"serviceBusEndpoint\":\"https://vijayjavaclienttests.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vinsutestgrp/providers/Microsoft.ServiceBus/namespaces/testvinsuStandard924\"\
-        ,\"name\":\"testvinsuStandard924\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"North Europe\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testvinsustandard924\"\
-        ,\"createdAt\":\"2015-09-25T00:34:59.83Z\",\"updatedAt\":\"2015-09-25T00:35:03.9Z\"\
-        ,\"serviceBusEndpoint\":\"https://testvinsuStandard924.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-WestUS/providers/Microsoft.ServiceBus/namespaces/TestingArmTeplateAuto1\"\
-        ,\"name\":\"TestingArmTeplateAuto1\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testingarmteplateauto1\"\
-        ,\"createdAt\":\"2018-01-13T00:03:43.23Z\",\"updatedAt\":\"2018-01-13T00:04:08.823Z\"\
-        ,\"serviceBusEndpoint\":\"https://TestingArmTeplateAuto1.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Premium\",\"tier\":\"Premium\"\
-        ,\"capacity\":1},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/EventHubGeoDRResourceGroup/providers/Microsoft.ServiceBus/namespaces/sb-geodr-ncus-1ardsouza-3-13-2018\"\
-        ,\"name\":\"sb-geodr-ncus-1ardsouza-3-13-2018\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"North Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-geodr-ncus-1ardsouza-3-13-2018\"\
-        ,\"createdAt\":\"2018-03-13T17:06:25.38Z\",\"updatedAt\":\"2018-03-13T17:16:41.773Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-geodr-ncus-1ardsouza-3-13-2018.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-EastAsia/providers/Microsoft.ServiceBus/namespaces/testhkn94\"\
-        ,\"name\":\"testhkn94\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"location\"\
-        :\"East Asia\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"\
-        ,\"metricId\":\"00000000-0000-0000-0000-000000000000:testhkn94\",\"createdAt\"\
-        :\"2015-09-04T12:21:47.223Z\",\"updatedAt\":\"2017-08-03T01:06:19.253Z\",\"\
-        serviceBusEndpoint\":\"https://testhkn94.servicebus.windows.net:443/\",\"\
-        status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-341-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-341-ns\"\
-        ,\"name\":\"sb-dotnet-av-341-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-341-ns\"\
-        ,\"createdAt\":\"2017-06-16T23:10:08.27Z\",\"updatedAt\":\"2017-06-16T23:10:33.223Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-341-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-south-central-us\"\
-        ,\"name\":\"sbgm-testns-prod-south-central-us\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"South Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-south-central-us\"\
-        ,\"createdAt\":\"2015-06-16T21:21:58.993Z\",\"updatedAt\":\"2017-08-25T19:57:36.087Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-south-central-us.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-WestUS/providers/Microsoft.ServiceBus/namespaces/TemplateNamspaceAutofwd\"\
-        ,\"name\":\"TemplateNamspaceAutofwd\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:templatenamspaceautofwd\"\
-        ,\"createdAt\":\"2018-01-13T00:16:40.47Z\",\"updatedAt\":\"2018-01-13T00:17:06.947Z\"\
-        ,\"serviceBusEndpoint\":\"https://TemplateNamspaceAutofwd.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-1901-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-1901-ns\"\
-        ,\"name\":\"sb-dotnet-av-1901-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-1901-ns\"\
-        ,\"createdAt\":\"2017-08-03T01:18:31.183Z\",\"updatedAt\":\"2017-08-03T01:18:58.497Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-1901-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-711-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-711-ns\"\
-        ,\"name\":\"sb-dotnet-av-711-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-711-ns\"\
-        ,\"createdAt\":\"2017-06-30T02:19:49.3Z\",\"updatedAt\":\"2017-06-30T02:20:13.493Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-711-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-2232-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-2232-ns\"\
-        ,\"name\":\"sb-dotnet-av-2232-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-2232-ns\"\
-        ,\"createdAt\":\"2017-08-10T06:30:30.913Z\",\"updatedAt\":\"2017-08-10T06:30:54.147Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-2232-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-1711-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-1711-ns\"\
-        ,\"name\":\"sb-dotnet-av-1711-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-1711-ns\"\
-        ,\"createdAt\":\"2017-07-27T22:14:08.153Z\",\"updatedAt\":\"2017-07-27T22:14:31.02Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-1711-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace\"\
-        ,\"name\":\"testingpythontestcasenamespace\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{\"tag1\":\"value1\",\"tag2\":\"value2\"\
-        },\"properties\":{\"provisioningState\":\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testingpythontestcasenamespace\"\
-        ,\"createdAt\":\"2018-04-21T00:27:30.67Z\",\"updatedAt\":\"2018-04-21T00:27:54.417Z\"\
-        ,\"serviceBusEndpoint\":\"https://testingpythontestcasenamespace.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-WestIndia/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-west-india\"\
-        ,\"name\":\"sbgm-testns-prod-west-india\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West India\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-west-india\"\
-        ,\"createdAt\":\"2017-01-20T23:53:32.69Z\",\"updatedAt\":\"2017-01-20T23:53:56.937Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-west-india.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dstucki-test-rg-usw/providers/Microsoft.ServiceBus/namespaces/dstucki-sb-usw\"\
-        ,\"name\":\"dstucki-sb-usw\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:dstucki-sb-usw\"\
-        ,\"createdAt\":\"2018-01-23T19:47:12.25Z\",\"updatedAt\":\"2018-01-30T21:12:01.27Z\"\
-        ,\"serviceBusEndpoint\":\"https://dstucki-sb-usw.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ARM-ManagementClient-Testing-RG/providers/Microsoft.ServiceBus/namespaces/ardsouza-test7-24\"\
-        ,\"name\":\"ardsouza-test7-24\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Canada Central\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:ardsouza-test7-24\"\
-        ,\"createdAt\":\"2017-07-24T23:34:29.137Z\",\"updatedAt\":\"2017-07-24T23:34:51.3Z\"\
-        ,\"serviceBusEndpoint\":\"https://ardsouza-test7-24.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Basic\",\"tier\":\"Basic\"},\"\
-        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/binzytest/providers/Microsoft.ServiceBus/namespaces/rrama-8-22\"\
-        ,\"name\":\"rrama-8-22\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"location\"\
-        :\"West US\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"\
-        ,\"metricId\":\"00000000-0000-0000-0000-000000000000:rrama-8-22\",\"createdAt\"\
-        :\"2016-08-22T23:06:13.51Z\",\"updatedAt\":\"2017-08-25T01:15:37.553Z\",\"\
-        serviceBusEndpoint\":\"https://rrama-8-22.servicebus.windows.net:443/\",\"\
-        status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/binzytest/providers/Microsoft.ServiceBus/namespaces/rrama-ns-8-9\"\
-        ,\"name\":\"rrama-ns-8-9\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\":\"\
-        Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:rrama-ns-8-9\"\
-        ,\"createdAt\":\"2016-08-09T23:05:49.883Z\",\"updatedAt\":\"2017-08-25T01:11:13.767Z\"\
-        ,\"serviceBusEndpoint\":\"https://rrama-ns-8-9.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-731-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-731-ns\"\
-        ,\"name\":\"sb-dotnet-av-731-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-731-ns\"\
-        ,\"createdAt\":\"2017-06-30T05:16:14.243Z\",\"updatedAt\":\"2017-06-30T05:16:39.583Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-731-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TwitterGroup/providers/Microsoft.ServiceBus/namespaces/saz-test-22\"\
-        ,\"name\":\"saz-test-22\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\":\"\
-        Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:saz-test-22\"\
-        ,\"createdAt\":\"2016-07-06T00:00:07.063Z\",\"updatedAt\":\"2017-08-25T01:06:33.797Z\"\
-        ,\"serviceBusEndpoint\":\"https://saz-test-22.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-1421-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-1421-ns\"\
-        ,\"name\":\"sb-dotnet-av-1421-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-1421-ns\"\
-        ,\"createdAt\":\"2017-07-19T19:41:41.643Z\",\"updatedAt\":\"2017-07-19T19:42:08.99Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-1421-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4531-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4531-ns\"\
-        ,\"name\":\"sb-dotnet-av-4531-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4531-ns\"\
-        ,\"createdAt\":\"2017-12-15T11:21:34.167Z\",\"updatedAt\":\"2017-12-15T11:21:59.73Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4531-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-311-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-311-ns\"\
-        ,\"name\":\"sb-dotnet-av-311-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-311-ns\"\
-        ,\"createdAt\":\"2017-06-16T00:49:46.527Z\",\"updatedAt\":\"2017-06-16T00:50:07.52Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-311-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RapscallionResources/providers/Microsoft.ServiceBus/namespaces/RapscallionsDisabled\"\
-        ,\"name\":\"RapscallionsDisabled\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:rapscallionsdisabled\"\
-        ,\"createdAt\":\"2016-10-06T21:36:02.35Z\",\"updatedAt\":\"2017-08-17T21:28:17.957Z\"\
-        ,\"serviceBusEndpoint\":\"https://RapscallionsDisabled.servicebus.windows.net:443/\"\
-        ,\"status\":\"Disabled\"}},{\"sku\":{\"name\":\"Premium\",\"tier\":\"Premium\"\
-        ,\"capacity\":1},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-BizTalk-West-US/providers/Microsoft.ServiceBus/namespaces/oiwjoidjojs\"\
-        ,\"name\":\"oiwjoidjojs\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\":\"\
-        Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:oiwjoidjojs\"\
-        ,\"createdAt\":\"2017-04-26T22:26:11.71Z\",\"updatedAt\":\"2017-04-26T22:27:29.077Z\"\
-        ,\"serviceBusEndpoint\":\"https://oiwjoidjojs.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-AustraliaEast/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-4216\"\
-        ,\"name\":\"sdk-Namespace-4216\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Australia East\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sdk-namespace-4216\"\
-        ,\"createdAt\":\"2017-08-09T23:36:40.42Z\",\"updatedAt\":\"2017-08-17T20:47:30.167Z\"\
-        ,\"serviceBusEndpoint\":\"https://sdk-Namespace-4216.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4322-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4322-ns\"\
-        ,\"name\":\"sb-dotnet-av-4322-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4322-ns\"\
-        ,\"createdAt\":\"2017-12-13T19:45:46.753Z\",\"updatedAt\":\"2017-12-13T19:46:10.733Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4322-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4491-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4491-ns\"\
-        ,\"name\":\"sb-dotnet-av-4491-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4491-ns\"\
-        ,\"createdAt\":\"2017-12-15T09:29:28.107Z\",\"updatedAt\":\"2017-12-15T09:30:05.927Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4491-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Basic\",\"tier\":\"Basic\"},\"\
-        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RapscallionResources/providers/Microsoft.ServiceBus/namespaces/Rapscallion\"\
-        ,\"name\":\"Rapscallion\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:rapscallion\"\
-        ,\"createdAt\":\"2016-08-22T23:24:10.64Z\",\"updatedAt\":\"2017-08-17T21:25:41.847Z\"\
-        ,\"serviceBusEndpoint\":\"https://Rapscallion.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RapscallionResources/providers/Microsoft.ServiceBus/namespaces/Rapscallions\"\
-        ,\"name\":\"Rapscallions\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:rapscallions\"\
-        ,\"createdAt\":\"2016-08-23T17:41:32.93Z\",\"updatedAt\":\"2017-08-17T21:25:43.197Z\"\
-        ,\"serviceBusEndpoint\":\"https://Rapscallions.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4511-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4511-ns\"\
-        ,\"name\":\"sb-dotnet-av-4511-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4511-ns\"\
-        ,\"createdAt\":\"2017-12-15T10:30:12.217Z\",\"updatedAt\":\"2017-12-15T10:30:40.197Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4511-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-331-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-331-ns\"\
-        ,\"name\":\"sb-dotnet-av-331-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-331-ns\"\
-        ,\"createdAt\":\"2017-06-16T18:47:43.827Z\",\"updatedAt\":\"2017-06-16T18:48:09.61Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-331-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-1871-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-1871-ns\"\
-        ,\"name\":\"sb-dotnet-av-1871-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-1871-ns\"\
-        ,\"createdAt\":\"2017-08-02T22:34:52.633Z\",\"updatedAt\":\"2017-08-02T22:35:19.733Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-1871-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-282-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-282-ns\"\
-        ,\"name\":\"sb-dotnet-av-282-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-282-ns\"\
-        ,\"createdAt\":\"2017-06-15T21:55:36.727Z\",\"updatedAt\":\"2017-06-15T21:55:58.583Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-282-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-3681-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-3681-ns\"\
-        ,\"name\":\"sb-dotnet-av-3681-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-3681-ns\"\
-        ,\"createdAt\":\"2017-10-07T00:29:31.463Z\",\"updatedAt\":\"2017-10-07T00:29:54.887Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-3681-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Premium\",\"tier\":\"Premium\"\
-        ,\"capacity\":1},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/alitest/providers/Microsoft.ServiceBus/namespaces/sbns-primary-ali\"\
-        ,\"name\":\"sbns-primary-ali\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"East US 2\",\"tags\":{\"displayName\":\"ServiceBus1\"},\"\
-        properties\":{\"provisioningState\":\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbns-primary-ali\"\
-        ,\"createdAt\":\"2018-02-28T01:50:32.4Z\",\"updatedAt\":\"2018-03-13T16:53:15.663Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbns-primary-ali.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TwitterGroup/providers/Microsoft.ServiceBus/namespaces/saz-test-222\"\
-        ,\"name\":\"saz-test-222\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\":\"\
-        Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:saz-test-222\"\
-        ,\"createdAt\":\"2016-07-06T00:14:40.12Z\",\"updatedAt\":\"2017-08-25T01:03:04.827Z\"\
-        ,\"serviceBusEndpoint\":\"https://saz-test-222.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-SouthCentralUS/providers/Microsoft.ServiceBus/namespaces/deadletterforwardtotest\"\
-        ,\"name\":\"deadletterforwardtotest\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"South Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:deadletterforwardtotest\"\
-        ,\"createdAt\":\"2017-07-27T17:38:39.35Z\",\"updatedAt\":\"2017-07-27T17:39:12.15Z\"\
-        ,\"serviceBusEndpoint\":\"https://deadletterforwardtotest.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4441-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4441-ns\"\
-        ,\"name\":\"sb-dotnet-av-4441-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4441-ns\"\
-        ,\"createdAt\":\"2017-12-15T04:55:32.543Z\",\"updatedAt\":\"2017-12-15T04:55:57.27Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4441-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testeh-delete/providers/Microsoft.ServiceBus/namespaces/rrama-arm-easdtus-8-4-2\"\
-        ,\"name\":\"rrama-arm-easdtus-8-4-2\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"East US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:rrama-arm-easdtus-8-4-2\"\
-        ,\"createdAt\":\"2017-08-04T17:27:56.02Z\",\"updatedAt\":\"2017-08-04T17:28:22.91Z\"\
-        ,\"serviceBusEndpoint\":\"https://rrama-arm-easdtus-8-4-2.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testeh-delete/providers/Microsoft.ServiceBus/namespaces/rrama-arm-easdtus-8-4-1\"\
-        ,\"name\":\"rrama-arm-easdtus-8-4-1\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"East US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:rrama-arm-easdtus-8-4-1\"\
-        ,\"createdAt\":\"2017-08-04T17:21:35.86Z\",\"updatedAt\":\"2017-08-04T17:22:01.66Z\"\
-        ,\"serviceBusEndpoint\":\"https://rrama-arm-easdtus-8-4-1.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-CentralUS/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-central-us\"\
-        ,\"name\":\"sbgm-testns-prod-central-us\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-central-us\"\
-        ,\"createdAt\":\"2015-06-16T21:17:36.18Z\",\"updatedAt\":\"2017-01-12T23:24:03.893Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-central-us.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4792-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4792-ns\"\
-        ,\"name\":\"sb-dotnet-av-4792-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4792-ns\"\
-        ,\"createdAt\":\"2018-02-13T02:24:40.277Z\",\"updatedAt\":\"2018-02-13T02:25:07.41Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4792-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/alitest/providers/Microsoft.ServiceBus/namespaces/alitestsb-backup\"\
-        ,\"name\":\"alitestsb-backup\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"North Central US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:alitestsb-backup\"\
-        ,\"createdAt\":\"2017-12-07T22:21:52.317Z\",\"updatedAt\":\"2017-12-07T22:22:21.23Z\"\
-        ,\"serviceBusEndpoint\":\"https://alitestsb-backup.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/LuesbuebliResources/providers/Microsoft.ServiceBus/namespaces/sblues\"\
-        ,\"name\":\"sblues\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"location\"\
-        :\"Central US\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"\
-        ,\"metricId\":\"00000000-0000-0000-0000-000000000000:sblues\",\"createdAt\"\
-        :\"2016-09-01T01:03:51.877Z\",\"updatedAt\":\"2017-08-17T21:23:20.527Z\",\"\
-        serviceBusEndpoint\":\"https://sblues.servicebus.windows.net:443/\",\"status\"\
-        :\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"},\"id\"\
-        :\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-EastUS2/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-east-us-2\"\
-        ,\"name\":\"sbgm-testns-prod-east-us-2\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"East US 2\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-east-us-2\"\
-        ,\"createdAt\":\"2015-06-16T21:19:47.437Z\",\"updatedAt\":\"2017-01-12T23:24:05.097Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-east-us-2.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-WestUS/providers/Microsoft.ServiceBus/namespaces/testingTopicAuto11\"\
-        ,\"name\":\"testingTopicAuto11\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testingtopicauto11\"\
-        ,\"createdAt\":\"2018-01-12T23:58:06.097Z\",\"updatedAt\":\"2018-01-12T23:58:35.127Z\"\
-        ,\"serviceBusEndpoint\":\"https://testingTopicAuto11.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4332-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4332-ns\"\
-        ,\"name\":\"sb-dotnet-av-4332-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4332-ns\"\
-        ,\"createdAt\":\"2017-12-13T22:56:21.083Z\",\"updatedAt\":\"2017-12-13T22:56:47.513Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4332-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-SouthIndia/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-south-india\"\
-        ,\"name\":\"sbgm-testns-prod-south-india\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"South India\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Created\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-south-india\"\
-        ,\"createdAt\":\"2015-09-25T18:53:03.69Z\",\"updatedAt\":\"2017-01-12T23:24:39.58Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-south-india.servicebus.windows.net:443/\"\
-        ,\"status\":\"Activating\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-JapanEast/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-japan-east\"\
-        ,\"name\":\"sbgm-testns-prod-japan-east\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Japan East\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-japan-east\"\
-        ,\"createdAt\":\"2015-06-18T01:53:13.697Z\",\"updatedAt\":\"2017-08-16T03:42:22.983Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-japan-east.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4611-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4611-ns\"\
-        ,\"name\":\"sb-dotnet-av-4611-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4611-ns\"\
-        ,\"createdAt\":\"2017-12-15T19:23:03.03Z\",\"updatedAt\":\"2017-12-15T19:23:28.387Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4611-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vijayjavaclienttests/providers/Microsoft.ServiceBus/namespaces/VijayBYNS\"\
-        ,\"name\":\"VijayBYNS\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"location\"\
-        :\"West US\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"\
-        ,\"metricId\":\"00000000-0000-0000-0000-000000000000:vijaybyns\",\"createdAt\"\
-        :\"2018-01-04T23:24:03.083Z\",\"updatedAt\":\"2018-01-04T23:24:26.063Z\",\"\
-        serviceBusEndpoint\":\"https://VijayBYNS.servicebus.windows.net:443/\",\"\
-        status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-AustraliaEast/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-2850\"\
-        ,\"name\":\"sdk-Namespace-2850\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Australia East\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sdk-namespace-2850\"\
-        ,\"createdAt\":\"2017-08-16T00:33:12.503Z\",\"updatedAt\":\"2017-08-17T20:47:43.95Z\"\
-        ,\"serviceBusEndpoint\":\"https://sdk-Namespace-2850.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-BrazilSouth/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-brazil-south\"\
-        ,\"name\":\"sbgm-testns-prod-brazil-south\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Brazil South\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-brazil-south\"\
-        ,\"createdAt\":\"2015-06-16T21:26:22.883Z\",\"updatedAt\":\"2017-08-15T23:24:43.767Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-brazil-south.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Premium\",\"tier\":\"Premium\"\
-        ,\"capacity\":4},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vinsutest/providers/Microsoft.ServiceBus/namespaces/premiumrepro1032017\"\
-        ,\"name\":\"premiumrepro1032017\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:premiumrepro1032017\"\
-        ,\"createdAt\":\"2016-10-03T21:58:59.23Z\",\"updatedAt\":\"2016-10-03T21:59:53.897Z\"\
-        ,\"serviceBusEndpoint\":\"https://premiumrepro1032017.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-WestUS/providers/Microsoft.ServiceBus/namespaces/TestingRCPwr2017\"\
-        ,\"name\":\"TestingRCPwr2017\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:testingrcpwr2017\"\
-        ,\"createdAt\":\"2017-08-08T01:14:33.473Z\",\"updatedAt\":\"2017-08-08T01:15:02.303Z\"\
-        ,\"serviceBusEndpoint\":\"https://TestingRCPwr2017.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-AustraliaEast/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-australia-east\"\
-        ,\"name\":\"sbgm-testns-prod-australia-east\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"Australia East\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-australia-east\"\
-        ,\"createdAt\":\"2015-06-16T21:19:52.407Z\",\"updatedAt\":\"2017-08-17T18:58:27.143Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-australia-east.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4822-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4822-ns\"\
-        ,\"name\":\"sb-dotnet-av-4822-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4822-ns\"\
-        ,\"createdAt\":\"2018-02-13T05:17:25.433Z\",\"updatedAt\":\"2018-02-13T05:17:51.43Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4822-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-4362-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-4362-ns\"\
-        ,\"name\":\"sb-dotnet-av-4362-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-4362-ns\"\
-        ,\"createdAt\":\"2017-12-14T03:31:01.483Z\",\"updatedAt\":\"2017-12-14T03:31:26.583Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-4362-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sb-dotnet-av-5091-rg/providers/Microsoft.ServiceBus/namespaces/sb-dotnet-av-5091-ns\"\
-        ,\"name\":\"sb-dotnet-av-5091-ns\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"West US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sb-dotnet-av-5091-ns\"\
-        ,\"createdAt\":\"2018-03-29T23:50:43.503Z\",\"updatedAt\":\"2018-03-29T23:51:06.183Z\"\
-        ,\"serviceBusEndpoint\":\"https://sb-dotnet-av-5091-ns.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/newVinsu/providers/Microsoft.ServiceBus/namespaces/newVinsu1028\"\
-        ,\"name\":\"newVinsu1028\",\"type\":\"Microsoft.ServiceBus/Namespaces\",\"\
-        location\":\"East US\",\"tags\":{},\"properties\":{\"provisioningState\":\"\
-        Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:newvinsu1028\"\
-        ,\"createdAt\":\"2016-10-28T17:34:58.937Z\",\"updatedAt\":\"2017-08-25T16:39:31.713Z\"\
-        ,\"serviceBusEndpoint\":\"https://newVinsu1028.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-EastAsia/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-east-asia\"\
-        ,\"name\":\"sbgm-testns-prod-east-asia\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"East Asia\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-east-asia\"\
-        ,\"createdAt\":\"2015-06-16T21:24:47.43Z\",\"updatedAt\":\"2017-08-03T01:00:57.87Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-east-asia.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}},{\"sku\":{\"name\":\"Standard\",\"tier\":\"Standard\"\
-        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ServiceBus-EastUS/providers/Microsoft.ServiceBus/namespaces/sbgm-testns-prod-ch1\"\
-        ,\"name\":\"sbgm-testns-prod-ch1\",\"type\":\"Microsoft.ServiceBus/Namespaces\"\
-        ,\"location\":\"East US\",\"tags\":{},\"properties\":{\"provisioningState\"\
-        :\"Succeeded\",\"metricId\":\"00000000-0000-0000-0000-000000000000:sbgm-testns-prod-ch1\"\
-        ,\"createdAt\":\"2015-06-16T21:22:38.45Z\",\"updatedAt\":\"2017-01-12T23:23:42.847Z\"\
-        ,\"serviceBusEndpoint\":\"https://sbgm-testns-prod-ch1.servicebus.windows.net:443/\"\
-        ,\"status\":\"Active\"}}]}"}
+    body:
+      string: '{"value":[{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-bcea5dd6-b929-4fb4-a577-2eca84","name":"net-servicebus-bcea5dd6-b929-4fb4-a577-2eca84","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-25T04:50:54Z","cleanup-after":"2020-02-26T04:50:54Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-bcea5dd6-b929-4fb4-a577-2eca84","createdAt":"2020-02-25T04:50:57.377Z","updatedAt":"2020-02-25T04:51:39.907Z","serviceBusEndpoint":"https://net-servicebus-bcea5dd6-b929-4fb4-a577-2eca84.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/jolovservicebus","name":"jolovservicebus","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:jolovservicebus","createdAt":"2020-01-21T21:22:04.863Z","updatedAt":"2020-01-21T21:22:46.82Z","serviceBusEndpoint":"https://jolovservicebus.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/node-sdk-perf/providers/Microsoft.ServiceBus/namespaces/arm-azure-sdk-test-browser-p1","name":"arm-azure-sdk-test-browser-p1","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:arm-azure-sdk-test-browser-p1","createdAt":"2020-01-15T23:13:59.58Z","updatedAt":"2020-01-15T23:14:42.087Z","serviceBusEndpoint":"https://arm-azure-sdk-test-browser-p1.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-c9a28226-2e88-4e6d-9201-d7602b","name":"net-servicebus-c9a28226-2e88-4e6d-9201-d7602b","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-21T20:11:52Z","cleanup-after":"2020-02-22T20:11:52Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-c9a28226-2e88-4e6d-9201-d7602b","createdAt":"2020-02-21T20:11:58.117Z","updatedAt":"2020-02-21T20:12:43.287Z","serviceBusEndpoint":"https://net-servicebus-c9a28226-2e88-4e6d-9201-d7602b.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-491eb0e0-9730-4dd1-afa9-1b3dcf","name":"net-servicebus-491eb0e0-9730-4dd1-afa9-1b3dcf","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-21T20:13:32Z","cleanup-after":"2020-02-22T20:13:32Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-491eb0e0-9730-4dd1-afa9-1b3dcf","createdAt":"2020-02-21T20:13:33.137Z","updatedAt":"2020-02-21T20:14:17.763Z","serviceBusEndpoint":"https://net-servicebus-491eb0e0-9730-4dd1-afa9-1b3dcf.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/HarshasPrivateResourceGroup/providers/Microsoft.ServiceBus/namespaces/harshansb","name":"harshansb","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:harshansb","createdAt":"2020-01-08T23:02:57.8Z","updatedAt":"2020-01-08T23:03:39.99Z","serviceBusEndpoint":"https://harshansb.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/VGroup/providers/Microsoft.ServiceBus/namespaces/vgtestbus","name":"vgtestbus","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:vgtestbus","createdAt":"2019-01-11T01:27:39.21Z","updatedAt":"2019-01-11T01:28:02.693Z","serviceBusEndpoint":"https://vgtestbus.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Premium","tier":"Premium","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/service-bus-group/providers/Microsoft.ServiceBus/namespaces/AdvancedServiceBus","name":"AdvancedServiceBus","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:advancedservicebus","createdAt":"2019-01-18T19:05:51.99Z","updatedAt":"2019-01-18T19:06:34.407Z","serviceBusEndpoint":"https://AdvancedServiceBus.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-97c948c8-d628-477c-8c65-b882cc","name":"net-servicebus-97c948c8-d628-477c-8c65-b882cc","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-25T23:54:40Z","cleanup-after":"2020-02-26T23:54:40Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-97c948c8-d628-477c-8c65-b882cc","createdAt":"2020-02-25T23:54:41.65Z","updatedAt":"2020-02-25T23:55:26.02Z","serviceBusEndpoint":"https://net-servicebus-97c948c8-d628-477c-8c65-b882cc.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-d8bb0fd9-70f0-4b83-b45d-133598","name":"net-servicebus-d8bb0fd9-70f0-4b83-b45d-133598","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-25T05:43:29Z","cleanup-after":"2020-02-26T05:43:29Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-d8bb0fd9-70f0-4b83-b45d-133598","createdAt":"2020-02-25T05:43:34.197Z","updatedAt":"2020-02-25T05:44:18.44Z","serviceBusEndpoint":"https://net-servicebus-d8bb0fd9-70f0-4b83-b45d-133598.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/node-sdk-perf/providers/Microsoft.ServiceBus/namespaces/ServiceBusLocalTests","name":"ServiceBusLocalTests","type":"Microsoft.ServiceBus/Namespaces","location":"East
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:servicebuslocaltests","createdAt":"2019-04-12T23:17:53.317Z","updatedAt":"2019-05-23T00:44:23.833Z","serviceBusEndpoint":"https://ServiceBusLocalTests.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sampleservicebusgroup/providers/Microsoft.ServiceBus/namespaces/net-servicebus-6b8db0bd-aa46-444b-a9e4-80799f","name":"net-servicebus-6b8db0bd-aa46-444b-a9e4-80799f","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-14T22:52:22Z","cleanup-after":"2020-02-15T22:52:22Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-6b8db0bd-aa46-444b-a9e4-80799f","createdAt":"2020-02-14T22:52:24.107Z","updatedAt":"2020-02-14T22:53:06.833Z","serviceBusEndpoint":"https://net-servicebus-6b8db0bd-aa46-444b-a9e4-80799f.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/service-bus-py-dev/providers/Microsoft.ServiceBus/namespaces/t1sbtest","name":"t1sbtest","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:t1sbtest","createdAt":"2019-12-20T18:45:36.287Z","updatedAt":"2019-12-20T18:46:21.15Z","serviceBusEndpoint":"https://t1sbtest.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/uxstudy-rg/providers/Microsoft.ServiceBus/namespaces/uri-sb-01","name":"uri-sb-01","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:uri-sb-01","createdAt":"2020-02-01T00:39:18.817Z","updatedAt":"2020-02-01T00:40:03.74Z","serviceBusEndpoint":"https://uri-sb-01.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/storage-playground/providers/Microsoft.ServiceBus/namespaces/StandardFruitsServiveBus","name":"StandardFruitsServiveBus","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:standardfruitsservivebus","createdAt":"2019-01-18T21:07:59.34Z","updatedAt":"2019-03-08T17:53:48.547Z","serviceBusEndpoint":"https://StandardFruitsServiveBus.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sampleservicebusgroup/providers/Microsoft.ServiceBus/namespaces/SamplesServiceBus","name":"SamplesServiceBus","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:samplesservicebus","createdAt":"2018-12-20T22:55:21.077Z","updatedAt":"2018-12-20T22:55:45.43Z","serviceBusEndpoint":"https://SamplesServiceBus.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-0b399156-8e89-42ba-b9f7-d5625f","name":"net-servicebus-0b399156-8e89-42ba-b9f7-d5625f","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-21T20:09:54Z","cleanup-after":"2020-02-22T20:09:54Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-0b399156-8e89-42ba-b9f7-d5625f","createdAt":"2020-02-21T20:09:55.47Z","updatedAt":"2020-02-21T20:10:36.633Z","serviceBusEndpoint":"https://net-servicebus-0b399156-8e89-42ba-b9f7-d5625f.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-12163171-b0a9-4910-89d2-a218cd","name":"net-servicebus-12163171-b0a9-4910-89d2-a218cd","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-25T04:52:07Z","cleanup-after":"2020-02-26T04:52:07Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-12163171-b0a9-4910-89d2-a218cd","createdAt":"2020-02-25T04:52:09.77Z","updatedAt":"2020-02-25T04:52:55.023Z","serviceBusEndpoint":"https://net-servicebus-12163171-b0a9-4910-89d2-a218cd.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-d165e718-372d-475f-99cb-ee1ee1","name":"net-servicebus-d165e718-372d-475f-99cb-ee1ee1","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-25T04:28:45Z","cleanup-after":"2020-02-26T04:28:45Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-d165e718-372d-475f-99cb-ee1ee1","createdAt":"2020-02-25T04:28:48.14Z","updatedAt":"2020-02-25T04:29:30.753Z","serviceBusEndpoint":"https://net-servicebus-d165e718-372d-475f-99cb-ee1ee1.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/service-bus-group/providers/Microsoft.ServiceBus/namespaces/TestSampleQueue","name":"TestSampleQueue","type":"Microsoft.ServiceBus/Namespaces","location":"East
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testsamplequeue","createdAt":"2019-05-02T21:22:01.323Z","updatedAt":"2019-05-02T21:22:25.45Z","serviceBusEndpoint":"https://TestSampleQueue.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-80aec8c6-17c2-4869-86f5-de3165","name":"net-servicebus-80aec8c6-17c2-4869-86f5-de3165","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-25T00:40:54Z","cleanup-after":"2020-02-26T00:40:54Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-80aec8c6-17c2-4869-86f5-de3165","createdAt":"2020-02-25T00:40:57.217Z","updatedAt":"2020-02-25T00:41:39.927Z","serviceBusEndpoint":"https://net-servicebus-80aec8c6-17c2-4869-86f5-de3165.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-898a6945-98ab-4930-b2c5-d4466c","name":"net-servicebus-898a6945-98ab-4930-b2c5-d4466c","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-21T20:11:06Z","cleanup-after":"2020-02-22T20:11:06Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-898a6945-98ab-4930-b2c5-d4466c","createdAt":"2020-02-21T20:11:07.51Z","updatedAt":"2020-02-21T20:11:51.083Z","serviceBusEndpoint":"https://net-servicebus-898a6945-98ab-4930-b2c5-d4466c.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-2f5ae660-68a4-4038-9fc6-e4cf48","name":"net-servicebus-2f5ae660-68a4-4038-9fc6-e4cf48","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-25T00:46:01Z","cleanup-after":"2020-02-26T00:46:01Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-2f5ae660-68a4-4038-9fc6-e4cf48","createdAt":"2020-02-25T00:46:11.91Z","updatedAt":"2020-02-25T00:46:56.533Z","serviceBusEndpoint":"https://net-servicebus-2f5ae660-68a4-4038-9fc6-e4cf48.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Premium","tier":"Premium","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzureSDKCTI/providers/Microsoft.ServiceBus/namespaces/prjtest","name":"prjtest","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:prjtest","createdAt":"2019-12-25T05:44:25.373Z","updatedAt":"2019-12-25T05:45:27.233Z","serviceBusEndpoint":"https://prjtest.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tonggroup/providers/Microsoft.ServiceBus/namespaces/xutoservicebus","name":"xutoservicebus","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:xutoservicebus","createdAt":"2020-01-14T01:02:09.91Z","updatedAt":"2020-01-14T01:02:52.293Z","serviceBusEndpoint":"https://xutoservicebus.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-5959eb18-78b0-4959-bf6a-ec6b18","name":"net-servicebus-5959eb18-78b0-4959-bf6a-ec6b18","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-29T01:20:05Z","cleanup-after":"2020-03-01T01:20:05Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-5959eb18-78b0-4959-bf6a-ec6b18","createdAt":"2020-02-29T01:20:06.55Z","updatedAt":"2020-02-29T01:20:49.933Z","serviceBusEndpoint":"https://net-servicebus-5959eb18-78b0-4959-bf6a-ec6b18.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/HarshasPrivateResourceGroup/providers/Microsoft.ServiceBus/namespaces/harshan-servicebus","name":"harshan-servicebus","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:harshan-servicebus","createdAt":"2020-03-02T23:53:45.033Z","updatedAt":"2020-03-02T23:54:28.42Z","serviceBusEndpoint":"https://harshan-servicebus.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/node-sdk-perf/providers/Microsoft.ServiceBus/namespaces/PerfTestStandard","name":"PerfTestStandard","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:perfteststandard","createdAt":"2019-03-21T00:22:15.77Z","updatedAt":"2019-03-21T00:22:40.317Z","serviceBusEndpoint":"https://PerfTestStandard.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-3be5d982-09be-4d69-8526-7462e9","name":"net-servicebus-3be5d982-09be-4d69-8526-7462e9","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-25T04:31:59Z","cleanup-after":"2020-02-26T04:31:59Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-3be5d982-09be-4d69-8526-7462e9","createdAt":"2020-02-25T04:32:18.967Z","updatedAt":"2020-02-25T04:33:04.5Z","serviceBusEndpoint":"https://net-servicebus-3be5d982-09be-4d69-8526-7462e9.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-93c93816-c842-478d-9704-a036fd","name":"net-servicebus-93c93816-c842-478d-9704-a036fd","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-29T01:22:58Z","cleanup-after":"2020-03-01T01:22:58Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-93c93816-c842-478d-9704-a036fd","createdAt":"2020-02-29T01:22:59.37Z","updatedAt":"2020-02-29T01:24:04.91Z","serviceBusEndpoint":"https://net-servicebus-93c93816-c842-478d-9704-a036fd.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/event-hubs-py-dev/providers/Microsoft.ServiceBus/namespaces/sbmodelupdate","name":"sbmodelupdate","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:sbmodelupdate","createdAt":"2019-10-03T08:33:58.18Z","updatedAt":"2019-10-03T08:34:41.837Z","serviceBusEndpoint":"https://sbmodelupdate.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sampleservicebusgroup/providers/Microsoft.ServiceBus/namespaces/net-servicebus-051a93b2-e6e3-4e77-bf82-cbb94e","name":"net-servicebus-051a93b2-e6e3-4e77-bf82-cbb94e","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-15T00:15:36Z","cleanup-after":"2020-02-16T00:15:36Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-051a93b2-e6e3-4e77-bf82-cbb94e","createdAt":"2020-02-15T00:15:38.053Z","updatedAt":"2020-02-15T00:16:22.38Z","serviceBusEndpoint":"https://net-servicebus-051a93b2-e6e3-4e77-bf82-cbb94e.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/conniey-rg/providers/Microsoft.ServiceBus/namespaces/connieysb","name":"connieysb","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:connieysb","createdAt":"2020-03-02T05:47:39.99Z","updatedAt":"2020-03-02T05:48:22.573Z","serviceBusEndpoint":"https://connieysb.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/node-sdk-perf/providers/Microsoft.ServiceBus/namespaces/ServiceBusLocalTestsPerf5","name":"ServiceBusLocalTestsPerf5","type":"Microsoft.ServiceBus/Namespaces","location":"East
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:servicebuslocaltestsperf5","createdAt":"2019-10-30T21:14:23.74Z","updatedAt":"2019-10-30T21:15:05.053Z","serviceBusEndpoint":"https://ServiceBusLocalTestsPerf5.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/service-bus-group/providers/Microsoft.ServiceBus/namespaces/TestServiceBusStandard","name":"TestServiceBusStandard","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testservicebusstandard","createdAt":"2019-04-02T18:18:48.637Z","updatedAt":"2019-04-02T18:19:11.183Z","serviceBusEndpoint":"https://TestServiceBusStandard.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/node-sdk-perf/providers/Microsoft.ServiceBus/namespaces/ServiceBusLocalTestsPerf1","name":"ServiceBusLocalTestsPerf1","type":"Microsoft.ServiceBus/Namespaces","location":"East
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:servicebuslocaltestsperf1","createdAt":"2019-08-06T15:51:00.83Z","updatedAt":"2019-08-06T15:51:44.023Z","serviceBusEndpoint":"https://ServiceBusLocalTestsPerf1.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/node-sdk-perf/providers/Microsoft.ServiceBus/namespaces/ServiceBusLocalTestsPerf2","name":"ServiceBusLocalTestsPerf2","type":"Microsoft.ServiceBus/Namespaces","location":"East
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:servicebuslocaltestsperf2","createdAt":"2019-08-06T16:07:24.1Z","updatedAt":"2019-08-06T16:08:06.343Z","serviceBusEndpoint":"https://ServiceBusLocalTestsPerf2.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/service-bus-python-dev/providers/Microsoft.ServiceBus/namespaces/servicebusuamqp11","name":"servicebusuamqp11","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:servicebusuamqp11","createdAt":"2019-06-07T21:55:53.6Z","updatedAt":"2019-06-07T21:56:39.13Z","serviceBusEndpoint":"https://servicebusuamqp11.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/storage-playground/providers/Microsoft.ServiceBus/namespaces/BasicFruitsServiceBus","name":"BasicFruitsServiceBus","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:basicfruitsservicebus","createdAt":"2019-01-24T05:42:31.677Z","updatedAt":"2019-03-08T17:53:48.527Z","serviceBusEndpoint":"https://BasicFruitsServiceBus.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/service-bus-python-dev/providers/Microsoft.ServiceBus/namespaces/servicebusuamqp12","name":"servicebusuamqp12","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:servicebusuamqp12","createdAt":"2019-06-07T21:06:07.187Z","updatedAt":"2019-06-07T21:06:49.407Z","serviceBusEndpoint":"https://servicebusuamqp12.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sampleservicebusgroup/providers/Microsoft.ServiceBus/namespaces/net-servicebus-9fc8f951-e966-4922-a04d-d8f34c","name":"net-servicebus-9fc8f951-e966-4922-a04d-d8f34c","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-25T18:30:38Z","cleanup-after":"2020-02-26T18:30:38Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-9fc8f951-e966-4922-a04d-d8f34c","createdAt":"2020-02-25T18:30:39.107Z","updatedAt":"2020-02-25T18:31:25.19Z","serviceBusEndpoint":"https://net-servicebus-9fc8f951-e966-4922-a04d-d8f34c.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/service-bus-playground/providers/Microsoft.ServiceBus/namespaces/azure-sdk-test-net-playground","name":"azure-sdk-test-net-playground","type":"Microsoft.ServiceBus/Namespaces","location":"East
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:azure-sdk-test-net-playground","createdAt":"2019-03-13T02:03:15.877Z","updatedAt":"2019-03-13T02:03:39.497Z","serviceBusEndpoint":"https://azure-sdk-test-net-playground.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/node-sdk-perf/providers/Microsoft.ServiceBus/namespaces/PerfTestBasic","name":"PerfTestBasic","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:perftestbasic","createdAt":"2019-03-18T21:01:30.97Z","updatedAt":"2019-03-18T21:02:03.877Z","serviceBusEndpoint":"https://PerfTestBasic.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chradek/providers/Microsoft.ServiceBus/namespaces/chradek-sbusns-aad","name":"chradek-sbusns-aad","type":"Microsoft.ServiceBus/Namespaces","location":"East
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:chradek-sbusns-aad","createdAt":"2019-05-31T20:32:23.003Z","updatedAt":"2019-05-31T20:33:06.953Z","serviceBusEndpoint":"https://chradek-sbusns-aad.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sampleservicebusgroup/providers/Microsoft.ServiceBus/namespaces/net-servicebus-185251f2-7eed-47e2-8198-3c426c","name":"net-servicebus-185251f2-7eed-47e2-8198-3c426c","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-14T21:25:17Z","cleanup-after":"2020-02-15T21:25:17Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-185251f2-7eed-47e2-8198-3c426c","createdAt":"2020-02-14T21:25:26.21Z","updatedAt":"2020-02-14T21:26:11.03Z","serviceBusEndpoint":"https://net-servicebus-185251f2-7eed-47e2-8198-3c426c.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kibrantn-test/providers/Microsoft.ServiceBus/namespaces/kibrantn-azure-sdk-test","name":"kibrantn-azure-sdk-test","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:kibrantn-azure-sdk-test","createdAt":"2019-10-08T23:53:12.1Z","updatedAt":"2019-10-08T23:53:55.747Z","serviceBusEndpoint":"https://kibrantn-azure-sdk-test.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-f7317b14-1cc0-4843-8076-41ac72","name":"net-servicebus-f7317b14-1cc0-4843-8076-41ac72","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-29T01:18:39Z","cleanup-after":"2020-03-01T01:18:39Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-f7317b14-1cc0-4843-8076-41ac72","createdAt":"2020-02-29T01:18:40.997Z","updatedAt":"2020-02-29T01:19:22.977Z","serviceBusEndpoint":"https://net-servicebus-f7317b14-1cc0-4843-8076-41ac72.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/node-sdk-perf/providers/Microsoft.ServiceBus/namespaces/sblocaltestsversion2","name":"sblocaltestsversion2","type":"Microsoft.ServiceBus/Namespaces","location":"East
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:sblocaltestsversion2","createdAt":"2019-04-23T21:20:29.927Z","updatedAt":"2019-05-23T00:48:45.43Z","serviceBusEndpoint":"https://sblocaltestsversion2.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace","name":"testingpythontestcasenamespace","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasenamespace","createdAt":"2020-03-03T01:15:52.967Z","updatedAt":"2020-03-03T01:16:36.24Z","serviceBusEndpoint":"https://testingpythontestcasenamespace.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-a98ab27c-b358-41ad-b4bf-e7f3dc","name":"net-servicebus-a98ab27c-b358-41ad-b4bf-e7f3dc","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-29T01:17:41Z","cleanup-after":"2020-03-01T01:17:41Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-a98ab27c-b358-41ad-b4bf-e7f3dc","createdAt":"2020-02-29T01:17:48.01Z","updatedAt":"2020-02-29T01:18:31.2Z","serviceBusEndpoint":"https://net-servicebus-a98ab27c-b358-41ad-b4bf-e7f3dc.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-747c4b66-52f4-46cc-b447-57ecf5","name":"net-servicebus-747c4b66-52f4-46cc-b447-57ecf5","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-29T01:22:26Z","cleanup-after":"2020-03-01T01:22:26Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-747c4b66-52f4-46cc-b447-57ecf5","createdAt":"2020-02-29T01:22:27.237Z","updatedAt":"2020-02-29T01:23:10.393Z","serviceBusEndpoint":"https://net-servicebus-747c4b66-52f4-46cc-b447-57ecf5.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/caperal-dev/providers/Microsoft.ServiceBus/namespaces/servicebustestcp","name":"servicebustestcp","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:servicebustestcp","createdAt":"2019-11-13T23:22:29.97Z","updatedAt":"2019-11-13T23:23:11.747Z","serviceBusEndpoint":"https://servicebustestcp.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Premium","tier":"Premium","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ruih_cloud_pattern/providers/Microsoft.ServiceBus/namespaces/mycompetinconsumer","name":"mycompetinconsumer","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:mycompetinconsumer","createdAt":"2019-12-25T07:55:51.997Z","updatedAt":"2019-12-25T07:56:52.343Z","serviceBusEndpoint":"https://mycompetinconsumer.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/jolovtest","name":"jolovtest","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:jolovtest","createdAt":"2019-08-27T20:45:52.987Z","updatedAt":"2019-08-27T20:46:35.893Z","serviceBusEndpoint":"https://jolovtest.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/service-bus-group/providers/Microsoft.ServiceBus/namespaces/sdk-playground-basic","name":"sdk-playground-basic","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:sdk-playground-basic","createdAt":"2019-01-15T18:59:41.14Z","updatedAt":"2019-01-15T19:00:05.69Z","serviceBusEndpoint":"https://sdk-playground-basic.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/service-bus-group/providers/Microsoft.ServiceBus/namespaces/sdk-playground","name":"sdk-playground","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:sdk-playground","createdAt":"2018-11-27T19:00:39.13Z","updatedAt":"2018-11-27T19:01:03.18Z","serviceBusEndpoint":"https://sdk-playground.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/node-sdk-perf/providers/Microsoft.ServiceBus/namespaces/arm-azure-sdk-test-p1","name":"arm-azure-sdk-test-p1","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:arm-azure-sdk-test-p1","createdAt":"2020-01-15T23:13:59.76Z","updatedAt":"2020-01-15T23:14:42.487Z","serviceBusEndpoint":"https://arm-azure-sdk-test-p1.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-ca8d2d00-4f7c-4609-b3fd-4b5e5f","name":"net-servicebus-ca8d2d00-4f7c-4609-b3fd-4b5e5f","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-25T00:43:27Z","cleanup-after":"2020-02-26T00:43:27Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-ca8d2d00-4f7c-4609-b3fd-4b5e5f","createdAt":"2020-02-25T00:43:31.197Z","updatedAt":"2020-02-25T00:44:16.023Z","serviceBusEndpoint":"https://net-servicebus-ca8d2d00-4f7c-4609-b3fd-4b5e5f.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SampleFruitsResourceGroup/providers/Microsoft.ServiceBus/namespaces/FruitServiceBus","name":"FruitServiceBus","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:fruitservicebus","createdAt":"2018-12-19T00:03:40.487Z","updatedAt":"2019-01-02T18:27:29.917Z","serviceBusEndpoint":"https://FruitServiceBus.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-b15e47ce-21b0-468e-96b6-dd2978","name":"net-servicebus-b15e47ce-21b0-468e-96b6-dd2978","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-25T00:54:21Z","cleanup-after":"2020-02-26T00:54:21Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-b15e47ce-21b0-468e-96b6-dd2978","createdAt":"2020-02-25T00:54:25.73Z","updatedAt":"2020-02-25T00:55:08.953Z","serviceBusEndpoint":"https://net-servicebus-b15e47ce-21b0-468e-96b6-dd2978.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mikeharder-perf-automation/providers/Microsoft.ServiceBus/namespaces/mikeharder-perf-automation","name":"mikeharder-perf-automation","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        Central US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:mikeharder-perf-automation","createdAt":"2020-02-13T23:55:29.473Z","updatedAt":"2020-02-13T23:56:14.703Z","serviceBusEndpoint":"https://mikeharder-perf-automation.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Premium","tier":"Premium","capacity":4},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzureSDKCTI/providers/Microsoft.ServiceBus/namespaces/PremiumBusCTI","name":"PremiumBusCTI","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:premiumbuscti","createdAt":"2019-11-22T05:52:51.967Z","updatedAt":"2019-11-22T05:53:48.663Z","serviceBusEndpoint":"https://PremiumBusCTI.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bterlson-testbed/providers/Microsoft.ServiceBus/namespaces/bterlsonsb","name":"bterlsonsb","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:bterlsonsb","createdAt":"2019-02-09T00:46:18.34Z","updatedAt":"2019-02-09T00:46:43.24Z","serviceBusEndpoint":"https://bterlsonsb.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-fa17ae33-96e1-46ed-8381-83bcd2","name":"net-servicebus-fa17ae33-96e1-46ed-8381-83bcd2","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-21T20:13:09Z","cleanup-after":"2020-02-22T20:13:09Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-fa17ae33-96e1-46ed-8381-83bcd2","createdAt":"2020-02-21T20:13:10.373Z","updatedAt":"2020-02-21T20:13:52.97Z","serviceBusEndpoint":"https://net-servicebus-fa17ae33-96e1-46ed-8381-83bcd2.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/service-bus-python-dev/providers/Microsoft.ServiceBus/namespaces/service-bus-dev-py","name":"service-bus-dev-py","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:service-bus-dev-py","createdAt":"2019-04-05T21:11:47.217Z","updatedAt":"2019-04-05T21:12:15.15Z","serviceBusEndpoint":"https://service-bus-dev-py.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/riparkdev/providers/Microsoft.ServiceBus/namespaces/riparkdev2","name":"riparkdev2","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US 2","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:riparkdev2","createdAt":"2019-12-03T22:18:03.707Z","updatedAt":"2019-12-03T22:18:44.907Z","serviceBusEndpoint":"https://riparkdev2.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/antisch/providers/Microsoft.ServiceBus/namespaces/pysbtest","name":"pysbtest","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:pysbtest","createdAt":"2019-09-17T18:26:15.983Z","updatedAt":"2019-09-17T18:26:57.977Z","serviceBusEndpoint":"https://pysbtest.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-79c783d2-3297-4274-b3a8-f11f8d","name":"net-servicebus-79c783d2-3297-4274-b3a8-f11f8d","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-25T21:20:48Z","cleanup-after":"2020-02-26T21:20:48Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-79c783d2-3297-4274-b3a8-f11f8d","createdAt":"2020-02-25T21:20:49.61Z","updatedAt":"2020-02-25T21:21:33.683Z","serviceBusEndpoint":"https://net-servicebus-79c783d2-3297-4274-b3a8-f11f8d.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pakrym-resources/providers/Microsoft.ServiceBus/namespaces/pakrymsb","name":"pakrymsb","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:pakrymsb","createdAt":"2019-07-31T17:43:43.923Z","updatedAt":"2019-07-31T17:44:27.813Z","serviceBusEndpoint":"https://pakrymsb.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chradek/providers/Microsoft.ServiceBus/namespaces/chradek-bus","name":"chradek-bus","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:chradek-bus","createdAt":"2019-05-23T20:36:54.927Z","updatedAt":"2019-05-23T20:37:37.58Z","serviceBusEndpoint":"https://chradek-bus.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jolov/providers/Microsoft.ServiceBus/namespaces/net-servicebus-5bf84a7c-637a-432c-bf75-efab69","name":"net-servicebus-5bf84a7c-637a-432c-bf75-efab69","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"source":"Azure.Messaging.ServiceBus.Tests","platform":"Microsoft
+        Windows 10.0.18363 ","framework":".NET Core 4.6.28325.01","created":"2020-02-25T00:42:03Z","cleanup-after":"2020-02-26T00:42:03Z"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:net-servicebus-5bf84a7c-637a-432c-bf75-efab69","createdAt":"2020-02-25T00:42:13.22Z","updatedAt":"2020-02-25T00:42:55.503Z","serviceBusEndpoint":"https://net-servicebus-5bf84a7c-637a-432c-bf75-efab69.servicebus.windows.net:443/","status":"Active"}},{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/node-sdk-perf/providers/Microsoft.ServiceBus/namespaces/ServiceBusBrowserTestsLocal","name":"ServiceBusBrowserTestsLocal","type":"Microsoft.ServiceBus/Namespaces","location":"East
+        US","tags":{},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:servicebusbrowsertestslocal","createdAt":"2019-06-13T21:26:02.533Z","updatedAt":"2019-06-13T21:26:47.51Z","serviceBusEndpoint":"https://ServiceBusBrowserTestsLocal.servicebus.windows.net:443/","status":"Active"}}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['92081']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:28:02 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '49814'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:16:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/RootManageSharedAccessKey?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/RootManageSharedAccessKey","name":"RootManageSharedAccessKey","type":"","location":"West
-        US","properties":{"rights":["Listen","Manage","Send"]}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/RootManageSharedAccessKey","name":"RootManageSharedAccessKey","type":"Microsoft.ServiceBus/Namespaces/AuthorizationRules","location":"West
+        US","properties":{"rights":["Listen","Manage","Send"]}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['378']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:28:19 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '428'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:16:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"rights": ["Send", "Listen"]}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['46']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/testingauthrulepy?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"","location":"West
-        US","properties":{"rights":["Send","Listen"]}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/AuthorizationRules","location":"West
+        US","properties":{"rights":["Send","Listen"]}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['353']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:28:35 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '403'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:17:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/testingauthrulepy?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"","location":"West
-        US","properties":{"rights":["Send","Listen"]}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/AuthorizationRules","location":"West
+        US","properties":{"rights":["Send","Listen"]}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['353']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:28:36 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '403'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:17:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"rights": ["Send", "Listen", "Manage"]}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['56']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/testingauthrulepy?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"","location":"West
-        US","properties":{"rights":["Send","Listen","Manage"]}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/AuthorizationRules","location":"West
+        US","properties":{"rights":["Send","Listen","Manage"]}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['362']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:28:52 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '412'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:17:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules?api-version=2017-04-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/RootManageSharedAccessKey","name":"RootManageSharedAccessKey","type":"","location":"West
-        US","properties":{"rights":["Listen","Manage","Send"]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"","location":"West
-        US","properties":{"rights":["Send","Listen","Manage"]}}]}'}
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/RootManageSharedAccessKey","name":"RootManageSharedAccessKey","type":"Microsoft.ServiceBus/Namespaces/AuthorizationRules","location":"West
+        US","properties":{"rights":["Listen","Manage","Send"]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/AuthorizationRules","location":"West
+        US","properties":{"rights":["Send","Listen","Manage"]}}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['753']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:28:54 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '853'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:17:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/testingauthrulepy/listKeys?api-version=2017-04-01
   response:
-    body: {string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasenamespace.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=kZTROPc/pT8xeE6Zte7GxldXVbkb5Vso/OBxJ950+lg=","secondaryConnectionString":"Endpoint=sb://testingpythontestcasenamespace.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=iN+3Fy9mWI5a8T0A3y2k94ASOMlDBF8TED/4NG1gMnY=","primaryKey":"kZTROPc/pT8xeE6Zte7GxldXVbkb5Vso/OBxJ950+lg=","secondaryKey":"iN+3Fy9mWI5a8T0A3y2k94ASOMlDBF8TED/4NG1gMnY=","keyName":"testingauthrulepy"}'}
+    body:
+      string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasenamespace.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=+kLd7s3YDbC3kL9TRGNnedAuppXLHeBQwt+5TLZis0s=","secondaryConnectionString":"Endpoint=sb://testingpythontestcasenamespace.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=x6PaQUb/DR9oGrpB0k7b3XQ2T5HcVI/xRuUT/QIPYbw=","primaryKey":"+kLd7s3YDbC3kL9TRGNnedAuppXLHeBQwt+5TLZis0s=","secondaryKey":"x6PaQUb/DR9oGrpB0k7b3XQ2T5HcVI/xRuUT/QIPYbw=","keyName":"testingauthrulepy"}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['547']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:28:56 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '547'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:17:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"keyType": "PrimaryKey"}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['25']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '25'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/testingauthrulepy/regenerateKeys?api-version=2017-04-01
   response:
-    body: {string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasenamespace.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=6E6NfG2hkSM+iG9aMVV7+hanwVU6irnocBWR2UVSQek=","secondaryConnectionString":"Endpoint=sb://testingpythontestcasenamespace.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=iN+3Fy9mWI5a8T0A3y2k94ASOMlDBF8TED/4NG1gMnY=","primaryKey":"6E6NfG2hkSM+iG9aMVV7+hanwVU6irnocBWR2UVSQek=","secondaryKey":"iN+3Fy9mWI5a8T0A3y2k94ASOMlDBF8TED/4NG1gMnY=","keyName":"testingauthrulepy"}'}
+    body:
+      string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasenamespace.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=6zpCLH/oDQyoSP95WljWU/QlvYO4yQINxk89Psd6vyo=","secondaryConnectionString":"Endpoint=sb://testingpythontestcasenamespace.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=x6PaQUb/DR9oGrpB0k7b3XQ2T5HcVI/xRuUT/QIPYbw=","primaryKey":"6zpCLH/oDQyoSP95WljWU/QlvYO4yQINxk89Psd6vyo=","secondaryKey":"x6PaQUb/DR9oGrpB0k7b3XQ2T5HcVI/xRuUT/QIPYbw=","keyName":"testingauthrulepy"}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['547']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:29:12 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '547'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:17:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"keyType": "SecondaryKey"}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['27']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/testingauthrulepy/regenerateKeys?api-version=2017-04-01
   response:
-    body: {string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasenamespace.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=6E6NfG2hkSM+iG9aMVV7+hanwVU6irnocBWR2UVSQek=","secondaryConnectionString":"Endpoint=sb://testingpythontestcasenamespace.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=jvtCmmuhQKR8w6iHfEAo9bt4OpUOpXqTAHBOy51aSio=","primaryKey":"6E6NfG2hkSM+iG9aMVV7+hanwVU6irnocBWR2UVSQek=","secondaryKey":"jvtCmmuhQKR8w6iHfEAo9bt4OpUOpXqTAHBOy51aSio=","keyName":"testingauthrulepy"}'}
+    body:
+      string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasenamespace.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=6zpCLH/oDQyoSP95WljWU/QlvYO4yQINxk89Psd6vyo=","secondaryConnectionString":"Endpoint=sb://testingpythontestcasenamespace.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=MJg4EKl1w+EwYMFYFFtaSJpXL2GV4xL3cYnqzp2j594=","primaryKey":"6zpCLH/oDQyoSP95WljWU/QlvYO4yQINxk89Psd6vyo=","secondaryKey":"MJg4EKl1w+EwYMFYFFtaSJpXL2GV4xL3cYnqzp2j594=","keyName":"testingauthrulepy"}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['547']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:29:28 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '547'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:18:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/testingauthrulepy?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:29:45 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:18:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules?api-version=2017-04-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/RootManageSharedAccessKey","name":"RootManageSharedAccessKey","type":"","location":"West
-        US","properties":{"rights":["Listen","Manage","Send"]}}]}'}
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/AuthorizationRules/RootManageSharedAccessKey","name":"RootManageSharedAccessKey","type":"Microsoft.ServiceBus/Namespaces/AuthorizationRules","location":"West
+        US","properties":{"rights":["Listen","Manage","Send"]}}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['390']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:29:46 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '440'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:18:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:29:47 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/operationresults/testingpythontestcasenamespace?api-version=2017-04-01']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 202, message: Accepted}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:18:21 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/operationresults/testingpythontestcasenamespace?api-version=2017-04-01
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 202
+      message: Accepted
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_namespace_test_sb_namespace_curdde57183c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasenamespace/operationresults/testingpythontestcasenamespace?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:30:18 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:18:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/sdk/servicebus/azure-mgmt-servicebus/tests/recordings/test_azure_mgmt_servicebus_queue.test_sb_queue_curd.yaml
+++ b/sdk/servicebus/azure-mgmt-servicebus/tests/recordings/test_azure_mgmt_servicebus_queue.test_sb_queue_curd.yaml
@@ -3,553 +3,1006 @@ interactions:
     body: '{"location": "westus", "tags": {"tag1": "value1", "tag2": "value2"}, "sku":
       {"name": "Standard"}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['97']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '97'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue?api-version=2017-04-01
   response:
-    body: {string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue","name":"testingpythontestcasequeue","type":"Microsoft.ServiceBus/Namespaces","location":"West
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasequeue","createdAt":"2018-04-21T00:30:43.68Z","updatedAt":"2018-04-21T00:30:43.68Z","serviceBusEndpoint":"https://testingpythontestcasequeue.servicebus.windows.net:443/","status":"Activating"}}'}
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue","name":"testingpythontestcasequeue","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasequeue","createdAt":"2020-03-03T01:18:55.953Z","updatedAt":"2020-03-03T01:18:55.953Z","serviceBusEndpoint":"https://testingpythontestcasequeue.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['693']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:30:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '695'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:18:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue?api-version=2017-04-01
   response:
-    body: {string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue","name":"testingpythontestcasequeue","type":"Microsoft.ServiceBus/Namespaces","location":"West
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasequeue","createdAt":"2018-04-21T00:30:43.68Z","updatedAt":"2018-04-21T00:31:07.017Z","serviceBusEndpoint":"https://testingpythontestcasequeue.servicebus.windows.net:443/","status":"Active"}}'}
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue","name":"testingpythontestcasequeue","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasequeue","createdAt":"2020-03-03T01:18:55.953Z","updatedAt":"2020-03-03T01:18:55.953Z","serviceBusEndpoint":"https://testingpythontestcasequeue.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['692']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:31:14 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '695'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:19:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue?api-version=2017-04-01
   response:
-    body: {string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue","name":"testingpythontestcasequeue","type":"Microsoft.ServiceBus/Namespaces","location":"West
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasequeue","createdAt":"2018-04-21T00:30:43.68Z","updatedAt":"2018-04-21T00:31:07.017Z","serviceBusEndpoint":"https://testingpythontestcasequeue.servicebus.windows.net:443/","status":"Active"}}'}
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue","name":"testingpythontestcasequeue","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasequeue","createdAt":"2020-03-03T01:18:55.953Z","updatedAt":"2020-03-03T01:19:39.1Z","serviceBusEndpoint":"https://testingpythontestcasequeue.servicebus.windows.net:443/","status":"Active"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['692']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:31:15 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '691'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:19:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue?api-version=2017-04-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue","name":"testingpythontestcasequeue","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasequeue","createdAt":"2020-03-03T01:18:55.953Z","updatedAt":"2020-03-03T01:19:39.1Z","serviceBusEndpoint":"https://testingpythontestcasequeue.servicebus.windows.net:443/","status":"Active"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '691'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:19:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue","name":"testingpythonsdkqueue","type":"Microsoft.ServiceBus/Namespaces/Queues","location":"West
-        US","properties":{"lockDuration":"PT1M","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"enableBatchedOperations":true,"duplicateDetectionHistoryTimeWindow":"PT10M","maxDeliveryCount":10,"sizeInBytes":0,"messageCount":0,"status":"Active","autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"createdAt":"2018-04-21T00:31:18.083Z","updatedAt":"2018-04-21T00:31:18.147Z","accessedAt":"0001-01-01T00:00:00"}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue","name":"testingpythonsdkqueue","type":"Microsoft.ServiceBus/Namespaces/Queues","location":"West
+        US","properties":{"lockDuration":"PT1M","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"enableBatchedOperations":true,"duplicateDetectionHistoryTimeWindow":"PT10M","maxDeliveryCount":10,"sizeInBytes":0,"messageCount":0,"status":"Active","autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"createdAt":"2020-03-03T01:19:59.193Z","updatedAt":"2020-03-03T01:19:59.27Z","accessedAt":"0001-01-01T00:00:00"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1065']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:31:18 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1064'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:19:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue","name":"testingpythonsdkqueue","type":"Microsoft.ServiceBus/Namespaces/Queues","location":"West
-        US","properties":{"lockDuration":"PT1M","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"enableBatchedOperations":true,"duplicateDetectionHistoryTimeWindow":"PT10M","maxDeliveryCount":10,"sizeInBytes":0,"messageCount":0,"status":"Active","autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"createdAt":"2018-04-21T00:31:18.083Z","updatedAt":"2018-04-21T00:31:18.147Z","accessedAt":"0001-01-01T00:00:00Z"}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue","name":"testingpythonsdkqueue","type":"Microsoft.ServiceBus/Namespaces/Queues","location":"West
+        US","properties":{"lockDuration":"PT1M","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"enableBatchedOperations":true,"duplicateDetectionHistoryTimeWindow":"PT10M","maxDeliveryCount":10,"sizeInBytes":0,"messageCount":0,"status":"Active","autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"createdAt":"2020-03-03T01:19:59.193Z","updatedAt":"2020-03-03T01:19:59.27Z","accessedAt":"0001-01-01T00:00:00Z"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1066']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:31:21 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1065'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:19:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues?api-version=2017-04-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue","name":"testingpythonsdkqueue","type":"Microsoft.ServiceBus/Namespaces/Queues","location":"West
-        US","properties":{"lockDuration":"PT1M","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"enableBatchedOperations":true,"duplicateDetectionHistoryTimeWindow":"PT10M","maxDeliveryCount":10,"sizeInBytes":0,"messageCount":0,"status":"Active","autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"createdAt":"2018-04-21T00:31:18.083Z","updatedAt":"2018-04-21T00:31:18.147Z","accessedAt":"0001-01-01T00:00:00Z"}}]}'}
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue","name":"testingpythonsdkqueue","type":"Microsoft.ServiceBus/Namespaces/Queues","location":"West
+        US","properties":{"lockDuration":"PT1M","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"enableBatchedOperations":true,"duplicateDetectionHistoryTimeWindow":"PT10M","maxDeliveryCount":10,"sizeInBytes":0,"messageCount":0,"status":"Active","autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"createdAt":"2020-03-03T01:19:59.193Z","updatedAt":"2020-03-03T01:19:59.27Z","accessedAt":"0001-01-01T00:00:00Z"}}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1078']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:31:22 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-inline-count: ['']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1077'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:20:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-inline-count:
+      - ''
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"maxSizeInMegabytes": 1024, "maxDeliveryCount": 5, "enableExpress":
       true}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['90']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '90'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue","name":"testingpythonsdkqueue","type":"Microsoft.ServiceBus/Namespaces/Queues","location":"West
-        US","properties":{"lockDuration":"PT1M","maxSizeInMegabytes":1024,"requiresDuplicateDetection":false,"requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"enableBatchedOperations":true,"duplicateDetectionHistoryTimeWindow":"PT10M","maxDeliveryCount":5,"sizeInBytes":0,"messageCount":0,"status":"Active","autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":true,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"createdAt":"0001-01-01T00:00:00","updatedAt":"0001-01-01T00:00:00","accessedAt":"0001-01-01T00:00:00"}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue","name":"testingpythonsdkqueue","type":"Microsoft.ServiceBus/Namespaces/Queues","location":"West
+        US","properties":{"lockDuration":"PT1M","maxSizeInMegabytes":1024,"requiresDuplicateDetection":false,"requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"enableBatchedOperations":true,"duplicateDetectionHistoryTimeWindow":"PT10M","maxDeliveryCount":5,"sizeInBytes":0,"messageCount":0,"status":"Active","autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":true,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"createdAt":"0001-01-01T00:00:00","updatedAt":"0001-01-01T00:00:00","accessedAt":"0001-01-01T00:00:00"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1053']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:31:24 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1053'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:20:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"rights": ["Send", "Listen"]}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['46']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules/testingauthrulepy?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/Queues/AuthorizationRules","location":"West
-        US","properties":{"rights":["Send","Listen"]}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/Queues/AuthorizationRules","location":"West
+        US","properties":{"rights":["Send","Listen"]}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['427']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:31:25 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '427'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:20:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules/testingauthrulepy?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/Queues/AuthorizationRules","location":"West
-        US","properties":{"rights":["Send","Listen"]}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/Queues/AuthorizationRules","location":"West
+        US","properties":{"rights":["Send","Listen"]}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['427']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:31:26 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '427'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:20:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"rights": ["Send", "Listen", "Manage"]}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['56']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules/testingauthrulepy?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/Queues/AuthorizationRules","location":"West
-        US","properties":{"rights":["Send","Listen","Manage"]}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/Queues/AuthorizationRules","location":"West
+        US","properties":{"rights":["Send","Listen","Manage"]}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['436']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:31:28 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '436'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:20:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules?api-version=2017-04-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/Queues/AuthorizationRules","location":"West
-        US","properties":{"rights":["Send","Listen","Manage"]}}]}'}
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/Queues/AuthorizationRules","location":"West
+        US","properties":{"rights":["Send","Listen","Manage"]}}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['448']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:31:28 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '448'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:20:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules/testingauthrulepy/ListKeys?api-version=2017-04-01
   response:
-    body: {string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasequeue.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=L/jeGDlEQG3PMZ9Wxi/oLIDeXef/iyut05Zb0YLMKfI=;EntityPath=testingpythonsdkqueue","secondaryConnectionString":"Endpoint=sb://testingpythontestcasequeue.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=yY2I4ga5Z7LGmczOcCYZ0vvYc0/vDV500E46Evh9uyQ=;EntityPath=testingpythonsdkqueue","primaryKey":"L/jeGDlEQG3PMZ9Wxi/oLIDeXef/iyut05Zb0YLMKfI=","secondaryKey":"yY2I4ga5Z7LGmczOcCYZ0vvYc0/vDV500E46Evh9uyQ=","keyName":"testingauthrulepy"}'}
+    body:
+      string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasequeue.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=b/9h6OvubODxYh+9aJVPkQlmgCDf0RrMG8gbzuMehTU=;EntityPath=testingpythonsdkqueue","secondaryConnectionString":"Endpoint=sb://testingpythontestcasequeue.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=aqwFIk3hvFTBpP/bzL82dC6ZQMh1QWdetddxuaD2RFQ=;EntityPath=testingpythonsdkqueue","primaryKey":"b/9h6OvubODxYh+9aJVPkQlmgCDf0RrMG8gbzuMehTU=","secondaryKey":"aqwFIk3hvFTBpP/bzL82dC6ZQMh1QWdetddxuaD2RFQ=","keyName":"testingauthrulepy"}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['605']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:31:29 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '605'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:20:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"keyType": "PrimaryKey"}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['25']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '25'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules/testingauthrulepy/regenerateKeys?api-version=2017-04-01
   response:
-    body: {string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasequeue.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=9a1fkmlNDNe1zPMEv5zPfq+gPcd1IM6nLJ8uKBUiXcM=;EntityPath=testingpythonsdkqueue","secondaryConnectionString":"Endpoint=sb://testingpythontestcasequeue.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=yY2I4ga5Z7LGmczOcCYZ0vvYc0/vDV500E46Evh9uyQ=;EntityPath=testingpythonsdkqueue","primaryKey":"9a1fkmlNDNe1zPMEv5zPfq+gPcd1IM6nLJ8uKBUiXcM=","secondaryKey":"yY2I4ga5Z7LGmczOcCYZ0vvYc0/vDV500E46Evh9uyQ=","keyName":"testingauthrulepy"}'}
+    body:
+      string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasequeue.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=q/BZv5i5qYEAKkKWTFcMSvylxMgQ2IPZtC3GQEivLfE=;EntityPath=testingpythonsdkqueue","secondaryConnectionString":"Endpoint=sb://testingpythontestcasequeue.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=aqwFIk3hvFTBpP/bzL82dC6ZQMh1QWdetddxuaD2RFQ=;EntityPath=testingpythonsdkqueue","primaryKey":"q/BZv5i5qYEAKkKWTFcMSvylxMgQ2IPZtC3GQEivLfE=","secondaryKey":"aqwFIk3hvFTBpP/bzL82dC6ZQMh1QWdetddxuaD2RFQ=","keyName":"testingauthrulepy"}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['605']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:31:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '605'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:20:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"keyType": "SecondaryKey"}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['27']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules/testingauthrulepy/regenerateKeys?api-version=2017-04-01
   response:
-    body: {string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasequeue.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=9a1fkmlNDNe1zPMEv5zPfq+gPcd1IM6nLJ8uKBUiXcM=;EntityPath=testingpythonsdkqueue","secondaryConnectionString":"Endpoint=sb://testingpythontestcasequeue.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=MZuaN9HpO0yZhwmJAUcdxVHF2Bg27hcAy9i/Dmuf+IQ=;EntityPath=testingpythonsdkqueue","primaryKey":"9a1fkmlNDNe1zPMEv5zPfq+gPcd1IM6nLJ8uKBUiXcM=","secondaryKey":"MZuaN9HpO0yZhwmJAUcdxVHF2Bg27hcAy9i/Dmuf+IQ=","keyName":"testingauthrulepy"}'}
+    body:
+      string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasequeue.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=q/BZv5i5qYEAKkKWTFcMSvylxMgQ2IPZtC3GQEivLfE=;EntityPath=testingpythonsdkqueue","secondaryConnectionString":"Endpoint=sb://testingpythontestcasequeue.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=agoUE9oHeKkRmCUztA5UOo1dNUBudjvElOEYcawYPRA=;EntityPath=testingpythonsdkqueue","primaryKey":"q/BZv5i5qYEAKkKWTFcMSvylxMgQ2IPZtC3GQEivLfE=","secondaryKey":"agoUE9oHeKkRmCUztA5UOo1dNUBudjvElOEYcawYPRA=","keyName":"testingauthrulepy"}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['605']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:31:31 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '605'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:20:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules/testingauthrulepy?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:31:33 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:20:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue/authorizationRules?api-version=2017-04-01
   response:
-    body: {string: '{"value":[]}'}
+    body:
+      string: '{"value":[]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['12']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:31:34 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:20:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/queues/testingpythonsdkqueue?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:31:35 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:20:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:31:36 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/operationresults/testingpythontestcasequeue?api-version=2017-04-01']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 202, message: Accepted}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:20:09 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/operationresults/testingpythontestcasequeue?api-version=2017-04-01
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 202
+      message: Accepted
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_queue_test_sb_queue_curd2a35152c/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasequeue/operationresults/testingpythontestcasequeue?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:32:07 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:20:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/sdk/servicebus/azure-mgmt-servicebus/tests/recordings/test_azure_mgmt_servicebus_topic.test_sb_topic_curd.yaml
+++ b/sdk/servicebus/azure-mgmt-servicebus/tests/recordings/test_azure_mgmt_servicebus_topic.test_sb_topic_curd.yaml
@@ -3,553 +3,1006 @@ interactions:
     body: '{"location": "westus", "tags": {"tag1": "value1", "tag2": "value2"}, "sku":
       {"name": "Standard"}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['97']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '97'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic?api-version=2017-04-01
   response:
-    body: {string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic","name":"testingpythontestcasetopic","type":"Microsoft.ServiceBus/Namespaces","location":"West
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasetopic","createdAt":"2018-04-21T00:33:59.467Z","updatedAt":"2018-04-21T00:33:59.467Z","serviceBusEndpoint":"https://testingpythontestcasetopic.servicebus.windows.net:443/","status":"Activating"}}'}
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic","name":"testingpythontestcasetopic","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasetopic","createdAt":"2020-03-03T01:20:44.05Z","updatedAt":"2020-03-03T01:20:44.05Z","serviceBusEndpoint":"https://testingpythontestcasetopic.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['695']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:33:59 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '693'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:20:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic?api-version=2017-04-01
   response:
-    body: {string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic","name":"testingpythontestcasetopic","type":"Microsoft.ServiceBus/Namespaces","location":"West
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasetopic","createdAt":"2018-04-21T00:33:59.467Z","updatedAt":"2018-04-21T00:34:23.203Z","serviceBusEndpoint":"https://testingpythontestcasetopic.servicebus.windows.net:443/","status":"Active"}}'}
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic","name":"testingpythontestcasetopic","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasetopic","createdAt":"2020-03-03T01:20:44.05Z","updatedAt":"2020-03-03T01:20:44.05Z","serviceBusEndpoint":"https://testingpythontestcasetopic.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['693']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:34:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '693'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:21:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic?api-version=2017-04-01
   response:
-    body: {string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic","name":"testingpythontestcasetopic","type":"Microsoft.ServiceBus/Namespaces","location":"West
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasetopic","createdAt":"2018-04-21T00:33:59.467Z","updatedAt":"2018-04-21T00:34:23.203Z","serviceBusEndpoint":"https://testingpythontestcasetopic.servicebus.windows.net:443/","status":"Active"}}'}
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic","name":"testingpythontestcasetopic","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasetopic","createdAt":"2020-03-03T01:20:44.05Z","updatedAt":"2020-03-03T01:21:25.553Z","serviceBusEndpoint":"https://testingpythontestcasetopic.servicebus.windows.net:443/","status":"Active"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['693']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:34:31 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '692'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:21:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic?api-version=2017-04-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic","name":"testingpythontestcasetopic","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasetopic","createdAt":"2020-03-03T01:20:44.05Z","updatedAt":"2020-03-03T01:21:25.553Z","serviceBusEndpoint":"https://testingpythontestcasetopic.servicebus.windows.net:443/","status":"Active"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '692'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:21:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic","name":"testingpythonsdktopic","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
-        US","properties":{"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2018-04-21T00:34:34.043Z","updatedAt":"2018-04-21T00:34:34.183Z","accessedAt":"0001-01-01T00:00:00","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic","name":"testingpythonsdktopic","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
+        US","properties":{"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2020-03-03T01:21:47.067Z","updatedAt":"2020-03-03T01:21:47.187Z","accessedAt":"0001-01-01T00:00:00","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['984']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:34:33 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '984'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:21:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic","name":"testingpythonsdktopic","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
-        US","properties":{"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2018-04-21T00:34:34.043Z","updatedAt":"2018-04-21T00:34:34.183Z","accessedAt":"0001-01-01T00:00:00Z","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic","name":"testingpythonsdktopic","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
+        US","properties":{"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2020-03-03T01:21:47.067Z","updatedAt":"2020-03-03T01:21:47.187Z","accessedAt":"0001-01-01T00:00:00Z","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['985']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:34:34 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '985'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:21:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics?api-version=2017-04-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic","name":"testingpythonsdktopic","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
-        US","properties":{"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2018-04-21T00:34:34.043Z","updatedAt":"2018-04-21T00:34:34.183Z","accessedAt":"0001-01-01T00:00:00Z","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}]}'}
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic","name":"testingpythonsdktopic","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
+        US","properties":{"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2020-03-03T01:21:47.067Z","updatedAt":"2020-03-03T01:21:47.187Z","accessedAt":"0001-01-01T00:00:00Z","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['997']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:34:36 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-inline-count: ['']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '997'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:21:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-inline-count:
+      - ''
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"maxSizeInMegabytes": 1024, "enableBatchedOperations":
       true, "enableExpress": true}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['100']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '100'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic","name":"testingpythonsdktopic","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
-        US","properties":{"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":1024,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":true,"createdAt":"0001-01-01T00:00:00","updatedAt":"0001-01-01T00:00:00","accessedAt":"0001-01-01T00:00:00","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic","name":"testingpythonsdktopic","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
+        US","properties":{"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":1024,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":true,"createdAt":"0001-01-01T00:00:00","updatedAt":"0001-01-01T00:00:00","accessedAt":"0001-01-01T00:00:00","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['973']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:34:38 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '973'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:21:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"rights": ["Send", "Listen"]}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['46']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules/testingauthrulepy?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/Topics/AuthorizationRules","location":"West
-        US","properties":{"rights":["Send","Listen"]}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/Topics/AuthorizationRules","location":"West
+        US","properties":{"rights":["Send","Listen"]}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['427']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:34:40 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '427'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:21:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules/testingauthrulepy?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/Topics/AuthorizationRules","location":"West
-        US","properties":{"rights":["Send","Listen"]}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/Topics/AuthorizationRules","location":"West
+        US","properties":{"rights":["Send","Listen"]}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['427']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:34:40 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '427'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:21:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"rights": ["Send", "Listen", "Manage"]}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['56']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules/testingauthrulepy?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/Topics/AuthorizationRules","location":"West
-        US","properties":{"rights":["Send","Listen","Manage"]}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/Topics/AuthorizationRules","location":"West
+        US","properties":{"rights":["Send","Listen","Manage"]}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['436']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:34:42 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '436'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:21:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules?api-version=2017-04-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/Topics/AuthorizationRules","location":"West
-        US","properties":{"rights":["Send","Listen","Manage"]}}]}'}
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules/testingauthrulepy","name":"testingauthrulepy","type":"Microsoft.ServiceBus/Namespaces/Topics/AuthorizationRules","location":"West
+        US","properties":{"rights":["Send","Listen","Manage"]}}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['448']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:34:43 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '448'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:21:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules/testingauthrulepy/ListKeys?api-version=2017-04-01
   response:
-    body: {string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasetopic.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=EJRFXg6APMBOguIn7f5hXTyCmbAjLjQRmNDDcwsb6go=;EntityPath=testingpythonsdktopic","secondaryConnectionString":"Endpoint=sb://testingpythontestcasetopic.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=qYH1bp0447J9CVqYejVR3MODJGKcJPG2Sel6buReH9Q=;EntityPath=testingpythonsdktopic","primaryKey":"EJRFXg6APMBOguIn7f5hXTyCmbAjLjQRmNDDcwsb6go=","secondaryKey":"qYH1bp0447J9CVqYejVR3MODJGKcJPG2Sel6buReH9Q=","keyName":"testingauthrulepy"}'}
+    body:
+      string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasetopic.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=9Qc1V2Uff0oOWbeHs4mJHvsMXmz/OD1mIVyDLxGW5aE=;EntityPath=testingpythonsdktopic","secondaryConnectionString":"Endpoint=sb://testingpythontestcasetopic.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=81BKNZYHa+ixXfz9A17kj0zGUWl4G9RACzQIvEwL4SM=;EntityPath=testingpythonsdktopic","primaryKey":"9Qc1V2Uff0oOWbeHs4mJHvsMXmz/OD1mIVyDLxGW5aE=","secondaryKey":"81BKNZYHa+ixXfz9A17kj0zGUWl4G9RACzQIvEwL4SM=","keyName":"testingauthrulepy"}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['605']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:34:43 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '605'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:21:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"keyType": "PrimaryKey"}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['25']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '25'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules/testingauthrulepy/regenerateKeys?api-version=2017-04-01
   response:
-    body: {string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasetopic.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=guBMVKlg99ZciGOi4uXNsy9rf0RrOazg1CTNaCq6DqU=;EntityPath=testingpythonsdktopic","secondaryConnectionString":"Endpoint=sb://testingpythontestcasetopic.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=qYH1bp0447J9CVqYejVR3MODJGKcJPG2Sel6buReH9Q=;EntityPath=testingpythonsdktopic","primaryKey":"guBMVKlg99ZciGOi4uXNsy9rf0RrOazg1CTNaCq6DqU=","secondaryKey":"qYH1bp0447J9CVqYejVR3MODJGKcJPG2Sel6buReH9Q=","keyName":"testingauthrulepy"}'}
+    body:
+      string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasetopic.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=YwrEWzT4fdZTJvvaWBqfXHXkfhUklnilIMACXt3wxDc=;EntityPath=testingpythonsdktopic","secondaryConnectionString":"Endpoint=sb://testingpythontestcasetopic.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=81BKNZYHa+ixXfz9A17kj0zGUWl4G9RACzQIvEwL4SM=;EntityPath=testingpythonsdktopic","primaryKey":"YwrEWzT4fdZTJvvaWBqfXHXkfhUklnilIMACXt3wxDc=","secondaryKey":"81BKNZYHa+ixXfz9A17kj0zGUWl4G9RACzQIvEwL4SM=","keyName":"testingauthrulepy"}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['605']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:34:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '605'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:21:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"keyType": "SecondaryKey"}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['27']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules/testingauthrulepy/regenerateKeys?api-version=2017-04-01
   response:
-    body: {string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasetopic.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=guBMVKlg99ZciGOi4uXNsy9rf0RrOazg1CTNaCq6DqU=;EntityPath=testingpythonsdktopic","secondaryConnectionString":"Endpoint=sb://testingpythontestcasetopic.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=Z0uQaPxN5HpNy5bve5Z2L/byGHJQCyPh/PUzduTSwCE=;EntityPath=testingpythonsdktopic","primaryKey":"guBMVKlg99ZciGOi4uXNsy9rf0RrOazg1CTNaCq6DqU=","secondaryKey":"Z0uQaPxN5HpNy5bve5Z2L/byGHJQCyPh/PUzduTSwCE=","keyName":"testingauthrulepy"}'}
+    body:
+      string: '{"primaryConnectionString":"Endpoint=sb://testingpythontestcasetopic.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=YwrEWzT4fdZTJvvaWBqfXHXkfhUklnilIMACXt3wxDc=;EntityPath=testingpythonsdktopic","secondaryConnectionString":"Endpoint=sb://testingpythontestcasetopic.servicebus.windows.net/;SharedAccessKeyName=testingauthrulepy;SharedAccessKey=p1YeXZfsU2eUa3OpuXsyRedTmaHpF/4vWGp68nok8d4=;EntityPath=testingpythonsdktopic","primaryKey":"YwrEWzT4fdZTJvvaWBqfXHXkfhUklnilIMACXt3wxDc=","secondaryKey":"p1YeXZfsU2eUa3OpuXsyRedTmaHpF/4vWGp68nok8d4=","keyName":"testingauthrulepy"}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['605']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:34:46 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '605'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:21:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules/testingauthrulepy?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:34:47 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:21:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic/authorizationRules?api-version=2017-04-01
   response:
-    body: {string: '{"value":[]}'}
+    body:
+      string: '{"value":[]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['12']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:34:47 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:21:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/topics/testingpythonsdktopic?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:34:49 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:21:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:34:51 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/operationresults/testingpythontestcasetopic?api-version=2017-04-01']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 202, message: Accepted}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:21:56 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/operationresults/testingpythontestcasetopic?api-version=2017-04-01
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 202
+      message: Accepted
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_test_sb_topic_curd29a11520/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasetopic/operationresults/testingpythontestcasetopic?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:35:21 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:22:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/sdk/servicebus/azure-mgmt-servicebus/tests/recordings/test_azure_mgmt_servicebus_topic_subscription.test_sb_subscription_curd.yaml
+++ b/sdk/servicebus/azure-mgmt-servicebus/tests/recordings/test_azure_mgmt_servicebus_topic_subscription.test_sb_subscription_curd.yaml
@@ -3,375 +3,694 @@ interactions:
     body: '{"location": "westus", "tags": {"tag1": "value1", "tag2": "value2"}, "sku":
       {"name": "Standard"}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['97']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '97'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription?api-version=2017-04-01
   response:
-    body: {string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription","name":"testingpythontestcasesubscription","type":"Microsoft.ServiceBus/Namespaces","location":"West
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasesubscription","createdAt":"2018-04-21T00:43:10.35Z","updatedAt":"2018-04-21T00:43:10.35Z","serviceBusEndpoint":"https://testingpythontestcasesubscription.servicebus.windows.net:443/","status":"Activating"}}'}
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription","name":"testingpythontestcasesubscription","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasesubscription","createdAt":"2020-03-03T01:22:31.16Z","updatedAt":"2020-03-03T01:22:31.16Z","serviceBusEndpoint":"https://testingpythontestcasesubscription.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['741']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:43:10 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '741'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:22:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription?api-version=2017-04-01
   response:
-    body: {string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription","name":"testingpythontestcasesubscription","type":"Microsoft.ServiceBus/Namespaces","location":"West
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasesubscription","createdAt":"2018-04-21T00:43:10.35Z","updatedAt":"2018-04-21T00:43:33.243Z","serviceBusEndpoint":"https://testingpythontestcasesubscription.servicebus.windows.net:443/","status":"Active"}}'}
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription","name":"testingpythontestcasesubscription","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasesubscription","createdAt":"2020-03-03T01:22:31.16Z","updatedAt":"2020-03-03T01:22:31.16Z","serviceBusEndpoint":"https://testingpythontestcasesubscription.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['740']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:43:41 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '741'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:23:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription?api-version=2017-04-01
   response:
-    body: {string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription","name":"testingpythontestcasesubscription","type":"Microsoft.ServiceBus/Namespaces","location":"West
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasesubscription","createdAt":"2018-04-21T00:43:10.35Z","updatedAt":"2018-04-21T00:43:33.243Z","serviceBusEndpoint":"https://testingpythontestcasesubscription.servicebus.windows.net:443/","status":"Active"}}'}
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription","name":"testingpythontestcasesubscription","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasesubscription","createdAt":"2020-03-03T01:22:31.16Z","updatedAt":"2020-03-03T01:23:14.383Z","serviceBusEndpoint":"https://testingpythontestcasesubscription.servicebus.windows.net:443/","status":"Active"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['740']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:43:41 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '740'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:23:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription?api-version=2017-04-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription","name":"testingpythontestcasesubscription","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcasesubscription","createdAt":"2020-03-03T01:22:31.16Z","updatedAt":"2020-03-03T01:23:14.383Z","serviceBusEndpoint":"https://testingpythontestcasesubscription.servicebus.windows.net:443/","status":"Active"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '740'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:23:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic","name":"testingpythonsdktopic","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
-        US","properties":{"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2018-04-21T00:43:44.763Z","updatedAt":"2018-04-21T00:43:44.84Z","accessedAt":"0001-01-01T00:00:00","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic","name":"testingpythonsdktopic","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
+        US","properties":{"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2020-03-03T01:23:34.13Z","updatedAt":"2020-03-03T01:23:34.167Z","accessedAt":"0001-01-01T00:00:00","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1010']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:43:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1010'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:23:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic","name":"testingpythonsdktopic","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
-        US","properties":{"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2018-04-21T00:43:44.763Z","updatedAt":"2018-04-21T00:43:44.84Z","accessedAt":"0001-01-01T00:00:00Z","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic","name":"testingpythonsdktopic","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
+        US","properties":{"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2020-03-03T01:23:34.13Z","updatedAt":"2020-03-03T01:23:34.167Z","accessedAt":"0001-01-01T00:00:00Z","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1011']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:43:46 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1011'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:23:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription","name":"testingpythonsdksubscription","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions","location":"West
-        US","properties":{"lockDuration":"PT1M","requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"deadLetteringOnFilterEvaluationExceptions":true,"messageCount":0,"maxDeliveryCount":10,"status":"Active","enableBatchedOperations":true,"createdAt":"2018-04-21T00:43:48.7684716Z","updatedAt":"2018-04-21T00:43:48.7684716Z","accessedAt":"0001-01-01T00:00:00","countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S"}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription","name":"testingpythonsdksubscription","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions","location":"West
+        US","properties":{"lockDuration":"PT1M","requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"deadLetteringOnFilterEvaluationExceptions":true,"messageCount":0,"maxDeliveryCount":10,"status":"Active","enableBatchedOperations":true,"createdAt":"2020-03-03T01:23:37.1995852Z","updatedAt":"2020-03-03T01:23:37.1995852Z","accessedAt":"0001-01-01T00:00:00","countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1041']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:43:48 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1041'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:23:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription","name":"testingpythonsdksubscription","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions","location":"West
-        US","properties":{"lockDuration":"PT1M","requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"deadLetteringOnFilterEvaluationExceptions":true,"messageCount":0,"maxDeliveryCount":10,"status":"Active","enableBatchedOperations":true,"createdAt":"2018-04-21T00:43:48.7831449Z","updatedAt":"2018-04-21T00:43:48.7831449Z","accessedAt":"2018-04-21T00:43:48.7831449Z","countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S"}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription","name":"testingpythonsdksubscription","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions","location":"West
+        US","properties":{"lockDuration":"PT1M","requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"deadLetteringOnFilterEvaluationExceptions":true,"messageCount":0,"maxDeliveryCount":10,"status":"Active","enableBatchedOperations":true,"createdAt":"2020-03-03T01:23:37.1857525Z","updatedAt":"2020-03-03T01:23:37.1857525Z","accessedAt":"2020-03-03T01:23:37.187Z","countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1050']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:43:49 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1046'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:23:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic/subscriptions?api-version=2017-04-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription","name":"testingpythonsdksubscription","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions","location":"West
-        US","properties":{"lockDuration":"PT1M","requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"deadLetteringOnFilterEvaluationExceptions":true,"messageCount":0,"maxDeliveryCount":10,"status":"Active","enableBatchedOperations":true,"createdAt":"2018-04-21T00:43:48.7831449Z","updatedAt":"2018-04-21T00:43:48.7831449Z","accessedAt":"2018-04-21T00:43:48.7831449Z","countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S"}}]}'}
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription","name":"testingpythonsdksubscription","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions","location":"West
+        US","properties":{"lockDuration":"PT1M","requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"deadLetteringOnFilterEvaluationExceptions":true,"messageCount":0,"maxDeliveryCount":10,"status":"Active","enableBatchedOperations":true,"createdAt":"2020-03-03T01:23:37.1857525Z","updatedAt":"2020-03-03T01:23:37.1857525Z","accessedAt":"2020-03-03T01:23:37.187Z","countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S"}}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1062']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:43:50 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-inline-count: ['']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1058'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:23:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-inline-count:
+      - ''
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"deadLetteringOnMessageExpiration": true, "enableBatchedOperations":
       true}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['91']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription","name":"testingpythonsdksubscription","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions","location":"West
-        US","properties":{"lockDuration":"PT1M","requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":true,"deadLetteringOnFilterEvaluationExceptions":true,"messageCount":0,"maxDeliveryCount":10,"status":"Active","enableBatchedOperations":true,"createdAt":"2018-04-21T00:43:52.6680403Z","updatedAt":"2018-04-21T00:43:52.6680403Z","accessedAt":"0001-01-01T00:00:00","countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S"}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription","name":"testingpythonsdksubscription","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions","location":"West
+        US","properties":{"lockDuration":"PT1M","requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":true,"deadLetteringOnFilterEvaluationExceptions":true,"messageCount":0,"maxDeliveryCount":10,"status":"Active","enableBatchedOperations":true,"createdAt":"2020-03-03T01:23:39.4329812Z","updatedAt":"2020-03-03T01:23:39.4329812Z","accessedAt":"0001-01-01T00:00:00","countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1040']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:43:51 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1040'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:23:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:43:53 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:23:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/topics/testingpythonsdktopic?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:43:58 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:23:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:44:00 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/operationresults/testingpythontestcasesubscription?api-version=2017-04-01']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 202, message: Accepted}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:23:40 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/operationresults/testingpythontestcasesubscription?api-version=2017-04-01
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 202
+      message: Accepted
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_test_sb_subscription_curd2f101daa/providers/Microsoft.ServiceBus/namespaces/testingpythontestcasesubscription/operationresults/testingpythontestcasesubscription?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:44:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:24:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/sdk/servicebus/azure-mgmt-servicebus/tests/recordings/test_azure_mgmt_servicebus_topic_subscription_rule.test_sb_rule_curd.yaml
+++ b/sdk/servicebus/azure-mgmt-servicebus/tests/recordings/test_azure_mgmt_servicebus_topic_subscription_rule.test_sb_rule_curd.yaml
@@ -3,435 +3,798 @@ interactions:
     body: '{"location": "westus", "tags": {"tag1": "value1", "tag2": "value2"}, "sku":
       {"name": "Standard"}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['97']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '97'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule?api-version=2017-04-01
   response:
-    body: {string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule","name":"testingpythontestcaserule","type":"Microsoft.ServiceBus/Namespaces","location":"West
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcaserule","createdAt":"2018-04-21T00:48:51.573Z","updatedAt":"2018-04-21T00:48:51.573Z","serviceBusEndpoint":"https://testingpythontestcaserule.servicebus.windows.net:443/","status":"Activating"}}'}
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule","name":"testingpythontestcaserule","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcaserule","createdAt":"2020-03-03T01:24:15.267Z","updatedAt":"2020-03-03T01:24:15.267Z","serviceBusEndpoint":"https://testingpythontestcaserule.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['708']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:48:51 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '708'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:24:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule?api-version=2017-04-01
   response:
-    body: {string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule","name":"testingpythontestcaserule","type":"Microsoft.ServiceBus/Namespaces","location":"West
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcaserule","createdAt":"2018-04-21T00:48:51.573Z","updatedAt":"2018-04-21T00:49:15.673Z","serviceBusEndpoint":"https://testingpythontestcaserule.servicebus.windows.net:443/","status":"Active"}}'}
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule","name":"testingpythontestcaserule","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Created","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcaserule","createdAt":"2020-03-03T01:24:15.267Z","updatedAt":"2020-03-03T01:24:15.267Z","serviceBusEndpoint":"https://testingpythontestcaserule.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['706']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:49:21 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '708'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:24:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule?api-version=2017-04-01
   response:
-    body: {string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule","name":"testingpythontestcaserule","type":"Microsoft.ServiceBus/Namespaces","location":"West
-        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcaserule","createdAt":"2018-04-21T00:48:51.573Z","updatedAt":"2018-04-21T00:49:15.673Z","serviceBusEndpoint":"https://testingpythontestcaserule.servicebus.windows.net:443/","status":"Active"}}'}
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule","name":"testingpythontestcaserule","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcaserule","createdAt":"2020-03-03T01:24:15.267Z","updatedAt":"2020-03-03T01:24:57.837Z","serviceBusEndpoint":"https://testingpythontestcaserule.servicebus.windows.net:443/","status":"Active"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['706']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:49:23 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '706'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:25:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule?api-version=2017-04-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule","name":"testingpythontestcaserule","type":"Microsoft.ServiceBus/Namespaces","location":"West
+        US","tags":{"tag1":"value1","tag2":"value2"},"properties":{"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:testingpythontestcaserule","createdAt":"2020-03-03T01:24:15.267Z","updatedAt":"2020-03-03T01:24:57.837Z","serviceBusEndpoint":"https://testingpythontestcaserule.servicebus.windows.net:443/","status":"Active"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '706'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:25:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic","name":"testingpythonsdktopic","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
-        US","properties":{"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2018-04-21T00:49:26.46Z","updatedAt":"2018-04-21T00:49:26.617Z","accessedAt":"0001-01-01T00:00:00","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic","name":"testingpythonsdktopic","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
+        US","properties":{"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2020-03-03T01:25:18.247Z","updatedAt":"2020-03-03T01:25:18.327Z","accessedAt":"0001-01-01T00:00:00","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['999']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:49:27 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1000'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:25:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic","name":"testingpythonsdktopic","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
-        US","properties":{"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2018-04-21T00:49:26.46Z","updatedAt":"2018-04-21T00:49:26.617Z","accessedAt":"0001-01-01T00:00:00Z","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic","name":"testingpythonsdktopic","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
+        US","properties":{"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":5120,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2020-03-03T01:25:18.247Z","updatedAt":"2020-03-03T01:25:18.327Z","accessedAt":"0001-01-01T00:00:00Z","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1000']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:49:27 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1001'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:25:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription","name":"testingpythonsdksubscription","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions","location":"West
-        US","properties":{"lockDuration":"PT1M","requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"deadLetteringOnFilterEvaluationExceptions":true,"messageCount":0,"maxDeliveryCount":10,"status":"Active","enableBatchedOperations":true,"createdAt":"2018-04-21T00:49:30.4059948Z","updatedAt":"2018-04-21T00:49:30.4059948Z","accessedAt":"0001-01-01T00:00:00","countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S"}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription","name":"testingpythonsdksubscription","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions","location":"West
+        US","properties":{"lockDuration":"PT1M","requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"deadLetteringOnFilterEvaluationExceptions":true,"messageCount":0,"maxDeliveryCount":10,"status":"Active","enableBatchedOperations":true,"createdAt":"2020-03-03T01:25:21.3803547Z","updatedAt":"2020-03-03T01:25:21.3803547Z","accessedAt":"0001-01-01T00:00:00","countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1030']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:49:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1030'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:25:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription","name":"testingpythonsdksubscription","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions","location":"West
-        US","properties":{"lockDuration":"PT1M","requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"deadLetteringOnFilterEvaluationExceptions":true,"messageCount":0,"maxDeliveryCount":10,"status":"Active","enableBatchedOperations":true,"createdAt":"2018-04-21T00:49:30.4125879Z","updatedAt":"2018-04-21T00:49:30.4125879Z","accessedAt":"2018-04-21T00:49:30.413Z","countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S"}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription","name":"testingpythonsdksubscription","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions","location":"West
+        US","properties":{"lockDuration":"PT1M","requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"deadLetteringOnFilterEvaluationExceptions":true,"messageCount":0,"maxDeliveryCount":10,"status":"Active","enableBatchedOperations":true,"createdAt":"2020-03-03T01:25:21.4153415Z","updatedAt":"2020-03-03T01:25:21.4153415Z","accessedAt":"2020-03-03T01:25:21.417Z","countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1035']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:49:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1035'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:25:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription/rules/testingpythonsdkrule?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription/rules/testingpythonsdkrule","name":"testingpythonsdkrule","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules","location":"West
-        US","properties":{"action":{},"filterType":"SqlFilter","sqlFilter":{"sqlExpression":"1=1","compatibilityLevel":20}}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription/rules/testingpythonsdkrule","name":"testingpythonsdkrule","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules","location":"West
+        US","properties":{"action":{},"filterType":"SqlFilter","sqlFilter":{"sqlExpression":"1=1","compatibilityLevel":20}}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['550']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:49:34 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '550'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:25:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription/rules/testingpythonsdkrule?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription/rules/testingpythonsdkrule","name":"testingpythonsdkrule","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules","location":"West
-        US","properties":{"action":{},"filterType":"SqlFilter","sqlFilter":{"sqlExpression":"1=1","compatibilityLevel":20}}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription/rules/testingpythonsdkrule","name":"testingpythonsdkrule","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules","location":"West
+        US","properties":{"action":{},"filterType":"SqlFilter","sqlFilter":{"sqlExpression":"1=1","compatibilityLevel":20}}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['550']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:49:35 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '550'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:25:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription/rules?api-version=2017-04-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription/rules/testingpythonsdkrule","name":"testingpythonsdkrule","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules","location":"West
-        US","properties":{"action":{},"filterType":"SqlFilter","sqlFilter":{"sqlExpression":"1=1","compatibilityLevel":20}}}]}'}
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription/rules/testingpythonsdkrule","name":"testingpythonsdkrule","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules","location":"West
+        US","properties":{"action":{},"filterType":"SqlFilter","sqlFilter":{"sqlExpression":"1=1","compatibilityLevel":20}}}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['562']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:49:36 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-inline-count: ['']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '562'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:25:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-inline-count:
+      - ''
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"filterType": "SqlFilter", "sqlFilter": {"sqlExpression":
       "myproperty=''test''", "requiresPreprocessing": true}}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['127']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription/rules/testingpythonsdkrule?api-version=2017-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription/rules/testingpythonsdkrule","name":"testingpythonsdkrule","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules","location":"West
-        US","properties":{"action":{},"filterType":"SqlFilter","sqlFilter":{"sqlExpression":"myproperty=''test''","compatibilityLevel":20}}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription/rules/testingpythonsdkrule","name":"testingpythonsdkrule","type":"Microsoft.ServiceBus/Namespaces/Topics/Subscriptions/Rules","location":"West
+        US","properties":{"action":{},"filterType":"SqlFilter","sqlFilter":{"sqlExpression":"myproperty=''test''","compatibilityLevel":20}}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['564']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Apr 2018 00:49:38 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '564'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 03 Mar 2020 01:25:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic/subscriptions/testingpythonsdksubscription?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:49:39 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:25:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/topics/testingpythonsdktopic?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:49:41 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:25:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:49:42 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/operationresults/testingpythontestcaserule?api-version=2017-04-01']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 202, message: Accepted}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:25:27 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/operationresults/testingpythontestcaserule?api-version=2017-04-01
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 202
+      message: Accepted
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python/3.6.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-servicebus/0.5.0 Azure-SDK-For-Python]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
+        azure-mgmt-servicebus/0.6.0 Azure-SDK-For-Python
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_azure_mgmt_servicebus_topic_subscription_rule_test_sb_rule_curdd7b71c54/providers/Microsoft.ServiceBus/namespaces/testingpythontestcaserule/operationresults/testingpythontestcaserule?api-version=2017-04-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Sat, 21 Apr 2018 00:50:13 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Service-Bus-Resource-Provider/CH3, Microsoft-HTTPAPI/2.0]
-      server-sb: [Service-Bus-Resource-Provider/CH3]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 03 Mar 2020 01:25:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/SN1
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/SN1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/sdk/servicebus/azure-mgmt-servicebus/tests/test_azure_mgmt_servicebus_namespace.py
+++ b/sdk/servicebus/azure-mgmt-servicebus/tests/test_azure_mgmt_servicebus_namespace.py
@@ -29,7 +29,7 @@ class MgmtServiceBusTest(AzureMgmtTestCase):
         resource_group_name = resource_group.name #"ardsouza-resourcemovetest-group2"
 
         # Create a Namespace
-        namespace_name = "testingpythontestcasenamespace"
+        namespace_name = self.get_replayable_random_resource_name("testingpythontestcasenamespace")
 
         namespaceparameter=SBNamespace(location=location,tags={'tag1':'value1','tag2':'value2'},sku=SBSku(name=SkuName.standard))
         creatednamespace = self.servicebus_client.namespaces.create_or_update(resource_group_name, namespace_name, namespaceparameter).result()
@@ -51,13 +51,13 @@ class MgmtServiceBusTest(AzureMgmtTestCase):
         self.assertGreater(len(listbysubscriptionresponse), 0, "No Namespace returned, List is empty")
 
         # get the default authorizationrule
-        defaultauthorule_name = "RootManageSharedAccessKey"
+        defaultauthorule_name = self.get_replayable_random_resource_name("RootManageSharedAccessKey")
         defaultamespaceauthorule = self.servicebus_client.namespaces.get_authorization_rule(resource_group_name, namespace_name, defaultauthorule_name)
         self.assertEqual(defaultamespaceauthorule.name, defaultauthorule_name,"Default Authorization rule not returned - RootManageSharedAccessKey")
         self.assertEqual(len(defaultamespaceauthorule.rights), 3, "rights for deafult not as required - send, listen and manage ")
 
         # Create a new authorizationrule
-        authoRule_name = "testingauthrulepy"
+        authoRule_name = self.get_replayable_random_resource_name("testingauthrulepy")
         createnamespaceauthorule = self.servicebus_client.namespaces.create_or_update_authorization_rule(resource_group_name,namespace_name,authoRule_name,[AccessRights('Send'),AccessRights('Listen')])
         self.assertEqual(createnamespaceauthorule.name,authoRule_name, "Authorization rule name not as created - create_or_update_authorization_rule ")
         self.assertEqual(len(createnamespaceauthorule.rights),2)

--- a/sdk/servicebus/azure-mgmt-servicebus/tests/test_azure_mgmt_servicebus_queue.py
+++ b/sdk/servicebus/azure-mgmt-servicebus/tests/test_azure_mgmt_servicebus_queue.py
@@ -30,7 +30,7 @@ class MgmtServiceBusTest(AzureMgmtTestCase):
         resource_group_name = resource_group.name
 
         # Create a Namespace
-        namespace_name = "testingpythontestcasequeue"
+        namespace_name = self.get_replayable_random_resource_name("testingpythontestcasequeue")
 
         namespaceparameter = SBNamespace(location=location, tags={'tag1': 'value1', 'tag2': 'value2'}, sku=SBSku(name=SkuName.standard))
         creatednamespace = self.servicebus_client.namespaces.create_or_update(resource_group_name, namespace_name, namespaceparameter).result()
@@ -42,7 +42,7 @@ class MgmtServiceBusTest(AzureMgmtTestCase):
             continue
 
         # Create a Queue
-        queue_name = "testingpythonsdkqueue"
+        queue_name = self.get_replayable_random_resource_name("testingpythonsdkqueue")
         createqueueresponse = self.servicebus_client.queues.create_or_update(resource_group_name, namespace_name,queue_name,SBQueue())
         self.assertEqual(createqueueresponse.name, queue_name)
 
@@ -63,7 +63,7 @@ class MgmtServiceBusTest(AzureMgmtTestCase):
         self.assertEqual(updatequeueresponse.enable_express, True)
 
         # Create a new authorizationrule
-        authoRule_name = "testingauthrulepy"
+        authoRule_name = self.get_replayable_random_resource_name("testingauthrulepy")
         createqueueauthorule = self.servicebus_client.queues.create_or_update_authorization_rule(resource_group_name, namespace_name, queue_name, authoRule_name, [AccessRights('Send'), AccessRights('Listen')])
         self.assertEqual(createqueueauthorule.name, authoRule_name,"Authorization rule name not as created - create_or_update_authorization_rule ")
         self.assertEqual(len(createqueueauthorule.rights), 2)

--- a/sdk/servicebus/azure-mgmt-servicebus/tests/test_azure_mgmt_servicebus_topic.py
+++ b/sdk/servicebus/azure-mgmt-servicebus/tests/test_azure_mgmt_servicebus_topic.py
@@ -30,7 +30,7 @@ class MgmtServiceBusTest(AzureMgmtTestCase):
         resource_group_name = resource_group.name  # "ardsouza-resourcemovetest-group2"
 
         # Create a Namespace
-        namespace_name = "testingpythontestcasetopic"
+        namespace_name = self.get_replayable_random_resource_name("testingpythontestcasetopic")
 
         namespaceparameter = SBNamespace(location=location, tags={'tag1': 'value1', 'tag2': 'value2'}, sku=SBSku(name=SkuName.standard))
         creatednamespace = self.servicebus_client.namespaces.create_or_update(resource_group_name, namespace_name, namespaceparameter).result()
@@ -42,7 +42,7 @@ class MgmtServiceBusTest(AzureMgmtTestCase):
             continue
 
         # Create a Topic
-        topic_name = "testingpythonsdktopic"
+        topic_name = self.get_replayable_random_resource_name("testingpythonsdktopic")
         createtopicresponse = self.servicebus_client.topics.create_or_update(resource_group_name, namespace_name,topic_name,SBTopic())
         self.assertEqual(createtopicresponse.name, topic_name)
 
@@ -63,7 +63,7 @@ class MgmtServiceBusTest(AzureMgmtTestCase):
         self.assertEqual(updatetopicresponse.enable_express, True)
 
         # Create a new authorizationrule
-        authoRule_name = "testingauthrulepy"
+        authoRule_name = self.get_replayable_random_resource_name("testingauthrulepy")
         createtopicauthorule = self.servicebus_client.topics.create_or_update_authorization_rule(resource_group_name, namespace_name, topic_name, authoRule_name, [AccessRights('Send'), AccessRights('Listen')])
         self.assertEqual(createtopicauthorule.name, authoRule_name,"Authorization rule name not as created - create_or_update_authorization_rule ")
         self.assertEqual(len(createtopicauthorule.rights), 2)

--- a/sdk/servicebus/azure-mgmt-servicebus/tests/test_azure_mgmt_servicebus_topic_subscription.py
+++ b/sdk/servicebus/azure-mgmt-servicebus/tests/test_azure_mgmt_servicebus_topic_subscription.py
@@ -30,7 +30,7 @@ class MgmtServiceBusTest(AzureMgmtTestCase):
         resource_group_name = resource_group.name  # "ardsouza-resourcemovetest-group2"
 
         # Create a Namespace
-        namespace_name = "testingpythontestcasesubscription"
+        namespace_name = self.get_replayable_random_resource_name("testingpythontestcasesubscription")
 
         namespaceparameter = SBNamespace(location=location, tags={'tag1': 'value1', 'tag2': 'value2'}, sku=SBSku(name=SkuName.standard))
         creatednamespace = self.servicebus_client.namespaces.create_or_update(resource_group_name, namespace_name, namespaceparameter).result()
@@ -42,7 +42,7 @@ class MgmtServiceBusTest(AzureMgmtTestCase):
             continue
 
         # Create a Topic
-        topic_name = "testingpythonsdktopic"
+        topic_name = self.get_replayable_random_resource_name("testingpythonsdktopic")
         createtopicresponse = self.servicebus_client.topics.create_or_update(resource_group_name, namespace_name,topic_name,SBTopic())
         self.assertEqual(createtopicresponse.name, topic_name)
 
@@ -51,7 +51,7 @@ class MgmtServiceBusTest(AzureMgmtTestCase):
         self.assertEqual(gettopicresponse.name, topic_name)
 
         # Create subscription
-        subscription_name = "testingpythonsdksubscription"
+        subscription_name = self.get_replayable_random_resource_name("testingpythonsdksubscription")
         createsubscriptionresponse =self.servicebus_client.subscriptions.create_or_update(resource_group_name, namespace_name,topic_name,subscription_name,SBSubscription())
         self.assertEqual(createsubscriptionresponse.name, subscription_name)
 

--- a/sdk/servicebus/azure-mgmt-servicebus/tests/test_azure_mgmt_servicebus_topic_subscription_rule.py
+++ b/sdk/servicebus/azure-mgmt-servicebus/tests/test_azure_mgmt_servicebus_topic_subscription_rule.py
@@ -30,7 +30,7 @@ class MgmtServiceBusTest(AzureMgmtTestCase):
         resource_group_name = resource_group.name  # "ardsouza-resourcemovetest-group2"
 
         # Create a Namespace
-        namespace_name = "testingpythontestcaserule"
+        namespace_name = self.get_replayable_random_resource_name("testingpythontestcaserule")
 
         namespaceparameter = SBNamespace(location=location, tags={'tag1': 'value1', 'tag2': 'value2'}, sku=SBSku(name=SkuName.standard))
         creatednamespace = self.servicebus_client.namespaces.create_or_update(resource_group_name, namespace_name, namespaceparameter).result()
@@ -42,7 +42,7 @@ class MgmtServiceBusTest(AzureMgmtTestCase):
             continue
 
         # Create a Topic
-        topic_name = "testingpythonsdktopic"
+        topic_name = self.get_replayable_random_resource_name("testingpythonsdktopic")
         createtopicresponse = self.servicebus_client.topics.create_or_update(resource_group_name, namespace_name, topic_name, SBTopic())
         self.assertEqual(createtopicresponse.name, topic_name)
 
@@ -51,7 +51,7 @@ class MgmtServiceBusTest(AzureMgmtTestCase):
         self.assertEqual(gettopicresponse.name, topic_name)
 
         # Create subscription
-        subscription_name = "testingpythonsdksubscription"
+        subscription_name = self.get_replayable_random_resource_name("testingpythonsdksubscription")
         createsubscriptionresponse =self.servicebus_client.subscriptions.create_or_update(resource_group_name, namespace_name, topic_name, subscription_name, SBSubscription())
         self.assertEqual(createsubscriptionresponse.name, subscription_name)
 
@@ -60,7 +60,7 @@ class MgmtServiceBusTest(AzureMgmtTestCase):
         self.assertEqual(getsubscriptionresponse.name, subscription_name)
 
         # create rule
-        rule_name = "testingpythonsdkrule"
+        rule_name = self.get_replayable_random_resource_name("testingpythonsdkrule")
         createruleresponse = self.servicebus_client.rules.create_or_update(resource_group_name, namespace_name, topic_name, subscription_name, rule_name, Rule())
         self.assertEqual(createruleresponse.name, rule_name)
 

--- a/sdk/servicebus/azure-servicebus/tests/servicebus_preparer.py
+++ b/sdk/servicebus/azure-servicebus/tests/servicebus_preparer.py
@@ -40,6 +40,8 @@ class ServiceBusNamespacePreparer(AzureMgmtPreparer):
         self.resource_group_parameter_name = resource_group_parameter_name
         self.parameter_name = parameter_name
         self.connection_string = ''
+        if random_name_enabled:
+            self.resource_moniker = self.name_prefix + "sbname"
 
     def create_resource(self, name, **kwargs):
         if self.is_live:
@@ -59,6 +61,11 @@ class ServiceBusNamespacePreparer(AzureMgmtPreparer):
             self.connection_string = key.primary_connection_string
             self.key_name = key.key_name
             self.primary_key = key.primary_key
+
+            self.test_class_instance.scrubber.register_name_pair(
+                name,
+                self.resource_moniker
+            )
         else:
             self.resource = FakeResource(name=name, id=name)
             self.connection_string = 'Endpoint=sb://test-azure-sdk-test.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX='
@@ -134,6 +141,8 @@ class ServiceBusTopicPreparer(_ServiceBusChildResourcePreparer):
                                                      playback_fake_resource=playback_fake_resource,
                                                      client_kwargs=client_kwargs)
         self.parameter_name = parameter_name
+        if random_name_enabled:
+            self.resource_moniker = self.name_prefix + "sbtopic"
 
     def create_resource(self, name, **kwargs):
         if self.is_live:
@@ -145,6 +154,11 @@ class ServiceBusTopicPreparer(_ServiceBusChildResourcePreparer):
                 namespace.name,
                 name,
                 {}
+            )
+
+            self.test_class_instance.scrubber.register_name_pair(
+                name,
+                self.resource_moniker
             )
         else:
             self.resource = FakeResource(name=name, id=name)
@@ -178,6 +192,8 @@ class ServiceBusSubscriptionPreparer(_ServiceBusChildResourcePreparer):
                                                      client_kwargs=client_kwargs)
         self.servicebus_topic_parameter_name = servicebus_topic_parameter_name
         self.parameter_name = parameter_name
+        if random_name_enabled:
+            self.resource_moniker = self.name_prefix + "sbsub"
 
     def create_resource(self, name, **kwargs):
         if self.is_live:
@@ -191,6 +207,11 @@ class ServiceBusSubscriptionPreparer(_ServiceBusChildResourcePreparer):
                 topic.name,
                 name,
                 {}
+            )
+
+            self.test_class_instance.scrubber.register_name_pair(
+                name,
+                self.resource_moniker
             )
         else:
             self.resource = FakeResource(name=name, id=name)
@@ -240,6 +261,8 @@ class ServiceBusQueuePreparer(_ServiceBusChildResourcePreparer):
         self.requires_duplicate_detection=requires_duplicate_detection
         self.dead_lettering_on_message_expiration=dead_lettering_on_message_expiration
         self.requires_session=requires_session
+        if random_name_enabled:
+            self.resource_moniker = self.name_prefix + "sbqueue"
 
     def create_resource(self, name, **kwargs):
         if self.is_live:
@@ -255,6 +278,11 @@ class ServiceBusQueuePreparer(_ServiceBusChildResourcePreparer):
                     requires_duplicate_detection = self.requires_duplicate_detection,
                     dead_lettering_on_message_expiration = self.dead_lettering_on_message_expiration,
                     requires_session = self.requires_session)
+            )
+
+            self.test_class_instance.scrubber.register_name_pair(
+                name,
+                self.resource_moniker
             )
         else:
             self.resource = FakeResource(name=name, id=name)
@@ -287,6 +315,8 @@ class ServiceBusNamespaceAuthorizationRulePreparer(_ServiceBusChildResourcePrepa
                                                      client_kwargs=client_kwargs)
         self.parameter_name = parameter_name
         self.access_rights = access_rights
+        if random_name_enabled:
+            self.resource_moniker = self.name_prefix + "sbnameauth"
 
     def create_resource(self, name, **kwargs):
         if self.is_live:
@@ -302,6 +332,11 @@ class ServiceBusNamespaceAuthorizationRulePreparer(_ServiceBusChildResourcePrepa
 
             key = self.client.namespaces.list_keys(group.name, namespace.name, name)
             connection_string = key.primary_connection_string
+
+            self.test_class_instance.scrubber.register_name_pair(
+                name,
+                self.resource_moniker
+            )
         else:
             self.resource = FakeResource(name=name, id=name)
             connection_string = 'https://microsoft.com'
@@ -337,6 +372,8 @@ class ServiceBusQueueAuthorizationRulePreparer(_ServiceBusChildResourcePreparer)
         self.parameter_name = parameter_name
         self.access_rights = access_rights
         self.servicebus_queue_parameter_name = servicebus_queue_parameter_name
+        if random_name_enabled:
+            self.resource_moniker = self.name_prefix + "sbqueueauth"
 
     def create_resource(self, name, **kwargs):
         if self.is_live:
@@ -354,6 +391,11 @@ class ServiceBusQueueAuthorizationRulePreparer(_ServiceBusChildResourcePreparer)
 
             key = self.client.queues.list_keys(group.name, namespace.name, queue.name, name)
             connection_string = key.primary_connection_string
+
+            self.test_class_instance.scrubber.register_name_pair(
+                name,
+                self.resource_moniker
+            )
         else:
             self.resource = FakeResource(name=name, id=name)
             connection_string = 'https://microsoft.com'

--- a/tools/azure-sdk-tools/devtools_testutils/azure_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/azure_testcase.py
@@ -238,6 +238,16 @@ class AzureTestCase(ReplayableTest):
         """Alias to create_random_name for back compatibility."""
         return self.create_random_name(name)
 
+    def get_replayable_random_resource_name(self, name):
+        """In a replay scenario, (is not live) gives the static moniker.  In the random scenario, gives generated name."""
+        if self.is_live:
+            created_name = self.create_random_name(name)
+            self.scrubber.register_name_pair(
+                created_name,
+                name
+            )
+        return name
+
     def get_preparer_resource_name(self, prefix):
         """Random name generation for use by preparers.
 


### PR DESCRIPTION
- Create a new helper in azure_testcase, get_replayable_random_resource_name, to be used by mgmt tests to properly fetch names in live vs nonlive scenarios while still aligning recordings.
- Emplace this helper in servicebus management tests and regenerate recordings.
- Ensure servicebus preparers use the scrubber to properly align live and nonlive test names.

Addresses issue #10008