### PR TITLE
Fix coverage warning issue when no coverage is available

### DIFF
--- a/eng/pipelines/templates/steps/publish-coverage.yml
+++ b/eng/pipelines/templates/steps/publish-coverage.yml
@@ -2,11 +2,6 @@ parameters:
   RunCoverage: false
 
 steps:
-  - script: |
-      coverage xml -i --omit="*test*,*example*"
-    displayName: 'Generate Coverage XML'
-    continueOnError: true
-    condition: and(succeededOrFailed(), ${{ parameters.RunCoverage }})
 
   - script: |
       codecov -t $(codecov-python-repository-token)

--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -137,6 +137,18 @@ def collect_tox_coverage_files(targeted_packages):
         dest = os.path.join(root_dir, ".coverage")
 
         shutil.move(source, dest)
+        # Generate coverage XML
+        generate_coverage_xml()
+
+
+def generate_coverage_xml():
+    coverage_path = os.path.join(root_dir, ".coverage")
+    if os.path.exists(coverage_path):
+        logging.info("Generating coverage XML")
+        commands = ["coverage", "xml", "-i", "--omit", '"*test*,*example*"']
+        run_check_call(commands, root_dir)
+    else:
+        logging.error("Coverage file is not available in {} to generate coverage XML".format(coverage_path))
 
 
 def individual_workload(tox_command_tuple, workload_results):

--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -146,7 +146,7 @@ def generate_coverage_xml():
     if os.path.exists(coverage_path):
         logging.info("Generating coverage XML")
         commands = ["coverage", "xml", "-i", "--omit", '"*test*,*example*"']
-        run_check_call(commands, root_dir)
+        run_check_call(commands, root_dir, always_exit = False)
     else:
         logging.error("Coverage file is not available in {} to generate coverage XML".format(coverage_path))
 


### PR DESCRIPTION
CI step to generate coverage XML file is failing and that marks CI in warning state. PR is to handle coverage XML file generation within python script and handle any error code to avoid tagging CI as completed with error.