### PR TITLE
Enable PR testing on Windows

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -19,7 +19,7 @@ parameters:
       OSVmImage: 'ubuntu-16.04'
       PythonVersion: '3.5'
       CoverageArg: ''
-      RunForPR: true
+      RunForPR: false
     Linux_Python36:
       OSName: 'Linux'
       OSVmImage: 'ubuntu-16.04'
@@ -43,7 +43,7 @@ parameters:
       OSVmImage: 'windows-2019'
       PythonVersion: '3.5'
       CoverageArg: ''
-      RunForPR: false
+      RunForPR: true
     MacOS_Python27:
       OSName: 'MacOS'
       OSVmImage: 'macOS-10.15'


### PR DESCRIPTION
PR needs to be tested on Windows Image. This PR is to switch testing of python 3.5 from Linux image to Windows image.