### PR TITLE
Ensure open() idempotency in track 2 service bus handlers.

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -171,11 +171,15 @@ class ServiceBusReceiver(BaseHandler, ReceiverMixin):  # pylint: disable=too-man
 
         auth = None if self._connection else create_authentication(self)
         self._create_handler(auth)
-        self._handler.open(connection=self._connection)
-        self._message_iter = self._handler.receive_messages_iter()
-        while not self._handler.client_ready():
-            time.sleep(0.05)
-        self._running = True
+        try:
+            self._handler.open(connection=self._connection)
+            self._message_iter = self._handler.receive_messages_iter()
+            while not self._handler.client_ready():
+                time.sleep(0.05)
+            self._running = True
+        except:
+            self.close()
+            raise
 
     def _receive(self, max_batch_size=None, timeout=None):
         self._open()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_sender.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_sender.py
@@ -169,12 +169,16 @@ class ServiceBusSender(BaseHandler, SenderMixin):
 
         auth = None if self._connection else create_authentication(self)
         self._create_handler(auth)
-        self._handler.open(connection=self._connection)
-        while not self._handler.client_ready():
-            time.sleep(0.05)
-        self._running = True
-        self._max_message_size_on_link = self._handler.message_handler._link.peer_max_message_size \
-                                         or uamqp.constants.MAX_MESSAGE_LENGTH_BYTES
+        try:
+            self._handler.open(connection=self._connection)
+            while not self._handler.client_ready():
+                time.sleep(0.05)
+            self._running = True
+            self._max_message_size_on_link = self._handler.message_handler._link.peer_max_message_size \
+                                             or uamqp.constants.MAX_MESSAGE_LENGTH_BYTES
+        except:
+            self.close()
+            raise
 
     def _send(self, message, timeout=None, last_exception=None):
         self._open()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
@@ -163,11 +163,15 @@ class ServiceBusReceiver(collections.abc.AsyncIterator, BaseHandlerAsync, Receiv
             await self._handler.close_async()
         auth = None if self._connection else (await create_authentication(self))
         self._create_handler(auth)
-        await self._handler.open_async(connection=self._connection)
-        self._message_iter = self._handler.receive_messages_iter_async()
-        while not await self._handler.client_ready_async():
-            await asyncio.sleep(0.05)
-        self._running = True
+        try:
+            await self._handler.open_async(connection=self._connection)
+            self._message_iter = self._handler.receive_messages_iter_async()
+            while not await self._handler.client_ready_async():
+                await asyncio.sleep(0.05)
+            self._running = True
+        except:
+            self.close()
+            raise
 
     async def _receive(self, max_batch_size=None, timeout=None):
         await self._open()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_sender_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_sender_async.py
@@ -120,12 +120,16 @@ class ServiceBusSender(BaseHandlerAsync, SenderMixin):
             await self._handler.close_async()
         auth = None if self._connection else (await create_authentication(self))
         self._create_handler(auth)
-        await self._handler.open_async(connection=self._connection)
-        while not await self._handler.client_ready_async():
-            await asyncio.sleep(0.05)
-        self._running = True
-        self._max_message_size_on_link = self._handler.message_handler._link.peer_max_message_size \
-                                         or uamqp.constants.MAX_MESSAGE_LENGTH_BYTES
+        try:
+            await self._handler.open_async(connection=self._connection)
+            while not await self._handler.client_ready_async():
+                await asyncio.sleep(0.05)
+            self._running = True
+            self._max_message_size_on_link = self._handler.message_handler._link.peer_max_message_size \
+                                             or uamqp.constants.MAX_MESSAGE_LENGTH_BYTES
+        except:
+            self.close()
+            raise
 
     async def _send(self, message, timeout=None, last_exception=None):
         await self._open()

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
@@ -823,7 +823,7 @@ class ServiceBusAsyncSessionTests(AzureMgmtTestCase):
     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
     @ServiceBusTopicPreparer(name_prefix='servicebustest')
     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', requires_session=True)
-    async def test_session_basic_topic_subscription_send_and_receive(self, servicebus_namespace_connection_string, servicebus_topic, servicebus_subscription, **kwargs):
+    async def test_async_session_basic_topic_subscription_send_and_receive(self, servicebus_namespace_connection_string, servicebus_topic, servicebus_subscription, **kwargs):
         async with ServiceBusClient.from_connection_string(
                 servicebus_namespace_connection_string,
                 logging_enable=False
@@ -843,3 +843,41 @@ class ServiceBusAsyncSessionTests(AzureMgmtTestCase):
                     count += 1
                     await message.complete()
             assert count == 1
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    async def test_async_session_connection_failure_is_idempotent(self, servicebus_namespace_connection_string, servicebus_queue, **kwargs):
+        #Technically this validates for all senders/receivers, not just session, but since it uses session to generate a recoverable failure, putting it in here.
+        async with ServiceBusClient.from_connection_string(
+            servicebus_namespace_connection_string, logging_enable=False) as sb_client:
+    
+            # First let's just try the naive failure cases.
+            receiver = sb_client.get_queue_receiver("THIS_IS_WRONG_ON_PURPOSE")
+            with pytest.raises(ServiceBusConnectionError):
+                await receiver._open_with_retry()
+            assert not receiver._running
+            assert not receiver._handler
+    
+            sender = sb_client.get_queue_sender("THIS_IS_WRONG_ON_PURPOSE")
+            with pytest.raises(ServiceBusConnectionError):
+                await sender._open_with_retry()
+            assert not receiver._running
+            assert not receiver._handler
+
+            # Then let's try a case we can recover from to make sure everything works on reestablishment.
+            receiver = sb_client.get_queue_session_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE)
+            with pytest.raises(NoActiveSession):
+                await receiver._open_with_retry()
+
+            session_id = str(uuid.uuid4())
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                await sender.send(Message("test session sender", session_id=session_id))
+
+            async with sb_client.get_queue_session_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE, idle_timeout=5) as receiver:
+                messages = []
+                async for message in receiver:
+                    messages.append(message)
+                assert len(messages) == 1


### PR DESCRIPTION
Ensure that open() leaves handlers in a sane state even on failure, and that recovery can happen properly.

Adds tests to validate this.