### PR TITLE
[formrecognizer] rename async training method to train_model and sync method to begin_train_model

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_form_training_client.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_form_training_client.py
@@ -66,7 +66,7 @@ class FormTrainingClient(object):
         )
 
     @distributed_trace
-    def begin_training(self, training_files, use_labels=False, **kwargs):
+    def begin_train_model(self, training_files, use_labels=False, **kwargs):
         # type: (str, Optional[bool], Any) -> LROPoller
         """Create and train a custom model. The request must include a `training_files` parameter that is an
         externally accessible Azure storage blob container Uri (preferably a Shared Access Signature Uri).

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/aio/_form_training_client_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/aio/_form_training_client_async.py
@@ -69,7 +69,7 @@ class FormTrainingClient(object):
         )
 
     @distributed_trace_async
-    async def training(
+    async def train_model(
             self,
             training_files: str,
             use_labels: Optional[bool] = False,

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms.py
@@ -58,7 +58,7 @@ class TestCustomForms(FormRecognizerTest):
     def test_custom_form_unlabeled(self, client, container_sas_url):
         training_client = client.get_form_training_client()
 
-        poller = training_client.begin_training(container_sas_url)
+        poller = training_client.begin_train_model(container_sas_url)
         model = poller.result()
 
         with open(self.form_jpg, "rb") as fd:
@@ -86,7 +86,7 @@ class TestCustomForms(FormRecognizerTest):
     def test_custom_form_labeled(self, client, container_sas_url):
         training_client = client.get_form_training_client()
 
-        poller = training_client.begin_training(
+        poller = training_client.begin_train_model(
             container_sas_url,
             use_labels=True
         )
@@ -112,7 +112,7 @@ class TestCustomForms(FormRecognizerTest):
     def test_custom_form_unlabeled_transform(self, client, container_sas_url):
         training_client = client.get_form_training_client()
 
-        poller = training_client.begin_training(container_sas_url)
+        poller = training_client.begin_train_model(container_sas_url)
         model = poller.result()
 
         responses = []
@@ -149,7 +149,7 @@ class TestCustomForms(FormRecognizerTest):
     def test_custom_form_labeled_transform(self, client, container_sas_url):
         training_client = client.get_form_training_client()
 
-        poller = training_client.begin_training(container_sas_url, use_labels=True)
+        poller = training_client.begin_train_model(container_sas_url, use_labels=True)
         model = poller.result()
 
         responses = []

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_async.py
@@ -60,7 +60,7 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     async def test_custom_form_unlabeled(self, client, container_sas_url):
         training_client = client.get_form_training_client()
 
-        model = await training_client.training(container_sas_url)
+        model = await training_client.train_model(container_sas_url)
 
         with open(self.form_jpg, "rb") as fd:
             myfile = fd.read()
@@ -82,7 +82,7 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     async def test_custom_form_labeled(self, client, container_sas_url):
         training_client = client.get_form_training_client()
 
-        model = await training_client.training(container_sas_url, use_labels=True)
+        model = await training_client.train_model(container_sas_url, use_labels=True)
 
         with open(self.form_jpg, "rb") as fd:
             myfile = fd.read()
@@ -103,7 +103,7 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     async def test_form_unlabeled_transform(self, client, container_sas_url):
         training_client = client.get_form_training_client()
 
-        model = await training_client.training(container_sas_url)
+        model = await training_client.train_model(container_sas_url)
 
         responses = []
 
@@ -139,7 +139,7 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
     async def test_form_labeled_transform(self, client, container_sas_url):
         training_client = client.get_form_training_client()
 
-        model = await training_client.training(container_sas_url, use_labels=True)
+        model = await training_client.train_model(container_sas_url, use_labels=True)
 
         responses = []
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_from_url.py
@@ -54,7 +54,7 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     def test_custom_form_unlabeled(self, client, container_sas_url):
         training_client = client.get_form_training_client()
 
-        poller = training_client.begin_training(container_sas_url)
+        poller = training_client.begin_train_model(container_sas_url)
         model = poller.result()
 
         poller = client.begin_recognize_custom_forms_from_url(model.model_id, self.form_url_jpg)
@@ -75,7 +75,7 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     def test_custom_form_labeled(self, client, container_sas_url):
         training_client = client.get_form_training_client()
 
-        poller = training_client.begin_training(container_sas_url, use_labels=True)
+        poller = training_client.begin_train_model(container_sas_url, use_labels=True)
         model = poller.result()
 
         poller = client.begin_recognize_custom_forms_from_url(model.model_id, self.form_url_jpg)
@@ -95,7 +95,7 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     def test_form_unlbld_transform(self, client, container_sas_url):
         training_client = client.get_form_training_client()
 
-        poller = training_client.begin_training(container_sas_url)
+        poller = training_client.begin_train_model(container_sas_url)
         model = poller.result()
 
         responses = []
@@ -129,7 +129,7 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     def test_form_labeled_transform(self, client, container_sas_url):
         training_client = client.get_form_training_client()
 
-        poller = training_client.begin_training(container_sas_url, use_labels=True)
+        poller = training_client.begin_train_model(container_sas_url, use_labels=True)
         model = poller.result()
 
         responses = []

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_from_url_async.py
@@ -54,7 +54,7 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     async def test_form_unlabeled(self, client, container_sas_url):
         training_client = client.get_form_training_client()
 
-        model = await training_client.training(container_sas_url)
+        model = await training_client.train_model(container_sas_url)
 
         form = await client.recognize_custom_forms_from_url(model.model_id, self.form_url_jpg)
 
@@ -73,7 +73,7 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     async def test_form_labeled(self, client, container_sas_url):
         training_client = client.get_form_training_client()
 
-        model = await training_client.training(container_sas_url, use_labels=True)
+        model = await training_client.train_model(container_sas_url, use_labels=True)
 
         form = await client.recognize_custom_forms_from_url(model.model_id, self.form_url_jpg)
 
@@ -91,7 +91,7 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     async def test_fr_unlbld_trnsfrm(self, client, container_sas_url):
         training_client = client.get_form_training_client()
 
-        model = await training_client.training(container_sas_url)
+        model = await training_client.train_model(container_sas_url)
 
         responses = []
 
@@ -124,7 +124,7 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     async def test_fr_lbld_transform(self, client, container_sas_url):
         training_client = client.get_form_training_client()
 
-        model = await training_client.training(container_sas_url, use_labels=True)
+        model = await training_client.train_model(container_sas_url, use_labels=True)
 
         responses = []
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_mgmt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_mgmt.py
@@ -56,7 +56,7 @@ class TestManagement(FormRecognizerTest):
     @GlobalTrainingAccountPreparer()
     def test_mgmt_model_labeled(self, client, container_sas_url):
 
-        poller = client.begin_training(container_sas_url, use_labels=True)
+        poller = client.begin_train_model(container_sas_url, use_labels=True)
         labeled_model_from_train = poller.result()
 
         labeled_model_from_get = client.get_custom_model(labeled_model_from_train.model_id)
@@ -92,7 +92,7 @@ class TestManagement(FormRecognizerTest):
     @GlobalTrainingAccountPreparer()
     def test_mgmt_model_unlabeled(self, client, container_sas_url):
 
-        poller = client.begin_training(container_sas_url)
+        poller = client.begin_train_model(container_sas_url)
         unlabeled_model_from_train = poller.result()
 
         unlabeled_model_from_get = client.get_custom_model(unlabeled_model_from_train.model_id)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_mgmt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_mgmt_async.py
@@ -57,7 +57,7 @@ class TestManagementAsync(AsyncFormRecognizerTest):
     @GlobalTrainingAccountPreparer()
     async def test_mgmt_model_labeled(self, client, container_sas_url):
 
-        labeled_model_from_train = await client.training(container_sas_url, use_labels=True)
+        labeled_model_from_train = await client.train_model(container_sas_url, use_labels=True)
 
         labeled_model_from_get = await client.get_custom_model(labeled_model_from_train.model_id)
 
@@ -91,7 +91,7 @@ class TestManagementAsync(AsyncFormRecognizerTest):
     @GlobalFormAndStorageAccountPreparer()
     @GlobalTrainingAccountPreparer()
     async def test_mgmt_model_unlabeled(self, client, container_sas_url):
-        unlabeled_model_from_train = await client.training(container_sas_url)
+        unlabeled_model_from_train = await client.train_model(container_sas_url)
 
         unlabeled_model_from_get = await client.get_custom_model(unlabeled_model_from_train.model_id)
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_training.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_training.py
@@ -23,13 +23,13 @@ class TestTraining(FormRecognizerTest):
     def test_training_auth_bad_key(self, resource_group, location, form_recognizer_account, form_recognizer_account_key):
         client = FormTrainingClient(form_recognizer_account, AzureKeyCredential("xxxx"))
         with self.assertRaises(ClientAuthenticationError):
-            poller = client.begin_training("xx")
+            poller = client.begin_train_model("xx")
 
     @GlobalFormAndStorageAccountPreparer()
     @GlobalTrainingAccountPreparer()
     def test_training(self, client, container_sas_url):
 
-        poller = client.begin_training(container_sas_url)
+        poller = client.begin_train_model(container_sas_url)
         model = poller.result()
 
         self.assertIsNotNone(model.model_id)
@@ -60,7 +60,7 @@ class TestTraining(FormRecognizerTest):
             raw_response.append(raw_model)
             raw_response.append(custom_model)
 
-        poller = client.begin_training(container_sas_url, cls=callback)
+        poller = client.begin_train_model(container_sas_url, cls=callback)
         model = poller.result()
 
         raw_model = raw_response[0]
@@ -71,7 +71,7 @@ class TestTraining(FormRecognizerTest):
     @GlobalTrainingAccountPreparer()
     def test_training_with_labels(self, client, container_sas_url):
 
-        poller = client.begin_training(container_sas_url, use_labels=True)
+        poller = client.begin_train_model(container_sas_url, use_labels=True)
         model = poller.result()
 
         self.assertIsNotNone(model.model_id)
@@ -102,7 +102,7 @@ class TestTraining(FormRecognizerTest):
             raw_response.append(raw_model)
             raw_response.append(custom_model)
 
-        poller = client.begin_training(container_sas_url, use_labels=True, cls=callback)
+        poller = client.begin_train_model(container_sas_url, use_labels=True, cls=callback)
         model = poller.result()
 
         raw_model = raw_response[0]
@@ -113,7 +113,7 @@ class TestTraining(FormRecognizerTest):
     @GlobalTrainingAccountPreparer()
     def test_training_with_files_filter(self, client, container_sas_url):
 
-        poller = client.begin_training(container_sas_url, include_sub_folders=True)
+        poller = client.begin_train_model(container_sas_url, include_sub_folders=True)
         model = poller.result()
 
         self.assertIsNotNone(model.model_id)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_training_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_training_async.py
@@ -23,13 +23,13 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     async def test_training_auth_bad_key(self, resource_group, location, form_recognizer_account, form_recognizer_account_key):
         client = FormTrainingClient(form_recognizer_account, AzureKeyCredential("xxxx"))
         with self.assertRaises(ClientAuthenticationError):
-            result = await client.training("xx")
+            result = await client.train_model("xx")
 
     @GlobalFormAndStorageAccountPreparer()
     @GlobalTrainingAccountPreparer()
     async def test_training(self, client, container_sas_url):
 
-        model = await client.training(container_sas_url)
+        model = await client.train_model(container_sas_url)
 
         self.assertIsNotNone(model.model_id)
         self.assertIsNotNone(model.created_on)
@@ -59,7 +59,7 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
             raw_response.append(raw_model)
             raw_response.append(custom_model)
 
-        model = await client.training(container_sas_url, cls=callback)
+        model = await client.train_model(container_sas_url, cls=callback)
 
         raw_model = raw_response[0]
         custom_model = raw_response[1]
@@ -69,7 +69,7 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @GlobalTrainingAccountPreparer()
     async def test_training_with_labels(self, client, container_sas_url):
 
-        model = await client.training(container_sas_url, use_labels=True)
+        model = await client.train_model(container_sas_url, use_labels=True)
 
         self.assertIsNotNone(model.model_id)
         self.assertIsNotNone(model.created_on)
@@ -99,7 +99,7 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
             raw_response.append(raw_model)
             raw_response.append(custom_model)
 
-        model = await client.training(container_sas_url, use_labels=True, cls=callback)
+        model = await client.train_model(container_sas_url, use_labels=True, cls=callback)
 
         raw_model = raw_response[0]
         custom_model = raw_response[1]
@@ -109,13 +109,13 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
     @GlobalTrainingAccountPreparer()
     async def test_training_with_files_filter(self, client, container_sas_url):
 
-        model = await client.training(container_sas_url, include_sub_folders=True)
+        model = await client.train_model(container_sas_url, include_sub_folders=True)
         self.assertEqual(len(model.training_documents), 6)
         self.assertEqual(model.training_documents[-1].document_name, "subfolder/Form_6.jpg")  # we traversed subfolders
 
-        model = await client.training(container_sas_url, prefix="subfolder", include_sub_folders=True)
+        model = await client.train_model(container_sas_url, prefix="subfolder", include_sub_folders=True)
         self.assertEqual(len(model.training_documents), 1)
         self.assertEqual(model.training_documents[0].document_name, "subfolder/Form_6.jpg")  # we filtered for only subfolders
 
-        model = await client.training(container_sas_url, prefix="xxx")
+        model = await client.train_model(container_sas_url, prefix="xxx")
         self.assertEqual(model.status, "invalid")  # prefix doesn't include any files so training fails


### PR DESCRIPTION
This async method used to be called `begin_training` but since it does not return a poller object, we need to drop the `begin_` prefix. `training` as a method name lacks a verb prefix and does not comply with guidelines so in this PR we rename it to `train_model`.

Edit: Also changing the sync method from `begin_training` -> `begin_train_model` so we have consistency between sync/async method names.