### PR TITLE
Bump Selected Warden Version

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -9,7 +9,7 @@ tox-monorepo==0.1.2
 twine==1.15.0
 pathlib2==2.3.5
 readme-renderer[md]==25.0
-doc-warden==0.5.3
+doc-warden==0.5.4
 coverage==4.5.4
 codecov==2.0.22 
 beautifulsoup4==4.8.2


### PR DESCRIPTION
Earlier version of warden was a bit less forgiving than we'd want. Did not anticipate a properly formatted setup.py that ALSO threw a code 1 expectedly. We updated `doc-warden` to be a bit more forgiving and we're taking advantage of that here.