### PR TITLE
Reduce tox name for minimum dependency test

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -114,11 +114,11 @@ jobs:
     - pwsh: |
         $toxenvvar = "whl,sdist"
         if (('$(Build.Reason)' -eq 'Schedule') -and ('$(System.TeamProject)' -eq 'internal')) {
-          $toxenvvar = "whl,sdist,depends,latestdependency,minimumdependency"
+          $toxenvvar = "whl,sdist,depends,latestdependency,mindependency"
         }
 
         if ('$(Run.DependencyTest)' -eq 'true') {
-          $toxenvvar = "whl,sdist,depends,latestdependency,minimumdependency"
+          $toxenvvar = "whl,sdist,depends,latestdependency,mindependency"
         }
         echo "##vso[task.setvariable variable=toxenv]$toxenvvar"
       displayName: "Set Tox Environment"

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -208,7 +208,7 @@ commands =
     {[deptestcommands]commands}
 
 
-[testenv:minimumdependency]
+[testenv:mindependency]
 pre-deps =
   wheel packaging
 deps = {[tools]deps}


### PR DESCRIPTION
Minimum dependency test is failing for azure-eventhub-checkpointstore-aio due to long path name. Quick fix for now is to reduce tox name to "mindependency".

 