### PR TITLE
Initial proposal for auto-complete on the receiver.  

### DIFF
--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -1202,3 +1202,39 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
         receiver = sb_client.get_queue_receiver(queue_name="mock")
         assert receiver._config.http_proxy == http_proxy
         assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
+
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest')
+    def test_queue_by_servicebus_conn_str_autocomplete(self, servicebus_namespace_connection_string, servicebus_queue, **kwargs):
+     
+        with ServiceBusClient.from_connection_string(
+            servicebus_namespace_connection_string, logging_enable=False) as sb_client:
+            
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message = Message("Test Message")
+                sender.send(message)
+    
+            with sb_client.get_queue_receiver(servicebus_queue.name, idle_timeout=1, auto_complete=True) as receiver:
+                try:
+                    for message in receiver:
+                        print_message(_logger, message)
+                        raise Exception("Intentional Failure to trigger auto-abandon.")
+                except Exception as e:
+                    print(e)
+                    pass
+
+            with sb_client.get_queue_receiver(servicebus_queue.name, idle_timeout=5, auto_complete=True) as receiver:
+                count = 0
+                for message in receiver:
+                    print_message(_logger, message)
+                    count += 1
+                assert count==1
+
+            with sb_client.get_queue_receiver(servicebus_queue.name, idle_timeout=5, prefetch=0, auto_complete=True) as receiver:
+                #should auto complete this time.
+                remaining_messages = receiver.receive()
+                assert len(remaining_messages) == 0


### PR DESCRIPTION
One of two ways I see to do this, the other being a context-manager helper ala `with AutoComplete(message):`  (or even off of the message, such as`with message.auto_completer`)

This current idea has the pitfall of only working for push-based.  The latter has an issue wherein it requires an additional scope and concept, and only saves a try/except block.  A lot of me likes the latter, simpler approach, since it works more generically as a helper, although it offers less sugar.  (I intentionally only implemented the former for sync to avoid throwaway work if we don't go this route)