### PR TITLE
Make live test timeout configurable

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -11,6 +11,7 @@ parameters:
   BuildDocs: true
   JobName: Test
   AllocateResourceGroup: 'true'
+  TestTimeoutInMinutes: 120
   Matrix:
     Linux_Python35:
       OSName: 'Linux'
@@ -39,7 +40,7 @@ jobs:
       skipComponentGovernanceDetection: true
       CoverageArg: --disablecov
 
-    timeoutInMinutes: 120
+    timeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
     strategy:
       maxParallel: ${{ parameters.MaxParallel }}
       matrix: ${{ parameters.Matrix }}


### PR DESCRIPTION
Time out is set to 120 and it is not configurable now. This PR is to make timeout for live test a configurable parameter