### PR TITLE
Enforce https in search

### DIFF
--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from azure.core.tracing.decorator import distributed_trace
 
+from .search_service_client_base import SearchServiceClientBase
 from ._generated import SearchServiceClient as _SearchServiceClient
 from .._headers_mixin import HeadersMixin
 from .._version import SDK_MONIKER
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
     from azure.core.credentials import AzureKeyCredential
 
 
-class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-methods
+class SearchServiceClient(SearchServiceClientBase):  # pylint: disable=too-many-public-methods
     """A client to interact with an existing Azure search service.
 
     :param endpoint: The URL endpoint of an Azure search service
@@ -44,21 +45,7 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
 
     def __init__(self, endpoint, credential, **kwargs):
         # type: (str, AzureKeyCredential, **Any) -> None
-
-        try:
-            if endpoint.lower().startswith('http') and not endpoint.lower().startswith('https'):
-                raise ValueError("Endpoint should be secure. Use https.")
-            if not endpoint.lower().startswith('http'):
-                endpoint = "https://" + endpoint
-        except AttributeError:
-            raise ValueError("Endpoint must be a string")
-
-        self._endpoint = endpoint  # type: str
-        self._credential = credential  # type: AzureKeyCredential
-        self._client = _SearchServiceClient(
-            endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
-        )  # type: _SearchServiceClient
-
+        super(SearchServiceClient, self).__init__(endpoint, credential, **kwargs)
         self._indexes_client = SearchIndexesClient(endpoint, credential, **kwargs)
 
         self._synonym_maps_client = SearchSynonymMapsClient(
@@ -72,10 +59,6 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
         )
 
         self._indexers_client = SearchIndexersClient(endpoint, credential, **kwargs)
-
-    def __repr__(self):
-        # type: () -> str
-        return "<SearchServiceClient [endpoint={}]>".format(repr(self._endpoint))[:1024]
 
     def __enter__(self):
         # type: () -> SearchServiceClient

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client.py
@@ -7,9 +7,8 @@ from typing import TYPE_CHECKING
 
 from azure.core.tracing.decorator import distributed_trace
 
-from .search_service_client_base import SearchServiceClientBase
+from ._search_service_client_base import SearchServiceClientBase
 from ._generated import SearchServiceClient as _SearchServiceClient
-from .._headers_mixin import HeadersMixin
 from .._version import SDK_MONIKER
 from ._datasources_client import SearchDataSourcesClient
 from ._indexes_client import SearchIndexesClient
@@ -46,6 +45,9 @@ class SearchServiceClient(SearchServiceClientBase):  # pylint: disable=too-many-
     def __init__(self, endpoint, credential, **kwargs):
         # type: (str, AzureKeyCredential, **Any) -> None
         super(SearchServiceClient, self).__init__(endpoint, credential, **kwargs)
+        self._client = _SearchServiceClient(
+            endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
+        )  # type: _SearchServiceClient
         self._indexes_client = SearchIndexesClient(endpoint, credential, **kwargs)
 
         self._synonym_maps_client = SearchSynonymMapsClient(

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client.py
@@ -45,6 +45,14 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
     def __init__(self, endpoint, credential, **kwargs):
         # type: (str, AzureKeyCredential, **Any) -> None
 
+        try:
+            if endpoint.lower().startswith('http') and not endpoint.lower().startswith('https'):
+                raise ValueError("Endpoint should be secure. Use https.")
+            if not endpoint.lower().startswith('http'):
+                endpoint = "https://" + endpoint
+        except AttributeError:
+            raise ValueError("Endpoint must be a string")
+
         self._endpoint = endpoint  # type: str
         self._credential = credential  # type: AzureKeyCredential
         self._client = _SearchServiceClient(

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client_base.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client_base.py
@@ -1,0 +1,64 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from typing import TYPE_CHECKING
+
+from azure.core.tracing.decorator_async import distributed_trace_async
+
+from .._generated.aio import SearchServiceClient as _SearchServiceClient
+from ..._headers_mixin import HeadersMixin
+from ..._version import SDK_MONIKER
+from ._datasources_client import SearchDataSourcesClient
+from ._indexes_client import SearchIndexesClient
+from ._indexers_client import SearchIndexersClient
+from ._skillsets_client import SearchSkillsetsClient
+from ._synonym_maps_client import SearchSynonymMapsClient
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import,ungrouped-imports
+    from typing import Any, Dict, List, Optional, Sequence
+    from azure.core.credentials import AzureKeyCredential
+
+
+class SearchServiceClientBase(HeadersMixin):  # pylint: disable=too-many-public-methods
+    """A client to interact with an existing Azure search service.
+
+    :param endpoint: The URL endpoint of an Azure search service
+    :type endpoint: str
+    :param credential: A credential to authorize search client requests
+    :type credential: ~azure.core.credentials import AzureKeyCredential
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/async_samples/sample_authentication_async.py
+            :start-after: [START create_search_service_with_key_async]
+            :end-before: [END create_search_service_with_key_async]
+            :language: python
+            :dedent: 4
+            :caption: Creating the SearchServiceClient with an API key.
+    """
+
+    _ODATA_ACCEPT = "application/json;odata.metadata=minimal"  # type: str
+
+    def __init__(self, endpoint, credential, **kwargs):
+        # type: (str, AzureKeyCredential, **Any) -> None
+
+        try:
+            if endpoint.lower().startswith('http') and not endpoint.lower().startswith('https'):
+                raise ValueError("Bearer token authentication is not permitted for non-TLS protected (non-https) URLs.")
+            if not endpoint.lower().startswith('http'):
+                endpoint = "https://" + endpoint
+        except AttributeError:
+            raise ValueError("Endpoint must be a string.")
+
+        self._endpoint = endpoint  # type: str
+        self._credential = credential  # type: AzureKeyCredential
+        self._client = _SearchServiceClient(
+            endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
+        )  # type: _SearchServiceClient
+
+    def __repr__(self):
+        # type: () -> str
+        return "<SearchServiceClient [endpoint={}]>".format(repr(self._endpoint))[:1024]

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client_base.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client_base.py
@@ -6,6 +6,7 @@
 from typing import TYPE_CHECKING
 
 from .._headers_mixin import HeadersMixin
+from ._utils import _normalize_endpoint
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
@@ -42,12 +43,3 @@ class SearchServiceClientBase(HeadersMixin):  # pylint: disable=too-many-public-
     def __repr__(self):
         # type: () -> str
         return "<SearchServiceClient [endpoint={}]>".format(repr(self._endpoint))[:1024]
-
-    def _normalize_endpoint(endpoint):
-        try:
-            if not endpoint.lower().startswith('http'):
-                endpoint = "https://" + endpoint
-            elif not endpoint.lower().startswith('https'):
-                raise ValueError("Bearer token authentication is not permitted for non-TLS protected (non-https) URLs.")
-        except AttributeError:
-            raise ValueError("Endpoint must be a string.")

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client_base.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client_base.py
@@ -5,11 +5,7 @@
 # --------------------------------------------------------------------------
 from typing import TYPE_CHECKING
 
-from azure.core.tracing.decorator_async import distributed_trace_async
-
-from .._generated.aio import SearchServiceClient as _SearchServiceClient
-from ..._headers_mixin import HeadersMixin
-from ..._version import SDK_MONIKER
+from .._headers_mixin import HeadersMixin
 from ._datasources_client import SearchDataSourcesClient
 from ._indexes_client import SearchIndexesClient
 from ._indexers_client import SearchIndexersClient
@@ -32,9 +28,9 @@ class SearchServiceClientBase(HeadersMixin):  # pylint: disable=too-many-public-
 
     .. admonition:: Example:
 
-        .. literalinclude:: ../samples/async_samples/sample_authentication_async.py
-            :start-after: [START create_search_service_with_key_async]
-            :end-before: [END create_search_service_with_key_async]
+        .. literalinclude:: ../samples/sample_authentication.py
+            :start-after: [START create_search_service_with_key]
+            :end-before: [END create_search_service_with_key]
             :language: python
             :dedent: 4
             :caption: Creating the SearchServiceClient with an API key.
@@ -42,7 +38,7 @@ class SearchServiceClientBase(HeadersMixin):  # pylint: disable=too-many-public-
 
     _ODATA_ACCEPT = "application/json;odata.metadata=minimal"  # type: str
 
-    def __init__(self, endpoint, credential, **kwargs):
+    def __init__(self, endpoint, credential):
         # type: (str, AzureKeyCredential, **Any) -> None
 
         try:
@@ -55,9 +51,6 @@ class SearchServiceClientBase(HeadersMixin):  # pylint: disable=too-many-public-
 
         self._endpoint = endpoint  # type: str
         self._credential = credential  # type: AzureKeyCredential
-        self._client = _SearchServiceClient(
-            endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
-        )  # type: _SearchServiceClient
 
     def __repr__(self):
         # type: () -> str

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client_base.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client_base.py
@@ -6,11 +6,6 @@
 from typing import TYPE_CHECKING
 
 from .._headers_mixin import HeadersMixin
-from ._datasources_client import SearchDataSourcesClient
-from ._indexes_client import SearchIndexesClient
-from ._indexers_client import SearchIndexersClient
-from ._skillsets_client import SearchSkillsetsClient
-from ._synonym_maps_client import SearchSynonymMapsClient
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
@@ -41,6 +36,14 @@ class SearchServiceClientBase(HeadersMixin):  # pylint: disable=too-many-public-
     def __init__(self, endpoint, credential):
         # type: (str, AzureKeyCredential) -> None
 
+        self._endpoint = _normalize_endpoint(endpoint)  # type: str
+        self._credential = credential  # type: AzureKeyCredential
+
+    def __repr__(self):
+        # type: () -> str
+        return "<SearchServiceClient [endpoint={}]>".format(repr(self._endpoint))[:1024]
+
+    def _normalize_endpoint(endpoint):
         try:
             if not endpoint.lower().startswith('http'):
                 endpoint = "https://" + endpoint
@@ -48,10 +51,3 @@ class SearchServiceClientBase(HeadersMixin):  # pylint: disable=too-many-public-
                 raise ValueError("Bearer token authentication is not permitted for non-TLS protected (non-https) URLs.")
         except AttributeError:
             raise ValueError("Endpoint must be a string.")
-
-        self._endpoint = endpoint  # type: str
-        self._credential = credential  # type: AzureKeyCredential
-
-    def __repr__(self):
-        # type: () -> str
-        return "<SearchServiceClient [endpoint={}]>".format(repr(self._endpoint))[:1024]

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client_base.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client_base.py
@@ -21,15 +21,6 @@ class SearchServiceClientBase(HeadersMixin):  # pylint: disable=too-many-public-
     :type endpoint: str
     :param credential: A credential to authorize search client requests
     :type credential: ~azure.core.credentials import AzureKeyCredential
-
-    .. admonition:: Example:
-
-        .. literalinclude:: ../samples/sample_authentication.py
-            :start-after: [START create_search_service_with_key]
-            :end-before: [END create_search_service_with_key]
-            :language: python
-            :dedent: 4
-            :caption: Creating the SearchServiceClient with an API key.
     """
 
     _ODATA_ACCEPT = "application/json;odata.metadata=minimal"  # type: str

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client_base.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client_base.py
@@ -39,7 +39,7 @@ class SearchServiceClientBase(HeadersMixin):  # pylint: disable=too-many-public-
     _ODATA_ACCEPT = "application/json;odata.metadata=minimal"  # type: str
 
     def __init__(self, endpoint, credential):
-        # type: (str, AzureKeyCredential, **Any) -> None
+        # type: (str, AzureKeyCredential) -> None
 
         try:
             if endpoint.lower().startswith('http') and not endpoint.lower().startswith('https'):

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client_base.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_search_service_client_base.py
@@ -42,10 +42,10 @@ class SearchServiceClientBase(HeadersMixin):  # pylint: disable=too-many-public-
         # type: (str, AzureKeyCredential) -> None
 
         try:
-            if endpoint.lower().startswith('http') and not endpoint.lower().startswith('https'):
-                raise ValueError("Bearer token authentication is not permitted for non-TLS protected (non-https) URLs.")
             if not endpoint.lower().startswith('http'):
                 endpoint = "https://" + endpoint
+            elif not endpoint.lower().startswith('https'):
+                raise ValueError("Bearer token authentication is not permitted for non-TLS protected (non-https) URLs.")
         except AttributeError:
             raise ValueError("Endpoint must be a string.")
 

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/_utils.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/_utils.py
@@ -187,3 +187,13 @@ def get_access_conditions(model, match_condition=MatchConditions.Unconditionally
         return (error_map, AccessCondition(if_match=if_match, if_none_match=if_none_match))
     except AttributeError:
         raise ValueError("Unable to get e_tag from the model")
+
+def _normalize_endpoint(endpoint):
+    try:
+        if not endpoint.lower().startswith('http'):
+            endpoint = "https://" + endpoint
+        elif not endpoint.lower().startswith('https'):
+            raise ValueError("Bearer token authentication is not permitted for non-TLS protected (non-https) URLs.")
+        return endpoint
+    except AttributeError:
+        raise ValueError("Endpoint must be a string.")

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_search_service_client_async.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_search_service_client_async.py
@@ -8,8 +8,7 @@ from typing import TYPE_CHECKING
 from azure.core.tracing.decorator_async import distributed_trace_async
 
 from .._generated.aio import SearchServiceClient as _SearchServiceClient
-from ..search_service_client_base import SearchServiceClientBase
-from ..._headers_mixin import HeadersMixin
+from .._search_service_client_base import SearchServiceClientBase
 from ..._version import SDK_MONIKER
 from ._datasources_client import SearchDataSourcesClient
 from ._indexes_client import SearchIndexesClient
@@ -47,6 +46,10 @@ class SearchServiceClient(SearchServiceClientBase):  # pylint: disable=too-many-
         # type: (str, AzureKeyCredential, **Any) -> None
 
         super().__init__(endpoint, credential, **kwargs)
+        self._client = _SearchServiceClient(
+            endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
+        )  # type: _SearchServiceClient
+
         self._indexes_client = SearchIndexesClient(endpoint, credential, **kwargs)
 
         self._synonym_maps_client = SearchSynonymMapsClient(

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_search_service_client_async.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_search_service_client_async.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from azure.core.tracing.decorator_async import distributed_trace_async
 
 from .._generated.aio import SearchServiceClient as _SearchServiceClient
+from ..search_service_client_base import SearchServiceClientBase
 from ..._headers_mixin import HeadersMixin
 from ..._version import SDK_MONIKER
 from ._datasources_client import SearchDataSourcesClient
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
     from azure.core.credentials import AzureKeyCredential
 
 
-class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-methods
+class SearchServiceClient(SearchServiceClientBase):  # pylint: disable=too-many-public-methods
     """A client to interact with an existing Azure search service.
 
     :param endpoint: The URL endpoint of an Azure search service
@@ -45,20 +46,7 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
     def __init__(self, endpoint, credential, **kwargs):
         # type: (str, AzureKeyCredential, **Any) -> None
 
-        try:
-            if endpoint.lower().startswith('http') and not endpoint.lower().startswith('https'):
-                raise ValueError("Endpoint should be secure. Use https.")
-            if not endpoint.lower().startswith('http'):
-                endpoint = "https://" + endpoint
-        except AttributeError:
-            raise ValueError("Endpoint must be a string")
-
-        self._endpoint = endpoint  # type: str
-        self._credential = credential  # type: AzureKeyCredential
-        self._client = _SearchServiceClient(
-            endpoint=endpoint, sdk_moniker=SDK_MONIKER, **kwargs
-        )  # type: _SearchServiceClient
-
+        super().__init__(endpoint, credential, **kwargs)
         self._indexes_client = SearchIndexesClient(endpoint, credential, **kwargs)
 
         self._synonym_maps_client = SearchSynonymMapsClient(
@@ -72,10 +60,6 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
         )
 
         self._indexers_client = SearchIndexersClient(endpoint, credential, **kwargs)
-
-    def __repr__(self):
-        # type: () -> str
-        return "<SearchServiceClient [endpoint={}]>".format(repr(self._endpoint))[:1024]
 
     async def __aenter__(self):
         # type: () -> SearchServiceClient

--- a/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_search_service_client_async.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_service/aio/_search_service_client_async.py
@@ -45,6 +45,14 @@ class SearchServiceClient(HeadersMixin):  # pylint: disable=too-many-public-meth
     def __init__(self, endpoint, credential, **kwargs):
         # type: (str, AzureKeyCredential, **Any) -> None
 
+        try:
+            if endpoint.lower().startswith('http') and not endpoint.lower().startswith('https'):
+                raise ValueError("Endpoint should be secure. Use https.")
+            if not endpoint.lower().startswith('http'):
+                endpoint = "https://" + endpoint
+        except AttributeError:
+            raise ValueError("Endpoint must be a string")
+
         self._endpoint = endpoint  # type: str
         self._credential = credential  # type: AzureKeyCredential
         self._client = _SearchServiceClient(

--- a/sdk/search/azure-search-documents/tests/test_search_service_client.py
+++ b/sdk/search/azure-search-documents/tests/test_search_service_client.py
@@ -40,7 +40,7 @@ class TestSearchServiceClient(object):
     def test_repr(self):
         client = SearchServiceClient("endpoint", CREDENTIAL)
         assert repr(client) == "<SearchServiceClient [endpoint={}]>".format(
-            repr("endpoint")
+            repr("https://endpoint")
         )
 
     @mock.patch(
@@ -52,3 +52,17 @@ class TestSearchServiceClient(object):
         assert mock_get_stats.called
         assert mock_get_stats.call_args[0] == ()
         assert mock_get_stats.call_args[1] == {"headers": client._headers}
+
+    def test_endpoint_https(self):
+        credential = AzureKeyCredential(key="old_api_key")
+        client = SearchServiceClient("endpoint", credential)
+        assert client._endpoint.startswith('https')
+
+        client = SearchServiceClient("https://endpoint", credential)
+        assert client._endpoint.startswith('https')
+
+        with pytest.raises(ValueError):
+            client = SearchServiceClient("http://endpoint", credential)
+
+        with pytest.raises(ValueError):
+            client = SearchServiceClient(12345, credential)


### PR DESCRIPTION
Fixes #10981 

Case1: "xyz.search.windows.net"
Current Behavior: throws some random key error because it fails to parse in azure core
Changed to: "https://xyz.search.windows.net"

Case2: "https://xyz.search.windows.net"
No behavior changed - correct endpoint

Case3: "http://xyz.search.windows.net"
Behavior changed to raising value error and warn to use https

Case4: 1234 (non string)
Raises a value error