### PR TITLE
[text analtyics] fixed alternate document input samples

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_alternative_document_input_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_alternative_document_input_async.py
@@ -44,7 +44,7 @@ class AlternativeDocumentInputSampleAsync(object):
              "text": "L'hôtel n'était pas très confortable. L'éclairage était trop sombre."}
         ]
         async with text_analytics_client:
-            result = await text_analytics_client.detect_language(documents)
+            result = await text_analytics_client.analyze_sentiment(documents)
 
         for idx, doc in enumerate(result):
             if not doc.is_error:

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_alternative_document_input.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_alternative_document_input.py
@@ -44,7 +44,7 @@ class AlternativeDocumentInputSample(object):
              "text": "L'hôtel n'était pas très confortable. L'éclairage était trop sombre."}
         ]
 
-        result = text_analytics_client.detect_language(documents)
+        result = text_analytics_client.analyze_sentiment(documents)
 
         for idx, doc in enumerate(result):
             if not doc.is_error:


### PR DESCRIPTION
Doesn't make sense to call `detect_language` in these samples, switching to `analyze_sentiment`