### PR TITLE
[Event Hubs] Workaround pylint unused-import false positive

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer_client.py
@@ -4,27 +4,28 @@
 # --------------------------------------------------------------------------------------------
 import logging
 import threading
-from typing import (  # pylint: disable=unused-import
-    Any,
-    Union,
-    Dict,
-    Tuple,
-    TYPE_CHECKING,
-    Callable,
-    List,
-    Optional,
-)
+from typing import TYPE_CHECKING
 
-from ._common import EventData
 from ._client_base import ClientBase
 from ._consumer import EventHubConsumer
 from ._constants import ALL_PARTITIONS
 from ._eventprocessor.event_processor import EventProcessor
-from ._eventprocessor.partition_context import PartitionContext  # pylint: disable=unused-import
+
 
 if TYPE_CHECKING:
     import datetime
     from azure.core.credentials import TokenCredential
+    from typing import (  # pylint: disable=ungrouped-imports
+        Any,
+        Union,
+        Dict,
+        Tuple,
+        Callable,
+        List,
+        Optional,
+    )
+    from ._eventprocessor.partition_context import PartitionContext
+    from ._common import EventData
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer_client.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 import logging
 import threading
-from typing import (
+from typing import (  # pylint: disable=unused-import
     Any,
     Union,
     Dict,
@@ -13,14 +13,14 @@ from typing import (
     Callable,
     List,
     Optional,
-)  # pylint: disable=unused-import
+)
 
 from ._common import EventData
 from ._client_base import ClientBase
 from ._consumer import EventHubConsumer
 from ._constants import ALL_PARTITIONS
 from ._eventprocessor.event_processor import EventProcessor
-from ._eventprocessor.partition_context import PartitionContext
+from ._eventprocessor.partition_context import PartitionContext  # pylint: disable=unused-import
 
 if TYPE_CHECKING:
     import datetime


### PR DESCRIPTION
Pylint 2.3.1 sometimes wrongly report unused-import. 