### PR TITLE
Trim CI Matrix a bit

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -8,18 +8,6 @@ parameters:
   InjectedPackages: ''
   BuildDocs: true
   TestMatrix:
-    Linux_Python27:
-      OSName: 'Linux'
-      OSVmImage: 'ubuntu-18.04'
-      PythonVersion: '2.7'
-      CoverageArg: ''
-      RunForPR: true
-    Linux_Python35:
-      OSName: 'Linux'
-      OSVmImage: 'ubuntu-18.04'
-      PythonVersion: '3.5'
-      CoverageArg: ''
-      RunForPR: false
     Linux_Python36:
       OSName: 'Linux'
       OSVmImage: 'ubuntu-18.04'
@@ -49,7 +37,7 @@ parameters:
       OSVmImage: 'macOS-10.15'
       PythonVersion: '2.7'
       CoverageArg: ''
-      RunForPR: false
+      RunForPR: true
     Linux_pypy3:
       OSName: 'Linux'
       OSVmImage: 'ubuntu-18.04'


### PR DESCRIPTION
Remove duplicate coverage of `py2.7` and `py3.5` that are currently running on linux.

The `internal` build queue is under a LOT of pressure right now, so there is interest in further reducing the agent usage. 

@Azure/azure-sdk-eng 