### PR TITLE
[formrecognizer] rename input parameters

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
@@ -14,6 +14,10 @@
 - `FormField` does not have a page_number.
 - `begin_recognize_receipts` APIs now return `RecognizedReceipt` instead of `USReceipt`
 - `USReceiptType` is renamed to `ReceiptType`
+- `stream` and `url` parameters found on methods for `FormRecognizerClient` have been renamed to `form` and `form_url`, respectively.
+For recognize receipt methods, parameters have been renamed to `receipt` and `receipt_url`.
+
+
 
 **New features**
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/README.md
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/README.md
@@ -172,7 +172,7 @@ model_id = "<your custom model id>"
 with open("<path to your form>", "rb") as fd:
     form = fd.read()
 
-poller = form_recognizer_client.begin_recognize_custom_forms(model_id=model_id, stream=form)
+poller = form_recognizer_client.begin_recognize_custom_forms(model_id=model_id, form=form)
 result = poller.result()
 
 for recognized_form in result:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_form_recognizer_client.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_form_recognizer_client.py
@@ -77,15 +77,15 @@ class FormRecognizerClient(object):
         return prepare_us_receipt(analyze_result)
 
     @distributed_trace
-    def begin_recognize_receipts(self, stream, **kwargs):
+    def begin_recognize_receipts(self, receipt, **kwargs):
         # type: (Union[bytes, IO[bytes]], Any) -> LROPoller
         """Extract field text and semantic values from a given US sales receipt.
         The input document must be of one of the supported content types - 'application/pdf',
         'image/jpeg', 'image/png' or 'image/tiff'.
 
-        :param stream: JPEG, PNG, PDF and TIFF type file stream or bytes.
+        :param receipt: JPEG, PNG, PDF and TIFF type file stream or bytes.
              Currently only supports US sales receipts.
-        :type stream: bytes or IO[bytes]
+        :type receipt: bytes or IO[bytes]
         :keyword bool include_text_content:
             Whether or not to include text elements such as lines and words in addition to form fields.
         :keyword str content_type: Media type of the body sent to the API. Content-type is
@@ -116,10 +116,10 @@ class FormRecognizerClient(object):
         include_text_content = kwargs.pop("include_text_content", False)
 
         if content_type is None:
-            content_type = get_content_type(stream)
+            content_type = get_content_type(receipt)
 
         return self._client.begin_analyze_receipt_async(
-            file_stream=stream,
+            file_stream=receipt,
             content_type=content_type,
             include_text_details=include_text_content,
             cls=kwargs.pop("cls", self._receipt_callback),
@@ -129,12 +129,12 @@ class FormRecognizerClient(object):
         )
 
     @distributed_trace
-    def begin_recognize_receipts_from_url(self, url, **kwargs):
+    def begin_recognize_receipts_from_url(self, receipt_url, **kwargs):
         # type: (str, Any) -> LROPoller
         """Extract field text and semantic values from a given US sales receipt.
         The input document must be the location (Url) of the receipt to be analyzed.
 
-        :param str url: The url of the receipt to analyze. The input must be a valid, encoded url
+        :param str receipt_url: The url of the receipt to analyze. The input must be a valid, encoded url
             of one of the supported formats: JPEG, PNG, PDF and TIFF. Currently only supports
             US sales receipts.
         :keyword bool include_text_content:
@@ -160,7 +160,7 @@ class FormRecognizerClient(object):
         include_text_content = kwargs.pop("include_text_content", False)
 
         return self._client.begin_analyze_receipt_async(
-            file_stream={"source": url},
+            file_stream={"source": receipt_url},
             include_text_details=include_text_content,
             cls=kwargs.pop("cls", self._receipt_callback),
             polling=LROBasePolling(timeout=polling_interval, **kwargs),
@@ -173,14 +173,14 @@ class FormRecognizerClient(object):
         return prepare_content_result(analyze_result)
 
     @distributed_trace
-    def begin_recognize_content(self, stream, **kwargs):
+    def begin_recognize_content(self, form, **kwargs):
         # type: (Union[bytes, IO[bytes]], Any) -> LROPoller
         """Extract text and content/layout information from a given document.
         The input document must be of one of the supported content types - 'application/pdf',
         'image/jpeg', 'image/png' or 'image/tiff'.
 
-        :param stream: JPEG, PNG, PDF and TIFF type file stream or bytes.
-        :type stream: bytes or IO[bytes]
+        :param form: JPEG, PNG, PDF and TIFF type file stream or bytes.
+        :type form: bytes or IO[bytes]
         :keyword str content_type: Media type of the body sent to the API. Content-type is
             auto-detected, but can be overridden by passing this keyword argument. For options,
             see :class:`~azure.ai.formrecognizer.FormContentType`.
@@ -207,10 +207,10 @@ class FormRecognizerClient(object):
             raise TypeError("Call begin_recognize_content_from_url() to analyze a document from a url.")
 
         if content_type is None:
-            content_type = get_content_type(stream)
+            content_type = get_content_type(form)
 
         return self._client.begin_analyze_layout_async(
-            file_stream=stream,
+            file_stream=form,
             content_type=content_type,
             cls=kwargs.pop("cls", self._content_callback),
             polling=LROBasePolling(timeout=polling_interval, **kwargs),
@@ -219,12 +219,12 @@ class FormRecognizerClient(object):
         )
 
     @distributed_trace
-    def begin_recognize_content_from_url(self, url, **kwargs):
+    def begin_recognize_content_from_url(self, form_url, **kwargs):
         # type: (str, Any) -> LROPoller
         """Extract text and layout information from a given document.
         The input document must be the location (Url) of the document to be analyzed.
 
-        :param str url: The url of the form to analyze. The input must be a valid, encoded url
+        :param str form_url: The url of the form to analyze. The input must be a valid, encoded url
             of one of the supported formats: JPEG, PNG, PDF and TIFF.
         :keyword int polling_interval: Waiting time between two polls for LRO operations
             if no Retry-After header is present. Defaults to 5 seconds.
@@ -237,7 +237,7 @@ class FormRecognizerClient(object):
         polling_interval = kwargs.pop("polling_interval", POLLING_INTERVAL)
 
         return self._client.begin_analyze_layout_async(
-            file_stream={"source": url},
+            file_stream={"source": form_url},
             cls=kwargs.pop("cls", self._content_callback),
             polling=LROBasePolling(timeout=polling_interval, **kwargs),
             error_map=error_map,
@@ -245,7 +245,7 @@ class FormRecognizerClient(object):
         )
 
     @distributed_trace
-    def begin_recognize_custom_forms(self, model_id, stream, **kwargs):
+    def begin_recognize_custom_forms(self, model_id, form, **kwargs):
         # type: (str, Union[bytes, IO[bytes]], Any) -> LROPoller
         """Analyze a custom form with a model trained with or without labels. The form
         to analyze should be of the same type as the forms that were used to train the model.
@@ -253,8 +253,8 @@ class FormRecognizerClient(object):
         'image/jpeg', 'image/png' or 'image/tiff'.
 
         :param str model_id: Custom model identifier.
-        :param stream: JPEG, PNG, PDF and TIFF type file stream or bytes.
-        :type stream: bytes or IO[bytes]
+        :param form: JPEG, PNG, PDF and TIFF type file stream or bytes.
+        :type form: bytes or IO[bytes]
         :keyword bool include_text_content:
             Whether or not to include text elements such as lines and words in addition to form fields.
         :keyword str content_type: Media type of the body sent to the API. Content-type is
@@ -285,7 +285,7 @@ class FormRecognizerClient(object):
 
         include_text_content = kwargs.pop("include_text_content", False)
         if content_type is None:
-            content_type = get_content_type(stream)
+            content_type = get_content_type(form)
 
         def analyze_callback(raw_response, _, headers):  # pylint: disable=unused-argument
             analyze_result = self._client._deserialize(AnalyzeOperationResult, raw_response)
@@ -293,7 +293,7 @@ class FormRecognizerClient(object):
 
         deserialization_callback = cls if cls else analyze_callback
         return self._client.begin_analyze_with_custom_model(
-            file_stream=stream,
+            file_stream=form,
             model_id=model_id,
             include_text_details=include_text_content,
             content_type=content_type,
@@ -304,14 +304,14 @@ class FormRecognizerClient(object):
         )
 
     @distributed_trace
-    def begin_recognize_custom_forms_from_url(self, model_id, url, **kwargs):
+    def begin_recognize_custom_forms_from_url(self, model_id, form_url, **kwargs):
         # type: (str, str, Any) -> LROPoller
         """Analyze a custom form with a model trained with or without labels. The form
         to analyze should be of the same type as the forms that were used to train the model.
         The input document must be the location (Url) of the document to be analyzed.
 
         :param str model_id: Custom model identifier.
-        :param str url: The url of the form to analyze. The input must be a valid, encoded url
+        :param str form_url: The url of the form to analyze. The input must be a valid, encoded url
             of one of the supported formats: JPEG, PNG, PDF and TIFF.
         :keyword bool include_text_content:
             Whether or not to include text elements such as lines and words in addition to form fields.
@@ -333,7 +333,7 @@ class FormRecognizerClient(object):
 
         deserialization_callback = cls if cls else analyze_callback
         return self._client.begin_analyze_with_custom_model(
-            file_stream={"source": url},
+            file_stream={"source": form_url},
             model_id=model_id,
             include_text_details=include_text_content,
             cls=deserialization_callback,

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/aio/_form_recognizer_client_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/aio/_form_recognizer_client_async.py
@@ -89,16 +89,16 @@ class FormRecognizerClient(object):
     @distributed_trace_async
     async def recognize_receipts(
             self,
-            stream: Union[bytes, IO[bytes]],
+            receipt: Union[bytes, IO[bytes]],
             **kwargs: Any
     ) -> List["RecognizedReceipt"]:
         """Extract field text and semantic values from a given US sales receipt.
         The input document must be of one of the supported content types - 'application/pdf',
         'image/jpeg', 'image/png' or 'image/tiff'.
 
-        :param stream: JPEG, PNG, PDF and TIFF type file stream or bytes.
+        :param receipt: JPEG, PNG, PDF and TIFF type file stream or bytes.
             Currently only supports US sales receipts.
-        :type stream: bytes or IO[bytes]
+        :type receipt: bytes or IO[bytes]
         :keyword bool include_text_content:
             Whether or not to include text elements such as lines and words in addition to form fields.
         :keyword str content_type: Media type of the body sent to the API. Content-type is
@@ -128,10 +128,10 @@ class FormRecognizerClient(object):
         include_text_content = kwargs.pop("include_text_content", False)
 
         if content_type is None:
-            content_type = get_content_type(stream)
+            content_type = get_content_type(receipt)
 
         return await self._client.analyze_receipt_async(  # type: ignore
-            file_stream=stream,
+            file_stream=receipt,
             content_type=content_type,
             include_text_details=include_text_content,
             cls=kwargs.pop("cls", self._receipt_callback),
@@ -143,13 +143,13 @@ class FormRecognizerClient(object):
     @distributed_trace_async
     async def recognize_receipts_from_url(
             self,
-            url: str,
+            receipt_url: str,
             **kwargs: Any
     ) -> List["RecognizedReceipt"]:
         """Extract field text and semantic values from a given US sales receipt.
         The input document must be the location (Url) of the receipt to be analyzed.
 
-        :param str url: The url of the receipt to analyze. The input must be a valid, encoded url
+        :param str receipt_url: The url of the receipt to analyze. The input must be a valid, encoded url
             of one of the supported formats: JPEG, PNG, PDF and TIFF. Currently only supports
             US sales receipts.
         :keyword bool include_text_content:
@@ -174,7 +174,7 @@ class FormRecognizerClient(object):
         include_text_content = kwargs.pop("include_text_content", False)
 
         return await self._client.analyze_receipt_async(  # type: ignore
-            file_stream={"source": url},
+            file_stream={"source": receipt_url},
             include_text_details=include_text_content,
             cls=kwargs.pop("cls", self._receipt_callback),
             polling=AsyncLROBasePolling(timeout=polling_interval, **kwargs),
@@ -187,13 +187,13 @@ class FormRecognizerClient(object):
         return prepare_content_result(analyze_result)
 
     @distributed_trace_async
-    async def recognize_content(self, stream: Union[bytes, IO[bytes]], **kwargs: Any) -> List["FormPage"]:
+    async def recognize_content(self, form: Union[bytes, IO[bytes]], **kwargs: Any) -> List["FormPage"]:
         """Extract text and content/layout information from a given document.
         The input document must be of one of the supported content types - 'application/pdf',
         'image/jpeg', 'image/png' or 'image/tiff'.
 
-        :param stream: JPEG, PNG, PDF and TIFF type file stream or bytes.
-        :type stream: bytes or IO[bytes]
+        :param form: JPEG, PNG, PDF and TIFF type file stream or bytes.
+        :type form: bytes or IO[bytes]
         :keyword str content_type: Media type of the body sent to the API. Content-type is
             auto-detected, but can be overridden by passing this keyword argument. For options,
             see :class:`~azure.ai.formrecognizer.FormContentType`.
@@ -219,10 +219,10 @@ class FormRecognizerClient(object):
             raise TypeError("Call begin_recognize_content_from_url() to analyze a document from a url.")
 
         if content_type is None:
-            content_type = get_content_type(stream)
+            content_type = get_content_type(form)
 
         return await self._client.analyze_layout_async(  # type: ignore
-            file_stream=stream,
+            file_stream=form,
             content_type=content_type,
             cls=kwargs.pop("cls", self._content_callback),
             polling=AsyncLROBasePolling(timeout=polling_interval, **kwargs),
@@ -231,11 +231,11 @@ class FormRecognizerClient(object):
         )
 
     @distributed_trace_async
-    async def recognize_content_from_url(self, url: str, **kwargs: Any) -> List["FormPage"]:
+    async def recognize_content_from_url(self, form_url: str, **kwargs: Any) -> List["FormPage"]:
         """Extract text and layout information from a given document.
         The input document must be the location (Url) of the document to be analyzed.
 
-        :param str url: The url of the form to analyze. The input must be a valid, encoded url
+        :param str form_url: The url of the form to analyze. The input must be a valid, encoded url
             of one of the supported formats: JPEG, PNG, PDF and TIFF.
         :keyword int polling_interval: Waiting time between two polls for LRO operations
             if no Retry-After header is present. Defaults to 5 seconds.
@@ -246,7 +246,7 @@ class FormRecognizerClient(object):
 
         polling_interval = kwargs.pop("polling_interval", POLLING_INTERVAL)
         return await self._client.analyze_layout_async(  # type: ignore
-            file_stream={"source": url},
+            file_stream={"source": form_url},
             cls=kwargs.pop("cls", self._content_callback),
             polling=AsyncLROBasePolling(timeout=polling_interval, **kwargs),
             error_map=error_map,
@@ -257,7 +257,7 @@ class FormRecognizerClient(object):
     async def recognize_custom_forms(
             self,
             model_id: str,
-            stream: Union[bytes, IO[bytes]],
+            form: Union[bytes, IO[bytes]],
             **kwargs: Any
     ) -> List["RecognizedForm"]:
         """Analyze a custom form with a model trained with or without labels. The form
@@ -266,8 +266,8 @@ class FormRecognizerClient(object):
         'image/jpeg', 'image/png' or 'image/tiff'.
 
         :param str model_id: Custom model identifier.
-        :param stream: JPEG, PNG, PDF and TIFF type file stream or bytes.
-        :type stream: bytes or IO[bytes]
+        :param form: JPEG, PNG, PDF and TIFF type file stream or bytes.
+        :type form: bytes or IO[bytes]
         :keyword bool include_text_content:
             Whether or not to include text elements such as lines and words in addition to form fields.
         :keyword str content_type: Media type of the body sent to the API. Content-type is
@@ -298,7 +298,7 @@ class FormRecognizerClient(object):
         include_text_content = kwargs.pop("include_text_content", False)
 
         if content_type is None:
-            content_type = get_content_type(stream)
+            content_type = get_content_type(form)
 
         def analyze_callback(raw_response, _, headers):  # pylint: disable=unused-argument
             analyze_result = self._client._deserialize(AnalyzeOperationResult, raw_response)
@@ -306,7 +306,7 @@ class FormRecognizerClient(object):
 
         deserialization_callback = cls if cls else analyze_callback
         return await self._client.analyze_with_custom_model(  # type: ignore
-            file_stream=stream,
+            file_stream=form,
             model_id=model_id,
             include_text_details=include_text_content,
             content_type=content_type,
@@ -320,7 +320,7 @@ class FormRecognizerClient(object):
     async def recognize_custom_forms_from_url(
             self,
             model_id: str,
-            url: str,
+            form_url: str,
             **kwargs: Any
     ) -> List["RecognizedForm"]:
         """Analyze a custom form with a model trained with or without labels. The form
@@ -328,7 +328,7 @@ class FormRecognizerClient(object):
         The input document must be the location (Url) of the document to be analyzed.
 
         :param str model_id: Custom model identifier.
-        :param str url: The url of the form to analyze. The input must be a valid, encoded url
+        :param str form_url: The url of the form to analyze. The input must be a valid, encoded url
             of one of the supported formats: JPEG, PNG, PDF and TIFF.
         :keyword bool include_text_content:
             Whether or not to include text elements such as lines and words in addition to form fields.
@@ -349,7 +349,7 @@ class FormRecognizerClient(object):
 
         deserialization_callback = cls if cls else analyze_callback
         return await self._client.analyze_with_custom_model(  # type: ignore
-            file_stream={"source": url},
+            file_stream={"source": form_url},
             model_id=model_id,
             include_text_details=include_text_content,
             cls=deserialization_callback,

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_models_trained_with_and_without_labels_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_models_trained_with_and_without_labels_async.py
@@ -41,18 +41,20 @@ class DifferentiateOutputModelsTrainedWithAndWithoutLabelsSampleAsync(object):
     async def recognize_custom_forms(self):
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.formrecognizer.aio import FormRecognizerClient
+
+        path_to_sample_forms = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", "./sample_forms/forms/Form_1.jpg"))
         async with FormRecognizerClient(
             endpoint=self.endpoint, credential=AzureKeyCredential(self.key)
         ) as form_recognizer_client:
 
             # Make sure your form's type is included in the list of form types the custom model can recognize
-            with open("sample_forms/forms/Form_1.jpg", "rb") as f:
+            with open(path_to_sample_forms, "rb") as f:
                 stream = f.read()
             forms_with_labeled_model = await form_recognizer_client.recognize_custom_forms(
-                model_id=self.model_trained_with_labels_id, stream=stream
+                model_id=self.model_trained_with_labels_id, form=stream
             )
             forms_with_unlabeled_model = await form_recognizer_client.recognize_custom_forms(
-                model_id=self.model_trained_without_labels_id, stream=stream
+                model_id=self.model_trained_without_labels_id, form=stream
             )
 
             # With a form recognized by a model trained with labels, this 'name' key will be its

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_get_bounding_boxes_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_get_bounding_boxes_async.py
@@ -23,7 +23,6 @@ USAGE:
 
 import os
 import asyncio
-from pathlib import Path
 
 
 def format_bounding_box(bounding_box):
@@ -38,8 +37,7 @@ class GetBoundingBoxesSampleAsync(object):
     model_id = os.environ["CUSTOM_TRAINED_MODEL_ID"]
 
     async def get_bounding_boxes(self):
-        # the sample forms are located in this file's parent's parent's files.
-        path_to_sample_forms = Path(__file__).parent.parent.absolute() / Path("sample_forms/forms/Form_1.jpg")
+        path_to_sample_forms = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", "./sample_forms/forms/Form_1.jpg"))
         from azure.ai.formrecognizer import FormWord, FormLine
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.formrecognizer.aio import FormRecognizerClient
@@ -52,7 +50,7 @@ class GetBoundingBoxesSampleAsync(object):
             # Make sure your form's type is included in the list of form types the custom model can recognize
             with open(path_to_sample_forms, "rb") as f:
                 forms = await form_recognizer_client.recognize_custom_forms(
-                    model_id=self.model_id, stream=f.read(), include_text_content=True
+                    model_id=self.model_id, form=f.read(), include_text_content=True
                 )
 
             for idx, form in enumerate(forms):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_content_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_content_async.py
@@ -23,7 +23,6 @@ USAGE:
 
 import os
 import asyncio
-from pathlib import Path
 
 
 def format_bounding_box(bounding_box):
@@ -37,8 +36,7 @@ class RecognizeContentSampleAsync(object):
     key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
 
     async def recognize_content(self):
-        # the sample forms are located in this file's parent's parent's files.
-        path_to_sample_forms = Path(__file__).parent.parent.absolute() / Path("sample_forms/forms/Invoice_1.pdf")
+        path_to_sample_forms = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", "./sample_forms/forms/Invoice_1.pdf"))
         # [START recognize_content_async]
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.formrecognizer.aio import FormRecognizerClient
@@ -47,7 +45,7 @@ class RecognizeContentSampleAsync(object):
         ) as form_recognizer_client:
 
             with open(path_to_sample_forms, "rb") as f:
-                contents = await form_recognizer_client.recognize_content(stream=f.read())
+                contents = await form_recognizer_client.recognize_content(form=f.read())
 
             for idx, content in enumerate(contents):
                 print("----Recognizing content from page #{}----".format(idx))

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_custom_forms_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_custom_forms_async.py
@@ -35,8 +35,7 @@ class RecognizeCustomFormsSampleAsync(object):
     model_id = os.environ["CUSTOM_TRAINED_MODEL_ID"]
 
     async def recognize_custom_forms(self):
-        # the sample forms are located in this file's parent's parent's files.
-        path_to_sample_forms = Path(__file__).parent.parent.absolute() / Path("sample_forms/forms/Form_1.jpg")
+        path_to_sample_forms = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", "./sample_forms/forms/Form_1.jpg"))
         # [START recognize_custom_forms_async]
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.formrecognizer.aio import FormRecognizerClient
@@ -47,7 +46,7 @@ class RecognizeCustomFormsSampleAsync(object):
             # Make sure your form's type is included in the list of form types the custom model can recognize
             with open(path_to_sample_forms, "rb") as f:
                 forms = await form_recognizer_client.recognize_custom_forms(
-                    model_id=self.model_id, stream=f.read()
+                    model_id=self.model_id, form=f.read()
                 )
 
             for idx, form in enumerate(forms):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_receipts_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_receipts_async.py
@@ -31,8 +31,7 @@ class RecognizeReceiptsSampleAsync(object):
     key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
 
     async def recognize_receipts(self):
-        # the sample forms are located in this file's parent's parent's files.
-        path_to_sample_forms = Path(__file__).parent.parent.absolute() / Path("sample_forms/receipt/contoso-allinone.jpg")
+        path_to_sample_forms = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", "./sample_forms/receipt/contoso-allinone.jpg"))
         # [START recognize_receipts_async]
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.formrecognizer.aio import FormRecognizerClient
@@ -41,7 +40,7 @@ class RecognizeReceiptsSampleAsync(object):
         ) as form_recognizer_client:
 
             with open(path_to_sample_forms, "rb") as f:
-                receipts = await form_recognizer_client.recognize_receipts(stream=f.read())
+                receipts = await form_recognizer_client.recognize_receipts(receipt=f.read())
 
             for idx, receipt in enumerate(receipts):
                 print("--------Recognizing receipt #{}--------".format(idx))

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_receipts_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_receipts_from_url_async.py
@@ -37,7 +37,7 @@ class RecognizeReceiptsFromURLSampleAsync(object):
             endpoint=self.endpoint, credential=AzureKeyCredential(self.key)
         ) as form_recognizer_client:
             url = "https://raw.githubusercontent.com/Azure/azure-sdk-for-python/master/sdk/formrecognizer/azure-ai-formrecognizer/tests/sample_forms/receipt/contoso-receipt.png"
-            receipts = await form_recognizer_client.recognize_receipts_from_url(url=url)
+            receipts = await form_recognizer_client.recognize_receipts_from_url(receipt_url=url)
 
             for idx, receipt in enumerate(receipts):
                 print("--------Recognizing receipt #{}--------".format(idx))

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_models_trained_with_and_without_labels.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_models_trained_with_and_without_labels.py
@@ -49,10 +49,10 @@ class DifferentiateOutputModelsTrainedWithAndWithoutLabels(object):
         with open("sample_forms/forms/Form_1.jpg", "rb") as f:
             stream = f.read()
         forms_with_labeled_model_poller = form_recognizer_client.begin_recognize_custom_forms(
-            model_id=self.model_trained_with_labels_id, stream=stream
+            model_id=self.model_trained_with_labels_id, form=stream
         )
         forms_with_unlabeled_model_poller = form_recognizer_client.begin_recognize_custom_forms(
-            model_id=self.model_trained_without_labels_id, stream=stream
+            model_id=self.model_trained_without_labels_id, form=stream
         )
 
         # Calling result after kicking off each call allows for server-side paralellization

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_get_bounding_boxes.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_get_bounding_boxes.py
@@ -46,7 +46,7 @@ class GetBoundingBoxesSample(object):
         # Make sure your form's type is included in the list of form types the custom model can recognize
         with open("sample_forms/forms/Form_1.jpg", "rb") as f:
             poller = form_recognizer_client.begin_recognize_custom_forms(
-                model_id=self.model_id, stream=f, include_text_content=True
+                model_id=self.model_id, form=f, include_text_content=True
             )
         forms = poller.result()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_content.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_content.py
@@ -38,7 +38,7 @@ class RecognizeContentSample(object):
         from azure.ai.formrecognizer import FormRecognizerClient
         form_recognizer_client = FormRecognizerClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.key))
         with open("sample_forms/forms/Invoice_1.pdf", "rb") as f:
-            poller = form_recognizer_client.begin_recognize_content(stream=f)
+            poller = form_recognizer_client.begin_recognize_content(form=f)
         contents = poller.result()
 
         for idx, content in enumerate(contents):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_custom_forms.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_custom_forms.py
@@ -43,7 +43,7 @@ class RecognizeCustomForms(object):
         # Make sure your form's type is included in the list of form types the custom model can recognize
         with open("sample_forms/forms/Form_1.jpg", "rb") as f:
             poller = form_recognizer_client.begin_recognize_custom_forms(
-                model_id=self.model_id, stream=f
+                model_id=self.model_id, form=f
             )
         forms = poller.result()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_receipts.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_receipts.py
@@ -36,7 +36,7 @@ class RecognizeReceiptsSample(object):
             endpoint=self.endpoint, credential=AzureKeyCredential(self.key)
         )
         with open("sample_forms/receipt/contoso-allinone.jpg", "rb") as f:
-            poller = form_recognizer_client.begin_recognize_receipts(stream=f)
+            poller = form_recognizer_client.begin_recognize_receipts(receipt=f)
         receipts = poller.result()
 
         for idx, receipt in enumerate(receipts):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_receipts_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_receipts_from_url.py
@@ -36,7 +36,7 @@ class RecognizeReceiptsFromURLSample(object):
             endpoint=self.endpoint, credential=AzureKeyCredential(self.key)
         )
         url = "https://raw.githubusercontent.com/Azure/azure-sdk-for-python/master/sdk/formrecognizer/azure-ai-formrecognizer/tests/sample_forms/receipt/contoso-receipt.png"
-        poller = form_recognizer_client.begin_recognize_receipts_from_url(url=url)
+        poller = form_recognizer_client.begin_recognize_receipts_from_url(receipt_url=url)
         receipts = poller.result()
 
         for idx, receipt in enumerate(receipts):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms.py
@@ -25,20 +25,20 @@ class TestCustomForms(FormRecognizerTest):
             myfile = fd.read()
         with self.assertRaises(ServiceRequestError):
             client = FormRecognizerClient("http://notreal.azure.com", AzureKeyCredential(form_recognizer_account_key))
-            poller = client.begin_recognize_custom_forms(model_id="xx", stream=myfile)
+            poller = client.begin_recognize_custom_forms(model_id="xx", form=myfile)
 
     @GlobalFormRecognizerAccountPreparer()
     def test_authentication_bad_key(self, resource_group, location, form_recognizer_account, form_recognizer_account_key):
         client = FormRecognizerClient(form_recognizer_account, AzureKeyCredential("xxxx"))
         with self.assertRaises(ClientAuthenticationError):
-            poller = client.begin_recognize_custom_forms(model_id="xx", stream=b"xx", content_type="image/jpeg")
+            poller = client.begin_recognize_custom_forms(model_id="xx", form=b"xx", content_type="image/jpeg")
 
     @GlobalFormRecognizerAccountPreparer()
     def test_passing_unsupported_url_content_type(self, resource_group, location, form_recognizer_account, form_recognizer_account_key):
         client = FormRecognizerClient(form_recognizer_account, AzureKeyCredential(form_recognizer_account_key))
 
         with self.assertRaises(TypeError):
-            poller = client.begin_recognize_custom_forms(model_id="xx", stream="https://badurl.jpg", content_type="application/json")
+            poller = client.begin_recognize_custom_forms(model_id="xx", form="https://badurl.jpg", content_type="application/json")
 
     @GlobalFormRecognizerAccountPreparer()
     def test_auto_detect_unsupported_stream_content(self, resource_group, location, form_recognizer_account, form_recognizer_account_key):
@@ -50,7 +50,7 @@ class TestCustomForms(FormRecognizerTest):
         with self.assertRaises(ValueError):
             poller = client.begin_recognize_custom_forms(
                 model_id="xxx",
-                stream=myfile,
+                form=myfile,
             )
 
     @GlobalFormRecognizerAccountPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_async.py
@@ -27,20 +27,20 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
             myfile = fd.read()
         with self.assertRaises(ServiceRequestError):
             client = FormRecognizerClient("http://notreal.azure.com", AzureKeyCredential(form_recognizer_account_key))
-            result = await client.recognize_custom_forms(model_id="xx", stream=myfile)
+            result = await client.recognize_custom_forms(model_id="xx", form=myfile)
 
     @GlobalFormRecognizerAccountPreparer()
     async def test_authentication_bad_key(self, resource_group, location, form_recognizer_account, form_recognizer_account_key):
         client = FormRecognizerClient(form_recognizer_account, AzureKeyCredential("xxxx"))
         with self.assertRaises(ClientAuthenticationError):
-            result = await client.recognize_custom_forms(model_id="xx", stream=b"xx", content_type="image/jpeg")
+            result = await client.recognize_custom_forms(model_id="xx", form=b"xx", content_type="image/jpeg")
 
     @GlobalFormRecognizerAccountPreparer()
     async def test_passing_unsupported_url_content_type(self, resource_group, location, form_recognizer_account, form_recognizer_account_key):
         client = FormRecognizerClient(form_recognizer_account, AzureKeyCredential(form_recognizer_account_key))
 
         with self.assertRaises(TypeError):
-            result = await client.recognize_custom_forms(model_id="xx", stream="https://badurl.jpg", content_type="application/json")
+            result = await client.recognize_custom_forms(model_id="xx", form="https://badurl.jpg", content_type="application/json")
 
     @GlobalFormRecognizerAccountPreparer()
     async def test_auto_detect_unsupported_stream_content(self, resource_group, location, form_recognizer_account, form_recognizer_account_key):
@@ -52,7 +52,7 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
         with self.assertRaises(ValueError):
             poller = await client.recognize_custom_forms(
                 model_id="xxx",
-                stream=myfile,
+                form=myfile,
             )
 
     @GlobalFormRecognizerAccountPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_from_url.py
@@ -23,20 +23,20 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
     def test_custom_form_url_bad_endpoint(self, resource_group, location, form_recognizer_account, form_recognizer_account_key):
         with self.assertRaises(ServiceRequestError):
             client = FormRecognizerClient("http://notreal.azure.com", AzureKeyCredential(form_recognizer_account_key))
-            result = client.begin_recognize_custom_forms_from_url(model_id="xx", url=self.form_url_jpg)
+            result = client.begin_recognize_custom_forms_from_url(model_id="xx", form_url=self.form_url_jpg)
 
     @GlobalFormRecognizerAccountPreparer()
     def test_url_authentication_bad_key(self, resource_group, location, form_recognizer_account, form_recognizer_account_key):
         client = FormRecognizerClient(form_recognizer_account, AzureKeyCredential("xxxx"))
         with self.assertRaises(ClientAuthenticationError):
-            result = client.begin_recognize_custom_forms_from_url(model_id="xx", url=self.form_url_jpg)
+            result = client.begin_recognize_custom_forms_from_url(model_id="xx", form_url=self.form_url_jpg)
 
     @GlobalFormRecognizerAccountPreparer()
     def test_passing_bad_url(self, resource_group, location, form_recognizer_account, form_recognizer_account_key):
         client = FormRecognizerClient(form_recognizer_account, AzureKeyCredential(form_recognizer_account_key))
 
         with self.assertRaises(HttpResponseError):
-            poller = client.begin_recognize_custom_forms_from_url(model_id="xx", url="https://badurl.jpg")
+            poller = client.begin_recognize_custom_forms_from_url(model_id="xx", form_url="https://badurl.jpg")
 
     @GlobalFormRecognizerAccountPreparer()
     def test_pass_stream_into_url(self, resource_group, location, form_recognizer_account, form_recognizer_account_key):
@@ -46,7 +46,7 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
             with self.assertRaises(HttpResponseError):
                 poller = client.begin_recognize_custom_forms_from_url(
                     model_id="xxx",
-                    url=fd,
+                    form_url=fd,
                 )
 
     @GlobalFormRecognizerAccountPreparer()
@@ -60,7 +60,7 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
         with self.assertRaises(HttpResponseError):
             poller = fr_client.begin_recognize_custom_forms_from_url(
                 model.model_id,
-                url="https://badurl.jpg"
+                form_url="https://badurl.jpg"
             )
             form = poller.result()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_from_url_async.py
@@ -23,20 +23,20 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
     async def test_custom_form_url_bad_endpoint(self, resource_group, location, form_recognizer_account, form_recognizer_account_key):
         with self.assertRaises(ServiceRequestError):
             client = FormRecognizerClient("http://notreal.azure.com", AzureKeyCredential(form_recognizer_account_key))
-            result = await client.recognize_custom_forms_from_url(model_id="xx", url=self.form_url_jpg)
+            result = await client.recognize_custom_forms_from_url(model_id="xx", form_url=self.form_url_jpg)
 
     @GlobalFormRecognizerAccountPreparer()
     async def test_url_authentication_bad_key(self, resource_group, location, form_recognizer_account, form_recognizer_account_key):
         client = FormRecognizerClient(form_recognizer_account, AzureKeyCredential("xxxx"))
         with self.assertRaises(ClientAuthenticationError):
-            result = await client.recognize_custom_forms_from_url(model_id="xx", url=self.form_url_jpg)
+            result = await client.recognize_custom_forms_from_url(model_id="xx", form_url=self.form_url_jpg)
 
     @GlobalFormRecognizerAccountPreparer()
     async def test_passing_bad_url(self, resource_group, location, form_recognizer_account, form_recognizer_account_key):
         client = FormRecognizerClient(form_recognizer_account, AzureKeyCredential(form_recognizer_account_key))
 
         with self.assertRaises(HttpResponseError):
-            result = await client.recognize_custom_forms_from_url(model_id="xx", url="https://badurl.jpg")
+            result = await client.recognize_custom_forms_from_url(model_id="xx", form_url="https://badurl.jpg")
 
     @GlobalFormRecognizerAccountPreparer()
     async def test_pass_stream_into_url(self, resource_group, location, form_recognizer_account, form_recognizer_account_key):
@@ -46,7 +46,7 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
             with self.assertRaises(HttpResponseError):
                 result = await client.recognize_custom_forms_from_url(
                     model_id="xxx",
-                    url=fd,
+                    form_url=fd,
                 )
 
     @GlobalFormRecognizerAccountPreparer()
@@ -59,7 +59,7 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
         with self.assertRaises(HttpResponseError):
             form = await fr_client.recognize_custom_forms_from_url(
                 model.model_id,
-                url="https://badurl.jpg"
+                form_url="https://badurl.jpg"
             )
 
     @GlobalFormRecognizerAccountPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt.py
@@ -144,7 +144,7 @@ class TestReceiptFromStream(FormRecognizerTest):
             myfile = fd.read()
 
         poller = client.begin_recognize_receipts(
-            stream=myfile,
+            receipt=myfile,
             include_text_content=True,
             cls=callback
         )
@@ -209,7 +209,7 @@ class TestReceiptFromStream(FormRecognizerTest):
             myfile = fd.read()
 
         poller = client.begin_recognize_receipts(
-            stream=myfile,
+            receipt=myfile,
             include_text_content=True,
             cls=callback
         )
@@ -379,7 +379,7 @@ class TestReceiptFromStream(FormRecognizerTest):
             myfile = fd.read()
 
         poller = client.begin_recognize_receipts(
-            stream=myfile,
+            receipt=myfile,
             include_text_content=True,
             cls=callback
         )

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_async.py
@@ -143,7 +143,7 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
             myfile = fd.read()
 
         result = await client.recognize_receipts(
-            stream=myfile,
+            receipt=myfile,
             include_text_content=True,
             cls=callback
         )
@@ -207,7 +207,7 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
             myfile = fd.read()
 
         result = await client.recognize_receipts(
-            stream=myfile,
+            receipt=myfile,
             include_text_content=True,
             cls=callback
         )
@@ -373,7 +373,7 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
             myfile = fd.read()
 
         result = await client.recognize_receipts(
-            stream=myfile,
+            receipt=myfile,
             include_text_content=True,
             cls=callback
         )

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url.py
@@ -70,7 +70,7 @@ class TestReceiptFromUrl(FormRecognizerTest):
             responses.append(extracted_receipt)
 
         poller = client.begin_recognize_receipts_from_url(
-            url=self.receipt_url_jpg,
+            receipt_url=self.receipt_url_jpg,
             include_text_content=True,
             cls=callback
         )
@@ -132,7 +132,7 @@ class TestReceiptFromUrl(FormRecognizerTest):
             responses.append(extracted_receipt)
 
         poller = client.begin_recognize_receipts_from_url(
-            url=self.receipt_url_png,
+            receipt_url=self.receipt_url_png,
             include_text_content=True,
             cls=callback
         )


### PR DESCRIPTION
Issue is item on #11283 

During arch board, we got feedback that the naming of our input parameters was too specific since the input need not be a file stream (params presented at arch board were `form_file_stream` and `form_file_url`). This PR does the following renames:

* `url` -> `form_url` or `receipt_url`
* `stream` -> `form` or `receipt`

Also fixes some paths in the async samples.