### PR TITLE
Update tracing README sample

### DIFF
--- a/sdk/core/azure-core-tracing-opentelemetry/README.md
+++ b/sdk/core/azure-core-tracing-opentelemetry/README.md
@@ -39,7 +39,7 @@ from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
 settings.tracing_implementation = OpenTelemetrySpan
 
 # Example of Azure Monitor exporter, but you can use anything OpenTelemetry supports
-from opentelemetry.ext.azure_monitor import AzureMonitorSpanExporter
+from azure_monitor import AzureMonitorSpanExporter
 exporter = AzureMonitorSpanExporter(
     instrumentation_key="uuid of the instrumentation key (see your Azure Monitor account)"
 )
@@ -54,9 +54,9 @@ from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
 # Simple console exporter
 exporter = ConsoleSpanExporter()
 
-trace.set_preferred_tracer_implementation(lambda T: TracerSource())
+trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
 tracer = trace.get_tracer(__name__)
-tracer.tracer_source().add_span_processor(
+trace.tracer_source().add_span_processor(
     SimpleExportSpanProcessor(exporter)
 )
 
@@ -69,7 +69,7 @@ with tracer.start_as_current_span(name="MyApplication"):
     client.create_container('mycontainer')  # Call will be traced
 ```
 
-Azure Exporter can be found in the package `opentelemetry-azure-monitor-exporter`
+Azure Exporter can be found in the [package](https://github.com/microsoft/opentelemetry-exporters-python) `opentelemetry-azure-monitor-exporter`
 
 
 ## Troubleshooting


### PR DESCRIPTION
Up and running...otput as expected

```
Calling start() on a started span.
Calling start() on a started span.
Span(name="/mycontainer", context=SpanContext(trace_id=0x0e8fc47c6ba12003e2a5cdd08bbe9e49, span_id=0x6c43454898522146, trace_state={}), kind=SpanKind.CLIENT, parent=Span(name="BlobServiceClient.create_container", context=SpanContext(trace_id=0x0e8fc47c6ba12003e2a5cdd08bbe9e49, span_id=0x6fdf46f65f578bfb, trace_state={})), start_time=2020-03-19T21:34:22.012116Z, end_time=2020-03-19T21:34:22.973970Z)Span(name="BlobServiceClient.create_container", context=SpanContext(trace_id=0x0e8fc47c6ba12003e2a5cdd08bbe9e49, span_id=0x6fdf46f65f578bfb, trace_state={}), kind=SpanKind.INTERNAL, parent=Span(name="MyApplication", context=SpanContext(trace_id=0x0e8fc47c6ba12003e2a5cdd08bbe9e49, span_id=0x4b5089facaaba871, trace_state={})), start_time=2020-03-19T21:34:22.007130Z, end_time=2020-03-19T21:34:22.977961Z)Span(name="MyApplication", context=SpanContext(trace_id=0x0e8fc47c6ba12003e2a5cdd08bbe9e49, span_id=0x4b5089facaaba871, trace_state={}), kind=SpanKind.INTERNAL, parent=None, start_time=2020-03-19T21:34:22.007130Z, end_time=2020-03-19T21:34:22.977961Z)(trace)
```