### PR TITLE
Keep alive associated AMQP links via Service Bus management requests.

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/async_base_handler.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/async_base_handler.py
@@ -13,6 +13,7 @@ from uamqp.message import Message, MessageProperties
 from uamqp import authentication
 from uamqp import constants, errors
 
+from azure.servicebus.common.constants import ASSOCIATEDLINKPROPERTYNAME
 from azure.servicebus.common.utils import create_properties, get_running_loop
 from azure.servicebus.common.errors import (
     _ServiceBusErrorPolicy,
@@ -75,7 +76,7 @@ class BaseHandler:  # pylint: disable=too-many-instance-attributes
             raise InvalidHandlerState("Client connection is closed.")
 
         try:
-            application_properties = {"associated-link-name":self._handler.message_handler.name}
+            application_properties = {ASSOCIATEDLINKPROPERTYNAME:self._handler.message_handler.name}
         except AttributeError:
             application_properties = {}
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/async_base_handler.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/async_base_handler.py
@@ -74,12 +74,18 @@ class BaseHandler:  # pylint: disable=too-many-instance-attributes
         if not self.running:
             raise InvalidHandlerState("Client connection is closed.")
 
+        try:
+            application_properties = {"associated-link-name":self._handler.message_handler.name}
+        except AttributeError:
+            application_properties = {}
+
         mgmt_msg = Message(
             body=message,
             properties=MessageProperties(
                 reply_to=self.mgmt_target,
                 encoding=self.encoding,
-                **kwargs))
+                **kwargs),
+            application_properties=application_properties)
         try:
             return await self._handler.mgmt_request_async(
                 mgmt_msg,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/base_handler.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/base_handler.py
@@ -75,12 +75,18 @@ class BaseHandler(object):  # pylint: disable=too-many-instance-attributes
         if not self.running:
             raise InvalidHandlerState("Client connection is closed.")
 
+        try:
+            application_properties = {"associated-link-name":self._handler.message_handler.name}
+        except AttributeError:
+            application_properties = {}
+
         mgmt_msg = Message(
             body=message,
             properties=MessageProperties(
                 reply_to=self.mgmt_target,
                 encoding=self.encoding,
-                **kwargs))
+                **kwargs),
+            application_properties=application_properties)
         try:
             return self._handler.mgmt_request(
                 mgmt_msg,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/base_handler.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/base_handler.py
@@ -16,6 +16,7 @@ from uamqp import authentication
 from uamqp import constants, errors
 from uamqp.message import Message, MessageProperties
 
+from azure.servicebus.common.constants import ASSOCIATEDLINKPROPERTYNAME
 from azure.servicebus.common.utils import create_properties
 from azure.servicebus.common.errors import (
     _ServiceBusErrorPolicy,
@@ -76,7 +77,7 @@ class BaseHandler(object):  # pylint: disable=too-many-instance-attributes
             raise InvalidHandlerState("Client connection is closed.")
 
         try:
-            application_properties = {"associated-link-name":self._handler.message_handler.name}
+            application_properties = {ASSOCIATEDLINKPROPERTYNAME:self._handler.message_handler.name}
         except AttributeError:
             application_properties = {}
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/common/constants.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/common/constants.py
@@ -19,6 +19,7 @@ LOCKEDUNTILNAME = b"x-opt-locked-until"
 PARTITIONKEYNAME = b"x-opt-partition-key"
 DEADLETTERSOURCENAME = b"x-opt-deadletter-source"
 DEADLETTERNAME = VENDOR + b":dead-letter"
+ASSOCIATEDLINKPROPERTYNAME = b"associated-link-name"
 
 SESSION_FILTER = VENDOR + b":session-filter"
 SESSION_LOCKED_UNTIL = VENDOR + b":locked-until-utc"

--- a/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_queue_long_term_autorenew.py
+++ b/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_queue_long_term_autorenew.py
@@ -1,0 +1,60 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+import time
+from datetime import datetime, timedelta
+import concurrent
+
+import conftest
+from azure.servicebus import AutoLockRenew, ServiceBusClient, Message
+
+def send_message(client, queue_name):
+    queue_client = client.get_queue(queue_name)
+    msg = Message(b'Test')
+    queue_client.send(msg)
+    print('Message sent')
+
+
+def process_message(message):
+    print('Beginning Processing')
+    time.sleep(600)
+    print('Done Processing')
+
+
+def receive_process_and_complete_message(client, queue_name):
+    queue_client = client.get_queue(queue_name)
+    lock_renewal = AutoLockRenew(max_workers=4)
+    lock_renewal.renew_period = 120
+    with queue_client.get_receiver(keep_alive_interval=60) as queue_receiver:
+        for message in queue_receiver:
+            print("Received message: ", message)
+            lock_renewal.register(message, timeout=10800)
+            process_message(message)
+            print("Completing message")
+            message.complete()
+            break
+
+
+def stress_test_queue_long_term_autorenew(sb_config, queue_name):
+    client = ServiceBusClient(
+        service_namespace=sb_config['hostname'],
+        shared_access_key_name=sb_config['key_name'],
+        shared_access_key_value=sb_config['access_key'],
+        debug=False)
+
+    send_message(client, queue_name)
+    receive_process_and_complete_message(client, queue_name)
+
+
+if __name__ == '__main__':
+    live_config = conftest.get_live_servicebus_config()
+    queue_name = conftest.create_standard_queue(live_config)
+    print("Created queue {}".format(queue_name))
+    try:
+        stress_test_queue_long_term_autorenew(live_config, queue_name)
+    finally:
+        print("Cleaning up queue {}".format(queue_name))
+        conftest.cleanup_queue(live_config, queue_name)

--- a/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_queue_long_term_autorenew.py
+++ b/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_queue_long_term_autorenew.py
@@ -28,7 +28,7 @@ def receive_process_and_complete_message(client, queue_name):
     queue_client = client.get_queue(queue_name)
     lock_renewal = AutoLockRenew(max_workers=4)
     lock_renewal.renew_period = 120
-    with queue_client.get_receiver(keep_alive_interval=60) as queue_receiver:
+    with queue_client.get_receiver() as queue_receiver:
         for message in queue_receiver:
             print("Received message: ", message)
             lock_renewal.register(message, timeout=10800)


### PR DESCRIPTION
Adds the "associated-link-name" parameter to management requests so that they actually keep the primary sender/receiver link alive as well.

Prior to this change, links would be force disconnected by the service after 10 minutes idle, even if autorenew/keep-alive were present.

Also contains a stress test to validate this scenario before and after the change.  (Did a stress test in leiu of a unit test because the failure _requires_ a 10 minute wall-time delay to trigger the service force disconnect)

Should address #10127 so long as user enables an AutoLockRenew to be running (e.g. against the message in question) or calls renew() themselves within the expiry window.