### PR TITLE
Remove invalid link from DefaultAzureCredential docstring

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -40,7 +40,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
     3. On Windows only: a user who has signed in with a Microsoft application, such as Visual Studio. If multiple
        identities are in the cache, then the value of  the environment variable ``AZURE_USERNAME`` is used to select
        which identity to use. See :class:`~azure.identity.SharedTokenCacheCredential` for more details.
-    4. An Azure CLI access token. See :class:`~azure.identity.AzureCliCredential` for more details.
+    4. The identity currently logged in to the Azure CLI.
 
     This default behavior is configurable with keyword arguments.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -33,7 +33,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
     3. On Windows only: a user who has signed in with a Microsoft application, such as Visual Studio. If multiple
        identities are in the cache, then the value of  the environment variable ``AZURE_USERNAME`` is used to select
        which identity to use. See :class:`~azure.identity.aio.SharedTokenCacheCredential` for more details.
-    4. An Azure CLI access token. See :class:`~azure.identity.aio.AzureCliCredential` for more details.
+    4. The identity currently logged in to the Azure CLI.
 
     This default behavior is configurable with keyword arguments.
 


### PR DESCRIPTION
AzureCliCredential's documentation can't be linked, because it's internal.