### PR TITLE
Fix Cleanup failing on 3.8.3

### DIFF
--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/patches.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/patches.py
@@ -34,4 +34,4 @@ def mock_in_unit_test(unit_test, target, replacement):
 
     mp = mock.patch(target, replacement)
     mp.__enter__()
-    unit_test.addCleanup(mp.__exit__)
+    unit_test.addCleanup(mp.__exit__, None, None, None)


### PR DESCRIPTION
For some reason this was working in 3.8.2, but not in 3.8.3. Being `__exit__` contract is to get three args anyway, it was working for bad reasons, so fixing it