### PR TITLE
Merge azure-identity 1.3.1 hotfix

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -13,6 +13,14 @@ behavior was undefined, and dependened on the credential's type and internal
 state. ([#10243](https://github.com/Azure/azure-sdk-for-python/issues/10243))
 
 
+## 1.3.1 (2020-03-30)
+
+- `ManagedIdentityCredential` raises `CredentialUnavailableError` when no
+identity is configured for an IMDS endpoint. This causes
+`ChainedTokenCredential` to correctly try the next credential in the chain.
+([#10488](https://github.com/Azure/azure-sdk-for-python/issues/10488))
+
+
 ## 1.4.0b1 (2020-03-10)
 - `DefaultAzureCredential` can now authenticate using the identity logged in to
 the Azure CLI, unless explicitly disabled with a keyword argument:

--- a/sdk/identity/azure-identity/azure/identity/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_authn_client.py
@@ -101,7 +101,9 @@ class AuthnClientBase(ABC):
         if not payload or "access_token" not in payload or not ("expires_in" in payload or "expires_on" in payload):
             if payload and "access_token" in payload:
                 payload["access_token"] = "****"
-            raise ClientAuthenticationError(message="Unexpected response '{}'".format(payload))
+            raise ClientAuthenticationError(
+                message="Unexpected response '{}'".format(payload), response=response.http_response
+            )
 
         token = payload["access_token"]
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -4,9 +4,10 @@
 # ------------------------------------
 import os
 
+import six
 from azure.core.configuration import Configuration
 from azure.core.credentials import AccessToken
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
 from azure.core.pipeline.policies import (
     ContentDecodePolicy,
     DistributedTracingPolicy,
@@ -164,7 +165,24 @@ class ImdsCredential(_ManagedIdentityBase):
             params = {"api-version": "2018-02-01", "resource": resource}
             if self._client_id:
                 params["client_id"] = self._client_id
-            token = self._client.request_token(scopes, method="GET", params=params)
+
+            try:
+                token = self._client.request_token(scopes, method="GET", params=params)
+            except HttpResponseError as ex:
+                # 400 in response to a token request indicates managed identity is disabled,
+                # or the identity with the specified client_id is not available
+                if ex.status_code == 400:
+                    self._endpoint_available = False
+                    message = "ManagedIdentityCredential authentication unavailable. "
+                    if self._client_id:
+                        message += "The requested identity has not been assigned to this resource."
+                    else:
+                        message += "No identity has been assigned to this resource."
+                    six.raise_from(CredentialUnavailableError(message=message), ex)
+
+                # any other error is unexpected
+                six.raise_from(ClientAuthenticationError(message=ex.message, response=ex.response), None)
+
         return token
 
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -7,7 +7,7 @@ import os
 from typing import TYPE_CHECKING
 
 from azure.core.credentials import AccessToken
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
 from azure.core.pipeline.policies import AsyncRetryPolicy
 
 from azure.identity._credentials.managed_identity import _ManagedIdentityBase
@@ -131,7 +131,24 @@ class ImdsCredential(_AsyncManagedIdentityBase):
             params = {"api-version": "2018-02-01", "resource": resource}
             if self._client_id:
                 params["client_id"] = self._client_id
-            token = await self._client.request_token(scopes, method="GET", params=params)
+
+            try:
+                token = await self._client.request_token(scopes, method="GET", params=params)
+            except HttpResponseError as ex:
+                # 400 in response to a token request indicates managed identity is disabled,
+                # or the identity with the specified client_id is not available
+                if ex.status_code == 400:
+                    self._endpoint_available = False
+                    message = "ManagedIdentityCredential authentication unavailable. "
+                    if self._client_id:
+                        message += "The requested identity has not been assigned to this resource."
+                    else:
+                        message += "No identity has been assigned to this resource."
+                    raise CredentialUnavailableError(message=message) from ex
+
+                # any other error is unexpected
+                raise ClientAuthenticationError(message=ex.message, response=ex.response) from None
+
         return token
 
 

--- a/sdk/identity/azure-identity/tests/test_imds_credential.py
+++ b/sdk/identity/azure-identity/tests/test_imds_credential.py
@@ -3,11 +3,12 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from azure.core.pipeline.transport import HttpResponse
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
+from azure.identity import CredentialUnavailableError
 from azure.identity._credentials.managed_identity import ImdsCredential
 import pytest
 
-from helpers import mock, mock_response
+from helpers import mock, mock_response, Request, validating_transport
 
 
 def test_no_scopes():
@@ -30,3 +31,38 @@ def test_multiple_scopes():
 
     with pytest.raises(ValueError):
         credential.get_token("one scope", "and another")
+
+
+def test_identity_not_available():
+    """The credential should raise CredentialUnavailableError when the endpoint responds 400 to a token request"""
+
+    # first request is a probe, second a token request
+    transport = validating_transport(
+        requests=[Request()] * 2, responses=[mock_response(status_code=400, json_payload={})] * 2
+    )
+
+    credential = ImdsCredential(transport=transport)
+
+    with pytest.raises(CredentialUnavailableError):
+        credential.get_token("scope")
+
+
+def test_unexpected_error():
+    """The credential should raise ClientAuthenticationError when the endpoint returns an unexpected error"""
+
+    error_message = "something went wrong"
+
+    for code in range(401, 600):
+
+        def send(request, **_):
+            if "resource" not in request.query:
+                # availability probe
+                return mock_response(status_code=400, json_payload={})
+            return mock_response(status_code=code, json_payload={"error": error_message})
+
+        credential = ImdsCredential(transport=mock.Mock(send=send))
+
+        with pytest.raises(ClientAuthenticationError) as ex:
+            credential.get_token("scope")
+
+        assert error_message in ex.value.message

--- a/sdk/identity/azure-identity/tests/test_imds_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_imds_credential_async.py
@@ -4,12 +4,13 @@
 # ------------------------------------
 from unittest import mock
 
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
+from azure.identity import CredentialUnavailableError
 from azure.identity.aio._credentials.managed_identity import ImdsCredential
 import pytest
 
-from helpers import mock_response
-from helpers_async import AsyncMockTransport, get_completed_future
+from helpers import mock_response, Request
+from helpers_async import async_validating_transport, AsyncMockTransport, get_completed_future
 
 
 @pytest.mark.asyncio
@@ -56,3 +57,41 @@ async def test_imds_context_manager():
         pass
 
     assert transport.__aexit__.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_identity_not_available():
+    """The credential should raise CredentialUnavailableError when the endpoint responds 400 to a token request"""
+
+    # first request is a probe, second a token request
+    transport = async_validating_transport(
+        requests=[Request()] * 2, responses=[mock_response(status_code=400, json_payload={})] * 2
+    )
+
+    credential = ImdsCredential(transport=transport)
+
+    with pytest.raises(CredentialUnavailableError):
+        await credential.get_token("scope")
+
+
+@pytest.mark.asyncio
+async def test_unexpected_error():
+    """The credential should raise ClientAuthenticationError when the endpoint returns an unexpected error"""
+
+    error_message = "something went wrong"
+
+    for code in range(401, 600):
+
+        async def send(request, **_):
+            if "resource" not in request.query:
+                # availability probe
+                return mock_response(status_code=400, json_payload={})
+            return mock_response(status_code=code, json_payload={"error": error_message})
+
+        transport = mock.Mock(send=send, sleep=lambda _: get_completed_future())
+        credential = ImdsCredential(transport=transport)
+
+        with pytest.raises(ClientAuthenticationError) as ex:
+            await credential.get_token("scope")
+
+        assert error_message in ex.value.message


### PR DESCRIPTION
Merging the recent patch to azure-identity 1.3.0 (#10510, released as 1.3.1) into master so it becomes part of the next preview (1.4.0b2).

Closes #10488 