### PR TITLE
Smoke Tests use new workflow for package install

### DIFF
--- a/common/smoketest/dependencies.py
+++ b/common/smoketest/dependencies.py
@@ -28,7 +28,7 @@ def get_dependencies(packages):
         applicable_requirements = [r for r in package_info.requires() if r.marker is None or r.marker.evaluate()]
         requirements.extend(applicable_requirements)
 
-    return [get_freeze_string(r) for r in requirements]
+    return requirements
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -52,4 +52,7 @@ if __name__ == "__main__":
     # from dev feed
     dependencies = get_dependencies(package_names)
 
-    print("\n".join(dependencies))
+    # TODO: Do a better job of merging these that doesn't squash earlier entries
+    final_dependencies = {d.key: get_freeze_string(d) for d in dependencies}
+
+    print("\n".join(final_dependencies.values()))

--- a/common/smoketest/dependencies.py
+++ b/common/smoketest/dependencies.py
@@ -1,0 +1,55 @@
+import argparse
+import pkg_resources
+
+try:
+    # pip < 20
+    from pip._internal.req import parse_requirements
+    from pip._internal.download import PipSession
+except:
+    # pip >= 20
+    from pip._internal.req import parse_requirements
+    from pip._internal.network.session import PipSession
+
+def get_freeze_string(requirement):
+    output = []
+    output.append(requirement.project_name)
+    spec_list = [s[0] + s[1] for s in requirement.specs]
+
+    output.extend(','.join(spec_list))
+
+    return ''.join(output)
+
+
+def get_dependencies(packages):
+    requirements = []
+    for package in packages:
+        package_info = pkg_resources.working_set.by_key[package]
+
+        applicable_requirements = [r for r in package_info.requires() if r.marker is None or r.marker.evaluate()]
+        requirements.extend(applicable_requirements)
+
+    return [get_freeze_string(r) for r in requirements]
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="List dependencies for a given requirements.txt file"
+    )
+
+    parser.add_argument(
+        "-r",
+        "--requirements",
+        dest="requirements_file",
+        help="File containing list of packages for which to find dependencies",
+        required=True
+    )
+
+    args = parser.parse_args()
+    # Get package names from requirements.txt
+    requirements = parse_requirements(args.requirements_file, session=PipSession())
+    package_names = [item.req.name for item in requirements]
+
+    # Remove existing packages (that came from the public feed) and install
+    # from dev feed
+    dependencies = get_dependencies(package_names)
+
+    print("\n".join(dependencies))

--- a/common/smoketest/dependencies.py
+++ b/common/smoketest/dependencies.py
@@ -49,10 +49,16 @@ if __name__ == "__main__":
     requirements = parse_requirements(args.requirements_file, session=PipSession())
     package_names = [item.req.name for item in requirements]
 
-    # Remove existing packages (that came from the public feed) and install
-    # from dev feed
     dependencies = get_dependencies(package_names)
 
+    # It may be the case that packages have multiple sets of dependency
+    # requirements, for example:
+    # Package A requires Foo>=1.0.0,<2.0.0
+    # Package B requires Foo>=1.0.0,<1.2.3
+    # This combines all required versions into one string for pip to resolve
+    # Output: Foo>=1.0.0,<2.0.0,>=1.0.0,<1.2.3
+    # Pip parses this value using the Requirement object (https://setuptools.readthedocs.io/en/latest/pkg_resources.html#requirement-objects)
+    # According to https://packaging.python.org/glossary/#term-requirement-specifier
     grouped_dependencies = {}
     for dep in dependencies:
         if dep.key in grouped_dependencies:

--- a/common/smoketest/smoke-test.yml
+++ b/common/smoketest/smoke-test.yml
@@ -87,15 +87,18 @@ jobs:
       - script: pip install packaging pkginfo
         displayName: Install requirements for dev tools
 
-      - script: pip install -r ./common/smoketest/requirements.txt
-        displayName: "Install requirements.txt"
+      - script: pip install -r .\common\smoketest\requirements.txt --pre --no-deps --index-url https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple
+        displayName: Install requirements from dev feed without dependencies
 
       - script: pip install -r ./common/smoketest/requirements_async.txt
         displayName: "Install requirements_async.txt"
         condition: and(succeeded(), eq(variables['InstallAsyncRequirements'], 'true'))
 
-      - script: python ./eng/tox/install_dev_build_dependency.py -r ./common/smoketest/requirements.txt
-        displayName: "Install dev dependencies from feed"
+      - script: python ./eng/tox/install_dev_build_dependency.py -r ./common/smoketest/requirements.txt > ./common/smoketest/requirements_dependencies.txt
+        displayName: Install packages from the dev feed
+
+      - script: pip install -r ./common/smoketest/requirements_dependencies.txt
+        displayName: Install dev package dependencies from PyPI
 
       - template: /eng/common/TestResources/deploy-test-resources.yml
         parameters:
@@ -105,7 +108,7 @@ jobs:
           ArmTemplateParameters: $(ArmTemplateParameters)
 
       - script: python ./common/smoketest/program.py
-        displayName: "Run Smoke Test"
+        displayName: Run Smoke Test
 
       - template: /eng/common/TestResources/remove-test-resources.yml
         parameters:

--- a/common/smoketest/smoke-test.yml
+++ b/common/smoketest/smoke-test.yml
@@ -84,7 +84,7 @@ jobs:
           pip --version
         displayName: pip --version
 
-      - script: pip install -r .\common\smoketest\requirements.txt --pre --no-deps --index-url https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple
+      - script: pip install -r ./common/smoketest/requirements.txt --pre --no-deps --index-url https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple
         displayName: Install requirements from dev feed without dependencies
 
       - script: pip install -r ./common/smoketest/requirements_async.txt

--- a/common/smoketest/smoke-test.yml
+++ b/common/smoketest/smoke-test.yml
@@ -91,8 +91,8 @@ jobs:
         displayName: "Install requirements_async.txt"
         condition: and(succeeded(), eq(variables['InstallAsyncRequirements'], 'true'))
 
-      - script: python ./common/smoketest/dependencies.py -r ./common/smoketest/requirements.txt > ./common/smoketest/requirements_dependencies.txt
-        displayName: Install packages from the dev feed
+      - script: python ./common/smoketest/dependencies.py -r ./common/smoketest/requirements.txt | tee ./common/smoketest/requirements_dependencies.txt
+        displayName: Create dependency list from installed dev packages
 
       - script: pip install -r ./common/smoketest/requirements_dependencies.txt
         displayName: Install dev package dependencies from PyPI

--- a/common/smoketest/smoke-test.yml
+++ b/common/smoketest/smoke-test.yml
@@ -97,6 +97,9 @@ jobs:
       - script: pip install -r ./common/smoketest/requirements_dependencies.txt
         displayName: Install dev package dependencies from PyPI
 
+      - script: pip freeze
+        displayName: Show installed packages (pip freeze)
+
       - template: /eng/common/TestResources/deploy-test-resources.yml
         parameters:
           ServiceDirectory: '$(Build.SourcesDirectory)/common/smoketest/'

--- a/common/smoketest/smoke-test.yml
+++ b/common/smoketest/smoke-test.yml
@@ -91,7 +91,7 @@ jobs:
         displayName: "Install requirements_async.txt"
         condition: and(succeeded(), eq(variables['InstallAsyncRequirements'], 'true'))
 
-      - script: python ./eng/tox/install_dev_build_dependency.py -r ./common/smoketest/requirements.txt > ./common/smoketest/requirements_dependencies.txt
+      - script: python ./common/smoketest/dependencies.py -r ./common/smoketest/requirements.txt > ./common/smoketest/requirements_dependencies.txt
         displayName: Install packages from the dev feed
 
       - script: pip install -r ./common/smoketest/requirements_dependencies.txt

--- a/common/smoketest/smoke-test.yml
+++ b/common/smoketest/smoke-test.yml
@@ -84,9 +84,6 @@ jobs:
           pip --version
         displayName: pip --version
 
-      - script: pip install packaging pkginfo
-        displayName: Install requirements for dev tools
-
       - script: pip install -r .\common\smoketest\requirements.txt --pre --no-deps --index-url https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple
         displayName: Install requirements from dev feed without dependencies
 

--- a/eng/tox/install_dev_build_dependency.py
+++ b/eng/tox/install_dev_build_dependency.py
@@ -15,16 +15,6 @@ from subprocess import check_call
 
 from pip._internal.operations import freeze
 
-try:
-    # pip < 20
-    from pip._internal.req import parse_requirements
-    from pip._internal.download import PipSession
-except:
-    # pip >= 20
-    from pip._internal.req import parse_requirements
-    from pip._internal.network.session import PipSession
-
-
 # import common_task module
 root_dir = path.abspath(path.join(path.abspath(__file__), "..", "..", ".."))
 common_task_path = path.abspath(path.join(root_dir, "scripts", "devops_tasks"))
@@ -124,36 +114,15 @@ if __name__ == "__main__":
         "--target",
         dest="target_package",
         help="The target package directory on disk.",
-        required=False,
-    )
-
-    parser.add_argument(
-        "-r",
-        "--requirements",
-        dest="requirements_file",
-        help="Use dev builds of all installed azure-* packages",
-        required=False
+        required=True,
     )
 
     args = parser.parse_args()
-
-    if not args.target_package and not args.requirements_file:
-        raise "Must specify -t or -r"
 
     if args.target_package:
         # get target package name from target package path
         pkg_dir = path.abspath(args.target_package)
         pkg_name, _, ver = get_package_details(path.join(pkg_dir, "setup.py"))
         install_dev_build_packages(pkg_name)
-
-    elif args.requirements_file:
-        # Get package names from requirements.txt
-        requirements = parse_requirements(args.requirements_file, session=PipSession())
-        package_names = [item.req.name for item in requirements]
-
-        # Remove existing packages (that came from the public feed) and install
-        # from dev feed
-        uninstall_packages(package_names)
-        install_packages(package_names)
 
 


### PR DESCRIPTION
Problem: https://github.com/azure/azure-sdk-for-python/issues/11436

Fix workflow: 

1) Install smoke test `requirements.txt` packages from the dev feed by install no dependencies (e.g. `--no-deps`) 
1) List dependencies of the installed packages into a `requirements_dependencies.txt` 
1) Install using `requirements_dependencies.txt` 

Successful execution: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=392226&view=results

Couple decisions here: 

* There's no overlap between the code in the new `dependencies.py` and in `install_dev_build_dependnecy.py` and so I think all of the `requirements.txt` work should be removed from `isntall_dev_build_dependency.py` ... This workflow also differs from the tox preparation steps more than the previous implementation. 
*  New logic is instead placed in `dependencies.py` but that is not readily available to other scenarios. Should it be more available? 