### PR TITLE
DefaultAzureCredential configures InteractiveBrowserCredential's tenant

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release History
 
 ## 1.4.0b4 (Unreleased)
+- When constructing `DefaultAzureCredential`, you can now configure a tenant ID
+  for `InteractiveBrowserCredential`. When none is specified, the credential
+  authenticates users in their home tenants. To specify a different tenant, use
+  the keyword argument `interactive_browser_tenant_id`, or set the environment
+  variable `AZURE_TENANT_ID`.
+  ([#11548](https://github.com/Azure/azure-sdk-for-python/issues/11548))
 - The user authentication API added to `DeviceCodeCredential` and
   `InteractiveBrowserCredential` in 1.4.0b3 is available on
   `UsernamePasswordCredential` as well.

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -59,6 +59,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
         **False**.
     :keyword bool exclude_interactive_browser_credential: Whether to exclude interactive browser authentication (see
         :class:`~azure.identity.InteractiveBrowserCredential`). Defaults to **True**.
+    :keyword str interactive_browser_tenant_id: Tenant ID to use when authenticating a user through
+        :class:`~azure.identity.InteractiveBrowserCredential`. Defaults to the value of environment variable
+        AZURE_TENANT_ID, if any. If unspecified, users will authenticate in their home tenants.
     :keyword str shared_cache_username: Preferred username for :class:`~azure.identity.SharedTokenCacheCredential`.
         Defaults to the value of environment variable AZURE_USERNAME, if any.
     :keyword str shared_cache_tenant_id: Preferred tenant for :class:`~azure.identity.SharedTokenCacheCredential`.
@@ -68,6 +71,10 @@ class DefaultAzureCredential(ChainedTokenCredential):
     def __init__(self, **kwargs):
         authority = kwargs.pop("authority", None)
         authority = normalize_authority(authority) if authority else get_default_authority()
+
+        interactive_browser_tenant_id = kwargs.pop(
+            "interactive_browser_tenant_id", os.environ.get(EnvironmentVariables.AZURE_TENANT_ID)
+        )
 
         shared_cache_username = kwargs.pop("shared_cache_username", os.environ.get(EnvironmentVariables.AZURE_USERNAME))
         shared_cache_tenant_id = kwargs.pop(
@@ -101,7 +108,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
         if not exclude_cli_credential:
             credentials.append(AzureCliCredential())
         if not exclude_interactive_browser_credential:
-            credentials.append(InteractiveBrowserCredential())
+            credentials.append(InteractiveBrowserCredential(tenant_id=interactive_browser_tenant_id))
 
         super(DefaultAzureCredential, self).__init__(*credentials)
 


### PR DESCRIPTION
Today, when `DefaultAzureCredential` authenticates a user through `InteractiveBrowserCredential`, it always authenticates that user in the "organizations" tenant, i.e. that user's home tenant. This PR enables changing that behavior by specifying a tenant through environment variable `AZURE_TENANT_ID` or a keyword argument to `DefaultAzureCredential`, `interactive_browser_tenant_id` (this matches what we have in our .NET library).

Closes #11548 