### PR TITLE
Add uamqp dlq version bump to changelog

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -13,6 +13,7 @@
 **BugFixes**
 
 * Fixed bug in setting `description` when dead lettering messages (issue #9242).
+* Increments UAMQP dependency min version to 1.2.8, as a component of fixing the aformentioned dead letter issue.
 
 ## 0.50.2 (2019-12-9)
 


### PR DESCRIPTION
Truth in advertising.  Make sure we denote this to users so they're not surprised.