### PR TITLE
Support "Latest" Folder In JS Version Selector

### DIFF
--- a/doc/sphinx/_static/js/get_options.js
+++ b/doc/sphinx/_static/js/get_options.js
@@ -67,14 +67,21 @@ function populateOptions(optionSelector, otherSelectors){
 }
 
 function populateVersionDropDown(selector, values){
-    var select = $(selector);
-
-    $('option', select).remove();
+    var select = $(selector)
+    
+    $('option', select).remove()
 
     $.each(values, function(index, text) {
-      $('<option/>', { 'value' : text, 'text': text }).appendTo(select);
+      $('<option/>', { 'value' : text, 'text': text }).appendTo(select)
     });
-    select.val(currentVersion());  
+
+    var version = currentVersion()
+    if(version==='latest'){
+      select.selectedIndex = 0
+    }
+    else {
+      select.val(version)  
+    }
 }
 
 function getPackageUrl(language, package, version){


### PR DESCRIPTION
If you load up the "latest" folder the drop down should show you the latest version in the drop down menu. Currently it bugs out and shows blank.