### PR TITLE
[formrecognizer] map copy status to model status in CustomFormModelInfo

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
@@ -867,6 +867,8 @@ class CustomFormModelInfo(object):
 
     @classmethod
     def _from_generated(cls, model, model_id=None):
+        if model.status == "succeeded":  # map copy status to model status
+            model.status = "ready"
         return cls(
             model_id=model_id if model_id else model.model_id,
             status=model.status,

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_copy_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_copy_model.py
@@ -43,7 +43,7 @@ class TestCopyModel(FormRecognizerTest):
 
         copied_model = client.get_custom_model(copy.model_id)
 
-        self.assertEqual(copy.status, "succeeded")
+        self.assertEqual(copy.status, "ready")
         self.assertIsNotNone(copy.requested_on)
         self.assertIsNotNone(copy.completed_on)
         self.assertEqual(target["modelId"], copy.model_id)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_copy_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_copy_model_async.py
@@ -42,7 +42,7 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
 
         copied_model = await client.get_custom_model(copy.model_id)
 
-        self.assertEqual(copy.status, "succeeded")
+        self.assertEqual(copy.status, "ready")
         self.assertIsNotNone(copy.requested_on)
         self.assertIsNotNone(copy.completed_on)
         self.assertEqual(target["modelId"], copy.model_id)


### PR DESCRIPTION
The Copy API returns an OperationStatus which includes relevant statuses: "succeeded" and "failed". For a "failed" status we raise an exception, but for a "succeeded" status we return a CustomFormModelInfo. A CustomFormModelInfo has a status attribute which includes "ready", "invalid" and "creating".

Since we are re-using this model as the return type for Copy, we'll need to map the "succeeded" status to "ready". This will also make us consistent with other languages.