### PR TITLE
Fix quoting issue when deleting multiple blobs

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -168,7 +168,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             self.scheme,
             hostname,
             quote(container_name),
-            quote(self.blob_name, safe='~'),
+            quote(self.blob_name, safe='~/'),
             self._query_str)
 
     @classmethod

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
@@ -1109,7 +1109,7 @@ class ContainerClient(StorageAccountHostsMixin):
             blob_name = _get_blob_name(blob)
             req = HttpRequest(
                 "DELETE",
-                "/{}/{}".format(self.container_name, blob_name),
+                "/{}/{}".format(self.container_name, quote(blob_name, safe='~/')),
                 headers=header_parameters
             )
             req.format_parameters(query_parameters)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_container_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_container_client_async.py
@@ -11,6 +11,11 @@ from typing import (  # pylint: disable=unused-import
     TYPE_CHECKING
 )
 
+try:
+    from urllib.parse import quote
+except ImportError:
+    from urllib2 import quote # type: ignore
+
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.core.async_paging import AsyncItemPaged
@@ -938,7 +943,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase):
             blob_name = _get_blob_name(blob)
             req = HttpRequest(
                 "DELETE",
-                "/{}/{}".format(self.container_name, blob_name),
+                "/{}/{}".format(self.container_name, quote(blob_name, safe='~/')),
                 headers=header_parameters
             )
             req.format_parameters(query_parameters)

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
@@ -100,7 +100,7 @@ class PathClient(StorageAccountHostsMixin):
             self.scheme,
             hostname,
             quote(file_system_name),
-            quote(self.path_name, safe='~'),
+            quote(self.path_name, safe='~/'),
             self._query_str)
 
     def _create_path_options(self, resource_type, content_settings=None, metadata=None, **kwargs):


### PR DESCRIPTION
The blob name needs to be quoted.

See #10336 which has some discussion on why the blob name is quoted. This particular pull request doesn't try to address that issue, but just applies the same quoting as what's already present in the case of deleting a single blob.