### PR TITLE
Added user agent suffix

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
@@ -180,7 +180,7 @@ class CosmosClientConnection(object):  # pylint: disable=too-many-public-methods
         policies = [
             HeadersPolicy(**kwargs),
             ProxyPolicy(proxies=proxies),
-            UserAgentPolicy(base_user_agent=_utils.get_user_agent(), **kwargs),
+            UserAgentPolicy(base_user_agent=_utils.get_user_agent(self.connection_policy), **kwargs),
             ContentDecodePolicy(),
             retry_policy,
             CustomHookPolicy(**kwargs),

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_utils.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_utils.py
@@ -33,7 +33,7 @@ def get_user_agent(
     os_name = safe_user_agent_header(platform.platform())
     python_version = safe_user_agent_header(platform.python_version())
     user_agent_suffix = connection_policy.UserAgentSuffix[0:128]
-    user_agent = "azsdk-python-cosmos/{} Python/{} ({}){}".format(VERSION, python_version, os_name, user_agent_suffix)
+    user_agent = "azsdk-python-cosmos/{} Python/{} ({}) {}".format(VERSION, python_version, os_name, user_agent_suffix)
     return user_agent
 
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_utils.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_utils.py
@@ -25,12 +25,15 @@
 import platform
 import re
 from ._version import VERSION
+from .documents import ConnectionPolicy
 
-
-def get_user_agent():
+def get_user_agent(
+        connection_policy  # type: ConnectionPolicy
+):
     os_name = safe_user_agent_header(platform.platform())
     python_version = safe_user_agent_header(platform.python_version())
-    user_agent = "azsdk-python-cosmos/{} Python/{} ({})".format(VERSION, python_version, os_name)
+    user_agent_suffix = connection_policy.UserAgentSuffix[0:128]
+    user_agent = "azsdk-python-cosmos/{} Python/{} ({}){}".format(VERSION, python_version, os_name, user_agent_suffix)
     return user_agent
 
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
@@ -355,7 +355,10 @@ class ConnectionPolicy(object):  # pylint: disable=too-many-instance-attributes
     :ivar ConnectionRetryConfiguration:
         Retry Configuration to be used for connection retries.
     :vartype ConnectionRetryConfiguration:
-        int or azure.cosmos.ConnectionRetryPolicy or urllib3.util.retry
+        int or azure.cosmos.ConnectionRetryPolicy or urllib3.util.
+    :ivar string UserAgentSuffix:
+        The value to be appended to the user-agent header, used for monitoring purposes.
+
     """
 
     __defaultRequestTimeout = 60000  # milliseconds
@@ -371,6 +374,7 @@ class ConnectionPolicy(object):  # pylint: disable=too-many-instance-attributes
         self.DisableSSLVerification = False
         self.UseMultipleWriteLocations = False
         self.ConnectionRetryConfiguration = None
+        self.UserAgentSuffix = ""
 
 
 class _OperationType(object):

--- a/sdk/cosmos/azure-cosmos/test/utils_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/utils_tests.py
@@ -38,7 +38,7 @@ class UtilsTests(unittest.TestCase):
         connection_policy = ConnectionPolicy()
         user_agent = _utils.get_user_agent(connection_policy)
 
-        expected_user_agent = "azsdk-python-cosmos/{} Python/{} ({})".format(
+        expected_user_agent = "azsdk-python-cosmos/{} Python/{} ({}) ".format(
             azure.cosmos.__version__,
             platform.python_version(),
             platform.platform()
@@ -51,7 +51,7 @@ class UtilsTests(unittest.TestCase):
         connection_policy.UserAgentSuffix = user_agent_suffix
         user_agent = _utils.get_user_agent(connection_policy)
 
-        expected_user_agent = "azsdk-python-cosmos/{} Python/{} ({}){}".format(
+        expected_user_agent = "azsdk-python-cosmos/{} Python/{} ({}) {}".format(
             azure.cosmos.__version__,
             platform.python_version(),
             platform.platform(),

--- a/sdk/cosmos/azure-cosmos/test/utils_tests.py
+++ b/sdk/cosmos/azure-cosmos/test/utils_tests.py
@@ -23,6 +23,7 @@ import unittest
 import pytest
 import azure.cosmos
 import azure.cosmos._utils as _utils
+from azure.cosmos.documents import ConnectionPolicy
 import platform
 import test_config
 
@@ -34,7 +35,8 @@ class UtilsTests(unittest.TestCase):
     """
 
     def test_user_agent(self):
-        user_agent = _utils.get_user_agent()
+        connection_policy = ConnectionPolicy()
+        user_agent = _utils.get_user_agent(connection_policy)
 
         expected_user_agent = "azsdk-python-cosmos/{} Python/{} ({})".format(
             azure.cosmos.__version__,
@@ -42,6 +44,20 @@ class UtilsTests(unittest.TestCase):
             platform.platform()
         )
         self.assertEqual(user_agent, expected_user_agent)   
+
+    def test_user_agent_with_suffix(self):
+        user_agent_suffix = "sample app"
+        connection_policy = ConnectionPolicy()
+        connection_policy.UserAgentSuffix = user_agent_suffix
+        user_agent = _utils.get_user_agent(connection_policy)
+
+        expected_user_agent = "azsdk-python-cosmos/{} Python/{} ({}){}".format(
+            azure.cosmos.__version__,
+            platform.python_version(),
+            platform.platform(),
+            user_agent_suffix
+        )
+        self.assertEqual(user_agent, expected_user_agent)
 
     def test_connection_string(self):
         client = azure.cosmos.CosmosClient.from_connection_string(test_config._test_config.connection_str)


### PR DESCRIPTION
This PR implements support for adding a suffix to the user agent header, which can be used for monitoring purposes to find requests from a particular client/App.