### PR TITLE
Remove --pre from OT plugin guidance

### DIFF
--- a/sdk/core/azure-core-tracing-opentelemetry/README.md
+++ b/sdk/core/azure-core-tracing-opentelemetry/README.md
@@ -7,7 +7,7 @@
 Install the opentelemetry python for Python with [pip](https://pypi.org/project/pip/):
 
 ```bash
-pip install azure-core-tracing-opentelemetry --pre
+pip install azure-core-tracing-opentelemetry
 ```
 
 Now you can use opentelemetry for Python as usual with any SDKs that are compatible


### PR DESCRIPTION
Since OT plugin was only released as preview so far, --pre is unnecessary, let's keep the guidance the most clean possible