### PR TITLE
[text analytics] name changes

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log azure-ai-textanalytics
 
-## 1.0.0b3 (Unreleased)
+## 1.0.0b3 (2020-03-10)
 
 **Breaking changes**
 - `SentimentScorePerLabel` has been renamed to `SentimentConfidenceScores`

--- a/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.0.0b3 (Unreleased)
 
 **Breaking changes**
-- `SentimentScorePerLabel` has been renamed to `SentimentConfidenceScorePerLabel`
+- `SentimentScorePerLabel` has been renamed to `SentimentConfidenceScores`
 - `AnalyzeSentimentResult` and `SentenceSentiment` attribute `sentiment_scores` has been renamed to `confidence_scores`
 - `LinkedEntity` attribute `id` has been renamed to `data_source_entity_id`
 - Parameters `country_hint` and `language` are now passed as keyword arguments
@@ -20,7 +20,7 @@
 
 - The single text, module-level operations `single_detect_language()`, `single_recognize_entities()`, `single_extract_key_phrases()`, `single_analyze_sentiment()`, `single_recognize_pii_entities()`, and `single_recognize_linked_entities()`
 have been removed from the client library. Use the batching methods for optimal performance in production environments.
-- To use an API key as the credential for authenticating the client, a new credential class `TextAnalyticsApiKeyCredential("<api_key>")` must be passed in for the `credential` parameter. 
+- To use an API key as the credential for authenticating the client, a new credential class `TextAnalyticsApiKeyCredential("<api_key>")` must be passed in for the `credential` parameter.
 Passing the API key as a string is no longer supported.
 - `detect_languages()` is renamed to `detect_language()`.
 - The `TextAnalyticsError` model has been simplified to an object with only attributes `code`, `message`, and `target`.
@@ -89,8 +89,8 @@ https://azure.github.io/azure-sdk/releases/latest/python.html.
   - `show_stats` and `model_version` parameters move to keyword only arguments.
 
 - New return types
-  - The return types for the batching methods (`detect_languages`, `recognize_entities`, `recognize_pii_entities`, `recognize_linked_entities`, `extract_key_phrases`, `analyze_sentiment`) now return a heterogeneous list of 
-  result objects and document errors in the order passed in with the request. To iterate over the list and filter for result or error, a boolean property on each object called `is_error` can be used to determine whether the returned response object at 
+  - The return types for the batching methods (`detect_languages`, `recognize_entities`, `recognize_pii_entities`, `recognize_linked_entities`, `extract_key_phrases`, `analyze_sentiment`) now return a heterogeneous list of
+  result objects and document errors in the order passed in with the request. To iterate over the list and filter for result or error, a boolean property on each object called `is_error` can be used to determine whether the returned response object at
   that index is a result or an error:
   - `detect_languages` now returns a List[Union[`DetectLanguageResult`, `DocumentError`]]
   - `recognize_entities` now returns a List[Union[`RecognizeEntitiesResult`, `DocumentError`]]

--- a/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Breaking changes**
 - `SentimentScorePerLabel` has been renamed to `SentimentConfidenceScores`
 - `AnalyzeSentimentResult` and `SentenceSentiment` attribute `sentiment_scores` has been renamed to `confidence_scores`
+- `TextDocumentStatistics` attribute `character_count` has been renamed to `grapheme_count`
 - `LinkedEntity` attribute `id` has been renamed to `data_source_entity_id`
 - Parameters `country_hint` and `language` are now passed as keyword arguments
 - The keyword argument `response_hook` has been renamed to `raw_response_hook`

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/__init__.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/__init__.py
@@ -24,7 +24,7 @@ from ._models import (
     LinkedEntityMatch,
     TextDocumentBatchStatistics,
     SentenceSentiment,
-    SentimentConfidenceScorePerLabel,
+    SentimentConfidenceScores,
     PiiEntity
 )
 from ._credential import TextAnalyticsApiKeyCredential
@@ -48,7 +48,7 @@ __all__ = [
     'LinkedEntityMatch',
     'TextDocumentBatchStatistics',
     'SentenceSentiment',
-    'SentimentConfidenceScorePerLabel',
+    'SentimentConfidenceScores',
     'TextAnalyticsApiKeyCredential',
     'PiiEntity'
 ]

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
@@ -713,8 +713,8 @@ class SentenceSentiment(DictMixin):
 
 
 class SentimentConfidenceScores(DictMixin):
-    """The confidence scores (Softmax scores) between 0 and 1 across all sentiment
-    labels: positive, neutral, negative. Higher values indicate higher confidence.
+    """The confidence scores (Softmax scores) between 0 and 1.
+    Higher values indicate higher confidence.
 
     :param positive: Positive score.
     :type positive: float

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
@@ -422,16 +422,16 @@ class TextDocumentStatistics(DictMixin):
     """TextDocumentStatistics contains information about
     the document payload.
 
-    :param character_count: Number of text elements recognized in
+    :param grapheme_count: Number of text elements recognized in
         the document.
-    :type character_count: int
+    :type grapheme_count: int
     :param transaction_count: Number of transactions for the
         document.
     :type transaction_count: int
     """
 
     def __init__(self, **kwargs):
-        self.character_count = kwargs.get("character_count", None)
+        self.grapheme_count = kwargs.get("grapheme_count", None)
         self.transaction_count = kwargs.get("transaction_count", None)
 
     @classmethod
@@ -439,13 +439,13 @@ class TextDocumentStatistics(DictMixin):
         if stats is None:
             return None
         return cls(
-            character_count=stats.characters_count,
+            grapheme_count=stats.characters_count,
             transaction_count=stats.transactions_count,
         )
 
     def __repr__(self):
-        return "TextDocumentStatistics(character_count={}, transaction_count={})" \
-            .format(self.character_count, self.transaction_count)[:1024]
+        return "TextDocumentStatistics(grapheme_count={}, transaction_count={})" \
+            .format(self.grapheme_count, self.transaction_count)[:1024]
 
 
 class DocumentError(DictMixin):

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
@@ -396,7 +396,7 @@ class AnalyzeSentimentResult(DictMixin):
     :param confidence_scores: Document level sentiment confidence
         scores between 0 and 1 for each sentiment label.
     :type confidence_scores:
-        ~azure.ai.textanalytics.SentimentConfidenceScorePerLabel
+        ~azure.ai.textanalytics.SentimentConfidenceScores
     :param sentences: Sentence level sentiment analysis.
     :type sentences:
         list[~azure.ai.textanalytics.SentenceSentiment]
@@ -679,7 +679,7 @@ class SentenceSentiment(DictMixin):
     :param confidence_scores: The sentiment confidence score between 0
         and 1 for the sentence for all labels.
     :type confidence_scores:
-        ~azure.ai.textanalytics.SentimentConfidenceScorePerLabel
+        ~azure.ai.textanalytics.SentimentConfidenceScores
     :param grapheme_offset: The sentence offset from the start of the
         document.
     :type grapheme_offset: int
@@ -700,7 +700,7 @@ class SentenceSentiment(DictMixin):
     def _from_generated(cls, sentence):
         return cls(
             sentiment=sentence.sentiment.value,
-            confidence_scores=SentimentConfidenceScorePerLabel._from_generated(sentence.sentence_scores),  # pylint: disable=protected-access
+            confidence_scores=SentimentConfidenceScores._from_generated(sentence.sentence_scores),  # pylint: disable=protected-access
             grapheme_offset=sentence.offset,
             grapheme_length=sentence.length,
             warnings=sentence.warnings,
@@ -712,7 +712,7 @@ class SentenceSentiment(DictMixin):
                                      self.grapheme_length, self.warnings)[:1024]
 
 
-class SentimentConfidenceScorePerLabel(DictMixin):
+class SentimentConfidenceScores(DictMixin):
     """The confidence scores (Softmax scores) between 0 and 1 across all sentiment
     labels: positive, neutral, negative. Higher values indicate higher confidence.
 
@@ -738,5 +738,5 @@ class SentimentConfidenceScorePerLabel(DictMixin):
         )
 
     def __repr__(self):
-        return "SentimentConfidenceScorePerLabel(positive={}, neutral={}, negative={})" \
+        return "SentimentConfidenceScores(positive={}, neutral={}, negative={})" \
             .format(self.positive, self.neutral, self.negative)[:1024]

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_response_handlers.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_response_handlers.py
@@ -24,7 +24,7 @@ from ._models import (
     DetectLanguageResult,
     DetectedLanguage,
     DocumentError,
-    SentimentConfidenceScorePerLabel,
+    SentimentConfidenceScores,
     TextAnalyticsError,
     PiiEntity
 )
@@ -149,6 +149,6 @@ def sentiment_result(sentiment):
         id=sentiment.id,
         sentiment=sentiment.sentiment.value,
         statistics=TextDocumentStatistics._from_generated(sentiment.statistics),  # pylint: disable=protected-access
-        confidence_scores=SentimentConfidenceScorePerLabel._from_generated(sentiment.document_scores),  # pylint: disable=protected-access
+        confidence_scores=SentimentConfidenceScores._from_generated(sentiment.document_scores),  # pylint: disable=protected-access
         sentences=[SentenceSentiment._from_generated(s) for s in sentiment.sentences],  # pylint: disable=protected-access
     )

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_text_analytics.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_text_analytics.py
@@ -35,7 +35,7 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
         pii_entity = _models.PiiEntity(text="555-55-5555", category="SSN", subcategory=None, grapheme_offset=0,
                                        grapheme_length=8, score=0.899)
 
-        text_document_statistics = _models.TextDocumentStatistics(character_count=14, transaction_count=18)
+        text_document_statistics = _models.TextDocumentStatistics(grapheme_count=14, transaction_count=18)
 
         recognize_entities_result = _models.RecognizeEntitiesResult(
             id="1",
@@ -124,23 +124,23 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
                          repr(categorized_entity))
         self.assertEqual("PiiEntity(text=555-55-5555, category=SSN, subcategory=None, grapheme_offset=0, "
                          "grapheme_length=8, score=0.899)", repr(pii_entity))
-        self.assertEqual("TextDocumentStatistics(character_count=14, transaction_count=18)",
+        self.assertEqual("TextDocumentStatistics(grapheme_count=14, transaction_count=18)",
                          repr(text_document_statistics))
         self.assertEqual("RecognizeEntitiesResult(id=1, entities=[CategorizedEntity(text=Bill Gates, category=Person, "
                          "subcategory=Age, grapheme_offset=0, grapheme_length=8, score=0.899)], "
-                         "statistics=TextDocumentStatistics(character_count=14, transaction_count=18), "
+                         "statistics=TextDocumentStatistics(grapheme_count=14, transaction_count=18), "
                          "is_error=False)", repr(recognize_entities_result))
         self.assertEqual("RecognizePiiEntitiesResult(id=1, entities=[PiiEntity(text=555-55-5555, category=SSN, "
                          "subcategory=None, grapheme_offset=0, grapheme_length=8, score=0.899)], "
-                         "statistics=TextDocumentStatistics(character_count=14, transaction_count=18), "
+                         "statistics=TextDocumentStatistics(grapheme_count=14, transaction_count=18), "
                          "is_error=False)", repr(recognize_pii_entities_result))
         self.assertEqual("DetectLanguageResult(id=1, primary_language=DetectedLanguage(name=English, "
-                         "iso6391_name=en, score=1.0), statistics=TextDocumentStatistics(character_count=14, "
+                         "iso6391_name=en, score=1.0), statistics=TextDocumentStatistics(grapheme_count=14, "
                          "transaction_count=18), is_error=False)", repr(detect_language_result))
         self.assertEqual("TextAnalyticsError(code=invalidRequest, message=The request is invalid, target=request)",
                          repr(text_analytics_error))
         self.assertEqual("ExtractKeyPhrasesResult(id=1, key_phrases=['dog', 'cat', 'bird'], statistics="
-                         "TextDocumentStatistics(character_count=14, transaction_count=18), is_error=False)",
+                         "TextDocumentStatistics(grapheme_count=14, transaction_count=18), is_error=False)",
                          repr(extract_key_phrases_result))
         self.assertEqual("LinkedEntityMatch(score=0.999, text=Bill Gates, grapheme_offset=0, grapheme_length=8)",
                          repr(linked_entity_match))
@@ -153,7 +153,7 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
                          "grapheme_length=8), LinkedEntityMatch(score=0.999, text=Bill Gates, grapheme_offset=0, "
                          "grapheme_length=8)], language=English, data_source_entity_id=Bill Gates, "
                          "url=https://en.wikipedia.org/wiki/Bill_Gates, data_source=wikipedia)], "
-                         "statistics=TextDocumentStatistics(character_count=14, "
+                         "statistics=TextDocumentStatistics(grapheme_count=14, "
                          "transaction_count=18), is_error=False)", repr(recognize_linked_entities_result))
         self.assertEqual("SentimentConfidenceScores(positive=0.99, neutral=0.05, negative=0.02)",
                          repr(sentiment_confidence_score_per_label))
@@ -161,7 +161,7 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
                          "positive=0.99, neutral=0.05, negative=0.02), grapheme_offset=0, grapheme_length=10, warnings="
                          "['sentence was too short to find sentiment'])", repr(sentence_sentiment))
         self.assertEqual("AnalyzeSentimentResult(id=1, sentiment=positive, statistics=TextDocumentStatistics("
-                         "character_count=14, transaction_count=18), confidence_scores=SentimentConfidenceScores"
+                         "grapheme_count=14, transaction_count=18), confidence_scores=SentimentConfidenceScores"
                          "(positive=0.99, neutral=0.05, negative=0.02), "
                          "sentences=[SentenceSentiment(sentiment=neutral, confidence_scores="
                          "SentimentConfidenceScores(positive=0.99, neutral=0.05, negative=0.02), "

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_text_analytics.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_text_analytics.py
@@ -29,10 +29,10 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
     def test_repr(self):
         detected_language = _models.DetectedLanguage(name="English", iso6391_name="en", score=1.0)
 
-        categorized_entity = _models.CategorizedEntity(text="Bill Gates", category="Person", subcategory="Age", 
+        categorized_entity = _models.CategorizedEntity(text="Bill Gates", category="Person", subcategory="Age",
                                                        grapheme_offset=0, grapheme_length=8, score=0.899)
 
-        pii_entity = _models.PiiEntity(text="555-55-5555", category="SSN", subcategory=None, grapheme_offset=0, 
+        pii_entity = _models.PiiEntity(text="555-55-5555", category="SSN", subcategory=None, grapheme_offset=0,
                                        grapheme_length=8, score=0.899)
 
         text_document_statistics = _models.TextDocumentStatistics(character_count=14, transaction_count=18)
@@ -86,7 +86,7 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
             )
 
         sentiment_confidence_score_per_label = \
-            _models.SentimentConfidenceScorePerLabel(positive=0.99, neutral=0.05, negative=0.02)
+            _models.SentimentConfidenceScores(positive=0.99, neutral=0.05, negative=0.02)
 
         sentence_sentiment = _models.SentenceSentiment(
             sentiment="neutral",
@@ -155,16 +155,16 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
                          "url=https://en.wikipedia.org/wiki/Bill_Gates, data_source=wikipedia)], "
                          "statistics=TextDocumentStatistics(character_count=14, "
                          "transaction_count=18), is_error=False)", repr(recognize_linked_entities_result))
-        self.assertEqual("SentimentConfidenceScorePerLabel(positive=0.99, neutral=0.05, negative=0.02)",
+        self.assertEqual("SentimentConfidenceScores(positive=0.99, neutral=0.05, negative=0.02)",
                          repr(sentiment_confidence_score_per_label))
-        self.assertEqual("SentenceSentiment(sentiment=neutral, confidence_scores=SentimentConfidenceScorePerLabel("
+        self.assertEqual("SentenceSentiment(sentiment=neutral, confidence_scores=SentimentConfidenceScores("
                          "positive=0.99, neutral=0.05, negative=0.02), grapheme_offset=0, grapheme_length=10, warnings="
                          "['sentence was too short to find sentiment'])", repr(sentence_sentiment))
         self.assertEqual("AnalyzeSentimentResult(id=1, sentiment=positive, statistics=TextDocumentStatistics("
-                         "character_count=14, transaction_count=18), confidence_scores=SentimentConfidenceScorePerLabel"
+                         "character_count=14, transaction_count=18), confidence_scores=SentimentConfidenceScores"
                          "(positive=0.99, neutral=0.05, negative=0.02), "
                          "sentences=[SentenceSentiment(sentiment=neutral, confidence_scores="
-                         "SentimentConfidenceScorePerLabel(positive=0.99, neutral=0.05, negative=0.02), "
+                         "SentimentConfidenceScores(positive=0.99, neutral=0.05, negative=0.02), "
                          "grapheme_offset=0, grapheme_length=10, "
                          "warnings=['sentence was too short to find sentiment'])], is_error=False)",
                          repr(analyze_sentiment_result))


### PR DESCRIPTION
fixes #10111 

- [x] SentimentConfidenceScorePerLabel -> SentimentConfidenceScores
- [x] character_count - > grapheme_count

It appears vscode included some whitespace removal in the changelog. If you want me to revert these changes we can, but I think it's still better to remove those whitespaces