### PR TITLE
[formrecognizer] handle unsupervised pages better with service bug

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
@@ -15,20 +15,23 @@ import six
 def get_elements(field, read_result):
     text_elements = []
 
-    for item in field.elements:
-        nums = [int(s) for s in re.findall(r"\d+", item)]
-        read = nums[0]
-        line = nums[1]
-        if len(nums) == 3:
-            word = nums[2]
-            ocr_word = read_result[read].lines[line].words[word]
-            extracted_word = FormWord._from_generated(ocr_word, page=read + 1)
-            text_elements.append(extracted_word)
-            continue
-        ocr_line = read_result[read].lines[line]
-        extracted_line = FormLine._from_generated(ocr_line, page=read + 1)
-        text_elements.append(extracted_line)
-    return text_elements
+    try:
+        for item in field.elements:
+            nums = [int(s) for s in re.findall(r"\d+", item)]
+            read = nums[0]
+            line = nums[1]
+            if len(nums) == 3:
+                word = nums[2]
+                ocr_word = read_result[read].lines[line].words[word]
+                extracted_word = FormWord._from_generated(ocr_word, page=read + 1)
+                text_elements.append(extracted_word)
+                continue
+            ocr_line = read_result[read].lines[line]
+            extracted_line = FormLine._from_generated(ocr_line, page=read + 1)
+            text_elements.append(extracted_line)
+        return text_elements
+    except IndexError:
+        return None  # https://github.com/Azure/azure-sdk-for-python/issues/11014
 
 
 def get_field_value(field, value, read_result):  # pylint: disable=too-many-return-statements

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_response_handlers.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_response_handlers.py
@@ -126,7 +126,7 @@ def prepare_unlabeled_result(response):
     read_result = response.analyze_result.read_results
     page_result = response.analyze_result.page_results
 
-    for idx, page in enumerate(page_result):
+    for index, page in enumerate(page_result):
         unlabeled_fields = [FormField._from_generated_unlabeled(field, idx, page.page, read_result)
                             for idx, field in enumerate(page.key_value_pairs)] if page.key_value_pairs else None
         if unlabeled_fields:
@@ -138,7 +138,7 @@ def prepare_unlabeled_result(response):
             ),
             fields=unlabeled_fields,
             form_type="form-" + str(page.cluster_id) if page.cluster_id is not None else None,
-            pages=[form_pages[idx]]
+            pages=[form_pages[index]]
         )
         result.append(form)
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_response_handlers.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_response_handlers.py
@@ -99,7 +99,7 @@ def prepare_content_result(response):
     read_result = response.analyze_result.read_results
     page_result = response.analyze_result.page_results
 
-    for page in read_result:
+    for idx, page in enumerate(read_result):
         form_page = FormPage(
             page_number=page.page,
             text_angle=page.angle,
@@ -107,7 +107,7 @@ def prepare_content_result(response):
             height=page.height,
             unit=page.unit,
             lines=[FormLine._from_generated(line, page=page.page) for line in page.lines] if page.lines else None,
-            tables=prepare_tables(page_result[page.page-1], read_result),
+            tables=prepare_tables(page_result[idx], read_result),
         )
         pages.append(form_page)
     return pages
@@ -126,7 +126,7 @@ def prepare_unlabeled_result(response):
     read_result = response.analyze_result.read_results
     page_result = response.analyze_result.page_results
 
-    for page in page_result:
+    for idx, page in enumerate(page_result):
         unlabeled_fields = [FormField._from_generated_unlabeled(field, idx, page.page, read_result)
                             for idx, field in enumerate(page.key_value_pairs)] if page.key_value_pairs else None
         if unlabeled_fields:
@@ -138,7 +138,7 @@ def prepare_unlabeled_result(response):
             ),
             fields=unlabeled_fields,
             form_type="form-" + str(page.cluster_id) if page.cluster_id is not None else None,
-            pages=[form_pages[page.page-1]]
+            pages=[form_pages[idx]]
         )
         result.append(form)
 


### PR DESCRIPTION
Handle indexing into pages better since an open service bug can generate off-by-1 errors with pages and json pointer resolving.

See related issue: #11014 