### PR TITLE
Azure-Search Needs to be present on Search landing page

### DIFF
--- a/doc/sphinx/package_service_mapping.json
+++ b/doc/sphinx/package_service_mapping.json
@@ -866,6 +866,11 @@
     "service_name": "Search",
     "manually_generated": true
   },
+  "azure-search": {
+    "category": "Client",
+    "service_name": "Search",
+    "manually_generated": true
+  },
   "azure-keyvault-keys": {
     "category": "Client",
     "service_name": "Keyvault",


### PR DESCRIPTION
Re-adding. 

At least until we release the first version of `azure-search-documents`