### PR TITLE
Verify change log issue

### DIFF
--- a/scripts/devops_tasks/verify_change_log.py
+++ b/scripts/devops_tasks/verify_change_log.py
@@ -15,13 +15,15 @@ import logging
 
 from common_tasks import process_glob_string, parse_setup, run_check_call
 
-excluded_packages = ["azure"]
 
 logging.getLogger().setLevel(logging.INFO)
 
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", ".."))
 psscript = os.path.join(root_dir, "scripts", "devops_tasks", "find_change_log.ps1")
 
+# Service fabric change log name is History.md and as per the discussion with language team this should not be renamed to CHANGELOG.md
+# This script looks for "CHANGELOG.md" and fails if it is not found in package
+NON_STANDARD_CHANGE_LOG_PACKAGES = ["azure-servicefabric",]
 
 def find_change_log(targeted_package, version):
     # Execute powershell script to find a matching version in change log
@@ -58,7 +60,7 @@ def verify_packages(targeted_packages):
         pkg_name, version, _, _ = parse_setup(package)
 
         # Skip management packages
-        if "-mgmt" in pkg_name or pkg_name in excluded_packages:
+        if "-mgmt" in pkg_name or pkg_name in NON_STANDARD_CHANGE_LOG_PACKAGES:
             continue
 
         if not find_change_log(package, version):

--- a/scripts/devops_tasks/verify_change_log.py
+++ b/scripts/devops_tasks/verify_change_log.py
@@ -60,6 +60,7 @@ def verify_packages(targeted_packages):
         pkg_name, version, _, _ = parse_setup(package)
 
         # Skip management packages
+        # Skipping azure-servicefabric due to non-standard version format(e.g. 7.0.0.0) for the package
         if "-mgmt" in pkg_name or pkg_name in NON_STANDARD_CHANGE_LOG_PACKAGES:
             continue
 

--- a/scripts/devops_tasks/verify_change_log.py
+++ b/scripts/devops_tasks/verify_change_log.py
@@ -59,9 +59,9 @@ def verify_packages(targeted_packages):
         # Parse setup.py using common helper method to get version and package name
         pkg_name, version, _, _ = parse_setup(package)
 
-        # Skip management packages
-        # Skipping azure-servicefabric due to non-standard version format(e.g. 7.0.0.0) for the package
+        # Skip management packages and any explicitly excluded packages
         if "-mgmt" in pkg_name or pkg_name in NON_STANDARD_CHANGE_LOG_PACKAGES:
+            logging.info("Skipping {} due to known exclusion in change log verification".format(pkg_name))
             continue
 
         if not find_change_log(package, version):

--- a/scripts/devops_tasks/verify_change_log.py
+++ b/scripts/devops_tasks/verify_change_log.py
@@ -21,8 +21,8 @@ logging.getLogger().setLevel(logging.INFO)
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", ".."))
 psscript = os.path.join(root_dir, "scripts", "devops_tasks", "find_change_log.ps1")
 
-# Service fabric change log name is History.md and as per the discussion with language team this should not be renamed to CHANGELOG.md
-# This script looks for "CHANGELOG.md" and fails if it is not found in package
+# Service fabric change log has non standard versioning for e.g 7.0.0.0
+# Verify change log should skip this package since this script looks for standard version format of x.y.z
 NON_STANDARD_CHANGE_LOG_PACKAGES = ["azure-servicefabric",]
 
 def find_change_log(targeted_package, version):


### PR DESCRIPTION
Skip verifying change log for Service fabric package. Service fabric version is 7.0.0.0 and this is not as per standard Azure SDK versioning format. Change log extractor cannot find matching change log for package version and failing the check. As per the discussion with Language team, version should not be updated to standard format hence skipping this package from change log verification.