### PR TITLE
Initial prototype of adding deadletter receivers into servicebus.

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -214,6 +214,57 @@ class ServiceBusClient(object):
             **kwargs
         )
 
+
+    def get_queue_deadletter_receiver(self, queue_name, **kwargs):
+        # type: (str, Any) -> ServiceBusReceiver
+        """Get ServiceBusReceiver for the specific queue.
+
+        :param str queue_name: The path of specific Service Bus Queue the client connects to.
+        :keyword mode: The mode with which messages will be retrieved from the entity. The two options
+         are PeekLock and ReceiveAndDelete. Messages received with PeekLock must be settled within a given
+         lock period before they will be removed from the queue. Messages received with ReceiveAndDelete
+         will be immediately removed from the queue, and cannot be subsequently rejected or re-received if
+         the client fails to process the message. The default mode is PeekLock.
+        :paramtype mode: ~azure.servicebus.ReceiveSettleMode
+        :keyword int prefetch: The maximum number of messages to cache with each request to the service.
+         The default value is 0, meaning messages will be received from the service and processed
+         one at a time. Increasing this value will improve message throughput performance but increase
+         the change that messages will expire while they are cached if they're not processed fast enough.
+        :keyword float idle_timeout: The timeout in seconds between received messages after which the receiver will
+         automatically shutdown. The default value is 0, meaning no timeout.
+        :keyword int retry_total: The total number of attempts to redo a failed operation when an error occurs.
+         Default value is 3.
+        :param transfer_deadletter: Whether to connect to the transfer deadletter queue, or the standard
+         deadletter queue. Default is False, using the standard deadletter endpoint.
+        :type transfer_deadletter: bool
+        :rtype: ~azure.servicebus.ServiceBusReceiver
+        :raises: :class:`ServiceBusConnectionError`
+         :class:`ServiceBusAuthorizationError`
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sync_samples/sample_code_servicebus.py
+                :start-after: [START create_servicebus_receiver_from_sb_client_sync]
+                :end-before: [END create_servicebus_receiver_from_sb_client_sync]
+                :language: python
+                :dedent: 4
+                :caption: Create a new instance of the ServiceBusReceiver from ServiceBusClient.
+
+
+        """
+        # pylint: disable=protected-access
+        return ServiceBusReceiver(
+            fully_qualified_namespace=self.fully_qualified_namespace,
+            queue_name=queue_name,
+            credential=self._credential,
+            logging_enable=self._config.logging_enable,
+            transport_type=self._config.transport_type,
+            http_proxy=self._config.http_proxy,
+            connection=self._connection,
+            is_dead_letter_receiver=True,
+            **kwargs
+        )
+
     def get_topic_sender(self, topic_name, **kwargs):
         # type: (str, Any) -> ServiceBusSender
         """Get ServiceBusSender for the specific topic.

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -79,6 +79,11 @@ class ServiceBusReceiver(BaseHandler, ReceiverMixin):  # pylint: disable=too-man
     :keyword dict http_proxy: HTTP proxy settings. This must be a dictionary with the following
      keys: `'proxy_hostname'` (str value) and `'proxy_port'` (int value).
      Additionally the following keys may also be present: `'username', 'password'`.
+    :keyword bool is_dead_letter_receiver: Should this receiver connect to the dead-letter-queue associated
+     with the specified entity, instead of the entity itself.  Default is `False`.
+    :keyword bool transfer_deadletter: Whether to connect to the transfer deadletter queue, or the standard
+     deadletter queue. Default is False, using the standard deadletter endpoint.  Only valid if 
+     is_dead_letter_receiver is `True`, default is `False` regardless.
 
     .. admonition:: Example:
 
@@ -121,10 +126,7 @@ class ServiceBusReceiver(BaseHandler, ReceiverMixin):  # pylint: disable=too-man
                 entity_name=entity_name,
                 **kwargs
             )
-        self._message_iter = None
-        self._create_attribute(**kwargs)
-        self._connection = kwargs.get("connection")
-        self._prefetch = kwargs.get("prefetch")
+        self._populate_attributes(**kwargs)
 
     def __iter__(self):
         return self

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_session_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_session_receiver.py
@@ -75,7 +75,7 @@ class ServiceBusSessionReceiver(ServiceBusReceiver, SessionReceiverMixin):
     """
     def __init__(self, fully_qualified_namespace, credential, **kwargs):
         super(ServiceBusSessionReceiver, self).__init__(fully_qualified_namespace, credential, **kwargs)
-        self._create_session_attributes(**kwargs)
+        self._populate_session_attributes(**kwargs)
         self._session = ServiceBusSession(self._session_id, self, self._config.encoding)
 
     @property

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
@@ -79,6 +79,11 @@ class ServiceBusReceiver(collections.abc.AsyncIterator, BaseHandler, ReceiverMix
     :keyword dict http_proxy: HTTP proxy settings. This must be a dictionary with the following
      keys: `'proxy_hostname'` (str value) and `'proxy_port'` (int value).
      Additionally the following keys may also be present: `'username', 'password'`.
+    :keyword bool is_dead_letter_receiver: Should this receiver connect to the dead-letter-queue associated
+     with the specified entity, instead of the entity itself.  Default is `False`.
+    :keyword bool transfer_deadletter: Whether to connect to the transfer deadletter queue, or the standard
+     deadletter queue. Default is False, using the standard deadletter endpoint.  Only valid if 
+     is_dead_letter_receiver is `True`, default is `False` regardless.
 
     .. admonition:: Example:
 
@@ -121,9 +126,7 @@ class ServiceBusReceiver(collections.abc.AsyncIterator, BaseHandler, ReceiverMix
                 entity_name=str(entity_name),
                 **kwargs
             )
-        self._message_iter = None
-        self._create_attribute(**kwargs)
-        self._connection = kwargs.get("connection")
+        self._populate_attributes(**kwargs)
 
     async def __anext__(self):
         self._check_live()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_session_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_session_receiver_async.py
@@ -79,7 +79,7 @@ class ServiceBusSessionReceiver(ServiceBusReceiver, SessionReceiverMixin):
         **kwargs: Any
     ):
         super(ServiceBusSessionReceiver, self).__init__(fully_qualified_namespace, credential, **kwargs)
-        self._create_session_attributes(**kwargs)
+        self._populate_session_attributes(**kwargs)
         self._session = ServiceBusSession(self._session_id, self, self._config.encoding)
 
     @classmethod


### PR DESCRIPTION
Adds a top level function get_queue_deadletter_receiver to mirror existing endpoint patterns, and reenables tests to validate it.
Also refactors a tiny bit of receiver initialization code to be more consistent and clear.

Note: This is merely one proposal that I sketched out as the perhaps most obvious (in terms of alignment with the design thus far) to begin forming a stronger opinion about how we should take this, and familiarize myself with the DLQ flow.  I would mention the alternative proposals I can see offhand, and certainly ask others to chime in:
- The other option I see is to add "is_dead_letter_receiver" as a flag to the core get_<queue/subscription>_receiver calls, either taking an enum to support TransferDeadLetterQueue enablement, or as two separate variables.  I certainly have concerns about cluttering the client object with methods, and this may be a convenient way around it given how similar the flows are.