### PR TITLE
move smoke-test.yml to enable failure notification

### DIFF
--- a/common/smoketest/smoke-test.yml
+++ b/common/smoketest/smoke-test.yml
@@ -95,7 +95,7 @@ jobs:
       - script: python ./eng/tox/install_dev_build_dependency.py -r ./common/smoketest/requirements.txt
         displayName: "Install dev dependencies from feed"
 
-      - template: ../common/TestResources/deploy-test-resources.yml
+      - template: /eng/common/TestResources/deploy-test-resources.yml
         parameters:
           ServiceDirectory: '$(Build.SourcesDirectory)/common/smoketest/'
           CloudType: $(CloudType)
@@ -105,6 +105,6 @@ jobs:
       - script: python ./common/smoketest/program.py
         displayName: "Run Smoke Test"
 
-      - template: ../common/TestResources/remove-test-resources.yml
+      - template: /eng/common/TestResources/remove-test-resources.yml
         parameters:
           ServiceDirectory: '$(Build.SourcesDirectory)/common/smoketest/'


### PR DESCRIPTION
Example of successful execution: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=382162&view=results