### PR TITLE
Set time out to 90 mins for regression test

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -187,6 +187,7 @@ jobs:
   - job: 'RunRegression'
     condition: and(succeededOrFailed(), or(eq(variables['Run.Regression'], 'true'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['System.TeamProject'],'internal'))))
     displayName: 'Run Regression'
+    timeoutInMinutes: 90
     variables:
     - template: ../variables/globals.yml
 


### PR DESCRIPTION
Regression test is timing out after 60 mins. Test runs regression for latest released and oldest released dependent packages and this takes around 35 minutes each for azure-core. As per the current design test cannot be run in parallel on same machine since they use a cloned repo that is checked out to different released tags/branch based on the test it is running. One approach is to run these tests as two jobs in parallel. Temporary fix is to increase time out to 90 mins.