### PR TITLE
Fix typo in insert data example

### DIFF
--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -134,7 +134,7 @@ To insert items into a container, pass a dictionary containing your data to [Con
 This example inserts several items into the container, each with a unique `id`:
 
 ```Python
-database_client = client.get_database_client(database_name)
+database = client.get_database_client(database_name)
 container_client = database.get_container_client(container_name)
 
 for i in range(1, 10):


### PR DESCRIPTION
Replace errant `database_client` with `database`, which is consistent with other examples in the readme.