### PR TITLE
Remove authentication_record property

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
@@ -252,13 +252,7 @@ class InteractiveCredential(PublicClientCredential):
             scopes = _DEFAULT_AUTHENTICATE_SCOPES[self._authority]
 
         _ = self.get_token(*scopes, _allow_prompt=True, **kwargs)
-        return self.authentication_record  # type: ignore
-
-    @property
-    def authentication_record(self):
-        # type: () -> Optional[AuthenticationRecord]
-        """:class:`~azure.identity.AuthenticationRecord` for the most recent authentication"""
-        return self._auth_record
+        return self._auth_record  # type: ignore
 
     @wrap_exceptions
     def _acquire_token_silent(self, *scopes, **kwargs):

--- a/sdk/identity/azure-identity/tests/test_browser_credential.py
+++ b/sdk/identity/azure-identity/tests/test_browser_credential.py
@@ -83,11 +83,10 @@ def test_authenticate():
             )
             record = credential.authenticate(scopes=(scope,))
 
-    for auth_record in (record, credential.authentication_record):
-        assert auth_record.authority == environment
-        assert auth_record.home_account_id == object_id + "." + home_tenant
-        assert auth_record.tenant_id == home_tenant
-        assert auth_record.username == username
+    assert record.authority == environment
+    assert record.home_account_id == object_id + "." + home_tenant
+    assert record.tenant_id == home_tenant
+    assert record.username == username
 
     # credential should have a cached access token for the scope used in authenticate
     with patch(WEBBROWSER_OPEN, Mock(side_effect=Exception("credential should authenticate silently"))):

--- a/sdk/identity/azure-identity/tests/test_device_code_credential.py
+++ b/sdk/identity/azure-identity/tests/test_device_code_credential.py
@@ -78,11 +78,10 @@ def test_authenticate():
         _cache=TokenCache(),
     )
     record = credential.authenticate(scopes=(scope,))
-    for auth_record in (record, credential.authentication_record):
-        assert auth_record.authority == environment
-        assert auth_record.home_account_id == object_id + "." + home_tenant
-        assert auth_record.tenant_id == home_tenant
-        assert auth_record.username == username
+    assert record.authority == environment
+    assert record.home_account_id == object_id + "." + home_tenant
+    assert record.tenant_id == home_tenant
+    assert record.username == username
 
     # credential should have a cached access token for the scope used in authenticate
     token = credential.get_token(scope)

--- a/sdk/identity/azure-identity/tests/test_username_password_credential.py
+++ b/sdk/identity/azure-identity/tests/test_username_password_credential.py
@@ -126,11 +126,10 @@ def test_authenticate():
         transport=transport,
     )
     record = credential.authenticate(scopes=(scope,))
-    for auth_record in (record, credential.authentication_record):
-        assert auth_record.authority == environment
-        assert auth_record.home_account_id == object_id + "." + home_tenant
-        assert auth_record.tenant_id == home_tenant
-        assert auth_record.username == username
+    assert record.authority == environment
+    assert record.home_account_id == object_id + "." + home_tenant
+    assert record.tenant_id == home_tenant
+    assert record.username == username
 
     # credential should have a cached access token for the scope passed to authenticate
     token = credential.get_token(scope)


### PR DESCRIPTION
We aren't ready to commit to a property as the way to expose this--a callback may be better--so we'll revisit the design in another release.