### PR TITLE
Servicebus - Track2 - Remove timeout from Send

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -14,6 +14,7 @@
 **Breaking Changes**
 
 * Session receivers are now created via their own top level functions, e.g. `get_queue_sesison_receiver` and `get_subscription_session_receiver`.  Non session receivers no longer take session_id as a paramter.
+* `Send()` no longer takes a timeout parameter, as it should be redundant with retry options provided when creating the client.
 
 ## 7.0.0b1 (2020-04-06)
 

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -14,7 +14,7 @@
 **Breaking Changes**
 
 * Session receivers are now created via their own top level functions, e.g. `get_queue_sesison_receiver` and `get_subscription_session_receiver`.  Non session receivers no longer take session_id as a paramter.
-* `ServiceBusSender.Send()` no longer takes a timeout parameter, as it should be redundant with retry options provided when creating the client.
+* `ServiceBusSender.send()` no longer takes a timeout parameter, as it should be redundant with retry options provided when creating the client.
 
 ## 7.0.0b1 (2020-04-06)
 

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -14,7 +14,7 @@
 **Breaking Changes**
 
 * Session receivers are now created via their own top level functions, e.g. `get_queue_sesison_receiver` and `get_subscription_session_receiver`.  Non session receivers no longer take session_id as a paramter.
-* `Send()` no longer takes a timeout parameter, as it should be redundant with retry options provided when creating the client.
+* `ServiceBusSender.Send()` no longer takes a timeout parameter, as it should be redundant with retry options provided when creating the client.
 
 ## 7.0.0b1 (2020-04-06)
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_sender.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_sender.py
@@ -290,13 +290,12 @@ class ServiceBusSender(BaseHandler, SenderMixin):
         )
         return cls(**constructor_args)
 
-    def send(self, message, timeout=None):
+    def send(self, message):
         # type: (Union[Message, BatchMessage], float) -> None
         """Sends message and blocks until acknowledgement is received or operation times out.
 
         :param message: The ServiceBus message to be sent.
         :type message: ~azure.servicebus.Message
-        :param float timeout: The maximum wait time to send the event data.
         :rtype: None
         :raises: ~azure.servicebus.common.errors.MessageSendFailed if the message fails to
          send or ~azure.servicebus.common.errors.OperationTimeoutError if sending times out.
@@ -314,7 +313,6 @@ class ServiceBusSender(BaseHandler, SenderMixin):
         self._do_retryable_operation(
             self._send,
             message=message,
-            timeout=timeout,
             require_timeout=True,
             require_last_exception=True
         )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_sender_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_sender_async.py
@@ -238,13 +238,12 @@ class ServiceBusSender(BaseHandlerAsync, SenderMixin):
         )
         return cls(**constructor_args)
 
-    async def send(self, message, timeout=None):
+    async def send(self, message):
         # type: (Message, float) -> None
         """Sends message and blocks until acknowledgement is received or operation times out.
 
         :param message: The ServiceBus message to be sent.
         :type message: ~azure.servicebus.Message
-        :param float timeout: The maximum wait time to send the event data.
         :rtype: None
         :raises: ~azure.servicebus.common.errors.MessageSendFailed if the message fails to
          send or ~azure.servicebus.common.errors.OperationTimeoutError if sending times out.
@@ -262,7 +261,6 @@ class ServiceBusSender(BaseHandlerAsync, SenderMixin):
         await self._do_retryable_operation(
             self._send,
             message=message,
-            timeout=timeout,
             require_timeout=True,
             require_last_exception=True
         )


### PR DESCRIPTION
With retry options available, send should no longer require its own timeout.  Removes the parameter from sync and async clients.