### PR TITLE
Change product name to be formed properly (azure-service-bus not azure-servicebus) within samples readme

### DIFF
--- a/sdk/servicebus/azure-servicebus/samples/README.md
+++ b/sdk/servicebus/azure-servicebus/samples/README.md
@@ -4,7 +4,7 @@ languages:
   - python
 products:
   - azure
-  - azure-servicebus
+  - azure-service-bus
 urlFragment: servicebus-samples
 ---
 


### PR DESCRIPTION
Truth in advertizing.  Aligns with doc recommendations and other libs.