### PR TITLE
Hotfix some small doc changes before going live.

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -46,6 +46,7 @@ Version 7.0.0b1 is a preview of our efforts to create a client library that is u
     * `azure.servicebus.exceptions.MessageSettleFailed`
     * `azure.servicebus.exceptions.MessageAlreadySettled`
     * `azure.servicebus.exceptions.SessionLockExpired`
+* BatchMessage creation is now initiated via create_batch on a Sender, using .add() on the batch to add messages, in order to enforce service-side max batch sized limitations.
 * Session is now set on the message itself, via `session_id` parameter or property, as opposed to on `Send` or `get_sender` via `session`.  This is to allow sending a batch of messages destined to varied sessions.
 * Session management is now encapsulated within a property of a receiver, e.g. `receiver.session`, to better compartmentalize functionality specific to sessions.
     * To use `AutoLockRenew` against sessions, one would simply pass the inner session object, instead of the receiver itself.

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -46,7 +46,7 @@ Version 7.0.0b1 is a preview of our efforts to create a client library that is u
     * `azure.servicebus.exceptions.MessageSettleFailed`
     * `azure.servicebus.exceptions.MessageAlreadySettled`
     * `azure.servicebus.exceptions.SessionLockExpired`
-* BatchMessage creation is now initiated via create_batch on a Sender, using .add() on the batch to add messages, in order to enforce service-side max batch sized limitations.
+* BatchMessage creation is now initiated via `create_batch` on a Sender, using `add()` on the batch to add messages, in order to enforce service-side max batch sized limitations.
 * Session is now set on the message itself, via `session_id` parameter or property, as opposed to on `Send` or `get_sender` via `session`.  This is to allow sending a batch of messages destined to varied sessions.
 * Session management is now encapsulated within a property of a receiver, e.g. `receiver.session`, to better compartmentalize functionality specific to sessions.
     * To use `AutoLockRenew` against sessions, one would simply pass the inner session object, instead of the receiver itself.

--- a/sdk/servicebus/azure-servicebus/README.md
+++ b/sdk/servicebus/azure-servicebus/README.md
@@ -170,7 +170,7 @@ Please find further examples in the [samples](./samples) directory demonstrating
 
 ### Additional documentation
 
-For more extensive documentation on the Service Bus service, see the [Service Bus DB documentation][service_bus_docs] on docs.microsoft.com.
+For more extensive documentation on the Service Bus service, see the [Service Bus documentation][service_bus_docs] on docs.microsoft.com.
 
 ## Contributing
 
@@ -188,7 +188,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 <!-- LINKS -->
 [azure_cli]: https://docs.microsoft.com/cli/azure
-[api_docs]: https://docs.microsoft.com/python/api/overview/azure/servicebus/client?view=azure-python
+[api_docs]: https://azuresdkdocs.blob.core.windows.net/$web/python/azure-servicebus/7.0.0b1/index.html
 [product_docs]: https://docs.microsoft.com/azure/service-bus-messaging/
 [azure_portal]: https://portal.azure.com
 [azure_sub]: https://azure.microsoft.com/free/

--- a/sdk/servicebus/azure-servicebus/samples/README.md
+++ b/sdk/servicebus/azure-servicebus/samples/README.md
@@ -54,5 +54,5 @@ pip install --pre azure-servicebus
 
 ## Next steps
 
-Check out the [API reference documentation](https://docs.microsoft.com/en-us/python/api/azure-servicebus/azure.servicebus.receive_handler.sessionreceiver?view=azure-python) to learn more about
+Check out the [API reference documentation](https://azuresdkdocs.blob.core.windows.net/$web/python/azure-servicebus/7.0.0b1/index.html) to learn more about
 what you can do with the Azure Service Bus client library.


### PR DESCRIPTION
Point api ref docs at our blob docs instead of docs.microsoft.
Remove spurious "DB' string.
Mention batch creation in breaking changes.