### PR TITLE
[text analytics] score -> confidence_score rename

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log azure-ai-textanalytics
 
 ## 1.0.0b4 (Unreleased)
+**Breaking changes**
+- `score` attribute has been renamed to `confidence_score` for the `CategorizedEntity`, `LinkedEntityMatch`, and
+`PiiEntity` models
 
 
 ## 1.0.0b3 (2020-03-10)

--- a/sdk/textanalytics/azure-ai-textanalytics/README.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/README.md
@@ -238,7 +238,7 @@ result = [doc for doc in response if not doc.is_error]
 for doc in result:
     for entity in doc.entities:
         print("Entity: \t", entity.text, "\tCategory: \t", entity.category,
-              "\tConfidence Score: \t", entity.score)
+              "\tConfidence Score: \t", entity.confidence_score)
 ```
 
 The returned response is a heterogeneous list of result and error objects: list[[RecognizeEntitiesResult][recognize_entities_result], [DocumentError][document_error]]
@@ -266,7 +266,7 @@ result = [doc for doc in response if not doc.is_error]
 for doc in result:
     for entity in doc.entities:
         print("Entity: \t", entity.text, "\tCategory: \t", entity.category,
-              "\tConfidence Score: \t", entity.score)
+              "\tConfidence Score: \t", entity.confidence_score)
 ```
 
 The returned response is a heterogeneous list of result and error objects: list[[RecognizePiiEntitiesResult][recognize_pii_entities_result], [DocumentError][document_error]]
@@ -297,7 +297,7 @@ for doc in result:
         print("URL: {}".format(entity.url))
         print("Data Source: {}".format(entity.data_source))
         for match in entity.matches:
-            print("Score: {}".format(match.score))
+            print("Confidence Score: {}".format(match.confidence_score))
             print("Entity as appears in request: {}".format(match.text))
 ```
 

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
@@ -196,9 +196,9 @@ class CategorizedEntity(DictMixin):
     :param grapheme_length: Length (in Unicode characters) for the entity
         text.
     :type grapheme_length: int
-    :param score: Confidence score between 0 and 1 of the extracted
+    :param confidence_score: Confidence score between 0 and 1 of the extracted
         entity.
-    :type score: float
+    :type confidence_score: float
     """
 
     def __init__(self, **kwargs):
@@ -207,7 +207,7 @@ class CategorizedEntity(DictMixin):
         self.subcategory = kwargs.get('subcategory', None)
         self.grapheme_offset = kwargs.get('grapheme_offset', None)
         self.grapheme_length = kwargs.get('grapheme_length', None)
-        self.score = kwargs.get('score', None)
+        self.confidence_score = kwargs.get('confidence_score', None)
 
     @classmethod
     def _from_generated(cls, entity):
@@ -217,13 +217,13 @@ class CategorizedEntity(DictMixin):
             subcategory=entity.subtype,
             grapheme_offset=entity.offset,
             grapheme_length=entity.length,
-            score=entity.score,
+            confidence_score=entity.score,
         )
 
     def __repr__(self):
         return "CategorizedEntity(text={}, category={}, subcategory={}, grapheme_offset={}, grapheme_length={}, " \
-               "score={})".format(self.text, self.category, self.subcategory, self.grapheme_offset,
-                                  self.grapheme_length, self.score)[:1024]
+               "confidence_score={})".format(self.text, self.category, self.subcategory, self.grapheme_offset,
+                                  self.grapheme_length, self.confidence_score)[:1024]
 
 
 class PiiEntity(DictMixin):
@@ -244,9 +244,9 @@ class PiiEntity(DictMixin):
     :param grapheme_length: Length (in Unicode characters) for the entity
         text.
     :type grapheme_length: int
-    :param score: Confidence score between 0 and 1 of the extracted
+    :param confidence_score: Confidence score between 0 and 1 of the extracted
         entity.
-    :type score: float
+    :type confidence_score: float
     """
 
     def __init__(self, **kwargs):
@@ -255,7 +255,7 @@ class PiiEntity(DictMixin):
         self.subcategory = kwargs.get('subcategory', None)
         self.grapheme_offset = kwargs.get('grapheme_offset', None)
         self.grapheme_length = kwargs.get('grapheme_length', None)
-        self.score = kwargs.get('score', None)
+        self.confidence_score = kwargs.get('confidence_score', None)
 
     @classmethod
     def _from_generated(cls, entity):
@@ -265,13 +265,13 @@ class PiiEntity(DictMixin):
             subcategory=entity.subtype,
             grapheme_offset=entity.offset,
             grapheme_length=entity.length,
-            score=entity.score,
+            confidence_score=entity.score,
         )
 
     def __repr__(self):
         return "PiiEntity(text={}, category={}, subcategory={}, grapheme_offset={}, grapheme_length={}, " \
-               "score={})".format(self.text, self.category, self.subcategory, self.grapheme_offset,
-                                  self.grapheme_length, self.score)[:1024]
+               "confidence_score={})".format(self.text, self.category, self.subcategory, self.grapheme_offset,
+                                  self.grapheme_length, self.confidence_score)[:1024]
 
 
 class TextAnalyticsError(DictMixin):
@@ -574,10 +574,10 @@ class LinkedEntityMatch(DictMixin):
     the confidence score of the prediction and where the entity
     was found in the text.
 
-    :param score: If a well-known item is recognized, a
+    :param confidence_score: If a well-known item is recognized, a
         decimal number denoting the confidence level between 0 and 1 will be
         returned.
-    :type score: float
+    :type confidence_score: float
     :param text: Entity text as appears in the request.
     :type text: str
     :param grapheme_offset: Start position (in Unicode characters) for the
@@ -589,7 +589,7 @@ class LinkedEntityMatch(DictMixin):
     """
 
     def __init__(self, **kwargs):
-        self.score = kwargs.get("score", None)
+        self.confidence_score = kwargs.get("confidence_score", None)
         self.text = kwargs.get("text", None)
         self.grapheme_offset = kwargs.get("grapheme_offset", None)
         self.grapheme_length = kwargs.get("grapheme_length", None)
@@ -597,12 +597,15 @@ class LinkedEntityMatch(DictMixin):
     @classmethod
     def _from_generated(cls, match):
         return cls(
-            score=match.score, text=match.text, grapheme_offset=match.offset, grapheme_length=match.length
+            confidence_score=match.score,
+            text=match.text,
+            grapheme_offset=match.offset,
+            grapheme_length=match.length
         )
 
     def __repr__(self):
-        return "LinkedEntityMatch(score={}, text={}, grapheme_offset={}, grapheme_length={})" \
-            .format(self.score, self.text, self.grapheme_offset, self.grapheme_length)[:1024]
+        return "LinkedEntityMatch(confidence_score={}, text={}, grapheme_offset={}, grapheme_length={})" \
+            .format(self.confidence_score, self.text, self.grapheme_offset, self.grapheme_length)[:1024]
 
 
 class TextDocumentInput(MultiLanguageInput):

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_entities_async.py
@@ -49,7 +49,7 @@ class RecognizeEntitiesSampleAsync(object):
             print("\nDocument text: {}".format(documents[idx]))
             for entity in doc.entities:
                 print("Entity: \t", entity.text, "\tCategory: \t", entity.category,
-                      "\tConfidence Score: \t", entity.score)
+                      "\tConfidence Score: \t", entity.confidence_score)
         # [END batch_recognize_entities_async]
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_linked_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_linked_entities_async.py
@@ -54,7 +54,7 @@ class RecognizeLinkedEntitiesSampleAsync(object):
                 print("Url: {}".format(entity.url))
                 print("Data Source: {}".format(entity.data_source))
                 for match in entity.matches:
-                    print("Confidence Score: {}".format(match.score))
+                    print("Confidence Score: {}".format(match.confidence_score))
                     print("Entity as appears in request: {}".format(match.text))
             print("------------------------------------------")
         # [END batch_recognize_linked_entities_async]

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_pii_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_pii_entities_async.py
@@ -50,7 +50,7 @@ class RecognizePiiEntitiesSampleAsync(object):
             for entity in doc.entities:
                 print("Entity: {}".format(entity.text))
                 print("Category: {}".format(entity.category))
-                print("Confidence Score: {}\n".format(entity.score))
+                print("Confidence Score: {}\n".format(entity.confidence_score))
         # [END batch_recognize_pii_entities_async]
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_entities.py
@@ -45,7 +45,7 @@ class RecognizeEntitiesSample(object):
             print("\nDocument text: {}".format(documents[idx]))
             for entity in doc.entities:
                 print("Entity: \t", entity.text, "\tCategory: \t", entity.category,
-                      "\tConfidence Score: \t", entity.score)
+                      "\tConfidence Score: \t", entity.confidence_score)
         # [END batch_recognize_entities]
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_linked_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_linked_entities.py
@@ -50,7 +50,7 @@ class RecognizeLinkedEntitiesSample(object):
                 print("Url: {}".format(entity.url))
                 print("Data Source: {}".format(entity.data_source))
                 for match in entity.matches:
-                    print("Confidence Score: {}".format(match.score))
+                    print("Confidence Score: {}".format(match.confidence_score))
                     print("Entity as appears in request: {}".format(match.text))
             print("------------------------------------------")
         # [END batch_recognize_linked_entities]

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_pii_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_pii_entities.py
@@ -46,7 +46,7 @@ class RecognizePiiEntitiesSample(object):
             for entity in doc.entities:
                 print("Entity: {}".format(entity.text))
                 print("Category: {}".format(entity.category))
-                print("Confidence Score: {}\n".format(entity.score))
+                print("Confidence Score: {}\n".format(entity.confidence_score))
         # [END batch_recognize_pii_entities]
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities.py
@@ -43,7 +43,7 @@ class TestRecognizeEntities(TextAnalyticsTest):
                 self.assertIsNotNone(entity.category)
                 self.assertIsNotNone(entity.grapheme_offset)
                 self.assertIsNotNone(entity.grapheme_length)
-                self.assertIsNotNone(entity.score)
+                self.assertIsNotNone(entity.confidence_score)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_all_successful_passing_text_document_input(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -63,7 +63,7 @@ class TestRecognizeEntities(TextAnalyticsTest):
                 self.assertIsNotNone(entity.category)
                 self.assertIsNotNone(entity.grapheme_offset)
                 self.assertIsNotNone(entity.grapheme_length)
-                self.assertIsNotNone(entity.score)
+                self.assertIsNotNone(entity.confidence_score)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_passing_only_string(self, resource_group, location, text_analytics_account, text_analytics_account_key):

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities_async.py
@@ -60,7 +60,7 @@ class TestRecognizeEntities(AsyncTextAnalyticsTest):
                 self.assertIsNotNone(entity.category)
                 self.assertIsNotNone(entity.grapheme_offset)
                 self.assertIsNotNone(entity.grapheme_length)
-                self.assertIsNotNone(entity.score)
+                self.assertIsNotNone(entity.confidence_score)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -81,7 +81,7 @@ class TestRecognizeEntities(AsyncTextAnalyticsTest):
                 self.assertIsNotNone(entity.category)
                 self.assertIsNotNone(entity.grapheme_offset)
                 self.assertIsNotNone(entity.grapheme_length)
-                self.assertIsNotNone(entity.score)
+                self.assertIsNotNone(entity.confidence_score)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_pii_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_pii_entities.py
@@ -48,7 +48,7 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
                 self.assertIsNotNone(entity.category)
                 self.assertIsNotNone(entity.grapheme_offset)
                 self.assertIsNotNone(entity.grapheme_length)
-                self.assertIsNotNone(entity.score)
+                self.assertIsNotNone(entity.confidence_score)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_all_successful_passing_text_document_input(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -75,7 +75,7 @@ class TestRecognizePIIEntities(TextAnalyticsTest):
                 self.assertIsNotNone(entity.category)
                 self.assertIsNotNone(entity.grapheme_offset)
                 self.assertIsNotNone(entity.grapheme_length)
-                self.assertIsNotNone(entity.score)
+                self.assertIsNotNone(entity.confidence_score)
 
     @GlobalTextAnalyticsAccountPreparer()
     def test_length_with_emoji(self, resource_group, location, text_analytics_account, text_analytics_account_key):

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_pii_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_pii_entities_async.py
@@ -65,7 +65,7 @@ class TestRecognizePIIEntities(AsyncTextAnalyticsTest):
                 self.assertIsNotNone(entity.category)
                 self.assertIsNotNone(entity.grapheme_offset)
                 self.assertIsNotNone(entity.grapheme_length)
-                self.assertIsNotNone(entity.score)
+                self.assertIsNotNone(entity.confidence_score)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test
@@ -93,7 +93,7 @@ class TestRecognizePIIEntities(AsyncTextAnalyticsTest):
                 self.assertIsNotNone(entity.category)
                 self.assertIsNotNone(entity.grapheme_offset)
                 self.assertIsNotNone(entity.grapheme_length)
-                self.assertIsNotNone(entity.score)
+                self.assertIsNotNone(entity.confidence_score)
 
     @GlobalTextAnalyticsAccountPreparer()
     @AsyncTextAnalyticsTest.await_prepared_test

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_text_analytics.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_text_analytics.py
@@ -30,10 +30,10 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
         detected_language = _models.DetectedLanguage(name="English", iso6391_name="en", score=1.0)
 
         categorized_entity = _models.CategorizedEntity(text="Bill Gates", category="Person", subcategory="Age",
-                                                       grapheme_offset=0, grapheme_length=8, score=0.899)
+                                                       grapheme_offset=0, grapheme_length=8, confidence_score=0.899)
 
         pii_entity = _models.PiiEntity(text="555-55-5555", category="SSN", subcategory=None, grapheme_offset=0,
-                                       grapheme_length=8, score=0.899)
+                                       grapheme_length=8, confidence_score=0.899)
 
         text_document_statistics = _models.TextDocumentStatistics(grapheme_count=14, transaction_count=18)
 
@@ -69,7 +69,7 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
                 id="1", key_phrases=["dog", "cat", "bird"], statistics=text_document_statistics, is_error=False
             )
 
-        linked_entity_match = _models.LinkedEntityMatch(score=0.999, text="Bill Gates", grapheme_offset=0,
+        linked_entity_match = _models.LinkedEntityMatch(confidence_score=0.999, text="Bill Gates", grapheme_offset=0,
                                                         grapheme_length=8)
 
         linked_entity = _models.LinkedEntity(
@@ -120,18 +120,18 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
 
         self.assertEqual("DetectedLanguage(name=English, iso6391_name=en, score=1.0)", repr(detected_language))
         self.assertEqual("CategorizedEntity(text=Bill Gates, category=Person, subcategory=Age, grapheme_offset=0, "
-                         "grapheme_length=8, score=0.899)",
+                         "grapheme_length=8, confidence_score=0.899)",
                          repr(categorized_entity))
         self.assertEqual("PiiEntity(text=555-55-5555, category=SSN, subcategory=None, grapheme_offset=0, "
-                         "grapheme_length=8, score=0.899)", repr(pii_entity))
+                         "grapheme_length=8, confidence_score=0.899)", repr(pii_entity))
         self.assertEqual("TextDocumentStatistics(grapheme_count=14, transaction_count=18)",
                          repr(text_document_statistics))
         self.assertEqual("RecognizeEntitiesResult(id=1, entities=[CategorizedEntity(text=Bill Gates, category=Person, "
-                         "subcategory=Age, grapheme_offset=0, grapheme_length=8, score=0.899)], "
+                         "subcategory=Age, grapheme_offset=0, grapheme_length=8, confidence_score=0.899)], "
                          "statistics=TextDocumentStatistics(grapheme_count=14, transaction_count=18), "
                          "is_error=False)", repr(recognize_entities_result))
         self.assertEqual("RecognizePiiEntitiesResult(id=1, entities=[PiiEntity(text=555-55-5555, category=SSN, "
-                         "subcategory=None, grapheme_offset=0, grapheme_length=8, score=0.899)], "
+                         "subcategory=None, grapheme_offset=0, grapheme_length=8, confidence_score=0.899)], "
                          "statistics=TextDocumentStatistics(grapheme_count=14, transaction_count=18), "
                          "is_error=False)", repr(recognize_pii_entities_result))
         self.assertEqual("DetectLanguageResult(id=1, primary_language=DetectedLanguage(name=English, "
@@ -142,15 +142,15 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
         self.assertEqual("ExtractKeyPhrasesResult(id=1, key_phrases=['dog', 'cat', 'bird'], statistics="
                          "TextDocumentStatistics(grapheme_count=14, transaction_count=18), is_error=False)",
                          repr(extract_key_phrases_result))
-        self.assertEqual("LinkedEntityMatch(score=0.999, text=Bill Gates, grapheme_offset=0, grapheme_length=8)",
+        self.assertEqual("LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, grapheme_offset=0, grapheme_length=8)",
                          repr(linked_entity_match))
-        self.assertEqual("LinkedEntity(name=Bill Gates, matches=[LinkedEntityMatch(score=0.999, text=Bill Gates, "
-                         "grapheme_offset=0, grapheme_length=8), LinkedEntityMatch(score=0.999, text=Bill Gates, "
+        self.assertEqual("LinkedEntity(name=Bill Gates, matches=[LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, "
+                         "grapheme_offset=0, grapheme_length=8), LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, "
                          "grapheme_offset=0, grapheme_length=8)], language=English, data_source_entity_id=Bill Gates, "
                          "url=https://en.wikipedia.org/wiki/Bill_Gates, data_source=wikipedia)", repr(linked_entity))
         self.assertEqual("RecognizeLinkedEntitiesResult(id=1, entities=[LinkedEntity(name=Bill Gates, "
-                         "matches=[LinkedEntityMatch(score=0.999, text=Bill Gates, grapheme_offset=0, "
-                         "grapheme_length=8), LinkedEntityMatch(score=0.999, text=Bill Gates, grapheme_offset=0, "
+                         "matches=[LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, grapheme_offset=0, "
+                         "grapheme_length=8), LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, grapheme_offset=0, "
                          "grapheme_length=8)], language=English, data_source_entity_id=Bill Gates, "
                          "url=https://en.wikipedia.org/wiki/Bill_Gates, data_source=wikipedia)], "
                          "statistics=TextDocumentStatistics(grapheme_count=14, "


### PR DESCRIPTION
Renamed in `CategorizedEntity`, `LinkedEntityMatch`, and `PiiEntity`

fixes #10133 