### PR TITLE
Pass http proxy settings into AMQPClient

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
@@ -221,7 +221,10 @@ class ClientBase(object):  # pylint:disable=too-many-instance-attributes
         while retried_times <= self._config.max_retries:
             mgmt_auth = self._create_auth()
             mgmt_client = AMQPClient(
-                self._mgmt_target, auth=mgmt_auth, debug=self._config.network_tracing
+                self._mgmt_target,
+                auth=mgmt_auth,
+                debug=self._config.network_tracing,
+                http_proxy=self._config.http_proxy
             )
             try:
                 conn = self._conn_manager.get_connection(

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_client_base_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_client_base_async.py
@@ -160,7 +160,10 @@ class ClientBaseAsync(ClientBase):
         while retried_times <= self._config.max_retries:
             mgmt_auth = await self._create_auth_async()
             mgmt_client = AMQPClientAsync(
-                self._mgmt_target, auth=mgmt_auth, debug=self._config.network_tracing
+                self._mgmt_target,
+                auth=mgmt_auth,
+                debug=self._config.network_tracing,
+                http_proxy=self._config.http_proxy,
             )
             try:
                 conn = await self._conn_manager_async.get_connection(


### PR DESCRIPTION
We noticed that the AMQPClient spawned by a BlobCheckpointStore.from_connection_string and EventHubConsumerClient.from_connection_string were ignoring proxy settings.  This appears to fix things by passing down the `http_proxy` dict down into the AMQPClient created.