### PR TITLE
[textanalytics] missing preparer added back to async test

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_auth_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_auth_async.py
@@ -26,6 +26,7 @@ class AiohttpTestTransport(AioHttpTransport):
 
 class TestAuth(AsyncTextAnalyticsTest):
     @pytest.mark.live_test_only
+    @GlobalTextAnalyticsAccountPreparer()
     async def test_active_directory_auth(self):
         token = self.generate_oauth_token()
         endpoint = self.get_oauth_endpoint()


### PR DESCRIPTION
Otherwise this test won't be awaited, get skipped, but say "passed"