### PR TITLE
Make live managed identity tests independent of soft delete

### DIFF
--- a/sdk/identity/azure-identity/tests/azure-functions/readme.md
+++ b/sdk/identity/azure-identity/tests/azure-functions/readme.md
@@ -94,7 +94,7 @@ Allow the system-assigned identity to access the Key Vault:
 ```sh
 az keyvault set-policy -n $KEY_VAULT_NAME \
     --object-id $(az functionapp identity show -g $RESOURCE_GROUP -n $FUNCTION_APP_SYSTEM_ASSIGNED --query principalId -o tsv) \
-    --secret-permissions set delete
+    --secret-permissions list
 ```
 
 
@@ -108,7 +108,7 @@ Allow it to access the Key Vault:
 ```sh
 az keyvault set-policy -n $KEY_VAULT_NAME \
     --object-id $(az identity show -g $RESOURCE_GROUP -n $MANAGED_IDENTITY_NAME --query principalId -o tsv) \
-    --secret-permissions set delete
+    --secret-permissions list
 ```
 
 

--- a/sdk/identity/azure-identity/tests/managed-identity-live/appservice.md
+++ b/sdk/identity/azure-identity/tests/managed-identity-live/appservice.md
@@ -88,7 +88,7 @@ Allow the system-assigned identity to access the Key Vault:
 ```sh
 az keyvault set-policy -n $KEY_VAULT_NAME -g $RESOURCE_GROUP \
     --object-id $(az webapp show -n $WEB_APP_SYSTEM_ASSIGNED -g $RESOURCE_GROUP --query identity.principalId -o tsv) \
-    --secret-permissions set delete
+    --secret-permissions list
 ```
 
 ### Managed identity
@@ -103,7 +103,7 @@ Allow it to access the Key Vault:
 ```sh
 az keyvault set-policy -n $KEY_VAULT_NAME \
     --object-id $(az identity show -g $RESOURCE_GROUP -n $MANAGED_IDENTITY_NAME --query principalId -o tsv) \
-    --secret-permissions set delete
+    --secret-permissions list
 ```
 
 ### Web app: user-assigned identity

--- a/sdk/identity/azure-identity/tests/managed-identity-live/test_managed_identity_live.py
+++ b/sdk/identity/azure-identity/tests/managed-identity-live/test_managed_identity_live.py
@@ -16,5 +16,5 @@ def test_managed_identity_live(live_managed_identity_config):
 
     # do something with Key Vault to verify the credential can get a valid token
     client = SecretClient(live_managed_identity_config["vault_url"], credential, logging_enable=True)
-    secret = client.set_secret("managed-identity-test-secret", "value")
-    client.begin_delete_secret(secret.name)
+    for _ in client.list_properties_of_secrets():
+        pass

--- a/sdk/identity/azure-identity/tests/managed-identity-live/test_managed_identity_live_async.py
+++ b/sdk/identity/azure-identity/tests/managed-identity-live/test_managed_identity_live_async.py
@@ -20,5 +20,5 @@ async def test_managed_identity_live(live_managed_identity_config):
 
     # do something with Key Vault to verify the credential can get a valid token
     client = SecretClient(live_managed_identity_config["vault_url"], credential, logging_enable=True)
-    secret = await client.set_secret("managed-identity-test-secret", "value")
-    await client.delete_secret(secret.name)
+    async for _ in client.list_properties_of_secrets():
+        pass

--- a/sdk/identity/azure-identity/tests/managed-identity-live/vm.md
+++ b/sdk/identity/azure-identity/tests/managed-identity-live/vm.md
@@ -82,14 +82,14 @@ Allow the VM with system-assigned identity to access the Key Vault's secrets:
 ```sh
 az keyvault set-policy -n $KEY_VAULT_NAME \
     --object-id $(az vm show -n $VM_NAME_SYSTEM_ASSIGNED -g $RESOURCE_GROUP --query identity.principalId -o tsv) \
-    --secret-permissions set delete
+    --secret-permissions list
 ```
 
 Do the same for the user-assigned identity:
 ```sh
 az keyvault set-policy -n $KEY_VAULT_NAME \
     --object-id $(az identity show -g $RESOURCE_GROUP -n $MANAGED_IDENTITY_NAME --query principalId -o tsv) \
-    --secret-permissions set delete
+    --secret-permissions list
 ```
 
 # Install dependencies

--- a/sdk/identity/azure-identity/tests/pod-identity/readme.md
+++ b/sdk/identity/azure-identity/tests/pod-identity/readme.md
@@ -69,7 +69,7 @@ az keyvault create -g $RESOURCE_GROUP -n $KEY_VAULT_NAME --sku standard
 
 Add an access policy for the managed identity:
 ```sh
-az keyvault set-policy -n $KEY_VAULT_NAME --object-id $MANAGED_IDENTITY_PRINCIPAL_ID --secret-permissions set delete
+az keyvault set-policy -n $KEY_VAULT_NAME --object-id $MANAGED_IDENTITY_PRINCIPAL_ID --secret-permissions list
 ```
 
 ### container registry


### PR DESCRIPTION
When soft delete is enabled for the Key Vault used by these tests, the second case executed will fail because it tries to set and delete a secret deleted by the first case executed. When these tests were written soft delete was disabled by default on new Key Vaults. Now it's enabled by default.

It doesn't matter which Key Vault operation the tests attempt because the purpose is to validate the access token acquired by the credential. The simple fix here is to list the vault's secrets. This eliminates problems due to the state of the Vault's secrets (and requires authorization even when the vault has none).