### PR TITLE
Replace non-ASCII character

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py
@@ -264,7 +264,7 @@ class RetryPolicy(HTTPPolicy):
         presence of the aforementioned header.
 
         The behavior is:
-        -	If status_code < 400: don’t retry
+        -	If status_code < 400: don't retry
         -	Else if Retry-After present: retry
         -	Else: retry based on the safe status code list ([408, 429, 500, 502, 503, 504])
 


### PR DESCRIPTION
This one came in with #10788. I'm not sure how it got past CI and has survived since that PR, I can't load the module in 2.7:

>SyntaxError: Non-ASCII character '\xe2' in file ...\_retry.py on line 268, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details`