### PR TITLE
User authentication API for applications

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Release History
 
 ## 1.4.0b3 (Unreleased)
+- First preview of new API for authenticating users with `DeviceCodeCredential`
+  and `InteractiveBrowserCredential`
+  - new method `authenticate` authenticates a user, returns a serializable
+    `AuthenticationRecord`
+  - new constructor keyword arguments
+    - `authentication_record` enables initializing a credential with an
+      `AuthenticationRecord` from a prior authentication
+    - `disable_automatic_authentication=True` configures the credential to raise
+    `AuthenticationRequiredError` when interactive authentication is necessary
+    to acquire a token rather than immediately begin that authentication
+    - `enable_persistent_cache=True` configures these credentials to use a
+    persistent cache on supported platforms (in this release, Windows only).
+    By default they cache in memory only.
 
 
 ## 1.4.0b2 (2020-04-06)

--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 1.4.0b3 (Unreleased)
 - First preview of new API for authenticating users with `DeviceCodeCredential`
   and `InteractiveBrowserCredential`
-  - new method `authenticate` authenticates a user, returns a serializable
-    `AuthenticationRecord`
+  - new method `authenticate` interactively authenticates a user, returns a
+    serializable `AuthenticationRecord`
   - new constructor keyword arguments
     - `authentication_record` enables initializing a credential with an
       `AuthenticationRecord` from a prior authentication

--- a/sdk/identity/azure-identity/azure/identity/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/__init__.py
@@ -5,6 +5,7 @@
 """Credentials for Azure SDK clients."""
 
 from ._auth_record import AuthenticationRecord
+from ._exceptions import AuthenticationRequiredError, CredentialUnavailableError
 from ._constants import KnownAuthorities
 from ._credentials import (
     AuthorizationCodeCredential,
@@ -23,6 +24,7 @@ from ._credentials import (
 
 __all__ = [
     "AuthenticationRecord",
+    "AuthenticationRequiredError",
     "AuthorizationCodeCredential",
     "CertificateCredential",
     "ChainedTokenCredential",

--- a/sdk/identity/azure-identity/azure/identity/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/__init__.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 """Credentials for Azure SDK clients."""
 
-from ._exceptions import CredentialUnavailableError
+from ._auth_record import AuthenticationRecord
 from ._constants import KnownAuthorities
 from ._credentials import (
     AuthorizationCodeCredential,
@@ -22,6 +22,7 @@ from ._credentials import (
 
 
 __all__ = [
+    "AuthenticationRecord",
     "AuthorizationCodeCredential",
     "CertificateCredential",
     "ChainedTokenCredential",

--- a/sdk/identity/azure-identity/azure/identity/_auth_record.py
+++ b/sdk/identity/azure-identity/azure/identity/_auth_record.py
@@ -1,0 +1,91 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+class AuthenticationRecord(object):
+    """A record which can initialize :class:`DeviceCodeCredential` or :class:`InteractiveBrowserCredential`"""
+
+    def __init__(self, tenant_id, client_id, authority, home_account_id, username, **kwargs):
+        # type: (str, str, str, str, str, **Any) -> None
+        self._additional_data = kwargs
+        self._authority = authority
+        self._client_id = client_id
+        self._home_account_id = home_account_id
+        self._tenant_id = tenant_id
+        self._username = username
+
+    @property
+    def authority(self):
+        # type: () -> str
+        return self._authority
+
+    @property
+    def client_id(self):
+        # type: () -> str
+        return self._client_id
+
+    @property
+    def home_account_id(self):
+        # type: () -> str
+        return self._home_account_id
+
+    @property
+    def tenant_id(self):
+        # type: () -> str
+        return self._tenant_id
+
+    @property
+    def username(self):
+        # type: () -> str
+        """The authenticated user's username"""
+        return self._username
+
+    @property
+    def additional_data(self):
+        # type: () -> dict
+        """Keyword arguments serialized with the record"""
+
+        return dict(self._additional_data)
+
+    def __getitem__(self, key):
+        return getattr(self, key, None) or self._additional_data[key]
+
+    @classmethod
+    def deserialize(cls, json_string):
+        # type: (str) -> AuthenticationRecord
+        """Deserialize a record from JSON"""
+
+        deserialized = json.loads(json_string)
+
+        return cls(
+            authority=deserialized.pop("authority"),
+            client_id=deserialized.pop("client_id"),
+            home_account_id=deserialized.pop("home_account_id"),
+            tenant_id=deserialized.pop("tenant_id"),
+            username=deserialized.pop("username"),
+            **deserialized
+        )
+
+    def serialize(self, **kwargs):
+        # type: (**Any) -> str
+        """Serialize the record and any keyword arguments to JSON"""
+
+        record = dict(
+            {
+                "authority": self._authority,
+                "client_id": self._client_id,
+                "home_account_id": self._home_account_id,
+                "tenant_id": self._tenant_id,
+                "username": self._username,
+            },
+            **kwargs
+        )
+
+        return json.dumps(record)

--- a/sdk/identity/azure-identity/azure/identity/_auth_record.py
+++ b/sdk/identity/azure-identity/azure/identity/_auth_record.py
@@ -3,18 +3,13 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import json
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Any
 
 
 class AuthenticationRecord(object):
     """A record which can initialize :class:`DeviceCodeCredential` or :class:`InteractiveBrowserCredential`"""
 
-    def __init__(self, tenant_id, client_id, authority, home_account_id, username, **kwargs):
-        # type: (str, str, str, str, str, **Any) -> None
-        self._additional_data = kwargs
+    def __init__(self, tenant_id, client_id, authority, home_account_id, username):
+        # type: (str, str, str, str, str) -> None
         self._authority = authority
         self._client_id = client_id
         self._home_account_id = home_account_id
@@ -47,16 +42,6 @@ class AuthenticationRecord(object):
         """The authenticated user's username"""
         return self._username
 
-    @property
-    def additional_data(self):
-        # type: () -> dict
-        """Keyword arguments serialized with the record"""
-
-        return dict(self._additional_data)
-
-    def __getitem__(self, key):
-        return getattr(self, key, None) or self._additional_data[key]
-
     @classmethod
     def deserialize(cls, json_string):
         # type: (str) -> AuthenticationRecord
@@ -65,27 +50,23 @@ class AuthenticationRecord(object):
         deserialized = json.loads(json_string)
 
         return cls(
-            authority=deserialized.pop("authority"),
-            client_id=deserialized.pop("client_id"),
-            home_account_id=deserialized.pop("home_account_id"),
-            tenant_id=deserialized.pop("tenant_id"),
-            username=deserialized.pop("username"),
-            **deserialized
+            authority=deserialized["authority"],
+            client_id=deserialized["client_id"],
+            home_account_id=deserialized["home_account_id"],
+            tenant_id=deserialized["tenant_id"],
+            username=deserialized["username"],
         )
 
-    def serialize(self, **kwargs):
-        # type: (**Any) -> str
-        """Serialize the record and any keyword arguments to JSON"""
+    def serialize(self):
+        # type: () -> str
+        """Serialize the record to JSON"""
 
-        record = dict(
-            {
-                "authority": self._authority,
-                "client_id": self._client_id,
-                "home_account_id": self._home_account_id,
-                "tenant_id": self._tenant_id,
-                "username": self._username,
-            },
-            **kwargs
-        )
+        record = {
+            "authority": self._authority,
+            "client_id": self._client_id,
+            "home_account_id": self._home_account_id,
+            "tenant_id": self._tenant_id,
+            "username": self._username,
+        }
 
         return json.dumps(record)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -39,7 +39,8 @@ class InteractiveBrowserCredential(InteractiveCredential):
     :keyword AuthenticationRecord authentication_record: :class:`AuthenticationRecord` returned by :func:`authenticate`
     :keyword bool disable_automatic_authentication: if True, :func:`get_token` will raise
           :class:`AuthenticationRequiredError` when user interaction is required to acquire a token. Defaults to False.
-    :keyword bool disable_persistent_cache: if True, the credential will cache in memory only. Defaults to False.
+    :keyword bool enable_persistent_cache: if True, the credential will store tokens in a persistent cache shared by
+         other user credentials. **This is only supported on Windows.** Defaults to False.
     :keyword int timeout: seconds to wait for the user to complete authentication. Defaults to 300 (5 minutes).
     """
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user.py
@@ -125,7 +125,7 @@ class UsernamePasswordCredential(PublicClientCredential):
 
     def __init__(self, client_id, username, password, **kwargs):
         # type: (str, str, str, Any) -> None
-        super(UsernamePasswordCredential, self).__init__(client_id=client_id, **kwargs)
+        super(UsernamePasswordCredential, self).__init__(client_id=client_id, disable_persistent_cache=True, **kwargs)
         self._username = username
         self._password = password
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user.py
@@ -50,7 +50,8 @@ class DeviceCodeCredential(InteractiveCredential):
     :keyword AuthenticationRecord authentication_record: :class:`AuthenticationRecord` returned by :func:`authenticate`
     :keyword bool disable_automatic_authentication: if True, :func:`get_token` will raise
           :class:`AuthenticationRequiredError` when user interaction is required to acquire a token. Defaults to False.
-    :keyword bool disable_persistent_cache: if True, the credential will cache in memory only. Defaults to False.
+    :keyword bool enable_persistent_cache: if True, the credential will store tokens in a persistent cache shared by
+         other user credentials. **This is only supported on Windows.** Defaults to False.
     """
 
     def __init__(self, client_id, **kwargs):
@@ -125,7 +126,7 @@ class UsernamePasswordCredential(PublicClientCredential):
 
     def __init__(self, client_id, username, password, **kwargs):
         # type: (str, str, str, Any) -> None
-        super(UsernamePasswordCredential, self).__init__(client_id=client_id, disable_persistent_cache=True, **kwargs)
+        super(UsernamePasswordCredential, self).__init__(client_id=client_id, **kwargs)
         self._username = username
         self._password = password
 

--- a/sdk/identity/azure-identity/azure/identity/_exceptions.py
+++ b/sdk/identity/azure-identity/azure/identity/_exceptions.py
@@ -2,8 +2,37 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from typing import TYPE_CHECKING
+
 from azure.core.exceptions import ClientAuthenticationError
+
+if TYPE_CHECKING:
+    from typing import Any, Optional, Sequence
 
 
 class CredentialUnavailableError(ClientAuthenticationError):
     """The credential did not attempt to authenticate because required data or state is unavailable."""
+
+
+class AuthenticationRequiredError(CredentialUnavailableError):
+    """Interactive authentication is required to acquire a token."""
+
+    def __init__(self, scopes, message=None, error_details=None, **kwargs):
+        # type: (Sequence[str], Optional[str], Optional[str], **Any) -> None
+        self._scopes = scopes
+        self._error_details = error_details
+        if not message:
+            message = "Interactive authentication is required to get a token. Call 'authenticate' to begin."
+        super(AuthenticationRequiredError, self).__init__(message=message, **kwargs)
+
+    @property
+    def scopes(self):
+        # type: () -> Sequence[str]
+        """Scopes requested during the failed authentication"""
+        return self._scopes
+
+    @property
+    def error_details(self):
+        # type: () -> Optional[str]
+        """Additional authentication error details from Azure Active Directory"""
+        return self._error_details

--- a/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
@@ -34,7 +34,7 @@ from .aad_client import AadClient
 from .aad_client_base import AadClientBase
 from .auth_code_redirect_handler import AuthCodeRedirectServer
 from .exception_wrapper import wrap_exceptions
-from .msal_credentials import ConfidentialClientCredential, PublicClientCredential
+from .msal_credentials import ConfidentialClientCredential, InteractiveCredential, PublicClientCredential
 from .msal_transport_adapter import MsalTransportAdapter, MsalTransportResponse
 
 
@@ -52,10 +52,13 @@ def _scopes_to_resource(*scopes):
 
 
 __all__ = [
+    "_scopes_to_resource",
     "AadClient",
     "AadClientBase",
     "AuthCodeRedirectServer",
     "ConfidentialClientCredential",
+    "get_default_authority",
+    "InteractiveCredential",
     "MsalTransportAdapter",
     "MsalTransportResponse",
     "PublicClientCredential",

--- a/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
@@ -61,6 +61,7 @@ __all__ = [
     "InteractiveCredential",
     "MsalTransportAdapter",
     "MsalTransportResponse",
+    "normalize_authority",
     "PublicClientCredential",
     "wrap_exceptions",
 ]

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
@@ -6,15 +6,23 @@
 This entails monkeypatching MSAL's OAuth client with an adapter substituting an azure-core pipeline for Requests.
 """
 import abc
+import base64
+import json
+import logging
+import os
+import sys
 import time
 
 import msal
+from six.moves.urllib_parse import urlparse
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
 
 from .exception_wrapper import wrap_exceptions
 from .msal_transport_adapter import MsalTransportAdapter
+from .._exceptions import AuthenticationRequiredError
 from .._internal import get_default_authority, normalize_authority
+from .._auth_record import AuthenticationRecord
 
 try:
     ABC = abc.ABC
@@ -27,8 +35,55 @@ except ImportError:
     TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    # pylint:disable=unused-import
+    # pylint:disable=ungrouped-imports,unused-import
     from typing import Any, Mapping, Optional, Type, Union
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _decode_client_info(raw):
+    """Taken from msal.oauth2cli.oidc"""
+
+    raw += "=" * (-len(raw) % 4)
+    raw = str(raw)  # On Python 2.7, argument of urlsafe_b64decode must be str, not unicode.
+    return base64.urlsafe_b64decode(raw).decode("utf-8")
+
+
+def _build_auth_record(response):
+    """Build an AuthenticationRecord from the result of an MSAL ClientApplication token request"""
+
+    try:
+        client_info = json.loads(_decode_client_info(response["client_info"]))
+        id_token = response["id_token_claims"]
+
+        return AuthenticationRecord(
+            authority=urlparse(id_token["iss"]).netloc,  # "iss" is the URL of the issuing tenant
+            client_id=id_token["aud"],
+            home_account_id="{uid}.{utid}".format(**client_info),
+            tenant_id=id_token["tid"],  # tenant which issued the token, not necessarily user's home tenant
+            username=id_token["preferred_username"],
+        )
+    except (KeyError, ValueError):
+        # surprising: msal.ClientApplication always requests client_info and an id token, whose shapes shouldn't change
+        return None
+
+
+def _load_cache(disable_persistence):
+    # type: (bool) -> msal.TokenCache
+
+    if disable_persistence:
+        return msal.TokenCache()
+
+    if sys.platform.startswith("win") and "LOCALAPPDATA" in os.environ:
+        from msal_extensions.token_cache import WindowsTokenCache
+
+        return WindowsTokenCache(
+            cache_location=os.path.join(os.environ["LOCALAPPDATA"], ".IdentityService", "msal.cache")
+        )
+
+    _LOGGER.warning("Caching in memory because no persistent cache is available on this platform.")
+    return msal.TokenCache()
 
 
 class MsalCredential(ABC):
@@ -36,13 +91,19 @@ class MsalCredential(ABC):
 
     def __init__(self, client_id, client_credential=None, **kwargs):
         # type: (str, Optional[Union[str, Mapping[str, str]]], **Any) -> None
-        tenant_id = kwargs.pop("tenant_id", "organizations")
+        tenant_id = kwargs.pop("tenant_id", None) or "organizations"
         authority = kwargs.pop("authority", None)
         authority = normalize_authority(authority) if authority else get_default_authority()
 
         self._base_url = "/".join((authority, tenant_id.strip("/")))
+
         self._client_credential = client_credential
         self._client_id = client_id
+
+        self._cache = kwargs.pop("_cache", None)  # internal, for use in tests
+        if not self._cache:
+            disable_persistence = kwargs.pop("disable_persistent_cache", False)
+            self._cache = _load_cache(disable_persistence)
 
         self._adapter = kwargs.pop("msal_adapter", None) or MsalTransportAdapter(**kwargs)
 
@@ -66,7 +127,12 @@ class MsalCredential(ABC):
         # MSAL application initializers use msal.authority to send AAD tenant discovery requests
         with self._adapter:
             # MSAL's "authority" is a URL e.g. https://login.microsoftonline.com/common
-            app = cls(client_id=self._client_id, client_credential=self._client_credential, authority=self._base_url)
+            app = cls(
+                client_id=self._client_id,
+                client_credential=self._client_credential,
+                authority=self._base_url,
+                token_cache=self._cache,
+            )
 
         # monkeypatch the app to replace requests.Session with MsalTransportAdapter
         app.client.session.close()
@@ -116,3 +182,106 @@ class PublicClientCredential(MsalCredential):
         if not self._msal_app:
             self._msal_app = self._create_app(msal.PublicClientApplication)
         return self._msal_app
+
+
+class InteractiveCredential(PublicClientCredential):
+    def __init__(self, **kwargs):
+        self._disable_automatic_authentication = kwargs.pop("disable_automatic_authentication", False)
+        self._auth_record = kwargs.pop("authentication_record", None)  # type: Optional[AuthenticationRecord]
+        if self._auth_record:
+            kwargs.pop("client_id", None)  # authentication_record overrides client_id argument
+            tenant_id = kwargs.pop("tenant_id", None) or self._auth_record.tenant_id
+            super(InteractiveCredential, self).__init__(
+                client_id=self._auth_record.client_id,
+                authority=self._auth_record.authority,
+                tenant_id=tenant_id,
+                **kwargs
+            )
+        else:
+            super(InteractiveCredential, self).__init__(**kwargs)
+
+    def get_token(self, *scopes, **kwargs):
+        # type: (*str, **Any) -> AccessToken
+        """Request an access token for `scopes`.
+
+        .. note:: This method is called by Azure SDK clients. It isn't intended for use in application code.
+
+        :param str scopes: desired scopes for the access token. This method requires at least one scope.
+        :rtype: :class:`azure.core.credentials.AccessToken`
+        :raises CredentialUnavailableError: the credential is unable to attempt authentication because it lacks
+          required data, state, or platform support
+        :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The error's ``message``
+          attribute gives a reason.
+        :raises AuthenticationRequiredError: user interaction is necessary to acquire a token, and the credential is
+          configured not to begin this automatically. Call :func:`authenticate` to begin interactive authentication.
+        """
+        if not scopes:
+            raise ValueError("'get_token' requires at least one scope")
+
+        allow_prompt = kwargs.pop("_allow_prompt", not self._disable_automatic_authentication)
+        try:
+            return self._acquire_token_silent(*scopes, **kwargs)
+        except AuthenticationRequiredError:
+            if not allow_prompt:
+                raise
+
+        # silent authentication failed -> authenticate interactively
+        now = int(time.time())
+
+        result = self._request_token(*scopes, **kwargs)
+        if "access_token" not in result:
+            message = "Authentication failed: {}".format(result.get("error_description") or result.get("error"))
+            raise ClientAuthenticationError(message=message)
+
+        # this may be the first authentication, or the user may have authenticated a different identity
+        self._auth_record = _build_auth_record(result)
+
+        return AccessToken(result["access_token"], now + int(result["expires_in"]))
+
+    def authenticate(self, **kwargs):
+        # type: (**Any) -> AuthenticationRecord
+        """Interactively authenticate a user.
+
+        :keyword Sequence[str] scopes: optional scopes to request during authentication, such as those provided by
+          :func:`AuthenticationRequiredError.scopes`. If provided, successful authentication will cache an access token
+          for these scopes.
+        :rtype: ~azure.identity.AuthenticationRecord
+        :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The error's ``message``
+          attribute gives a reason.
+        """
+
+        scopes = kwargs.pop("scopes", None) or ("https://management.azure.com/.default",)
+        _ = self.get_token(*scopes, _allow_prompt=True, **kwargs)
+        return self.authentication_record  # type: ignore
+
+    @property
+    def authentication_record(self):
+        # type: () -> Optional[AuthenticationRecord]
+        """:class:`~azure.identity.AuthenticationRecord` for the most recent authentication"""
+        return self._auth_record
+
+    @wrap_exceptions
+    def _acquire_token_silent(self, *scopes, **kwargs):
+        # type: (*str, **Any) -> AccessToken
+        result = None
+        if self._auth_record:
+            app = self._get_app()
+            for account in app.get_accounts(username=self._auth_record.username):
+                if account.get("home_account_id") != self._auth_record.home_account_id:
+                    continue
+
+                now = int(time.time())
+                result = app.acquire_token_silent_with_error(list(scopes), account=account, **kwargs)
+                if result and "access_token" in result and "expires_in" in result:
+                    return AccessToken(result["access_token"], now + int(result["expires_in"]))
+
+        # if we get this far, result is either None or the content of an AAD error response
+        if result:
+            details = result.get("error_description") or result.get("error")
+            raise AuthenticationRequiredError(scopes, error_details=details)
+        raise AuthenticationRequiredError(scopes)
+
+    @abc.abstractmethod
+    def _request_token(self, *scopes, **kwargs):
+        # type: (*str, **Any) -> dict
+        """Request an access token via a non-silent MSAL token acquisition method, returning that method's result"""

--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -16,12 +16,29 @@ except ImportError:  # python < 3.3
 
 # build_* lifted from msal tests
 def build_id_token(
-    iss="issuer", sub="subject", aud="my_client_id", exp=None, iat=None, **claims
+    iss="issuer",
+    sub="subject",
+    aud="my_client_id",
+    username="username",
+    tenant_id="tenant id",
+    object_id="object id",
+    exp=None,
+    iat=None,
+    **claims
 ):  # AAD issues "preferred_username", ADFS issues "upn"
     return "header.%s.signature" % base64.b64encode(
         json.dumps(
             dict(
-                {"iss": iss, "sub": sub, "aud": aud, "exp": exp or (time.time() + 100), "iat": iat or time.time()},
+                {
+                    "iss": iss,
+                    "sub": sub,
+                    "aud": aud,
+                    "exp": exp or (time.time() + 100),
+                    "iat": iat or time.time(),
+                    "tid": tenant_id,
+                    "oid": object_id,
+                    "preferred_username": username,
+                },
                 **claims
             )
         ).encode()
@@ -83,7 +100,7 @@ class Request:
             discrepancies.append("{}:\n\t expected: {}\n\t   actual: {}".format(name, expected, actual))
 
         if self.base_url and self.base_url != request.url.split("?")[0]:
-            add_discrepancy('base url', self.base_url, request.url)
+            add_discrepancy("base url", self.base_url, request.url)
 
         if self.url and self.url != request.url:
             add_discrepancy("url", self.url, request.url)

--- a/sdk/identity/azure-identity/tests/test_auth_record.py
+++ b/sdk/identity/azure-identity/tests/test_auth_record.py
@@ -1,0 +1,33 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import json
+
+from azure.identity import AuthenticationRecord
+
+
+def test_serialization():
+    """serialize should accept arbitrary additional key/value pairs, which deserialize should ignore"""
+
+    attrs = ("authority", "client_id","home_account_id", "tenant_id", "username")
+    nums = (n for n in range(len(attrs)))
+    record_values = {attr: next(nums) for attr in attrs}
+    additional_data = {"foo": "bar", "bar": "foo"}
+
+    record = AuthenticationRecord(**record_values)
+    serialized = record.serialize(**additional_data)
+
+    # AuthenticationRecord's fields and the additional data should have been serialized
+    assert json.loads(serialized) == dict(record_values, **additional_data)
+
+    deserialized = AuthenticationRecord.deserialize(serialized)
+
+    # the deserialized record and the constructed record should have the same fields
+    assert sorted(vars(deserialized)) == sorted(vars(record))
+
+    # the constructed and deserialized records should have the same values
+    assert all(getattr(deserialized, attr) == record_values[attr] for attr in attrs)
+
+    # deserialized record should expose additional data like a dictionary
+    assert all(deserialized[key] == additional_data[key] for key in additional_data)

--- a/sdk/identity/azure-identity/tests/test_auth_record.py
+++ b/sdk/identity/azure-identity/tests/test_auth_record.py
@@ -13,13 +13,12 @@ def test_serialization():
     attrs = ("authority", "client_id","home_account_id", "tenant_id", "username")
     nums = (n for n in range(len(attrs)))
     record_values = {attr: next(nums) for attr in attrs}
-    additional_data = {"foo": "bar", "bar": "foo"}
 
     record = AuthenticationRecord(**record_values)
-    serialized = record.serialize(**additional_data)
+    serialized = record.serialize()
 
-    # AuthenticationRecord's fields and the additional data should have been serialized
-    assert json.loads(serialized) == dict(record_values, **additional_data)
+    # AuthenticationRecord's fields should have been serialized
+    assert json.loads(serialized) == record_values
 
     deserialized = AuthenticationRecord.deserialize(serialized)
 
@@ -28,6 +27,3 @@ def test_serialization():
 
     # the constructed and deserialized records should have the same values
     assert all(getattr(deserialized, attr) == record_values[attr] for attr in attrs)
-
-    # deserialized record should expose additional data like a dictionary
-    assert all(deserialized[key] == additional_data[key] for key in additional_data)

--- a/sdk/identity/azure-identity/tests/test_device_code_credential.py
+++ b/sdk/identity/azure-identity/tests/test_device_code_credential.py
@@ -6,11 +6,19 @@ import datetime
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.pipeline.policies import SansIOHTTPPolicy
-from azure.identity import DeviceCodeCredential
+from azure.identity import AuthenticationRequiredError, DeviceCodeCredential
 from azure.identity._internal.user_agent import USER_AGENT
+from msal import TokenCache
 import pytest
 
-from helpers import build_aad_response, get_discovery_response, mock_response, Request, validating_transport
+from helpers import (
+    build_aad_response,
+    build_id_token,
+    get_discovery_response,
+    mock_response,
+    Request,
+    validating_transport,
+)
 
 try:
     from unittest.mock import Mock
@@ -22,8 +30,74 @@ def test_no_scopes():
     """The credential should raise when get_token is called with no scopes"""
 
     credential = DeviceCodeCredential("client_id")
-    with pytest.raises(ClientAuthenticationError):
+    with pytest.raises(ValueError):
         credential.get_token()
+
+
+def test_authenticate():
+    client_id = "client-id"
+    environment = "localhost"
+    issuer = "https://" + environment
+    tenant_id = "some-tenant"
+    authority = issuer + "/" + tenant_id
+
+    access_token = "***"
+    scope = "scope"
+
+    # mock AAD response with id token
+    object_id = "object-id"
+    home_tenant = "home-tenant-id"
+    username = "me@work.com"
+    id_token = build_id_token(aud=client_id, iss=issuer, object_id=object_id, tenant_id=home_tenant, username=username)
+    auth_response = build_aad_response(
+        uid=object_id, utid=home_tenant, access_token=access_token, refresh_token="**", id_token=id_token
+    )
+
+    transport = validating_transport(
+        requests=[Request(url_substring=issuer)] * 4,
+        responses=[get_discovery_response(authority)] * 2  # instance and tenant discovery
+        + [
+            mock_response(  # start device code flow
+                json_payload={
+                    "device_code": "_",
+                    "user_code": "user-code",
+                    "verification_uri": "verification-uri",
+                    "expires_in": 42,
+                }
+            ),
+            mock_response(json_payload=dict(auth_response, scope=scope)),  # poll for completion
+        ],
+    )
+
+    credential = DeviceCodeCredential(
+        client_id,
+        prompt_callback=Mock(),  # prevent credential from printing to stdout
+        transport=transport,
+        authority=environment,
+        tenant_id=tenant_id,
+        _cache=TokenCache(),
+    )
+    record = credential.authenticate(scopes=(scope,))
+
+    # credential should have a cached access token for the scope used in authenticate
+    token = credential.get_token(scope)
+    assert token.token == access_token
+
+    assert record.authority == environment
+    assert record.home_account_id == object_id + "." + home_tenant
+    assert record.tenant_id == home_tenant
+    assert record.username == username
+
+
+def test_disable_automatic_authentication():
+    """When configured for strict silent auth, the credential should raise when silent auth fails"""
+
+    empty_cache = TokenCache()  # empty cache makes silent auth impossible
+    transport = Mock(send=Mock(side_effect=Exception("no request should be sent")))
+    credential = DeviceCodeCredential("client-id", disable_automatic_authentication=True, transport=transport, _cache=empty_cache)
+
+    with pytest.raises(AuthenticationRequiredError):
+        credential.get_token("scope")
 
 
 def test_policies_configurable():
@@ -47,7 +121,7 @@ def test_policies_configurable():
     )
 
     credential = DeviceCodeCredential(
-        client_id="client-id", prompt_callback=Mock(), policies=[policy], transport=transport
+        client_id="client-id", prompt_callback=Mock(), policies=[policy], transport=transport, _cache=TokenCache()
     )
 
     credential.get_token("scope")
@@ -72,7 +146,9 @@ def test_user_agent():
         ],
     )
 
-    credential = DeviceCodeCredential(client_id="client-id", prompt_callback=Mock(), transport=transport)
+    credential = DeviceCodeCredential(
+        client_id="client-id", prompt_callback=Mock(), transport=transport, _cache=TokenCache()
+    )
 
     credential.get_token("scope")
 
@@ -110,7 +186,7 @@ def test_device_code_credential():
 
     callback = Mock()
     credential = DeviceCodeCredential(
-        client_id="_", prompt_callback=callback, transport=transport, instance_discovery=False
+        client_id="_", prompt_callback=callback, transport=transport, instance_discovery=False, _cache=TokenCache()
     )
 
     now = datetime.datetime.utcnow()
@@ -142,7 +218,12 @@ def test_timeout():
     )
 
     credential = DeviceCodeCredential(
-        client_id="_", prompt_callback=Mock(), transport=transport, timeout=0.01, instance_discovery=False
+        client_id="_",
+        prompt_callback=Mock(),
+        transport=transport,
+        timeout=0.01,
+        instance_discovery=False,
+        _cache=TokenCache(),
     )
 
     with pytest.raises(ClientAuthenticationError) as ex:

--- a/sdk/identity/azure-identity/tests/test_msal_interactive_credential.py
+++ b/sdk/identity/azure-identity/tests/test_msal_interactive_credential.py
@@ -1,0 +1,199 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from azure.core.exceptions import ClientAuthenticationError
+from azure.identity import (
+    AuthenticationRequiredError,
+    AuthenticationRecord,
+    KnownAuthorities,
+    CredentialUnavailableError,
+)
+from azure.identity._internal.msal_credentials import InteractiveCredential
+from msal import TokenCache
+import pytest
+
+try:
+    from unittest.mock import Mock, patch
+except ImportError:  # python < 3.3
+    from mock import Mock, patch  # type: ignore
+
+
+class MockCredential(InteractiveCredential):
+    """Test class to drive InteractiveCredential.
+
+    Default instances have an empty in-memory cache, and raise rather than send an HTTP request.
+    """
+
+    def __init__(
+        self, client_id="...", request_token=None, cache=None, msal_app_factory=None, transport=None, **kwargs
+    ):
+        self._msal_app_factory = msal_app_factory
+        self._request_token_impl = request_token or Mock()
+        transport = transport or Mock(send=Mock(side_effect=Exception("credential shouldn't send a request")))
+        super(MockCredential, self).__init__(
+            client_id=client_id, _cache=cache or TokenCache(), transport=transport, **kwargs
+        )
+
+    def _request_token(self, *scopes, **kwargs):
+        return self._request_token_impl(*scopes, **kwargs)
+
+    def _get_app(self):
+        if self._msal_app_factory:
+            return self._create_app(self._msal_app_factory)
+        return super(MockCredential, self)._get_app()
+
+
+def test_no_scopes():
+    """The credential should raise when get_token is called with no scopes"""
+
+    request_token = Mock(side_effect=Exception("credential shouldn't begin interactive authentication"))
+    with pytest.raises(ValueError):
+        MockCredential(request_token=request_token).get_token()
+
+
+def test_authentication_record_argument():
+    """The credential should initialize its msal.ClientApplication with values from a given record"""
+
+    record = AuthenticationRecord("tenant-id", "client-id", "localhost", "object.tenant", "username")
+
+    def validate_app_parameters(authority, client_id, **_):
+        # the 'authority' argument to msal.ClientApplication should be a URL of the form https://authority/tenant
+        assert authority == "https://{}/{}".format(record.authority, record.tenant_id)
+        assert client_id == record.client_id
+        return Mock(get_accounts=Mock(return_value=[]))
+
+    app_factory = Mock(wraps=validate_app_parameters)
+    credential = MockCredential(
+        authentication_record=record, disable_automatic_authentication=True, msal_app_factory=app_factory,
+    )
+    with pytest.raises(AuthenticationRequiredError):
+        credential.get_token("scope")
+
+    assert app_factory.call_count == 1, "credential didn't create an msal application"
+
+
+def test_tenant_argument_overrides_record():
+    """The 'tenant_ic' keyword argument should override a given record's value"""
+
+    tenant_id = "some-guid"
+    authority = "localhost"
+    record = AuthenticationRecord(tenant_id, "client-id", authority, "object.tenant", "username")
+
+    expected_tenant = tenant_id[::-1]
+    expected_authority = "https://{}/{}".format(authority, expected_tenant)
+
+    def validate_authority(authority, **_):
+        assert authority == expected_authority
+        return Mock(get_accounts=Mock(return_value=[]))
+
+    credential = MockCredential(
+        authentication_record=record,
+        tenant_id=expected_tenant,
+        disable_automatic_authentication=True,
+        msal_app_factory=validate_authority,
+    )
+    with pytest.raises(AuthenticationRequiredError):
+        credential.get_token("scope")
+
+
+def test_disable_automatic_authentication():
+    """When silent auth fails the credential should raise, if it's configured not to authenticate automatically"""
+
+    expected_details = "something went wrong"
+    record = AuthenticationRecord("tenant-id", "client-id", "localhost", "object.tenant", "username")
+    msal_app = Mock(
+        acquire_token_silent_with_error=Mock(return_value={"error_description": expected_details}),
+        get_accounts=Mock(return_value=[{"home_account_id": record.home_account_id}]),
+    )
+
+    credential = MockCredential(
+        authentication_record=record,
+        disable_automatic_authentication=True,
+        msal_app_factory=lambda *_, **__: msal_app,
+        request_token=Mock(side_effect=Exception("credential shouldn't begin interactive authentication")),
+    )
+
+    scope = "scope"
+    with pytest.raises(AuthenticationRequiredError) as ex:
+        credential.get_token(scope)
+
+    # the exception should carry the requested scopes and any error message from AAD
+    assert ex.value.scopes == (scope,)
+    assert ex.value.error_details == expected_details
+
+
+def test_scopes_round_trip():
+    """authenticate should accept the value of AuthenticationRequiredError.scopes"""
+
+    scope = "scope"
+
+    def validate_scopes(*scopes, **_):
+        assert scopes == (scope,)
+        return {"access_token": "**", "expires_in": 42}
+
+    request_token = Mock(wraps=validate_scopes)
+    credential = MockCredential(disable_automatic_authentication=True, request_token=request_token)
+    with pytest.raises(AuthenticationRequiredError) as ex:
+        credential.get_token(scope)
+
+    credential.authenticate(scopes=ex.value.scopes)
+
+    assert request_token.call_count == 1, "validation method wasn't called"
+
+
+@pytest.mark.parametrize("option", (True, False))
+def test_authenticate_ignores_disable_automatic_authentication(option):
+    """authenticate should prompt for authentication regardless of the credential's configuration"""
+
+    request_token = Mock(return_value={"access_token": "**", "expires_in": 42})
+    MockCredential(request_token=request_token, disable_automatic_authentication=option).authenticate()
+    assert request_token.call_count == 1, "credential didn't begin interactive authentication"
+
+
+def test_get_token_wraps_exceptions():
+    """get_token shouldn't propagate exceptions from MSAL"""
+
+    class CustomException(Exception):
+        pass
+
+    expected_message = "something went wrong"
+    record = AuthenticationRecord("tenant-id", "client-id", "localhost", "object.tenant", "username")
+    msal_app = Mock(
+        acquire_token_silent_with_error=Mock(side_effect=CustomException(expected_message)),
+        get_accounts=Mock(return_value=[{"home_account_id": record.home_account_id}]),
+    )
+    credential = MockCredential(msal_app_factory=lambda *_, **__: msal_app, authentication_record=record)
+    with pytest.raises(ClientAuthenticationError) as ex:
+        credential.get_token("scope")
+
+    assert expected_message in ex.value.message
+    assert msal_app.acquire_token_silent_with_error.call_count == 1, "credential didn't attempt silent auth"
+
+
+def test_enable_persistent_cache():
+    """the credential should use the persistent cache only when given enable_persistent_cache=True"""
+
+    class TestCredential(InteractiveCredential):
+        def _request_token(self, *_, **__):
+            pass
+
+    expected_cache = Mock()
+    persistent_cache_loader = InteractiveCredential.__module__ + "._load_persistent_cache"
+
+    # credential should default to an in memory cache
+    raise_when_called = Mock(side_effect=Exception("credential shouldn't attempt to load a persistent cache"))
+    with patch(persistent_cache_loader, raise_when_called):
+        with patch(InteractiveCredential.__module__ + ".msal.TokenCache", lambda: expected_cache):
+            credential = TestCredential(client_id="...")
+    assert credential._cache is expected_cache
+
+    # keyword argument opts in to persistent cache
+    with patch(persistent_cache_loader, lambda: expected_cache):
+        credential = TestCredential(client_id="...", enable_persistent_cache=True)
+    assert credential._cache is expected_cache
+
+    # opting in on an unsupported platform raises an exception
+    with patch(InteractiveCredential.__module__ + ".sys.platform", "commodore64"):
+        with pytest.raises(NotImplementedError):
+            TestCredential(client_id="...", enable_persistent_cache=True)


### PR DESCRIPTION
The new API in this PR is intended for applications using credentials which require user interaction to authenticate (`DeviceCodeCredential` and `InteractiveBrowserCredential`).

Here's what it does and how:
- Allow applications to control the timing of interactive authentication prompts
  - The `authenticate` method begins interactive authentication. Applications can call it at their convenience.
  - `authenticate` accepts optional scopes, allowing an application which knows the scopes it needs to cache an access token for them before sending service requests
  - constructor argument `disable_automatic_authentication` configures `get_token` to raise `AuthenticationRequiredError` rather than immediately begin interactive authentication whenever it's necessary
- Enable applications to persist authentication details so they don't need to prompt for authentication every time they run
  - `DeviceCodeCredential` and `InteractiveBrowserCredential` use a persistent cache on supported platforms (today, Windows). Constructor argument `disable_persistent_cache` allows opting out, configuring a credential to cache in memory only.
  - `authenticate` returns a serializable `AuthenticationRecord`
  - applications can initialize a credential with an `AuthenticationRecord`, enabling that credential to use data cached during prior executions


## Usage
## Prompt a user to authenticate, store the record
```py
credential = InteractiveBrowserCredential()
record = credential.authenticate()
record_json = record.serialize(keyword='args', serialized='also')

with open(RECORD_PATH, 'w') as f:
    f.write(record_json)
```

## Initialize a credential with a record
```py
with open(RECORD_PATH, 'r') as f:
    record_json = f.read()

deserialized_record = AuthenticationRecord.deserialize(record_json)
credential = InteractiveBrowserCredential(authentication_record=deserialized_record)
```

## Prevent automatic authentication prompts
Applications decide how to respond when user interaction is required. This example demonstrates the simplest case, authenticating immediately and retrying a request, to show the API:
```py
credential = InteractiveBrowserCredential(disable_automatic_authentication=True)
try:
    result = service_client.do_something()
except AuthenticationRequiredError as ex:
    requested_scopes = ex.scopes
    credential.authenticate(scopes=requested_scopes)

    result = service_client.do_something()
```

Closes #11128, closes #11043, closes #10278, closes #9744 