### PR TITLE
Split Search Service Client

### DIFF
--- a/sdk/search/azure-search-documents/README.md
+++ b/sdk/search/azure-search-documents/README.md
@@ -36,7 +36,6 @@ Install the Azure Cognitive Search client library for Python with [pip](https://
 pip install azure-search-documents --pre
 ```
 
-
 ### Authenticate the client
 
 In order to interact with the Cognitive Search service you'll need to create an instance of the Search Client class.
@@ -53,6 +52,7 @@ To create a SearchClient, you will need an existing index name as well as the va
 [service endpoint](https://docs.microsoft.com/en-us/azure/search/search-create-service-portal#get-a-key-and-url-endpoint) and
 [api key](https://docs.microsoft.com/en-us/azure/search/search-security-api-keys).
 Note that you will need an admin key to index documents (query keys only work for queries).
+
 
 ```python
 from azure.core.credentials import AzureKeyCredential
@@ -102,8 +102,7 @@ Create a new index
 ```python
 from azure.core.credentials import AzureKeyCredential
 from azure.search.documents import SearchServiceClient, CorsOptions, Index, ScoringProfile
-client = SearchServiceClient("<service endpoint>", AzureKeyCredential("<api key>"))
-
+client = SearchServiceClient("<service endpoint>", AzureKeyCredential("<api key>")).get_indexes_client()
 name = "hotels"
 fields = [
     {

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_datasources_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_datasources_client.py
@@ -48,7 +48,7 @@ class SearchDataSourcesClient(HeadersMixin):
 
     def close(self):
         # type: () -> None
-        """Close the :class:`~azure.search.documents.DataSourcesClient` session.
+        """Close the :class:`~azure.search.documents.SearchDataSourcesClient` session.
 
         """
         return self._client.close()

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_datasources_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_datasources_client.py
@@ -1,0 +1,164 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from typing import TYPE_CHECKING
+
+from azure.core.tracing.decorator import distributed_trace
+
+from ._generated import SearchServiceClient as _SearchServiceClient
+from .._headers_mixin import HeadersMixin
+from .._version import SDK_MONIKER
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import,ungrouped-imports
+    from ._generated.models import DataSource
+    from typing import Any, Dict, Optional, Sequence
+    from azure.core.credentials import AzureKeyCredential
+
+
+class SearchDataSourcesClient(HeadersMixin):
+    """A client to interact with Azure search service Data Sources.
+
+    This class is not normally instantiated directly, instead use
+    `get_datasources_client()` from a `SearchServiceClient`
+
+    """
+
+    _ODATA_ACCEPT = "application/json;odata.metadata=minimal"  # type: str
+
+    def __init__(self, endpoint, credential, **kwargs):
+        # type: (str, AzureKeyCredential, **Any) -> None
+
+        self._endpoint = endpoint  # type: str
+        self._credential = credential  # type: AzureKeyCredential
+        self._client = _SearchServiceClient(
+            endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
+        )  # type: _SearchServiceClient
+
+    def __enter__(self):
+        # type: () -> SearchDataSourcesClient
+        self._client.__enter__()  # pylint:disable=no-member
+        return self
+
+    def __exit__(self, *args):
+        # type: (*Any) -> None
+        return self._client.__exit__(*args)  # pylint:disable=no-member
+
+    def close(self):
+        # type: () -> None
+        """Close the :class:`~azure.search.documents.DataSourcesClient` session.
+
+        """
+        return self._client.close()
+
+    @distributed_trace
+    def create_datasource(self, data_source, **kwargs):
+        # type: (DataSource, **Any) -> Dict[str, Any]
+        """Creates a new datasource.
+
+        :param data_source: The definition of the datasource to create.
+        :type data_source: ~search.models.DataSource
+        :return: The created DataSource
+        :rtype: dict
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_data_source_operations.py
+                :start-after: [START create_data_source]
+                :end-before: [END create_data_source]
+                :language: python
+                :dedent: 4
+                :caption: Create a Data Source
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = self._client.data_sources.create(data_source, **kwargs)
+        return result
+
+    @distributed_trace
+    def create_or_update_datasource(self, data_source, name=None, **kwargs):
+        # type: (DataSource, Optional[str], **Any) -> Dict[str, Any]
+        """Creates a new datasource or updates a datasource if it already exists.
+
+        :param name: The name of the datasource to create or update.
+        :type name: str
+        :param data_source: The definition of the datasource to create or update.
+        :type data_source: ~search.models.DataSource
+        :return: The created DataSource
+        :rtype: dict
+        """
+        # TODO: access_condition
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+
+        if not name:
+            name = data_source.name
+        result = self._client.data_sources.create_or_update(name, data_source, **kwargs)
+        return result
+
+    @distributed_trace
+    def get_datasource(self, name, **kwargs):
+        # type: (str, **Any) -> Dict[str, Any]
+        """Retrieves a datasource definition.
+
+        :param name: The name of the datasource to retrieve.
+        :type name: str
+        :return: The DataSource that is fetched.
+        :rtype: dict
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_data_source_operations.py
+                :start-after: [START get_data_source]
+                :end-before: [END get_data_source]
+                :language: python
+                :dedent: 4
+                :caption: Retrieve a DataSource
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = self._client.data_sources.get(name, **kwargs)
+        return result
+
+    @distributed_trace
+    def get_datasources(self, **kwargs):
+        # type: (**Any) -> Sequence[DataSource]
+        """Lists all datasources available for a search service.
+
+        :return: List of all the data sources.
+        :rtype: `list[dict]`
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_data_source_operations.py
+                :start-after: [START list_data_source]
+                :end-before: [END list_data_source]
+                :language: python
+                :dedent: 4
+                :caption: List all the DataSources
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = self._client.data_sources.list(**kwargs)
+        return result.data_sources
+
+    @distributed_trace
+    def delete_datasource(self, name, **kwargs):
+        # type: (str, **Any) -> None
+        """Deletes a datasource.
+
+        :param name: The name of the datasource to delete.
+        :type name: str
+
+        :return: None
+        :rtype: None
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_data_source_operations.py
+                :start-after: [START delete_data_source]
+                :end-before: [END delete_data_source]
+                :language: python
+                :dedent: 4
+                :caption: Delete a DataSource
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        self._client.data_sources.delete(name, **kwargs)

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_indexes_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_indexes_client.py
@@ -1,0 +1,266 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from typing import TYPE_CHECKING
+
+from azure.core.tracing.decorator import distributed_trace
+from azure.core import MatchConditions
+from azure.core.exceptions import (
+    ResourceExistsError,
+    ResourceNotFoundError,
+    ResourceModifiedError,
+    ResourceNotModifiedError,
+)
+
+from ._generated import SearchServiceClient as _SearchServiceClient
+from ._generated.models import AccessCondition
+from ._utils import (
+    delistize_flags_for_index,
+    listize_flags_for_index,
+    prep_if_match,
+    prep_if_none_match,
+)
+from .._headers_mixin import HeadersMixin
+from .._version import SDK_MONIKER
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import,ungrouped-imports
+    from ._generated.models import AnalyzeRequest, AnalyzeResult, Index
+    from typing import Any, Dict, List
+    from azure.core.credentials import AzureKeyCredential
+
+
+class SearchIndexesClient(HeadersMixin):
+    """A client to interact with Azure search service Indexes.
+
+    This class is not normally instantiated directly, instead use
+    `get_skillsets_client()` from a `SearchServiceClient`
+
+    """
+
+    _ODATA_ACCEPT = "application/json;odata.metadata=minimal"  # type: str
+
+    def __init__(self, endpoint, credential, **kwargs):
+        # type: (str, AzureKeyCredential, **Any) -> None
+
+        self._endpoint = endpoint  # type: str
+        self._credential = credential  # type: AzureKeyCredential
+        self._client = _SearchServiceClient(
+            endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
+        )  # type: _SearchServiceClient
+
+    def __enter__(self):
+        # type: () -> SearchIndexesClient
+        self._client.__enter__()  # pylint:disable=no-member
+        return self
+
+    def __exit__(self, *args):
+        # type: (*Any) -> None
+        return self._client.__exit__(*args)  # pylint:disable=no-member
+
+    def close(self):
+        # type: () -> None
+        """Close the :class:`~azure.search.documents.SearchIndexesClient` session.
+
+        """
+        return self._client.close()
+
+    @distributed_trace
+    def get_indexes(self, **kwargs):
+        # type: (**Any) -> List[Index]
+        """List the indexes in an Azure Search service.
+
+        :return: List of indexes
+        :rtype: list[~azure.search.documents.Index]
+        :raises: ~azure.core.exceptions.HttpResponseError
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = self._client.indexes.list(**kwargs)
+        indexes = [listize_flags_for_index(x) for x in result.indexes]
+        return indexes
+
+    @distributed_trace
+    def get_index(self, index_name, **kwargs):
+        # type: (str, **Any) -> Index
+        """
+
+        :param index_name: The name of the index to retrieve.
+        :type index_name: str
+        :return: Index object
+        :rtype: ~azure.search.documents.Index
+        :raises: ~azure.core.exceptions.HttpResponseError
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_index_crud_operations.py
+                :start-after: [START get_index]
+                :end-before: [END get_index]
+                :language: python
+                :dedent: 4
+                :caption: Get an index.
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = self._client.indexes.get(index_name, **kwargs)
+        return listize_flags_for_index(result)
+
+    @distributed_trace
+    def get_index_statistics(self, index_name, **kwargs):
+        # type: (str, **Any) -> dict
+        """Returns statistics for the given index, including a document count
+        and storage usage.
+
+        :param index_name: The name of the index to retrieve.
+        :type index_name: str
+        :return: Statistics for the given index, including a document count and storage usage.
+        :rtype: ~azure.search.documents.GetIndexStatisticsResult
+        :raises: ~azure.core.exceptions.HttpResponseError
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = self._client.indexes.get_statistics(index_name, **kwargs)
+        return result.as_dict()
+
+    @distributed_trace
+    def delete_index(self, index_name, **kwargs):
+        # type: (str, **Any) -> None
+        """Deletes a search index and all the documents it contains.
+
+        :param index_name: The name of the index to retrieve.
+        :type index_name: str
+        :raises: ~azure.core.exceptions.HttpResponseError
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_index_crud_operations.py
+                :start-after: [START delete_index]
+                :end-before: [END delete_index]
+                :language: python
+                :dedent: 4
+                :caption: Delete an index.
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        self._client.indexes.delete(index_name, **kwargs)
+
+    @distributed_trace
+    def create_index(self, index, **kwargs):
+        # type: (Index, **Any) -> Index
+        """Creates a new search index.
+
+        :param index: The index object.
+        :type index: ~azure.search.documents.Index
+        :return: The index created
+        :rtype: ~azure.search.documents.Index
+        :raises: ~azure.core.exceptions.HttpResponseError
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_index_crud_operations.py
+                :start-after: [START create_index]
+                :end-before: [END create_index]
+                :language: python
+                :dedent: 4
+                :caption: Creating a new index.
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        patched_index = delistize_flags_for_index(index)
+        result = self._client.indexes.create(patched_index, **kwargs)
+        return result
+
+    @distributed_trace
+    def create_or_update_index(
+        self,
+        index_name,
+        index,
+        allow_index_downtime=None,
+        match_condition=MatchConditions.Unconditionally,
+        **kwargs
+    ):
+        # type: (str, Index, bool, MatchConditions, **Any) -> Index
+        """Creates a new search index or updates an index if it already exists.
+
+        :param index_name: The name of the index.
+        :type index_name: str
+        :param index: The index object.
+        :type index: ~azure.search.documents.Index
+        :param allow_index_downtime: Allows new analyzers, tokenizers, token filters, or char filters
+         to be added to an index by taking the index offline for at least a few seconds. This
+         temporarily causes indexing and query requests to fail. Performance and write availability of
+         the index can be impaired for several minutes after the index is updated, or longer for very
+         large indexes.
+        :type allow_index_downtime: bool
+        :param match_condition: The match condition to use upon the etag
+        :type match_condition: ~azure.core.MatchConditions
+        :return: The index created or updated
+        :rtype: :class:`~azure.search.documents.Index`
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError`, \
+        :class:`~azure.core.exceptions.ResourceModifiedError`, \
+        :class:`~azure.core.exceptions.ResourceNotModifiedError`, \
+        :class:`~azure.core.exceptions.ResourceNotFoundError`, \
+        :class:`~azure.core.exceptions.ResourceExistsError`
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_index_crud_operations.py
+                :start-after: [START update_index]
+                :end-before: [END update_index]
+                :language: python
+                :dedent: 4
+                :caption: Update an index.
+        """
+        error_map = {404: ResourceNotFoundError}  # type: Dict[int, Any]
+        access_condition = None
+        if index.e_tag:
+            access_condition = AccessCondition()
+            access_condition.if_match = prep_if_match(index.e_tag, match_condition)
+            access_condition.if_none_match = prep_if_none_match(
+                index.e_tag, match_condition
+            )
+        if match_condition == MatchConditions.IfNotModified:
+            error_map[412] = ResourceModifiedError
+        if match_condition == MatchConditions.IfModified:
+            error_map[304] = ResourceNotModifiedError
+        if match_condition == MatchConditions.IfPresent:
+            error_map[412] = ResourceNotFoundError
+        if match_condition == MatchConditions.IfMissing:
+            error_map[412] = ResourceExistsError
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        patched_index = delistize_flags_for_index(index)
+        result = self._client.indexes.create_or_update(
+            index_name=index_name,
+            index=patched_index,
+            allow_index_downtime=allow_index_downtime,
+            access_condition=access_condition,
+            **kwargs
+        )
+        return result
+
+    @distributed_trace
+    def analyze_text(self, index_name, analyze_request, **kwargs):
+        # type: (str, AnalyzeRequest, **Any) -> AnalyzeResult
+        """Shows how an analyzer breaks text into tokens.
+
+        :param index_name: The name of the index for which to test an analyzer.
+        :type index_name: str
+        :param analyze_request: The text and analyzer or analysis components to test.
+        :type analyze_request: ~azure.search.documents.AnalyzeRequest
+        :return: AnalyzeResult
+        :rtype: ~azure.search.documents.AnalyzeResult
+        :raises: ~azure.core.exceptions.HttpResponseError
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_analyze_text.py
+                :start-after: [START simple_analyze_text]
+                :end-before: [END simple_analyze_text]
+                :language: python
+                :dedent: 4
+                :caption: Analyze text
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = self._client.indexes.analyze(
+            index_name=index_name, request=analyze_request, **kwargs
+        )
+        return result

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_models.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_models.py
@@ -3,10 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-from ._generated.models import (
-    Analyzer,
-    Tokenizer
-)
+from ._generated.models import Analyzer, Tokenizer
 
 
 class PatternAnalyzer(Analyzer):

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client.py
@@ -18,6 +18,7 @@ from ._generated.models import AccessCondition, Skillset, SynonymMap
 from .._headers_mixin import HeadersMixin
 from .._version import SDK_MONIKER
 from ._datasources_client import SearchDataSourcesClient
+from ._skillsets_client import SearchSkillsetsClient
 from ._utils import (
     delistize_flags_for_index,
     listize_flags_for_index,
@@ -62,6 +63,8 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
         self._client = _SearchServiceClient(
             endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
         )  # type: _SearchServiceClient
+
+        self._skillsets_client = SearchSkillsetsClient(endpoint, credential, **kwargs)
 
         self._datasources_client = SearchDataSourcesClient(
             endpoint, credential, **kwargs
@@ -418,152 +421,20 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
         result = self._client.synonym_maps.create_or_update(name, synonym_map, **kwargs)
         return listize_synonyms(result.as_dict())
 
-    # Skillset Operations
+    def get_skillsets_client(self):
+        # type: () -> SearchSkillsetsClient
+        """Return a client to perform operations on Skillsets.
 
-    @distributed_trace
-    def get_skillsets(self, **kwargs):
-        # type: (**Any) -> List[Skillset]
-        """List the Skillsets in an Azure Search service.
-
-        :return: List of Skillsets
-        :rtype: list[dict]
-        :raises: ~azure.core.exceptions.HttpResponseError
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/sample_skillset_operations.py
-                :start-after: [START get_skillsets]
-                :end-before: [END get_skillsets]
-                :language: python
-                :dedent: 4
-                :caption: List Skillsets
-
+        :return: The Skillsets client
+        :rtype: SearchSkillsetClient
         """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = self._client.skillsets.list(**kwargs)
-        return result.skillsets
+        return self._skillsets_client
 
-    @distributed_trace
-    def get_skillset(self, name, **kwargs):
-        # type: (str, **Any) -> Skillset
-        """Retrieve a named Skillset in an Azure Search service
-
-        :param name: The name of the Skillset to get
-        :type name: str
-        :return: The retrieved Skillset
-        :rtype: dict
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError`
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/sample_skillset_operations.py
-                :start-after: [START get_skillset]
-                :end-before: [END get_skillset]
-                :language: python
-                :dedent: 4
-                :caption: Get a Skillset
-
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        return self._client.skillsets.get(name, **kwargs)
-
-    @distributed_trace
-    def delete_skillset(self, name, **kwargs):
-        # type: (str, **Any) -> None
-        """Delete a named Skillset in an Azure Search service
-
-        :param name: The name of the Skillset to delete
-        :type name: str
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/sample_skillset_operations.py
-                :start-after: [START delete_skillset]
-                :end-before: [END delete_skillset]
-                :language: python
-                :dedent: 4
-                :caption: Delete a Skillset
-
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        self._client.skillsets.delete(name, **kwargs)
-
-    @distributed_trace
-    def create_skillset(self, name, skills, description, **kwargs):
-        # type: (str, Sequence[Skill], str, **Any) -> Skillset
-        """Create a new Skillset in an Azure Search service
-
-        :param name: The name of the Skillset to create
-        :type name: str
-        :param skills: A list of Skill objects to include in the Skillset
-        :type skills: List[Skill]]
-        :param description: A description for the Skillset
-        :type description: Optional[str]
-        :return: The created Skillset
-        :rtype: dict
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/sample_skillset_operations.py
-                :start-after: [START create_skillset]
-                :end-before: [END create_skillset]
-                :language: python
-                :dedent: 4
-                :caption: Create a Skillset
-
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-
-        skillset = Skillset(name=name, skills=list(skills), description=description)
-
-        return self._client.skillsets.create(skillset, **kwargs)
-
-    @distributed_trace
-    def create_or_update_skillset(self, name, **kwargs):
-        # type: (str, **Any) -> Skillset
-        """Create a new Skillset in an Azure Search service, or update an
-        existing one.
-
-        A `Skillset` object mat
-
-        :param name: The name of the Skillset to create or update
-        :type name: str
-        :param skills: A list of Skill objects to include in the Skillset
-        :type skills: List[Skill]
-        :param description: A description for the Skillset
-        :type description: Optional[str]
-        :param skillset: A Skillset to create or update.
-        :type skillset: :class:`~azure.search.documents.Skillset`
-        :return: The created or updated Skillset
-        :rtype: dict
-
-        If a `skillset` is passed in, any optional `skills`, or
-        `description` parameter values will override it.
-
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-
-        if "skillset" in kwargs:
-            skillset = kwargs.pop("skillset")
-            skillset = Skillset.deserialize(skillset.serialize())
-            skillset.name = name
-            for param in ("description", "skills"):
-                if param in kwargs:
-                    setattr(skillset, param, kwargs.pop(param))
-        else:
-
-            skillset = Skillset(
-                name=name,
-                description=kwargs.pop("description", None),
-                skills=kwargs.pop("skills", None),
-            )
-
-        return self._client.skillsets.create_or_update(name, skillset, **kwargs)
-
-    def get_datasources_client(self) -> SearchDataSourcesClient:
+    def get_datasources_client(self):
+        # type: () -> SearchDataSourcesClient
         """Return a client to perform operations on Data Sources.
 
         :return: The Data Sources client
-        :rtype: DataSourcesClient
+        :rtype: SearchDataSourcesClient
         """
         return self._datasources_client

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client.py
@@ -14,15 +14,15 @@ from azure.core.exceptions import (
     ResourceNotModifiedError,
 )
 from ._generated import SearchServiceClient as _SearchServiceClient
-from ._generated.models import AccessCondition, Skillset, SynonymMap
+from ._generated.models import AccessCondition
 from .._headers_mixin import HeadersMixin
 from .._version import SDK_MONIKER
 from ._datasources_client import SearchDataSourcesClient
 from ._skillsets_client import SearchSkillsetsClient
+from ._synonym_maps_client import SearchSynonymMapsClient
 from ._utils import (
     delistize_flags_for_index,
     listize_flags_for_index,
-    listize_synonyms,
     prep_if_match,
     prep_if_none_match,
 )
@@ -63,6 +63,10 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
         self._client = _SearchServiceClient(
             endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
         )  # type: _SearchServiceClient
+
+        self._synonym_maps_client = SearchSynonymMapsClient(
+            endpoint, credential, **kwargs
+        )
 
         self._skillsets_client = SearchSkillsetsClient(endpoint, credential, **kwargs)
 
@@ -302,124 +306,14 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
         )
         return result
 
-    # Synonym Maps Operations
+    def get_synonym_maps_client(self):
+        # type: () -> SearchSynonymMapsClient
+        """Return a client to perform operations on Synonym Maps.
 
-    @distributed_trace
-    def get_synonym_maps(self, **kwargs):
-        # type: (**Any) -> List[Dict[Any, Any]]
-        """List the Synonym Maps in an Azure Search service.
-
-        :return: List of synonym maps
-        :rtype: list[dict]
-        :raises: ~azure.core.exceptions.HttpResponseError
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/sample_synonym_map_operations.py
-                :start-after: [START get_synonym_maps]
-                :end-before: [END get_synonym_maps]
-                :language: python
-                :dedent: 4
-                :caption: List Synonym Maps
-
+        :return: The Synonym Maps client
+        :rtype: SearchSynonymMapsClient
         """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = self._client.synonym_maps.list(**kwargs)
-        return [listize_synonyms(x) for x in result.as_dict()["synonym_maps"]]
-
-    @distributed_trace
-    def get_synonym_map(self, name, **kwargs):
-        # type: (str, **Any) -> dict
-        """Retrieve a named Synonym Map in an Azure Search service
-
-        :param name: The name of the Synonym Map to get
-        :type name: str
-        :return: The retrieved Synonym Map
-        :rtype: dict
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError`
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/sample_synonym_map_operations.py
-                :start-after: [START get_synonym_map]
-                :end-before: [END get_synonym_map]
-                :language: python
-                :dedent: 4
-                :caption: Get a Synonym Map
-
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = self._client.synonym_maps.get(name, **kwargs)
-        return listize_synonyms(result.as_dict())
-
-    @distributed_trace
-    def delete_synonym_map(self, name, **kwargs):
-        # type: (str, **Any) -> None
-        """Delete a named Synonym Map in an Azure Search service
-
-        :param name: The name of the Synonym Map to delete
-        :type name: str
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/sample_synonym_map_operations.py
-                :start-after: [START delete_synonym_map]
-                :end-before: [END delete_synonym_map]
-                :language: python
-                :dedent: 4
-                :caption: Delete a Synonym Map
-
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        self._client.synonym_maps.delete(name, **kwargs)
-
-    @distributed_trace
-    def create_synonym_map(self, name, synonyms, **kwargs):
-        # type: (str, Sequence[str], **Any) -> dict
-        """Create a new Synonym Map in an Azure Search service
-
-        :param name: The name of the Synonym Map to create
-        :type name: str
-        :param synonyms: The list of synonyms in SOLR format
-        :type synonyms: List[str]
-        :return: The created Synonym Map
-        :rtype: dict
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/sample_synonym_map_operations.py
-                :start-after: [START create_synonym_map]
-                :end-before: [END create_synonym_map]
-                :language: python
-                :dedent: 4
-                :caption: Create a Synonym Map
-
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        solr_format_synonyms = "\n".join(synonyms)
-        synonym_map = SynonymMap(name=name, synonyms=solr_format_synonyms)
-        result = self._client.synonym_maps.create(synonym_map, **kwargs)
-        return listize_synonyms(result.as_dict())
-
-    @distributed_trace
-    def create_or_update_synonym_map(self, name, synonyms, **kwargs):
-        # type: (str, Sequence[str], **Any) -> dict
-        """Create a new Synonym Map in an Azure Search service, or update an
-        existing one.
-
-        :param name: The name of the Synonym Map to create or update
-        :type name: str
-        :param synonyms: A list of synonyms in SOLR format
-        :type synonyms: List[str]
-        :return: The created or updated Synonym Map
-        :rtype: dict
-
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        solr_format_synonyms = "\n".join(synonyms)
-        synonym_map = SynonymMap(name=name, synonyms=solr_format_synonyms)
-        result = self._client.synonym_maps.create_or_update(name, synonym_map, **kwargs)
-        return listize_synonyms(result.as_dict())
+        return self._synonym_maps_client
 
     def get_skillsets_client(self):
         # type: () -> SearchSkillsetsClient

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client.py
@@ -6,33 +6,19 @@
 from typing import TYPE_CHECKING
 
 from azure.core.tracing.decorator import distributed_trace
-from azure.core import MatchConditions
-from azure.core.exceptions import (
-    ResourceExistsError,
-    ResourceNotFoundError,
-    ResourceModifiedError,
-    ResourceNotModifiedError,
-)
+
 from ._generated import SearchServiceClient as _SearchServiceClient
-from ._generated.models import AccessCondition
 from .._headers_mixin import HeadersMixin
 from .._version import SDK_MONIKER
 from ._datasources_client import SearchDataSourcesClient
+from ._indexes_client import SearchIndexesClient
 from ._skillsets_client import SearchSkillsetsClient
 from ._synonym_maps_client import SearchSynonymMapsClient
-from ._utils import (
-    delistize_flags_for_index,
-    listize_flags_for_index,
-    prep_if_match,
-    prep_if_none_match,
-)
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
     from typing import Any, Dict, List, Optional, Sequence
     from azure.core.credentials import AzureKeyCredential
-    from ._generated.models import Skill, DataSource
-    from .. import Index, AnalyzeResult, AnalyzeRequest
 
 
 class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-methods
@@ -64,6 +50,8 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
             endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
         )  # type: _SearchServiceClient
 
+        self._indexes_client = SearchIndexesClient(endpoint, credential, **kwargs)
+
         self._synonym_maps_client = SearchSynonymMapsClient(
             endpoint, credential, **kwargs
         )
@@ -94,8 +82,6 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
         """
         return self._client.close()
 
-    ### Service Operations
-
     @distributed_trace
     def get_service_statistics(self, **kwargs):
         # type: (**Any) -> dict
@@ -106,205 +92,14 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
         result = self._client.get_service_statistics(**kwargs)
         return result.as_dict()
 
-    ### Index Operations
+    def get_indexes_client(self):
+        # type: () -> SearchIndexesClient
+        """Return a client to perform operations on Search Indexes.
 
-    @distributed_trace
-    def get_indexes(self, **kwargs):
-        # type: (**Any) -> List[Index]
-        """List the indexes in an Azure Search service.
-
-        :return: List of indexes
-        :rtype: list[~azure.search.documents.Index]
-        :raises: ~azure.core.exceptions.HttpResponseError
-
+        :return: The Search Indexes client
+        :rtype: SearchIndexesClient
         """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = self._client.indexes.list(**kwargs)
-        indexes = [listize_flags_for_index(x) for x in result.indexes]
-        return indexes
-
-    @distributed_trace
-    def get_index(self, index_name, **kwargs):
-        # type: (str, **Any) -> Index
-        """
-
-        :param index_name: The name of the index to retrieve.
-        :type index_name: str
-        :return: Index object
-        :rtype: ~azure.search.documents.Index
-        :raises: ~azure.core.exceptions.HttpResponseError
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/sample_index_crud_operations.py
-                :start-after: [START get_index]
-                :end-before: [END get_index]
-                :language: python
-                :dedent: 4
-                :caption: Get an index.
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = self._client.indexes.get(index_name, **kwargs)
-        return listize_flags_for_index(result)
-
-    @distributed_trace
-    def get_index_statistics(self, index_name, **kwargs):
-        # type: (str, **Any) -> dict
-        """Returns statistics for the given index, including a document count
-        and storage usage.
-
-        :param index_name: The name of the index to retrieve.
-        :type index_name: str
-        :return: Statistics for the given index, including a document count and storage usage.
-        :rtype: ~azure.search.documents.GetIndexStatisticsResult
-        :raises: ~azure.core.exceptions.HttpResponseError
-
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = self._client.indexes.get_statistics(index_name, **kwargs)
-        return result.as_dict()
-
-    @distributed_trace
-    def delete_index(self, index_name, **kwargs):
-        # type: (str, **Any) -> None
-        """Deletes a search index and all the documents it contains.
-
-        :param index_name: The name of the index to retrieve.
-        :type index_name: str
-        :raises: ~azure.core.exceptions.HttpResponseError
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/sample_index_crud_operations.py
-                :start-after: [START delete_index]
-                :end-before: [END delete_index]
-                :language: python
-                :dedent: 4
-                :caption: Delete an index.
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        self._client.indexes.delete(index_name, **kwargs)
-
-    @distributed_trace
-    def create_index(self, index, **kwargs):
-        # type: (Index, **Any) -> Index
-        """Creates a new search index.
-
-        :param index: The index object.
-        :type index: ~azure.search.documents.Index
-        :return: The index created
-        :rtype: ~azure.search.documents.Index
-        :raises: ~azure.core.exceptions.HttpResponseError
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/sample_index_crud_operations.py
-                :start-after: [START create_index]
-                :end-before: [END create_index]
-                :language: python
-                :dedent: 4
-                :caption: Creating a new index.
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        patched_index = delistize_flags_for_index(index)
-        result = self._client.indexes.create(patched_index, **kwargs)
-        return result
-
-    @distributed_trace
-    def create_or_update_index(
-        self,
-        index_name,
-        index,
-        allow_index_downtime=None,
-        match_condition=MatchConditions.Unconditionally,
-        **kwargs
-    ):
-        # type: (str, Index, bool, MatchConditions, **Any) -> Index
-        """Creates a new search index or updates an index if it already exists.
-
-        :param index_name: The name of the index.
-        :type index_name: str
-        :param index: The index object.
-        :type index: ~azure.search.documents.Index
-        :param allow_index_downtime: Allows new analyzers, tokenizers, token filters, or char filters
-         to be added to an index by taking the index offline for at least a few seconds. This
-         temporarily causes indexing and query requests to fail. Performance and write availability of
-         the index can be impaired for several minutes after the index is updated, or longer for very
-         large indexes.
-        :type allow_index_downtime: bool
-        :param match_condition: The match condition to use upon the etag
-        :type match_condition: ~azure.core.MatchConditions
-        :return: The index created or updated
-        :rtype: :class:`~azure.search.documents.Index`
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError`, \
-        :class:`~azure.core.exceptions.ResourceModifiedError`, \
-        :class:`~azure.core.exceptions.ResourceNotModifiedError`, \
-        :class:`~azure.core.exceptions.ResourceNotFoundError`, \
-        :class:`~azure.core.exceptions.ResourceExistsError`
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/sample_index_crud_operations.py
-                :start-after: [START update_index]
-                :end-before: [END update_index]
-                :language: python
-                :dedent: 4
-                :caption: Update an index.
-        """
-        error_map = {404: ResourceNotFoundError}  # type: Dict[int, Any]
-        access_condition = None
-        if index.e_tag:
-            access_condition = AccessCondition()
-            access_condition.if_match = prep_if_match(index.e_tag, match_condition)
-            access_condition.if_none_match = prep_if_none_match(
-                index.e_tag, match_condition
-            )
-        if match_condition == MatchConditions.IfNotModified:
-            error_map[412] = ResourceModifiedError
-        if match_condition == MatchConditions.IfModified:
-            error_map[304] = ResourceNotModifiedError
-        if match_condition == MatchConditions.IfPresent:
-            error_map[412] = ResourceNotFoundError
-        if match_condition == MatchConditions.IfMissing:
-            error_map[412] = ResourceExistsError
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        patched_index = delistize_flags_for_index(index)
-        result = self._client.indexes.create_or_update(
-            index_name=index_name,
-            index=patched_index,
-            allow_index_downtime=allow_index_downtime,
-            access_condition=access_condition,
-            **kwargs
-        )
-        return result
-
-    @distributed_trace
-    def analyze_text(self, index_name, analyze_request, **kwargs):
-        # type: (str, AnalyzeRequest, **Any) -> AnalyzeResult
-        """Shows how an analyzer breaks text into tokens.
-
-        :param index_name: The name of the index for which to test an analyzer.
-        :type index_name: str
-        :param analyze_request: The text and analyzer or analysis components to test.
-        :type analyze_request: ~azure.search.documents.AnalyzeRequest
-        :return: AnalyzeResult
-        :rtype: ~azure.search.documents.AnalyzeResult
-        :raises: ~azure.core.exceptions.HttpResponseError
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/sample_analyze_text.py
-                :start-after: [START simple_analyze_text]
-                :end-before: [END simple_analyze_text]
-                :language: python
-                :dedent: 4
-                :caption: Analyze text
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = self._client.indexes.analyze(
-            index_name=index_name, request=analyze_request, **kwargs
-        )
-        return result
+        return self._indexes_client
 
     def get_synonym_maps_client(self):
         # type: () -> SearchSynonymMapsClient

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_skillsets_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_skillsets_client.py
@@ -49,7 +49,7 @@ class SearchSkillsetsClient(HeadersMixin):
 
     def close(self):
         # type: () -> None
-        """Close the :class:`~azure.search.documents.DataSourcesClient` session.
+        """Close the :class:`~azure.search.documents.SearchSkillsetsClient` session.
 
         """
         return self._client.close()

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_skillsets_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_skillsets_client.py
@@ -1,0 +1,195 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from typing import TYPE_CHECKING
+
+from azure.core.tracing.decorator import distributed_trace
+
+from ._generated import SearchServiceClient as _SearchServiceClient
+from ._generated.models import Skillset
+from .._headers_mixin import HeadersMixin
+from .._version import SDK_MONIKER
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import,ungrouped-imports
+    from ._generated.models import Skill
+    from typing import Any, List, Sequence
+    from azure.core.credentials import AzureKeyCredential
+
+
+class SearchSkillsetsClient(HeadersMixin):
+    """A client to interact with Azure search service Skillsets.
+
+    This class is not normally instantiated directly, instead use
+    `get_skillsets_client()` from a `SearchServiceClient`
+
+    """
+
+    _ODATA_ACCEPT = "application/json;odata.metadata=minimal"  # type: str
+
+    def __init__(self, endpoint, credential, **kwargs):
+        # type: (str, AzureKeyCredential, **Any) -> None
+
+        self._endpoint = endpoint  # type: str
+        self._credential = credential  # type: AzureKeyCredential
+        self._client = _SearchServiceClient(
+            endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
+        )  # type: _SearchServiceClient
+
+    def __enter__(self):
+        # type: () -> SearchSkillsetsClient
+        self._client.__enter__()  # pylint:disable=no-member
+        return self
+
+    def __exit__(self, *args):
+        # type: (*Any) -> None
+        return self._client.__exit__(*args)  # pylint:disable=no-member
+
+    def close(self):
+        # type: () -> None
+        """Close the :class:`~azure.search.documents.DataSourcesClient` session.
+
+        """
+        return self._client.close()
+
+    @distributed_trace
+    def get_skillsets(self, **kwargs):
+        # type: (**Any) -> List[Skillset]
+        """List the Skillsets in an Azure Search service.
+
+        :return: List of Skillsets
+        :rtype: list[dict]
+        :raises: ~azure.core.exceptions.HttpResponseError
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_skillset_operations.py
+                :start-after: [START get_skillsets]
+                :end-before: [END get_skillsets]
+                :language: python
+                :dedent: 4
+                :caption: List Skillsets
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = self._client.skillsets.list(**kwargs)
+        return result.skillsets
+
+    @distributed_trace
+    def get_skillset(self, name, **kwargs):
+        # type: (str, **Any) -> Skillset
+        """Retrieve a named Skillset in an Azure Search service
+
+        :param name: The name of the Skillset to get
+        :type name: str
+        :return: The retrieved Skillset
+        :rtype: dict
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError`
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_skillset_operations.py
+                :start-after: [START get_skillset]
+                :end-before: [END get_skillset]
+                :language: python
+                :dedent: 4
+                :caption: Get a Skillset
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        return self._client.skillsets.get(name, **kwargs)
+
+    @distributed_trace
+    def delete_skillset(self, name, **kwargs):
+        # type: (str, **Any) -> None
+        """Delete a named Skillset in an Azure Search service
+
+        :param name: The name of the Skillset to delete
+        :type name: str
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_skillset_operations.py
+                :start-after: [START delete_skillset]
+                :end-before: [END delete_skillset]
+                :language: python
+                :dedent: 4
+                :caption: Delete a Skillset
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        self._client.skillsets.delete(name, **kwargs)
+
+    @distributed_trace
+    def create_skillset(self, name, skills, description, **kwargs):
+        # type: (str, Sequence[Skill], str, **Any) -> Skillset
+        """Create a new Skillset in an Azure Search service
+
+        :param name: The name of the Skillset to create
+        :type name: str
+        :param skills: A list of Skill objects to include in the Skillset
+        :type skills: List[Skill]]
+        :param description: A description for the Skillset
+        :type description: Optional[str]
+        :return: The created Skillset
+        :rtype: dict
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_skillset_operations.py
+                :start-after: [START create_skillset]
+                :end-before: [END create_skillset]
+                :language: python
+                :dedent: 4
+                :caption: Create a Skillset
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+
+        skillset = Skillset(name=name, skills=list(skills), description=description)
+
+        return self._client.skillsets.create(skillset, **kwargs)
+
+    @distributed_trace
+    def create_or_update_skillset(self, name, **kwargs):
+        # type: (str, **Any) -> Skillset
+        """Create a new Skillset in an Azure Search service, or update an
+        existing one.
+
+        A `Skillset` object mat
+
+        :param name: The name of the Skillset to create or update
+        :type name: str
+        :param skills: A list of Skill objects to include in the Skillset
+        :type skills: List[Skill]
+        :param description: A description for the Skillset
+        :type description: Optional[str]
+        :param skillset: A Skillset to create or update.
+        :type skillset: :class:`~azure.search.documents.Skillset`
+        :return: The created or updated Skillset
+        :rtype: dict
+
+        If a `skillset` is passed in, any optional `skills`, or
+        `description` parameter values will override it.
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+
+        if "skillset" in kwargs:
+            skillset = kwargs.pop("skillset")
+            skillset = Skillset.deserialize(skillset.serialize())
+            skillset.name = name
+            for param in ("description", "skills"):
+                if param in kwargs:
+                    setattr(skillset, param, kwargs.pop(param))
+        else:
+
+            skillset = Skillset(
+                name=name,
+                description=kwargs.pop("description", None),
+                skills=kwargs.pop("skills", None),
+            )
+
+        return self._client.skillsets.create_or_update(name, skillset, **kwargs)

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_synonym_maps_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_synonym_maps_client.py
@@ -50,7 +50,7 @@ class SearchSynonymMapsClient(HeadersMixin):
 
     def close(self):
         # type: () -> None
-        """Close the :class:`~azure.search.documents.DataSourcesClient` session.
+        """Close the :class:`~azure.search.documents.SearchSynonymMapsClient` session.
 
         """
         return self._client.close()

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_synonym_maps_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_synonym_maps_client.py
@@ -1,0 +1,173 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from typing import TYPE_CHECKING
+
+from azure.core.tracing.decorator import distributed_trace
+
+from ._generated import SearchServiceClient as _SearchServiceClient
+from ._generated.models import SynonymMap
+from ._utils import listize_synonyms
+from .._headers_mixin import HeadersMixin
+from .._version import SDK_MONIKER
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import,ungrouped-imports
+    from ._generated.models import Skill
+    from typing import Any, Dict, List, Sequence
+    from azure.core.credentials import AzureKeyCredential
+
+
+class SearchSynonymMapsClient(HeadersMixin):
+    """A client to interact with Azure search service Synonym Maps.
+
+    This class is not normally instantiated directly, instead use
+    `get_synonym_maps_client()` from a `SearchServiceClient`
+
+    """
+
+    _ODATA_ACCEPT = "application/json;odata.metadata=minimal"  # type: str
+
+    def __init__(self, endpoint, credential, **kwargs):
+        # type: (str, AzureKeyCredential, **Any) -> None
+
+        self._endpoint = endpoint  # type: str
+        self._credential = credential  # type: AzureKeyCredential
+        self._client = _SearchServiceClient(
+            endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
+        )  # type: _SearchServiceClient
+
+    def __enter__(self):
+        # type: () -> SearchSynonymMapsClient
+        self._client.__enter__()  # pylint:disable=no-member
+        return self
+
+    def __exit__(self, *args):
+        # type: (*Any) -> None
+        return self._client.__exit__(*args)  # pylint:disable=no-member
+
+    def close(self):
+        # type: () -> None
+        """Close the :class:`~azure.search.documents.DataSourcesClient` session.
+
+        """
+        return self._client.close()
+
+    @distributed_trace
+    def get_synonym_maps(self, **kwargs):
+        # type: (**Any) -> List[Dict[Any, Any]]
+        """List the Synonym Maps in an Azure Search service.
+
+        :return: List of synonym maps
+        :rtype: list[dict]
+        :raises: ~azure.core.exceptions.HttpResponseError
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_synonym_map_operations.py
+                :start-after: [START get_synonym_maps]
+                :end-before: [END get_synonym_maps]
+                :language: python
+                :dedent: 4
+                :caption: List Synonym Maps
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = self._client.synonym_maps.list(**kwargs)
+        return [listize_synonyms(x) for x in result.as_dict()["synonym_maps"]]
+
+    @distributed_trace
+    def get_synonym_map(self, name, **kwargs):
+        # type: (str, **Any) -> dict
+        """Retrieve a named Synonym Map in an Azure Search service
+
+        :param name: The name of the Synonym Map to get
+        :type name: str
+        :return: The retrieved Synonym Map
+        :rtype: dict
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError`
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_synonym_map_operations.py
+                :start-after: [START get_synonym_map]
+                :end-before: [END get_synonym_map]
+                :language: python
+                :dedent: 4
+                :caption: Get a Synonym Map
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = self._client.synonym_maps.get(name, **kwargs)
+        return listize_synonyms(result.as_dict())
+
+    @distributed_trace
+    def delete_synonym_map(self, name, **kwargs):
+        # type: (str, **Any) -> None
+        """Delete a named Synonym Map in an Azure Search service
+
+        :param name: The name of the Synonym Map to delete
+        :type name: str
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_synonym_map_operations.py
+                :start-after: [START delete_synonym_map]
+                :end-before: [END delete_synonym_map]
+                :language: python
+                :dedent: 4
+                :caption: Delete a Synonym Map
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        self._client.synonym_maps.delete(name, **kwargs)
+
+    @distributed_trace
+    def create_synonym_map(self, name, synonyms, **kwargs):
+        # type: (str, Sequence[str], **Any) -> dict
+        """Create a new Synonym Map in an Azure Search service
+
+        :param name: The name of the Synonym Map to create
+        :type name: str
+        :param synonyms: The list of synonyms in SOLR format
+        :type synonyms: List[str]
+        :return: The created Synonym Map
+        :rtype: dict
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sample_synonym_map_operations.py
+                :start-after: [START create_synonym_map]
+                :end-before: [END create_synonym_map]
+                :language: python
+                :dedent: 4
+                :caption: Create a Synonym Map
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        solr_format_synonyms = "\n".join(synonyms)
+        synonym_map = SynonymMap(name=name, synonyms=solr_format_synonyms)
+        result = self._client.synonym_maps.create(synonym_map, **kwargs)
+        return listize_synonyms(result.as_dict())
+
+    @distributed_trace
+    def create_or_update_synonym_map(self, name, synonyms, **kwargs):
+        # type: (str, Sequence[str], **Any) -> dict
+        """Create a new Synonym Map in an Azure Search service, or update an
+        existing one.
+
+        :param name: The name of the Synonym Map to create or update
+        :type name: str
+        :param synonyms: A list of synonyms in SOLR format
+        :type synonyms: List[str]
+        :return: The created or updated Synonym Map
+        :rtype: dict
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        solr_format_synonyms = "\n".join(synonyms)
+        synonym_map = SynonymMap(name=name, synonyms=solr_format_synonyms)
+        result = self._client.synonym_maps.create_or_update(name, synonym_map, **kwargs)
+        return listize_synonyms(result.as_dict())

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_utils.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_utils.py
@@ -113,14 +113,14 @@ def delistize_flags_for_index(index):
     # type: (Index) -> Index
     if index.analyzers:
         index.analyzers = [
-            delistize_flags_for_pattern_analyzer(x)
+            delistize_flags_for_pattern_analyzer(x)  # type: ignore
             if isinstance(x, PatternAnalyzer)
             else x
             for x in index.analyzers
-        ]
+        ]  # mypy: ignore
     if index.tokenizers:
         index.tokenizers = [
-            delistize_flags_for_pattern_tokenizer(x)
+            delistize_flags_for_pattern_tokenizer(x)  # type: ignore
             if isinstance(x, PatternTokenizer)
             else x
             for x in index.tokenizers
@@ -132,14 +132,14 @@ def listize_flags_for_index(index):
     # type: (Index) -> Index
     if index.analyzers:
         index.analyzers = [
-            listize_flags_for_pattern_analyzer(x)
+            listize_flags_for_pattern_analyzer(x)  # type: ignore
             if isinstance(x, _PatternAnalyzer)
             else x
             for x in index.analyzers
         ]
     if index.tokenizers:
         index.tokenizers = [
-            listize_flags_for_pattern_tokenizer(x)
+            listize_flags_for_pattern_tokenizer(x)  # type: ignore
             if isinstance(x, _PatternTokenizer)
             else x
             for x in index.tokenizers

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_datasources_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_datasources_client.py
@@ -1,0 +1,162 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from typing import TYPE_CHECKING
+
+from azure.core.tracing.decorator_async import distributed_trace_async
+
+from .._generated.aio import SearchServiceClient as _SearchServiceClient
+from ..._headers_mixin import HeadersMixin
+from ..._version import SDK_MONIKER
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import,ungrouped-imports
+    from .._generated.models import DataSource
+    from typing import Any, Dict, Optional, Sequence
+    from azure.core.credentials import AzureKeyCredential
+
+
+class SearchDataSourcesClient(HeadersMixin):
+    """A client to interact with Azure search service Data Sources.
+
+    This class is not normally instantiated directly, instead use
+    `get_datasources_client()` from a `SearchServiceClient`
+
+    """
+
+    _ODATA_ACCEPT = "application/json;odata.metadata=minimal"  # type: str
+
+    def __init__(self, endpoint, credential, **kwargs):
+        # type: (str, AzureKeyCredential, **Any) -> None
+
+        self._endpoint = endpoint  # type: str
+        self._credential = credential  # type: AzureKeyCredential
+        self._client = _SearchServiceClient(
+            endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
+        )  # type: _SearchServiceClient
+
+    async def __aenter__(self):
+        # type: () -> SearchDataSourcesClient
+        await self._client.__aenter__()  # pylint:disable=no-member
+        return self
+
+    async def __aexit__(self, *args):
+        # type: (*Any) -> None
+        return await self._client.__aexit__(*args)  # pylint:disable=no-member
+
+    async def close(self):
+        # type: () -> None
+        """Close the :class:`~azure.search.documents.DataSourcesClient` session.
+
+        """
+        return await self._client.close()
+
+    @distributed_trace_async
+    async def create_datasource(self, data_source, **kwargs):
+        # type: (DataSource, **Any) -> Dict[str, Any]
+        """Creates a new datasource.
+        :param data_source: The definition of the datasource to create.
+        :type data_source: ~search.models.DataSource
+        :return: The created DataSource
+        :rtype: dict
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_data_source_operations_async.py
+                :start-after: [START create_data_source_async]
+                :end-before: [END create_data_source_async]
+                :language: python
+                :dedent: 4
+                :caption: Create a DataSource
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = await self._client.data_sources.create(data_source, **kwargs)
+        return result
+
+    @distributed_trace_async
+    async def create_or_update_datasource(self, data_source, name=None, **kwargs):
+        # type: (DataSource, Optional[str], **Any) -> Dict[str, Any]
+        """Creates a new datasource or updates a datasource if it already exists.
+
+        :param name: The name of the datasource to create or update.
+        :type name: str
+        :param data_source: The definition of the datasource to create or update.
+        :type data_source: ~search.models.DataSource
+        :return: The created DataSource
+        :rtype: dict
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+
+        if not name:
+            name = data_source.name
+        result = await self._client.data_sources.create_or_update(
+            name, data_source, **kwargs
+        )
+        return result
+
+    @distributed_trace_async
+    async def delete_datasource(self, name, **kwargs):
+        # type: (str, **Any) -> None
+        """Deletes a datasource.
+
+        :param name: The name of the datasource to delete.
+        :type name: str
+
+        :return: None
+        :rtype: None
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_data_source_operations_async.py
+                :start-after: [START delete_data_source_async]
+                :end-before: [END delete_data_source_async]
+                :language: python
+                :dedent: 4
+                :caption: Delete a DataSource
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = await self._client.data_sources.delete(name, **kwargs)
+        return result
+
+    @distributed_trace_async
+    async def get_datasource(self, name, **kwargs):
+        # type: (str, **Any) -> Dict[str, Any]
+        """Retrieves a datasource definition.
+
+        :param name: The name of the datasource to retrieve.
+        :type name: str
+        :return: The DataSource that is fetched.
+
+            .. literalinclude:: ../samples/async_samples/sample_data_source_operations_async.py
+                :start-after: [START get_data_source_async]
+                :end-before: [END get_data_source_async]
+                :language: python
+                :dedent: 4
+                :caption: Retrieve a DataSource
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = await self._client.data_sources.get(name, **kwargs)
+        return result
+
+    @distributed_trace_async
+    async def get_datasources(self, **kwargs):
+        # type: (**Any) -> Sequence[DataSource]
+        """Lists all datasources available for a search service.
+
+        :return: List of all the data sources.
+        :rtype: `list[dict]`
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_data_source_operations_async.py
+                :start-after: [START list_data_source_async]
+                :end-before: [END list_data_source_async]
+                :language: python
+                :dedent: 4
+                :caption: List all DataSources
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = await self._client.data_sources.list(**kwargs)
+        return result.data_sources

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_datasources_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_datasources_client.py
@@ -48,7 +48,7 @@ class SearchDataSourcesClient(HeadersMixin):
 
     async def close(self):
         # type: () -> None
-        """Close the :class:`~azure.search.documents.DataSourcesClient` session.
+        """Close the :class:`~azure.search.documents.aio.SearchDataSourcesClient` session.
 
         """
         return await self._client.close()

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_indexes_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_indexes_client.py
@@ -1,0 +1,265 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from typing import TYPE_CHECKING
+
+from azure.core.tracing.decorator_async import distributed_trace_async
+from azure.core import MatchConditions
+from azure.core.exceptions import (
+    ResourceExistsError,
+    ResourceNotFoundError,
+    ResourceModifiedError,
+    ResourceNotModifiedError,
+)
+from .._generated.aio import SearchServiceClient as _SearchServiceClient
+from .._generated.models import AccessCondition
+from .._utils import (
+    delistize_flags_for_index,
+    listize_flags_for_index,
+    prep_if_match,
+    prep_if_none_match,
+)
+from ..._headers_mixin import HeadersMixin
+from ..._version import SDK_MONIKER
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import,ungrouped-imports
+    from .._generated.models import AnalyzeRequest, AnalyzeResult, Index
+    from typing import Any, Dict, List
+    from azure.core.credentials import AzureKeyCredential
+
+
+class SearchIndexesClient(HeadersMixin):
+    """A client to interact with Azure search service Indexes.
+
+    This class is not normally instantiated directly, instead use
+    `get_skillsets_client()` from a `SearchServiceClient`
+
+    """
+
+    _ODATA_ACCEPT = "application/json;odata.metadata=minimal"  # type: str
+
+    def __init__(self, endpoint, credential, **kwargs):
+        # type: (str, AzureKeyCredential, **Any) -> None
+
+        self._endpoint = endpoint  # type: str
+        self._credential = credential  # type: AzureKeyCredential
+        self._client = _SearchServiceClient(
+            endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
+        )  # type: _SearchServiceClient
+
+    async def __aenter__(self):
+        # type: () -> SearchIndexesClient
+        await self._client.__aenter__()  # pylint:disable=no-member
+        return self
+
+    async def __aexit__(self, *args):
+        # type: (*Any) -> None
+        return await self._client.__aexit__(*args)  # pylint:disable=no-member
+
+    async def close(self):
+        # type: () -> None
+        """Close the :class:`~azure.search.documents.SearchIndexesClient` session.
+
+        """
+        return await self._client.close()
+
+    @distributed_trace_async
+    async def get_indexes(self, **kwargs):
+        # type: (**Any) -> List[Index]
+        """List the indexes in an Azure Search service.
+
+        :return: List of indexes
+        :rtype: list[~azure.search.documents.Index]
+        :raises: ~azure.core.exceptions.HttpResponseError
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = await self._client.indexes.list(**kwargs)
+        indexes = [listize_flags_for_index(x) for x in result.indexes]
+        return indexes
+
+    @distributed_trace_async
+    async def get_index(self, index_name, **kwargs):
+        # type: (str, **Any) -> Index
+        """
+
+        :param index_name: The name of the index to retrieve.
+        :type index_name: str
+        :return: Index object
+        :rtype: ~azure.search.documents.Index
+        :raises: ~azure.core.exceptions.HttpResponseError
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_index_crud_operations_async.py
+                :start-after: [START get_index_async]
+                :end-before: [END get_index_async]
+                :language: python
+                :dedent: 4
+                :caption: Get an index.
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = await self._client.indexes.get(index_name, **kwargs)
+        return listize_flags_for_index(result)
+
+    @distributed_trace_async
+    async def get_index_statistics(self, index_name, **kwargs):
+        # type: (str, **Any) -> dict
+        """Returns statistics for the given index, including a document count
+        and storage usage.
+
+        :param index_name: The name of the index to retrieve.
+        :type index_name: str
+        :return: Statistics for the given index, including a document count and storage usage.
+        :rtype: ~azure.search.documents.GetIndexStatisticsResult
+        :raises: ~azure.core.exceptions.HttpResponseError
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = await self._client.indexes.get_statistics(index_name, **kwargs)
+        return result.as_dict()
+
+    @distributed_trace_async
+    async def delete_index(self, index_name, **kwargs):
+        # type: (str, **Any) -> None
+        """Deletes a search index and all the documents it contains.
+
+        :param index_name: The name of the index to retrieve.
+        :type index_name: str
+        :raises: ~azure.core.exceptions.HttpResponseError
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_index_crud_operations_async.py
+                :start-after: [START delete_index_async]
+                :end-before: [END delete_index_async]
+                :language: python
+                :dedent: 4
+                :caption: Delete an index.
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        await self._client.indexes.delete(index_name, **kwargs)
+
+    @distributed_trace_async
+    async def create_index(self, index, **kwargs):
+        # type: (Index, **Any) -> Index
+        """Creates a new search index.
+
+        :param index: The index object.
+        :type index: ~azure.search.documents.Index
+        :return: The index created
+        :rtype: ~azure.search.documents.Index
+        :raises: ~azure.core.exceptions.HttpResponseError
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_index_crud_operations_async.py
+                :start-after: [START create_index_async]
+                :end-before: [END create_index_async]
+                :language: python
+                :dedent: 4
+                :caption: Creating a new index.
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        patched_index = delistize_flags_for_index(index)
+        result = await self._client.indexes.create(patched_index, **kwargs)
+        return result
+
+    @distributed_trace_async
+    async def create_or_update_index(
+        self,
+        index_name,
+        index,
+        allow_index_downtime=None,
+        match_condition=MatchConditions.Unconditionally,
+        **kwargs
+    ):
+        # type: (str, Index, bool, MatchConditions, **Any) -> Index
+        """Creates a new search index or updates an index if it already exists.
+
+        :param index_name: The name of the index.
+        :type index_name: str
+        :param index: The index object.
+        :type index: ~azure.search.documents.Index
+        :param allow_index_downtime: Allows new analyzers, tokenizers, token filters, or char filters
+         to be added to an index by taking the index offline for at least a few seconds. This
+         temporarily causes indexing and query requests to fail. Performance and write availability of
+         the index can be impaired for several minutes after the index is updated, or longer for very
+         large indexes.
+        :type allow_index_downtime: bool
+        :param match_condition: The match condition to use upon the etag
+        :type match_condition: `~azure.core.MatchConditions`
+        :return: The index created or updated
+        :rtype: :class:`~azure.search.documents.Index`
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError`, \
+        :class:`~azure.core.exceptions.ResourceModifiedError`, \
+        :class:`~azure.core.exceptions.ResourceNotModifiedError`, \
+        :class:`~azure.core.exceptions.ResourceNotFoundError`, \
+        :class:`~azure.core.exceptions.ResourceExistsError`
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_index_crud_operations_async.py
+                :start-after: [START update_index_async]
+                :end-before: [END update_index_async]
+                :language: python
+                :dedent: 4
+                :caption: Update an index.
+        """
+        error_map = {404: ResourceNotFoundError}  # type: Dict[int, Any]
+        access_condition = None
+        if index.e_tag:
+            access_condition = AccessCondition()
+            access_condition.if_match = prep_if_match(index.e_tag, match_condition)
+            access_condition.if_none_match = prep_if_none_match(
+                index.e_tag, match_condition
+            )
+        if match_condition == MatchConditions.IfNotModified:
+            error_map[412] = ResourceModifiedError
+        if match_condition == MatchConditions.IfModified:
+            error_map[304] = ResourceNotModifiedError
+        if match_condition == MatchConditions.IfPresent:
+            error_map[412] = ResourceNotFoundError
+        if match_condition == MatchConditions.IfMissing:
+            error_map[412] = ResourceExistsError
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        patched_index = delistize_flags_for_index(index)
+        result = await self._client.indexes.create_or_update(
+            index_name=index_name,
+            index=patched_index,
+            allow_index_downtime=allow_index_downtime,
+            access_condition=access_condition,
+            **kwargs
+        )
+        return result
+
+    @distributed_trace_async
+    async def analyze_text(self, index_name, analyze_request, **kwargs):
+        # type: (str, AnalyzeRequest, **Any) -> AnalyzeResult
+        """Shows how an analyzer breaks text into tokens.
+
+        :param index_name: The name of the index for which to test an analyzer.
+        :type index_name: str
+        :param analyze_request: The text and analyzer or analysis components to test.
+        :type analyze_request: ~azure.search.documents.AnalyzeRequest
+        :return: AnalyzeResult
+        :rtype: ~azure.search.documents.AnalyzeResult
+        :raises: ~azure.core.exceptions.HttpResponseError
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_analyze_text_async.py
+                :start-after: [START simple_analyze_text_async]
+                :end-before: [END simple_analyze_text_async]
+                :language: python
+                :dedent: 4
+                :caption: Analyze text
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = await self._client.indexes.analyze(
+            index_name=index_name, request=analyze_request, **kwargs
+        )
+        return result

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_search_service_client_async.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_search_service_client_async.py
@@ -77,7 +77,7 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
 
     async def close(self):
         # type: () -> None
-        """Close the :class:`~azure.search.documents.SearchServiceClient` session.
+        """Close the :class:`~azure.search.documents.aio.SearchServiceClient` session.
 
         """
         return await self._client.close()

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_search_service_client_async.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_search_service_client_async.py
@@ -14,18 +14,18 @@ from azure.core.exceptions import (
     ResourceNotModifiedError,
 )
 from .._generated.aio import SearchServiceClient as _SearchServiceClient
-from .._generated.models import AccessCondition, Skillset, SynonymMap
+from .._generated.models import AccessCondition
 from ..._headers_mixin import HeadersMixin
 from ..._version import SDK_MONIKER
 from .._utils import (
     delistize_flags_for_index,
     listize_flags_for_index,
-    listize_synonyms,
     prep_if_match,
     prep_if_none_match,
 )
 from ._datasources_client import SearchDataSourcesClient
 from ._skillsets_client import SearchSkillsetsClient
+from ._synonym_maps_client import SearchSynonymMapsClient
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
@@ -63,6 +63,10 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
         self._client = _SearchServiceClient(
             endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
         )  # type: _SearchServiceClient
+
+        self._synonym_maps_client = SearchSynonymMapsClient(
+            endpoint, credential, **kwargs
+        )
 
         self._skillsets_client = SearchSkillsetsClient(endpoint, credential, **kwargs)
 
@@ -302,126 +306,14 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
         )
         return result
 
-    # Synonym Maps Operations
+    def get_synonym_maps_client(self):
+        # type: () -> SearchSynonymMapsClient
+        """Return a client to perform operations on Synonym Maps.
 
-    @distributed_trace_async
-    async def get_synonym_maps(self, **kwargs):
-        # type: (**Any) -> List[Dict[Any, Any]]
-        """List the Synonym Maps in an Azure Search service.
-
-        :return: List of synonym maps
-        :rtype: list[dict]
-        :raises: ~azure.core.exceptions.HttpResponseError
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/async_samples/sample_synonym_map_operations_async.py
-                :start-after: [START get_synonym_maps_async]
-                :end-before: [END get_synonym_maps_async]
-                :language: python
-                :dedent: 4
-                :caption: List Synonym Maps
-
+        :return: The Synonym Maps client
+        :rtype: SearchSynonymMapsClient
         """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = await self._client.synonym_maps.list(**kwargs)
-        return [listize_synonyms(x) for x in result.as_dict()["synonym_maps"]]
-
-    @distributed_trace_async
-    async def get_synonym_map(self, name, **kwargs):
-        # type: (str, **Any) -> dict
-        """Retrieve a named Synonym Map in an Azure Search service
-
-        :param name: The name of the Synonym Map to get
-        :type name: str
-        :return: The retrieved Synonym Map
-        :rtype: dict
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError`
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/async_samples/sample_synonym_map_operations_async.py
-                :start-after: [START get_synonym_map_async]
-                :end-before: [END get_synonym_map_async]
-                :language: python
-                :dedent: 4
-                :caption: Get a Synonym Map
-
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = await self._client.synonym_maps.get(name, **kwargs)
-        return listize_synonyms(result.as_dict())
-
-    @distributed_trace_async
-    async def delete_synonym_map(self, name, **kwargs):
-        # type: (str, **Any) -> None
-        """Delete a named Synonym Map in an Azure Search service
-
-        :param name: The name of the Synonym Map to delete
-        :type name: str
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/async_samples/sample_synonym_map_operations_async.py
-                :start-after: [START delete_synonym_map_async]
-                :end-before: [END delete_synonym_map_async]
-                :language: python
-                :dedent: 4
-                :caption: Delete a Synonym Map
-
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        await self._client.synonym_maps.delete(name, **kwargs)
-
-    @distributed_trace_async
-    async def create_synonym_map(self, name, synonyms, **kwargs):
-        # type: (str, Sequence[str], **Any) -> dict
-        """Create a new Synonym Map in an Azure Search service
-
-        :param name: The name of the Synonym Map to create
-        :type name: str
-        :param synonyms: A list of synonyms in SOLR format
-        :type synonyms: List[str]
-        :return: The created Synonym Map
-        :rtype: dict
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/async_samples/sample_synonym_map_operations_async.py
-                :start-after: [START create_synonym_map_async]
-                :end-before: [END create_synonym_map_async]
-                :language: python
-                :dedent: 4
-                :caption: Create a Synonym Map
-
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        solr_format_synonyms = "\n".join(synonyms)
-        synonym_map = SynonymMap(name=name, synonyms=solr_format_synonyms)
-        result = await self._client.synonym_maps.create(synonym_map, **kwargs)
-        return listize_synonyms(result.as_dict())
-
-    @distributed_trace_async
-    async def create_or_update_synonym_map(self, name, synonyms, **kwargs):
-        # type: (str, Sequence[str], **Any) -> dict
-        """Create a new Synonym Map in an Azure Search service, or update an
-        existing one.
-
-        :param name: The name of the Synonym Map to create or update
-        :type name: str
-        :param synonyms: A list of synonyms in SOLR format
-        :type synonyms: List[str]
-        :return: The created or updated Synonym Map
-        :rtype: dict
-
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        solr_format_synonyms = "\n".join(synonyms)
-        synonym_map = SynonymMap(name=name, synonyms=solr_format_synonyms)
-        result = await self._client.synonym_maps.create_or_update(
-            name, synonym_map, **kwargs
-        )
-        return listize_synonyms(result.as_dict())
+        return self._synonym_maps_client
 
     def get_skillsets_client(self) -> SearchSkillsetsClient:
         """Return a client to perform operations on Skillsets.

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_search_service_client_async.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_search_service_client_async.py
@@ -6,24 +6,12 @@
 from typing import TYPE_CHECKING
 
 from azure.core.tracing.decorator_async import distributed_trace_async
-from azure.core import MatchConditions
-from azure.core.exceptions import (
-    ResourceExistsError,
-    ResourceNotFoundError,
-    ResourceModifiedError,
-    ResourceNotModifiedError,
-)
+
 from .._generated.aio import SearchServiceClient as _SearchServiceClient
-from .._generated.models import AccessCondition
 from ..._headers_mixin import HeadersMixin
 from ..._version import SDK_MONIKER
-from .._utils import (
-    delistize_flags_for_index,
-    listize_flags_for_index,
-    prep_if_match,
-    prep_if_none_match,
-)
 from ._datasources_client import SearchDataSourcesClient
+from ._indexes_client import SearchIndexesClient
 from ._skillsets_client import SearchSkillsetsClient
 from ._synonym_maps_client import SearchSynonymMapsClient
 
@@ -31,8 +19,6 @@ if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
     from typing import Any, Dict, List, Optional, Sequence
     from azure.core.credentials import AzureKeyCredential
-    from .._generated.models import Skill
-    from ... import Index, AnalyzeResult, AnalyzeRequest
 
 
 class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-methods
@@ -64,6 +50,8 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
             endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
         )  # type: _SearchServiceClient
 
+        self._indexes_client = SearchIndexesClient(endpoint, credential, **kwargs)
+
         self._synonym_maps_client = SearchSynonymMapsClient(
             endpoint, credential, **kwargs
         )
@@ -94,8 +82,6 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
         """
         return await self._client.close()
 
-    ### Service Operations
-
     @distributed_trace_async
     async def get_service_statistics(self, **kwargs):
         # type: (**Any) -> dict
@@ -106,205 +92,14 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
         result = await self._client.get_service_statistics(**kwargs)
         return result.as_dict()
 
-    ### Index Operations
+    def get_indexes_client(self):
+        # type: () -> SearchIndexesClient
+        """Return a client to perform operations on Search Indexes.
 
-    @distributed_trace_async
-    async def get_indexes(self, **kwargs):
-        # type: (**Any) -> List[Index]
-        """List the indexes in an Azure Search service.
-
-        :return: List of indexes
-        :rtype: list[~azure.search.documents.Index]
-        :raises: ~azure.core.exceptions.HttpResponseError
-
+        :return: The Search Indexes client
+        :rtype: SearchIndexesClient
         """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = await self._client.indexes.list(**kwargs)
-        indexes = [listize_flags_for_index(x) for x in result.indexes]
-        return indexes
-
-    @distributed_trace_async
-    async def get_index(self, index_name, **kwargs):
-        # type: (str, **Any) -> Index
-        """
-
-        :param index_name: The name of the index to retrieve.
-        :type index_name: str
-        :return: Index object
-        :rtype: ~azure.search.documents.Index
-        :raises: ~azure.core.exceptions.HttpResponseError
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/async_samples/sample_index_crud_operations_async.py
-                :start-after: [START get_index_async]
-                :end-before: [END get_index_async]
-                :language: python
-                :dedent: 4
-                :caption: Get an index.
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = await self._client.indexes.get(index_name, **kwargs)
-        return listize_flags_for_index(result)
-
-    @distributed_trace_async
-    async def get_index_statistics(self, index_name, **kwargs):
-        # type: (str, **Any) -> dict
-        """Returns statistics for the given index, including a document count
-        and storage usage.
-
-        :param index_name: The name of the index to retrieve.
-        :type index_name: str
-        :return: Statistics for the given index, including a document count and storage usage.
-        :rtype: ~azure.search.documents.GetIndexStatisticsResult
-        :raises: ~azure.core.exceptions.HttpResponseError
-
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = await self._client.indexes.get_statistics(index_name, **kwargs)
-        return result.as_dict()
-
-    @distributed_trace_async
-    async def delete_index(self, index_name, **kwargs):
-        # type: (str, **Any) -> None
-        """Deletes a search index and all the documents it contains.
-
-        :param index_name: The name of the index to retrieve.
-        :type index_name: str
-        :raises: ~azure.core.exceptions.HttpResponseError
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/async_samples/sample_index_crud_operations_async.py
-                :start-after: [START delete_index_async]
-                :end-before: [END delete_index_async]
-                :language: python
-                :dedent: 4
-                :caption: Delete an index.
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        await self._client.indexes.delete(index_name, **kwargs)
-
-    @distributed_trace_async
-    async def create_index(self, index, **kwargs):
-        # type: (Index, **Any) -> Index
-        """Creates a new search index.
-
-        :param index: The index object.
-        :type index: ~azure.search.documents.Index
-        :return: The index created
-        :rtype: ~azure.search.documents.Index
-        :raises: ~azure.core.exceptions.HttpResponseError
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/async_samples/sample_index_crud_operations_async.py
-                :start-after: [START create_index_async]
-                :end-before: [END create_index_async]
-                :language: python
-                :dedent: 4
-                :caption: Creating a new index.
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        patched_index = delistize_flags_for_index(index)
-        result = await self._client.indexes.create(patched_index, **kwargs)
-        return result
-
-    @distributed_trace_async
-    async def create_or_update_index(
-        self,
-        index_name,
-        index,
-        allow_index_downtime=None,
-        match_condition=MatchConditions.Unconditionally,
-        **kwargs
-    ):
-        # type: (str, Index, bool, MatchConditions, **Any) -> Index
-        """Creates a new search index or updates an index if it already exists.
-
-        :param index_name: The name of the index.
-        :type index_name: str
-        :param index: The index object.
-        :type index: ~azure.search.documents.Index
-        :param allow_index_downtime: Allows new analyzers, tokenizers, token filters, or char filters
-         to be added to an index by taking the index offline for at least a few seconds. This
-         temporarily causes indexing and query requests to fail. Performance and write availability of
-         the index can be impaired for several minutes after the index is updated, or longer for very
-         large indexes.
-        :type allow_index_downtime: bool
-        :param match_condition: The match condition to use upon the etag
-        :type match_condition: `~azure.core.MatchConditions`
-        :return: The index created or updated
-        :rtype: :class:`~azure.search.documents.Index`
-        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError`, \
-        :class:`~azure.core.exceptions.ResourceModifiedError`, \
-        :class:`~azure.core.exceptions.ResourceNotModifiedError`, \
-        :class:`~azure.core.exceptions.ResourceNotFoundError`, \
-        :class:`~azure.core.exceptions.ResourceExistsError`
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/async_samples/sample_index_crud_operations_async.py
-                :start-after: [START update_index_async]
-                :end-before: [END update_index_async]
-                :language: python
-                :dedent: 4
-                :caption: Update an index.
-        """
-        error_map = {404: ResourceNotFoundError}  # type: Dict[int, Any]
-        access_condition = None
-        if index.e_tag:
-            access_condition = AccessCondition()
-            access_condition.if_match = prep_if_match(index.e_tag, match_condition)
-            access_condition.if_none_match = prep_if_none_match(
-                index.e_tag, match_condition
-            )
-        if match_condition == MatchConditions.IfNotModified:
-            error_map[412] = ResourceModifiedError
-        if match_condition == MatchConditions.IfModified:
-            error_map[304] = ResourceNotModifiedError
-        if match_condition == MatchConditions.IfPresent:
-            error_map[412] = ResourceNotFoundError
-        if match_condition == MatchConditions.IfMissing:
-            error_map[412] = ResourceExistsError
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        patched_index = delistize_flags_for_index(index)
-        result = await self._client.indexes.create_or_update(
-            index_name=index_name,
-            index=patched_index,
-            allow_index_downtime=allow_index_downtime,
-            access_condition=access_condition,
-            **kwargs
-        )
-        return result
-
-    @distributed_trace_async
-    async def analyze_text(self, index_name, analyze_request, **kwargs):
-        # type: (str, AnalyzeRequest, **Any) -> AnalyzeResult
-        """Shows how an analyzer breaks text into tokens.
-
-        :param index_name: The name of the index for which to test an analyzer.
-        :type index_name: str
-        :param analyze_request: The text and analyzer or analysis components to test.
-        :type analyze_request: ~azure.search.documents.AnalyzeRequest
-        :return: AnalyzeResult
-        :rtype: ~azure.search.documents.AnalyzeResult
-        :raises: ~azure.core.exceptions.HttpResponseError
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/async_samples/sample_analyze_text_async.py
-                :start-after: [START simple_analyze_text_async]
-                :end-before: [END simple_analyze_text_async]
-                :language: python
-                :dedent: 4
-                :caption: Analyze text
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = await self._client.indexes.analyze(
-            index_name=index_name, request=analyze_request, **kwargs
-        )
-        return result
+        return self._indexes_client
 
     def get_synonym_maps_client(self):
         # type: () -> SearchSynonymMapsClient

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_search_service_client_async.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_search_service_client_async.py
@@ -24,16 +24,17 @@ from .._utils import (
     prep_if_match,
     prep_if_none_match,
 )
+from ._datasources_client import SearchDataSourcesClient
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
-    from typing import Any, List, Optional, Sequence, Union
+    from typing import Any, Dict, List, Optional, Sequence
     from azure.core.credentials import AzureKeyCredential
     from .._generated.models import Skill
     from ... import Index, AnalyzeResult, AnalyzeRequest
 
 
-class SearchServiceClient(HeadersMixin): # pylint: disable=too-many-public-methods
+class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-methods
     """A client to interact with an existing Azure search service.
 
     :param endpoint: The URL endpoint of an Azure search service
@@ -61,6 +62,10 @@ class SearchServiceClient(HeadersMixin): # pylint: disable=too-many-public-metho
         self._client = _SearchServiceClient(
             endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
         )  # type: _SearchServiceClient
+
+        self._datasources_client = SearchDataSourcesClient(
+            endpoint, credential, **kwargs
+        )
 
     def __repr__(self):
         # type: () -> str
@@ -239,7 +244,7 @@ class SearchServiceClient(HeadersMixin): # pylint: disable=too-many-public-metho
                 :dedent: 4
                 :caption: Update an index.
         """
-        error_map = {404: ResourceNotFoundError}
+        error_map = {404: ResourceNotFoundError}  # type: Dict[int, Any]
         access_condition = None
         if index.e_tag:
             access_condition = AccessCondition()
@@ -298,7 +303,7 @@ class SearchServiceClient(HeadersMixin): # pylint: disable=too-many-public-metho
 
     @distributed_trace_async
     async def get_synonym_maps(self, **kwargs):
-        # type: (**Any) -> List[Index]
+        # type: (**Any) -> List[Dict[Any, Any]]
         """List the Synonym Maps in an Azure Search service.
 
         :return: List of synonym maps
@@ -517,7 +522,7 @@ class SearchServiceClient(HeadersMixin): # pylint: disable=too-many-public-metho
 
     @distributed_trace_async
     async def create_or_update_skillset(self, name, **kwargs):
-        # type: (str, Sequence[Skill], str, **Any) -> Skillset
+        # type: (str, **Any) -> Skillset
         """Create a new Skillset in an Azure Search service, or update an
         existing one.
 
@@ -556,108 +561,10 @@ class SearchServiceClient(HeadersMixin): # pylint: disable=too-many-public-metho
 
         return await self._client.skillsets.create_or_update(name, skillset, **kwargs)
 
-    @distributed_trace_async
-    async def create_datasource(self, data_source, **kwargs):
-        # type: (str, DataSource, **Any) -> Dict[str, Any]
-        """Creates a new datasource.
-        :param data_source: The definition of the datasource to create.
-        :type data_source: ~search.models.DataSource
-        :return: The created DataSource
-        :rtype: dict
+    def get_datasources_client(self) -> SearchDataSourcesClient:
+        """Return a client to perform operations on Data Sources.
 
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/async_samples/sample_data_source_operations_async.py
-                :start-after: [START create_data_source_async]
-                :end-before: [END create_data_source_async]
-                :language: python
-                :dedent: 4
-                :caption: Create a DataSource
+        :return: The Data Sources client
+        :rtype: DataSourcesClient
         """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = await self._client.data_sources.create(data_source, **kwargs)
-        return result
-
-    @distributed_trace_async
-    async def create_or_update_datasource(self, data_source, name=None, **kwargs):
-        # type: (str, DataSource, Optional[str], **Any) -> Dict[str, Any]
-        """Creates a new datasource or updates a datasource if it already exists.
-
-        :param name: The name of the datasource to create or update.
-        :type name: str
-        :param data_source: The definition of the datasource to create or update.
-        :type data_source: ~search.models.DataSource
-        :return: The created DataSource
-        :rtype: dict
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-
-        if not name:
-            name = data_source.name
-        result = await self._client.data_sources.create_or_update(name, data_source, **kwargs)
-        return result
-
-    @distributed_trace_async
-    async def delete_datasource(self, name, **kwargs):
-        # type: (str, **Any) -> None
-        """Deletes a datasource.
-
-        :param name: The name of the datasource to delete.
-        :type name: str
-
-        :return: None
-        :rtype: None
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/async_samples/sample_data_source_operations_async.py
-                :start-after: [START delete_data_source_async]
-                :end-before: [END delete_data_source_async]
-                :language: python
-                :dedent: 4
-                :caption: Delete a DataSource
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = await self._client.data_sources.delete(name, **kwargs)
-        return result
-
-    @distributed_trace_async
-    async def get_datasource(self, name, **kwargs):
-        # type: (str, **Any) -> Dict[str, Any]
-        """Retrieves a datasource definition.
-
-        :param name: The name of the datasource to retrieve.
-        :type name: str
-        :return: The DataSource that is fetched.
-
-            .. literalinclude:: ../samples/async_samples/sample_data_source_operations_async.py
-                :start-after: [START get_data_source_async]
-                :end-before: [END get_data_source_async]
-                :language: python
-                :dedent: 4
-                :caption: Retrieve a DataSource
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = await self._client.data_sources.get(name, **kwargs)
-        return result
-
-    @distributed_trace_async
-    async def get_datasources(self, **kwargs):
-        # type: (**Any) -> Sequence[DataSource]
-        """Lists all datasources available for a search service.
-
-        :return: List of all the data sources.
-        :rtype: `list[dict]`
-
-        .. admonition:: Example:
-
-            .. literalinclude:: ../samples/async_samples/sample_data_source_operations_async.py
-                :start-after: [START list_data_source_async]
-                :end-before: [END list_data_source_async]
-                :language: python
-                :dedent: 4
-                :caption: List all DataSources
-        """
-        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
-        result = await self._client.data_sources.list(**kwargs)
-        return result.data_sources
+        return self._datasources_client

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_skillsets_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_skillsets_client.py
@@ -1,0 +1,194 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from typing import TYPE_CHECKING
+
+from azure.core.tracing.decorator_async import distributed_trace_async
+
+from .._generated.aio import SearchServiceClient as _SearchServiceClient
+from .._generated.models import Skillset
+from ..._headers_mixin import HeadersMixin
+from ..._version import SDK_MONIKER
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import,ungrouped-imports
+    from .._generated.models import Skill
+    from typing import Any, List, Sequence
+    from azure.core.credentials import AzureKeyCredential
+
+
+class SearchSkillsetsClient(HeadersMixin):
+    """A client to interact with Azure search service Skillsets.
+
+    This class is not normally instantiated directly, instead use
+    `get_skillsets_client()` from a `SearchServiceClient`
+
+    """
+
+    _ODATA_ACCEPT = "application/json;odata.metadata=minimal"  # type: str
+
+    def __init__(self, endpoint, credential, **kwargs):
+        # type: (str, AzureKeyCredential, **Any) -> None
+
+        self._endpoint = endpoint  # type: str
+        self._credential = credential  # type: AzureKeyCredential
+        self._client = _SearchServiceClient(
+            endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
+        )  # type: _SearchServiceClient
+
+    async def __aenter__(self):
+        # type: () -> SearchSkillsetsClient
+        await self._client.__aenter__()  # pylint:disable=no-member
+        return self
+
+    async def __aexit__(self, *args):
+        # type: (*Any) -> None
+        return await self._client.__aexit__(*args)  # pylint:disable=no-member
+
+    async def close(self):
+        # type: () -> None
+        """Close the :class:`~azure.search.documents.DataSourcesClient` session.
+
+        """
+        return await self._client.close()
+
+    @distributed_trace_async
+    async def get_skillsets(self, **kwargs):
+        # type: (**Any) -> List[Skillset]
+        """List the Skillsets in an Azure Search service.
+
+        :return: List of Skillsets
+        :rtype: list[dict]
+        :raises: ~azure.core.exceptions.HttpResponseError
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_skillset_operations_async.py
+                :start-after: [START get_skillsets]
+                :end-before: [END get_skillsets]
+                :language: python
+                :dedent: 4
+                :caption: List Skillsets
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = await self._client.skillsets.list(**kwargs)
+        return result.skillsets
+
+    @distributed_trace_async
+    async def get_skillset(self, name, **kwargs):
+        # type: (str, **Any) -> Skillset
+        """Retrieve a named Skillset in an Azure Search service
+
+        :param name: The name of the Skillset to get
+        :type name: str
+        :return: The retrieved Skillset
+        :rtype: dict
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError`
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_skillset_operations_async.py
+                :start-after: [START get_skillset]
+                :end-before: [END get_skillset]
+                :language: python
+                :dedent: 4
+                :caption: Get a Skillset
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        return await self._client.skillsets.get(name, **kwargs)
+
+    @distributed_trace_async
+    async def delete_skillset(self, name, **kwargs):
+        # type: (str, **Any) -> None
+        """Delete a named Skillset in an Azure Search service
+
+        :param name: The name of the Skillset to delete
+        :type name: str
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_skillset_operations_async.py
+                :start-after: [START delete_skillset]
+                :end-before: [END delete_skillset]
+                :language: python
+                :dedent: 4
+                :caption: Delete a Skillset
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        await self._client.skillsets.delete(name, **kwargs)
+
+    @distributed_trace_async
+    async def create_skillset(self, name, skills, description, **kwargs):
+        # type: (str, Sequence[Skill], str, **Any) -> Skillset
+        """Create a new Skillset in an Azure Search service
+
+        :param name: The name of the Skillset to create
+        :type name: str
+        :param skills: A list of Skill objects to include in the Skillset
+        :type skills: List[Skill]]
+        :param description: A description for the Skillset
+        :type description: Optional[str]
+        :return: The created Skillset
+        :rtype: dict
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_skillset_operations_async.py
+                :start-after: [START create_skillset]
+                :end-before: [END create_skillset]
+                :language: python
+                :dedent: 4
+                :caption: Create a Skillset
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+
+        skillset = Skillset(name=name, skills=list(skills), description=description)
+
+        return await self._client.skillsets.create(skillset, **kwargs)
+
+    @distributed_trace_async
+    async def create_or_update_skillset(self, name, **kwargs):
+        # type: (str, **Any) -> Skillset
+        """Create a new Skillset in an Azure Search service, or update an
+        existing one.
+
+        :param name: The name of the Skillset to create or update
+        :type name: str
+        :param skills: A list of Skill objects to include in the Skillset
+        :type skills: List[Skill]
+        :param description: A description for the Skillset
+        :type description: Optional[str]
+        :param skillset: A Skillset to create or update.
+        :type skillset: :class:`~azure.search.documents.Skillset`
+        :return: The created or updated Skillset
+        :rtype: dict
+
+        If a `skillset` is passed in, any optional `skills`, or
+        `description` parameter values will override it.
+
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+
+        if "skillset" in kwargs:
+            skillset = kwargs.pop("skillset")
+            skillset = Skillset.deserialize(skillset.serialize())
+            skillset.name = name
+            for param in ("description", "skills"):
+                if param in kwargs:
+                    setattr(skillset, param, kwargs.pop(param))
+        else:
+
+            skillset = Skillset(
+                name=name,
+                description=kwargs.pop("description", None),
+                skills=kwargs.pop("skills", None),
+            )
+
+        return await self._client.skillsets.create_or_update(name, skillset, **kwargs)

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_skillsets_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_skillsets_client.py
@@ -49,7 +49,7 @@ class SearchSkillsetsClient(HeadersMixin):
 
     async def close(self):
         # type: () -> None
-        """Close the :class:`~azure.search.documents.DataSourcesClient` session.
+        """Close the :class:`~azure.search.documents.aio.SearchSkillsetsClient` session.
 
         """
         return await self._client.close()

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_synonym_maps_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_synonym_maps_client.py
@@ -1,0 +1,175 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from typing import TYPE_CHECKING
+
+from azure.core.tracing.decorator_async import distributed_trace_async
+
+from .._generated.aio import SearchServiceClient as _SearchServiceClient
+from .._generated.models import SynonymMap
+from .._utils import listize_synonyms
+from ..._headers_mixin import HeadersMixin
+from ..._version import SDK_MONIKER
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import,ungrouped-imports
+    from .._generated.models import Skill
+    from typing import Any, Dict, List, Sequence
+    from azure.core.credentials import AzureKeyCredential
+
+
+class SearchSynonymMapsClient(HeadersMixin):
+    """A client to interact with Azure search service Synonym Maps.
+
+    This class is not normally instantiated directly, instead use
+    `get_synonym_maps_client()` from a `SearchServiceClient`
+
+    """
+
+    _ODATA_ACCEPT = "application/json;odata.metadata=minimal"  # type: str
+
+    def __init__(self, endpoint, credential, **kwargs):
+        # type: (str, AzureKeyCredential, **Any) -> None
+
+        self._endpoint = endpoint  # type: str
+        self._credential = credential  # type: AzureKeyCredential
+        self._client = _SearchServiceClient(
+            endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
+        )  # type: _SearchServiceClient
+
+    async def __aenter__(self):
+        # type: () -> SearchSynonymMapsClient
+        await self._client.__aenter__()  # pylint:disable=no-member
+        return self
+
+    async def __aexit__(self, *args):
+        # type: (*Any) -> None
+        return await self._client.__aexit__(*args)  # pylint:disable=no-member
+
+    async def close(self):
+        # type: () -> None
+        """Close the :class:`~azure.search.documents.DataSourcesClient` session.
+
+        """
+        return await self._client.close()
+
+    @distributed_trace_async
+    async def get_synonym_maps(self, **kwargs):
+        # type: (**Any) -> List[Dict[Any, Any]]
+        """List the Synonym Maps in an Azure Search service.
+
+        :return: List of synonym maps
+        :rtype: list[dict]
+        :raises: ~azure.core.exceptions.HttpResponseError
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_synonym_map_operations_async.py
+                :start-after: [START get_synonym_maps_async]
+                :end-before: [END get_synonym_maps_async]
+                :language: python
+                :dedent: 4
+                :caption: List Synonym Maps
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = await self._client.synonym_maps.list(**kwargs)
+        return [listize_synonyms(x) for x in result.as_dict()["synonym_maps"]]
+
+    @distributed_trace_async
+    async def get_synonym_map(self, name, **kwargs):
+        # type: (str, **Any) -> dict
+        """Retrieve a named Synonym Map in an Azure Search service
+
+        :param name: The name of the Synonym Map to get
+        :type name: str
+        :return: The retrieved Synonym Map
+        :rtype: dict
+        :raises: :class:`~azure.core.exceptions.ResourceNotFoundError`
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_synonym_map_operations_async.py
+                :start-after: [START get_synonym_map_async]
+                :end-before: [END get_synonym_map_async]
+                :language: python
+                :dedent: 4
+                :caption: Get a Synonym Map
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        result = await self._client.synonym_maps.get(name, **kwargs)
+        return listize_synonyms(result.as_dict())
+
+    @distributed_trace_async
+    async def delete_synonym_map(self, name, **kwargs):
+        # type: (str, **Any) -> None
+        """Delete a named Synonym Map in an Azure Search service
+
+        :param name: The name of the Synonym Map to delete
+        :type name: str
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_synonym_map_operations_async.py
+                :start-after: [START delete_synonym_map_async]
+                :end-before: [END delete_synonym_map_async]
+                :language: python
+                :dedent: 4
+                :caption: Delete a Synonym Map
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        await self._client.synonym_maps.delete(name, **kwargs)
+
+    @distributed_trace_async
+    async def create_synonym_map(self, name, synonyms, **kwargs):
+        # type: (str, Sequence[str], **Any) -> dict
+        """Create a new Synonym Map in an Azure Search service
+
+        :param name: The name of the Synonym Map to create
+        :type name: str
+        :param synonyms: A list of synonyms in SOLR format
+        :type synonyms: List[str]
+        :return: The created Synonym Map
+        :rtype: dict
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_synonym_map_operations_async.py
+                :start-after: [START create_synonym_map_async]
+                :end-before: [END create_synonym_map_async]
+                :language: python
+                :dedent: 4
+                :caption: Create a Synonym Map
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        solr_format_synonyms = "\n".join(synonyms)
+        synonym_map = SynonymMap(name=name, synonyms=solr_format_synonyms)
+        result = await self._client.synonym_maps.create(synonym_map, **kwargs)
+        return listize_synonyms(result.as_dict())
+
+    @distributed_trace_async
+    async def create_or_update_synonym_map(self, name, synonyms, **kwargs):
+        # type: (str, Sequence[str], **Any) -> dict
+        """Create a new Synonym Map in an Azure Search service, or update an
+        existing one.
+
+        :param name: The name of the Synonym Map to create or update
+        :type name: str
+        :param synonyms: A list of synonyms in SOLR format
+        :type synonyms: List[str]
+        :return: The created or updated Synonym Map
+        :rtype: dict
+
+        """
+        kwargs["headers"] = self._merge_client_headers(kwargs.get("headers"))
+        solr_format_synonyms = "\n".join(synonyms)
+        synonym_map = SynonymMap(name=name, synonyms=solr_format_synonyms)
+        result = await self._client.synonym_maps.create_or_update(
+            name, synonym_map, **kwargs
+        )
+        return listize_synonyms(result.as_dict())

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_synonym_maps_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_synonym_maps_client.py
@@ -50,7 +50,7 @@ class SearchSynonymMapsClient(HeadersMixin):
 
     async def close(self):
         # type: () -> None
-        """Close the :class:`~azure.search.documents.DataSourcesClient` session.
+        """Close the :class:`~azure.search.documents.aio.SearchSynonymMapsClient` session.
 
         """
         return await self._client.close()

--- a/sdk/search/azure-search-documents/samples/async_samples/sample_data_source_operations_async.py
+++ b/sdk/search/azure-search-documents/samples/async_samples/sample_data_source_operations_async.py
@@ -9,7 +9,7 @@
 """
 FILE: sample_data_source_operations_async.py
 DESCRIPTION:
-    This sample demonstrates how to get, create, update, or delete a Synonym Map.
+    This sample demonstrates how to get, create, update, or delete a Data Source.
 USAGE:
     python sample_data_source_operations_async.py
 

--- a/sdk/search/azure-search-documents/samples/async_samples/sample_index_crud_operations_async.py
+++ b/sdk/search/azure-search-documents/samples/async_samples/sample_index_crud_operations_async.py
@@ -29,7 +29,7 @@ from azure.core.credentials import AzureKeyCredential
 from azure.search.documents.aio import SearchServiceClient
 from azure.search.documents import CorsOptions, Index, ScoringProfile
 
-service_client = SearchServiceClient(service_endpoint, AzureKeyCredential(key))
+client = SearchServiceClient(service_endpoint, AzureKeyCredential(key)).get_indexes_client()
 
 async def create_index():
     # [START create_index_async]
@@ -53,13 +53,13 @@ async def create_index():
         scoring_profiles=scoring_profiles,
         cors_options=cors_options)
 
-    result = await service_client.create_index(index)
+    result = await client.create_index(index)
     # [END create_index_async]
 
 async def get_index():
     # [START get_index_async]
     name = "hotels"
-    result = await service_client.get_index(name)
+    result = await client.get_index(name)
     # [END get_index_async]
 
 async def update_index():
@@ -88,13 +88,13 @@ async def update_index():
         scoring_profiles=scoring_profiles,
         cors_options=cors_options)
 
-    result = await service_client.create_or_update_index(index_name=index.name, index=index)
+    result = await client.create_or_update_index(index_name=index.name, index=index)
     # [END update_index_async]
 
 async def delete_index():
     # [START delete_index_async]
     name = "hotels"
-    await service_client.delete_index(name)
+    await client.delete_index(name)
     # [END delete_index_async]
 
 async def main():
@@ -102,7 +102,7 @@ async def main():
     await get_index()
     await update_index()
     await delete_index()
-    await service_client.close()
+    await client.close()
 
 if __name__ == '__main__':
     loop = asyncio.get_event_loop()

--- a/sdk/search/azure-search-documents/samples/async_samples/sample_synonym_map_operations_async.py
+++ b/sdk/search/azure-search-documents/samples/async_samples/sample_synonym_map_operations_async.py
@@ -27,11 +27,11 @@ key = os.getenv("AZURE_SEARCH_API_KEY")
 from azure.core.credentials import AzureKeyCredential
 from azure.search.documents.aio import SearchServiceClient
 
-service_client = SearchServiceClient(service_endpoint, AzureKeyCredential(key))
+client = SearchServiceClient(service_endpoint, AzureKeyCredential(key)).get_synonym_maps_client()
 
 async def create_synonym_map():
     # [START create_synonym_map_async]
-    result = await service_client.create_synonym_map("test-syn-map", [
+    result = await client.create_synonym_map("test-syn-map", [
         "USA, United States, United States of America",
         "Washington, Wash. => WA",
     ])
@@ -40,14 +40,14 @@ async def create_synonym_map():
 
 async def get_synonym_maps():
     # [START get_synonym_maps_async]
-    result = await service_client.get_synonym_maps()
+    result = await client.get_synonym_maps()
     names = [x["name"] for x in result]
     print("Found {} Synonym Maps in the service: {}".format(len(result), ", ".join(names)))
     # [END get_synonym_maps_async]
 
 async def get_synonym_map():
     # [START get_synonym_map_async]
-    result = await service_client.get_synonym_map("test-syn-map")
+    result = await client.get_synonym_map("test-syn-map")
     print("Retrived Synonym Map 'test-syn-map' with synonyms")
     for syn in result["synonyms"]:
         print("    {}".format(syn))
@@ -55,7 +55,7 @@ async def get_synonym_map():
 
 async def delete_synonym_map():
     # [START delete_synonym_map_async]
-    await service_client.delete_synonym_map("test-syn-map")
+    await client.delete_synonym_map("test-syn-map")
     print("Synonym Map 'test-syn-map' deleted")
     # [END delete_synonym_map_async]
 
@@ -64,7 +64,7 @@ async def main():
     await get_synonym_maps()
     await get_synonym_map()
     await delete_synonym_map()
-    await service_client.close()
+    await client.close()
 
 if __name__ == '__main__':
     loop = asyncio.get_event_loop()

--- a/sdk/search/azure-search-documents/samples/sample_index_crud_operations.py
+++ b/sdk/search/azure-search-documents/samples/sample_index_crud_operations.py
@@ -27,7 +27,7 @@ key = os.getenv("AZURE_SEARCH_API_KEY")
 from azure.core.credentials import AzureKeyCredential
 from azure.search.documents import SearchServiceClient, CorsOptions, Index, ScoringProfile
 
-service_client = SearchServiceClient(service_endpoint, AzureKeyCredential(key))
+client = SearchServiceClient(service_endpoint, AzureKeyCredential(key)).get_indexes_client()
 
 def create_index():
     # [START create_index]
@@ -51,13 +51,13 @@ def create_index():
         scoring_profiles=scoring_profiles,
         cors_options=cors_options)
 
-    result = service_client.create_index(index)
+    result = client.create_index(index)
     # [END create_index]
 
 def get_index():
     # [START get_index]
     name = "hotels"
-    result = service_client.get_index(name)
+    result = client.get_index(name)
     # [END get_index]
 
 def update_index():
@@ -86,13 +86,13 @@ def update_index():
         scoring_profiles=scoring_profiles,
         cors_options=cors_options)
 
-    result = service_client.create_or_update_index(index_name=index.name, index=index)
+    result = client.create_or_update_index(index_name=index.name, index=index)
     # [END update_index]
 
 def delete_index():
     # [START delete_index]
     name = "hotels"
-    service_client.delete_index(name)
+    client.delete_index(name)
     # [END delete_index]
 
 if __name__ == '__main__':

--- a/sdk/search/azure-search-documents/samples/sample_synonym_map_operations.py
+++ b/sdk/search/azure-search-documents/samples/sample_synonym_map_operations.py
@@ -26,11 +26,11 @@ key = os.getenv("AZURE_SEARCH_API_KEY")
 from azure.core.credentials import AzureKeyCredential
 from azure.search.documents import SearchServiceClient
 
-service_client = SearchServiceClient(service_endpoint, AzureKeyCredential(key))
+client = SearchServiceClient(service_endpoint, AzureKeyCredential(key)).get_synonym_maps_client()
 
 def create_synonym_map():
     # [START create_synonym_map]
-    result = service_client.create_synonym_map("test-syn-map", [
+    result = client.create_synonym_map("test-syn-map", [
         "USA, United States, United States of America",
         "Washington, Wash. => WA",
     ])
@@ -39,14 +39,14 @@ def create_synonym_map():
 
 def get_synonym_maps():
     # [START get_synonym_maps]
-    result = service_client.get_synonym_maps()
+    result = client.get_synonym_maps()
     names = [x["name"] for x in result]
     print("Found {} Synonym Maps in the service: {}".format(len(result), ", ".join(names)))
     # [END get_synonym_maps]
 
 def get_synonym_map():
     # [START get_synonym_map]
-    result = service_client.get_synonym_map("test-syn-map")
+    result = client.get_synonym_map("test-syn-map")
     print("Retrived Synonym Map 'test-syn-map' with synonyms")
     for syn in result["synonyms"]:
         print("    {}".format(syn))
@@ -54,7 +54,7 @@ def get_synonym_map():
 
 def delete_synonym_map():
     # [START delete_synonym_map]
-    service_client.delete_synonym_map("test-syn-map")
+    client.delete_synonym_map("test-syn-map")
     print("Synonym Map 'test-syn-map' deleted")
     # [END delete_synonym_map]
 

--- a/sdk/search/azure-search-documents/tests/async_tests/recordings/test_service_live_async.test_create_datasource_async.yaml
+++ b/sdk/search/azure-search-documents/tests/async_tests/recordings/test_service_live_async.test_create_datasource_async.yaml
@@ -11,37 +11,30 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - D59D8B92A259BB430B2DD58824AC5800
+      - 705C140806CA0B3C9E38BE08AF7425C2
     method: POST
     uri: https://search386b1565.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search386b1565.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B55FC94A6\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://search386b1565.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A051BE1734\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control: no-cache
       content-length: '370'
       content-type: application/json; odata.metadata=minimal
-      date: Thu, 23 Apr 2020 09:47:28 GMT
-      elapsed-time: '36'
-      etag: W/"0x8D7E76B55FC94A6"
+      date: Fri, 24 Apr 2020 22:39:16 GMT
+      elapsed-time: '43'
+      etag: W/"0x8D7E8A051BE1734"
       expires: '-1'
       location: https://search386b1565.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
       odata-version: '4.0'
       pragma: no-cache
       preference-applied: odata.include-annotations="*"
-      request-id: 71366868-8547-11ea-a573-2816a845e8c6
+      request-id: 6bd3982a-867c-11ea-8426-8c8590507855
       strict-transport-security: max-age=15724800; includeSubDomains
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - search386b1565.search.windows.net
-        - /datasources
-        - api-version=2019-05-06-Preview
-        - ''
+    url: https://search386b1565.search.windows.net/datasources?api-version=2019-05-06-Preview
 version: 1

--- a/sdk/search/azure-search-documents/tests/async_tests/recordings/test_service_live_async.test_create_or_update_datasource_async.yaml
+++ b/sdk/search/azure-search-documents/tests/async_tests/recordings/test_service_live_async.test_create_or_update_datasource_async.yaml
@@ -11,78 +11,64 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - F34B15CF6FD4025C37227F974B55974F
+      - E7945749FF105081C2F1294C34BF0BC7
     method: POST
     uri: https://search251c1987.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search251c1987.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B62D671B9\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://search251c1987.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A058BC72A1\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control: no-cache
       content-length: '370'
       content-type: application/json; odata.metadata=minimal
-      date: Thu, 23 Apr 2020 09:47:50 GMT
-      elapsed-time: '33'
-      etag: W/"0x8D7E76B62D671B9"
+      date: Fri, 24 Apr 2020 22:39:27 GMT
+      elapsed-time: '30'
+      etag: W/"0x8D7E8A058BC72A1"
       expires: '-1'
       location: https://search251c1987.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
       odata-version: '4.0'
       pragma: no-cache
       preference-applied: odata.include-annotations="*"
-      request-id: 7e1e1b12-8547-11ea-a5c9-2816a845e8c6
+      request-id: 72d7d8ac-867c-11ea-8426-8c8590507855
       strict-transport-security: max-age=15724800; includeSubDomains
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - search251c1987.search.windows.net
-        - /datasources
-        - api-version=2019-05-06-Preview
-        - ''
+    url: https://search251c1987.search.windows.net/datasources?api-version=2019-05-06-Preview
 - request:
     body: null
     headers:
       Accept:
       - application/json;odata.metadata=minimal
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - F34B15CF6FD4025C37227F974B55974F
+      - E7945749FF105081C2F1294C34BF0BC7
     method: GET
     uri: https://search251c1987.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search251c1987.search.windows.net/$metadata#datasources","value":[{"@odata.etag":"\"0x8D7E76B62D671B9\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}]}'
+      string: '{"@odata.context":"https://search251c1987.search.windows.net/$metadata#datasources","value":[{"@odata.etag":"\"0x8D7E8A058BC72A1\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}]}'
     headers:
       cache-control: no-cache
       content-encoding: gzip
-      content-length: '366'
+      content-length: '365'
       content-type: application/json; odata.metadata=minimal
-      date: Thu, 23 Apr 2020 09:47:50 GMT
-      elapsed-time: '52'
+      date: Fri, 24 Apr 2020 22:39:27 GMT
+      elapsed-time: '9'
       expires: '-1'
       odata-version: '4.0'
       pragma: no-cache
       preference-applied: odata.include-annotations="*"
-      request-id: 7e431602-8547-11ea-8aae-2816a845e8c6
+      request-id: 72ebd8d4-867c-11ea-8426-8c8590507855
       strict-transport-security: max-age=15724800; includeSubDomains
       vary: Accept-Encoding
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - search251c1987.search.windows.net
-        - /datasources
-        - api-version=2019-05-06-Preview
-        - ''
+    url: https://search251c1987.search.windows.net/datasources?api-version=2019-05-06-Preview
 - request:
     body: '{"name": "sample-datasource", "description": "updated", "type": "azureblob",
       "credentials": {"connectionString": "DefaultEndpointsProtocol=https;AccountName=storagename;AccountKey=NzhL3hKZbJBuJ2484dPTR+xF30kYaWSSCbs2BzLgVVI1woqeST/1IgqaLm6QAOTxtGvxctSNbIR/1hW8yH+bJg==;EndpointSuffix=core.windows.net"},
@@ -97,117 +83,96 @@ interactions:
       Prefer:
       - return=representation
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - F34B15CF6FD4025C37227F974B55974F
+      - E7945749FF105081C2F1294C34BF0BC7
     method: PUT
     uri: https://search251c1987.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search251c1987.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B62F151BA\"","name":"sample-datasource","description":"updated","type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://search251c1987.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A058CA09A5\"","name":"sample-datasource","description":"updated","type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control: no-cache
       content-encoding: gzip
-      content-length: '366'
+      content-length: '365'
       content-type: application/json; odata.metadata=minimal
-      date: Thu, 23 Apr 2020 09:47:50 GMT
-      elapsed-time: '35'
-      etag: W/"0x8D7E76B62F151BA"
+      date: Fri, 24 Apr 2020 22:39:27 GMT
+      elapsed-time: '27'
+      etag: W/"0x8D7E8A058CA09A5"
       expires: '-1'
       odata-version: '4.0'
       pragma: no-cache
       preference-applied: odata.include-annotations="*"
-      request-id: 7e51ffba-8547-11ea-afc8-2816a845e8c6
+      request-id: 72f134d2-867c-11ea-8426-8c8590507855
       strict-transport-security: max-age=15724800; includeSubDomains
       vary: Accept-Encoding
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - search251c1987.search.windows.net
-        - /datasources('sample-datasource')
-        - api-version=2019-05-06-Preview
-        - ''
+    url: https://search251c1987.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
 - request:
     body: null
     headers:
       Accept:
       - application/json;odata.metadata=minimal
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - F34B15CF6FD4025C37227F974B55974F
+      - E7945749FF105081C2F1294C34BF0BC7
     method: GET
     uri: https://search251c1987.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search251c1987.search.windows.net/$metadata#datasources","value":[{"@odata.etag":"\"0x8D7E76B62F151BA\"","name":"sample-datasource","description":"updated","type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}]}'
+      string: '{"@odata.context":"https://search251c1987.search.windows.net/$metadata#datasources","value":[{"@odata.etag":"\"0x8D7E8A058CA09A5\"","name":"sample-datasource","description":"updated","type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}]}'
     headers:
       cache-control: no-cache
       content-encoding: gzip
-      content-length: '372'
+      content-length: '371'
       content-type: application/json; odata.metadata=minimal
-      date: Thu, 23 Apr 2020 09:47:50 GMT
+      date: Fri, 24 Apr 2020 22:39:27 GMT
       elapsed-time: '9'
       expires: '-1'
       odata-version: '4.0'
       pragma: no-cache
       preference-applied: odata.include-annotations="*"
-      request-id: 7e5dde9c-8547-11ea-96e1-2816a845e8c6
+      request-id: 72f94122-867c-11ea-8426-8c8590507855
       strict-transport-security: max-age=15724800; includeSubDomains
       vary: Accept-Encoding
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - search251c1987.search.windows.net
-        - /datasources
-        - api-version=2019-05-06-Preview
-        - ''
+    url: https://search251c1987.search.windows.net/datasources?api-version=2019-05-06-Preview
 - request:
     body: null
     headers:
       Accept:
       - application/json;odata.metadata=minimal
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - F34B15CF6FD4025C37227F974B55974F
+      - E7945749FF105081C2F1294C34BF0BC7
     method: GET
     uri: https://search251c1987.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search251c1987.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B62F151BA\"","name":"sample-datasource","description":"updated","type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://search251c1987.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A058CA09A5\"","name":"sample-datasource","description":"updated","type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control: no-cache
       content-encoding: gzip
-      content-length: '366'
+      content-length: '365'
       content-type: application/json; odata.metadata=minimal
-      date: Thu, 23 Apr 2020 09:47:50 GMT
-      elapsed-time: '5'
-      etag: W/"0x8D7E76B62F151BA"
+      date: Fri, 24 Apr 2020 22:39:27 GMT
+      elapsed-time: '4'
+      etag: W/"0x8D7E8A058CA09A5"
       expires: '-1'
       odata-version: '4.0'
       pragma: no-cache
       preference-applied: odata.include-annotations="*"
-      request-id: 7e65b04c-8547-11ea-8ac9-2816a845e8c6
+      request-id: 72fe71ce-867c-11ea-8426-8c8590507855
       strict-transport-security: max-age=15724800; includeSubDomains
       vary: Accept-Encoding
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - search251c1987.search.windows.net
-        - /datasources('sample-datasource')
-        - api-version=2019-05-06-Preview
-        - ''
+    url: https://search251c1987.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
 version: 1

--- a/sdk/search/azure-search-documents/tests/async_tests/recordings/test_service_live_async.test_delete_datasource_async.yaml
+++ b/sdk/search/azure-search-documents/tests/async_tests/recordings/test_service_live_async.test_delete_datasource_async.yaml
@@ -11,87 +11,73 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - B9AD3FA1A5A00F28630A84A8C57C2595
+      - 7A89725BBC59BE289D165493C43F6C66
     method: POST
     uri: https://search38471564.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search38471564.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B7020FF97\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://search38471564.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A0605A970A\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control: no-cache
       content-length: '370'
       content-type: application/json; odata.metadata=minimal
-      date: Thu, 23 Apr 2020 09:48:12 GMT
-      elapsed-time: '52'
-      etag: W/"0x8D7E76B7020FF97"
+      date: Fri, 24 Apr 2020 22:39:39 GMT
+      elapsed-time: '56'
+      etag: W/"0x8D7E8A0605A970A"
       expires: '-1'
       location: https://search38471564.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
       odata-version: '4.0'
       pragma: no-cache
       preference-applied: odata.include-annotations="*"
-      request-id: 8b696eba-8547-11ea-a514-2816a845e8c6
+      request-id: 7a71a03e-867c-11ea-8426-8c8590507855
       strict-transport-security: max-age=15724800; includeSubDomains
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - search38471564.search.windows.net
-        - /datasources
-        - api-version=2019-05-06-Preview
-        - ''
+    url: https://search38471564.search.windows.net/datasources?api-version=2019-05-06-Preview
 - request:
     body: null
     headers:
       Accept:
       - application/json;odata.metadata=minimal
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - B9AD3FA1A5A00F28630A84A8C57C2595
+      - 7A89725BBC59BE289D165493C43F6C66
     method: GET
     uri: https://search38471564.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search38471564.search.windows.net/$metadata#datasources","value":[{"@odata.etag":"\"0x8D7E76B7020FF97\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}]}'
+      string: '{"@odata.context":"https://search38471564.search.windows.net/$metadata#datasources","value":[{"@odata.etag":"\"0x8D7E8A0605A970A\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}]}'
     headers:
       cache-control: no-cache
       content-encoding: gzip
-      content-length: '366'
+      content-length: '365'
       content-type: application/json; odata.metadata=minimal
-      date: Thu, 23 Apr 2020 09:48:12 GMT
-      elapsed-time: '22'
+      date: Fri, 24 Apr 2020 22:39:39 GMT
+      elapsed-time: '24'
       expires: '-1'
       odata-version: '4.0'
       pragma: no-cache
       preference-applied: odata.include-annotations="*"
-      request-id: 8b8d7e18-8547-11ea-8d15-2816a845e8c6
+      request-id: 7a88e582-867c-11ea-8426-8c8590507855
       strict-transport-security: max-age=15724800; includeSubDomains
       vary: Accept-Encoding
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - search38471564.search.windows.net
-        - /datasources
-        - api-version=2019-05-06-Preview
-        - ''
+    url: https://search38471564.search.windows.net/datasources?api-version=2019-05-06-Preview
 - request:
     body: null
     headers:
       Accept:
       - application/json;odata.metadata=minimal
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - B9AD3FA1A5A00F28630A84A8C57C2595
+      - 7A89725BBC59BE289D165493C43F6C66
     method: DELETE
     uri: https://search38471564.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
   response:
@@ -99,32 +85,25 @@ interactions:
       string: ''
     headers:
       cache-control: no-cache
-      date: Thu, 23 Apr 2020 09:48:12 GMT
-      elapsed-time: '26'
+      date: Fri, 24 Apr 2020 22:39:39 GMT
+      elapsed-time: '41'
       expires: '-1'
       pragma: no-cache
-      request-id: 8b97b236-8547-11ea-87a8-2816a845e8c6
+      request-id: 7a91254e-867c-11ea-8426-8c8590507855
       strict-transport-security: max-age=15724800; includeSubDomains
     status:
       code: 204
       message: No Content
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - search38471564.search.windows.net
-        - /datasources('sample-datasource')
-        - api-version=2019-05-06-Preview
-        - ''
+    url: https://search38471564.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
 - request:
     body: null
     headers:
       Accept:
       - application/json;odata.metadata=minimal
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - B9AD3FA1A5A00F28630A84A8C57C2595
+      - 7A89725BBC59BE289D165493C43F6C66
     method: GET
     uri: https://search38471564.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
@@ -135,24 +114,17 @@ interactions:
       content-encoding: gzip
       content-length: '202'
       content-type: application/json; odata.metadata=minimal
-      date: Thu, 23 Apr 2020 09:48:12 GMT
+      date: Fri, 24 Apr 2020 22:39:39 GMT
       elapsed-time: '5'
       expires: '-1'
       odata-version: '4.0'
       pragma: no-cache
       preference-applied: odata.include-annotations="*"
-      request-id: 8ba2572e-8547-11ea-b58f-2816a845e8c6
+      request-id: 7a9b8098-867c-11ea-8426-8c8590507855
       strict-transport-security: max-age=15724800; includeSubDomains
       vary: Accept-Encoding
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - search38471564.search.windows.net
-        - /datasources
-        - api-version=2019-05-06-Preview
-        - ''
+    url: https://search38471564.search.windows.net/datasources?api-version=2019-05-06-Preview
 version: 1

--- a/sdk/search/azure-search-documents/tests/async_tests/recordings/test_service_live_async.test_get_datasource_async.yaml
+++ b/sdk/search/azure-search-documents/tests/async_tests/recordings/test_service_live_async.test_get_datasource_async.yaml
@@ -11,77 +11,63 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - 51E1A53A641E5EE7069C83D5F23E7C4C
+      - 9F98C05C3DB836017EA5D1617BDE33AF
     method: POST
     uri: https://searchfa0d1431.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://searchfa0d1431.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B7D1B6295\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://searchfa0d1431.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A067C498B3\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control: no-cache
       content-length: '370'
       content-type: application/json; odata.metadata=minimal
-      date: Thu, 23 Apr 2020 09:48:33 GMT
-      elapsed-time: '38'
-      etag: W/"0x8D7E76B7D1B6295"
+      date: Fri, 24 Apr 2020 22:39:52 GMT
+      elapsed-time: '51'
+      etag: W/"0x8D7E8A067C498B3"
       expires: '-1'
       location: https://searchfa0d1431.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
       odata-version: '4.0'
       pragma: no-cache
       preference-applied: odata.include-annotations="*"
-      request-id: 98587b54-8547-11ea-8bd6-2816a845e8c6
+      request-id: 81dc3c58-867c-11ea-8426-8c8590507855
       strict-transport-security: max-age=15724800; includeSubDomains
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - searchfa0d1431.search.windows.net
-        - /datasources
-        - api-version=2019-05-06-Preview
-        - ''
+    url: https://searchfa0d1431.search.windows.net/datasources?api-version=2019-05-06-Preview
 - request:
     body: null
     headers:
       Accept:
       - application/json;odata.metadata=minimal
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - 51E1A53A641E5EE7069C83D5F23E7C4C
+      - 9F98C05C3DB836017EA5D1617BDE33AF
     method: GET
     uri: https://searchfa0d1431.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://searchfa0d1431.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B7D1B6295\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://searchfa0d1431.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A067C498B3\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control: no-cache
       content-encoding: gzip
-      content-length: '359'
+      content-length: '358'
       content-type: application/json; odata.metadata=minimal
-      date: Thu, 23 Apr 2020 09:48:33 GMT
+      date: Fri, 24 Apr 2020 22:39:52 GMT
       elapsed-time: '8'
-      etag: W/"0x8D7E76B7D1B6295"
+      etag: W/"0x8D7E8A067C498B3"
       expires: '-1'
       odata-version: '4.0'
       pragma: no-cache
       preference-applied: odata.include-annotations="*"
-      request-id: 9888909e-8547-11ea-9e77-2816a845e8c6
+      request-id: 81f2b212-867c-11ea-8426-8c8590507855
       strict-transport-security: max-age=15724800; includeSubDomains
       vary: Accept-Encoding
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - searchfa0d1431.search.windows.net
-        - /datasources('sample-datasource')
-        - api-version=2019-05-06-Preview
-        - ''
+    url: https://searchfa0d1431.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
 version: 1

--- a/sdk/search/azure-search-documents/tests/async_tests/recordings/test_service_live_async.test_list_datasource_async.yaml
+++ b/sdk/search/azure-search-documents/tests/async_tests/recordings/test_service_live_async.test_list_datasource_async.yaml
@@ -11,39 +11,32 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - 722B42706843D7367FB3BE7F15D7B37B
+      - ED8893C2638A62641BBB16E90D792BD3
     method: POST
     uri: https://search101414ad.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search101414ad.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B919F686C\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://search101414ad.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A06ED211CF\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control: no-cache
       content-length: '370'
       content-type: application/json; odata.metadata=minimal
-      date: Thu, 23 Apr 2020 09:49:08 GMT
-      elapsed-time: '74'
-      etag: W/"0x8D7E76B919F686C"
+      date: Fri, 24 Apr 2020 22:40:04 GMT
+      elapsed-time: '66'
+      etag: W/"0x8D7E8A06ED211CF"
       expires: '-1'
       location: https://search101414ad.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
       odata-version: '4.0'
       pragma: no-cache
       preference-applied: odata.include-annotations="*"
-      request-id: acde73ac-8547-11ea-8db0-2816a845e8c6
+      request-id: 88e8d61e-867c-11ea-8426-8c8590507855
       strict-transport-security: max-age=15724800; includeSubDomains
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - search101414ad.search.windows.net
-        - /datasources
-        - api-version=2019-05-06-Preview
-        - ''
+    url: https://search101414ad.search.windows.net/datasources?api-version=2019-05-06-Preview
 - request:
     body: '{"name": "another-sample", "type": "azureblob", "credentials": {"connectionString":
       "DefaultEndpointsProtocol=https;AccountName=storagename;AccountKey=NzhL3hKZbJBuJ2484dPTR+xF30kYaWSSCbs2BzLgVVI1woqeST/1IgqaLm6QAOTxtGvxctSNbIR/1hW8yH+bJg==;EndpointSuffix=core.windows.net"},
@@ -56,76 +49,62 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - 722B42706843D7367FB3BE7F15D7B37B
+      - ED8893C2638A62641BBB16E90D792BD3
     method: POST
     uri: https://search101414ad.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search101414ad.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B91AEAD78\"","name":"another-sample","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://search101414ad.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A06EDDFADA\"","name":"another-sample","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control: no-cache
       content-length: '367'
       content-type: application/json; odata.metadata=minimal
-      date: Thu, 23 Apr 2020 09:49:08 GMT
-      elapsed-time: '44'
-      etag: W/"0x8D7E76B91AEAD78"
+      date: Fri, 24 Apr 2020 22:40:04 GMT
+      elapsed-time: '33'
+      etag: W/"0x8D7E8A06EDDFADA"
       expires: '-1'
       location: https://search101414ad.search.windows.net/datasources('another-sample')?api-version=2019-05-06-Preview
       odata-version: '4.0'
       pragma: no-cache
       preference-applied: odata.include-annotations="*"
-      request-id: ad0c1cfe-8547-11ea-b589-2816a845e8c6
+      request-id: 8901cb7e-867c-11ea-8426-8c8590507855
       strict-transport-security: max-age=15724800; includeSubDomains
     status:
       code: 201
       message: Created
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - search101414ad.search.windows.net
-        - /datasources
-        - api-version=2019-05-06-Preview
-        - ''
+    url: https://search101414ad.search.windows.net/datasources?api-version=2019-05-06-Preview
 - request:
     body: null
     headers:
       Accept:
       - application/json;odata.metadata=minimal
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - 722B42706843D7367FB3BE7F15D7B37B
+      - ED8893C2638A62641BBB16E90D792BD3
     method: GET
     uri: https://search101414ad.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search101414ad.search.windows.net/$metadata#datasources","value":[{"@odata.etag":"\"0x8D7E76B91AEAD78\"","name":"another-sample","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null},{"@odata.etag":"\"0x8D7E76B919F686C\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}]}'
+      string: '{"@odata.context":"https://search101414ad.search.windows.net/$metadata#datasources","value":[{"@odata.etag":"\"0x8D7E8A06EDDFADA\"","name":"another-sample","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null},{"@odata.etag":"\"0x8D7E8A06ED211CF\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}]}'
     headers:
       cache-control: no-cache
       content-encoding: gzip
-      content-length: '390'
+      content-length: '389'
       content-type: application/json; odata.metadata=minimal
-      date: Thu, 23 Apr 2020 09:49:08 GMT
-      elapsed-time: '14'
+      date: Fri, 24 Apr 2020 22:40:04 GMT
+      elapsed-time: '15'
       expires: '-1'
       odata-version: '4.0'
       pragma: no-cache
       preference-applied: odata.include-annotations="*"
-      request-id: ad1b79f4-8547-11ea-9015-2816a845e8c6
+      request-id: 890b1fda-867c-11ea-8426-8c8590507855
       strict-transport-security: max-age=15724800; includeSubDomains
       vary: Accept-Encoding
     status:
       code: 200
       message: OK
-    url: !!python/object/new:yarl.URL
-      state: !!python/tuple
-      - !!python/object/new:urllib.parse.SplitResult
-        - https
-        - search101414ad.search.windows.net
-        - /datasources
-        - api-version=2019-05-06-Preview
-        - ''
+    url: https://search101414ad.search.windows.net/datasources?api-version=2019-05-06-Preview
 version: 1

--- a/sdk/search/azure-search-documents/tests/async_tests/test_service_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_service_live_async.py
@@ -189,12 +189,12 @@ class SearchClientTest(AzureMgmtTestCase):
         result = await client.analyze_text(index_name, analyze_request)
         assert len(result.tokens) == 2
 
-    # Synonym Map operations
+class SearchSynonymMapsClientTest(AzureMgmtTestCase):
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_create_synonym_map(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_synonym_maps_client()
         result = await client.create_synonym_map("test-syn-map", [
             "USA, United States, United States of America",
             "Washington, Wash. => WA",
@@ -210,7 +210,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_delete_synonym_map(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_synonym_maps_client()
         result = await client.create_synonym_map("test-syn-map", [
             "USA, United States, United States of America",
             "Washington, Wash. => WA",
@@ -222,7 +222,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_get_synonym_map(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_synonym_maps_client()
         await client.create_synonym_map("test-syn-map", [
             "USA, United States, United States of America",
             "Washington, Wash. => WA",
@@ -239,7 +239,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_get_synonym_maps(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_synonym_maps_client()
         await client.create_synonym_map("test-syn-map-1", [
             "USA, United States, United States of America",
         ])
@@ -254,7 +254,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_create_or_update_synonym_map(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_synonym_maps_client()
         await client.create_synonym_map("test-syn-map", [
             "USA, United States, United States of America",
         ])

--- a/sdk/search/azure-search-documents/tests/async_tests/test_service_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_service_live_async.py
@@ -55,19 +55,7 @@ def await_prepared_test(test_fn):
 
     return run
 
-
 class SearchClientTest(AzureMgmtTestCase):
-    def _create_datasource(self, name="sample-datasource"):
-        credentials = DataSourceCredentials(connection_string=CONNECTION_STRING)
-        container = DataContainer(name='searchcontainer')
-        data_source = DataSource(
-            name=name,
-            type="azureblob",
-            credentials=credentials,
-            container=container
-        )
-        return data_source
-
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer()
     async def test_get_service_statistics(self, api_key, endpoint, **kwargs):
@@ -381,10 +369,22 @@ class SearchClientTest(AzureMgmtTestCase):
         assert result.name == "test-ss"
         assert result.description == "desc2"
 
+class SearchDataSourcesClientTest(AzureMgmtTestCase):
+    def _create_datasource(self, name="sample-datasource"):
+        credentials = DataSourceCredentials(connection_string=CONNECTION_STRING)
+        container = DataContainer(name='searchcontainer')
+        data_source = DataSource(
+            name=name,
+            type="azureblob",
+            credentials=credentials,
+            container=container
+        )
+        return data_source
+
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_create_datasource_async(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_datasources_client()
         data_source = self._create_datasource()
         result = await client.create_datasource(data_source)
         assert result.name == "sample-datasource"
@@ -393,7 +393,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_delete_datasource_async(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_datasources_client()
         data_source = self._create_datasource()
         result = await client.create_datasource(data_source)
         assert len(await client.get_datasources()) == 1
@@ -403,7 +403,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_get_datasource_async(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_datasources_client()
         data_source = self._create_datasource()
         created = await client.create_datasource(data_source)
         result = await client.get_datasource("sample-datasource")
@@ -412,7 +412,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_list_datasource_async(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_datasources_client()
         data_source1 = self._create_datasource()
         data_source2 = self._create_datasource(name="another-sample")
         created1 = await client.create_datasource(data_source1)
@@ -424,7 +424,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_create_or_update_datasource_async(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_datasources_client()
         data_source = self._create_datasource()
         created = await client.create_datasource(data_source)
         assert len(await client.get_datasources()) == 1

--- a/sdk/search/azure-search-documents/tests/async_tests/test_service_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_service_live_async.py
@@ -270,12 +270,12 @@ class SearchClientTest(AzureMgmtTestCase):
             "Washington, Wash. => WA",
         ]
 
-    # Skillset operations
+class SearchDataSourcesClientTest(AzureMgmtTestCase):
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_create_skillset(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_skillsets_client()
 
         s = EntityRecognitionSkill(inputs=[InputFieldMappingEntry(name="text", source="/document/content")],
                                    outputs=[OutputFieldMappingEntry(name="organizations", target_name="organizations")])
@@ -293,7 +293,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_delete_skillset(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_skillsets_client()
         s = EntityRecognitionSkill(inputs=[InputFieldMappingEntry(name="text", source="/document/content")],
                                    outputs=[OutputFieldMappingEntry(name="organizations", target_name="organizations")])
 
@@ -308,7 +308,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_get_skillset(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_skillsets_client()
         s = EntityRecognitionSkill(inputs=[InputFieldMappingEntry(name="text", source="/document/content")],
                                    outputs=[OutputFieldMappingEntry(name="organizations", target_name="organizations")])
 
@@ -326,7 +326,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_get_skillsets(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_skillsets_client()
         s = EntityRecognitionSkill(inputs=[InputFieldMappingEntry(name="text", source="/document/content")],
                                    outputs=[OutputFieldMappingEntry(name="organizations", target_name="organizations")])
 
@@ -340,7 +340,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_create_or_update_skillset(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_skillsets_client()
         s = EntityRecognitionSkill(inputs=[InputFieldMappingEntry(name="text", source="/document/content")],
                                    outputs=[OutputFieldMappingEntry(name="organizations", target_name="organizations")])
 
@@ -356,7 +356,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_create_or_update_skillset_inplace(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_skillsets_client()
         s = EntityRecognitionSkill(inputs=[InputFieldMappingEntry(name="text", source="/document/content")],
                                    outputs=[OutputFieldMappingEntry(name="organizations", target_name="organizations")])
 
@@ -370,6 +370,7 @@ class SearchClientTest(AzureMgmtTestCase):
         assert result.description == "desc2"
 
 class SearchDataSourcesClientTest(AzureMgmtTestCase):
+
     def _create_datasource(self, name="sample-datasource"):
         credentials = DataSourceCredentials(connection_string=CONNECTION_STRING)
         container = DataContainer(name='searchcontainer')

--- a/sdk/search/azure-search-documents/tests/async_tests/test_service_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_service_live_async.py
@@ -64,19 +64,19 @@ class SearchClientTest(AzureMgmtTestCase):
         assert isinstance(result, dict)
         assert set(result.keys()) == {"counters", "limits"}
 
-    # Index operations
+class SearchIndexesClientTest(AzureMgmtTestCase):
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer()
     async def test_get_indexes_empty(self, api_key, endpoint, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_indexes_client()
         result = await client.get_indexes()
         assert len(result) == 0
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_get_indexes(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_indexes_client()
         result = await client.get_indexes()
         assert len(result) == 1
         assert result[0].name == index_name
@@ -84,21 +84,21 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_get_index(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_indexes_client()
         result = await client.get_index(index_name)
         assert result.name == index_name
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_get_index_statistics(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_indexes_client()
         result = await client.get_index_statistics(index_name)
         assert set(result.keys()) == {'document_count', 'storage_size'}
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_delete_indexes(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_indexes_client()
         await client.delete_index(index_name)
         import time
         if self.is_live:
@@ -132,7 +132,7 @@ class SearchClientTest(AzureMgmtTestCase):
             fields=fields,
             scoring_profiles=scoring_profiles,
             cors_options=cors_options)
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_indexes_client()
         result = await client.create_index(index)
         assert result.name == "hotels"
         assert result.scoring_profiles[0].name == scoring_profile.name
@@ -161,7 +161,7 @@ class SearchClientTest(AzureMgmtTestCase):
             fields=fields,
             scoring_profiles=scoring_profiles,
             cors_options=cors_options)
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_indexes_client()
         result = await client.create_or_update_index(index_name=index.name, index=index)
         assert len(result.scoring_profiles) == 0
         assert result.cors_options.allowed_origins == cors_options.allowed_origins
@@ -184,7 +184,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     async def test_analyze_text(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_indexes_client()
         analyze_request = AnalyzeRequest(text="One's <two/>", analyzer="standard.lucene")
         result = await client.analyze_text(index_name, analyze_request)
         assert len(result.tokens) == 2

--- a/sdk/search/azure-search-documents/tests/recordings/test_service_live.test_create_datasource.yaml
+++ b/sdk/search/azure-search-documents/tests/recordings/test_service_live.test_create_datasource.yaml
@@ -15,14 +15,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - 6EE1AFB6E75621F4C0D8091DB40240CE
+      - 5944A0DC7FD275C43424B38DC65B1807
     method: POST
     uri: https://search51c7106b.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search51c7106b.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B0EE7CAE6\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://search51c7106b.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A02E96F7B0\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control:
       - no-cache
@@ -31,11 +31,11 @@ interactions:
       content-type:
       - application/json; odata.metadata=minimal
       date:
-      - Thu, 23 Apr 2020 09:45:29 GMT
+      - Fri, 24 Apr 2020 22:38:16 GMT
       elapsed-time:
-      - '59'
+      - '29'
       etag:
-      - W/"0x8D7E76B0EE7CAE6"
+      - W/"0x8D7E8A02E96F7B0"
       expires:
       - '-1'
       location:
@@ -47,7 +47,7 @@ interactions:
       preference-applied:
       - odata.include-annotations="*"
       request-id:
-      - 29fadd68-8547-11ea-946b-2816a845e8c6
+      - 48ac5f12-867c-11ea-8426-8c8590507855
       strict-transport-security:
       - max-age=15724800; includeSubDomains
     status:

--- a/sdk/search/azure-search-documents/tests/recordings/test_service_live.test_create_or_update_datasource.yaml
+++ b/sdk/search/azure-search-documents/tests/recordings/test_service_live.test_create_or_update_datasource.yaml
@@ -15,14 +15,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - E4BC53B804F034F1EAA7589A86038793
+      - 2A0262C65D136295901F63CCBCC37D9A
     method: POST
     uri: https://searchcca148d.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://searchcca148d.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B1CF33474\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://searchcca148d.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A035B9F8F7\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control:
       - no-cache
@@ -31,11 +31,11 @@ interactions:
       content-type:
       - application/json; odata.metadata=minimal
       date:
-      - Thu, 23 Apr 2020 09:45:52 GMT
+      - Fri, 24 Apr 2020 22:38:28 GMT
       elapsed-time:
-      - '84'
+      - '54'
       etag:
-      - W/"0x8D7E76B1CF33474"
+      - W/"0x8D7E8A035B9F8F7"
       expires:
       - '-1'
       location:
@@ -47,7 +47,7 @@ interactions:
       preference-applied:
       - odata.include-annotations="*"
       request-id:
-      - 381dde6e-8547-11ea-9c14-2816a845e8c6
+      - 4fc0c6bc-867c-11ea-8426-8c8590507855
       strict-transport-security:
       - max-age=15724800; includeSubDomains
     status:
@@ -63,14 +63,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - E4BC53B804F034F1EAA7589A86038793
+      - 2A0262C65D136295901F63CCBCC37D9A
     method: GET
     uri: https://searchcca148d.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://searchcca148d.search.windows.net/$metadata#datasources","value":[{"@odata.etag":"\"0x8D7E76B1CF33474\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}]}'
+      string: '{"@odata.context":"https://searchcca148d.search.windows.net/$metadata#datasources","value":[{"@odata.etag":"\"0x8D7E8A035B9F8F7\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}]}'
     headers:
       cache-control:
       - no-cache
@@ -79,9 +79,9 @@ interactions:
       content-type:
       - application/json; odata.metadata=minimal
       date:
-      - Thu, 23 Apr 2020 09:45:52 GMT
+      - Fri, 24 Apr 2020 22:38:28 GMT
       elapsed-time:
-      - '19'
+      - '20'
       expires:
       - '-1'
       odata-version:
@@ -91,7 +91,7 @@ interactions:
       preference-applied:
       - odata.include-annotations="*"
       request-id:
-      - 386479e2-8547-11ea-b642-2816a845e8c6
+      - 4feb9bb2-867c-11ea-8426-8c8590507855
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       vary:
@@ -117,14 +117,14 @@ interactions:
       Prefer:
       - return=representation
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - E4BC53B804F034F1EAA7589A86038793
+      - 2A0262C65D136295901F63CCBCC37D9A
     method: PUT
     uri: https://searchcca148d.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://searchcca148d.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B1D1AC0E6\"","name":"sample-datasource","description":"updated","type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://searchcca148d.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A035D1F217\"","name":"sample-datasource","description":"updated","type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control:
       - no-cache
@@ -133,11 +133,11 @@ interactions:
       content-type:
       - application/json; odata.metadata=minimal
       date:
-      - Thu, 23 Apr 2020 09:45:52 GMT
+      - Fri, 24 Apr 2020 22:38:28 GMT
       elapsed-time:
-      - '34'
+      - '52'
       etag:
-      - W/"0x8D7E76B1D1AC0E6"
+      - W/"0x8D7E8A035D1F217"
       expires:
       - '-1'
       odata-version:
@@ -147,7 +147,7 @@ interactions:
       preference-applied:
       - odata.include-annotations="*"
       request-id:
-      - 3873ff9c-8547-11ea-bd5b-2816a845e8c6
+      - 4ff553c8-867c-11ea-8426-8c8590507855
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       vary:
@@ -165,14 +165,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - E4BC53B804F034F1EAA7589A86038793
+      - 2A0262C65D136295901F63CCBCC37D9A
     method: GET
     uri: https://searchcca148d.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://searchcca148d.search.windows.net/$metadata#datasources","value":[{"@odata.etag":"\"0x8D7E76B1D1AC0E6\"","name":"sample-datasource","description":"updated","type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}]}'
+      string: '{"@odata.context":"https://searchcca148d.search.windows.net/$metadata#datasources","value":[{"@odata.etag":"\"0x8D7E8A035D1F217\"","name":"sample-datasource","description":"updated","type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}]}'
     headers:
       cache-control:
       - no-cache
@@ -181,9 +181,9 @@ interactions:
       content-type:
       - application/json; odata.metadata=minimal
       date:
-      - Thu, 23 Apr 2020 09:45:52 GMT
+      - Fri, 24 Apr 2020 22:38:28 GMT
       elapsed-time:
-      - '9'
+      - '33'
       expires:
       - '-1'
       odata-version:
@@ -193,7 +193,7 @@ interactions:
       preference-applied:
       - odata.include-annotations="*"
       request-id:
-      - 38872d8a-8547-11ea-9731-2816a845e8c6
+      - 50038466-867c-11ea-8426-8c8590507855
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       vary:
@@ -211,14 +211,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - E4BC53B804F034F1EAA7589A86038793
+      - 2A0262C65D136295901F63CCBCC37D9A
     method: GET
     uri: https://searchcca148d.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://searchcca148d.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B1D1AC0E6\"","name":"sample-datasource","description":"updated","type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://searchcca148d.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A035D1F217\"","name":"sample-datasource","description":"updated","type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control:
       - no-cache
@@ -227,11 +227,11 @@ interactions:
       content-type:
       - application/json; odata.metadata=minimal
       date:
-      - Thu, 23 Apr 2020 09:45:52 GMT
+      - Fri, 24 Apr 2020 22:38:28 GMT
       elapsed-time:
-      - '6'
+      - '15'
       etag:
-      - W/"0x8D7E76B1D1AC0E6"
+      - W/"0x8D7E8A035D1F217"
       expires:
       - '-1'
       odata-version:
@@ -241,7 +241,7 @@ interactions:
       preference-applied:
       - odata.include-annotations="*"
       request-id:
-      - 389554ba-8547-11ea-8993-2816a845e8c6
+      - 500fdb12-867c-11ea-8426-8c8590507855
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       vary:

--- a/sdk/search/azure-search-documents/tests/recordings/test_service_live.test_delete_datasource.yaml
+++ b/sdk/search/azure-search-documents/tests/recordings/test_service_live.test_delete_datasource.yaml
@@ -15,14 +15,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - 8D1DA77C1D33A3A2C2E202F91D866E5C
+      - 0854D7F39E2712F07D51D39AD7B4BCB7
     method: POST
     uri: https://search51a9106a.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search51a9106a.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B266466FE\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://search51a9106a.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A03C7859A1\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control:
       - no-cache
@@ -31,11 +31,11 @@ interactions:
       content-type:
       - application/json; odata.metadata=minimal
       date:
-      - Thu, 23 Apr 2020 09:46:08 GMT
+      - Fri, 24 Apr 2020 22:38:39 GMT
       elapsed-time:
-      - '51'
+      - '64'
       etag:
-      - W/"0x8D7E76B266466FE"
+      - W/"0x8D7E8A03C7859A1"
       expires:
       - '-1'
       location:
@@ -47,7 +47,7 @@ interactions:
       preference-applied:
       - odata.include-annotations="*"
       request-id:
-      - 419d323e-8547-11ea-a215-2816a845e8c6
+      - 5687b41a-867c-11ea-8426-8c8590507855
       strict-transport-security:
       - max-age=15724800; includeSubDomains
     status:
@@ -63,14 +63,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - 8D1DA77C1D33A3A2C2E202F91D866E5C
+      - 0854D7F39E2712F07D51D39AD7B4BCB7
     method: GET
     uri: https://search51a9106a.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search51a9106a.search.windows.net/$metadata#datasources","value":[{"@odata.etag":"\"0x8D7E76B266466FE\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}]}'
+      string: '{"@odata.context":"https://search51a9106a.search.windows.net/$metadata#datasources","value":[{"@odata.etag":"\"0x8D7E8A03C7859A1\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}]}'
     headers:
       cache-control:
       - no-cache
@@ -79,9 +79,9 @@ interactions:
       content-type:
       - application/json; odata.metadata=minimal
       date:
-      - Thu, 23 Apr 2020 09:46:08 GMT
+      - Fri, 24 Apr 2020 22:38:39 GMT
       elapsed-time:
-      - '18'
+      - '39'
       expires:
       - '-1'
       odata-version:
@@ -91,7 +91,7 @@ interactions:
       preference-applied:
       - odata.include-annotations="*"
       request-id:
-      - 41d079fa-8547-11ea-9f01-2816a845e8c6
+      - 56a96858-867c-11ea-8426-8c8590507855
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       vary:
@@ -111,9 +111,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - 8D1DA77C1D33A3A2C2E202F91D866E5C
+      - 0854D7F39E2712F07D51D39AD7B4BCB7
     method: DELETE
     uri: https://search51a9106a.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
   response:
@@ -123,15 +123,15 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 23 Apr 2020 09:46:08 GMT
+      - Fri, 24 Apr 2020 22:38:39 GMT
       elapsed-time:
-      - '54'
+      - '44'
       expires:
       - '-1'
       pragma:
       - no-cache
       request-id:
-      - 41dff18c-8547-11ea-8d51-2816a845e8c6
+      - 56b5e736-867c-11ea-8426-8c8590507855
       strict-transport-security:
       - max-age=15724800; includeSubDomains
     status:
@@ -147,9 +147,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - 8D1DA77C1D33A3A2C2E202F91D866E5C
+      - 0854D7F39E2712F07D51D39AD7B4BCB7
     method: GET
     uri: https://search51a9106a.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
@@ -163,9 +163,9 @@ interactions:
       content-type:
       - application/json; odata.metadata=minimal
       date:
-      - Thu, 23 Apr 2020 09:46:08 GMT
+      - Fri, 24 Apr 2020 22:38:39 GMT
       elapsed-time:
-      - '6'
+      - '8'
       expires:
       - '-1'
       odata-version:
@@ -175,7 +175,7 @@ interactions:
       preference-applied:
       - odata.include-annotations="*"
       request-id:
-      - 41f5654a-8547-11ea-a7a9-2816a845e8c6
+      - 56c2b128-867c-11ea-8426-8c8590507855
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       vary:

--- a/sdk/search/azure-search-documents/tests/recordings/test_service_live.test_get_datasource.yaml
+++ b/sdk/search/azure-search-documents/tests/recordings/test_service_live.test_get_datasource.yaml
@@ -15,14 +15,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - 8CD7256132FD7881C2091E30F89DA85F
+      - 8F7E74DA6770FF09E7893CF94EE4ECAC
     method: POST
     uri: https://search22270f37.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search22270f37.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B3349695F\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://search22270f37.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A0435D5C22\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control:
       - no-cache
@@ -31,11 +31,11 @@ interactions:
       content-type:
       - application/json; odata.metadata=minimal
       date:
-      - Thu, 23 Apr 2020 09:46:30 GMT
+      - Fri, 24 Apr 2020 22:38:51 GMT
       elapsed-time:
-      - '49'
+      - '51'
       etag:
-      - W/"0x8D7E76B3349695F"
+      - W/"0x8D7E8A0435D5C22"
       expires:
       - '-1'
       location:
@@ -47,7 +47,7 @@ interactions:
       preference-applied:
       - odata.include-annotations="*"
       request-id:
-      - 4e608d6e-8547-11ea-8181-2816a845e8c6
+      - 5d6c2fea-867c-11ea-8426-8c8590507855
       strict-transport-security:
       - max-age=15724800; includeSubDomains
     status:
@@ -63,14 +63,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - 8CD7256132FD7881C2091E30F89DA85F
+      - 8F7E74DA6770FF09E7893CF94EE4ECAC
     method: GET
     uri: https://search22270f37.search.windows.net/datasources('sample-datasource')?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search22270f37.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B3349695F\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://search22270f37.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A0435D5C22\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control:
       - no-cache
@@ -79,11 +79,11 @@ interactions:
       content-type:
       - application/json; odata.metadata=minimal
       date:
-      - Thu, 23 Apr 2020 09:46:30 GMT
+      - Fri, 24 Apr 2020 22:38:51 GMT
       elapsed-time:
-      - '11'
+      - '10'
       etag:
-      - W/"0x8D7E76B3349695F"
+      - W/"0x8D7E8A0435D5C22"
       expires:
       - '-1'
       odata-version:
@@ -93,7 +93,7 @@ interactions:
       preference-applied:
       - odata.include-annotations="*"
       request-id:
-      - 4eb64b08-8547-11ea-a135-2816a845e8c6
+      - 5d8e1a88-867c-11ea-8426-8c8590507855
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       vary:

--- a/sdk/search/azure-search-documents/tests/recordings/test_service_live.test_list_datasource.yaml
+++ b/sdk/search/azure-search-documents/tests/recordings/test_service_live.test_list_datasource.yaml
@@ -15,14 +15,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - 886DBEB78F10DFC648810BF835D2FBCD
+      - D00E1CC05615AAE9C4EEF6A8E0D1659A
     method: POST
     uri: https://search32ba0fb3.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search32ba0fb3.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B3C7A050D\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://search32ba0fb3.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A04ABDE6B7\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control:
       - no-cache
@@ -31,11 +31,11 @@ interactions:
       content-type:
       - application/json; odata.metadata=minimal
       date:
-      - Thu, 23 Apr 2020 09:46:45 GMT
+      - Fri, 24 Apr 2020 22:39:04 GMT
       elapsed-time:
-      - '27'
+      - '60'
       etag:
-      - W/"0x8D7E76B3C7A050D"
+      - W/"0x8D7E8A04ABDE6B7"
       expires:
       - '-1'
       location:
@@ -47,7 +47,7 @@ interactions:
       preference-applied:
       - odata.include-annotations="*"
       request-id:
-      - 57b61746-8547-11ea-aa62-2816a845e8c6
+      - 64ce5bfa-867c-11ea-8426-8c8590507855
       strict-transport-security:
       - max-age=15724800; includeSubDomains
     status:
@@ -69,14 +69,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - 886DBEB78F10DFC648810BF835D2FBCD
+      - D00E1CC05615AAE9C4EEF6A8E0D1659A
     method: POST
     uri: https://search32ba0fb3.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search32ba0fb3.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E76B3C8B1F58\"","name":"another-sample","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
+      string: '{"@odata.context":"https://search32ba0fb3.search.windows.net/$metadata#datasources/$entity","@odata.etag":"\"0x8D7E8A04AC9A89E\"","name":"another-sample","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}'
     headers:
       cache-control:
       - no-cache
@@ -85,11 +85,11 @@ interactions:
       content-type:
       - application/json; odata.metadata=minimal
       date:
-      - Thu, 23 Apr 2020 09:46:45 GMT
+      - Fri, 24 Apr 2020 22:39:04 GMT
       elapsed-time:
-      - '28'
+      - '37'
       etag:
-      - W/"0x8D7E76B3C8B1F58"
+      - W/"0x8D7E8A04AC9A89E"
       expires:
       - '-1'
       location:
@@ -101,7 +101,7 @@ interactions:
       preference-applied:
       - odata.include-annotations="*"
       request-id:
-      - 57e5e03e-8547-11ea-87b0-2816a845e8c6
+      - 64ee6e36-867c-11ea-8426-8c8590507855
       strict-transport-security:
       - max-age=15724800; includeSubDomains
     status:
@@ -117,14 +117,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Windows-10-10.0.17763-SP0)
+      - azsdk-python-search-documents/1.0.0b3 Python/3.7.3 (Darwin-19.3.0-x86_64-i386-64bit)
       api-key:
-      - 886DBEB78F10DFC648810BF835D2FBCD
+      - D00E1CC05615AAE9C4EEF6A8E0D1659A
     method: GET
     uri: https://search32ba0fb3.search.windows.net/datasources?api-version=2019-05-06-Preview
   response:
     body:
-      string: '{"@odata.context":"https://search32ba0fb3.search.windows.net/$metadata#datasources","value":[{"@odata.etag":"\"0x8D7E76B3C8B1F58\"","name":"another-sample","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null},{"@odata.etag":"\"0x8D7E76B3C7A050D\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}]}'
+      string: '{"@odata.context":"https://search32ba0fb3.search.windows.net/$metadata#datasources","value":[{"@odata.etag":"\"0x8D7E8A04AC9A89E\"","name":"another-sample","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null},{"@odata.etag":"\"0x8D7E8A04ABDE6B7\"","name":"sample-datasource","description":null,"type":"azureblob","subtype":null,"credentials":{"connectionString":null},"container":{"name":"searchcontainer","query":null},"dataChangeDetectionPolicy":null,"dataDeletionDetectionPolicy":null}]}'
     headers:
       cache-control:
       - no-cache
@@ -133,9 +133,9 @@ interactions:
       content-type:
       - application/json; odata.metadata=minimal
       date:
-      - Thu, 23 Apr 2020 09:46:45 GMT
+      - Fri, 24 Apr 2020 22:39:04 GMT
       elapsed-time:
-      - '32'
+      - '18'
       expires:
       - '-1'
       odata-version:
@@ -145,7 +145,7 @@ interactions:
       preference-applied:
       - odata.include-annotations="*"
       request-id:
-      - 57f6c49c-8547-11ea-a5de-2816a845e8c6
+      - 64fa2d0c-867c-11ea-8426-8c8590507855
       strict-transport-security:
       - max-age=15724800; includeSubDomains
       vary:

--- a/sdk/search/azure-search-documents/tests/test_service_live.py
+++ b/sdk/search/azure-search-documents/tests/test_service_live.py
@@ -173,12 +173,12 @@ class SearchClientTest(AzureMgmtTestCase):
         result = client.analyze_text(index_name, analyze_request)
         assert len(result.tokens) == 2
 
-    # Synonym Map operations
+class SearchSynonymMapsClientTest(AzureMgmtTestCase):
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_create_synonym_map(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_synonym_maps_client()
         result = client.create_synonym_map("test-syn-map", [
             "USA, United States, United States of America",
             "Washington, Wash. => WA",
@@ -194,7 +194,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_delete_synonym_map(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_synonym_maps_client()
         result = client.create_synonym_map("test-syn-map", [
             "USA, United States, United States of America",
             "Washington, Wash. => WA",
@@ -206,7 +206,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_get_synonym_map(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_synonym_maps_client()
         client.create_synonym_map("test-syn-map", [
             "USA, United States, United States of America",
             "Washington, Wash. => WA",
@@ -223,7 +223,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_get_synonym_maps(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_synonym_maps_client()
         client.create_synonym_map("test-syn-map-1", [
             "USA, United States, United States of America",
         ])
@@ -238,7 +238,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_create_or_update_synonym_map(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_synonym_maps_client()
         client.create_synonym_map("test-syn-map", [
             "USA, United States, United States of America",
         ])

--- a/sdk/search/azure-search-documents/tests/test_service_live.py
+++ b/sdk/search/azure-search-documents/tests/test_service_live.py
@@ -39,16 +39,6 @@ TIME_TO_SLEEP = 5
 CONNECTION_STRING = 'DefaultEndpointsProtocol=https;AccountName=storagename;AccountKey=NzhL3hKZbJBuJ2484dPTR+xF30kYaWSSCbs2BzLgVVI1woqeST/1IgqaLm6QAOTxtGvxctSNbIR/1hW8yH+bJg==;EndpointSuffix=core.windows.net'
 
 class SearchClientTest(AzureMgmtTestCase):
-    def _create_datasource(self, name="sample-datasource"):
-        credentials = DataSourceCredentials(connection_string=CONNECTION_STRING)
-        container = DataContainer(name='searchcontainer')
-        data_source = DataSource(
-            name=name,
-            type="azureblob",
-            credentials=credentials,
-            container=container
-        )
-        return data_source
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer()
@@ -361,10 +351,22 @@ class SearchClientTest(AzureMgmtTestCase):
         assert result.name == "test-ss"
         assert result.description == "desc2"
 
+class SearchDataSourcesClientTest(AzureMgmtTestCase):
+    def _create_datasource(self, name="sample-datasource"):
+        credentials = DataSourceCredentials(connection_string=CONNECTION_STRING)
+        container = DataContainer(name='searchcontainer')
+        data_source = DataSource(
+            name=name,
+            type="azureblob",
+            credentials=credentials,
+            container=container
+        )
+        return data_source
+
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_create_datasource(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_datasources_client()
         data_source = self._create_datasource()
         result = client.create_datasource(data_source)
         assert result.name == "sample-datasource"
@@ -373,7 +375,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_delete_datasource(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_datasources_client()
         data_source = self._create_datasource()
         result = client.create_datasource(data_source)
         assert len(client.get_datasources()) == 1
@@ -383,7 +385,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_get_datasource(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_datasources_client()
         data_source = self._create_datasource()
         created = client.create_datasource(data_source)
         result = client.get_datasource("sample-datasource")
@@ -392,7 +394,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_list_datasource(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_datasources_client()
         data_source1 = self._create_datasource()
         data_source2 = self._create_datasource(name="another-sample")
         created1 = client.create_datasource(data_source1)
@@ -404,7 +406,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_create_or_update_datasource(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_datasources_client()
         data_source = self._create_datasource()
         created = client.create_datasource(data_source)
         assert len(client.get_datasources()) == 1

--- a/sdk/search/azure-search-documents/tests/test_service_live.py
+++ b/sdk/search/azure-search-documents/tests/test_service_live.py
@@ -48,19 +48,19 @@ class SearchClientTest(AzureMgmtTestCase):
         assert isinstance(result, dict)
         assert set(result.keys()) == {"counters", "limits"}
 
-    # Index operations
+class SearchIndexesClientTest(AzureMgmtTestCase):
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer()
     def test_get_indexes_empty(self, api_key, endpoint, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_indexes_client()
         result = client.get_indexes()
         assert len(result) == 0
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_get_indexes(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_indexes_client()
         result = client.get_indexes()
         assert len(result) == 1
         assert result[0].name == index_name
@@ -68,21 +68,21 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_get_index(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_indexes_client()
         result = client.get_index(index_name)
         assert result.name == index_name
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_get_index_statistics(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_indexes_client()
         result = client.get_index_statistics(index_name)
         assert set(result.keys()) == {'document_count', 'storage_size'}
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_delete_indexes(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_indexes_client()
         client.delete_index(index_name)
         import time
         if self.is_live:
@@ -116,7 +116,7 @@ class SearchClientTest(AzureMgmtTestCase):
             fields=fields,
             scoring_profiles=scoring_profiles,
             cors_options=cors_options)
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_indexes_client()
         result = client.create_index(index)
         assert result.name == "hotels"
         assert result.scoring_profiles[0].name == scoring_profile.name
@@ -145,7 +145,7 @@ class SearchClientTest(AzureMgmtTestCase):
             fields=fields,
             scoring_profiles=scoring_profiles,
             cors_options=cors_options)
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_indexes_client()
         result = client.create_or_update_index(index_name=index.name, index=index)
         assert len(result.scoring_profiles) == 0
         assert result.cors_options.allowed_origins == cors_options.allowed_origins
@@ -168,7 +168,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_analyze_text(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_indexes_client()
         analyze_request = AnalyzeRequest(text="One's <two/>", analyzer="standard.lucene")
         result = client.analyze_text(index_name, analyze_request)
         assert len(result.tokens) == 2

--- a/sdk/search/azure-search-documents/tests/test_service_live.py
+++ b/sdk/search/azure-search-documents/tests/test_service_live.py
@@ -254,12 +254,12 @@ class SearchClientTest(AzureMgmtTestCase):
             "Washington, Wash. => WA",
         ]
 
-    # Skillset operations
+class SearchSkillsetClientTest(AzureMgmtTestCase):
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_create_skillset(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_skillsets_client()
 
         s = EntityRecognitionSkill(inputs=[InputFieldMappingEntry(name="text", source="/document/content")],
                                    outputs=[OutputFieldMappingEntry(name="organizations", target_name="organizations")])
@@ -277,7 +277,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_delete_skillset(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_skillsets_client()
         s = EntityRecognitionSkill(inputs=[InputFieldMappingEntry(name="text", source="/document/content")],
                                    outputs=[OutputFieldMappingEntry(name="organizations", target_name="organizations")])
 
@@ -290,7 +290,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_get_skillset(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_skillsets_client()
         s = EntityRecognitionSkill(inputs=[InputFieldMappingEntry(name="text", source="/document/content")],
                                    outputs=[OutputFieldMappingEntry(name="organizations", target_name="organizations")])
 
@@ -308,7 +308,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_get_skillsets(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_skillsets_client()
         s = EntityRecognitionSkill(inputs=[InputFieldMappingEntry(name="text", source="/document/content")],
                                    outputs=[OutputFieldMappingEntry(name="organizations", target_name="organizations")])
 
@@ -322,7 +322,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_create_or_update_skillset(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_skillsets_client()
         s = EntityRecognitionSkill(inputs=[InputFieldMappingEntry(name="text", source="/document/content")],
                                    outputs=[OutputFieldMappingEntry(name="organizations", target_name="organizations")])
 
@@ -338,7 +338,7 @@ class SearchClientTest(AzureMgmtTestCase):
     @ResourceGroupPreparer(random_name_enabled=True)
     @SearchServicePreparer(schema=SCHEMA, index_batch=BATCH)
     def test_create_or_update_skillset_inplace(self, api_key, endpoint, index_name, **kwargs):
-        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key))
+        client = SearchServiceClient(endpoint, AzureKeyCredential(api_key)).get_skillsets_client()
         s = EntityRecognitionSkill(inputs=[InputFieldMappingEntry(name="text", source="/document/content")],
                                    outputs=[OutputFieldMappingEntry(name="organizations", target_name="organizations")])
 
@@ -352,6 +352,7 @@ class SearchClientTest(AzureMgmtTestCase):
         assert result.description == "desc2"
 
 class SearchDataSourcesClientTest(AzureMgmtTestCase):
+
     def _create_datasource(self, name="sample-datasource"):
         credentials = DataSourceCredentials(connection_string=CONNECTION_STRING)
         container = DataContainer(name='searchcontainer')


### PR DESCRIPTION
This PR splits off the service sub-clients, accessible via the following new methods:
```
def get_indexes_client(self) -> SearchIndexesClient:
def get_synonym_maps_client(self) -> SearchSynonymMapsClient:
def get_skillsets_client(self) -> SearchSkillsetsClient:
def get_datasources_client(self) -> SearchDataSourcesClient:
```
Work to add indexers at all is still TBD this week. 

The bulk of the work was the splitting, if there are any tweaks to names those will be easy to accommodate from any discussion here. 