### PR TITLE
README, migration guide, changelog and associatedLink keepalive cleanup.

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 **Breaking Changes**
 
-* Session receivers are now created via their own top level functions, e.g. `get_queue_sesison_receiver` and `get_subscription_session_receiver`
+* Session receivers are now created via their own top level functions, e.g. `get_queue_sesison_receiver` and `get_subscription_session_receiver`.  Non session receivers no longer take session_id as a paramter.
 
 ## 7.0.0b1 (2020-04-06)
 

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -36,6 +36,7 @@ Version 7.0.0b1 is a preview of our efforts to create a client library that is u
     * `get_queue` no longer exists, utilize `get_queue_sender/receiver` instead.
     * `peek` and other `queue_client` functions have moved to their respective sender/receiver.
     * Renamed `fetch_next` to `receive`.
+    * Renamed `session` to `session_id` to normalize naming when requesting a receiver against a given session.
     * `reconnect` no longer exists, and is performed implicitly if needed.
     * `open` no longer exists, and is performed implicitly if needed.
 * Normalized top level client parameters with idiomatic and consistent naming.

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 * Fig bug where http_proxy and transport_type in ServiceBusClient are not propagated into Sender/Receiver creation properly.
 
+**Breaking Changes**
+
+* Session receivers are now created via their own top level functions, e.g. `get_queue_sesison_receiver` and `get_subscription_session_receiver`
+
 ## 7.0.0b1 (2020-04-06)
 
 Version 7.0.0b1 is a preview of our efforts to create a client library that is user friendly and idiomatic to the Python ecosystem. The reasons for most of the changes in this update can be found in the Azure SDK Design Guidelines for Python. For more information, please visit https://aka.ms/azure-sdk-preview1-python.

--- a/sdk/servicebus/azure-servicebus/README.md
+++ b/sdk/servicebus/azure-servicebus/README.md
@@ -162,6 +162,20 @@ with ServiceBusClient.from_connection_string(connstr) as client:
 - Enable `uamqp` logger to collect traces from the underlying uAMQP library.
 - Enable AMQP frame level trace by setting `logging_enable=True` when creating the client.
 
+### Timeouts
+
+There are various timeouts a user should be aware of within the library.
+- 10 minute service side link closure:  A link, once opened, will be closed after 10 minutes idle to protect the service against resource leakage.  This should largely
+be transparent to a user, but if you notice a reconnect occuring after such a duration, this is why.  Performing any operations, including management operations, on the
+link will extend this timeout.
+- idle_timeout: Provided on creation of a receiver, the time after which the underlying UAMQP link will be closed after no traffic.  This primarily dictates the length
+a generator-style receive will run for before exiting if there are no messages.  Passing None (default) will wait forever, up until the 10 minute threshold if no other action is taken.
+- max_wait_time: Provided when calling receive() to fetch a batch of messages.  Dictates how long the receive() will wait for more messages before returning, similarly up to the aformentioned limits.
+
+### Common Exceptions
+
+Please view the [exceptions](./azure/servicebus/exceptions.py) file for detailed descriptions of our common Exception types.
+
 ## Next steps
 
 ### More sample code

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_base_handler.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_base_handler.py
@@ -30,7 +30,8 @@ from ._common.constants import (
     CONTAINER_PREFIX,
     MANAGEMENT_PATH_SUFFIX,
     TOKEN_TYPE_SASTOKEN,
-    MGMT_REQUEST_OP_TYPE_ENTITY_MGMT
+    MGMT_REQUEST_OP_TYPE_ENTITY_MGMT,
+    ASSOCIATEDLINKPROPERTYNAME
 )
 
 if TYPE_CHECKING:
@@ -233,10 +234,18 @@ class BaseHandler(object):  # pylint:disable=too-many-instance-attributes
         )
         raise last_exception
 
-    def _mgmt_request_response(self, mgmt_operation, message, callback, **kwargs):
+    def _mgmt_request_response(self, mgmt_operation, message, callback, keep_alive_associated_link=True, **kwargs):
         self._open()
         if not self._running:
             raise InvalidHandlerState("Client connection is closed.")
+
+        application_properties = {}
+        # Some mgmt calls do not support an associated link name (such as list_sessions).  Most do, so on by default.
+        if keep_alive_associated_link:
+            try:
+                application_properties = {ASSOCIATEDLINKPROPERTYNAME:self._handler.message_handler.name}
+            except AttributeError:
+                pass
 
         mgmt_msg = uamqp.Message(
             body=message,
@@ -244,7 +253,8 @@ class BaseHandler(object):  # pylint:disable=too-many-instance-attributes
                 reply_to=self._mgmt_target,
                 encoding=self._config.encoding,
                 **kwargs
-            )
+            ),
+            application_properties=application_properties
         )
         try:
             return self._handler.mgmt_request(

--- a/sdk/servicebus/azure-servicebus/migration_guide.md
+++ b/sdk/servicebus/azure-servicebus/migration_guide.md
@@ -18,6 +18,8 @@ In v7 we've simplified the API surface, making two distinct clients, rather than
 and [Async API](https://azuresdkdocs.blob.core.windows.net/$web/python/azure-servicebus/7.0.0b1/azure.servicebus.aio.html#azure.servicebus.aio.ServiceBusSender)
 * `ServiceBusReceiver` for receiving messages. [Sync API](https://azuresdkdocs.blob.core.windows.net/$web/python/azure-servicebus/7.0.0b1/azure.servicebus.html#azure.servicebus.ServiceBusReceiver)
 and [Async API](https://azuresdkdocs.blob.core.windows.net/$web/python/azure-servicebus/7.0.0b1/azure.servicebus.aio.html#azure.servicebus.aio.ServiceBusReceiver)
+* `ServiceBusSessionReceiver` for receiving messages from a session. [Sync API](https://azuresdkdocs.blob.core.windows.net/$web/python/azure-servicebus/7.0.0b1/azure.servicebus.html#azure.servicebus.ServiceBusSessionReceiver)
+and [Async API](https://azuresdkdocs.blob.core.windows.net/$web/python/azure-servicebus/7.0.0b1/azure.servicebus.aio.html#azure.servicebus.aio.ServiceBusSessionReceiver)
 
 As a user this will be largely transparent to you, as initialization will still occur primarily via the top level ServiceBusClient,
 the primary difference will be that rather than creating a queue_client, for instance, and then a sender off of that, you would simply
@@ -52,8 +54,8 @@ semantics with the sender or receiver lifetime.
 | In v0.50 | Equivalent in v7 | Sample |
 |---|---|---|
 | `queue_client.send(message, session='foo')  and queue_client.get_sender(session='foo').send(message)`| `sb_client.get_queue_sender().send(Message('body', session_id='foo'))`| [Send a message to a session](./samples/sync_samples/session_send_receive.py) |
-| `AutoLockRenew().register(queue_client.get_receiver(session_id='foo'))`| `AutoLockRenew().register(sb_client.get_queue_receiver(session_id='foo').session)`| [Access a session and ensure its lock is auto-renewed](./samples/sync_samples/session_send_receive.py) |
-
+| `AutoLockRenew().register(queue_client.get_receiver(session='foo'))`| `AutoLockRenew().register(sb_client.get_queue_session_receiver(session_id='foo').session)`| [Access a session and ensure its lock is auto-renewed](./samples/sync_samples/session_send_receive.py) |
+| `receiver.get_session_state()` | `receiver.session.get_session_state()` | [Perform session specific operations on a receiver](./samples/sync_samples/session_send_receive.py)
 
 ## Migration samples
 
@@ -68,6 +70,8 @@ batch of messages, or iterate over the receiver to receive continuously.
 
 In v7, users should initialize the client via `ServiceBusClient.get_queue_receiver`.  Single-batch-receive
 has been renamed to `receive`, iterating over the receiver for continual message consumption has not changed.
+It should also be noted that if a session receiver is desired, to use the `get_<queue/subscription>_session_receiver`
+function.
 
 For example, this code which keeps receiving from a partition in v0.50:
 


### PR DESCRIPTION
- Bolster troubleshooting section in README, adding details of key timeout periods and where to find details on exceptions.
- Add addition migration_guide notes for accessing session functionality, and requesting a session receiver.
- Correct changelog entry with another breaking change (session->session_id)
- Add AssociatedLinkName to handlers to keep underlying link alive.