### PR TITLE
locking dev reqs

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -1,16 +1,35 @@
-setuptools
-wheel 
-Jinja2
-packaging
-tox
-tox-monorepo
-twine
-pathlib2
-readme-renderer[md]
+# requirements leveraged by ci tools
+setuptools==44.1.0; python_version == '2.7'
+setuptools==45.1.0; python_version >= '3.5'
+wheel==0.34.2 
+Jinja2==2.11.1
+packaging==20.3
+tox==3.14.6
+tox-monorepo==0.1.2
+twine==1.15.0; python_version == '2.7'
+twine==3.1.1; python_version >= '3.5'
+pathlib2==2.3.5
+readme-renderer[md]==25.0
 doc-warden==0.5.3
 coverage==4.5.4
-codecov
-beautifulsoup4
-pkginfo
+codecov==2.0.22 
+beautifulsoup4==4.8.2
+pkginfo==1.5.0.1
+
+# locking packages defined as deps from azure-sdk-tools or azure-devtools
+pytoml==0.1.21
+pyOpenSSL==19.1.0
+json-delta==2.0
+ConfigArgParse==1.1
+six==1.14.0
+vcrpy==3.0.0
+pytest==5.4.1; python_version >= '3.5'
+pytest==4.6.9; python_version == '2.7'
+pytest-cov==2.8.1
+
+# local dev packages
 ./tools/azure-devtools
 ./tools/azure-sdk-tools
+
+
+

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -6,8 +6,7 @@ Jinja2==2.11.1
 packaging==20.3
 tox==3.14.6
 tox-monorepo==0.1.2
-twine==1.15.0; python_version == '2.7'
-twine==3.1.1; python_version >= '3.5'
+twine==1.15.0
 pathlib2==2.3.5
 readme-renderer[md]==25.0
 doc-warden==0.5.3

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -22,6 +22,7 @@ json-delta==2.0
 ConfigArgParse==1.1
 six==1.14.0
 vcrpy==3.0.0
+pyyaml==5.3.1
 pytest==5.4.1; python_version >= '3.5'
 pytest==4.6.9; python_version == '2.7'
 pytest-cov==2.8.1

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -1,7 +1,23 @@
-pytest-custom_exit_code
-pytest-cov
-pytest-xdist
-pytest-asyncio; python_version >= '3.5'
+# requirements leveraged by ci for testing
+pytest==5.4.1;python_version >= '3.5'
+pytest==4.6.9; python_version == '2.7'
+pytest-asyncio==0.10.0; python_version >= '3.5'
+pytest-cov==2.8.1
+pytest-custom-exit-code==0.3.0
+pytest-xdist==1.31.0
 coverage==4.5.4
+
+# locking packages defined as deps from azure-sdk-tools or azure-devtools
+pytoml==0.1.21
+readme-renderer[md]==25.0
+pyOpenSSL==19.1.0
+json-delta==2.0
+ConfigArgParse==1.1
+six==1.14.0
+vcrpy==3.0.0
+packaging==20.3
+wheel==0.34.2
+Jinja2==2.11.1
+
 ../../../tools/azure-devtools
 ../../../tools/azure-sdk-tools

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -15,6 +15,7 @@ json-delta==2.0
 ConfigArgParse==1.1
 six==1.14.0
 vcrpy==3.0.0
+pyyaml==5.3.1
 packaging==20.3
 wheel==0.34.2
 Jinja2==2.11.1

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -1,5 +1,5 @@
 # requirements leveraged by ci for testing
-pytest==5.4.1;python_version >= '3.5'
+pytest==5.4.1; python_version >= '3.5'
 pytest==4.6.9; python_version == '2.7'
 pytest-asyncio==0.10.0; python_version >= '3.5'
 pytest-cov==2.8.1

--- a/sdk/appconfiguration/azure-appconfiguration/dev_requirements.txt
+++ b/sdk/appconfiguration/azure-appconfiguration/dev_requirements.txt
@@ -5,4 +5,4 @@
 aiohttp>=3.0; python_version >= '3.5'
 aiodns>=2.0; python_version >= '3.5'
 msrest>=0.6.10
-pytest
+

--- a/sdk/core/azure-mgmt-core/dev_requirements.txt
+++ b/sdk/core/azure-mgmt-core/dev_requirements.txt
@@ -6,6 +6,3 @@ typing_extensions>=3.7.2
 -e ../azure-core
 mock;python_version<="2.7"
 httpretty
-pytest
-pytest-cov
-pytest-asyncio;python_full_version>="3.5.2"

--- a/sdk/eventhub/azure-eventhub/dev_requirements.txt
+++ b/sdk/eventhub/azure-eventhub/dev_requirements.txt
@@ -6,4 +6,3 @@ aiohttp>=3.0; python_version >= '3.5'
 docutils>=0.14
 pygments>=2.2.0
 behave==1.2.6
-wheel

--- a/sdk/identity/azure-identity/dev_requirements.txt
+++ b/sdk/identity/azure-identity/dev_requirements.txt
@@ -1,5 +1,3 @@
 ../../core/azure-core
 aiohttp;python_full_version>="3.5.3"
-pytest
-pytest-asyncio;python_full_version>="3.5.3"
 typing_extensions>=3.7.2

--- a/sdk/search/azure-search-documents/dev_requirements.txt
+++ b/sdk/search/azure-search-documents/dev_requirements.txt
@@ -3,4 +3,3 @@
 ../../core/azure-core
 ../azure-search-nspkg
 aiohttp>=3.0; python_version >= '3.5'
-pytest

--- a/sdk/storage/azure-storage-blob/dev_requirements.txt
+++ b/sdk/storage/azure-storage-blob/dev_requirements.txt
@@ -3,4 +3,4 @@
 ../../core/azure-core
 -e ../../identity/azure-identity
 aiohttp>=3.0; python_version >= '3.5'
-pytest
+

--- a/sdk/storage/azure-storage-file-datalake/dev_requirements.txt
+++ b/sdk/storage/azure-storage-file-datalake/dev_requirements.txt
@@ -4,4 +4,3 @@
 ../azure-storage-blob
 -e ../../identity/azure-identity
 aiohttp>=3.0; python_version >= '3.5'
-pytest

--- a/sdk/storage/azure-storage-file-share/dev_requirements.txt
+++ b/sdk/storage/azure-storage-file-share/dev_requirements.txt
@@ -3,4 +3,3 @@
 ../../core/azure-core
 -e ../../identity/azure-identity
 aiohttp>=3.0; python_version >= '3.5'
-pytest

--- a/sdk/storage/azure-storage-queue/dev_requirements.txt
+++ b/sdk/storage/azure-storage-queue/dev_requirements.txt
@@ -3,4 +3,4 @@
 ../../core/azure-core
 -e ../../identity/azure-identity
 aiohttp>=3.0; python_version >= '3.5'
-pytest
+

--- a/tools/azure-devtools/dev_requirements.txt
+++ b/tools/azure-devtools/dev_requirements.txt
@@ -1,4 +1,4 @@
 -e .[ci_tools]
 
 mock;python_version<="2.7"
-pytest
+


### PR DESCRIPTION
Due to conflicts beginning to be introduced due to py2.7 EoL. We wanted everything to float forward and just deal, but given that isn't really possible with py2.7 conflicts being introduced.

Given that wanted to do "all or nothing" with pinned dev deps, here's the "all"