### PR TITLE
Improve core and sample readmes with breadcrumbs to common points of confusion

### DIFF
--- a/sdk/servicebus/azure-servicebus/README.md
+++ b/sdk/servicebus/azure-servicebus/README.md
@@ -242,6 +242,12 @@ Please find further examples in the [samples](./samples) directory demonstrating
 
 For more extensive documentation on the Service Bus service, see the [Service Bus documentation][service_bus_docs] on docs.microsoft.com.
 
+### Management capabilities and documentation
+
+For users seeking to perform management operations against ServiceBus (Creating a queue/topic/etc, altering filter rules, enumerating entities)
+please see the [azure-mgmt-servicebus documentation][service_bus_mgmt_docs] for API documentation.  Terse usage examples can be found
+[here](../azure-mgmt-servicebus/tests) as well.
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
@@ -273,6 +279,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 [service_bus_overview]: https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messaging-overview
 [queue_status_codes]: https://docs.microsoft.com/rest/api/servicebus/create-queue#response-codes
 [service_bus_docs]: https://docs.microsoft.com/azure/service-bus/
+[service_bus_mgmt_docs]: https://docs.microsoft.com/en-us/python/api/overview/azure/servicebus/management?view=azure-python
 [queue_concept]: https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview#queues
 [topic_concept]: https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview#topics
 [subscription_concept]: https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-queues-topics-subscriptions#topics-and-subscriptions

--- a/sdk/servicebus/azure-servicebus/samples/README.md
+++ b/sdk/servicebus/azure-servicebus/samples/README.md
@@ -10,6 +10,9 @@ urlFragment: servicebus-samples
 
 # Azure Service Bus client library for Python Samples
 
+> **NOTE**: This document outlines the samples for the **preview** of the next version of the `azure-servicebus` package
+> which has different APIs than the current version (0.50). Please visit [this link](https://github.com/Azure/azure-sdk-for-python/tree/servicebus_v0.50.2/sdk/servicebus/azure-servicebus/samples) for samples of the existing library.
+
 These are code samples that show common scenario operations with the Azure Service Bus client library.
 Both [sync version](./sync_samples) and [async version](./async_samples) of samples are provided, async samples require Python 3.5 or later.
 


### PR DESCRIPTION
Add a snippet to the Samples readme mirroring the core readme, guiding users to the currently mainline version of the lib if the end up on the wrong page.

Also adds a snippet to the core README documenting breadcrumbs to the mgmt libs and samples, following feedback from users that this was not always obvious.