### PR TITLE
Fix dependency issue in verifying installed package using pip freeze

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -28,7 +28,9 @@ steps:
       OSName: ${{ parameters.OSName }}
 
   - script: |
+      python -m pip install pip == 20.1
       pip install -r eng/ci_tools.txt
+      pip --version
     displayName: 'Prep Environment'
 
   - ${{ parameters.BeforeTestSteps }}

--- a/eng/tox/verify_installed_packages.py
+++ b/eng/tox/verify_installed_packages.py
@@ -29,7 +29,7 @@ def verify_packages(package_file_path):
         sys.exit(1)
 
     # find installed and expected packages
-    installed = dict(p.split('==') for p in freeze.freeze() if p.startswith('azure'))
+    installed = dict(p.split('==') for p in freeze.freeze() if p.startswith('azure') and "==" in p)
     expected = dict(p.split('==') for p in packages)
 
     missing_packages = [pkg for pkg in expected.keys() if installed.get(pkg) != expected.get(pkg)]


### PR DESCRIPTION
Latest and min dependency issue verifies installed packages version for released required packages to ensure we are testing with valid dependent packages. This check utilizes pip freeze method . Pip freeze is not finding package version in some cases and returns package installation path instead and this causes a breakage in package validation because validation logic expects a list of <packagename>== <version> as return value from pip freeze.  Fix is to ensure that we generate dict only for packages that has version present. Version name is missing only for packages installed using direct or relative reference to source or prebuilt wheel. And validation check is mainly to verify installed packages from PyPI and version is expected in this case in pip freeze results for those installed from PyPI.