### PR TITLE
Pin astroid to 2.3.3 to fix pylint failure

### DIFF
--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -20,5 +20,10 @@ packaging==20.3
 wheel==0.34.2
 Jinja2==2.11.1
 
+# Locking pylint and required packages
+pylint==2.3.1; python_version >= '3.4'
+pylint==1.8.4; python_version < '3.4'
+astroid==2.3.3; python_version >= '3.4'
+
 ../../../tools/azure-devtools
 ../../../tools/azure-sdk-tools

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -54,8 +54,6 @@ usedevelop = true
 changedir = {toxinidir}
 deps =
   {[base]deps}
-  pylint==2.3.1; python_version >= '3.4'
-  pylint==1.8.4; python_version < '3.4'
   -e {toxinidir}/../../scripts/pylint_custom_plugin
 commands = 
     {envbindir}/python {toxinidir}/../../../eng/tox/run_pylint.py -t {toxinidir}


### PR DESCRIPTION
pylint requires astroid package. We have already pinned pylint to 2.3.1 but it's required package ``astroid`` has a new version released yesterday and cause CI failures. This PR will pin ``astroid`` package to 2.3.3 to fix this issue.