### PR TITLE
[textanalytics] check for model version/stats in response hook policy

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_policies.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_policies.py
@@ -23,8 +23,9 @@ class TextAnalyticsResponseHookPolicy(SansIOHTTPPolicy):
             statistics = data.get("statistics", None)
             model_version = data.get("modelVersion", None)
 
-            batch_statistics = TextDocumentBatchStatistics._from_generated(statistics)  # pylint: disable=protected-access
-            response.statistics = batch_statistics
-            response.model_version = model_version
-            response.raw_response = data
-            self._response_callback(response)
+            if statistics or model_version:
+                batch_statistics = TextDocumentBatchStatistics._from_generated(statistics)  # pylint: disable=protected-access
+                response.statistics = batch_statistics
+                response.model_version = model_version
+                response.raw_response = data
+                self._response_callback(response)

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_policies_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_policies_async.py
@@ -25,11 +25,12 @@ class AsyncTextAnalyticsResponseHookPolicy(SansIOHTTPPolicy):
             statistics = data.get("statistics", None)
             model_version = data.get("modelVersion", None)
 
-            batch_statistics = TextDocumentBatchStatistics._from_generated(statistics)  # pylint: disable=protected-access
-            response.statistics = batch_statistics
-            response.model_version = model_version
-            response.raw_response = data
-            if asyncio.iscoroutine(self._response_callback):
-                await self._response_callback(response)
-            else:
-                self._response_callback(response)
+            if statistics or model_version:
+                batch_statistics = TextDocumentBatchStatistics._from_generated(statistics)  # pylint: disable=protected-access
+                response.statistics = batch_statistics
+                response.model_version = model_version
+                response.raw_response = data
+                if asyncio.iscoroutine(self._response_callback):
+                    await self._response_callback(response)
+                else:
+                    self._response_callback(response)


### PR DESCRIPTION
With new data limits of v3.0 of service, we are hitting the rate limit more frequently in tests. We retry on 429s and should wait to make the call to the user-provided callback function until properties are populated.

Edit: Last 10 live test passes on this PR: https://dev.azure.com/azure-sdk/internal/_build?definitionId=1314