### PR TITLE
Simplify AzureCliCredential working directory

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -82,34 +82,15 @@ def parse_token(output):
 
 
 def get_safe_working_dir():
-    """Invoke 'az' from a directory on $PATH or a well-known install location, not the executing program's directory"""
-
-    path = os.environ.get("PATH")
+    """Invoke 'az' from a directory controlled by the OS, not the executing program's directory"""
 
     if sys.platform.startswith("win"):
-        if path:
-            return path.split(";")[0]
+        path = os.environ.get("SYSTEMROOT")
+        if not path:
+            raise CredentialUnavailableError(message="Environment variable 'SYSTEMROOT' has no value")
+        return path
 
-        # no system path; check well-known install locations
-        cli_path = "Microsoft SDKs\\Azure\\CLI2\\wbin"
-        for directory in (os.environ.get("PROGRAMFILES(X86)"), os.environ.get("PROGRAMFILES")):
-            if directory:
-                path = os.path.join(directory, cli_path)
-                if os.path.exists(os.path.join(path, "az.cmd")):
-                    return path
-
-        raise CredentialUnavailableError(message=CLI_NOT_FOUND)
-
-    # linux or mac
-    if path:
-        return path.split(":")[0]
-
-    # no system path; check well-known install locations
-    for path in ("/usr/bin", "/usr/local/bin"):
-        if os.path.exists(path + "/az"):
-            return path
-
-    raise CredentialUnavailableError(message=CLI_NOT_FOUND)
+    return "/bin"
 
 
 def sanitize_output(output):


### PR DESCRIPTION
Rather than trying an arbitrary entry of $PATH, or searching known install locations, for the first preview we'll instead execute from `%SYSTEMROOT%` on Windows, `/bin` everywhere else.