### PR TITLE
Azure-Search-Documents Docs.MS Mandated Cleanup

### DIFF
--- a/sdk/search/azure-search-documents/azure/search/documents/_index/aio/_search_index_client_async.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_index/aio/_search_index_client_async.py
@@ -33,7 +33,7 @@ class SearchIndexClient(HeadersMixin):
     :type credential: ~azure.core.credentials.AzureKeyCredential
 
     .. admonition:: Example:
-    
+
         .. literalinclude:: ../samples/async_samples/sample_authentication_async.py
             :start-after: [START create_search_client_with_key_async]
             :end-before: [END create_search_client_with_key_async]

--- a/sdk/search/azure-search-documents/azure/search/documents/_index/aio/_search_index_client_async.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_index/aio/_search_index_client_async.py
@@ -33,6 +33,7 @@ class SearchIndexClient(HeadersMixin):
     :type credential: ~azure.core.credentials.AzureKeyCredential
 
     .. admonition:: Example:
+    
         .. literalinclude:: ../samples/async_samples/sample_authentication_async.py
             :start-after: [START create_search_client_with_key_async]
             :end-before: [END create_search_client_with_key_async]


### PR DESCRIPTION
Admonition directives MUST have a trailing whitespace line.

Docs.MS has a matched warning for not having one, which halts the CI job. An issue is coming to catch this going forward.

