### PR TITLE
Fix mocks for mindependency tests

### DIFF
--- a/sdk/identity/azure-identity/tests/test_imds_credential.py
+++ b/sdk/identity/azure-identity/tests/test_imds_credential.py
@@ -2,18 +2,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from azure.core.pipeline.transport import HttpResponse
 from azure.core.exceptions import HttpResponseError
 from azure.identity._credentials.managed_identity import ImdsCredential
 import pytest
 
-from helpers import mock
+from helpers import mock, mock_response
 
 
 def test_no_scopes():
     """The credential should raise ValueError when get_token is called with no scopes"""
 
-    # the credential will probe the endpoint, taking HttpResponseError as indicating availability
-    transport = mock.Mock(send=mock.Mock(side_effect=HttpResponseError()))
+    successful_probe = mock_response(status_code=400, json_payload={})
+    transport = mock.Mock(send=mock.Mock(return_value=successful_probe))
     credential = ImdsCredential(transport=transport)
 
     with pytest.raises(ValueError):
@@ -23,8 +24,8 @@ def test_no_scopes():
 def test_multiple_scopes():
     """The credential should raise ValueError when get_token is called with more than one scope"""
 
-    # the credential will probe the endpoint, taking HttpResponseError as indicating availability
-    transport = mock.Mock(send=mock.Mock(side_effect=HttpResponseError()))
+    successful_probe = mock_response(status_code=400, json_payload={})
+    transport = mock.Mock(send=mock.Mock(return_value=successful_probe))
     credential = ImdsCredential(transport=transport)
 
     with pytest.raises(ValueError):

--- a/sdk/identity/azure-identity/tests/test_imds_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_imds_credential_async.py
@@ -8,15 +8,16 @@ from azure.core.exceptions import HttpResponseError
 from azure.identity.aio._credentials.managed_identity import ImdsCredential
 import pytest
 
-from helpers_async import AsyncMockTransport
+from helpers import mock_response
+from helpers_async import AsyncMockTransport, get_completed_future
 
 
 @pytest.mark.asyncio
 async def test_no_scopes():
     """The credential should raise ValueError when get_token is called with no scopes"""
 
-    # the credential will probe the endpoint, taking HttpResponseError as indicating availability
-    transport = mock.Mock(send=mock.Mock(side_effect=HttpResponseError()))
+    successful_probe = mock_response(status_code=400, json_payload={})
+    transport = mock.Mock(send=mock.Mock(return_value=get_completed_future(successful_probe)))
     credential = ImdsCredential(transport=transport)
 
     with pytest.raises(ValueError):
@@ -27,8 +28,8 @@ async def test_no_scopes():
 async def test_multiple_scopes():
     """The credential should raise ValueError when get_token is called with more than one scope"""
 
-    # the credential will probe the endpoint, taking HttpResponseError as indicating availability
-    transport = mock.Mock(send=mock.Mock(side_effect=HttpResponseError()))
+    successful_probe = mock_response(status_code=400, json_payload={})
+    transport = mock.Mock(send=mock.Mock(return_value=get_completed_future(successful_probe)))
     credential = ImdsCredential(transport=transport)
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
The mindependency environment runs the test suite with azure-core 1.0.0, whose policies require these tests to actually return a (mock) response.