### PR TITLE
Install tools packages in dev requirements from regression test branch

### DIFF
--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -410,3 +410,11 @@ def find_packages_missing_on_pypi(path):
         logging.error("Packages not found on PyPI: {}".format(missing_packages))
     return missing_packages
 
+
+def find_tools_packages(root_path):
+    """Find packages in tools directory. For e.g. azure-sdk-tools, azure-devtools
+    """
+    glob_string = os.path.join(root_path, "tools", "*", "setup.py")
+    pkgs = [os.path.basename(os.path.dirname(p)) for p in glob.glob(glob_string)]
+    logging.info("Packages in tools: {}".format(pkgs))
+    return pkgs


### PR DESCRIPTION
Latest version of Azure-sdk-tools and azure-devtools are installed in virtual env when testing regression against released packages. They should be installed from the branch we are running tests for instead of latest version.