### PR TITLE
Bryanv/10661 async with samples

### DIFF
--- a/sdk/search/azure-search-documents/samples/async_samples/sample_analyze_text_async.py
+++ b/sdk/search/azure-search-documents/samples/async_samples/sample_analyze_text_async.py
@@ -32,9 +32,13 @@ async def simple_analyze_text():
     from azure.search.documents.aio import SearchServiceClient
     from azure.search.documents import AnalyzeRequest
 
-    client = SearchServiceClient(service_endpoint, AzureKeyCredential(key))
+    service_client = SearchServiceClient(service_endpoint, AzureKeyCredential(key))
+
     analyze_request = AnalyzeRequest(text="One's <two/>", analyzer="standard.lucene")
-    result = await client.analyze_text(index_name, analyze_request)
+
+    async with service_client:
+        result = await service_client.analyze_text(index_name, analyze_request)
+        print(result.as_dict())
     # [END simple_analyze_text_async]
 
 if __name__ == '__main__':

--- a/sdk/search/azure-search-documents/samples/async_samples/sample_autocomplete_async.py
+++ b/sdk/search/azure-search-documents/samples/async_samples/sample_autocomplete_async.py
@@ -38,13 +38,12 @@ async def autocomplete_query():
 
     query = AutocompleteQuery(search_text="bo", suggester_name="sg")
 
-    results = await search_client.autocomplete(query=query)
+    async with search_client:
+        results = await search_client.autocomplete(query=query)
 
-    print("Autocomplete suggestions for 'bo'")
-    for result in results:
-        print("    Completion: {}".format(result["text"]))
-
-    await search_client.close()
+        print("Autocomplete suggestions for 'bo'")
+        for result in results:
+            print("    Completion: {}".format(result["text"]))
     # [END autocomplete_query_async]
 
 if __name__ == '__main__':

--- a/sdk/search/azure-search-documents/samples/async_samples/sample_facet_query_async.py
+++ b/sdk/search/azure-search-documents/samples/async_samples/sample_facet_query_async.py
@@ -38,15 +38,14 @@ async def filter_query():
 
     query = SearchQuery(search_text="WiFi", facets=["Category"], top=0)
 
-    results = await search_client.search(query=query)
+    async with search_client:
+        results = await search_client.search(query=query)
 
-    facets = await results.get_facets()
+        facets = await results.get_facets()
 
-    print("Catgory facet counts for hotels:")
-    for facet in facets["Category"]:
-        print("    {}".format(facet))
-
-    await search_client.close()
+        print("Catgory facet counts for hotels:")
+        for facet in facets["Category"]:
+            print("    {}".format(facet))
     # [END facet_query_async]
 
 if __name__ == '__main__':

--- a/sdk/search/azure-search-documents/samples/async_samples/sample_filter_query_async.py
+++ b/sdk/search/azure-search-documents/samples/async_samples/sample_filter_query_async.py
@@ -41,13 +41,12 @@ async def filter_query():
     query.select("HotelName", "Rating")
     query.order_by("Rating desc")
 
-    results = await search_client.search(query=query)
+    async with search_client:
+        results = await search_client.search(query=query)
 
-    print("Florida hotels containing 'WiFi', sorted by Rating:")
-    async for result in results:
-        print("    Name: {} (rating {})".format(result["HotelName"], result["Rating"]))
-
-    await search_client.close()
+        print("Florida hotels containing 'WiFi', sorted by Rating:")
+        async for result in results:
+            print("    Name: {} (rating {})".format(result["HotelName"], result["Rating"]))
     # [END filter_query_async]
 
 if __name__ == '__main__':

--- a/sdk/search/azure-search-documents/samples/async_samples/sample_get_document_async.py
+++ b/sdk/search/azure-search-documents/samples/async_samples/sample_get_document_async.py
@@ -35,14 +35,13 @@ async def autocomplete_query():
 
     search_client = SearchIndexClient(service_endpoint, index_name, AzureKeyCredential(key))
 
-    result = await search_client.get_document(key="23")
+    async with search_client:
+        result = await search_client.get_document(key="23")
 
-    print("Details for hotel '23' are:")
-    print("        Name: {}".format(result["HotelName"]))
-    print("      Rating: {}".format(result["Rating"]))
-    print("    Category: {}".format(result["Category"]))
-
-    await search_client.close()
+        print("Details for hotel '23' are:")
+        print("        Name: {}".format(result["HotelName"]))
+        print("      Rating: {}".format(result["Rating"]))
+        print("    Category: {}".format(result["Category"]))
     # [END get_document_async]
 
 if __name__ == '__main__':

--- a/sdk/search/azure-search-documents/samples/async_samples/sample_index_crud_operations_async.py
+++ b/sdk/search/azure-search-documents/samples/async_samples/sample_index_crud_operations_async.py
@@ -29,7 +29,7 @@ from azure.core.credentials import AzureKeyCredential
 from azure.search.documents.aio import SearchServiceClient
 from azure.search.documents import CorsOptions, Index, ScoringProfile
 
-client = SearchServiceClient(service_endpoint, AzureKeyCredential(key))
+service_client = SearchServiceClient(service_endpoint, AzureKeyCredential(key))
 
 async def create_index():
     # [START create_index_async]
@@ -53,13 +53,13 @@ async def create_index():
         scoring_profiles=scoring_profiles,
         cors_options=cors_options)
 
-    result = await client.create_index(index)
+    result = await service_client.create_index(index)
     # [END create_index_async]
 
 async def get_index():
     # [START get_index_async]
     name = "hotels"
-    result = await client.get_index(name)
+    result = await service_client.get_index(name)
     # [END get_index_async]
 
 async def update_index():
@@ -88,13 +88,13 @@ async def update_index():
         scoring_profiles=scoring_profiles,
         cors_options=cors_options)
 
-    result = await client.create_or_update_index(index_name=index.name, index=index)
+    result = await service_client.create_or_update_index(index_name=index.name, index=index)
     # [END update_index_async]
 
 async def delete_index():
     # [START delete_index_async]
     name = "hotels"
-    await client.delete_index(name)
+    await service_client.delete_index(name)
     # [END delete_index_async]
 
 async def main():
@@ -102,7 +102,7 @@ async def main():
     await get_index()
     await update_index()
     await delete_index()
-    await client.close()
+    await service_client.close()
 
 if __name__ == '__main__':
     loop = asyncio.get_event_loop()

--- a/sdk/search/azure-search-documents/samples/async_samples/sample_simple_query_async.py
+++ b/sdk/search/azure-search-documents/samples/async_samples/sample_simple_query_async.py
@@ -35,13 +35,12 @@ async def simple_text_query():
 
     search_client = SearchIndexClient(service_endpoint, index_name, AzureKeyCredential(key))
 
-    results = await search_client.search(query="spa")
+    async with search_client:
+        results = await search_client.search(query="spa")
 
-    print("Hotels containing 'spa' in the name (or other fields):")
-    async for result in results:
-        print("    Name: {} (rating {})".format(result["HotelName"], result["Rating"]))
-
-    await search_client.close()
+        print("Hotels containing 'spa' in the name (or other fields):")
+        async for result in results:
+            print("    Name: {} (rating {})".format(result["HotelName"], result["Rating"]))
     # [END simple_query_async]
 
 if __name__ == '__main__':

--- a/sdk/search/azure-search-documents/samples/async_samples/sample_suggestions_async.py
+++ b/sdk/search/azure-search-documents/samples/async_samples/sample_suggestions_async.py
@@ -38,14 +38,13 @@ async def suggest_query():
 
     query = SuggestQuery(search_text="coffee", suggester_name="sg")
 
-    results = await search_client.suggest(query=query)
+    async with search_client:
+        results = await search_client.suggest(query=query)
 
-    print("Search suggestions for 'coffee'")
-    for result in results:
-        hotel = await search_client.get_document(key=result["HotelId"])
-        print("    Text: {} for Hotel: {}".format(repr(result["text"]), hotel["HotelName"]))
-
-    await search_client.close()
+        print("Search suggestions for 'coffee'")
+        for result in results:
+            hotel = await search_client.get_document(key=result["HotelId"])
+            print("    Text: {} for Hotel: {}".format(repr(result["text"]), hotel["HotelName"]))
     # [END suggest_query_async]
 
 if __name__ == '__main__':

--- a/sdk/search/azure-search-documents/samples/sample_analyze_text.py
+++ b/sdk/search/azure-search-documents/samples/sample_analyze_text.py
@@ -30,9 +30,12 @@ def simple_analyze_text():
     from azure.core.credentials import AzureKeyCredential
     from azure.search.documents import SearchServiceClient, AnalyzeRequest
 
-    client = SearchServiceClient(service_endpoint, AzureKeyCredential(key))
+    service_client = SearchServiceClient(service_endpoint, AzureKeyCredential(key))
+
     analyze_request = AnalyzeRequest(text="One's <two/>", analyzer="standard.lucene")
-    result = client.analyze_text(index_name, analyze_request)
+
+    result = service_client.analyze_text(index_name, analyze_request)
+    print(result.as_dict())
     # [END simple_analyze_text]
 
 if __name__ == '__main__':

--- a/sdk/search/azure-search-documents/samples/sample_index_crud_operations.py
+++ b/sdk/search/azure-search-documents/samples/sample_index_crud_operations.py
@@ -27,7 +27,7 @@ key = os.getenv("AZURE_SEARCH_API_KEY")
 from azure.core.credentials import AzureKeyCredential
 from azure.search.documents import SearchServiceClient, CorsOptions, Index, ScoringProfile
 
-client = SearchServiceClient(service_endpoint, AzureKeyCredential(key))
+service_client = SearchServiceClient(service_endpoint, AzureKeyCredential(key))
 
 def create_index():
     # [START create_index]
@@ -51,13 +51,13 @@ def create_index():
         scoring_profiles=scoring_profiles,
         cors_options=cors_options)
 
-    result = client.create_index(index)
+    result = service_client.create_index(index)
     # [END create_index]
 
 def get_index():
     # [START get_index]
     name = "hotels"
-    result = client.get_index(name)
+    result = service_client.get_index(name)
     # [END get_index]
 
 def update_index():
@@ -86,13 +86,13 @@ def update_index():
         scoring_profiles=scoring_profiles,
         cors_options=cors_options)
 
-    result = client.create_or_update_index(index_name=index.name, index=index)
+    result = service_client.create_or_update_index(index_name=index.name, index=index)
     # [END update_index]
 
 def delete_index():
     # [START delete_index]
     name = "hotels"
-    client.delete_index(name)
+    service_client.delete_index(name)
     # [END delete_index]
 
 if __name__ == '__main__':


### PR DESCRIPTION
fixes #10661 

This PR switches to use `async with` where reasonable (i.e. not in the cases that re-use a client across multiple places). Also the `client` name was renamed to `service_client` to match the `search_client` usage in the P1 examples. 