### PR TITLE
Update Artifact Name for azure-mgmt-eventhub

### DIFF
--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -51,5 +51,5 @@ stages:
       safeName: azureeventhubcheckpointstoreblobaio
     - name: azure_eventhub_checkpointstoreblob
       safeName: azureeventhubcheckpointstoreblob
-    - name: azure-mgmt-eventhub
+    - name: azure_mgmt_eventhub
       safeName: azuremgmteventhub


### PR DESCRIPTION
We don't pick up the wheel when it's improperly set like the one there.  We miss picking up the `whl` artifact when staging artifacts.

#11397 will ensure that this artifact name is more forgiving.