### PR TITLE
InteractiveBrowserCredential is unavailable when it can't bind a port

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
 
 ## 1.4.0b4 (Unreleased)
+- `InteractiveBrowserCredential` raises `CredentialUnavailableError` when it
+  can't start an HTTP server on `localhost`.
+  ([#11665](https://github.com/Azure/azure-sdk-for-python/pull/11665))
 - When constructing `DefaultAzureCredential`, you can now configure a tenant ID
   for `InteractiveBrowserCredential`. When none is specified, the credential
   authenticates users in their home tenants. To specify a different tenant, use

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -58,6 +58,7 @@ class InteractiveBrowserCredential(InteractiveCredential):
         # type: (*str, **Any) -> dict
 
         # start an HTTP server on localhost to receive the redirect
+        redirect_uri = None
         for port in range(8400, 9000):
             try:
                 server = self._server_class(port, timeout=self._timeout)

--- a/sdk/identity/azure-identity/tests/test_browser_credential.py
+++ b/sdk/identity/azure-identity/tests/test_browser_credential.py
@@ -10,7 +10,7 @@ import time
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.pipeline.policies import SansIOHTTPPolicy
-from azure.identity import AuthenticationRequiredError, InteractiveBrowserCredential
+from azure.identity import AuthenticationRequiredError, CredentialUnavailableError, InteractiveBrowserCredential
 from azure.identity._internal import AuthCodeRedirectServer
 from azure.identity._internal.user_agent import USER_AGENT
 from msal import TokenCache
@@ -299,6 +299,14 @@ def test_no_browser():
         client_id="client-id", server_class=Mock(), transport=transport, _cache=TokenCache()
     )
     with pytest.raises(ClientAuthenticationError, match=r".*browser.*"):
+        credential.get_token("scope")
+
+
+def test_cannot_bind_port():
+    """get_token should raise CredentialUnavailableError when the redirect listener can't bind a port"""
+
+    credential = InteractiveBrowserCredential(server_class=Mock(side_effect=socket.error))
+    with pytest.raises(CredentialUnavailableError):
         credential.get_token("scope")
 
 


### PR DESCRIPTION
`get_token` loops over local ports, trying to start an HTTP server on one of them. The credential should raise `CredentialUnavailableError` when the server fails to bind a port. However, when that happens `redirect_uri` is unassigned and one gets a different error when `get_token` references it after the loop.