### PR TITLE
Prevent passing 'auth' argument to pipeline.run

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_transport_adapter.py
@@ -106,6 +106,10 @@ class MsalTransportAdapter(object):
         request = HttpRequest("GET", url, headers=headers)
         if params:
             request.format_parameters(params)
+
+        # msal passes auth=None, which we don't want to pass along to pipeline.run
+        kwargs.pop("auth", None)
+
         response = self._pipeline.run(
             request, stream=False, connection_timeout=timeout, connection_verify=verify, **kwargs
         )
@@ -128,6 +132,10 @@ class MsalTransportAdapter(object):
         if data:
             request.headers["Content-Type"] = "application/x-www-form-urlencoded"
             request.set_formdata_body(data)
+
+        # msal passes auth=None, which we don't want to pass along to pipeline.run
+        kwargs.pop("auth", None)
+
         response = self._pipeline.run(
             request, stream=False, connection_timeout=timeout, connection_verify=verify, **kwargs
         )

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/msal_transport_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/msal_transport_adapter.py
@@ -78,6 +78,9 @@ class MsalTransportAdapter:
         if params:
             request.format_parameters(params)
 
+        # msal passes auth=None, which we don't want to pass along to pipeline.run
+        kwargs.pop("auth", None)
+
         future = asyncio.run_coroutine_threadsafe(  # type: ignore
             self._pipeline.run(request, connection_timeout=timeout, connection_verify=verify, **kwargs), loop
         )
@@ -103,6 +106,9 @@ class MsalTransportAdapter:
         if data:
             request.headers["Content-Type"] = "application/x-www-form-urlencoded"
             request.set_formdata_body(data)
+
+        # msal passes auth=None, which we don't want to pass along to pipeline.run
+        kwargs.pop("auth", None)
 
         future = asyncio.run_coroutine_threadsafe(  # type: ignore
             self._pipeline.run(request, connection_timeout=timeout, connection_verify=verify, **kwargs), loop


### PR DESCRIPTION
MSAL passes `auth=None` with its transport calls. Our adapter has no use for the argument and passes it along to the pipeline, which also has no use for it. It appears MSAL's behavior here will change in its next version, but in the meantime this PR unblocks enforcing known keyword arguments to `pipeline.run`.