### PR TITLE
Prevent test failure due to operation timing

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
@@ -208,13 +208,15 @@ class CertificateClientTests(KeyVaultTestCase):
         cert = client.get_certificate(certificate_name=cert_name)
         self._validate_certificate_bundle(cert=cert, cert_name=cert_name, cert_policy=cert_policy)
 
-        # update certificate
+        # update certificate, ensuring the new updated_on value is at least one second later than the original
+        if self.is_live:
+            time.sleep(1)
         tags = {"tag1": "updated_value1"}
-        cert_bundle = client.update_certificate_properties(cert_name, tags=tags)
-        self._validate_certificate_bundle(cert=cert_bundle, cert_name=cert_name, cert_policy=cert_policy)
-        self.assertEqual(tags, cert_bundle.properties.tags)
-        self.assertEqual(cert.id, cert_bundle.id)
-        self.assertNotEqual(cert.properties.updated_on, cert_bundle.properties.updated_on)
+        updated_cert = client.update_certificate_properties(cert_name, tags=tags)
+        self._validate_certificate_bundle(cert=updated_cert, cert_name=cert_name, cert_policy=cert_policy)
+        self.assertEqual(tags, updated_cert.properties.tags)
+        self.assertEqual(cert.id, updated_cert.id)
+        self.assertNotEqual(cert.properties.updated_on, updated_cert.properties.updated_on)
 
         # delete certificate
         delete_cert_poller = client.begin_delete_certificate(cert_name)

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client_async.py
@@ -205,13 +205,15 @@ class CertificateClientTests(KeyVaultTestCase):
         cert = await client.get_certificate(certificate_name=cert_name)
         self._validate_certificate_bundle(cert=cert, cert_name=cert_name, cert_policy=cert_policy)
 
-        # update certificate
+        # update certificate, ensuring the new updated_on value is at least one second later than the original
+        if self.is_live:
+            await asyncio.sleep(1)
         tags = {"tag1": "updated_value1"}
-        cert_bundle = await client.update_certificate_properties(cert_name, tags=tags)
-        self._validate_certificate_bundle(cert=cert_bundle, cert_name=cert_name, cert_policy=cert_policy)
-        self.assertEqual(tags, cert_bundle.properties.tags)
-        self.assertEqual(cert.id, cert_bundle.id)
-        self.assertNotEqual(cert.properties.updated_on, cert_bundle.properties.updated_on)
+        updated_cert = await client.update_certificate_properties(cert_name, tags=tags)
+        self._validate_certificate_bundle(cert=updated_cert, cert_name=cert_name, cert_policy=cert_policy)
+        self.assertEqual(tags, updated_cert.properties.tags)
+        self.assertEqual(cert.id, updated_cert.id)
+        self.assertNotEqual(cert.properties.updated_on, updated_cert.properties.updated_on)
 
         # delete certificate
         deleted_cert_bundle = await client.delete_certificate(certificate_name=cert_name)


### PR DESCRIPTION
This test creates a cert, then updates it and asserts the cert's updated_on time has changed since the cert was created. However, Key Vault's updated_on time has resolution only down to the second. Therefore when the stars align and the update operation completes less than a second after the cert was created, the updated_on value is unchanged, causing the test to fail. This PR prevents that by inserting a one second sleep between creating and updating the cert.