### PR TITLE
Persistent caching for interactive credentials on Linux and macOS

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -1,7 +1,15 @@
 # Release History
 
 ## 1.4.0b4 (Unreleased)
-
+- The optional persistent cache for `DeviceCodeCredential` and
+  `InteractiveBrowserCredential` added in 1.4.0b3 is now available on Linux and
+  macOS as well as Windows.
+  ([#11134](https://github.com/Azure/azure-sdk-for-python/issues/11134))
+  - On Linux, the persistent cache requires libsecret and `pygobject`. If these
+    are unavailable, or libsecret is unusable (e.g. in an SSH session), loading
+    the persistent cache will raise an error. You may optionally configure the
+    credential to fall back to an unencrypted cache by constructing it with
+    keyword argument `allow_unencrypted_cache=True`.
 
 ## 1.4.0b3 (2020-05-04)
 - `EnvironmentCredential` correctly initializes `UsernamePasswordCredential`

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -40,7 +40,9 @@ class InteractiveBrowserCredential(InteractiveCredential):
     :keyword bool disable_automatic_authentication: if True, :func:`get_token` will raise
           :class:`AuthenticationRequiredError` when user interaction is required to acquire a token. Defaults to False.
     :keyword bool enable_persistent_cache: if True, the credential will store tokens in a persistent cache shared by
-         other user credentials. **This is only supported on Windows.** Defaults to False.
+         other user credentials. Defaults to False.
+    :keyword bool allow_unencrypted_cache: if True, the credential will fall back to a plaintext cache on platforms
+          where encryption is unavailable. Default to False. Has no effect when `enable_persistent_cache` is False.
     :keyword int timeout: seconds to wait for the user to complete authentication. Defaults to 300 (5 minutes).
     """
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/device_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/device_code.py
@@ -50,7 +50,9 @@ class DeviceCodeCredential(InteractiveCredential):
     :keyword bool disable_automatic_authentication: if True, :func:`get_token` will raise
           :class:`AuthenticationRequiredError` when user interaction is required to acquire a token. Defaults to False.
     :keyword bool enable_persistent_cache: if True, the credential will store tokens in a persistent cache shared by
-         other user credentials. **This is only supported on Windows.** Defaults to False.
+         other user credentials. Defaults to False.
+    :keyword bool allow_unencrypted_cache: if True, the credential will fall back to a plaintext cache on platforms
+          where encryption is unavailable. Default to False. Has no effect when `enable_persistent_cache` is False.
     """
 
     def __init__(self, client_id, **kwargs):

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
@@ -9,8 +9,6 @@ import abc
 import base64
 import json
 import logging
-import os
-import sys
 import time
 
 import msal
@@ -20,6 +18,7 @@ from azure.core.exceptions import ClientAuthenticationError
 
 from .exception_wrapper import wrap_exceptions
 from .msal_transport_adapter import MsalTransportAdapter
+from .persistent_cache import load_persistent_cache
 from .._constants import KnownAuthorities
 from .._exceptions import AuthenticationRequiredError, CredentialUnavailableError
 from .._internal import get_default_authority, normalize_authority
@@ -77,19 +76,6 @@ def _build_auth_record(response):
         return None
 
 
-def _load_persistent_cache():
-    # type: () -> msal.TokenCache
-
-    if sys.platform.startswith("win") and "LOCALAPPDATA" in os.environ:
-        from msal_extensions.token_cache import WindowsTokenCache
-
-        return WindowsTokenCache(
-            cache_location=os.path.join(os.environ["LOCALAPPDATA"], ".IdentityService", "msal.cache")
-        )
-
-    raise NotImplementedError("A persistent cache is not available on this platform.")
-
-
 class MsalCredential(ABC):
     """Base class for credentials wrapping MSAL applications"""
 
@@ -105,7 +91,8 @@ class MsalCredential(ABC):
         self._cache = kwargs.pop("_cache", None)  # internal, for use in tests
         if not self._cache:
             if kwargs.pop("enable_persistent_cache", False):
-                self._cache = _load_persistent_cache()
+                allow_unencrypted = kwargs.pop("allow_unencrypted_cache", False)
+                self._cache = load_persistent_cache(allow_unencrypted)
             else:
                 self._cache = msal.TokenCache()
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/persistent_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/persistent_cache.py
@@ -48,6 +48,6 @@ def load_persistent_cache(allow_unencrypted):
                 )
             persistence = msal_extensions.FilePersistence(file_path)
     else:
-        raise NotImplementedError("A persistent cache is not available on this platform.")
+        raise NotImplementedError("A persistent cache is not available in this environment.")
 
     return msal_extensions.PersistedTokenCache(persistence)

--- a/sdk/identity/azure-identity/azure/identity/_internal/persistent_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/persistent_cache.py
@@ -1,0 +1,53 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import os
+import sys
+from typing import TYPE_CHECKING
+
+import msal_extensions
+
+if TYPE_CHECKING:
+    from typing import Optional
+    import msal
+
+
+def load_persistent_cache(allow_unencrypted):
+    # type: (Optional[bool]) -> msal.TokenCache
+    """Load the persistent cache using msal_extensions.
+
+    On Windows the cache is a file protected by the Data Protection API. On Linux and macOS the cache is stored by
+    libsecret and Keychain, respectively. On those platforms the cache uses the modified timestamp of a file on disk to
+    decide whether to reload the cache.
+
+    :param bool allow_unencrypted: when True, the cache will be kept in plaintext should encryption be impossible in the
+        current environment
+    """
+
+    if sys.platform.startswith("win") and "LOCALAPPDATA" in os.environ:
+        cache_location = os.path.join(os.environ["LOCALAPPDATA"], ".IdentityService", "msal.cache")
+        persistence = msal_extensions.FilePersistenceWithDataProtection(cache_location)
+    elif sys.platform.startswith("darwin"):
+        # the cache uses this file's modified timestamp to decide whether to reload
+        file_path = os.path.expanduser(os.path.join("~", ".IdentityService", "msal.cache"))
+        persistence = msal_extensions.KeychainPersistence(file_path, "Microsoft.Developer.IdentityService", "MSALCache")
+    elif sys.platform.startswith("linux"):
+        # The cache uses this file's modified timestamp to decide whether to reload. Note this path is the same
+        # as that of the plaintext fallback: a new encrypted cache will stomp an unencrypted cache.
+        file_path = os.path.expanduser(os.path.join("~", ".IdentityService", "msal.cache"))
+        try:
+            persistence = msal_extensions.LibsecretPersistence(
+                file_path, "msal.cache", {"MsalClientID": "Microsoft.Developer.IdentityService"}, label="MSALCache"
+            )
+        except ImportError:
+            if not allow_unencrypted:
+                raise ValueError(
+                    "PyGObject is required to encrypt the persistent cache. Please install that library or ",
+                    "specify 'allow_unencrypted_cache=True' to store the cache without encryption.",
+                )
+            persistence = msal_extensions.FilePersistence(file_path)
+    else:
+        raise NotImplementedError("A persistent cache is not available on this platform.")
+
+    return msal_extensions.PersistedTokenCache(persistence)

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -99,11 +99,11 @@ class SharedTokenCacheBase(ABC):
         cache = kwargs.pop("_cache", None)  # for ease of testing
 
         if not cache and sys.platform.startswith("win") and "LOCALAPPDATA" in os.environ:
-            from msal_extensions.token_cache import WindowsTokenCache
+            from msal_extensions import FilePersistenceWithDataProtection, PersistedTokenCache
 
-            cache = WindowsTokenCache(
-                cache_location=os.path.join(os.environ["LOCALAPPDATA"], ".IdentityService", "msal.cache")
-            )
+            file_location = os.path.join(os.environ["LOCALAPPDATA"], ".IdentityService", "msal.cache")
+            persistence = FilePersistenceWithDataProtection(file_location)
+            cache = PersistedTokenCache(persistence)
 
             # prevent writing to the shared cache
             # TODO: seperating deserializing access tokens from caching them would make this cleaner

--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -73,7 +73,7 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.0.0",
         "cryptography>=2.1.4",
-        "msal<2.0.0,>=1.0.0",
+        "msal<2.0.0,>=1.1.0",
         "msal-extensions~=0.2.2",
         "six>=1.6",
     ],

--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -74,7 +74,7 @@ setup(
         "azure-core<2.0.0,>=1.0.0",
         "cryptography>=2.1.4",
         "msal<2.0.0,>=1.0.0",
-        "msal-extensions~=0.1.3",
+        "msal-extensions~=0.2.2",
         "six>=1.6",
     ],
     extras_require={

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -95,7 +95,7 @@ cryptography>=2.1.4
 futures
 mock
 typing
-msal<2.0.0,>=1.0.0
+msal<2.0.0,>=1.1.0
 msal-extensions~=0.2.2
 msrest>=0.5.0
 msrestazure<2.0.0,>=0.4.32

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -96,7 +96,7 @@ futures
 mock
 typing
 msal<2.0.0,>=1.0.0
-msal-extensions~=0.1.3
+msal-extensions~=0.2.2
 msrest>=0.5.0
 msrestazure<2.0.0,>=0.4.32
 azure-mgmt-core<2.0.0,>=1.0.0


### PR DESCRIPTION
This adopts msal-extensions 0.2.2 to enable persistent token caching on Linux and macOS for `DeviceCodeCredential` and `InteractiveBrowserCredential`. It also adds a new keyword argument for those credentials, `allow_unencrypted_cache`, which determines whether to fall back to a plaintext cache on Linux when libsecret or PyGObject are unavailable (defaults `False`).

Strings and paths for the new platforms are from Azure/azure-sdk-for-java#9188 and the default behavior of [MSAL's Java extension library](https://github.com/AzureAD/microsoft-authentication-extensions-for-java/tree/dev/src/main/java/com/microsoft/aad/msal4jextensions).
