### PR TITLE
[formrecognizer] update receipt tests

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt.py
@@ -344,8 +344,7 @@ class TestReceiptFromStream(FormRecognizerTest):
         self.assertEqual(receipt.merchant_name.value, 'Bilbo Baggins')
         self.assertEqual(receipt.merchant_phone_number.value, '+15555555555')
         self.assertEqual(receipt.subtotal.value, 300.0)
-        # TODO: revert after service side fix
-        self.assertIsNotNone(receipt.total.value)
+        self.assertEqual(receipt.total.value, 100.0)
         self.assertEqual(receipt.page_range.first_page, 1)
         self.assertEqual(receipt.page_range.last_page, 1)
         self.assertFormPagesHasValues(receipt.pages)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_async.py
@@ -338,8 +338,7 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
         self.assertEqual(receipt.merchant_name.value, 'Bilbo Baggins')
         self.assertEqual(receipt.merchant_phone_number.value, '+15555555555')
         self.assertEqual(receipt.subtotal.value, 300.0)
-        # TODO: revert after service side fix
-        self.assertIsNotNone(receipt.total.value)
+        self.assertEqual(receipt.total.value, 100.0)
         self.assertEqual(receipt.page_range.first_page, 1)
         self.assertEqual(receipt.page_range.last_page, 1)
         self.assertFormPagesHasValues(receipt.pages)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url.py
@@ -263,8 +263,7 @@ class TestReceiptFromUrl(FormRecognizerTest):
         self.assertEqual(receipt.merchant_name.value, 'Bilbo Baggins')
         self.assertEqual(receipt.merchant_phone_number.value, '+15555555555')
         self.assertEqual(receipt.subtotal.value, 300.0)
-        # TODO: revert after service side fix
-        self.assertIsNotNone(receipt.total.value)
+        self.assertEqual(receipt.total.value, 100.0)
         self.assertEqual(receipt.page_range.first_page, 1)
         self.assertEqual(receipt.page_range.last_page, 1)
         self.assertFormPagesHasValues(receipt.pages)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url_async.py
@@ -269,8 +269,7 @@ class TestReceiptFromUrlAsync(AsyncFormRecognizerTest):
         self.assertEqual(receipt.merchant_name.value, 'Bilbo Baggins')
         self.assertEqual(receipt.merchant_phone_number.value, '+15555555555')
         self.assertEqual(receipt.subtotal.value, 300.0)
-        # TODO: revert after service side fix
-        self.assertIsNotNone(receipt.total.value)
+        self.assertEqual(receipt.total.value, 100.0)
         self.assertEqual(receipt.page_range.first_page, 1)
         self.assertEqual(receipt.page_range.last_page, 1)
         self.assertFormPagesHasValues(receipt.pages)


### PR DESCRIPTION
Resolves #11241 

The service has been consistently returning `100` for the Total value on the multipage receipt tests and I think we can assume this is the "new normal". I'd rather test for the value here to flag us in case we see the service change again.