### PR TITLE
Add certificates library to Key Vault metapackage

### DIFF
--- a/sdk/keyvault/azure-keyvault/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 4.1.0 (2020-04-10)
+**Disclaimer**
+
+This package and the `azure.keyvault` namespace does not contain code anymore. This package now installs three sub-packages instead:
+
+* [azure-keyvault-certificates](https://pypi.org/project/azure-keyvault-certificates/)
+* [azure-keyvault-keys](https://pypi.org/project/azure-keyvault-keys/)
+* [azure-keyvault-secrets](https://pypi.org/project/azure-keyvault-secrets/)
+
+All code needs to be adapted to use the new namespaces. See individual package readmes for details.
+
+ 
 ## 4.0.0 (2019-10-31)
 
 **Disclaimer**

--- a/sdk/keyvault/azure-keyvault/setup.py
+++ b/sdk/keyvault/azure-keyvault/setup.py
@@ -38,8 +38,8 @@ setup(
     ],
     zip_safe=False,
     install_requires=[
-        'azure-keyvault-certificates~=4.0',
-        'azure-keyvault-secrets~=4.0',
-        'azure-keyvault-keys~=4.0',
+        'azure-keyvault-certificates~=4.1',
+        'azure-keyvault-secrets~=4.1',
+        'azure-keyvault-keys~=4.1',
     ],
 )

--- a/sdk/keyvault/azure-keyvault/setup.py
+++ b/sdk/keyvault/azure-keyvault/setup.py
@@ -16,7 +16,7 @@ with open("CHANGELOG.md", encoding="utf-8") as f:
 
 setup(
     name='azure-keyvault',
-    version='4.0.0',
+    version='4.1.0',
     description='Microsoft Azure Key Vault Client Libraries for Python',
     long_description=README + "\n\n" + CHANGELOG,
     long_description_content_type="text/markdown",
@@ -38,6 +38,7 @@ setup(
     ],
     zip_safe=False,
     install_requires=[
+        'azure-keyvault-certificates~=4.0',
         'azure-keyvault-secrets~=4.0',
         'azure-keyvault-keys~=4.0',
     ],


### PR DESCRIPTION
azure-keyvault-certificates is out of preview, so it should join the Key Vault metapackage.