### PR TITLE
Smoke Tests: enable using other clouds

### DIFF
--- a/common/smoketest/event_hubs_async.py
+++ b/common/smoketest/event_hubs_async.py
@@ -54,6 +54,7 @@ class EventHubAsync:
             # on_event will close the consumer_client which resumes execution
             on_event=self.on_event,
             on_error=self.on_error,
+            timeout=RECEIVE_TIMEOUT,
             starting_position=STARTING_POSITION
         )
 

--- a/common/smoketest/event_hubs_async.py
+++ b/common/smoketest/event_hubs_async.py
@@ -54,7 +54,6 @@ class EventHubAsync:
             # on_event will close the consumer_client which resumes execution
             on_event=self.on_event,
             on_error=self.on_error,
-            timeout=RECEIVE_TIMEOUT,
             starting_position=STARTING_POSITION
         )
 

--- a/common/smoketest/key_vault_certificates.py
+++ b/common/smoketest/key_vault_certificates.py
@@ -14,7 +14,8 @@ class KeyVaultCertificates:
         # * AZURE_CLIENT_ID
         # * AZURE_CLIENT_SECRET
         # * AZURE_TENANT_ID
-        credential = DefaultAzureCredential()
+        authority_host = os.environ.get('AZURE_AUTHORITY_HOST') or KnownAuthorities.AZURE_PUBLIC_CLOUD
+        credential = DefaultAzureCredential(authority=authority_host)
         self.certificate_client = CertificateClient(
             vault_url=os.environ["AZURE_PROJECT_URL"], credential=credential
         )

--- a/common/smoketest/key_vault_certificates_async.py
+++ b/common/smoketest/key_vault_certificates_async.py
@@ -14,7 +14,8 @@ class KeyVaultCertificates:
         # * AZURE_CLIENT_ID
         # * AZURE_CLIENT_SECRET
         # * AZURE_TENANT_ID
-        credential = DefaultAzureCredential()
+        authority_host = os.environ.get('AZURE_AUTHORITY_HOST') or KnownAuthorities.AZURE_PUBLIC_CLOUD
+        credential = DefaultAzureCredential(authority=authority_host)
         self.certificate_client = CertificateClient(
             vault_url=os.environ["AZURE_PROJECT_URL"], credential=credential
         )

--- a/common/smoketest/key_vault_keys.py
+++ b/common/smoketest/key_vault_keys.py
@@ -14,7 +14,8 @@ class KeyVaultKeys:
         # * AZURE_CLIENT_ID
         # * AZURE_CLIENT_SECRET
         # * AZURE_TENANT_ID
-        credential = DefaultAzureCredential()
+        authority_host = os.environ.get('AZURE_AUTHORITY_HOST') or KnownAuthorities.AZURE_PUBLIC_CLOUD
+        credential = DefaultAzureCredential(authority=authority_host)
         self.key_client = KeyClient(
             vault_url=os.environ["AZURE_PROJECT_URL"], credential=credential
         )

--- a/common/smoketest/key_vault_keys_async.py
+++ b/common/smoketest/key_vault_keys_async.py
@@ -14,7 +14,8 @@ class KeyVaultKeys:
         # * AZURE_CLIENT_ID
         # * AZURE_CLIENT_SECRET
         # * AZURE_TENANT_ID
-        credential = DefaultAzureCredential()
+        authority_host = os.environ.get('AZURE_AUTHORITY_HOST') or KnownAuthorities.AZURE_PUBLIC_CLOUD
+        credential = DefaultAzureCredential(authority=authority_host)
         self.key_client = KeyClient(
             vault_url=os.environ["AZURE_PROJECT_URL"], credential=credential
         )

--- a/common/smoketest/key_vault_secrets.py
+++ b/common/smoketest/key_vault_secrets.py
@@ -14,7 +14,8 @@ class KeyVaultSecrets:
         # * AZURE_CLIENT_ID
         # * AZURE_CLIENT_SECRET
         # * AZURE_TENANT_ID
-        credential = DefaultAzureCredential()
+        authority_host = os.environ.get('AZURE_AUTHORITY_HOST') or KnownAuthorities.AZURE_PUBLIC_CLOUD
+        credential = DefaultAzureCredential(authority=authority_host)
         self.secret_client = SecretClient(
             vault_url=os.environ["AZURE_PROJECT_URL"], credential=credential
         )

--- a/common/smoketest/key_vault_secrets_async.py
+++ b/common/smoketest/key_vault_secrets_async.py
@@ -14,7 +14,8 @@ class KeyVaultSecrets:
         # * AZURE_CLIENT_ID
         # * AZURE_CLIENT_SECRET
         # * AZURE_TENANT_ID
-        credential = DefaultAzureCredential()
+        authority_host = os.environ.get('AZURE_AUTHORITY_HOST') or KnownAuthorities.AZURE_PUBLIC_CLOUD
+        credential = DefaultAzureCredential(authority=authority_host)
         self.secret_client = SecretClient(
             vault_url=os.environ["AZURE_PROJECT_URL"], credential=credential
         )

--- a/common/smoketest/smoke_test_async.py
+++ b/common/smoketest/smoke_test_async.py
@@ -10,7 +10,7 @@ from event_hubs_async import EventHubAsync
 from storage_blob_async import StorageBlobAsync
 
 
-def execute_async_smoke_tests:
+def execute_async_smoke_tests():
     print("")
     print("==========================================")
     print("   AZURE TRACK 2 SDKs SMOKE TEST ASYNC")

--- a/eng/pipelines/smoke-test.yml
+++ b/eng/pipelines/smoke-test.yml
@@ -55,6 +55,7 @@ jobs:
           AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
           AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
           AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+          AZURE_AUTHORITY_HOST: $(aad-azure-sdk-test-authority-host-py)
           AZURE_PROJECT_URL: $(smoke-tests-key-vault-project-url)
           EVENT_HUBS_CONNECTION_STRING: $(smoke-tests-event-hubs-connection-string)
           COSMOS_ENDPOINT: $(smoke-tests-cosmos-endpoint)

--- a/eng/pipelines/smoke-test.yml
+++ b/eng/pipelines/smoke-test.yml
@@ -5,28 +5,43 @@ jobs:
   - job:
     strategy:
       matrix:
-        Python_27_Linux:
+        Python_27_Linux (Public):
           PythonVersion: '2.7'
           InstallAsyncRequirements: false
           OSVmImage: ubuntu-18.04
-        Python_37_Linux:
+          CloudType: public
+        Python_37_Linux (Public):
           PythonVersion: '3.7'
           OSVmImage: ubuntu-18.04
-        Python_38_Linux:
+          CloudType: public
+        Python_38_Linux (Public):
           PythonVersion: '3.8'
           OSVmImage: ubuntu-18.04
-        Python_37_Windows:
+          CloudType: public
+        Python_37_Windows (Public):
           PythonVersion: '3.7'
           OSVmImage: windows-2019
-        Python_38_Windows:
+          CloudType: public
+        Python_38_Windows (Public):
           PythonVersion: '3.8'
           OSVmImage: windows-2019
-        Python_37_Mac:
+          CloudType: public
+        Python_37_Mac (Public):
           PythonVersion: '3.7'
           OSVmImage: macOS-10.15
-        Python_38_Mac:
+          CloudType: public
+        Python_38_Mac (Public):
           PythonVersion: '3.8'
           OSVmImage: macOS-10.15
+          CloudType: public
+        Python_38_Linux (Gov):
+          PythonVersion: '3.8'
+          OSVmImage: ubuntu-18.04
+          CloudType: public
+        Python_37_Windows (Gov):
+          PythonVersion: '3.7'
+          OSVmImage: windows-2019
+          CloudType: public
 
     pool:
       vmImage: $(OSVmImage)
@@ -49,15 +64,46 @@ jobs:
       - script: python ./eng/tox/install_dev_build_dependency.py -r ./common/smoketest/requirements.txt
         displayName: "Install dev dependencies from feed"
 
+      # Set secret environment variables for different clouds
+      - pwsh: |
+          $variables = @{
+            AZURE_CLIENT_ID='$(aad-azure-sdk-test-client-id)'
+            AZURE_CLIENT_SECRET='$(aad-azure-sdk-test-client-secret)'
+            AZURE_TENANT_ID='$(aad-azure-sdk-test-tenant-id)'
+            AZURE_AUTHORITY_HOST='$(aad-azure-sdk-test-authority-host)'
+            AZURE_PROJECT_URL='$(smoke-tests-key-vault-project-url)'
+            EVENT_HUBS_CONNECTION_STRING='$(smoke-tests-event-hubs-connection-string)'
+            COSMOS_ENDPOINT='$(smoke-tests-cosmos-endpoint)'
+            COSMOS_KEY='$(smoke-tests-cosmos-key)'
+            STORAGE_CONNECTION_STRING='$(smoke-tests-storage-connection-string)'
+          };
+          foreach ($key in $variables.Keys) {
+            Write-Host "Setting variable '$key'"
+            Write-Host "##vso[task.setvariable variable=_$key;issecret=true;]$($variables[$key])"
+            Write-Host "##vso[task.setvariable variable=$key;]$($variables[$key])"
+          }
+        displayName: Set secrets for public cloud
+        condition: and(succeeded(), eq(variables['CloudType'], 'public'))
+
+      - pwsh: |
+          $variables = @{
+            AZURE_CLIENT_ID='$(aad-azure-sdk-test-client-id-gov)'
+            AZURE_CLIENT_SECRET='$(aad-azure-sdk-test-client-secret-gov)'
+            AZURE_TENANT_ID='$(aad-azure-sdk-test-tenant-id-gov)'
+            AZURE_AUTHORITY_HOST='$(aad-azure-sdk-test-authority-host-gov)'
+            AZURE_PROJECT_URL='$(smoke-tests-key-vault-project-url-gov)'
+            EVENT_HUBS_CONNECTION_STRING='$(smoke-tests-event-hubs-connection-string-gov)'
+            COSMOS_ENDPOINT='$(smoke-tests-cosmos-endpoint-gov)'
+            COSMOS_KEY='$(smoke-tests-cosmos-key-gov)'
+            STORAGE_CONNECTION_STRING='$(smoke-tests-storage-connection-string-gov)'
+          };
+          foreach ($key in $variables.Keys) {
+            Write-Host "Setting variable '$key'"
+            Write-Host "##vso[task.setvariable variable=_$key;issecret=true;]$($variables[$key])"
+            Write-Host "##vso[task.setvariable variable=$key;]$($variables[$key])"
+          }
+        displayName: Set secrets for public cloud
+        condition: and(succeeded(), eq(variables['CloudType'], 'gov'))
+
       - script: python ./common/smoketest/program.py
         displayName: "Run Smoke Test"
-        env:
-          AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-          AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
-          AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-          AZURE_AUTHORITY_HOST: $(aad-azure-sdk-test-authority-host)
-          AZURE_PROJECT_URL: $(smoke-tests-key-vault-project-url)
-          EVENT_HUBS_CONNECTION_STRING: $(smoke-tests-event-hubs-connection-string)
-          COSMOS_ENDPOINT: $(smoke-tests-cosmos-endpoint)
-          COSMOS_KEY: $(smoke-tests-cosmos-key)
-          STORAGE_CONNECTION_STRING: $(smoke-tests-storage-connection-string)

--- a/eng/pipelines/smoke-test.yml
+++ b/eng/pipelines/smoke-test.yml
@@ -61,6 +61,10 @@ jobs:
       - script: pip install -r ./common/smoketest/requirements.txt
         displayName: "Install requirements.txt"
 
+      - script: pip install -r ./common/smoketest/requirements_async.txt
+        displayName: "Install requirements_async.txt"
+        condition: and(succeeded(), eq(variables['InstallAsyncRequirements'], 'true'))
+
       - script: python ./eng/tox/install_dev_build_dependency.py -r ./common/smoketest/requirements.txt
         displayName: "Install dev dependencies from feed"
 

--- a/eng/pipelines/smoke-test.yml
+++ b/eng/pipelines/smoke-test.yml
@@ -37,11 +37,11 @@ jobs:
         Python_38_Linux (Gov):
           PythonVersion: '3.8'
           OSVmImage: ubuntu-18.04
-          CloudType: public
+          CloudType: gov
         Python_37_Windows (Gov):
           PythonVersion: '3.7'
           OSVmImage: windows-2019
-          CloudType: public
+          CloudType: gov
 
     pool:
       vmImage: $(OSVmImage)

--- a/eng/pipelines/smoke-test.yml
+++ b/eng/pipelines/smoke-test.yml
@@ -55,7 +55,7 @@ jobs:
           AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
           AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
           AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-          AZURE_AUTHORITY_HOST: $(aad-azure-sdk-test-authority-host-py)
+          AZURE_AUTHORITY_HOST: $(aad-azure-sdk-test-authority-host)
           AZURE_PROJECT_URL: $(smoke-tests-key-vault-project-url)
           EVENT_HUBS_CONNECTION_STRING: $(smoke-tests-event-hubs-connection-string)
           COSMOS_ENDPOINT: $(smoke-tests-cosmos-endpoint)


### PR DESCRIPTION
Adds ability to specify an authority host via environment variables. This can be used to authenticate with other clouds.