### PR TITLE
Lint error in cosmos

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
@@ -24,7 +24,9 @@
 
 """Document client class for the Azure Cosmos database service.
 """
-from typing import Dict, Any, Optional
+# https://github.com/PyCQA/pylint/issues/3112
+# Currently pylint is locked to 2.3.3 and this is fixed in 2.4.4
+from typing import Dict, Any, Optional # pylint: disable=unused-import
 import six
 from urllib3.util.retry import Retry
 from azure.core.paging import ItemPaged  # type: ignore


### PR DESCRIPTION
Issue: https://github.com/PyCQA/pylint/issues/3112

`from typing import Optional` throws a lint error despite of using the import as `Optional[something]`

Currently pylint is locked to 2.3.3 and this is fixed in 2.4.4