### PR TITLE
Fix core auth

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -89,9 +89,10 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, SansIOHTTPPo
         """
         self._enforce_https(request)
 
+        # new token is needed if token is None or token is expired
         if self._need_new_token:
             self._token = self._credential.get_token(*self._scopes)
-            self._update_headers(request.http_request.headers, self._token.token)
+        self._update_headers(request.http_request.headers, self._token.token)  # ignore
 
 
 class AzureKeyCredentialPolicy(SansIOHTTPPolicy):

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -89,10 +89,9 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, SansIOHTTPPo
         """
         self._enforce_https(request)
 
-        # new token is needed if token is None or token is expired
-        if self._need_new_token:
+        if self._token is None or self._need_new_token:
             self._token = self._credential.get_token(*self._scopes)
-        self._update_headers(request.http_request.headers, self._token.token)  # ignore
+        self._update_headers(request.http_request.headers, self._token.token)
 
 
 class AzureKeyCredentialPolicy(SansIOHTTPPolicy):

--- a/sdk/core/azure-core/tests/azure_core_asynctests/test_authentication.py
+++ b/sdk/core/azure-core/tests/azure_core_asynctests/test_authentication.py
@@ -18,7 +18,8 @@ import pytest
 @pytest.mark.asyncio
 async def test_bearer_policy_adds_header():
     """The bearer token policy should add a header containing a token from its credential"""
-    expected_token = AccessToken("expected_token", 0)
+    # 2524608000 == 01/01/2050 @ 12:00am (UTC)
+    expected_token = AccessToken("expected_token", 2524608000)
 
     async def verify_authorization_header(request):
         assert request.http_request.headers["Authorization"] == "Bearer {}".format(expected_token.token)
@@ -35,6 +36,10 @@ async def test_bearer_policy_adds_header():
     pipeline = AsyncPipeline(transport=Mock(), policies=policies)
 
     await pipeline.run(HttpRequest("GET", "https://spam.eggs"), context=None)
+    assert get_token_calls == 1
+
+    await pipeline.run(HttpRequest("GET", "https://spam.eggs"), context=None)
+    # Didn't need a new token
     assert get_token_calls == 1
 
 


### PR DESCRIPTION
Fix regression introduced in #10653 

The type ignore was necessary to avoid that:
> _authentication.py:93: error: Item "None" of "Optional[AccessToken]" has no attribute "token"

In this particular case, we could 1) type ignore, 2) use a cast 3) add an (unnecessary) check for None in the if to allow mypy to be certain it's not None. 

I don't like type ignore since we lose all benefits of typing.
Cast is better, but has the problem of disabling mypy and telling it "shut up we know the type", which may or may not be a problem if we refactor the code at some point.
The if is more explicit (and thus more zen) and has the advantage to be robust to refactoring, since mypy will complain again if those lines are touched

Being the name of the property `_need_new_token`, checking None doesn't seem stretched to me (even if I understand the property also check it)
