### PR TITLE
[text analtyics] Pass optional encoding to endpoint, remove grapheme prefix

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Added `text` property to `SentenceSentiment`
 
 **Breaking changes**
-- Each endpoint now has a required parameter `encoding` that specifies the encoding you would like each text unit to be recognized as.
+- Each endpoint now has a kwarg parameter `encoding` that specifies the encoding you would like each text unit to be recognized as. Though it is not required,
+we strongly suggest users to pass in a value to `encoding` since we can't guarantee the consistency of the returned offset, lengths, and counts if not.
 - `grapheme_length` and `grapheme_offset` attributes have been renamed to `length` and `offset` for the `SentenceSentiment`,
 `CategorizedEntity`, `PiiEntity`, and `LinkedEntityMatch` models. Their encoding will be the value passed in the `encoding` parameter
 to each endpoint

--- a/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Added `text` property to `SentenceSentiment`
 
 **Breaking changes**
+- Each endpoint now has a required parameter `encoding` that specifies the encoding you would like each text unit to be recognized as.
+- `grapheme_length` and `grapheme_offset` attributes have been renamed to `length` and `offset` for the `SentenceSentiment`,
+`CategorizedEntity`, `PiiEntity`, and `LinkedEntityMatch` models. Their encoding will be the value passed in the `encoding` parameter
+to each endpoint
+- `grapheme_count` in `TextDocumentStatistics` has been renamed to `count`
 - `score` attribute of `DetectedLanguage` has been renamed to `confidence_score`
 
 ## 1.0.0b4 (2020-04-07)

--- a/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
@@ -5,12 +5,15 @@
 **New features**
 - We now have a `warnings` property on each document-level response object returned from the endpoints. It is a list of `TextAnalyticsWarning`s.
 - Added `text` property to `SentenceSentiment`
+- `SentenceSentiment`, `CategorizedEntity`, and `LinkedEntityMatch` will have new property `encoding`, which details the
+encoding used to determine the text unit in their `offset` and `length` properties
+- `TextDocumentStatistics` will also have new property `encoding`, which details the encoding used to determine the text unit of the `count` property.
 
 **Breaking changes**
 - Each endpoint now has a kwarg parameter `encoding` that specifies the encoding you would like each text unit to be recognized as. Though it is not required,
 we strongly suggest users to pass in a value to `encoding` since we can't guarantee the consistency of the returned offset, lengths, and counts if not.
 - `grapheme_length` and `grapheme_offset` attributes have been renamed to `length` and `offset` for the `SentenceSentiment`,
-`CategorizedEntity`, `PiiEntity`, and `LinkedEntityMatch` models. Their encoding will be the value passed in the `encoding` parameter
+`CategorizedEntity`, and `LinkedEntityMatch` models. Their encoding will be the value passed in the `encoding` parameter
 to each endpoint
 - `grapheme_count` in `TextDocumentStatistics` has been renamed to `count`
 - `score` attribute of `DetectedLanguage` has been renamed to `confidence_score`

--- a/sdk/textanalytics/azure-ai-textanalytics/README.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/README.md
@@ -192,7 +192,7 @@ The following section provides several code snippets covering some of the most c
 
 ```python
 from azure.core.credentials import AzureKeyCredential
-from azure.ai.textanalytics import TextAnalyticsClient
+from azure.ai.textanalytics import TextAnalyticsClient, Encoding
 
 credential = AzureKeyCredential("<api_key>")
 endpoint="https://<region>.api.cognitive.microsoft.com/"
@@ -205,7 +205,7 @@ documents = [
     "The food was yummy. :)"
 ]
 
-response = text_analytics_client.analyze_sentiment(documents, language="en")
+response = text_analytics_client.analyze_sentiment(documents, language="en", encoding=Encoding.grapheme)
 result = [doc for doc in response if not doc.is_error]
 
 for doc in result:
@@ -226,7 +226,7 @@ Please refer to the service documentation for a conceptual discussion of [sentim
 
 ```python
 from azure.core.credentials import AzureKeyCredential
-from azure.ai.textanalytics import TextAnalyticsClient
+from azure.ai.textanalytics import TextAnalyticsClient, Encoding
 
 credential = AzureKeyCredential("<api_key>")
 endpoint="https://<region>.api.cognitive.microsoft.com/"
@@ -239,7 +239,7 @@ documents = [
     "Jeff bought three dozen eggs because there was a 50% discount."
 ]
 
-response = text_analytics_client.recognize_entities(documents, language="en")
+response = text_analytics_client.recognize_entities(documents, language="en", encoding=Encoding.grapheme)
 result = [doc for doc in response if not doc.is_error]
 
 for doc in result:
@@ -260,7 +260,7 @@ Roman god of war). Recognized entities are associated with URLs to a well-known 
 
 ```python
 from azure.core.credentials import AzureKeyCredential
-from azure.ai.textanalytics import TextAnalyticsClient
+from azure.ai.textanalytics import TextAnalyticsClient, Encoding
 
 credential = AzureKeyCredential("<api_key>")
 endpoint="https://<region>.api.cognitive.microsoft.com/"
@@ -272,7 +272,7 @@ documents = [
     "Easter Island, a Chilean territory, is a remote volcanic island in Polynesia."
 ]
 
-response = text_analytics_client.recognize_linked_entities(documents, language="en")
+response = text_analytics_client.recognize_linked_entities(documents, language="en", encoding=Encoding.grapheme)
 result = [doc for doc in response if not doc.is_error]
 
 for doc in result:
@@ -295,7 +295,7 @@ and [supported types][linked_entities_categories].
 
 ```python
 from azure.core.credentials import AzureKeyCredential
-from azure.ai.textanalytics import TextAnalyticsClient
+from azure.ai.textanalytics import TextAnalyticsClient, Encoding
 
 credential = AzureKeyCredential("<api_key>")
 endpoint="https://<region>.api.cognitive.microsoft.com/"
@@ -308,7 +308,7 @@ documents = [
     "I will travel to South America in the summer."
 ]
 
-response = text_analytics_client.extract_key_phrases(documents, language="en")
+response = text_analytics_client.extract_key_phrases(documents, language="en", encoding=Encoding.grapheme)
 result = [doc for doc in response if not doc.is_error]
 
 for doc in result:
@@ -324,7 +324,7 @@ Please refer to the service documentation for a conceptual discussion of [key ph
 
 ```python
 from azure.core.credentials import AzureKeyCredential
-from azure.ai.textanalytics import TextAnalyticsClient
+from azure.ai.textanalytics import TextAnalyticsClient, Encoding
 
 credential = AzureKeyCredential("<api_key>")
 endpoint="https://<region>.api.cognitive.microsoft.com/"
@@ -337,7 +337,7 @@ documents = [
     "Dies ist in deutsche Sprache verfasst."
 ]
 
-response = text_analytics_client.detect_language(documents)
+response = text_analytics_client.detect_language(documents, encoding=Encoding.grapheme)
 result = [doc for doc in response if not doc.is_error]
 
 for doc in result:

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/__init__.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/__init__.py
@@ -7,6 +7,7 @@
 from ._text_analytics_client import TextAnalyticsClient
 from ._version import VERSION
 from ._models import (
+    Encoding,
     DetectLanguageInput,
     TextDocumentInput,
     DetectedLanguage,
@@ -28,6 +29,7 @@ from ._models import (
 )
 
 __all__ = [
+    'Encoding',
     'TextAnalyticsClient',
     'DetectLanguageInput',
     'TextDocumentInput',

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
@@ -4,9 +4,9 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
+from enum import Enum
 from ._generated.models._models import LanguageInput
 from ._generated.models._models import MultiLanguageInput
-from enum import Enum
 
 
 class DictMixin(object):

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
@@ -173,11 +173,12 @@ class CategorizedEntity(DictMixin):
     :type category: str
     :param subcategory: Entity subcategory, such as Age/Year/TimeRange etc
     :type subcategory: str
+    :param str encoding: The specified encoding for `offset` and `length`
     :param offset: Start position for the entity text. Its encoding is
-        determined by the value for `encoding` passed into `recognize_entities`
+        determined by the value for `encoding`
     :type offset: int
     :param length: Length for the entity text. Its encoding is
-        determined by the value for `encoding` passed into `recognize_entities`
+        determined by the value for `encoding`
     :type length: int
     :param confidence_score: Confidence score between 0 and 1 of the extracted
         entity.
@@ -188,25 +189,27 @@ class CategorizedEntity(DictMixin):
         self.text = kwargs.get('text', None)
         self.category = kwargs.get('category', None)
         self.subcategory = kwargs.get('subcategory', None)
+        self.encoding = kwargs.get('encoding', None)
         self.offset = kwargs.get('offset', None)
         self.length = kwargs.get('length', None)
         self.confidence_score = kwargs.get('confidence_score', None)
 
     @classmethod
-    def _from_generated(cls, entity):
+    def _from_generated(cls, entity, encoding):
         return cls(
             text=entity.text,
             category=entity.category,
             subcategory=entity.subcategory,
+            encoding=encoding,
             offset=entity.offset,
             length=entity.length,
             confidence_score=entity.confidence_score,
         )
 
     def __repr__(self):
-        return "CategorizedEntity(text={}, category={}, subcategory={}, offset={}, length={}, " \
-               "confidence_score={})".format(self.text, self.category, self.subcategory, self.offset,
-                                  self.length, self.confidence_score)[:1024]
+        return "CategorizedEntity(text={}, category={}, subcategory={}, encoding={}, offset={}, length={}, " \
+               "confidence_score={})".format(self.text, self.category, self.subcategory, self.encoding,
+                                  self.offset, self.length, self.confidence_score)[:1024]
 
 
 class TextAnalyticsError(DictMixin):
@@ -396,6 +399,7 @@ class TextDocumentStatistics(DictMixin):
     """TextDocumentStatistics contains information about
     the document payload.
 
+    :param str encoding: The specified encoding for `count`
     :param count: Number of text elements recognized in
         the document. Its encoding is determined by the value for `encoding` passed into
         the endpoint.
@@ -406,21 +410,23 @@ class TextDocumentStatistics(DictMixin):
     """
 
     def __init__(self, **kwargs):
+        self.encoding = kwargs.get("encoding", None)
         self.count = kwargs.get("count", None)
         self.transaction_count = kwargs.get("transaction_count", None)
 
     @classmethod
-    def _from_generated(cls, stats):
+    def _from_generated(cls, stats, encoding):
         if stats is None:
             return None
         return cls(
+            encoding=encoding,
             count=stats.characters_count,
             transaction_count=stats.transactions_count,
         )
 
     def __repr__(self):
-        return "TextDocumentStatistics(count={}, transaction_count={})" \
-            .format(self.count, self.transaction_count)[:1024]
+        return "TextDocumentStatistics(encoding={}, count={}, transaction_count={})" \
+            .format(self.encoding, self.count, self.transaction_count)[:1024]
 
 
 class DocumentError(DictMixin):
@@ -528,10 +534,10 @@ class LinkedEntity(DictMixin):
         self.data_source = kwargs.get("data_source", None)
 
     @classmethod
-    def _from_generated(cls, entity):
+    def _from_generated(cls, entity, encoding):
         return cls(
             name=entity.name,
-            matches=[LinkedEntityMatch._from_generated(e) for e in entity.matches],  # pylint: disable=protected-access
+            matches=[LinkedEntityMatch._from_generated(e, encoding) for e in entity.matches],  # pylint: disable=protected-access
             language=entity.language,
             data_source_entity_id=entity.id,
             url=entity.url,
@@ -555,6 +561,7 @@ class LinkedEntityMatch(DictMixin):
     :type confidence_score: float
     :param text: Entity text as appears in the request.
     :type text: str
+    :param str encoding: The specified encoding for `offset` and `length`
     :param offset: Start position for the entity match text. Its encoding is
         determined by the value for `encoding` passed into `recognize_linked_entities`
     :type offset: int
@@ -566,21 +573,23 @@ class LinkedEntityMatch(DictMixin):
     def __init__(self, **kwargs):
         self.confidence_score = kwargs.get("confidence_score", None)
         self.text = kwargs.get("text", None)
+        self.encoding = kwargs.get("encoding", None)
         self.offset = kwargs.get("offset", None)
         self.length = kwargs.get("length", None)
 
     @classmethod
-    def _from_generated(cls, match):
+    def _from_generated(cls, match, encoding):
         return cls(
             confidence_score=match.confidence_score,
             text=match.text,
+            encoding=encoding,
             offset=match.offset,
             length=match.length
         )
 
     def __repr__(self):
-        return "LinkedEntityMatch(confidence_score={}, text={}, offset={}, length={})" \
-            .format(self.confidence_score, self.text, self.offset, self.length)[:1024]
+        return "LinkedEntityMatch(confidence_score={}, text={}, encoding={}, offset={}, length={})" \
+            .format(self.confidence_score, self.text, self.encoding, self.offset, self.length)[:1024]
 
 
 class TextDocumentInput(MultiLanguageInput):
@@ -660,6 +669,7 @@ class SentenceSentiment(DictMixin):
         and 1 for the sentence for all labels.
     :type confidence_scores:
         ~azure.ai.textanalytics.SentimentConfidenceScores
+    :param str encoding: The specified encoding for `offset` and `length`
     :param offset: The sentence offset from the start of the
         document. Its encoding is determined by the value for `encoding`
         passed into `analyze_sentiment`
@@ -674,23 +684,25 @@ class SentenceSentiment(DictMixin):
         self.text = kwargs.get("text", None)
         self.sentiment = kwargs.get("sentiment", None)
         self.confidence_scores = kwargs.get("confidence_scores", None)
+        self.encoding = kwargs.get("encoding", None)
         self.offset = kwargs.get("offset", None)
         self.length = kwargs.get("length", None)
 
     @classmethod
-    def _from_generated(cls, sentence):
+    def _from_generated(cls, sentence, encoding):
         return cls(
             text=sentence.text,
             sentiment=sentence.sentiment,
             confidence_scores=SentimentConfidenceScores._from_generated(sentence.confidence_scores),  # pylint: disable=protected-access
+            encoding=encoding,
             offset=sentence.offset,
             length=sentence.length
         )
 
     def __repr__(self):
-        return "SentenceSentiment(text={}, sentiment={}, confidence_scores={}, offset={}, "\
+        return "SentenceSentiment(text={}, sentiment={}, confidence_scores={}, encoding={}, offset={}, "\
             "length={})".format(self.text, self.sentiment, repr(self.confidence_scores),
-            self.offset, self.length
+            self.encoding, self.offset, self.length
         )[:1024]
 
 

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_response_handlers.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_response_handlers.py
@@ -59,7 +59,7 @@ def order_results(response, combined):
 
 
 def prepare_result(func):
-    def wrapper(response, obj, response_headers):  # pylint: disable=unused-argument
+    def wrapper(response, obj, response_headers, encoding):  # pylint: disable=unused-argument
         if obj.errors:
             combined = obj.documents + obj.errors
             results = order_results(response, combined)
@@ -70,59 +70,59 @@ def prepare_result(func):
             if hasattr(item, "error"):
                 results[idx] = DocumentError(id=item.id, error=TextAnalyticsError._from_generated(item.error))  # pylint: disable=protected-access
             else:
-                results[idx] = func(item)
+                results[idx] = func(item, encoding)
         return results
 
     return wrapper
 
 
 @prepare_result
-def language_result(language):
+def language_result(language, encoding):
     return DetectLanguageResult(
         id=language.id,
         primary_language=DetectedLanguage._from_generated(language.detected_language),  # pylint: disable=protected-access
         warnings=[TextAnalyticsWarning._from_generated(w) for w in language.warnings],  # pylint: disable=protected-access
-        statistics=TextDocumentStatistics._from_generated(language.statistics),  # pylint: disable=protected-access
+        statistics=TextDocumentStatistics._from_generated(language.statistics, encoding),  # pylint: disable=protected-access
     )
 
 
 @prepare_result
-def entities_result(entity):
+def entities_result(entity, encoding):
     return RecognizeEntitiesResult(
         id=entity.id,
-        entities=[CategorizedEntity._from_generated(e) for e in entity.entities],  # pylint: disable=protected-access
+        entities=[CategorizedEntity._from_generated(e, encoding) for e in entity.entities],  # pylint: disable=protected-access
         warnings=[TextAnalyticsWarning._from_generated(w) for w in entity.warnings],  # pylint: disable=protected-access
-        statistics=TextDocumentStatistics._from_generated(entity.statistics),  # pylint: disable=protected-access
+        statistics=TextDocumentStatistics._from_generated(entity.statistics, encoding),  # pylint: disable=protected-access
     )
 
 
 @prepare_result
-def linked_entities_result(entity):
+def linked_entities_result(entity, encoding):
     return RecognizeLinkedEntitiesResult(
         id=entity.id,
-        entities=[LinkedEntity._from_generated(e) for e in entity.entities],  # pylint: disable=protected-access
+        entities=[LinkedEntity._from_generated(e, encoding) for e in entity.entities],  # pylint: disable=protected-access
         warnings=[TextAnalyticsWarning._from_generated(w) for w in entity.warnings],  # pylint: disable=protected-access
-        statistics=TextDocumentStatistics._from_generated(entity.statistics),  # pylint: disable=protected-access
+        statistics=TextDocumentStatistics._from_generated(entity.statistics, encoding),  # pylint: disable=protected-access
     )
 
 
 @prepare_result
-def key_phrases_result(phrases):
+def key_phrases_result(phrases, encoding):
     return ExtractKeyPhrasesResult(
         id=phrases.id,
         key_phrases=phrases.key_phrases,
         warnings=[TextAnalyticsWarning._from_generated(w) for w in phrases.warnings],  # pylint: disable=protected-access
-        statistics=TextDocumentStatistics._from_generated(phrases.statistics),  # pylint: disable=protected-access
+        statistics=TextDocumentStatistics._from_generated(phrases.statistics, encoding),  # pylint: disable=protected-access
     )
 
 
 @prepare_result
-def sentiment_result(sentiment):
+def sentiment_result(sentiment, encoding):
     return AnalyzeSentimentResult(
         id=sentiment.id,
         sentiment=sentiment.sentiment,
         warnings=[TextAnalyticsWarning._from_generated(w) for w in sentiment.warnings],  # pylint: disable=protected-access
-        statistics=TextDocumentStatistics._from_generated(sentiment.statistics),  # pylint: disable=protected-access
+        statistics=TextDocumentStatistics._from_generated(sentiment.statistics, encoding),  # pylint: disable=protected-access
         confidence_scores=SentimentConfidenceScores._from_generated(sentiment.confidence_scores),  # pylint: disable=protected-access
-        sentences=[SentenceSentiment._from_generated(s) for s in sentiment.sentences],  # pylint: disable=protected-access
+        sentences=[SentenceSentiment._from_generated(s, encoding) for s in sentiment.sentences],  # pylint: disable=protected-access
     )

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
@@ -3,7 +3,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-
+from functools import partial
 from typing import (  # pylint: disable=unused-import
     Union,
     Optional,
@@ -25,6 +25,8 @@ from ._response_handlers import (
     language_result
 )
 
+from ._models import Encoding
+
 if TYPE_CHECKING:
     from azure.core.credentials import TokenCredential, AzureKeyCredential
     from ._models import (
@@ -35,7 +37,7 @@ if TYPE_CHECKING:
         RecognizeLinkedEntitiesResult,
         ExtractKeyPhrasesResult,
         AnalyzeSentimentResult,
-        DocumentError,
+        DocumentError
     )
 
 
@@ -93,7 +95,6 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
     def detect_language(  # type: ignore
         self,
         documents,  # type: Union[List[str], List[DetectLanguageInput], List[Dict[str, str]]]
-        encoding,  # type: Union[str, Encoding]
         **kwargs  # type: Any
     ):
         # type: (...) -> List[Union[DetectLanguageResult, DocumentError]]
@@ -113,8 +114,10 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             `{"id": "1", "country_hint": "us", "text": "hello world"}`.
         :type documents:
             list[str] or list[~azure.ai.textanalytics.DetectLanguageInput]
-        :param encoding: The encoding in which you would like each text unit to be recognized as.
-        :type encoding: str or ~azure.ai.textanalytics.Encoding
+        :keyword encoding: The encoding in which you would like each text unit to be recognized as.
+            The default is `None`, but we can not guarantee the output for counts
+            will stay consistent unless you pass in a value from :class:`~azure.ai.textanalytics.Encoding`.
+        :paramtype encoding: str or ~azure.ai.textanalytics.Encoding
         :keyword str country_hint: A country hint for the entire batch. Accepts two
             letter country codes specified by ISO 3166-1 alpha-2. Per-document
             country hints will take precedence over whole batch hints. Defaults to
@@ -145,12 +148,13 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         docs = _validate_batch_input(documents, "country_hint", country_hint)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
+        encoding = kwargs.pop("encoding", None)
         try:
             return self._client.languages(
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", language_result),
+                cls=kwargs.pop("cls", partial(language_result, encoding=None)),
                 **kwargs
             )
         except HttpResponseError as error:
@@ -160,7 +164,6 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
     def recognize_entities(  # type: ignore
         self,
         documents,  # type: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]]
-        encoding,  # type: Union[str, Encoding]
         **kwargs  # type: Any
     ):
         # type: (...) -> List[Union[RecognizeEntitiesResult, DocumentError]]
@@ -180,8 +183,10 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             like `{"id": "1", "language": "en", "text": "hello world"}`.
         :type documents:
             list[str] or list[~azure.ai.textanalytics.TextDocumentInput]
-        :param encoding: The encoding in which you would like each text unit to be recognized as.
-        :type encoding: str or ~azure.ai.textanalytics.Encoding
+        :keyword encoding: The encoding in which you would like each text unit to be recognized as.
+            The default is `None`, but we can not guarantee the output for offsets, lengths, and counts
+            will stay consistent unless you pass in a value from :class:`~azure.ai.textanalytics.Encoding`.
+        :paramtype encoding: str or ~azure.ai.textanalytics.Encoding
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
             If not set, uses "en" for English as default. Per-document language will
@@ -212,12 +217,13 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         docs = _validate_batch_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
+        encoding = kwargs.pop("encoding", None)
         try:
             return self._client.entities_recognition_general(
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", entities_result),
+                cls=kwargs.pop("cls", partial(entities_result, encoding=None)),
                 **kwargs
             )
         except HttpResponseError as error:
@@ -227,7 +233,6 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
     def recognize_linked_entities(  # type: ignore
         self,
         documents,  # type: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]]
-        encoding,  # type: Union[str, Encoding]
         **kwargs  # type: Any
     ):
         # type: (...) -> List[Union[RecognizeLinkedEntitiesResult, DocumentError]]
@@ -248,8 +253,10 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             `{"id": "1", "language": "en", "text": "hello world"}`.
         :type documents:
             list[str] or list[~azure.ai.textanalytics.TextDocumentInput]
-        :param encoding: The encoding in which you would like each text unit to be recognized as.
-        :type encoding: str or ~azure.ai.textanalytics.Encoding
+        :keyword encoding: The encoding in which you would like each text unit to be recognized as.
+            The default is `None`, but we can not guarantee the output for offsets, lengths, and counts
+            will stay consistent unless you pass in a value from :class:`~azure.ai.textanalytics.Encoding`.
+        :paramtype encoding: str or ~azure.ai.textanalytics.Encoding
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
             If not set, uses "en" for English as default. Per-document language will
@@ -280,12 +287,13 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         docs = _validate_batch_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
+        encoding = kwargs.pop("encoding", None)
         try:
             return self._client.entities_linking(
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", linked_entities_result),
+                cls=kwargs.pop("cls", partial(linked_entities_result, encoding=None)),
                 **kwargs
             )
         except HttpResponseError as error:
@@ -295,7 +303,6 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
     def extract_key_phrases(  # type: ignore
         self,
         documents,  # type: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]]
-        encoding,  # type: Union[str, Encoding]
         **kwargs  # type: Any
     ):
         # type: (...) -> List[Union[ExtractKeyPhrasesResult, DocumentError]]
@@ -316,8 +323,10 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             `{"id": "1", "language": "en", "text": "hello world"}`.
         :type documents:
             list[str] or list[~azure.ai.textanalytics.TextDocumentInput]
-        :param encoding: The encoding in which you would like each text unit to be recognized as.
-        :type encoding: str or ~azure.ai.textanalytics.Encoding
+        :keyword encoding: The encoding in which you would like each text unit to be recognized as.
+            The default is `None`, but we can not guarantee the output for counts
+            will stay consistent unless you pass in a value from :class:`~azure.ai.textanalytics.Encoding`.
+        :paramtype encoding: str or ~azure.ai.textanalytics.Encoding
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
             If not set, uses "en" for English as default. Per-document language will
@@ -348,12 +357,13 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         docs = _validate_batch_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
+        encoding = kwargs.pop("encoding", None)
         try:
             return self._client.key_phrases(
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", key_phrases_result),
+                cls=kwargs.pop("cls", partial(key_phrases_result, encoding=None)),
                 **kwargs
             )
         except HttpResponseError as error:
@@ -363,7 +373,6 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
     def analyze_sentiment(  # type: ignore
         self,
         documents,  # type: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]]
-        encoding,  # type: Union[str, Encoding]
         **kwargs  # type: Any
     ):
         # type: (...) -> List[Union[AnalyzeSentimentResult, DocumentError]]
@@ -383,8 +392,10 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             `{"id": "1", "language": "en", "text": "hello world"}`.
         :type documents:
             list[str] or list[~azure.ai.textanalytics.TextDocumentInput]
-        :param encoding: The encoding in which you would like each text unit to be recognized as.
-        :type encoding: str or ~azure.ai.textanalytics.Encoding
+        :keyword encoding: The encoding in which you would like each text unit to be recognized as.
+            The default is `None`, but we can not guarantee the output for offsets, lengths, and counts
+            will stay consistent unless you pass in a value from :class:`~azure.ai.textanalytics.Encoding`.
+        :paramtype encoding: str or ~azure.ai.textanalytics.Encoding
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
             If not set, uses "en" for English as default. Per-document language will
@@ -415,12 +426,13 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         docs = _validate_batch_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
+        encoding = kwargs.pop("encoding", None)
         try:
             return self._client.sentiment(
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", sentiment_result),
+                cls=kwargs.pop("cls", partial(sentiment_result, encoding=encoding)),
                 **kwargs
             )
         except HttpResponseError as error:

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
@@ -93,6 +93,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
     def detect_language(  # type: ignore
         self,
         documents,  # type: Union[List[str], List[DetectLanguageInput], List[Dict[str, str]]]
+        encoding,  # type: Union[str, Encoding]
         **kwargs  # type: Any
     ):
         # type: (...) -> List[Union[DetectLanguageResult, DocumentError]]
@@ -112,6 +113,8 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             `{"id": "1", "country_hint": "us", "text": "hello world"}`.
         :type documents:
             list[str] or list[~azure.ai.textanalytics.DetectLanguageInput]
+        :param encoding: The encoding in which you would like each text unit to be recognized as.
+        :type encoding: str or ~azure.ai.textanalytics.Encoding
         :keyword str country_hint: A country hint for the entire batch. Accepts two
             letter country codes specified by ISO 3166-1 alpha-2. Per-document
             country hints will take precedence over whole batch hints. Defaults to
@@ -157,6 +160,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
     def recognize_entities(  # type: ignore
         self,
         documents,  # type: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]]
+        encoding,  # type: Union[str, Encoding]
         **kwargs  # type: Any
     ):
         # type: (...) -> List[Union[RecognizeEntitiesResult, DocumentError]]
@@ -176,6 +180,8 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             like `{"id": "1", "language": "en", "text": "hello world"}`.
         :type documents:
             list[str] or list[~azure.ai.textanalytics.TextDocumentInput]
+        :param encoding: The encoding in which you would like each text unit to be recognized as.
+        :type encoding: str or ~azure.ai.textanalytics.Encoding
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
             If not set, uses "en" for English as default. Per-document language will
@@ -221,6 +227,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
     def recognize_linked_entities(  # type: ignore
         self,
         documents,  # type: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]]
+        encoding,  # type: Union[str, Encoding]
         **kwargs  # type: Any
     ):
         # type: (...) -> List[Union[RecognizeLinkedEntitiesResult, DocumentError]]
@@ -241,6 +248,8 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             `{"id": "1", "language": "en", "text": "hello world"}`.
         :type documents:
             list[str] or list[~azure.ai.textanalytics.TextDocumentInput]
+        :param encoding: The encoding in which you would like each text unit to be recognized as.
+        :type encoding: str or ~azure.ai.textanalytics.Encoding
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
             If not set, uses "en" for English as default. Per-document language will
@@ -286,6 +295,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
     def extract_key_phrases(  # type: ignore
         self,
         documents,  # type: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]]
+        encoding,  # type: Union[str, Encoding]
         **kwargs  # type: Any
     ):
         # type: (...) -> List[Union[ExtractKeyPhrasesResult, DocumentError]]
@@ -306,6 +316,8 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             `{"id": "1", "language": "en", "text": "hello world"}`.
         :type documents:
             list[str] or list[~azure.ai.textanalytics.TextDocumentInput]
+        :param encoding: The encoding in which you would like each text unit to be recognized as.
+        :type encoding: str or ~azure.ai.textanalytics.Encoding
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
             If not set, uses "en" for English as default. Per-document language will
@@ -351,6 +363,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
     def analyze_sentiment(  # type: ignore
         self,
         documents,  # type: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]]
+        encoding,  # type: Union[str, Encoding]
         **kwargs  # type: Any
     ):
         # type: (...) -> List[Union[AnalyzeSentimentResult, DocumentError]]
@@ -370,6 +383,8 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             `{"id": "1", "language": "en", "text": "hello world"}`.
         :type documents:
             list[str] or list[~azure.ai.textanalytics.TextDocumentInput]
+        :param encoding: The encoding in which you would like each text unit to be recognized as.
+        :type encoding: str or ~azure.ai.textanalytics.Encoding
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
             If not set, uses "en" for English as default. Per-document language will

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
@@ -25,8 +25,6 @@ from ._response_handlers import (
     language_result
 )
 
-from ._models import Encoding
-
 if TYPE_CHECKING:
     from azure.core.credentials import TokenCredential, AzureKeyCredential
     from ._models import (
@@ -154,7 +152,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", partial(language_result, encoding=None)),
+                cls=kwargs.pop("cls", partial(language_result, encoding=encoding)),
                 **kwargs
             )
         except HttpResponseError as error:
@@ -223,7 +221,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", partial(entities_result, encoding=None)),
+                cls=kwargs.pop("cls", partial(entities_result, encoding=encoding)),
                 **kwargs
             )
         except HttpResponseError as error:
@@ -293,7 +291,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", partial(linked_entities_result, encoding=None)),
+                cls=kwargs.pop("cls", partial(linked_entities_result, encoding=encoding)),
                 **kwargs
             )
         except HttpResponseError as error:
@@ -363,7 +361,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", partial(key_phrases_result, encoding=None)),
+                cls=kwargs.pop("cls", partial(key_phrases_result, encoding=encoding)),
                 **kwargs
             )
         except HttpResponseError as error:

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
@@ -3,7 +3,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-
+from functools import partial
 from typing import (  # pylint: disable=unused-import
     Union,
     Optional,
@@ -33,6 +33,7 @@ from .._models import (
     ExtractKeyPhrasesResult,
     AnalyzeSentimentResult,
     DocumentError,
+    Encoding
 )
 
 if TYPE_CHECKING:
@@ -116,6 +117,10 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             `{"id": "1", "country_hint": "us", "text": "hello world"}`.
         :type documents:
             list[str] or list[~azure.ai.textanalytics.DetectLanguageInput]
+        :keyword encoding: The encoding in which you would like each text unit to be recognized as.
+            The default is `None`, but we can not guarantee the output for counts
+            will stay consistent unless you pass in a value from :class:`~azure.ai.textanalytics.Encoding`.
+        :paramtype encoding: str or ~azure.ai.textanalytics.Encoding
         :keyword str country_hint: A country hint for the entire batch. Accepts two
             letter country codes specified by ISO 3166-1 alpha-2. Per-document
             country hints will take precedence over whole batch hints. Defaults to
@@ -146,12 +151,13 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         docs = _validate_batch_input(documents, "country_hint", country_hint)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
+        encoding = kwargs.pop("encoding", None)
         try:
             return await self._client.languages(
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", language_result),
+                cls=kwargs.pop("cls", partial(language_result, encoding=None)),
                 **kwargs
             )
         except HttpResponseError as error:
@@ -179,6 +185,10 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             `{"id": "1", "language": "en", "text": "hello world"}`.
         :type documents:
             list[str] or list[~azure.ai.textanalytics.TextDocumentInput]
+        :keyword encoding: The encoding in which you would like each text unit to be recognized as.
+            The default is `None`, but we can not guarantee the output for offsets, lengths, and counts
+            will stay consistent unless you pass in a value from :class:`~azure.ai.textanalytics.Encoding`.
+        :paramtype encoding: str or ~azure.ai.textanalytics.Encoding
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
             If not set, uses "en" for English as default. Per-document language will
@@ -209,12 +219,13 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         docs = _validate_batch_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
+        encoding = kwargs.pop("encoding", None)
         try:
             return await self._client.entities_recognition_general(
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", entities_result),
+                cls=kwargs.pop("cls", partial(entities_result, encoding=None)),
                 **kwargs
             )
         except HttpResponseError as error:
@@ -243,6 +254,10 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             `{"id": "1", "language": "en", "text": "hello world"}`.
         :type documents:
             list[str] or list[~azure.ai.textanalytics.TextDocumentInput]
+        :keyword encoding: The encoding in which you would like each text unit to be recognized as.
+            The default is `None`, but we can not guarantee the output for offsets, lengths, and counts
+            will stay consistent unless you pass in a value from :class:`~azure.ai.textanalytics.Encoding`.
+        :paramtype encoding: str or ~azure.ai.textanalytics.Encoding
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
             If not set, uses "en" for English as default. Per-document language will
@@ -273,12 +288,13 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         docs = _validate_batch_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
+        encoding = kwargs.pop("encoding", None)
         try:
             return await self._client.entities_linking(
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", linked_entities_result),
+                cls=kwargs.pop("cls", partial(linked_entities_result, encoding=None)),
                 **kwargs
             )
         except HttpResponseError as error:
@@ -307,6 +323,10 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             `{"id": "1", "language": "en", "text": "hello world"}`.
         :type documents:
             list[str] or list[~azure.ai.textanalytics.TextDocumentInput]
+        :keyword encoding: The encoding in which you would like each text unit to be recognized as.
+            The default is `None`, but we can not guarantee the output for counts
+            will stay consistent unless you pass in a value from :class:`~azure.ai.textanalytics.Encoding`.
+        :paramtype encoding: str or ~azure.ai.textanalytics.Encoding
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
             If not set, uses "en" for English as default. Per-document language will
@@ -337,12 +357,13 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         docs = _validate_batch_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
+        encoding = kwargs.pop("encoding", None)
         try:
             return await self._client.key_phrases(
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", key_phrases_result),
+                cls=kwargs.pop("cls", partial(key_phrases_result, encoding=None)),
                 **kwargs
             )
         except HttpResponseError as error:
@@ -370,6 +391,10 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             `{"id": "1", "language": "en", "text": "hello world"}`.
         :type documents:
             list[str] or list[~azure.ai.textanalytics.TextDocumentInput]
+        :keyword encoding: The encoding in which you would like each text unit to be recognized as.
+            The default is `None`, but we can not guarantee the output for offsets, lengths, and counts
+            will stay consistent unless you pass in a value from :class:`~azure.ai.textanalytics.Encoding`.
+        :paramtype encoding: str or ~azure.ai.textanalytics.Encoding
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
             If not set, uses "en" for English as default. Per-document language will
@@ -400,12 +425,13 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         docs = _validate_batch_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
+        encoding = kwargs.pop("encoding", None)
         try:
             return await self._client.sentiment(
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", sentiment_result),
+                cls=kwargs.pop("cls", partial(sentiment_result, encoding=None)),
                 **kwargs
             )
         except HttpResponseError as error:

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
@@ -32,8 +32,7 @@ from .._models import (
     RecognizeLinkedEntitiesResult,
     ExtractKeyPhrasesResult,
     AnalyzeSentimentResult,
-    DocumentError,
-    Encoding
+    DocumentError
 )
 
 if TYPE_CHECKING:
@@ -157,7 +156,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", partial(language_result, encoding=None)),
+                cls=kwargs.pop("cls", partial(language_result, encoding=encoding)),
                 **kwargs
             )
         except HttpResponseError as error:
@@ -225,7 +224,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", partial(entities_result, encoding=None)),
+                cls=kwargs.pop("cls", partial(entities_result, encoding=encoding)),
                 **kwargs
             )
         except HttpResponseError as error:
@@ -294,7 +293,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", partial(linked_entities_result, encoding=None)),
+                cls=kwargs.pop("cls", partial(linked_entities_result, encoding=encoding)),
                 **kwargs
             )
         except HttpResponseError as error:
@@ -363,7 +362,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", partial(key_phrases_result, encoding=None)),
+                cls=kwargs.pop("cls", partial(key_phrases_result, encoding=encoding)),
                 **kwargs
             )
         except HttpResponseError as error:
@@ -431,7 +430,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                 documents=docs,
                 model_version=model_version,
                 show_stats=show_stats,
-                cls=kwargs.pop("cls", partial(sentiment_result, encoding=None)),
+                cls=kwargs.pop("cls", partial(sentiment_result, encoding=encoding)),
                 **kwargs
             )
         except HttpResponseError as error:

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_alternative_document_input_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_alternative_document_input_async.py
@@ -32,6 +32,7 @@ class AlternativeDocumentInputSampleAsync(object):
 
     async def alternative_document_input(self):
         from azure.core.credentials import AzureKeyCredential
+        from azure.ai.textanalytics import Encoding
         from azure.ai.textanalytics.aio import TextAnalyticsClient
         text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.key))
 
@@ -44,7 +45,7 @@ class AlternativeDocumentInputSampleAsync(object):
              "text": "L'hôtel n'était pas très confortable. L'éclairage était trop sombre."}
         ]
         async with text_analytics_client:
-            result = await text_analytics_client.detect_language(documents)
+            result = await text_analytics_client.detect_language(documents, encoding=Encoding.grapheme)
 
         for idx, doc in enumerate(result):
             if not doc.is_error:

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_analyze_sentiment_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_analyze_sentiment_async.py
@@ -33,6 +33,7 @@ class AnalyzeSentimentSampleAsync(object):
     async def analyze_sentiment_async(self):
         # [START batch_analyze_sentiment_async]
         from azure.core.credentials import AzureKeyCredential
+        from azure.ai.textanalytics import Encoding
         from azure.ai.textanalytics.aio import TextAnalyticsClient
         text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.key))
         documents = [
@@ -43,7 +44,7 @@ class AnalyzeSentimentSampleAsync(object):
         ]
 
         async with text_analytics_client:
-            result = await text_analytics_client.analyze_sentiment(documents)
+            result = await text_analytics_client.analyze_sentiment(documents, encoding=Encoding.grapheme)
 
         docs = [doc for doc in result if not doc.is_error]
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_detect_language_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_detect_language_async.py
@@ -33,6 +33,7 @@ class DetectLanguageSampleAsync(object):
     async def detect_language_async(self):
         # [START batch_detect_language_async]
         from azure.core.credentials import AzureKeyCredential
+        from azure.ai.textanalytics import Encoding
         from azure.ai.textanalytics.aio import TextAnalyticsClient
         text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.key))
         documents = [
@@ -43,7 +44,7 @@ class DetectLanguageSampleAsync(object):
             "Detta är ett dokument skrivet på engelska."
         ]
         async with text_analytics_client:
-            result = await text_analytics_client.detect_language(documents)
+            result = await text_analytics_client.detect_language(documents, encoding=Encoding.grapheme)
 
         for idx, doc in enumerate(result):
             if not doc.is_error:

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_extract_key_phrases_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_extract_key_phrases_async.py
@@ -32,6 +32,7 @@ class ExtractKeyPhrasesSampleAsync(object):
     async def extract_key_phrases_async(self):
         # [START batch_extract_key_phrases_async]
         from azure.core.credentials import AzureKeyCredential
+        from azure.ai.textanalytics import Encoding
         from azure.ai.textanalytics.aio import TextAnalyticsClient
         text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.key))
         documents = [
@@ -41,7 +42,7 @@ class ExtractKeyPhrasesSampleAsync(object):
         ]
 
         async with text_analytics_client:
-            result = await text_analytics_client.extract_key_phrases(documents)
+            result = await text_analytics_client.extract_key_phrases(documents, encoding=Encoding.grapheme)
 
         for doc in result:
             if not doc.is_error:

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_get_detailed_diagnostics_information_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_get_detailed_diagnostics_information_async.py
@@ -34,6 +34,7 @@ class GetDetailedDiagnosticsInformationSampleAsync(object):
 
     async def get_detailed_diagnostics_information_async(self):
         from azure.core.credentials import AzureKeyCredential
+        from azure.ai.textanalytics import Encoding
         from azure.ai.textanalytics.aio import TextAnalyticsClient
         text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.key))
 
@@ -55,6 +56,7 @@ class GetDetailedDiagnosticsInformationSampleAsync(object):
         async with text_analytics_client:
             result = await text_analytics_client.extract_key_phrases(
                 documents,
+                encoding=Encoding.grapheme,
                 show_stats=True,
                 model_version="latest",
                 raw_response_hook=callback

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_entities_async.py
@@ -32,6 +32,7 @@ class RecognizeEntitiesSampleAsync(object):
     async def recognize_entities_async(self):
         # [START batch_recognize_entities_async]
         from azure.core.credentials import AzureKeyCredential
+        from azure.ai.textanalytics import Encoding
         from azure.ai.textanalytics.aio import TextAnalyticsClient
         text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.key))
         documents = [
@@ -41,7 +42,7 @@ class RecognizeEntitiesSampleAsync(object):
         ]
 
         async with text_analytics_client:
-            result = await text_analytics_client.recognize_entities(documents)
+            result = await text_analytics_client.recognize_entities(documents, encoding=Encoding.grapheme)
 
         docs = [doc for doc in result if not doc.is_error]
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_linked_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_linked_entities_async.py
@@ -34,6 +34,7 @@ class RecognizeLinkedEntitiesSampleAsync(object):
     async def recognize_linked_entities_async(self):
         # [START batch_recognize_linked_entities_async]
         from azure.core.credentials import AzureKeyCredential
+        from azure.ai.textanalytics import Encoding
         from azure.ai.textanalytics.aio import TextAnalyticsClient
         text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.key))
         documents = [
@@ -43,7 +44,7 @@ class RecognizeLinkedEntitiesSampleAsync(object):
         ]
 
         async with text_analytics_client:
-            result = await text_analytics_client.recognize_linked_entities(documents)
+            result = await text_analytics_client.recognize_linked_entities(documents, encoding=Encoding.grapheme)
 
         docs = [doc for doc in result if not doc.is_error]
 

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_alternative_document_input.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_alternative_document_input.py
@@ -32,7 +32,7 @@ class AlternativeDocumentInputSample(object):
 
     def alternative_document_input(self):
         from azure.core.credentials import AzureKeyCredential
-        from azure.ai.textanalytics import TextAnalyticsClient
+        from azure.ai.textanalytics import TextAnalyticsClient, Encoding
         text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.key))
 
         documents = [
@@ -44,7 +44,7 @@ class AlternativeDocumentInputSample(object):
              "text": "L'hôtel n'était pas très confortable. L'éclairage était trop sombre."}
         ]
 
-        result = text_analytics_client.detect_language(documents)
+        result = text_analytics_client.detect_language(documents, encoding=Encoding.grapheme)
 
         for idx, doc in enumerate(result):
             if not doc.is_error:

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_analyze_sentiment.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_analyze_sentiment.py
@@ -32,7 +32,7 @@ class AnalyzeSentimentSample(object):
     def analyze_sentiment(self):
         # [START batch_analyze_sentiment]
         from azure.core.credentials import AzureKeyCredential
-        from azure.ai.textanalytics import TextAnalyticsClient
+        from azure.ai.textanalytics import TextAnalyticsClient, Encoding
         text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.key))
         documents = [
             "I had the best day of my life.",
@@ -41,7 +41,7 @@ class AnalyzeSentimentSample(object):
             "L'hôtel n'était pas très confortable. L'éclairage était trop sombre."
         ]
 
-        result = text_analytics_client.analyze_sentiment(documents)
+        result = text_analytics_client.analyze_sentiment(documents, encoding=Encoding.grapheme)
         docs = [doc for doc in result if not doc.is_error]
 
         for idx, doc in enumerate(docs):

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_detect_language.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_detect_language.py
@@ -32,7 +32,7 @@ class DetectLanguageSample(object):
     def detect_language(self):
         # [START batch_detect_language]
         from azure.core.credentials import AzureKeyCredential
-        from azure.ai.textanalytics import TextAnalyticsClient
+        from azure.ai.textanalytics import TextAnalyticsClient, Encoding
         text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.key))
         documents = [
             "This document is written in English.",
@@ -42,7 +42,7 @@ class DetectLanguageSample(object):
             "Detta är ett dokument skrivet på engelska."
         ]
 
-        result = text_analytics_client.detect_language(documents)
+        result = text_analytics_client.detect_language(documents, encoding=Encoding.grapheme)
 
         for idx, doc in enumerate(result):
             if not doc.is_error:

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_extract_key_phrases.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_extract_key_phrases.py
@@ -31,7 +31,7 @@ class ExtractKeyPhrasesSample(object):
     def extract_key_phrases(self):
         # [START batch_extract_key_phrases]
         from azure.core.credentials import AzureKeyCredential
-        from azure.ai.textanalytics import TextAnalyticsClient
+        from azure.ai.textanalytics import TextAnalyticsClient, Encoding
         text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.key))
         documents = [
             "Redmond is a city in King County, Washington, United States, located 15 miles east of Seattle.",
@@ -39,7 +39,7 @@ class ExtractKeyPhrasesSample(object):
             "I will travel to South America in the summer.",
         ]
 
-        result = text_analytics_client.extract_key_phrases(documents)
+        result = text_analytics_client.extract_key_phrases(documents, encoding=Encoding.grapheme)
         for doc in result:
             if not doc.is_error:
                 print(doc.key_phrases)

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_get_detailed_diagnostics_information.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_get_detailed_diagnostics_information.py
@@ -32,7 +32,7 @@ class GetDetailedDiagnosticsInformationSample(object):
 
     def get_detailed_diagnostics_information(self):
         from azure.core.credentials import AzureKeyCredential
-        from azure.ai.textanalytics import TextAnalyticsClient
+        from azure.ai.textanalytics import TextAnalyticsClient, Encoding
         text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.key))
 
         documents = [
@@ -52,6 +52,7 @@ class GetDetailedDiagnosticsInformationSample(object):
 
         result = text_analytics_client.extract_key_phrases(
             documents,
+            encoding=Encoding.grapheme,
             show_stats=True,
             model_version="latest",
             raw_response_hook=callback

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_entities.py
@@ -31,7 +31,7 @@ class RecognizeEntitiesSample(object):
     def recognize_entities(self):
         # [START batch_recognize_entities]
         from azure.core.credentials import AzureKeyCredential
-        from azure.ai.textanalytics import TextAnalyticsClient
+        from azure.ai.textanalytics import TextAnalyticsClient, Encoding
         text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.key))
         documents = [
             "Microsoft was founded by Bill Gates and Paul Allen.",
@@ -39,7 +39,7 @@ class RecognizeEntitiesSample(object):
             "I visited the Space Needle 2 times.",
         ]
 
-        result = text_analytics_client.recognize_entities(documents)
+        result = text_analytics_client.recognize_entities(documents, encoding=Encoding.grapheme)
         docs = [doc for doc in result if not doc.is_error]
 
         for idx, doc in enumerate(docs):

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_linked_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_linked_entities.py
@@ -33,7 +33,7 @@ class RecognizeLinkedEntitiesSample(object):
     def recognize_linked_entities(self):
         # [START batch_recognize_linked_entities]
         from azure.core.credentials import AzureKeyCredential
-        from azure.ai.textanalytics import TextAnalyticsClient
+        from azure.ai.textanalytics import TextAnalyticsClient, Encoding
         text_analytics_client = TextAnalyticsClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.key))
         documents = [
             "Microsoft moved its headquarters to Bellevue, Washington in January 1979.",
@@ -41,7 +41,7 @@ class RecognizeLinkedEntitiesSample(object):
             "Microsoft superó a Apple Inc. como la compañía más valiosa que cotiza en bolsa en el mundo.",
         ]
 
-        result = text_analytics_client.recognize_linked_entities(documents)
+        result = text_analytics_client.recognize_linked_entities(documents, encoding=Encoding.grapheme)
         docs = [doc for doc in result if not doc.is_error]
 
         for idx, doc in enumerate(docs):

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze_sentiment.test_using_default_encoding.yaml
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze_sentiment.test_using_default_encoding.yaml
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: '{"documents": [{"id": "1", "text": "Microsoft was founded by Bill Gates
+      and Paul Allen.", "language": "en"}, {"id": "2", "text": "I did not like the
+      hotel we stayed at. It was too expensive.", "language": "en"}, {"id": "3", "text":
+      "The restaurant had really good food. I recommend you try it.", "language":
+      "en"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-textanalytics/1.0.0b5 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+        Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/sentiment?showStats=true
+  response:
+    body:
+      string: '{"statistics":{"documentsCount":3,"validDocumentsCount":3,"erroneousDocumentsCount":0,"transactionsCount":3},"documents":[{"id":"1","sentiment":"neutral","statistics":{"charactersCount":51,"transactionsCount":1},"confidenceScores":{"positive":0.01,"neutral":0.99,"negative":0.0},"sentences":[{"sentiment":"neutral","confidenceScores":{"positive":0.01,"neutral":0.99,"negative":0.0},"offset":0,"length":51,"text":"Microsoft
+        was founded by Bill Gates and Paul Allen."}],"warnings":[]},{"id":"2","sentiment":"negative","statistics":{"charactersCount":60,"transactionsCount":1},"confidenceScores":{"positive":0.01,"neutral":0.22,"negative":0.77},"sentences":[{"sentiment":"negative","confidenceScores":{"positive":0.01,"neutral":0.45,"negative":0.54},"offset":0,"length":38,"text":"I
+        did not like the hotel we stayed at."},{"sentiment":"negative","confidenceScores":{"positive":0.0,"neutral":0.0,"negative":1.0},"offset":39,"length":21,"text":"It
+        was too expensive."}],"warnings":[]},{"id":"3","sentiment":"positive","statistics":{"charactersCount":60,"transactionsCount":1},"confidenceScores":{"positive":0.98,"neutral":0.02,"negative":0.0},"sentences":[{"sentiment":"positive","confidenceScores":{"positive":1.0,"neutral":0.0,"negative":0.0},"offset":0,"length":36,"text":"The
+        restaurant had really good food."},{"sentiment":"positive","confidenceScores":{"positive":0.96,"neutral":0.03,"negative":0.01},"offset":37,"length":23,"text":"I
+        recommend you try it."}],"warnings":[]}],"errors":[],"modelVersion":"2019-10-01"}'
+    headers:
+      apim-request-id:
+      - 3931f12e-6cca-4985-8986-668d56892e2b
+      content-type:
+      - application/json; charset=utf-8
+      csp-billing-usage:
+      - CognitiveServices.TextAnalytics.BatchScoring=3
+      date:
+      - Tue, 28 Apr 2020 23:23:41 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '140'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze_sentiment_async.test_using_default_encoding.yaml
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_analyze_sentiment_async.test_using_default_encoding.yaml
@@ -1,0 +1,41 @@
+interactions:
+- request:
+    body: '{"documents": [{"id": "1", "text": "Microsoft was founded by Bill Gates
+      and Paul Allen.", "language": "en"}, {"id": "2", "text": "I did not like the
+      hotel we stayed at. It was too expensive.", "language": "en"}, {"id": "3", "text":
+      "The restaurant had really good food. I recommend you try it.", "language":
+      "en"}]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-textanalytics/1.0.0b5 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+        Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/sentiment?showStats=true
+  response:
+    body:
+      string: '{"statistics":{"documentsCount":3,"validDocumentsCount":3,"erroneousDocumentsCount":0,"transactionsCount":3},"documents":[{"id":"1","sentiment":"neutral","statistics":{"charactersCount":51,"transactionsCount":1},"confidenceScores":{"positive":0.01,"neutral":0.99,"negative":0.0},"sentences":[{"sentiment":"neutral","confidenceScores":{"positive":0.01,"neutral":0.99,"negative":0.0},"offset":0,"length":51,"text":"Microsoft
+        was founded by Bill Gates and Paul Allen."}],"warnings":[]},{"id":"2","sentiment":"negative","statistics":{"charactersCount":60,"transactionsCount":1},"confidenceScores":{"positive":0.01,"neutral":0.22,"negative":0.77},"sentences":[{"sentiment":"negative","confidenceScores":{"positive":0.01,"neutral":0.45,"negative":0.54},"offset":0,"length":38,"text":"I
+        did not like the hotel we stayed at."},{"sentiment":"negative","confidenceScores":{"positive":0.0,"neutral":0.0,"negative":1.0},"offset":39,"length":21,"text":"It
+        was too expensive."}],"warnings":[]},{"id":"3","sentiment":"positive","statistics":{"charactersCount":60,"transactionsCount":1},"confidenceScores":{"positive":0.98,"neutral":0.02,"negative":0.0},"sentences":[{"sentiment":"positive","confidenceScores":{"positive":1.0,"neutral":0.0,"negative":0.0},"offset":0,"length":36,"text":"The
+        restaurant had really good food."},{"sentiment":"positive","confidenceScores":{"positive":0.96,"neutral":0.03,"negative":0.01},"offset":37,"length":23,"text":"I
+        recommend you try it."}],"warnings":[]}],"errors":[],"modelVersion":"2019-10-01"}'
+    headers:
+      apim-request-id: 60ffd0a2-b98e-4b69-a3b2-0dc79695cdb3
+      content-type: application/json; charset=utf-8
+      csp-billing-usage: CognitiveServices.TextAnalytics.BatchScoring=3
+      date: Tue, 28 Apr 2020 23:23:42 GMT
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      x-content-type-options: nosniff
+      x-envoy-upstream-service-time: '152'
+    status:
+      code: 200
+      message: OK
+    url: https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/sentiment?showStats=true
+version: 1

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_detect_language.test_using_default_encoding.yaml
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_detect_language.test_using_default_encoding.yaml
@@ -1,0 +1,47 @@
+interactions:
+- request:
+    body: '{"documents": [{"id": "1", "text": "I should take my cat to the veterinarian.",
+      "countryHint": "US"}, {"id": "2", "text": "Este es un document escrito en Espa\u00f1ol.",
+      "countryHint": "US"}, {"id": "3", "text": "\u732b\u306f\u5e78\u305b", "countryHint":
+      "US"}, {"id": "4", "text": "Fahrt nach Stuttgart und dann zum Hotel zu Fu.",
+      "countryHint": "US"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '354'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-textanalytics/1.0.0b5 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+        Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/languages?showStats=true
+  response:
+    body:
+      string: '{"statistics":{"documentsCount":4,"validDocumentsCount":4,"erroneousDocumentsCount":0,"transactionsCount":4},"documents":[{"id":"1","detectedLanguage":{"name":"English","iso6391Name":"en","confidenceScore":1.0},"statistics":{"charactersCount":41,"transactionsCount":1},"warnings":[]},{"id":"2","detectedLanguage":{"name":"Spanish","iso6391Name":"es","confidenceScore":1.0},"statistics":{"charactersCount":39,"transactionsCount":1},"warnings":[]},{"id":"3","detectedLanguage":{"name":"Japanese","iso6391Name":"ja","confidenceScore":1.0},"statistics":{"charactersCount":4,"transactionsCount":1},"warnings":[]},{"id":"4","detectedLanguage":{"name":"German","iso6391Name":"de","confidenceScore":1.0},"statistics":{"charactersCount":46,"transactionsCount":1},"warnings":[]}],"errors":[],"modelVersion":"2019-10-01"}'
+    headers:
+      apim-request-id:
+      - 1c87789b-3a5e-4605-848b-5a74c434c55e
+      content-type:
+      - application/json; charset=utf-8
+      csp-billing-usage:
+      - CognitiveServices.TextAnalytics.BatchScoring=4
+      date:
+      - Tue, 28 Apr 2020 23:23:43 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '8'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_detect_language_async.test_using_default_encoding.yaml
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_detect_language_async.test_using_default_encoding.yaml
@@ -1,0 +1,36 @@
+interactions:
+- request:
+    body: '{"documents": [{"id": "1", "text": "I should take my cat to the veterinarian.",
+      "countryHint": "US"}, {"id": "2", "text": "Este es un document escrito en Espa\u00f1ol.",
+      "countryHint": "US"}, {"id": "3", "text": "\u732b\u306f\u5e78\u305b", "countryHint":
+      "US"}, {"id": "4", "text": "Fahrt nach Stuttgart und dann zum Hotel zu Fu.",
+      "countryHint": "US"}]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '354'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-textanalytics/1.0.0b5 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+        Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/languages?showStats=true
+  response:
+    body:
+      string: '{"statistics":{"documentsCount":4,"validDocumentsCount":4,"erroneousDocumentsCount":0,"transactionsCount":4},"documents":[{"id":"1","detectedLanguage":{"name":"English","iso6391Name":"en","confidenceScore":1.0},"statistics":{"charactersCount":41,"transactionsCount":1},"warnings":[]},{"id":"2","detectedLanguage":{"name":"Spanish","iso6391Name":"es","confidenceScore":1.0},"statistics":{"charactersCount":39,"transactionsCount":1},"warnings":[]},{"id":"3","detectedLanguage":{"name":"Japanese","iso6391Name":"ja","confidenceScore":1.0},"statistics":{"charactersCount":4,"transactionsCount":1},"warnings":[]},{"id":"4","detectedLanguage":{"name":"German","iso6391Name":"de","confidenceScore":1.0},"statistics":{"charactersCount":46,"transactionsCount":1},"warnings":[]}],"errors":[],"modelVersion":"2019-10-01"}'
+    headers:
+      apim-request-id: 47531740-c949-498e-bf6d-86d75455beb4
+      content-type: application/json; charset=utf-8
+      csp-billing-usage: CognitiveServices.TextAnalytics.BatchScoring=4
+      date: Tue, 28 Apr 2020 23:23:42 GMT
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      x-content-type-options: nosniff
+      x-envoy-upstream-service-time: '4'
+    status:
+      code: 200
+      message: OK
+    url: https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/languages?showStats=true
+version: 1

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_extract_key_phrases.test_using_default_encoding.yaml
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_extract_key_phrases.test_using_default_encoding.yaml
@@ -1,0 +1,47 @@
+interactions:
+- request:
+    body: '{"documents": [{"id": "1", "text": "Microsoft was founded by Bill Gates
+      and Paul Allen", "language": "en"}, {"id": "2", "text": "Microsoft fue fundado
+      por Bill Gates y Paul Allen", "language": "es"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '200'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-textanalytics/1.0.0b5 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+        Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/keyPhrases?showStats=true
+  response:
+    body:
+      string: '{"statistics":{"documentsCount":2,"validDocumentsCount":2,"erroneousDocumentsCount":0,"transactionsCount":2},"documents":[{"id":"1","keyPhrases":["Bill
+        Gates","Paul Allen","Microsoft"],"statistics":{"charactersCount":50,"transactionsCount":1},"warnings":[]},{"id":"2","keyPhrases":["Bill
+        Gates","Paul Allen","Microsoft"],"statistics":{"charactersCount":49,"transactionsCount":1},"warnings":[]}],"errors":[],"modelVersion":"2019-10-01"}'
+    headers:
+      apim-request-id:
+      - 5564ede8-7053-4b85-83dc-d4d225576dfa
+      content-type:
+      - application/json; charset=utf-8
+      csp-billing-usage:
+      - CognitiveServices.TextAnalytics.BatchScoring=2
+      date:
+      - Tue, 28 Apr 2020 23:23:43 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '5'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_extract_key_phrases_async.test_using_default_encoding.yaml
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_extract_key_phrases_async.test_using_default_encoding.yaml
@@ -1,0 +1,36 @@
+interactions:
+- request:
+    body: '{"documents": [{"id": "1", "text": "Microsoft was founded by Bill Gates
+      and Paul Allen", "language": "en"}, {"id": "2", "text": "Microsoft fue fundado
+      por Bill Gates y Paul Allen", "language": "es"}]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '200'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-textanalytics/1.0.0b5 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+        Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/keyPhrases?showStats=true
+  response:
+    body:
+      string: '{"statistics":{"documentsCount":2,"validDocumentsCount":2,"erroneousDocumentsCount":0,"transactionsCount":2},"documents":[{"id":"1","keyPhrases":["Bill
+        Gates","Paul Allen","Microsoft"],"statistics":{"charactersCount":50,"transactionsCount":1},"warnings":[]},{"id":"2","keyPhrases":["Bill
+        Gates","Paul Allen","Microsoft"],"statistics":{"charactersCount":49,"transactionsCount":1},"warnings":[]}],"errors":[],"modelVersion":"2019-10-01"}'
+    headers:
+      apim-request-id: 3cc2a139-c1d7-4bdd-9dbb-e6014349aaaa
+      content-type: application/json; charset=utf-8
+      csp-billing-usage: CognitiveServices.TextAnalytics.BatchScoring=2
+      date: Tue, 28 Apr 2020 23:23:43 GMT
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      x-content-type-options: nosniff
+      x-envoy-upstream-service-time: '6'
+    status:
+      code: 200
+      message: OK
+    url: https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/keyPhrases?showStats=true
+version: 1

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_recognize_entities.test_using_default_encoding.yaml
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_recognize_entities.test_using_default_encoding.yaml
@@ -1,0 +1,49 @@
+interactions:
+- request:
+    body: '{"documents": [{"id": "1", "text": "Microsoft was founded by Bill Gates
+      and Paul Allen.", "language": "en"}, {"id": "2", "text": "I did not like the
+      hotel we stayed at. It was too expensive.", "language": "en"}, {"id": "3", "text":
+      "The restaurant had really good food. I recommend you try it.", "language":
+      "en"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-textanalytics/1.0.0b5 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+        Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/entities/recognition/general?showStats=true
+  response:
+    body:
+      string: '{"statistics":{"documentsCount":3,"validDocumentsCount":3,"erroneousDocumentsCount":0,"transactionsCount":3},"documents":[{"id":"1","statistics":{"charactersCount":51,"transactionsCount":1},"entities":[{"text":"Microsoft","category":"Organization","offset":0,"length":9,"confidenceScore":0.52},{"text":"Bill
+        Gates","category":"Person","offset":25,"length":10,"confidenceScore":0.51},{"text":"Paul
+        Allen","category":"Person","offset":40,"length":10,"confidenceScore":0.76}],"warnings":[]},{"id":"2","statistics":{"charactersCount":60,"transactionsCount":1},"entities":[{"text":"hotel","category":"Location","offset":19,"length":5,"confidenceScore":0.74}],"warnings":[]},{"id":"3","statistics":{"charactersCount":60,"transactionsCount":1},"entities":[{"text":"restaurant","category":"Location","subcategory":"LOCATION.STRUCTURAL","offset":4,"length":10,"confidenceScore":0.71}],"warnings":[]}],"errors":[],"modelVersion":"2020-04-01"}'
+    headers:
+      apim-request-id:
+      - 5bc9aa07-82fd-48f9-a676-7cf8b7605338
+      content-type:
+      - application/json; charset=utf-8
+      csp-billing-usage:
+      - CognitiveServices.TextAnalytics.BatchScoring=3
+      date:
+      - Tue, 28 Apr 2020 23:23:44 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '137'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_recognize_entities_async.test_using_default_encoding.yaml
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_recognize_entities_async.test_using_default_encoding.yaml
@@ -1,0 +1,38 @@
+interactions:
+- request:
+    body: '{"documents": [{"id": "1", "text": "Microsoft was founded by Bill Gates
+      and Paul Allen.", "language": "en"}, {"id": "2", "text": "I did not like the
+      hotel we stayed at. It was too expensive.", "language": "en"}, {"id": "3", "text":
+      "The restaurant had really good food. I recommend you try it.", "language":
+      "en"}]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-textanalytics/1.0.0b5 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+        Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/entities/recognition/general?showStats=true
+  response:
+    body:
+      string: '{"statistics":{"documentsCount":3,"validDocumentsCount":3,"erroneousDocumentsCount":0,"transactionsCount":3},"documents":[{"id":"1","statistics":{"charactersCount":51,"transactionsCount":1},"entities":[{"text":"Microsoft","category":"Organization","offset":0,"length":9,"confidenceScore":0.52},{"text":"Bill
+        Gates","category":"Person","offset":25,"length":10,"confidenceScore":0.51},{"text":"Paul
+        Allen","category":"Person","offset":40,"length":10,"confidenceScore":0.76}],"warnings":[]},{"id":"2","statistics":{"charactersCount":60,"transactionsCount":1},"entities":[{"text":"hotel","category":"Location","offset":19,"length":5,"confidenceScore":0.74}],"warnings":[]},{"id":"3","statistics":{"charactersCount":60,"transactionsCount":1},"entities":[{"text":"restaurant","category":"Location","subcategory":"LOCATION.STRUCTURAL","offset":4,"length":10,"confidenceScore":0.71}],"warnings":[]}],"errors":[],"modelVersion":"2020-04-01"}'
+    headers:
+      apim-request-id: b47e44e3-3f60-405c-9e48-60e0933060ce
+      content-type: application/json; charset=utf-8
+      csp-billing-usage: CognitiveServices.TextAnalytics.BatchScoring=3
+      date: Tue, 28 Apr 2020 23:23:44 GMT
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      x-content-type-options: nosniff
+      x-envoy-upstream-service-time: '105'
+    status:
+      code: 200
+      message: OK
+    url: https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/entities/recognition/general?showStats=true
+version: 1

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_recognize_linked_entities.test_using_default_encoding.yaml
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_recognize_linked_entities.test_using_default_encoding.yaml
@@ -1,0 +1,51 @@
+interactions:
+- request:
+    body: '{"documents": [{"id": "1", "text": "Microsoft was founded by Bill Gates
+      and Paul Allen.", "language": "en"}, {"id": "2", "text": "I did not like the
+      hotel we stayed at. It was too expensive.", "language": "en"}, {"id": "3", "text":
+      "The restaurant had really good food. I recommend you try it.", "language":
+      "en"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-textanalytics/1.0.0b5 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+        Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/entities/linking?showStats=true
+  response:
+    body:
+      string: '{"statistics":{"documentsCount":3,"validDocumentsCount":3,"erroneousDocumentsCount":0,"transactionsCount":3},"documents":[{"id":"1","statistics":{"charactersCount":51,"transactionsCount":1},"entities":[{"name":"Bill
+        Gates","matches":[{"text":"Bill Gates","offset":25,"length":10,"confidenceScore":0.0}],"language":"en","id":"Bill
+        Gates","url":"https://en.wikipedia.org/wiki/Bill_Gates","dataSource":"Wikipedia"},{"name":"Paul
+        Allen","matches":[{"text":"Paul Allen","offset":40,"length":10,"confidenceScore":0.0}],"language":"en","id":"Paul
+        Allen","url":"https://en.wikipedia.org/wiki/Paul_Allen","dataSource":"Wikipedia"},{"name":"Microsoft","matches":[{"text":"Microsoft","offset":0,"length":9,"confidenceScore":0.0}],"language":"en","id":"Microsoft","url":"https://en.wikipedia.org/wiki/Microsoft","dataSource":"Wikipedia"}],"warnings":[]},{"id":"2","statistics":{"charactersCount":60,"transactionsCount":1},"entities":[],"warnings":[]},{"id":"3","statistics":{"charactersCount":60,"transactionsCount":1},"entities":[],"warnings":[]}],"errors":[],"modelVersion":"2020-02-01"}'
+    headers:
+      apim-request-id:
+      - bb3fd847-7747-4d9e-aa5c-25be1ccc3289
+      content-type:
+      - application/json; charset=utf-8
+      csp-billing-usage:
+      - CognitiveServices.TextAnalytics.BatchScoring=3
+      date:
+      - Tue, 28 Apr 2020 23:23:45 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '31'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_recognize_linked_entities_async.test_using_default_encoding.yaml
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/recordings/test_recognize_linked_entities_async.test_using_default_encoding.yaml
@@ -1,0 +1,40 @@
+interactions:
+- request:
+    body: '{"documents": [{"id": "1", "text": "Microsoft was founded by Bill Gates
+      and Paul Allen.", "language": "en"}, {"id": "2", "text": "I did not like the
+      hotel we stayed at. It was too expensive.", "language": "en"}, {"id": "3", "text":
+      "The restaurant had really good food. I recommend you try it.", "language":
+      "en"}]}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-ai-textanalytics/1.0.0b5 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+        Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/entities/linking?showStats=true
+  response:
+    body:
+      string: '{"statistics":{"documentsCount":3,"validDocumentsCount":3,"erroneousDocumentsCount":0,"transactionsCount":3},"documents":[{"id":"1","statistics":{"charactersCount":51,"transactionsCount":1},"entities":[{"name":"Bill
+        Gates","matches":[{"text":"Bill Gates","offset":25,"length":10,"confidenceScore":0.0}],"language":"en","id":"Bill
+        Gates","url":"https://en.wikipedia.org/wiki/Bill_Gates","dataSource":"Wikipedia"},{"name":"Paul
+        Allen","matches":[{"text":"Paul Allen","offset":40,"length":10,"confidenceScore":0.0}],"language":"en","id":"Paul
+        Allen","url":"https://en.wikipedia.org/wiki/Paul_Allen","dataSource":"Wikipedia"},{"name":"Microsoft","matches":[{"text":"Microsoft","offset":0,"length":9,"confidenceScore":0.0}],"language":"en","id":"Microsoft","url":"https://en.wikipedia.org/wiki/Microsoft","dataSource":"Wikipedia"}],"warnings":[]},{"id":"2","statistics":{"charactersCount":60,"transactionsCount":1},"entities":[],"warnings":[]},{"id":"3","statistics":{"charactersCount":60,"transactionsCount":1},"entities":[],"warnings":[]}],"errors":[],"modelVersion":"2020-02-01"}'
+    headers:
+      apim-request-id: b45d45a5-6e72-4310-a752-4d2801a6f508
+      content-type: application/json; charset=utf-8
+      csp-billing-usage: CognitiveServices.TextAnalytics.BatchScoring=3
+      date: Tue, 28 Apr 2020 23:23:45 GMT
+      strict-transport-security: max-age=31536000; includeSubDomains; preload
+      transfer-encoding: chunked
+      x-content-type-options: nosniff
+      x-envoy-upstream-service-time: '31'
+    status:
+      code: 200
+      message: OK
+    url: https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/entities/linking?showStats=true
+version: 1

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_sentiment_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_sentiment_async.py
@@ -16,7 +16,8 @@ from azure.ai.textanalytics.aio import TextAnalyticsClient
 from azure.ai.textanalytics import (
     VERSION,
     DetectLanguageInput,
-    TextDocumentInput
+    TextDocumentInput,
+    Encoding
 )
 
 from testcase import GlobalTextAnalyticsAccountPreparer
@@ -43,7 +44,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
     @TextAnalyticsClientPreparer()
     async def test_no_single_input(self, client):
         with self.assertRaises(TypeError):
-            response = await client.analyze_sentiment("hello world")
+            response = await client.analyze_sentiment("hello world", encoding=Encoding.grapheme)
 
     @GlobalTextAnalyticsAccountPreparer()
     @TextAnalyticsClientPreparer()
@@ -52,7 +53,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
                 {"id": "2", "language": "en", "text": "I did not like the hotel we stayed at. It was too expensive."},
                 {"id": "3", "language": "en", "text": "The restaurant had really good food. I recommend you try it."}]
 
-        response = await client.analyze_sentiment(docs, show_stats=True)
+        response = await client.analyze_sentiment(docs, show_stats=True, encoding=Encoding.grapheme)
         self.assertEqual(response[0].sentiment, "neutral")
         self.assertEqual(response[1].sentiment, "negative")
         self.assertEqual(response[2].sentiment, "positive")
@@ -71,6 +72,10 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
         self.assertEqual(len(response[2].sentences), 2)
         self.assertEqual(response[2].sentences[0].text, "The restaurant had really good food.")
         self.assertEqual(response[2].sentences[1].text, "I recommend you try it.")
+        [
+            self.assertEqual(sentence.encoding, Encoding.grapheme)
+            for sentence in doc.sentences for doc in response
+        ]
 
     @GlobalTextAnalyticsAccountPreparer()
     @TextAnalyticsClientPreparer()
@@ -81,7 +86,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
             TextDocumentInput(id="3", text="The restaurant had really good food. I recommend you try it."),
         ]
 
-        response = await client.analyze_sentiment(docs)
+        response = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
         self.assertEqual(response[0].sentiment, "neutral")
         self.assertEqual(response[1].sentiment, "negative")
         self.assertEqual(response[2].sentiment, "positive")
@@ -89,6 +94,10 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
         for doc in response:
             self.assertIsNotNone(doc.confidence_scores)
             self.assertIsNotNone(doc.sentences)
+            [
+                self.assertEqual(sentence.encoding, Encoding.grapheme)
+                for sentence in doc.sentences
+            ]
 
         self.assertEqual(len(response[0].sentences), 1)
         self.assertEqual(response[0].sentences[0].text, "Microsoft was founded by Bill Gates and Paul Allen.")
@@ -101,6 +110,23 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
 
     @GlobalTextAnalyticsAccountPreparer()
     @TextAnalyticsClientPreparer()
+    async def test_using_default_encoding(self, client):
+        docs = [
+            TextDocumentInput(id="1", text="Microsoft was founded by Bill Gates and Paul Allen."),
+            TextDocumentInput(id="2", text="I did not like the hotel we stayed at. It was too expensive."),
+            TextDocumentInput(id="3", text="The restaurant had really good food. I recommend you try it."),
+        ]
+
+        response = await client.analyze_sentiment(docs, show_stats=True)
+        for doc in response:
+            [
+                self.assertIsNone(sentence.encoding)
+                for sentence in doc.sentences
+            ]
+            self.assertIsNone(doc.statistics.encoding)
+
+    @GlobalTextAnalyticsAccountPreparer()
+    @TextAnalyticsClientPreparer()
     async def test_passing_only_string(self, client):
         docs = [
             u"Microsoft was founded by Bill Gates and Paul Allen.",
@@ -109,7 +135,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
             u""
         ]
 
-        response = await client.analyze_sentiment(docs)
+        response = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
         self.assertEqual(response[0].sentiment, "neutral")
         self.assertEqual(response[1].sentiment, "negative")
         self.assertEqual(response[2].sentiment, "positive")
@@ -122,7 +148,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
                 {"id": "2", "language": "english", "text": "I did not like the hotel we stayed at. It was too expensive."},
                 {"id": "3", "language": "en", "text": "The restaurant had really good food. I recommend you try it."}]
 
-        response = await client.analyze_sentiment(docs)
+        response = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
         self.assertTrue(response[0].is_error)
         self.assertTrue(response[1].is_error)
         self.assertFalse(response[2].is_error)
@@ -134,7 +160,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
                 {"id": "2", "language": "english", "text": "I did not like the hotel we stayed at. It was too expensive."},
                 {"id": "3", "language": "en", "text": ""}]
 
-        response = await client.analyze_sentiment(docs)
+        response = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
         self.assertTrue(response[0].is_error)
         self.assertTrue(response[1].is_error)
         self.assertTrue(response[2].is_error)
@@ -144,7 +170,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
     async def test_empty_credential_class(self, client):
         with self.assertRaises(ClientAuthenticationError):
             response = await client.analyze_sentiment(
-                ["This is written in English."]
+                ["This is written in English."], encoding=Encoding.grapheme
             )
 
     @GlobalTextAnalyticsAccountPreparer()
@@ -152,7 +178,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
     async def test_bad_credentials(self, client):
         with self.assertRaises(ClientAuthenticationError):
             response = await client.analyze_sentiment(
-                ["This is written in English."]
+                ["This is written in English."], encoding=Encoding.grapheme
             )
 
     @GlobalTextAnalyticsAccountPreparer()
@@ -161,7 +187,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
         with self.assertRaises(HttpResponseError):
             response = await client.analyze_sentiment(
                 documents=["Microsoft was founded by Bill Gates."],
-                model_version="old"
+                model_version="old", encoding=Encoding.grapheme
             )
 
     @GlobalTextAnalyticsAccountPreparer()
@@ -170,7 +196,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
         docs = "This is the wrong type"
 
         with self.assertRaises(TypeError):
-            response = await client.analyze_sentiment(docs)
+            response = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
 
     @GlobalTextAnalyticsAccountPreparer()
     @TextAnalyticsClientPreparer()
@@ -181,7 +207,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
             u"You cannot mix string input with the above inputs"
         ]
         with self.assertRaises(TypeError):
-            response = await client.analyze_sentiment(docs)
+            response = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
 
     @GlobalTextAnalyticsAccountPreparer()
     @TextAnalyticsClientPreparer()
@@ -192,7 +218,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
                 {"id": "19", "text": ":P"},
                 {"id": "1", "text": ":D"}]
 
-        response = await client.analyze_sentiment(docs)
+        response = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
         in_order = ["56", "0", "22", "19", "1"]
         for idx, resp in enumerate(response):
             self.assertEqual(resp.id, in_order[idx])
@@ -218,7 +244,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
             docs,
             show_stats=True,
             model_version="latest",
-            raw_response_hook=callback
+            raw_response_hook=callback, encoding=Encoding.grapheme
         )
 
     @GlobalTextAnalyticsAccountPreparer()
@@ -226,7 +252,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
     async def test_batch_size_over_limit(self, client):
         docs = [u"hello world"] * 1050
         with self.assertRaises(HttpResponseError):
-            response = await client.analyze_sentiment(docs)
+            response = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
 
     @GlobalTextAnalyticsAccountPreparer()
     @TextAnalyticsClientPreparer()
@@ -242,7 +268,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
             u"The restaurant was not as good as I hoped."
         ]
 
-        response = await client.analyze_sentiment(docs, language="fr", raw_response_hook=callback)
+        response = await client.analyze_sentiment(docs, language="fr", raw_response_hook=callback, encoding=Encoding.grapheme)
 
     @GlobalTextAnalyticsAccountPreparer()
     @TextAnalyticsClientPreparer()
@@ -258,7 +284,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
             u"The restaurant was not as good as I hoped."
         ]
 
-        response = await client.analyze_sentiment(docs, language="", raw_response_hook=callback)
+        response = await client.analyze_sentiment(docs, language="", raw_response_hook=callback, encoding=Encoding.grapheme)
 
     @GlobalTextAnalyticsAccountPreparer()
     @TextAnalyticsClientPreparer()
@@ -276,7 +302,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
                 {"id": "2", "language": "", "text": "I did not like the hotel we stayed at."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = await client.analyze_sentiment(docs, raw_response_hook=callback)
+        response = await client.analyze_sentiment(docs, raw_response_hook=callback, encoding=Encoding.grapheme)
 
     @GlobalTextAnalyticsAccountPreparer()
     @TextAnalyticsClientPreparer()
@@ -292,7 +318,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
             TextDocumentInput(id="3", text="猫は幸せ"),
         ]
 
-        response = await client.analyze_sentiment(docs, language="de", raw_response_hook=callback)
+        response = await client.analyze_sentiment(docs, language="de", raw_response_hook=callback, encoding=Encoding.grapheme)
 
     @GlobalTextAnalyticsAccountPreparer()
     @TextAnalyticsClientPreparer()
@@ -306,7 +332,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
                 {"id": "2", "text": "I did not like the hotel we stayed at."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = await client.analyze_sentiment(docs, language="es", raw_response_hook=callback)
+        response = await client.analyze_sentiment(docs, language="es", raw_response_hook=callback, encoding=Encoding.grapheme)
 
     @GlobalTextAnalyticsAccountPreparer()
     @TextAnalyticsClientPreparer()
@@ -325,7 +351,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
             TextDocumentInput(id="3", text="猫は幸せ"),
         ]
 
-        response = await client.analyze_sentiment(docs, language="en", raw_response_hook=callback)
+        response = await client.analyze_sentiment(docs, language="en", raw_response_hook=callback, encoding=Encoding.grapheme)
 
     @GlobalTextAnalyticsAccountPreparer()
     @TextAnalyticsClientPreparer()
@@ -343,7 +369,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
                 {"id": "2", "language": "es", "text": "I did not like the hotel we stayed at."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = await client.analyze_sentiment(docs, language="en", raw_response_hook=callback)
+        response = await client.analyze_sentiment(docs, language="en", raw_response_hook=callback, encoding=Encoding.grapheme)
 
     @GlobalTextAnalyticsAccountPreparer()
     @TextAnalyticsClientPreparer(client_kwargs={"default_language": "es"})
@@ -362,9 +388,9 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
                 {"id": "2", "text": "I did not like the hotel we stayed at."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = await client.analyze_sentiment(docs, raw_response_hook=callback)
-        response = await client.analyze_sentiment(docs, language="en", raw_response_hook=callback_2)
-        response = await client.analyze_sentiment(docs, raw_response_hook=callback)
+        response = await client.analyze_sentiment(docs, raw_response_hook=callback, encoding=Encoding.grapheme)
+        response = await client.analyze_sentiment(docs, language="en", raw_response_hook=callback_2, encoding=Encoding.grapheme)
+        response = await client.analyze_sentiment(docs, raw_response_hook=callback, encoding=Encoding.grapheme)
 
     @GlobalTextAnalyticsAccountPreparer()
     async def test_rotate_subscription_key(self, resource_group, location, text_analytics_account, text_analytics_account_key):
@@ -375,15 +401,15 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
                 {"id": "2", "text": "I did not like the hotel we stayed at."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = await client.analyze_sentiment(docs)
+        response = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
         self.assertIsNotNone(response)
 
         credential.update("xxx")  # Make authentication fail
         with self.assertRaises(ClientAuthenticationError):
-            response = await client.analyze_sentiment(docs)
+            response = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
 
         credential.update(text_analytics_account_key)  # Authenticate successfully again
-        response = await client.analyze_sentiment(docs)
+        response = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
         self.assertIsNotNone(response)
 
     @GlobalTextAnalyticsAccountPreparer()
@@ -399,13 +425,13 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
                 {"id": "2", "text": "I did not like the hotel we stayed at."},
                 {"id": "3", "text": "The restaurant had really good food."}]
 
-        response = await client.analyze_sentiment(docs, raw_response_hook=callback)
+        response = await client.analyze_sentiment(docs, raw_response_hook=callback, encoding=Encoding.grapheme)
 
     @GlobalTextAnalyticsAccountPreparer()
     @TextAnalyticsClientPreparer()
     async def test_document_attribute_error_no_result_attribute(self, client):
         docs = [{"id": "1", "text": ""}]
-        response = await client.analyze_sentiment(docs)
+        response = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
 
         # Attributes on DocumentError
         self.assertTrue(response[0].is_error)
@@ -427,7 +453,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
     @TextAnalyticsClientPreparer()
     async def test_document_attribute_error_nonexistent_attribute(self, client):
         docs = [{"id": "1", "text": ""}]
-        response = await client.analyze_sentiment(docs)
+        response = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
 
         # Attribute not found on DocumentError or result obj, default behavior/message
         try:
@@ -444,7 +470,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
         docs = [{"id": "1", "language": "english", "text": "I did not like the hotel we stayed at."}]
 
         try:
-            result = await client.analyze_sentiment(docs, model_version="bad")
+            result = await client.analyze_sentiment(docs, model_version="bad", encoding=Encoding.grapheme)
         except HttpResponseError as err:
             self.assertEqual(err.error.code, "InvalidRequest")
             self.assertIsNotNone(err.error.message)
@@ -460,7 +486,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
                 {"id": "2", "language": "english", "text": "I did not like the hotel we stayed at."},
                 {"id": "3", "text": text}]
 
-        doc_errors = await client.analyze_sentiment(docs)
+        doc_errors = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
         self.assertEqual(doc_errors[0].error.code, "InvalidDocument")
         self.assertIsNotNone(doc_errors[0].error.message)
         self.assertEqual(doc_errors[1].error.code, "UnsupportedLanguageCode")
@@ -476,7 +502,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
             {"id": "1", "text": "This won't actually create a warning :'("},
         ]
 
-        result = await client.analyze_sentiment(docs)
+        result = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
         for doc in result:
             doc_warnings = doc.warnings
             self.assertEqual(len(doc_warnings), 0)
@@ -486,7 +512,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
     async def test_missing_input_records_error(self, client):
         docs = []
         with pytest.raises(ValueError) as excinfo:
-            await client.analyze_sentiment(docs)
+            await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
         assert "Input documents can not be empty" in str(excinfo.value)
 
     @GlobalTextAnalyticsAccountPreparer()
@@ -496,7 +522,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
         docs = [{"id": "1", "text": "hello world"},
                 {"id": "1", "text": "I did not like the hotel we stayed at."}]
         try:
-            result = await client.analyze_sentiment(docs)
+            result = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
         except HttpResponseError as err:
             self.assertEqual(err.error.code, "InvalidDocument")
             self.assertIsNotNone(err.error.message)
@@ -507,7 +533,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
         # Batch size over limit
         docs = [u"hello world"] * 1001
         try:
-            response = await client.analyze_sentiment(docs)
+            response = await client.analyze_sentiment(docs, encoding=Encoding.grapheme)
         except HttpResponseError as err:
             self.assertEqual(err.error.code, "InvalidDocumentBatch")
             self.assertIsNotNone(err.error.message)
@@ -526,7 +552,7 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
             model_version="latest",
             show_stats=True,
             language="es",
-            raw_response_hook=callback
+            raw_response_hook=callback, encoding=Encoding.grapheme
         )
 
     @GlobalTextAnalyticsAccountPreparer()
@@ -536,6 +562,6 @@ class TestAnalyzeSentiment(AsyncTextAnalyticsTest):
             return "cls result"
         res = await client.analyze_sentiment(
             documents=["Test passing cls to endpoint"],
-            cls=callback
+            cls=callback, encoding=Encoding.grapheme
         )
         assert res == "cls result"

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities.py
@@ -44,8 +44,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
             for entity in doc.entities:
                 self.assertIsNotNone(entity.text)
                 self.assertIsNotNone(entity.category)
-                self.assertIsNotNone(entity.grapheme_offset)
-                self.assertIsNotNone(entity.grapheme_length)
+                self.assertIsNotNone(entity.offset)
+                self.assertIsNotNone(entity.length)
                 self.assertIsNotNone(entity.confidence_score)
 
     @GlobalTextAnalyticsAccountPreparer()
@@ -63,8 +63,8 @@ class TestRecognizeEntities(TextAnalyticsTest):
             for entity in doc.entities:
                 self.assertIsNotNone(entity.text)
                 self.assertIsNotNone(entity.category)
-                self.assertIsNotNone(entity.grapheme_offset)
-                self.assertIsNotNone(entity.grapheme_length)
+                self.assertIsNotNone(entity.offset)
+                self.assertIsNotNone(entity.length)
                 self.assertIsNotNone(entity.confidence_score)
 
     @GlobalTextAnalyticsAccountPreparer()

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_recognize_entities_async.py
@@ -60,8 +60,8 @@ class TestRecognizeEntities(AsyncTextAnalyticsTest):
             for entity in doc.entities:
                 self.assertIsNotNone(entity.text)
                 self.assertIsNotNone(entity.category)
-                self.assertIsNotNone(entity.grapheme_offset)
-                self.assertIsNotNone(entity.grapheme_length)
+                self.assertIsNotNone(entity.offset)
+                self.assertIsNotNone(entity.length)
                 self.assertIsNotNone(entity.confidence_score)
 
     @GlobalTextAnalyticsAccountPreparer()
@@ -79,8 +79,8 @@ class TestRecognizeEntities(AsyncTextAnalyticsTest):
             for entity in doc.entities:
                 self.assertIsNotNone(entity.text)
                 self.assertIsNotNone(entity.category)
-                self.assertIsNotNone(entity.grapheme_offset)
-                self.assertIsNotNone(entity.grapheme_length)
+                self.assertIsNotNone(entity.offset)
+                self.assertIsNotNone(entity.length)
                 self.assertIsNotNone(entity.confidence_score)
 
     @GlobalTextAnalyticsAccountPreparer()

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_text_analytics.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_text_analytics.py
@@ -30,7 +30,7 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
         detected_language = _models.DetectedLanguage(name="English", iso6391_name="en", confidence_score=1.0)
 
         categorized_entity = _models.CategorizedEntity(text="Bill Gates", category="Person", subcategory="Age",
-                                                       offset=0, length=8, confidence_score=0.899)
+                                                       offset=0, length=8, confidence_score=0.899, encoding=_models.Encoding.grapheme)
 
         text_document_statistics = _models.TextDocumentStatistics(count=14, transaction_count=18)
 
@@ -64,7 +64,7 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
             )
 
         linked_entity_match = _models.LinkedEntityMatch(confidence_score=0.999, text="Bill Gates", offset=0,
-                                                        length=8)
+                                                        length=8, encoding=_models.Encoding.grapheme)
 
         linked_entity = _models.LinkedEntity(
             name="Bill Gates",
@@ -87,7 +87,8 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
             sentiment="neutral",
             confidence_scores=sentiment_confidence_score_per_label,
             offset=0,
-            length=10
+            length=10,
+            encoding=_models.Encoding.grapheme
         )
 
         analyze_sentiment_result = _models.AnalyzeSentimentResult(
@@ -114,59 +115,59 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
         )
 
         self.assertEqual("DetectedLanguage(name=English, iso6391_name=en, confidence_score=1.0)", repr(detected_language))
-        self.assertEqual("CategorizedEntity(text=Bill Gates, category=Person, subcategory=Age, offset=0, "
+        self.assertEqual("CategorizedEntity(text=Bill Gates, category=Person, subcategory=Age, encoding=grapheme, offset=0, "
                          "length=8, confidence_score=0.899)",
                          repr(categorized_entity))
-        self.assertEqual("TextDocumentStatistics(count=14, transaction_count=18)",
+        self.assertEqual("TextDocumentStatistics(encoding=None, count=14, transaction_count=18)",
                          repr(text_document_statistics))
         self.assertEqual("RecognizeEntitiesResult(id=1, entities=[CategorizedEntity(text=Bill Gates, category=Person, "
-                         "subcategory=Age, offset=0, length=8, confidence_score=0.899)], "
+                         "subcategory=Age, encoding=grapheme, offset=0, length=8, confidence_score=0.899)], "
                          "warnings=[TextAnalyticsWarning(code=LongWordsInDocument, message=The document contains very long words (longer than 64 characters). "
                          "These words will be truncated and may result in unreliable model predictions.)], "
-                         "statistics=TextDocumentStatistics(count=14, transaction_count=18), "
+                         "statistics=TextDocumentStatistics(encoding=None, count=14, transaction_count=18), "
                          "is_error=False)", repr(recognize_entities_result))
         self.assertEqual("DetectLanguageResult(id=1, primary_language=DetectedLanguage(name=English, "
                          "iso6391_name=en, confidence_score=1.0), "
                          "warnings=[TextAnalyticsWarning(code=LongWordsInDocument, message=The document contains very long words (longer than 64 characters). "
                          "These words will be truncated and may result in unreliable model predictions.)], "
-                         "statistics=TextDocumentStatistics(count=14, "
+                         "statistics=TextDocumentStatistics(encoding=None, count=14, "
                          "transaction_count=18), is_error=False)", repr(detect_language_result))
         self.assertEqual("TextAnalyticsError(code=invalidRequest, message=The request is invalid, target=request)",
                          repr(text_analytics_error))
         self.assertEqual("ExtractKeyPhrasesResult(id=1, key_phrases=['dog', 'cat', 'bird'], "
                          "warnings=[TextAnalyticsWarning(code=LongWordsInDocument, message=The document contains very long words (longer than 64 characters). "
                          "These words will be truncated and may result in unreliable model predictions.)], "
-                         "statistics=TextDocumentStatistics(count=14, transaction_count=18), is_error=False)",
+                         "statistics=TextDocumentStatistics(encoding=None, count=14, transaction_count=18), is_error=False)",
                          repr(extract_key_phrases_result))
-        self.assertEqual("LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, offset=0, length=8)",
+        self.assertEqual("LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, encoding=grapheme, offset=0, length=8)",
                          repr(linked_entity_match))
         self.assertEqual("LinkedEntity(name=Bill Gates, matches=[LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, "
-                         "offset=0, length=8), LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, "
-                         "offset=0, length=8)], language=English, data_source_entity_id=Bill Gates, "
+                         "encoding=grapheme, offset=0, length=8), LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, "
+                         "encoding=grapheme, offset=0, length=8)], language=English, data_source_entity_id=Bill Gates, "
                          "url=https://en.wikipedia.org/wiki/Bill_Gates, data_source=wikipedia)", repr(linked_entity))
         self.assertEqual("RecognizeLinkedEntitiesResult(id=1, entities=[LinkedEntity(name=Bill Gates, "
-                         "matches=[LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, offset=0, "
-                         "length=8), LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, offset=0, "
+                         "matches=[LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, encoding=grapheme, offset=0, "
+                         "length=8), LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, encoding=grapheme, offset=0, "
                          "length=8)], language=English, data_source_entity_id=Bill Gates, "
                          "url=https://en.wikipedia.org/wiki/Bill_Gates, data_source=wikipedia)], "
                          "warnings=[TextAnalyticsWarning(code=LongWordsInDocument, message=The document contains very long words (longer than 64 characters). "
                          "These words will be truncated and may result in unreliable model predictions.)], "
-                         "statistics=TextDocumentStatistics(count=14, "
+                         "statistics=TextDocumentStatistics(encoding=None, count=14, "
                          "transaction_count=18), is_error=False)", repr(recognize_linked_entities_result))
         self.assertEqual("SentimentConfidenceScores(positive=0.99, neutral=0.05, negative=0.02)",
                          repr(sentiment_confidence_score_per_label))
         self.assertEqual("SentenceSentiment(text=This is a sentence., sentiment=neutral, confidence_scores=SentimentConfidenceScores("
-                         "positive=0.99, neutral=0.05, negative=0.02), offset=0, length=10)",
+                         "positive=0.99, neutral=0.05, negative=0.02), encoding=grapheme, offset=0, length=10)",
                          repr(sentence_sentiment))
         self.assertEqual("AnalyzeSentimentResult(id=1, sentiment=positive, "
                          "warnings=[TextAnalyticsWarning(code=LongWordsInDocument, message=The document contains very long words (longer than 64 characters). "
                          "These words will be truncated and may result in unreliable model predictions.)], "
                          "statistics=TextDocumentStatistics("
-                         "count=14, transaction_count=18), confidence_scores=SentimentConfidenceScores"
+                         "encoding=None, count=14, transaction_count=18), confidence_scores=SentimentConfidenceScores"
                          "(positive=0.99, neutral=0.05, negative=0.02), "
                          "sentences=[SentenceSentiment(text=This is a sentence., sentiment=neutral, confidence_scores="
                          "SentimentConfidenceScores(positive=0.99, neutral=0.05, negative=0.02), "
-                         "offset=0, length=10)], "
+                         "encoding=grapheme, offset=0, length=10)], "
                          "is_error=False)",
                          repr(analyze_sentiment_result))
         self.assertEqual("DocumentError(id=1, error=TextAnalyticsError(code=invalidRequest, "

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_text_analytics.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_text_analytics.py
@@ -30,9 +30,9 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
         detected_language = _models.DetectedLanguage(name="English", iso6391_name="en", confidence_score=1.0)
 
         categorized_entity = _models.CategorizedEntity(text="Bill Gates", category="Person", subcategory="Age",
-                                                       grapheme_offset=0, grapheme_length=8, confidence_score=0.899)
+                                                       offset=0, length=8, confidence_score=0.899)
 
-        text_document_statistics = _models.TextDocumentStatistics(grapheme_count=14, transaction_count=18)
+        text_document_statistics = _models.TextDocumentStatistics(count=14, transaction_count=18)
 
         warnings = [_models.TextAnalyticsWarning(code="LongWordsInDocument", message="The document contains very long words (longer than 64 characters). These words will be truncated and may result in unreliable model predictions.")]
 
@@ -63,8 +63,8 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
                 id="1", key_phrases=["dog", "cat", "bird"], warnings=warnings, statistics=text_document_statistics, is_error=False
             )
 
-        linked_entity_match = _models.LinkedEntityMatch(confidence_score=0.999, text="Bill Gates", grapheme_offset=0,
-                                                        grapheme_length=8)
+        linked_entity_match = _models.LinkedEntityMatch(confidence_score=0.999, text="Bill Gates", offset=0,
+                                                        length=8)
 
         linked_entity = _models.LinkedEntity(
             name="Bill Gates",
@@ -86,8 +86,8 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
             text="This is a sentence.",
             sentiment="neutral",
             confidence_scores=sentiment_confidence_score_per_label,
-            grapheme_offset=0,
-            grapheme_length=10
+            offset=0,
+            length=10
         )
 
         analyze_sentiment_result = _models.AnalyzeSentimentResult(
@@ -114,59 +114,59 @@ class TextAnalyticsTest(TestAnalyticsTestCase):
         )
 
         self.assertEqual("DetectedLanguage(name=English, iso6391_name=en, confidence_score=1.0)", repr(detected_language))
-        self.assertEqual("CategorizedEntity(text=Bill Gates, category=Person, subcategory=Age, grapheme_offset=0, "
-                         "grapheme_length=8, confidence_score=0.899)",
+        self.assertEqual("CategorizedEntity(text=Bill Gates, category=Person, subcategory=Age, offset=0, "
+                         "length=8, confidence_score=0.899)",
                          repr(categorized_entity))
-        self.assertEqual("TextDocumentStatistics(grapheme_count=14, transaction_count=18)",
+        self.assertEqual("TextDocumentStatistics(count=14, transaction_count=18)",
                          repr(text_document_statistics))
         self.assertEqual("RecognizeEntitiesResult(id=1, entities=[CategorizedEntity(text=Bill Gates, category=Person, "
-                         "subcategory=Age, grapheme_offset=0, grapheme_length=8, confidence_score=0.899)], "
+                         "subcategory=Age, offset=0, length=8, confidence_score=0.899)], "
                          "warnings=[TextAnalyticsWarning(code=LongWordsInDocument, message=The document contains very long words (longer than 64 characters). "
                          "These words will be truncated and may result in unreliable model predictions.)], "
-                         "statistics=TextDocumentStatistics(grapheme_count=14, transaction_count=18), "
+                         "statistics=TextDocumentStatistics(count=14, transaction_count=18), "
                          "is_error=False)", repr(recognize_entities_result))
         self.assertEqual("DetectLanguageResult(id=1, primary_language=DetectedLanguage(name=English, "
                          "iso6391_name=en, confidence_score=1.0), "
                          "warnings=[TextAnalyticsWarning(code=LongWordsInDocument, message=The document contains very long words (longer than 64 characters). "
                          "These words will be truncated and may result in unreliable model predictions.)], "
-                         "statistics=TextDocumentStatistics(grapheme_count=14, "
+                         "statistics=TextDocumentStatistics(count=14, "
                          "transaction_count=18), is_error=False)", repr(detect_language_result))
         self.assertEqual("TextAnalyticsError(code=invalidRequest, message=The request is invalid, target=request)",
                          repr(text_analytics_error))
         self.assertEqual("ExtractKeyPhrasesResult(id=1, key_phrases=['dog', 'cat', 'bird'], "
                          "warnings=[TextAnalyticsWarning(code=LongWordsInDocument, message=The document contains very long words (longer than 64 characters). "
                          "These words will be truncated and may result in unreliable model predictions.)], "
-                         "statistics=TextDocumentStatistics(grapheme_count=14, transaction_count=18), is_error=False)",
+                         "statistics=TextDocumentStatistics(count=14, transaction_count=18), is_error=False)",
                          repr(extract_key_phrases_result))
-        self.assertEqual("LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, grapheme_offset=0, grapheme_length=8)",
+        self.assertEqual("LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, offset=0, length=8)",
                          repr(linked_entity_match))
         self.assertEqual("LinkedEntity(name=Bill Gates, matches=[LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, "
-                         "grapheme_offset=0, grapheme_length=8), LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, "
-                         "grapheme_offset=0, grapheme_length=8)], language=English, data_source_entity_id=Bill Gates, "
+                         "offset=0, length=8), LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, "
+                         "offset=0, length=8)], language=English, data_source_entity_id=Bill Gates, "
                          "url=https://en.wikipedia.org/wiki/Bill_Gates, data_source=wikipedia)", repr(linked_entity))
         self.assertEqual("RecognizeLinkedEntitiesResult(id=1, entities=[LinkedEntity(name=Bill Gates, "
-                         "matches=[LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, grapheme_offset=0, "
-                         "grapheme_length=8), LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, grapheme_offset=0, "
-                         "grapheme_length=8)], language=English, data_source_entity_id=Bill Gates, "
+                         "matches=[LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, offset=0, "
+                         "length=8), LinkedEntityMatch(confidence_score=0.999, text=Bill Gates, offset=0, "
+                         "length=8)], language=English, data_source_entity_id=Bill Gates, "
                          "url=https://en.wikipedia.org/wiki/Bill_Gates, data_source=wikipedia)], "
                          "warnings=[TextAnalyticsWarning(code=LongWordsInDocument, message=The document contains very long words (longer than 64 characters). "
                          "These words will be truncated and may result in unreliable model predictions.)], "
-                         "statistics=TextDocumentStatistics(grapheme_count=14, "
+                         "statistics=TextDocumentStatistics(count=14, "
                          "transaction_count=18), is_error=False)", repr(recognize_linked_entities_result))
         self.assertEqual("SentimentConfidenceScores(positive=0.99, neutral=0.05, negative=0.02)",
                          repr(sentiment_confidence_score_per_label))
         self.assertEqual("SentenceSentiment(text=This is a sentence., sentiment=neutral, confidence_scores=SentimentConfidenceScores("
-                         "positive=0.99, neutral=0.05, negative=0.02), grapheme_offset=0, grapheme_length=10)",
+                         "positive=0.99, neutral=0.05, negative=0.02), offset=0, length=10)",
                          repr(sentence_sentiment))
         self.assertEqual("AnalyzeSentimentResult(id=1, sentiment=positive, "
                          "warnings=[TextAnalyticsWarning(code=LongWordsInDocument, message=The document contains very long words (longer than 64 characters). "
                          "These words will be truncated and may result in unreliable model predictions.)], "
                          "statistics=TextDocumentStatistics("
-                         "grapheme_count=14, transaction_count=18), confidence_scores=SentimentConfidenceScores"
+                         "count=14, transaction_count=18), confidence_scores=SentimentConfidenceScores"
                          "(positive=0.99, neutral=0.05, negative=0.02), "
                          "sentences=[SentenceSentiment(text=This is a sentence., sentiment=neutral, confidence_scores="
                          "SentimentConfidenceScores(positive=0.99, neutral=0.05, negative=0.02), "
-                         "grapheme_offset=0, grapheme_length=10)], "
+                         "offset=0, length=10)], "
                          "is_error=False)",
                          repr(analyze_sentiment_result))
         self.assertEqual("DocumentError(id=1, error=TextAnalyticsError(code=invalidRequest, "


### PR DESCRIPTION
Haven't fixed samples to include `encoding`, will be doing that tomorrow