### PR TITLE
Raise CredentialUnavailableError when IMDS identity is unavailable

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 1.3.1 (Unreleased)
+
+- `ManagedIdentityCredential` raises `CredentialUnavailableError` when no
+identity is configured for an IMDS endpoint. This causes
+`ChainedTokenCredential` to correctly try the next credential in the chain.
+([#10488](https://github.com/Azure/azure-sdk-for-python/issues/10488))
+
+
 ## 1.3.0 (2020-02-11)
 
 - Correctly parse token expiration time on Windows App Service

--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -101,7 +101,9 @@ class AuthnClientBase(ABC):
         if not payload or "access_token" not in payload or not ("expires_in" in payload or "expires_on" in payload):
             if payload and "access_token" in payload:
                 payload["access_token"] = "****"
-            raise ClientAuthenticationError(message="Unexpected response '{}'".format(payload))
+            raise ClientAuthenticationError(
+                message="Unexpected response '{}'".format(payload), response=response.http_response
+            )
 
         token = payload["access_token"]
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -7,7 +7,7 @@ import os
 import six
 from azure.core.configuration import Configuration
 from azure.core.credentials import AccessToken
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
 from azure.core.pipeline.policies import (
     ContentDecodePolicy,
     DistributedTracingPolicy,
@@ -179,8 +179,8 @@ class ImdsCredential(_ManagedIdentityBase):
                         message += "No identity has been assigned to this resource."
                     six.raise_from(CredentialUnavailableError(message=message), ex)
 
-                # any other error is unexpected, so we propagate the exception
-                raise
+                # any other error is unexpected
+                six.raise_from(ClientAuthenticationError(message=ex.message, response=ex.response), None)
 
         return token
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 import os
 
+import six
 from azure.core.configuration import Configuration
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import HttpResponseError
@@ -163,7 +164,24 @@ class ImdsCredential(_ManagedIdentityBase):
             params = {"api-version": "2018-02-01", "resource": resource}
             if self._client_id:
                 params["client_id"] = self._client_id
-            token = self._client.request_token(scopes, method="GET", params=params)
+
+            try:
+                token = self._client.request_token(scopes, method="GET", params=params)
+            except HttpResponseError as ex:
+                # 400 in response to a token request indicates managed identity is disabled,
+                # or the identity with the specified client_id is not available
+                if ex.status_code == 400:
+                    self._endpoint_available = False
+                    message = "ManagedIdentityCredential authentication unavailable. "
+                    if self._client_id:
+                        message += "The requested identity has not been assigned to this resource."
+                    else:
+                        message += "No identity has been assigned to this resource."
+                    six.raise_from(CredentialUnavailableError(message=message), ex)
+
+                # any other error is unexpected, so we propagate the exception
+                raise
+
         return token
 
 

--- a/sdk/identity/azure-identity/azure/identity/_version.py
+++ b/sdk/identity/azure-identity/azure/identity/_version.py
@@ -2,4 +2,4 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-VERSION = "1.3.0"
+VERSION = "1.3.1"

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -7,7 +7,7 @@ import os
 from typing import TYPE_CHECKING
 
 from azure.core.credentials import AccessToken
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
 from azure.core.pipeline.policies import AsyncRetryPolicy
 
 from azure.identity._credentials.managed_identity import _ManagedIdentityBase
@@ -144,8 +144,8 @@ class ImdsCredential(_AsyncManagedIdentityBase):
                         message += "No identity has been assigned to this resource."
                     raise CredentialUnavailableError(message=message) from ex
 
-                # any other error is unexpected, so we propagate the exception
-                raise
+                # any other error is unexpected
+                raise ClientAuthenticationError(message=ex.message, response=ex.response) from None
 
         return token
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -129,7 +129,24 @@ class ImdsCredential(_AsyncManagedIdentityBase):
             params = {"api-version": "2018-02-01", "resource": resource}
             if self._client_id:
                 params["client_id"] = self._client_id
-            token = await self._client.request_token(scopes, method="GET", params=params)
+
+            try:
+                token = await self._client.request_token(scopes, method="GET", params=params)
+            except HttpResponseError as ex:
+                # 400 in response to a token request indicates managed identity is disabled,
+                # or the identity with the specified client_id is not available
+                if ex.status_code == 400:
+                    self._endpoint_available = False
+                    message = "ManagedIdentityCredential authentication unavailable. "
+                    if self._client_id:
+                        message += "The requested identity has not been assigned to this resource."
+                    else:
+                        message += "No identity has been assigned to this resource."
+                    raise CredentialUnavailableError(message=message) from ex
+
+                # any other error is unexpected, so we propagate the exception
+                raise
+
         return token
 
 

--- a/sdk/identity/azure-identity/tests/test_imds_credential.py
+++ b/sdk/identity/azure-identity/tests/test_imds_credential.py
@@ -2,72 +2,45 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from unittest import mock
-
 from azure.core.exceptions import ClientAuthenticationError
+from azure.core.exceptions import HttpResponseError
 from azure.identity import CredentialUnavailableError
-from azure.identity.aio._credentials.managed_identity import ImdsCredential
+from azure.identity._credentials.managed_identity import ImdsCredential
 import pytest
 
-from helpers import mock_response, Request
-from helpers_async import async_validating_transport, AsyncMockTransport, get_completed_future
+from helpers import mock, mock_response, Request, validating_transport
 
 
-@pytest.mark.asyncio
-async def test_imds_close():
-    transport = AsyncMockTransport()
-
-    credential = ImdsCredential(transport=transport)
-
-    await credential.close()
-
-    assert transport.__aexit__.call_count == 1
-
-
-@pytest.mark.asyncio
-async def test_imds_context_manager():
-    transport = AsyncMockTransport()
-    credential = ImdsCredential(transport=transport)
-
-    async with credential:
-        pass
-
-    assert transport.__aexit__.call_count == 1
-
-
-@pytest.mark.asyncio
-async def test_identity_not_available():
+def test_identity_not_available():
     """The credential should raise CredentialUnavailableError when the endpoint responds 400 to a token request"""
 
     # first request is a probe, second a token request
-    transport = async_validating_transport(
+    transport = validating_transport(
         requests=[Request()] * 2, responses=[mock_response(status_code=400, json_payload={})] * 2
     )
 
     credential = ImdsCredential(transport=transport)
 
     with pytest.raises(CredentialUnavailableError):
-        await credential.get_token("scope")
+        credential.get_token("scope")
 
 
-@pytest.mark.asyncio
-async def test_unexpected_error():
+def test_unexpected_error():
     """The credential should raise ClientAuthenticationError when the endpoint returns an unexpected error"""
 
     error_message = "something went wrong"
 
     for code in range(401, 600):
 
-        async def send(request, **_):
+        def send(request, **_):
             if "resource" not in request.query:
                 # availability probe
                 return mock_response(status_code=400, json_payload={})
             return mock_response(status_code=code, json_payload={"error": error_message})
 
-        transport = mock.Mock(send=send, sleep=lambda _: get_completed_future())
-        credential = ImdsCredential(transport=transport)
+        credential = ImdsCredential(transport=mock.Mock(send=send))
 
         with pytest.raises(ClientAuthenticationError) as ex:
-            await credential.get_token("scope")
+            credential.get_token("scope")
 
         assert error_message in ex.value.message


### PR DESCRIPTION
The IMDS endpoint responds 400 when managed identity is unavailable, either because the feature is disabled entirely or the specified identity is not available. Upon receiving such a response, `ImdsCredential` should raise `CredentialUnavailableError` to signal it cannot authenticate and a `ChainedTokenCredential` should try the next credential in its chain.

Fixes #10488 