### PR TITLE
update CODEOWNERS with smoke test owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,6 +40,9 @@
 /sdk/textanalytics/                                                  @kristapratico @iscai-msft
 /sdk/formrecognizer/                                                 @kristapratico @iscai-msft
 
+# Smoke Tests
+/common/smoketest/                                                   @lmazuel @chlowell @annatisch @rakshith91 @shurd
+
 # Management Plane
 /**/*mgmt*/     @zikalino
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,7 +41,7 @@
 /sdk/formrecognizer/                                                 @kristapratico @iscai-msft
 
 # Smoke Tests
-/common/smoketest/                                                   @lmazuel @chlowell @annatisch @rakshith91 @shurd
+/common/smoketest/                                                   @lmazuel @chlowell @annatisch @rakshith91 @shurd @southpolesteve
 
 # Management Plane
 /**/*mgmt*/     @zikalino


### PR DESCRIPTION
This change (arbitrarily) selects code owners for the Smoke Tests pipelines. You will receive email notifications from Azure DevOps when the smoke tests fail. If someone else should be in your place please comment here. 

What are smoke tests? 
https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/198/Smoke-Testing

Who is being subscribed? 
@lmazuel @chlowell @annatisch @rakshith91 @shurd