### PR TITLE
Fix AzureCliCredential tests on Windows Python < 3.8

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -41,7 +41,7 @@ class AzureCliCredential(AsyncCredentialBase):
         """
         # only ProactorEventLoop supports subprocesses on Windows (and it isn't the default loop on Python < 3.8)
         if sys.platform.startswith("win") and not isinstance(asyncio.get_event_loop(), asyncio.ProactorEventLoop):
-            return _SyncAzureCliCredential().get_token(scopes, **kwargs)
+            return _SyncAzureCliCredential().get_token(*scopes, **kwargs)
 
         resource = _scopes_to_resource(*scopes)
         output = await _run_command(COMMAND_LINE.format(resource))

--- a/sdk/identity/azure-identity/conftest.py
+++ b/sdk/identity/azure-identity/conftest.py
@@ -113,3 +113,22 @@ def live_user_details():
         pytest.skip("To test username/password authentication, set $AZURE_USERNAME, $AZURE_PASSWORD, $USER_TENANT")
     else:
         return user_details
+
+@pytest.fixture()
+def event_loop():
+    """Ensure the event loop used by pytest-asyncio on Windows is ProactorEventLoop, which supports subprocesses.
+
+    This is necessary because SelectorEventLoop, which does not support subprocesses, is the default on Python < 3.8.
+    """
+
+    if not sys.platform.startswith("win"):
+        return
+
+    try:
+        import asyncio
+    except:
+        return
+
+    loop = asyncio.ProactorEventLoop()
+    yield loop
+    loop.close()

--- a/sdk/identity/azure-identity/conftest.py
+++ b/sdk/identity/azure-identity/conftest.py
@@ -121,14 +121,15 @@ def event_loop():
     This is necessary because SelectorEventLoop, which does not support subprocesses, is the default on Python < 3.8.
     """
 
-    if not sys.platform.startswith("win"):
-        return
-
     try:
         import asyncio
     except:
         return
 
-    loop = asyncio.ProactorEventLoop()
+    if sys.platform.startswith("win"):
+        loop = asyncio.ProactorEventLoop()
+    else:
+        loop = asyncio.new_event_loop()
+
     yield loop
     loop.close()


### PR DESCRIPTION
This ensures the event loop used by pytest-asyncio on Windows is ProactorEventLoop, which supports subprocesses (and is not the default loop for Python < 3.8). It also fixes a bug in the test of the async AzureCliCredential's fallback to the sync implementation when the configured event loop doesn't support subprocessing.