### PR TITLE
get_token consistently requires at least one scope

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -5,7 +5,7 @@
 raising an error when none is passed. Although `get_token()` may sometimes
 have succeeded in prior versions, it couldn't do so consistently because its
 behavior was undefined, and dependened on the credential's type and internal
-state. ([#10366](https://github.com/Azure/azure-sdk-for-python/pull/10366))
+state. ([#10243](https://github.com/Azure/azure-sdk-for-python/pull/10243))
 
 
 ## 1.4.0b1 (2020-03-10)

--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release History
 
 ## 1.4.0b2 (Unreleased)
+- All `get_token` methods consistently require at least one scope argument,
+raising an error when none is passed. Although `get_token()` may sometimes
+have succeeded in prior versions, it couldn't do so consistently because its
+behavior was undefined, and dependened on the credential's type and internal
+state. ([#10366](https://github.com/Azure/azure-sdk-for-python/pull/10366))
 
 
 ## 1.4.0b1 (2020-03-10)

--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -5,7 +5,7 @@
 raising an error when none is passed. Although `get_token()` may sometimes
 have succeeded in prior versions, it couldn't do so consistently because its
 behavior was undefined, and dependened on the credential's type and internal
-state. ([#10243](https://github.com/Azure/azure-sdk-for-python/pull/10243))
+state. ([#10243](https://github.com/Azure/azure-sdk-for-python/issues/10243))
 
 
 ## 1.4.0b1 (2020-03-10)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -42,13 +42,13 @@ class AuthorizationCodeCredential(object):
         # type: (*str, **Any) -> AccessToken
         """Request an access token for `scopes`.
 
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
         The first time this method is called, the credential will redeem its authorization code. On subsequent calls
         the credential will return a cached access token or redeem a refresh token, if it acquired a refresh token upon
         redeeming the authorization code.
 
-        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
-
-        :param str scopes: desired scopes for the access token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The error's ``message``
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -54,6 +54,8 @@ class AuthorizationCodeCredential(object):
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's
           ``response`` attribute.
         """
+        if not scopes:
+            raise ValueError("'get_token' requires at least one scope")
 
         if self._authorization_code:
             token = self._client.obtain_token_by_authorization_code(

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -41,9 +41,9 @@ class AzureCliCredential(object):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        Only one scope is supported per request. This credential won't cache tokens. Every call invokes the Azure CLI.
+        This credential won't cache tokens. Every call invokes the Azure CLI.
 
-        :param str scopes: desired scopes for the token. Only **one** scope is supported per call.
+        :param str scopes: desired scope for the access token. This credential allows only one scope per request.
         :rtype: :class:`azure.core.credentials.AccessToken`
 
         :raises ~azure.identity.CredentialUnavailableError: the credential was unable to invoke the Azure CLI.

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -66,6 +66,9 @@ class InteractiveBrowserCredential(PublicClientCredential):
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's
           ``response`` attribute.
         """
+        if not scopes:
+            raise ValueError("'get_token' requires at least one scope")
+
         return self._get_token_from_cache(scopes, **kwargs) or self._get_token_by_auth_code(scopes, **kwargs)
 
     def _get_token_from_cache(self, scopes, **kwargs):

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -58,7 +58,7 @@ class InteractiveBrowserCredential(PublicClientCredential):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.identity.CredentialUnavailableError: the credential is unable to start an HTTP server on
           localhost, or is unable to open a browser

--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -52,7 +52,7 @@ class ChainedTokenCredential(object):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :raises ~azure.core.exceptions.ClientAuthenticationError: no credential in the chain provided a token
         """
         history = []

--- a/sdk/identity/azure-identity/azure/identity/_credentials/client_credential.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/client_credential.py
@@ -45,6 +45,9 @@ class ClientSecretCredential(ClientSecretCredentialBase):
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's
           ``response`` attribute.
         """
+        if not scopes:
+            raise ValueError("'get_token' requires at least one scope")
+
         token = self._client.get_cached_token(scopes)
         if not token:
             data = dict(self._form_data, scope=" ".join(scopes))
@@ -79,6 +82,9 @@ class CertificateCredential(CertificateCredentialBase):
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's
           ``response`` attribute.
         """
+        if not scopes:
+            raise ValueError("'get_token' requires at least one scope")
+
         token = self._client.get_cached_token(scopes)
         if not token:
             data = self._get_request_data(*scopes)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/client_credential.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/client_credential.py
@@ -39,7 +39,7 @@ class ClientSecretCredential(ClientSecretCredentialBase):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The error's ``message``
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's
@@ -76,7 +76,7 @@ class CertificateCredential(CertificateCredentialBase):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The error's ``message``
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -104,7 +104,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The exception has a
           `message` attribute listing each authentication attempt and its error message.
         """

--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -105,7 +105,7 @@ class EnvironmentCredential(object):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.identity.CredentialUnavailableError: environment variable configuration is incomplete
         """

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -153,7 +153,7 @@ class ImdsCredential(_ManagedIdentityBase):
             raise CredentialUnavailableError(message="IMDS endpoint unavailable")
 
         if len(scopes) != 1:
-            raise ValueError("this credential supports one scope per request")
+            raise ValueError("This credential requires exactly one scope per token request.")
 
         token = self._client.get_cached_token(scopes)
         if not token:
@@ -192,7 +192,7 @@ class MsiCredential(_ManagedIdentityBase):
             raise CredentialUnavailableError(message="MSI endpoint unavailable")
 
         if len(scopes) != 1:
-            raise ValueError("this credential supports only one scope per request")
+            raise ValueError("This credential requires exactly one scope per token request.")
 
         token = self._client.get_cached_token(scopes)
         if not token:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -55,7 +55,7 @@ class ManagedIdentityCredential(object):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scope for the access token. This credential allows only one scope per request.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.identity.CredentialUnavailableError: managed identity isn't available in the hosting environment
         """
@@ -118,7 +118,6 @@ class _ManagedIdentityBase(object):
 class ImdsCredential(_ManagedIdentityBase):
     """Authenticates with a managed identity via the IMDS endpoint.
 
-
     :keyword str client_id: ID of a user-assigned identity. Leave unspecified to use a system-assigned identity.
     """
 
@@ -131,7 +130,9 @@ class ImdsCredential(_ManagedIdentityBase):
         # type: (*str, **Any) -> AccessToken
         """Request an access token for `scopes`.
 
-        :param str scopes: desired scopes for the token
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
+        :param str scopes: desired scope for the access token. This credential allows only one scope per request.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.identity.CredentialUnavailableError: the IMDS endpoint is unreachable
         """
@@ -183,7 +184,9 @@ class MsiCredential(_ManagedIdentityBase):
         # type: (*str, **Any) -> AccessToken
         """Request an access token for `scopes`.
 
-        :param str scopes: desired scopes for the token
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
+        :param str scopes: desired scope for the access token. This credential allows only one scope per request.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.identity.CredentialUnavailableError: the MSI endpoint is unavailable
         """

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -50,6 +50,8 @@ class SharedTokenCacheCredential(SharedTokenCacheBase):
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's
           ``response`` attribute.
         """
+        if not scopes:
+            raise ValueError("'get_token' requires at least one scope")
 
         if not self._client:
             raise CredentialUnavailableError(message="Shared token cache unavailable")

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -42,7 +42,7 @@ class SharedTokenCacheCredential(SharedTokenCacheBase):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.identity.CredentialUnavailableError: the cache is unavailable or contains insufficient user
             information

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user.py
@@ -72,6 +72,8 @@ class DeviceCodeCredential(PublicClientCredential):
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's
           ``response`` attribute.
         """
+        if not scopes:
+            raise ValueError("'get_token' requires at least one scope")
 
         # MSAL requires scopes be a list
         scopes = list(scopes)  # type: ignore
@@ -154,6 +156,8 @@ class UsernamePasswordCredential(PublicClientCredential):
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's
           ``response`` attribute.
         """
+        if not scopes:
+            raise ValueError("'get_token' requires at least one scope")
 
         # MSAL requires scopes be a list
         scopes = list(scopes)  # type: ignore

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user.py
@@ -66,7 +66,7 @@ class DeviceCodeCredential(PublicClientCredential):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The error's ``message``
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's
@@ -150,7 +150,7 @@ class UsernamePasswordCredential(PublicClientCredential):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The error's ``message``
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's

--- a/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
@@ -14,7 +14,7 @@ def _scopes_to_resource(*scopes):
     """Convert an AADv2 scope to an AADv1 resource"""
 
     if len(scopes) != 1:
-        raise ValueError("This credential supports only one scope per token request")
+        raise ValueError("This credential requires exactly one scope per token request.")
 
     resource = scopes[0]
     if resource.endswith("/.default"):

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -70,6 +70,8 @@ class AuthorizationCodeCredential(AsyncCredentialBase):
         :keyword loop: An event loop on which to schedule network I/O. If not provided, the currently running
             loop will be used.
         """
+        if not scopes:
+            raise ValueError("'get_token' requires at least one scope")
 
         if self._authorization_code:
             loop = kwargs.pop("loop", None) or asyncio.get_event_loop()

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -55,13 +55,13 @@ class AuthorizationCodeCredential(AsyncCredentialBase):
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":
         """Request an access token for `scopes`.
 
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
         The first time this method is called, the credential will redeem its authorization code. On subsequent calls
         the credential will return a cached access token or redeem a refresh token, if it acquired a refresh token upon
         redeeming the authorization code.
 
-        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
-
-        :param str scopes: desired scopes for the access token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The error's ``message``
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -30,9 +30,9 @@ class AzureCliCredential(AsyncCredentialBase):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        Only one scope is supported per request. This credential won't cache tokens. Every call invokes the Azure CLI.
+        This credential won't cache tokens. Every call invokes the Azure CLI.
 
-        :param str scopes: desired scopes for the token. Only **one** scope is supported per call.
+        :param str scopes: desired scope for the access token. This credential allows only one scope per request.
         :rtype: :class:`azure.core.credentials.AccessToken`
 
         :raises ~azure.identity.CredentialUnavailableError: the credential was unable to invoke the Azure CLI.

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
@@ -44,7 +44,7 @@ class ChainedTokenCredential(AsyncCredentialBase):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :raises ~azure.core.exceptions.ClientAuthenticationError: no credential in the chain provided a token
         """
         history = []

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_credential.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_credential.py
@@ -49,6 +49,9 @@ class ClientSecretCredential(ClientSecretCredentialBase, AsyncCredentialBase):
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's
           ``response`` attribute.
         """
+        if not scopes:
+            raise ValueError("'get_token' requires at least one scope")
+
         token = self._client.get_cached_token(scopes)
         if not token:
             data = dict(self._form_data, scope=" ".join(scopes))
@@ -91,6 +94,9 @@ class CertificateCredential(CertificateCredentialBase, AsyncCredentialBase):
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's
           ``response`` attribute.
         """
+        if not scopes:
+            raise ValueError("'get_token' requires at least one scope")
+
         token = self._client.get_cached_token(scopes)
         if not token:
             data = self._get_request_data(*scopes)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_credential.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_credential.py
@@ -43,7 +43,7 @@ class ClientSecretCredential(ClientSecretCredentialBase, AsyncCredentialBase):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The error's ``message``
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's
@@ -88,7 +88,7 @@ class CertificateCredential(CertificateCredentialBase, AsyncCredentialBase):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The error's ``message``
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -91,7 +91,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The exception has a
           `message` attribute listing each authentication attempt and its error message.
         """

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -72,7 +72,7 @@ class EnvironmentCredential(AsyncCredentialBase):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.identity.CredentialUnavailableError: environment variable configuration is incomplete
         """

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -52,7 +52,7 @@ class ManagedIdentityCredential(AsyncCredentialBase):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scope for the access token. This credential allows only one scope per request.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.identity.CredentialUnavailableError: managed identity isn't available in the hosting environment
         """
@@ -97,7 +97,9 @@ class ImdsCredential(_AsyncManagedIdentityBase):
     async def get_token(self, *scopes: str, **kwargs: "Any") -> AccessToken:  # pylint:disable=unused-argument
         """Asynchronously request an access token for `scopes`.
 
-        :param str scopes: desired scopes for the token
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
+        :param str scopes: desired scope for the access token. This credential allows only one scope per request.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.identity.CredentialUnavailableError: the IMDS endpoint is unreachable
         """
@@ -147,7 +149,9 @@ class MsiCredential(_AsyncManagedIdentityBase):
     async def get_token(self, *scopes: str, **kwargs: "Any") -> AccessToken:  # pylint:disable=unused-argument
         """Asynchronously request an access token for `scopes`.
 
-        :param str scopes: desired scopes for the token
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
+        :param str scopes: desired scope for the access token. This credential allows only one scope per request.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.identity.CredentialUnavailableError: the MSI endpoint is unavailable
         """

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -119,7 +119,7 @@ class ImdsCredential(_AsyncManagedIdentityBase):
             raise CredentialUnavailableError(message="IMDS endpoint unavailable")
 
         if len(scopes) != 1:
-            raise ValueError("this credential supports one scope per request")
+            raise ValueError("This credential requires exactly one scope per token request.")
 
         token = self._client.get_cached_token(scopes)
         if not token:
@@ -155,7 +155,7 @@ class MsiCredential(_AsyncManagedIdentityBase):
             raise CredentialUnavailableError(message="MSI endpoint unavailable")
 
         if len(scopes) != 1:
-            raise ValueError("this credential supports only one scope per request")
+            raise ValueError("This credential requires exactly one scope per token request.")
 
         token = self._client.get_cached_token(scopes)
         if not token:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
@@ -50,7 +50,7 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncCredentialBase):
 
         .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
 
-        :param str scopes: desired scopes for the token
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
         :rtype: :class:`azure.core.credentials.AccessToken`
         :raises ~azure.identity.CredentialUnavailableError: the cache is unavailable or contains insufficient user
             information

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
@@ -58,6 +58,8 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncCredentialBase):
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's
           ``response`` attribute.
         """
+        if not scopes:
+            raise ValueError("'get_token' requires at least one scope")
 
         if not self._client:
             raise CredentialUnavailableError(message="Shared token cache unavailable")

--- a/sdk/identity/azure-identity/tests/test_auth_code.py
+++ b/sdk/identity/azure-identity/tests/test_auth_code.py
@@ -6,6 +6,7 @@ from azure.core.credentials import AccessToken
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.identity import AuthorizationCodeCredential
 from azure.identity._internal.user_agent import USER_AGENT
+import pytest
 
 from helpers import build_aad_response, mock_response, Request, validating_transport
 
@@ -13,6 +14,14 @@ try:
     from unittest.mock import Mock
 except ImportError:  # python < 3.3
     from mock import Mock  # type: ignore
+
+
+def test_no_scopes():
+    """The credential should raise ValueError when get_token is called with no scopes"""
+
+    credential = AuthorizationCodeCredential("tenant-id", "client-id", "auth-code", "http://localhost")
+    with pytest.raises(ValueError):
+        credential.get_token()
 
 
 def test_policies_configurable():

--- a/sdk/identity/azure-identity/tests/test_auth_code_async.py
+++ b/sdk/identity/azure-identity/tests/test_auth_code_async.py
@@ -17,6 +17,15 @@ from helpers_async import async_validating_transport, AsyncMockTransport, wrap_i
 
 
 @pytest.mark.asyncio
+async def test_no_scopes():
+    """The credential should raise ValueError when get_token is called with no scopes"""
+
+    credential = AuthorizationCodeCredential("tenant-id", "client-id", "auth-code", "http://localhost")
+    with pytest.raises(ValueError):
+        await credential.get_token()
+
+
+@pytest.mark.asyncio
 async def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
 

--- a/sdk/identity/azure-identity/tests/test_certificate_credential.py
+++ b/sdk/identity/azure-identity/tests/test_certificate_credential.py
@@ -28,6 +28,14 @@ CERT_PASSWORD = "password"
 BOTH_CERTS = ((CERT_PATH, None), (CERT_WITH_PASSWORD_PATH, CERT_PASSWORD))
 
 
+def test_no_scopes():
+    """The credential should raise ValueError when get_token is called with no scopes"""
+
+    credential = CertificateCredential("tenant-id", "client-id", CERT_PATH)
+    with pytest.raises(ValueError):
+        credential.get_token()
+
+
 def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
 

--- a/sdk/identity/azure-identity/tests/test_certificate_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_certificate_credential_async.py
@@ -17,6 +17,15 @@ from test_certificate_credential import BOTH_CERTS, CERT_PATH, validate_jwt
 
 
 @pytest.mark.asyncio
+async def test_no_scopes():
+    """The credential should raise ValueError when get_token is called with no scopes"""
+
+    credential = CertificateCredential("tenant-id", "client-id", CERT_PATH)
+    with pytest.raises(ValueError):
+        await credential.get_token()
+
+
+@pytest.mark.asyncio
 async def test_close():
     transport = AsyncMockTransport()
     credential = CertificateCredential("tenant-id", "client-id", CERT_PATH, transport=transport)

--- a/sdk/identity/azure-identity/tests/test_cli_credential.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential.py
@@ -33,6 +33,20 @@ def raise_called_process_error(return_code, output, cmd="..."):
     return mock.Mock(side_effect=error)
 
 
+def test_no_scopes():
+    """The credential should raise ValueError when get_token is called with no scopes"""
+
+    with pytest.raises(ValueError):
+        AzureCliCredential().get_token()
+
+
+def test_multiple_scopes():
+    """The credential should raise ValueError when get_token is called with more than one scope"""
+
+    with pytest.raises(ValueError):
+        AzureCliCredential().get_token("one scope", "and another")
+
+
 def test_get_token():
     """The credential should parse the CLI's output to an AccessToken"""
 

--- a/sdk/identity/azure-identity/tests/test_cli_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential_async.py
@@ -28,6 +28,22 @@ def mock_exec(stdout, stderr="", return_code=0):
 
 
 @pytest.mark.asyncio
+async def test_no_scopes():
+    """The credential should raise ValueError when get_token is called with no scopes"""
+
+    with pytest.raises(ValueError):
+        await AzureCliCredential().get_token()
+
+
+@pytest.mark.asyncio
+async def test_multiple_scopes():
+    """The credential should raise ValueError when get_token is called with more than one scope"""
+
+    with pytest.raises(ValueError):
+        await AzureCliCredential().get_token("one scope", "and another")
+
+
+@pytest.mark.asyncio
 async def test_close():
     """The credential must define close, although it's a no-op because the credential has no transport"""
 

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential.py
@@ -8,6 +8,7 @@ from azure.core.credentials import AccessToken
 from azure.core.pipeline.policies import ContentDecodePolicy, SansIOHTTPPolicy
 from azure.identity import ClientSecretCredential
 from azure.identity._internal.user_agent import USER_AGENT
+import pytest
 
 from helpers import build_aad_response, mock_response, Request, validating_transport
 
@@ -15,6 +16,14 @@ try:
     from unittest.mock import Mock
 except ImportError:  # python < 3.3
     from mock import Mock  # type: ignore
+
+
+def test_no_scopes():
+    """The credential should raise ValueError when get_token is called with no scopes"""
+
+    credential = ClientSecretCredential("tenant-id", "client-id", "client-secret")
+    with pytest.raises(ValueError):
+        credential.get_token()
 
 
 def test_policies_configurable():

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential_async.py
@@ -17,6 +17,15 @@ import pytest
 
 
 @pytest.mark.asyncio
+async def test_no_scopes():
+    """The credential should raise ValueError when get_token is called with no scopes"""
+
+    credential = ClientSecretCredential("tenant-id", "client-id", "client-secret")
+    with pytest.raises(ValueError):
+        await credential.get_token()
+
+
+@pytest.mark.asyncio
 async def test_close():
     transport = AsyncMockTransport()
     credential = ClientSecretCredential("tenant-id", "client-id", "client-secret", transport=transport)

--- a/sdk/identity/azure-identity/tests/test_device_code_credential.py
+++ b/sdk/identity/azure-identity/tests/test_device_code_credential.py
@@ -18,6 +18,14 @@ except ImportError:  # python < 3.3
     from mock import Mock  # type: ignore
 
 
+def test_no_scopes():
+    """The credential should raise when get_token is called with no scopes"""
+
+    credential = DeviceCodeCredential("client_id")
+    with pytest.raises(ClientAuthenticationError):
+        credential.get_token()
+
+
 def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
 

--- a/sdk/identity/azure-identity/tests/test_imds_credential.py
+++ b/sdk/identity/azure-identity/tests/test_imds_credential.py
@@ -2,17 +2,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from unittest import mock
-
 from azure.core.exceptions import HttpResponseError
-from azure.identity.aio._credentials.managed_identity import ImdsCredential
+from azure.identity._credentials.managed_identity import ImdsCredential
 import pytest
 
-from helpers_async import AsyncMockTransport
+from helpers import mock
 
 
-@pytest.mark.asyncio
-async def test_no_scopes():
+def test_no_scopes():
     """The credential should raise ValueError when get_token is called with no scopes"""
 
     # the credential will probe the endpoint, taking HttpResponseError as indicating availability
@@ -20,11 +17,10 @@ async def test_no_scopes():
     credential = ImdsCredential(transport=transport)
 
     with pytest.raises(ValueError):
-        await credential.get_token()
+        credential.get_token()
 
 
-@pytest.mark.asyncio
-async def test_multiple_scopes():
+def test_multiple_scopes():
     """The credential should raise ValueError when get_token is called with more than one scope"""
 
     # the credential will probe the endpoint, taking HttpResponseError as indicating availability
@@ -32,26 +28,4 @@ async def test_multiple_scopes():
     credential = ImdsCredential(transport=transport)
 
     with pytest.raises(ValueError):
-        await credential.get_token("one scope", "and another")
-
-
-@pytest.mark.asyncio
-async def test_imds_close():
-    transport = AsyncMockTransport()
-
-    credential = ImdsCredential(transport=transport)
-
-    await credential.close()
-
-    assert transport.__aexit__.call_count == 1
-
-
-@pytest.mark.asyncio
-async def test_imds_context_manager():
-    transport = AsyncMockTransport()
-    credential = ImdsCredential(transport=transport)
-
-    async with credential:
-        pass
-
-    assert transport.__aexit__.call_count == 1
+        credential.get_token("one scope", "and another")

--- a/sdk/identity/azure-identity/tests/test_interactive_credential.py
+++ b/sdk/identity/azure-identity/tests/test_interactive_credential.py
@@ -24,6 +24,13 @@ except ImportError:  # python < 3.3
     from mock import Mock, patch  # type: ignore
 
 
+def test_no_scopes():
+    """The credential should raise when get_token is called with no scopes"""
+
+    with pytest.raises(ClientAuthenticationError):
+        InteractiveBrowserCredential().get_token()
+
+
 @patch("azure.identity._credentials.browser.webbrowser.open", lambda _: True)
 def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())

--- a/sdk/identity/azure-identity/tests/test_msi_credential.py
+++ b/sdk/identity/azure-identity/tests/test_msi_credential.py
@@ -1,0 +1,29 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from azure.identity._constants import EnvironmentVariables
+from azure.identity._credentials.managed_identity import MsiCredential
+import pytest
+
+from helpers import mock
+
+
+def test_no_scopes():
+    """The credential should raise ValueError when get_token is called with no scopes"""
+
+    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: "https://url"}):
+        credential = MsiCredential()
+
+    with pytest.raises(ValueError):
+        credential.get_token()
+
+
+def test_multiple_scopes():
+    """The credential should raise ValueError when get_token is called with more than one scope"""
+
+    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: "https://url"}):
+        credential = MsiCredential()
+
+    with pytest.raises(ValueError):
+        credential.get_token("one scope", "and another")

--- a/sdk/identity/azure-identity/tests/test_msi_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_msi_credential_async.py
@@ -12,6 +12,28 @@ from helpers_async import AsyncMockTransport
 
 
 @pytest.mark.asyncio
+async def test_no_scopes():
+    """The credential should raise ValueError when get_token is called with no scopes"""
+
+    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: "https://url"}):
+        credential = MsiCredential()
+
+    with pytest.raises(ValueError):
+        await credential.get_token()
+
+
+@pytest.mark.asyncio
+async def test_multiple_scopes():
+    """The credential should raise ValueError when get_token is called with more than one scope"""
+
+    with mock.patch("os.environ", {EnvironmentVariables.MSI_ENDPOINT: "https://url"}):
+        credential = MsiCredential()
+
+    with pytest.raises(ValueError):
+        await credential.get_token("one scope", "and another")
+
+
+@pytest.mark.asyncio
 async def test_close():
     transport = AsyncMockTransport()
 

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
@@ -24,6 +24,14 @@ except ImportError:  # python < 3.3
 from helpers import build_aad_response, build_id_token, mock_response, Request, validating_transport
 
 
+def test_no_scopes():
+    """The credential should raise when get_token is called with no scopes"""
+
+    credential = SharedTokenCacheCredential(_cache=TokenCache())
+    with pytest.raises(ClientAuthenticationError):
+        credential.get_token()
+
+
 def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
 

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
@@ -25,6 +25,15 @@ from test_shared_cache_credential import get_account_event, populated_cache
 
 
 @pytest.mark.asyncio
+async def test_no_scopes():
+    """The credential should raise when get_token is called with no scopes"""
+
+    credential = SharedTokenCacheCredential(_cache=TokenCache())
+    with pytest.raises(ClientAuthenticationError):
+        await credential.get_token()
+
+
+@pytest.mark.asyncio
 async def test_close():
     transport = AsyncMockTransport()
     credential = SharedTokenCacheCredential(

--- a/sdk/identity/azure-identity/tests/test_username_password_credential.py
+++ b/sdk/identity/azure-identity/tests/test_username_password_credential.py
@@ -2,15 +2,26 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from azure.core.exceptions import ClientAuthenticationError
 from azure.core.pipeline.policies import ContentDecodePolicy, SansIOHTTPPolicy
 from azure.identity import UsernamePasswordCredential
 from azure.identity._internal.user_agent import USER_AGENT
+import pytest
+
 from helpers import build_aad_response, get_discovery_response, mock_response, Request, validating_transport
 
 try:
     from unittest.mock import Mock
 except ImportError:  # python < 3.3
     from mock import Mock  # type: ignore
+
+
+def test_no_scopes():
+    """The credential should raise when get_token is called with no scopes"""
+
+    credential = UsernamePasswordCredential("client-id", "username", "password")
+    with pytest.raises(ClientAuthenticationError):
+        credential.get_token()
 
 
 def test_policies_configurable():


### PR DESCRIPTION
Calling a credential's `get_token` method with no argument is equivalent to requesting an access token from Azure AD for no particular scope. Azure AD rejects such requests as malformed. Allowing `get_token()` also doesn't make sense in the Azure SDK because the caller presumably wants a token to authorize some request, which implies the caller knows details of that request including the required scope of authorization.

`get_token()` should therefore raise an error, and it typically does. However, in some cases it can succeed due to unintended consequences of a credential's internal use of `msal`. To prevent confusing failure and misleading success (see #10243 for an example), this change defines the behavior of `get_token()`: it raises in all cases.