### PR TITLE
Remove unnecessary import

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -28,7 +28,6 @@ from azure.storage.blob import (
     generate_container_sas,
     PartialBatchErrorException
 )
-from azure.identity import ClientSecretCredential
 
 from _shared.testcase import StorageTestCase, LogCaptured, GlobalStorageAccountPreparer
 import pytest


### PR DESCRIPTION
Remove an unnecessary import:
- Not used in the file
- The test framework will decide if identity should be imported or not depending of the live status, no direct usage should be done in any tests anyway

Caught it since it breaks my machine right now that has some identity issues. And it breaks it for no reason :)