### PR TITLE
Add ServiceDirectory to usage of remove-test-resources.yml

### DIFF
--- a/eng/pipelines/smoke-test.yml
+++ b/eng/pipelines/smoke-test.yml
@@ -106,3 +106,5 @@ jobs:
         displayName: "Run Smoke Test"
 
       - template: ../common/TestResources/remove-test-resources.yml
+        parameters:
+          ServiceDirectory: '$(Build.SourcesDirectory)/common/smoketest/'


### PR DESCRIPTION
The change that this is merging ahead of is: https://github.com/Azure/azure-sdk-tools/pull/549 

If we don't add the `ServiceDirectory` we'll see failures during the de-provisioning step.