### PR TITLE
updating setup template

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/templates/setup.py
+++ b/tools/azure-sdk-tools/packaging_tools/templates/setup.py
@@ -36,7 +36,10 @@ except ImportError:
     pass
 
 # Version extraction inspired from 'requests'
-with open(os.path.join(package_folder_path, 'version.py'), 'r') as fd:
+# Version extraction inspired from 'requests'
+with open(os.path.join(package_folder_path, 'version.py') 
+          if os.path.exists(os.path.join(package_folder_path, 'version.py'))
+          else os.path.join(package_folder_path, '_version.py'), 'r') as fd:
     version = re.search(r'^VERSION\s*=\s*[\'"]([^\'"]*)[\'"]',
                         fd.read(), re.MULTILINE).group(1)
 


### PR DESCRIPTION
Track2 SDK has renamed version.py -> _version.py
Setup script must be able to handle both scenarios.