### PR TITLE
Sphinx mapping: add reference to local object database shipped by pyt…

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -59,7 +59,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.doctes
 
 intersphinx_mapping = {
     # Dependencies
-    'python': ('https://docs.python.org/3.8', None),
+    'python': ('https://docs.python.org/3.8', ('/usr/share/doc/python3-doc/html/objects.inv', None)),
     'msrestazure': ('http://msrestazure.readthedocs.io/en/latest/', None),
     'msrest': ('http://msrest.readthedocs.io/en/latest/', None),
     'requests': ('https://requests.kennethreitz.org/en/master/', None),


### PR DESCRIPTION
…hon3-doc

In Debian/Ubuntu, python3-doc ships a local sphinx documentation object
database that can be used to do offline documentation builds.
Add a reference to it, so that the network is only used if it is not
present, as a fallback.
Necessary to make the build reproducible (note that as other dependencies
do not ship these files yet, we have to patch them out downstream to
make the build fully reproducible).