### PR TITLE
Add AzureCliCredential and VSCodeCredential to public API

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
 
 ## 1.4.0b4 (Unreleased)
+- `AzureCliCredential` and `VSCodeCredential`, which enable authenticating as
+  the identity signed in to the Azure CLI and Visual Studio Code, respectively,
+  can be imported from `azure.identity` and `azure.identity.aio`.
 - `azure.identity.aio.AuthorizationCodeCredential.get_token()` no longer accepts
   optional keyword arguments `executor` or `loop`. Prior versions of the method
   didn't use these correctly, provoking exceptions, and internal changes in this

--- a/sdk/identity/azure-identity/azure/identity/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/__init__.py
@@ -8,6 +8,7 @@ from ._auth_record import AuthenticationRecord
 from ._exceptions import AuthenticationRequiredError, CredentialUnavailableError
 from ._constants import KnownAuthorities
 from ._credentials import (
+    AzureCliCredential,
     AuthorizationCodeCredential,
     CertificateCredential,
     ChainedTokenCredential,
@@ -19,11 +20,13 @@ from ._credentials import (
     ManagedIdentityCredential,
     SharedTokenCacheCredential,
     UsernamePasswordCredential,
+    VSCodeCredential,
 )
 
 
 __all__ = [
     "AuthenticationRecord",
+    "AzureCliCredential",
     "AuthenticationRequiredError",
     "AuthorizationCodeCredential",
     "CertificateCredential",
@@ -38,6 +41,7 @@ __all__ = [
     "ManagedIdentityCredential",
     "SharedTokenCacheCredential",
     "UsernamePasswordCredential",
+    "VSCodeCredential",
 ]
 
 from ._version import VERSION

--- a/sdk/identity/azure-identity/azure/identity/_credentials/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/__init__.py
@@ -14,10 +14,12 @@ from .shared_cache import SharedTokenCacheCredential
 from .azure_cli import AzureCliCredential
 from .device_code import DeviceCodeCredential
 from .user_password import UsernamePasswordCredential
+from .vscode_credential import VSCodeCredential
 
 
 __all__ = [
     "AuthorizationCodeCredential",
+    "AzureCliCredential",
     "CertificateCredential",
     "ChainedTokenCredential",
     "ClientSecretCredential",
@@ -29,4 +31,5 @@ __all__ = [
     "SharedTokenCacheCredential",
     "AzureCliCredential",
     "UsernamePasswordCredential",
+    "VSCodeCredential",
 ]

--- a/sdk/identity/azure-identity/azure/identity/aio/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/__init__.py
@@ -6,6 +6,7 @@
 
 from ._credentials import (
     AuthorizationCodeCredential,
+    AzureCliCredential,
     CertificateCredential,
     ChainedTokenCredential,
     ClientSecretCredential,
@@ -13,11 +14,13 @@ from ._credentials import (
     EnvironmentCredential,
     ManagedIdentityCredential,
     SharedTokenCacheCredential,
+    VSCodeCredential,
 )
 
 
 __all__ = [
     "AuthorizationCodeCredential",
+    "AzureCliCredential",
     "CertificateCredential",
     "ClientSecretCredential",
     "DefaultAzureCredential",
@@ -25,4 +28,5 @@ __all__ = [
     "ManagedIdentityCredential",
     "ChainedTokenCredential",
     "SharedTokenCacheCredential",
+    "VSCodeCredential",
 ]

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/__init__.py
@@ -11,6 +11,7 @@ from .certificate import CertificateCredential
 from .client_secret import ClientSecretCredential
 from .shared_cache import SharedTokenCacheCredential
 from .azure_cli import AzureCliCredential
+from .vscode_credential import VSCodeCredential
 
 
 __all__ = [
@@ -23,4 +24,5 @@ __all__ = [
     "EnvironmentCredential",
     "ManagedIdentityCredential",
     "SharedTokenCacheCredential",
+    "VSCodeCredential",
 ]

--- a/sdk/identity/azure-identity/tests/test_cli_credential.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential.py
@@ -5,8 +5,8 @@
 from datetime import datetime
 import json
 
-from azure.identity import CredentialUnavailableError
-from azure.identity._credentials.azure_cli import AzureCliCredential, CLI_NOT_FOUND
+from azure.identity import AzureCliCredential, CredentialUnavailableError
+from azure.identity._credentials.azure_cli import CLI_NOT_FOUND
 from azure.core.exceptions import ClientAuthenticationError
 
 import subprocess

--- a/sdk/identity/azure-identity/tests/test_cli_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential_async.py
@@ -8,7 +8,7 @@ import sys
 from unittest import mock
 
 from azure.identity import CredentialUnavailableError
-from azure.identity.aio._credentials.azure_cli import AzureCliCredential
+from azure.identity.aio import AzureCliCredential
 from azure.identity._credentials.azure_cli import CLI_NOT_FOUND
 from azure.core.exceptions import ClientAuthenticationError
 import pytest

--- a/sdk/identity/azure-identity/tests/test_vscode_credential.py
+++ b/sdk/identity/azure-identity/tests/test_vscode_credential.py
@@ -3,18 +3,20 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import sys
-import pytest
+
 from azure.core.credentials import AccessToken
-from azure.identity import CredentialUnavailableError
+from azure.identity import CredentialUnavailableError, VSCodeCredential
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.identity._internal.user_agent import USER_AGENT
+from azure.identity._credentials.vscode_credential import get_credentials
+import pytest
+
 from helpers import build_aad_response, mock_response, Request, validating_transport
 
 try:
     from unittest import mock
 except ImportError:  # python < 3.3
     import mock
-from azure.identity._credentials.vscode_credential import VSCodeCredential, get_credentials
 
 
 def test_no_scopes():

--- a/sdk/identity/azure-identity/tests/test_vscode_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_vscode_credential_async.py
@@ -2,15 +2,17 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-import pytest
+from unittest import mock
+
 from azure.core.credentials import AccessToken
-from azure.identity._internal.user_agent import USER_AGENT
 from azure.identity import CredentialUnavailableError
+from azure.identity.aio import VSCodeCredential
+from azure.identity._internal.user_agent import USER_AGENT
 from azure.core.pipeline.policies import SansIOHTTPPolicy
+import pytest
+
 from helpers import build_aad_response, mock_response, Request
 from helpers_async import async_validating_transport, AsyncMockTransport, wrap_in_future
-from unittest import mock
-from azure.identity.aio._credentials.vscode_credential import VSCodeCredential
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
That is to say, enable importing them from `azure.identity` and `azure.identity.aio`.