### PR TITLE
track2 - servicebus - flaky test and documentation improvements for preview 3

### DIFF
--- a/sdk/servicebus/azure-servicebus/README.md
+++ b/sdk/servicebus/azure-servicebus/README.md
@@ -228,6 +228,11 @@ link will extend this timeout.
 a generator-style receive will run for before exiting if there are no messages.  Passing None (default) will wait forever, up until the 10 minute threshold if no other action is taken.
 - max_wait_time: Provided when calling receive() to fetch a batch of messages.  Dictates how long the receive() will wait for more messages before returning, similarly up to the aformentioned limits.
 
+### AutoLockRenew
+
+If for any reason auto-renewal has been interrupted or failed, this can be observed via the `auto_renew_error` property on the object being renewed.
+It would also manifest when trying to take action (such as completing a message) on the specified object.
+
 ### Common Exceptions
 
 Please view the [exceptions](./azure/servicebus/exceptions.py) file for detailed descriptions of our common Exception types.

--- a/sdk/servicebus/azure-servicebus/migration_guide.md
+++ b/sdk/servicebus/azure-servicebus/migration_guide.md
@@ -64,10 +64,11 @@ semantics with the sender or receiver lifetime.
 | `AutoLockRenew().register(queue_client.get_receiver(session='foo'))`| `AutoLockRenew().register(sb_client.get_queue_session_receiver(session_id='foo').session)`| [Access a session and ensure its lock is auto-renewed](./samples/sync_samples/session_send_receive.py) |
 | `receiver.get_session_state()` | `receiver.session.get_session_state()` | [Perform session specific operations on a receiver](./samples/sync_samples/session_send_receive.py)
 
-### Working with messages
+### Working with UTC time
 | In v0.50 | Equivalent in v7 | Note |
 |---|---|---|
-| `message.locked_until < datetime.now()`| `message.locked_until_utc < datetime.utcnow()`| All datetimes are now UTC and named as such|
+| `session.locked_until < datetime.now()`| `session.locked_until_utc < datetime.utcnow()`| All datetimes are now UTC and named as such|
+| `message.scheduled_enqueue_time < datetime.now()`| `message.scheduled_enqueue_time_utc < datetime.utcnow()`| UTC Datetime normalization applies across all objects and datetime fields|
 
 ## Migration samples
 

--- a/sdk/servicebus/azure-servicebus/migration_guide.md
+++ b/sdk/servicebus/azure-servicebus/migration_guide.md
@@ -64,6 +64,11 @@ semantics with the sender or receiver lifetime.
 | `AutoLockRenew().register(queue_client.get_receiver(session='foo'))`| `AutoLockRenew().register(sb_client.get_queue_session_receiver(session_id='foo').session)`| [Access a session and ensure its lock is auto-renewed](./samples/sync_samples/session_send_receive.py) |
 | `receiver.get_session_state()` | `receiver.session.get_session_state()` | [Perform session specific operations on a receiver](./samples/sync_samples/session_send_receive.py)
 
+### Working with messages
+| In v0.50 | Equivalent in v7 | Note |
+|---|---|---|
+| `message.locked_until < datetime.now()`| `message.locked_until_utc < datetime.utcnow()`| All datetimes are now UTC and named as such|
+
 ## Migration samples
 
 * [Receiving messages](#migrating-code-from-queueclient-and-receiver-to-servicebusreceiver-for-receiving-messages)

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -659,7 +659,7 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
                 finally:
                     await messages[0].complete()
                     await messages[1].complete()
-                    time.sleep(30)
+                    sleep_until_expired(messages[2])
                     with pytest.raises(MessageLockExpired):
                         await messages[2].complete()
 

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -785,7 +785,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                     messages[0].complete()
                     messages[1].complete()
                     assert (messages[2].locked_until_utc - utc_now()) <= timedelta(seconds=60)
-                    time.sleep((messages[2].locked_until_utc - utc_now()).total_seconds())
+                    sleep_until_expired(messages[2])
                     with pytest.raises(MessageLockExpired):
                         messages[2].complete()
     

--- a/sdk/servicebus/azure-servicebus/tests/test_sessions.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sessions.py
@@ -25,7 +25,8 @@ from azure.servicebus.exceptions import (
     MessageLockExpired,
     MessageAlreadySettled,
     AutoLockRenewTimeout,
-    MessageSettleFailed)
+    MessageSettleFailed,
+    MessageSendFailed)
 
 from devtools_testutils import AzureMgmtTestCase, CachedResourceGroupPreparer
 from servicebus_preparer import (
@@ -908,12 +909,16 @@ class ServiceBusSessionTests(AzureMgmtTestCase):
                     message = Message("Handler message no. {}".format(i), session_id=session_id)
                     sender.send(message)
 
-            with sb_client.get_queue_session_receiver(servicebus_queue.name, session_id=session_id, prefetch=0) as receiver:
+            with sb_client.get_queue_session_receiver(servicebus_queue.name, session_id=session_id, prefetch=0, idle_timeout=1) as receiver:
                 message = receiver.next()
                 assert message.sequence_number == 1
                 message.abandon()
-                second_message = receiver.next()
-                assert second_message.sequence_number == 1
+                while True: # we can't be sure there won't be a service delay, so we may not get the message back _immediately_, even if in most cases it shows right back up.
+                    second_message = receiver.next()
+                    if not second_message:
+                        raise "Did not successfully re-receive abandoned message, sequence_number 1 was not observed."
+                    if second_message.sequence_number == 1:
+                        return
 
     @pytest.mark.liveTest
     @pytest.mark.live_test_only
@@ -942,3 +947,18 @@ class ServiceBusSessionTests(AzureMgmtTestCase):
                     message.complete()
             assert count == 1
 
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    def test_session_non_session_send_to_session_queue_should_fail(self, servicebus_namespace_connection_string, servicebus_queue, **kwargs):
+        with ServiceBusClient.from_connection_string(
+            servicebus_namespace_connection_string, logging_enable=False) as sb_client:
+
+            session_id = str(uuid.uuid4())
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message = Message("This should be an invalid non session message")
+                with pytest.raises(MessageSendFailed):
+                    sender.send(message)


### PR DESCRIPTION
- Fix flaky tests to be more robust by adding dynamic expiry timers, remove reliance on message abandon ordering, and add additional test for session message error handling.  
- Additionally adds a helpful note to the README on how to handle autolockrenew failure in response to customer feedback; and a note in the migration guide about message datetime timezone and naming changes.