### PR TITLE
Add EnvVar AZURE_AUTHORITY_HOST

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -15,6 +15,10 @@ state. ([#10243](https://github.com/Azure/azure-sdk-for-python/issues/10243))
 cache is available but contains ambiguous or insufficient information. This
 causes `ChainedTokenCredential` to correctly try the next credential in the
 chain. ([#10631](https://github.com/Azure/azure-sdk-for-python/issues/10631))
+- The host of the Active Directory endpoint credentials should use can be set
+in the environment variable `AZURE_AUTHORITY_HOST`. See
+`azure.identity.KnownAuthorities` for a list of common values.
+([#8094](https://github.com/Azure/azure-sdk-for-python/issues/8094))
 
 
 ## 1.3.1 (2020-03-30)

--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -5,7 +5,6 @@
 import abc
 import calendar
 import time
-import os
 
 from msal import TokenCache
 
@@ -23,7 +22,8 @@ from azure.core.pipeline.policies import (
     UserAgentPolicy,
 )
 from azure.core.pipeline.transport import RequestsTransport, HttpRequest
-from ._constants import AZURE_CLI_CLIENT_ID, KnownAuthorities, EnvironmentVariables
+from ._constants import AZURE_CLI_CLIENT_ID
+from ._internal import get_default_authority
 from ._internal.user_agent import USER_AGENT
 
 try:
@@ -62,9 +62,7 @@ class AuthnClientBase(ABC):
         else:
             if not tenant:
                 raise ValueError("'tenant' is required")
-            if not authority:
-                authority = os.environ.get(
-                    EnvironmentVariables.AZURE_AUTHORITY_HOST, KnownAuthorities.AZURE_PUBLIC_CLOUD)
+            authority = authority or get_default_authority()
             self._auth_url = "https://" + "/".join((authority.strip("/"), tenant.strip("/"), "oauth2/v2.0/token"))
         self._cache = kwargs.get("cache") or TokenCache()  # type: TokenCache
 

--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -5,6 +5,7 @@
 import abc
 import calendar
 import time
+import os
 
 from msal import TokenCache
 
@@ -22,7 +23,7 @@ from azure.core.pipeline.policies import (
     UserAgentPolicy,
 )
 from azure.core.pipeline.transport import RequestsTransport, HttpRequest
-from ._constants import AZURE_CLI_CLIENT_ID, KnownAuthorities
+from ._constants import AZURE_CLI_CLIENT_ID, KnownAuthorities, EnvironmentVariables
 from ._internal.user_agent import USER_AGENT
 
 try:
@@ -61,7 +62,9 @@ class AuthnClientBase(ABC):
         else:
             if not tenant:
                 raise ValueError("'tenant' is required")
-            authority = authority or KnownAuthorities.AZURE_PUBLIC_CLOUD
+            if not authority:
+                authority = os.environ.get(
+                    EnvironmentVariables.AZURE_AUTHORITY_HOST, KnownAuthorities.AZURE_PUBLIC_CLOUD)
             self._auth_url = "https://" + "/".join((authority.strip("/"), tenant.strip("/"), "oauth2/v2.0/token"))
         self._cache = kwargs.get("cache") or TokenCache()  # type: TokenCache
 

--- a/sdk/identity/azure-identity/azure/identity/_constants.py
+++ b/sdk/identity/azure-identity/azure/identity/_constants.py
@@ -29,6 +29,7 @@ class EnvironmentVariables:
 
     MSI_ENDPOINT = "MSI_ENDPOINT"
     MSI_SECRET = "MSI_SECRET"
+    AZURE_AUTHORITY_HOST = "AZURE_AUTHORITY_HOST"
 
 
 class Endpoints:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -61,7 +61,8 @@ class DefaultAzureCredential(ChainedTokenCredential):
     """
 
     def __init__(self, **kwargs):
-        authority = kwargs.pop("authority", None) or KnownAuthorities.AZURE_PUBLIC_CLOUD
+        authority = kwargs.pop("authority", None) or os.environ.get(
+            EnvironmentVariables.AZURE_AUTHORITY_HOST, KnownAuthorities.AZURE_PUBLIC_CLOUD)
 
         shared_cache_username = kwargs.pop("shared_cache_username", os.environ.get(EnvironmentVariables.AZURE_USERNAME))
         shared_cache_tenant_id = kwargs.pop(

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -5,7 +5,8 @@
 import logging
 import os
 
-from .._constants import EnvironmentVariables, KnownAuthorities
+from .._constants import EnvironmentVariables
+from .._internal import get_default_authority
 from .browser import InteractiveBrowserCredential
 from .chained import ChainedTokenCredential
 from .environment import EnvironmentCredential
@@ -61,8 +62,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
     """
 
     def __init__(self, **kwargs):
-        authority = kwargs.pop("authority", None) or os.environ.get(
-            EnvironmentVariables.AZURE_AUTHORITY_HOST, KnownAuthorities.AZURE_PUBLIC_CLOUD)
+        authority = kwargs.pop("authority", None) or get_default_authority()
 
         shared_cache_username = kwargs.pop("shared_cache_username", os.environ.get(EnvironmentVariables.AZURE_USERNAME))
         shared_cache_tenant_id = kwargs.pop(

--- a/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
@@ -2,6 +2,16 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import os
+
+from .._constants import EnvironmentVariables, KnownAuthorities
+
+
+def get_default_authority():
+    return os.environ.get(EnvironmentVariables.AZURE_AUTHORITY_HOST, KnownAuthorities.AZURE_PUBLIC_CLOUD)
+
+
+# pylint:disable=wrong-import-position
 from .aad_client import AadClient
 from .aad_client_base import AadClientBase
 from .auth_code_redirect_handler import AuthCodeRedirectServer

--- a/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
@@ -6,6 +6,7 @@ import abc
 import copy
 import functools
 import time
+import os
 
 try:
     from typing import TYPE_CHECKING
@@ -17,7 +18,7 @@ from msal.oauth2cli.oauth2 import Client
 
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
-from .._constants import KnownAuthorities
+from .._constants import KnownAuthorities, EnvironmentVariables
 
 try:
     ABC = abc.ABC
@@ -34,7 +35,8 @@ class AadClientBase(ABC):
 
     def __init__(self, tenant_id, client_id, cache=None, **kwargs):
         # type: (str, str, Optional[TokenCache], **Any) -> None
-        authority = kwargs.pop("authority", KnownAuthorities.AZURE_PUBLIC_CLOUD)
+        authority = kwargs.pop("authority", None) or os.environ.get(
+            EnvironmentVariables.AZURE_AUTHORITY_HOST, KnownAuthorities.AZURE_PUBLIC_CLOUD)
         if authority[-1] == "/":
             authority = authority[:-1]
         token_endpoint = "https://" + "/".join((authority, tenant_id, "oauth2/v2.0/token"))

--- a/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
@@ -6,7 +6,6 @@ import abc
 import copy
 import functools
 import time
-import os
 
 try:
     from typing import TYPE_CHECKING
@@ -18,7 +17,7 @@ from msal.oauth2cli.oauth2 import Client
 
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
-from .._constants import KnownAuthorities, EnvironmentVariables
+from . import get_default_authority
 
 try:
     ABC = abc.ABC
@@ -35,8 +34,7 @@ class AadClientBase(ABC):
 
     def __init__(self, tenant_id, client_id, cache=None, **kwargs):
         # type: (str, str, Optional[TokenCache], **Any) -> None
-        authority = kwargs.pop("authority", None) or os.environ.get(
-            EnvironmentVariables.AZURE_AUTHORITY_HOST, KnownAuthorities.AZURE_PUBLIC_CLOUD)
+        authority = kwargs.pop("authority", None) or get_default_authority()
         if authority[-1] == "/":
             authority = authority[:-1]
         token_endpoint = "https://" + "/".join((authority, tenant_id, "oauth2/v2.0/token"))

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
@@ -7,6 +7,7 @@ This entails monkeypatching MSAL's OAuth client with an adapter substituting an 
 """
 import abc
 import time
+import os
 
 import msal
 from azure.core.credentials import AccessToken
@@ -14,7 +15,7 @@ from azure.core.exceptions import ClientAuthenticationError
 
 from .exception_wrapper import wrap_exceptions
 from .msal_transport_adapter import MsalTransportAdapter
-from .._constants import KnownAuthorities
+from .._constants import KnownAuthorities, EnvironmentVariables
 
 try:
     ABC = abc.ABC
@@ -37,7 +38,8 @@ class MsalCredential(ABC):
     def __init__(self, client_id, client_credential=None, **kwargs):
         # type: (str, Optional[Union[str, Mapping[str, str]]], **Any) -> None
         tenant_id = kwargs.pop("tenant_id", "organizations")
-        authority = kwargs.pop("authority", KnownAuthorities.AZURE_PUBLIC_CLOUD)
+        authority = kwargs.pop("authority", None) or os.environ.get(
+            EnvironmentVariables.AZURE_AUTHORITY_HOST, KnownAuthorities.AZURE_PUBLIC_CLOUD)
         self._base_url = "https://" + "/".join((authority.strip("/"), tenant_id.strip("/")))
         self._client_credential = client_credential
         self._client_id = client_id

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
@@ -7,7 +7,6 @@ This entails monkeypatching MSAL's OAuth client with an adapter substituting an 
 """
 import abc
 import time
-import os
 
 import msal
 from azure.core.credentials import AccessToken
@@ -15,7 +14,7 @@ from azure.core.exceptions import ClientAuthenticationError
 
 from .exception_wrapper import wrap_exceptions
 from .msal_transport_adapter import MsalTransportAdapter
-from .._constants import KnownAuthorities, EnvironmentVariables
+from .._internal import get_default_authority
 
 try:
     ABC = abc.ABC
@@ -38,8 +37,7 @@ class MsalCredential(ABC):
     def __init__(self, client_id, client_credential=None, **kwargs):
         # type: (str, Optional[Union[str, Mapping[str, str]]], **Any) -> None
         tenant_id = kwargs.pop("tenant_id", "organizations")
-        authority = kwargs.pop("authority", None) or os.environ.get(
-            EnvironmentVariables.AZURE_AUTHORITY_HOST, KnownAuthorities.AZURE_PUBLIC_CLOUD)
+        authority = kwargs.pop("authority", None) or get_default_authority()
         self._base_url = "https://" + "/".join((authority.strip("/"), tenant_id.strip("/")))
         self._client_credential = client_credential
         self._client_id = client_id

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -9,7 +9,8 @@ import sys
 from msal import TokenCache
 
 from .. import CredentialUnavailableError
-from .._constants import KnownAuthorities, EnvironmentVariables
+from .._constants import KnownAuthorities
+from .._internal import get_default_authority
 
 try:
     ABC = abc.ABC
@@ -86,8 +87,7 @@ class SharedTokenCacheBase(ABC):
     def __init__(self, username=None, **kwargs):  # pylint:disable=unused-argument
         # type: (Optional[str], **Any) -> None
 
-        self._authority = kwargs.pop("authority", None) or os.environ.get(
-            EnvironmentVariables.AZURE_AUTHORITY_HOST, KnownAuthorities.AZURE_PUBLIC_CLOUD)
+        self._authority = kwargs.pop("authority", None) or get_default_authority()
         self._authority_aliases = KNOWN_ALIASES.get(self._authority) or frozenset((self._authority,))
         self._username = username
         self._tenant_id = kwargs.pop("tenant_id", None)

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -8,8 +8,9 @@ import sys
 
 from msal import TokenCache
 
-from .. import CredentialUnavailableError
-from .._constants import KnownAuthorities
+from azure.core.exceptions import ClientAuthenticationError
+from .._constants import KnownAuthorities, EnvironmentVariables
+
 
 try:
     ABC = abc.ABC
@@ -86,7 +87,8 @@ class SharedTokenCacheBase(ABC):
     def __init__(self, username=None, **kwargs):  # pylint:disable=unused-argument
         # type: (Optional[str], **Any) -> None
 
-        self._authority = kwargs.pop("authority", None) or KnownAuthorities.AZURE_PUBLIC_CLOUD
+        self._authority = kwargs.pop("authority", None) or os.environ.get(
+            EnvironmentVariables.AZURE_AUTHORITY_HOST, KnownAuthorities.AZURE_PUBLIC_CLOUD)
         self._authority_aliases = KNOWN_ALIASES.get(self._authority) or frozenset((self._authority,))
         self._username = username
         self._tenant_id = kwargs.pop("tenant_id", None)

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -8,9 +8,8 @@ import sys
 
 from msal import TokenCache
 
-from azure.core.exceptions import ClientAuthenticationError
+from .. import CredentialUnavailableError
 from .._constants import KnownAuthorities, EnvironmentVariables
-
 
 try:
     ABC = abc.ABC

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -6,7 +6,8 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
-from ..._constants import EnvironmentVariables, KnownAuthorities
+from ..._constants import EnvironmentVariables
+from ..._internal import get_default_authority
 from .azure_cli import AzureCliCredential
 from .chained import ChainedTokenCredential
 from .environment import EnvironmentCredential
@@ -52,8 +53,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
     """
 
     def __init__(self, **kwargs):
-        authority = kwargs.pop("authority", None) or os.environ.get(
-            EnvironmentVariables.AZURE_AUTHORITY_HOST, KnownAuthorities.AZURE_PUBLIC_CLOUD)
+        authority = kwargs.pop("authority", None) or get_default_authority()
 
         shared_cache_username = kwargs.pop("shared_cache_username", os.environ.get(EnvironmentVariables.AZURE_USERNAME))
         shared_cache_tenant_id = kwargs.pop(

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -52,7 +52,8 @@ class DefaultAzureCredential(ChainedTokenCredential):
     """
 
     def __init__(self, **kwargs):
-        authority = kwargs.pop("authority", None) or KnownAuthorities.AZURE_PUBLIC_CLOUD
+        authority = kwargs.pop("authority", None) or os.environ.get(
+            EnvironmentVariables.AZURE_AUTHORITY_HOST, KnownAuthorities.AZURE_PUBLIC_CLOUD)
 
         shared_cache_username = kwargs.pop("shared_cache_username", os.environ.get(EnvironmentVariables.AZURE_USERNAME))
         shared_cache_tenant_id = kwargs.pop(

--- a/sdk/identity/azure-identity/tests/test_aad_client_async.py
+++ b/sdk/identity/azure-identity/tests/test_aad_client_async.py
@@ -2,9 +2,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from urllib.parse import urlparse
 
+from azure.identity._constants import EnvironmentVariables
 from azure.identity.aio._internal.aad_client import AadClient
 import pytest
 
@@ -55,5 +56,11 @@ async def test_request_url():
 
     client = AadClient(tenant, "client id", transport=Mock(send=send), authority=authority)
 
+    await client.obtain_token_by_authorization_code("code", "uri", "scope")
+    await client.obtain_token_by_refresh_token("refresh token", "scope")
+
+    # authority can be configured via environment variable
+    with patch.dict("os.environ", {EnvironmentVariables.AZURE_AUTHORITY_HOST: authority}, clear=True):
+        client = AadClient(tenant_id=tenant, client_id="client id", transport=Mock(send=send))
     await client.obtain_token_by_authorization_code("code", "uri", "scope")
     await client.obtain_token_by_refresh_token("refresh token", "scope")

--- a/sdk/identity/azure-identity/tests/test_authn_client_async.py
+++ b/sdk/identity/azure-identity/tests/test_authn_client_async.py
@@ -3,10 +3,11 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import asyncio
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from urllib.parse import urlparse
 
 import pytest
+from azure.identity._constants import EnvironmentVariables
 from azure.identity.aio._authn_client import AsyncAuthnClient
 
 from helpers import mock_response
@@ -27,3 +28,8 @@ async def test_request_url():
 
     client = AsyncAuthnClient(tenant=tenant, transport=Mock(send=wrap_in_future(mock_send)), authority=authority)
     await client.request_token(("scope",))
+
+    # authority can be configured via environment variable
+    with patch.dict("os.environ", {EnvironmentVariables.AZURE_AUTHORITY_HOST: authority}, clear=True):
+        client = AsyncAuthnClient(tenant=tenant, transport=Mock(send=wrap_in_future(mock_send)))
+        await client.request_token(("scope",))

--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -45,65 +45,49 @@ def test_iterates_only_once():
         assert successful_credential.get_token.call_count == n + 1
 
 
-def test_default_credential_authority():
-    expected_access_token = "***"
-    response = mock_response(
-        json_payload={
-            "access_token": expected_access_token,
-            "expires_in": 0,
-            "expires_on": 42,
-            "not_before": 0,
-            "resource": "scope",
-            "token_type": "Bearer",
-        }
-    )
+def test__authority():
+    """the credential should accept authority configuration by keyword argument or environment"""
 
-    def exercise_credentials(authority_kwarg, expected_authority=None):
-        expected_authority = expected_authority or authority_kwarg
+    def test_initialization(mock_credential, expect_argument):
+        authority = "localhost"
 
-        def send(request, **_):
-            url = urlparse(request.url)
-            assert url.scheme == "https", "Unexpected scheme '{}'".format(url.scheme)
-            assert url.netloc == expected_authority, "Expected authority '{}', actual was '{}'".format(
-                expected_authority, url.netloc
-            )
-            return response
+        DefaultAzureCredential(authority=authority)
+        assert mock_credential.call_count == 1
 
-        # environment credential configured with client secret should respect authority
-        environment = {
-            EnvironmentVariables.AZURE_CLIENT_ID: "client_id",
-            EnvironmentVariables.AZURE_CLIENT_SECRET: "secret",
-            EnvironmentVariables.AZURE_TENANT_ID: "tenant_id",
-        }
-        if os.environ.get(EnvironmentVariables.AZURE_AUTHORITY_HOST):
-            environment.update({EnvironmentVariables.AZURE_AUTHORITY_HOST: os.environ.get(
-                EnvironmentVariables.AZURE_AUTHORITY_HOST)})
-        with patch("os.environ", environment):
-            transport = Mock(send=send)
-            access_token, _ = DefaultAzureCredential(authority=authority_kwarg, transport=transport).get_token("scope")
-            assert access_token == expected_access_token
+        # N.B. if os.environ has been patched somewhere in the stack, that patch is in place here
+        environment = dict(os.environ, **{EnvironmentVariables.AZURE_AUTHORITY_HOST: authority})
+        with patch.dict(DefaultAzureCredential.__module__ + ".os.environ", environment, clear=True):
+            DefaultAzureCredential()
+        assert mock_credential.call_count == 2
 
-        # managed identity credential should ignore authority
-        with patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: "https://some.url"}):
-            transport = Mock(send=lambda *_, **__: response)
-            access_token, _ = DefaultAzureCredential(authority=authority_kwarg, transport=transport).get_token("scope")
-            assert access_token == expected_access_token
+        for _, kwargs in mock_credential.call_args_list:
+            if expect_argument:
+                assert kwargs["authority"] == authority
+            else:
+                assert "authority" not in kwargs
 
-        # shared cache credential should respect authority
-        upn = os.environ.get(EnvironmentVariables.AZURE_USERNAME, "spam@eggs")  # preferring environment values to
-        tenant = os.environ.get(EnvironmentVariables.AZURE_TENANT_ID, "tenant")  # prevent failure during live runs
-        account = get_account_event(username=upn, uid="guid", utid=tenant, authority=authority_kwarg)
-        cache = populated_cache(account)
-        with patch.object(SharedTokenCacheCredential, "supported"):
-            credential = DefaultAzureCredential(_cache=cache, authority=authority_kwarg, transport=Mock(send=send))
-        access_token, _ = credential.get_token("scope")
-        assert access_token == expected_access_token
+    # authority should be passed to EnvironmentCredential as a keyword argument
+    environment = {var: "foo" for var in EnvironmentVariables.CLIENT_SECRET_VARS}
+    with patch(DefaultAzureCredential.__module__ + ".EnvironmentCredential") as mock_credential:
+        with patch.dict("os.environ", environment, clear=True):
+            test_initialization(mock_credential, expect_argument=True)
 
-    # all credentials not representing managed identities should use a specified authority or default to public cloud
-    exercise_credentials("authority.com")
-    exercise_credentials(None, KnownAuthorities.AZURE_PUBLIC_CLOUD)
-    with patch('os.environ', {EnvironmentVariables.AZURE_AUTHORITY_HOST: "localhost.com"}):
-        exercise_credentials(None, os.environ.get(EnvironmentVariables.AZURE_AUTHORITY_HOST))
+    # authority should be passed to SharedTokenCacheCredential as a keyword argument
+    with patch(DefaultAzureCredential.__module__ + ".SharedTokenCacheCredential") as mock_credential:
+        mock_credential.supported = lambda: True
+        test_initialization(mock_credential, expect_argument=True)
+
+    # authority should not be passed to ManagedIdentityCredential
+    with patch(DefaultAzureCredential.__module__ + ".ManagedIdentityCredential") as mock_credential:
+        with patch.dict("os.environ", {EnvironmentVariables.MSI_ENDPOINT: "localhost"}, clear=True):
+            test_initialization(mock_credential, expect_argument=False)
+
+    # authority should not be passed to AzureCliCredential
+    with patch(DefaultAzureCredential.__module__ + ".AzureCliCredential") as mock_credential:
+        with patch(DefaultAzureCredential.__module__ + ".SharedTokenCacheCredential") as shared_cache:
+            shared_cache.supported = lambda: False
+            with patch.dict("os.environ", {}, clear=True):
+                test_initialization(mock_credential, expect_argument=False)
 
 
 def test_exclude_options():

--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -75,6 +75,9 @@ def test_default_credential_authority():
             EnvironmentVariables.AZURE_CLIENT_SECRET: "secret",
             EnvironmentVariables.AZURE_TENANT_ID: "tenant_id",
         }
+        if os.environ.get(EnvironmentVariables.AZURE_AUTHORITY_HOST):
+            environment.update({EnvironmentVariables.AZURE_AUTHORITY_HOST: os.environ.get(
+                EnvironmentVariables.AZURE_AUTHORITY_HOST)})
         with patch("os.environ", environment):
             transport = Mock(send=send)
             access_token, _ = DefaultAzureCredential(authority=authority_kwarg, transport=transport).get_token("scope")
@@ -99,6 +102,8 @@ def test_default_credential_authority():
     # all credentials not representing managed identities should use a specified authority or default to public cloud
     exercise_credentials("authority.com")
     exercise_credentials(None, KnownAuthorities.AZURE_PUBLIC_CLOUD)
+    with patch('os.environ', {EnvironmentVariables.AZURE_AUTHORITY_HOST: "localhost.com"}):
+        exercise_credentials(None, os.environ.get(EnvironmentVariables.AZURE_AUTHORITY_HOST))
 
 
 def test_exclude_options():

--- a/sdk/identity/azure-identity/tests/test_default_async.py
+++ b/sdk/identity/azure-identity/tests/test_default_async.py
@@ -72,6 +72,9 @@ async def test_default_credential_authority():
             EnvironmentVariables.AZURE_CLIENT_SECRET: "secret",
             EnvironmentVariables.AZURE_TENANT_ID: "tenant_id",
         }
+        if os.environ.get(EnvironmentVariables.AZURE_AUTHORITY_HOST):
+            environment.update({EnvironmentVariables.AZURE_AUTHORITY_HOST: os.environ.get(
+                EnvironmentVariables.AZURE_AUTHORITY_HOST)})
         with patch("os.environ", environment):
             transport = Mock(send=send)
             if authority_kwarg:
@@ -104,6 +107,8 @@ async def test_default_credential_authority():
     # all credentials not representing managed identities should use a specified authority or default to public cloud
     await exercise_credentials("authority.com")
     await exercise_credentials(None, KnownAuthorities.AZURE_PUBLIC_CLOUD)
+    with patch('os.environ', {EnvironmentVariables.AZURE_AUTHORITY_HOST: "localhost.com"}):
+        await exercise_credentials(None, os.environ.get(EnvironmentVariables.AZURE_AUTHORITY_HOST))
 
 
 def test_exclude_options():

--- a/sdk/identity/azure-identity/tests/test_default_async.py
+++ b/sdk/identity/azure-identity/tests/test_default_async.py
@@ -40,75 +40,50 @@ async def test_iterates_only_once():
         assert successful_credential.get_token.call_count == n + 1
 
 
-@pytest.mark.asyncio
-async def test_default_credential_authority():
-    authority = "authority.com"
-    expected_access_token = "***"
-    response = mock_response(
-        json_payload={
-            "access_token": expected_access_token,
-            "expires_in": 0,
-            "expires_on": 42,
-            "not_before": 0,
-            "resource": "scope",
-            "token_type": "Bearer",
-        }
-    )
+def test_authority():
+    """the credential should accept authority configuration by keyword argument or environment"""
 
-    async def exercise_credentials(authority_kwarg, expected_authority=None):
-        expected_authority = expected_authority or authority_kwarg
+    def test_initialization(mock_credential, expect_argument):
+        authority = "localhost"
 
-        async def send(request, **_):
-            url = urlparse(request.url)
-            assert url.scheme == "https", "Unexpected scheme '{}'".format(url.scheme)
-            assert url.netloc == expected_authority, "Expected authority '{}', actual was '{}'".format(
-                expected_authority, url.netloc
-            )
-            return response
+        DefaultAzureCredential(authority=authority)
+        assert mock_credential.call_count == 1
 
-        # environment credential configured with client secret should respect authority
-        environment = {
-            EnvironmentVariables.AZURE_CLIENT_ID: "client_id",
-            EnvironmentVariables.AZURE_CLIENT_SECRET: "secret",
-            EnvironmentVariables.AZURE_TENANT_ID: "tenant_id",
-        }
-        if os.environ.get(EnvironmentVariables.AZURE_AUTHORITY_HOST):
-            environment.update({EnvironmentVariables.AZURE_AUTHORITY_HOST: os.environ.get(
-                EnvironmentVariables.AZURE_AUTHORITY_HOST)})
-        with patch("os.environ", environment):
-            transport = Mock(send=send)
-            if authority_kwarg:
-                credential = DefaultAzureCredential(authority=authority_kwarg, transport=transport)
+        # N.B. if os.environ has been patched somewhere in the stack, that patch is in place here
+        environment = dict(os.environ, **{EnvironmentVariables.AZURE_AUTHORITY_HOST: authority})
+        with patch.dict(DefaultAzureCredential.__module__ + ".os.environ", environment, clear=True):
+            DefaultAzureCredential()
+        assert mock_credential.call_count == 2
+
+        for _, kwargs in mock_credential.call_args_list:
+            if expect_argument:
+                assert kwargs["authority"] == authority
             else:
-                credential = DefaultAzureCredential(transport=transport)
-            access_token, _ = await credential.get_token("scope")
-            assert access_token == expected_access_token
+                assert "authority" not in kwargs
 
-        # managed identity credential should ignore authority
-        with patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: "https://some.url"}):
-            transport = Mock(send=wrap_in_future(lambda *_, **__: response))
-            if authority_kwarg:
-                credential = DefaultAzureCredential(authority=authority_kwarg, transport=transport)
-            else:
-                credential = DefaultAzureCredential(transport=transport)
-            access_token, _ = await credential.get_token("scope")
-            assert access_token == expected_access_token
+    # authority should be passed to EnvironmentCredential as a keyword argument
+    environment = {var: "foo" for var in EnvironmentVariables.CLIENT_SECRET_VARS}
+    with patch(DefaultAzureCredential.__module__ + ".EnvironmentCredential") as mock_credential:
+        with patch.dict("os.environ", environment, clear=True):
+            test_initialization(mock_credential, expect_argument=True)
 
-        # shared cache credential should respect authority
-        upn = os.environ.get(EnvironmentVariables.AZURE_USERNAME, "spam@eggs")  # preferring environment values to
-        tenant = os.environ.get(EnvironmentVariables.AZURE_TENANT_ID, "tenant")  # prevent failure during live runs
-        account = get_account_event(username=upn, uid="guid", utid=tenant, authority=authority_kwarg)
-        cache = populated_cache(account)
-        with patch.object(SharedTokenCacheCredential, "supported"):
-            credential = DefaultAzureCredential(_cache=cache, authority=authority_kwarg, transport=Mock(send=send))
-        access_token, _ = await credential.get_token("scope")
-        assert access_token == expected_access_token
+    # authority should be passed to SharedTokenCacheCredential as a keyword argument
+    with patch(DefaultAzureCredential.__module__ + ".SharedTokenCacheCredential") as mock_credential:
+        mock_credential.supported = lambda: True
+        with patch.dict("os.environ", {}, clear=True):
+            test_initialization(mock_credential, expect_argument=True)
 
-    # all credentials not representing managed identities should use a specified authority or default to public cloud
-    await exercise_credentials("authority.com")
-    await exercise_credentials(None, KnownAuthorities.AZURE_PUBLIC_CLOUD)
-    with patch('os.environ', {EnvironmentVariables.AZURE_AUTHORITY_HOST: "localhost.com"}):
-        await exercise_credentials(None, os.environ.get(EnvironmentVariables.AZURE_AUTHORITY_HOST))
+    # authority should not be passed to ManagedIdentityCredential
+    with patch(DefaultAzureCredential.__module__ + ".ManagedIdentityCredential") as mock_credential:
+        with patch.dict("os.environ", {EnvironmentVariables.MSI_ENDPOINT: "_"}, clear=True):
+            test_initialization(mock_credential, expect_argument=False)
+
+    # authority should not be passed to AzureCliCredential
+    with patch(DefaultAzureCredential.__module__ + ".AzureCliCredential") as mock_credential:
+        with patch(DefaultAzureCredential.__module__ + ".SharedTokenCacheCredential") as shared_cache:
+            shared_cache.supported = lambda: False
+            with patch.dict("os.environ", {}, clear=True):
+                test_initialization(mock_credential, expect_argument=False)
 
 
 def test_exclude_options():

--- a/sdk/identity/azure-identity/tests/test_environment_credential.py
+++ b/sdk/identity/azure-identity/tests/test_environment_credential.py
@@ -31,3 +31,25 @@ def test_incomplete_configuration():
         with mock.patch.dict(os.environ, {a: "a", b: "b"}, clear=True):
             with pytest.raises(CredentialUnavailableError) as ex:
                 EnvironmentCredential().get_token("scope")
+
+
+@pytest.mark.parametrize(
+    "credential_name,environment_variables",
+    (
+        ("ClientSecretCredential", EnvironmentVariables.CLIENT_SECRET_VARS),
+        ("CertificateCredential", EnvironmentVariables.CERT_VARS),
+        ("UsernamePasswordCredential", EnvironmentVariables.USERNAME_PASSWORD_VARS),
+    ),
+)
+def test_passes_authority_argument(credential_name, environment_variables):
+    """the credential pass the 'authority' keyword argument to its inner credential"""
+
+    authority = "authority"
+
+    with mock.patch.dict("os.environ", {variable: "foo" for variable in environment_variables}, clear=True):
+        with mock.patch(EnvironmentCredential.__module__ + "." + credential_name) as mock_credential:
+            EnvironmentCredential(authority=authority)
+
+    assert mock_credential.call_count == 1
+    _, kwargs = mock_credential.call_args
+    assert kwargs["authority"] == authority

--- a/sdk/identity/azure-identity/tests/test_environment_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_environment_credential_async.py
@@ -5,7 +5,9 @@
 import itertools
 import os
 
-from azure.identity import CredentialUnavailableError, EnvironmentCredential
+from azure.identity import CredentialUnavailableError
+from azure.identity.aio import EnvironmentCredential
+from azure.identity._constants import EnvironmentVariables
 import pytest
 
 from helpers import mock
@@ -24,3 +26,24 @@ async def test_incomplete_configuration():
         with mock.patch.dict(os.environ, {a: "a", b: "b"}, clear=True):
             with pytest.raises(CredentialUnavailableError) as ex:
                 await EnvironmentCredential().get_token("scope")
+
+
+@pytest.mark.parametrize(
+    "credential_name,environment_variables",
+    (
+        ("ClientSecretCredential", EnvironmentVariables.CLIENT_SECRET_VARS),
+        ("CertificateCredential", EnvironmentVariables.CERT_VARS),
+    ),
+)
+def test_passes_authority_argument(credential_name, environment_variables):
+    """the credential pass the 'authority' keyword argument to its inner credential"""
+
+    authority = "authority"
+
+    with mock.patch.dict("os.environ", {variable: "foo" for variable in environment_variables}, clear=True):
+        with mock.patch(EnvironmentCredential.__module__ + "." + credential_name) as mock_credential:
+            EnvironmentCredential(authority=authority)
+
+    assert mock_credential.call_count == 1
+    _, kwargs = mock_credential.call_args
+    assert kwargs["authority"] == authority

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
@@ -5,6 +5,7 @@
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.identity import CredentialUnavailableError, KnownAuthorities, SharedTokenCacheCredential
+from azure.identity._constants import EnvironmentVariables
 from azure.identity._internal.shared_token_cache import (
     KNOWN_ALIASES,
     MULTIPLE_ACCOUNTS,
@@ -15,6 +16,7 @@ from azure.identity._internal.shared_token_cache import (
 from azure.identity._internal.user_agent import USER_AGENT
 from msal import TokenCache
 import pytest
+import os
 
 try:
     from unittest.mock import Mock
@@ -473,7 +475,8 @@ def get_account_event(
             foci="1",
         ),
         "client_id": client_id,
-        "token_endpoint": "https://" + "/".join((authority or KnownAuthorities.AZURE_PUBLIC_CLOUD, utid, "/path")),
+        "token_endpoint": "https://" + "/".join((authority or os.environ.get(
+            EnvironmentVariables.AZURE_AUTHORITY_HOST, KnownAuthorities.AZURE_PUBLIC_CLOUD), utid, "/path")),
         "scope": scopes or ["scope"],
     }
 


### PR DESCRIPTION
Added EnvVar AZURE_AUTHORITY_HOST to azure.identity._constants.
TokenCredentialOptions has an AuthorityHost property.  
This will be modified to support EnvVar override with AZURE_AUTHORITY_HOST.
[Azure/azure-sdk-for-java/issues/5967](https://github.com/Azure/azure-sdk-for-java/issues/5967)