### PR TITLE
[Blob][Bug]Fix Batch Set Tiers and Batch Delete Blobs Bug

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -625,6 +625,7 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
             delete_snapshots = DeleteSnapshotsOptionType(delete_snapshots)
         options = {
             'timeout': kwargs.pop('timeout', None),
+            'snapshot': kwargs.pop('snapshot', None),  # this is added for delete_blobs
             'delete_snapshots': delete_snapshots or None,
             'lease_access_conditions': access_conditions,
             'modified_access_conditions': mod_conditions}

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_models.py
@@ -477,61 +477,17 @@ class BlobProperties(DictMixin):
         container-level scope is configured to allow overrides. Otherwise an error will be raised.
     :ivar bool request_server_encrypted:
         Whether this blob is encrypted.
-
-    :keyword str name:
-        The name of the blob.
-    :keyword str container:
-        The container in which the blob resides.
-    :keyword str snapshot:
-        Datetime value that uniquely identifies the blob snapshot.
-    :keyword str delete_snapshots:
-        Required if a blob has associated snapshots. Values include:
-         - "only": Deletes only the blobs snapshots.
-         - "include": Deletes the blob along with all snapshots.
-    :keyword lease_id:
-        Required if a blob has an active lease. Value can be a BlobLeaseClient object
-        or the lease ID as a string.
-    :paramtype lease_id: ~azure.storage.blob.BlobLeaseClient or str
-    :keyword ~datetime.datetime if_modified_since:
-        A DateTime value. Azure expects the date value passed in to be UTC.
-        If timezone is included, any non-UTC datetimes will be converted to UTC.
-        If a date is passed in without timezone info, it is assumed to be UTC.
-        Specify this header to perform the operation only
-        if the resource has been modified since the specified time.
-    :keyword ~datetime.datetime if_unmodified_since:
-        A DateTime value. Azure expects the date value passed in to be UTC.
-        If timezone is included, any non-UTC datetimes will be converted to UTC.
-        If a date is passed in without timezone info, it is assumed to be UTC.
-        Specify this header to perform the operation only if
-        the resource has not been modified since the specified date/time.
-    :keyword str etag:
-        An ETag value, or the wildcard character (*). Used to check if the resource has changed,
-        and act according to the condition specified by the `match_condition` parameter.
-    :keyword ~azure.core.MatchConditions match_condition:
-        The match condition to use upon the etag.
-    :keyword standard_blob_tier:
-        Indicates the tier to be set on the blob. Options include 'Hot', 'Cool',
-        'Archive'. The hot tier is optimized for storing data that is accessed
-        frequently. The cool storage tier is optimized for storing data that
-        is infrequently accessed and stored for at least a month. The archive
-        tier is optimized for storing data that is rarely accessed and stored
-        for at least six months with flexible latency requirements.
-    :paramtype standard_blob_tier: str or ~azure.storage.blob.StandardBlobTier
-    :keyword ~azure.storage.blob.RehydratePriority rehydrate_priority:
-        Indicates the priority with which to rehydrate an archived blob
-    :keyword int timeout:
-        The timeout parameter is expressed in seconds.
     """
 
     def __init__(self, **kwargs):
         self.name = kwargs.get('name')
         self.container = None
-        self.snapshot = kwargs.get('snapshot') or kwargs.get('x-ms-snapshot')
+        self.snapshot = kwargs.get('x-ms-snapshot')
         self.blob_type = BlobType(kwargs['x-ms-blob-type']) if kwargs.get('x-ms-blob-type') else None
         self.metadata = kwargs.get('metadata')
         self.encrypted_metadata = kwargs.get('encrypted_metadata')
         self.last_modified = kwargs.get('Last-Modified')
-        self.etag = kwargs.get('etag') or kwargs.get('ETag')
+        self.etag = kwargs.get('ETag')
         self.size = kwargs.get('Content-Length')
         self.content_range = kwargs.get('Content-Range')
         self.append_blob_committed_block_count = kwargs.get('x-ms-blob-committed-block-count')
@@ -540,7 +496,7 @@ class BlobProperties(DictMixin):
         self.copy = CopyProperties(**kwargs)
         self.content_settings = ContentSettings(**kwargs)
         self.lease = LeaseProperties(**kwargs)
-        self.blob_tier = kwargs.get('blob-tier') or kwargs.get('x-ms-access-tier')
+        self.blob_tier = kwargs.get('x-ms-access-tier')
         self.blob_tier_change_time = kwargs.get('x-ms-access-tier-change-time')
         self.blob_tier_inferred = kwargs.get('x-ms-access-tier-inferred')
         self.deleted = False
@@ -552,16 +508,16 @@ class BlobProperties(DictMixin):
         self.encryption_scope = kwargs.get('x-ms-encryption-scope')
         self.request_server_encrypted = kwargs.get('x-ms-server-encrypted')
 
-        # these are for delete_blobs settings
-        self.delete_snapshots = kwargs.pop('delete_snapshots', None)
-        self.lease_id = kwargs.pop('lease_id', None)
-        self.if_modified_since = kwargs.pop('if_modified_since', None)
-        self.if_unmodified_since = kwargs.pop('if_unmodified_since', None)
-        self.match_condition = kwargs.pop('match_condition', None)
-        self.timeout = kwargs.pop('timeout', None)
-
-        # these are for set_standard_blob_tier_blobs settings
-        self.rehydrate_priority = kwargs.pop('rehydrate_priority', None)
+        # # these are for delete_blobs settings
+        # self.delete_snapshots = kwargs.pop('delete_snapshots', None)
+        # self.lease_id = kwargs.pop('lease_id', None)
+        # self.if_modified_since = kwargs.pop('if_modified_since', None)
+        # self.if_unmodified_since = kwargs.pop('if_unmodified_since', None)
+        # self.match_condition = kwargs.pop('match_condition', None)
+        # self.timeout = kwargs.pop('timeout', None)
+        #
+        # # these are for set_standard_blob_tier_blobs settings
+        # self.rehydrate_priority = kwargs.pop('rehydrate_priority', None)
 
     @classmethod
     def _from_generated(cls, generated):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_models.py
@@ -508,17 +508,6 @@ class BlobProperties(DictMixin):
         self.encryption_scope = kwargs.get('x-ms-encryption-scope')
         self.request_server_encrypted = kwargs.get('x-ms-server-encrypted')
 
-        # # these are for delete_blobs settings
-        # self.delete_snapshots = kwargs.pop('delete_snapshots', None)
-        # self.lease_id = kwargs.pop('lease_id', None)
-        # self.if_modified_since = kwargs.pop('if_modified_since', None)
-        # self.if_unmodified_since = kwargs.pop('if_unmodified_since', None)
-        # self.match_condition = kwargs.pop('match_condition', None)
-        # self.timeout = kwargs.pop('timeout', None)
-        #
-        # # these are for set_standard_blob_tier_blobs settings
-        # self.rehydrate_priority = kwargs.pop('rehydrate_priority', None)
-
     @classmethod
     def _from_generated(cls, generated):
         blob = BlobProperties()

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_serialize.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_serialize.py
@@ -40,7 +40,7 @@ def _get_match_headers(kwargs, match_param, etag_param):
     elif match_condition == MatchConditions.IfMissing:
         if_none_match = '*'
     elif match_condition is None:
-        if etag_param in kwargs:
+        if kwargs.get(etag_param):
             raise ValueError("'{}' specified without '{}'.".format(etag_param, match_param))
     else:
         raise TypeError("Invalid match condition: {}".format(match_condition))

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
@@ -257,18 +257,24 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         # Pop it here, so requests doesn't feel bad about additional kwarg
         raise_on_any_failure = kwargs.pop("raise_on_any_failure", True)
         request = self._client._client.post(  # pylint: disable=protected-access
-            url='https://{}/?comp=batch'.format(self.primary_hostname),
+            url='{}://{}/?comp=batch{}{}'.format(
+                self.scheme,
+                self.primary_hostname,
+                kwargs.pop('sas', None),
+                kwargs.pop('timeout', None)
+            ),
             headers={
                 'x-ms-version': self.api_version
             }
         )
 
+        policies = [StorageHeadersPolicy()]
+        if self._credential_policy:
+            policies.append(self._credential_policy)
+
         request.set_multipart_mixed(
             *reqs,
-            policies=[
-                StorageHeadersPolicy(),
-                self._credential_policy
-            ],
+            policies=policies,
             enforce_https=False
         )
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client_async.py
@@ -113,18 +113,24 @@ class AsyncStorageAccountHostsMixin(object):
         # Pop it here, so requests doesn't feel bad about additional kwarg
         raise_on_any_failure = kwargs.pop("raise_on_any_failure", True)
         request = self._client._client.post(  # pylint: disable=protected-access
-            url='https://{}/?comp=batch'.format(self.primary_hostname),
+            url='{}://{}/?comp=batch{}{}'.format(
+                self.scheme,
+                self.primary_hostname,
+                kwargs.pop('sas', None),
+                kwargs.pop('timeout', None)
+            ),
             headers={
                 'x-ms-version': self.api_version
             }
         )
 
+        policies = [StorageHeadersPolicy()]
+        if self._credential_policy:
+            policies.append(self._credential_policy)
+
         request.set_multipart_mixed(
             *reqs,
-            policies=[
-                StorageHeadersPolicy(),
-                self._credential_policy
-            ],
+            policies=policies,
             enforce_https=False
         )
 

--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -1009,11 +1009,16 @@ class StorageContainerTest(StorageTestCase):
         blob_props = blob_client1.get_blob_properties()
         blob_props.snapshot = snapshot['snapshot']
 
+        blob_props_d = dict()
+        blob_props_d['name'] = "blobd"
+        blob_props_d['delete_snapshots'] = "include"
+        blob_props_d['lease_id'] = lease.id
+
         response = container.delete_blobs(
             blob_props,
             'blobb',
             'blobc',
-            BlobProperties(name="blobd", lease_id=lease.id, delete_snapshots="include"),
+            blob_props_d,
             timeout=3
         )
         response = list(response)

--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -26,8 +26,8 @@ from azure.storage.blob import (
     StandardBlobTier,
     PremiumPageBlobTier,
     generate_container_sas,
-    PartialBatchErrorException
-)
+    PartialBatchErrorException,
+    generate_account_sas, ResourceTypes, AccountSasPermissions, BlobProperties)
 
 from _shared.testcase import StorageTestCase, LogCaptured, GlobalStorageAccountPreparer
 import pytest
@@ -976,6 +976,53 @@ class StorageContainerTest(StorageTestCase):
         assert response[1].status_code == 202
         assert response[2].status_code == 202
 
+    @pytest.mark.live_test_only
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="Batch not supported on Python 2.7")
+    @GlobalStorageAccountPreparer()
+    def test_delete_blobs_and_snapshot_using_sas(self, resource_group, location, storage_account, storage_account_key):
+        # Arrange
+        sas_token = generate_account_sas(
+            storage_account.name,
+            account_key=storage_account_key,
+            resource_types=ResourceTypes(object=True, container=True),
+            permission=AccountSasPermissions(read=True, write=True, delete=True, list=True),
+            expiry=datetime.utcnow() + timedelta(hours=1)
+        )
+        bsc = BlobServiceClient(self.account_url(storage_account, "blob"), sas_token)
+        container = self._create_container(bsc)
+        data = b'hello world'
+
+        # blob with snapshot
+        blob_client1 = container.get_blob_client('bloba')
+        blob_client1.upload_blob(data, overwrite=True)
+        snapshot = blob_client1.create_snapshot()
+
+        container.get_blob_client('blobb').upload_blob(data, overwrite=True)
+        container.get_blob_client('blobc').upload_blob(data, overwrite=True)
+
+        # blob with lease
+        blob_client4 = container.get_blob_client('blobd')
+        blob_client4.upload_blob(data, overwrite=True)
+        lease = blob_client4.acquire_lease()
+
+        # Act
+        blob_props = blob_client1.get_blob_properties()
+        blob_props.snapshot = snapshot['snapshot']
+
+        response = container.delete_blobs(
+            blob_props,
+            'blobb',
+            'blobc',
+            BlobProperties(name="blobd", lease_id=lease.id, delete_snapshots="include"),
+            timeout=3
+        )
+        response = list(response)
+        assert len(response) == 4
+        assert response[0].status_code == 202
+        assert response[1].status_code == 202
+        assert response[2].status_code == 202
+        assert response[3].status_code == 202
+
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="Batch not supported on Python 2.7")
     @GlobalStorageAccountPreparer()
     def test_delete_blobs_simple_no_raise(self, resource_group, location, storage_account, storage_account_key):
@@ -1070,6 +1117,64 @@ class StorageContainerTest(StorageTestCase):
                 'blob1',
                 'blob2',
                 'blob3',
+            )
+
+            parts = list(parts)
+            assert len(parts) == 3
+
+            assert parts[0].status_code in [200, 202]
+            assert parts[1].status_code in [200, 202]
+            assert parts[2].status_code in [200, 202]
+
+            blob_ref2 = blob.get_blob_properties()
+            assert tier == blob_ref2.blob_tier
+            assert not blob_ref2.blob_tier_inferred
+            assert blob_ref2.blob_tier_change_time is not None
+
+        response = container.delete_blobs(
+            'blob1',
+            'blob2',
+            'blob3',
+            raise_on_any_failure=False
+        )
+
+    @pytest.mark.live_test_only
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="Batch not supported on Python 2.7")
+    @GlobalStorageAccountPreparer()
+    def test_standard_blob_tier_set_tiers_with_sas(self, resource_group, location, storage_account,
+                                                   storage_account_key):
+        sas_token = generate_account_sas(
+            storage_account.name,
+            account_key=storage_account_key,
+            resource_types=ResourceTypes(object=True, container=True),
+            permission=AccountSasPermissions(read=True, write=True, delete=True, list=True),
+            expiry=datetime.utcnow() + timedelta(hours=1)
+        )
+        bsc = BlobServiceClient(self.account_url(storage_account, "blob"), sas_token)
+        container = self._create_container(bsc)
+        tiers = [StandardBlobTier.Archive, StandardBlobTier.Cool, StandardBlobTier.Hot]
+
+        for tier in tiers:
+            response = container.delete_blobs(
+                'blob1',
+                'blob2',
+                'blob3',
+                raise_on_any_failure=False
+            )
+            blob = container.get_blob_client('blob1')
+            data = b'hello world'
+            blob.upload_blob(data)
+            container.get_blob_client('blob2').upload_blob(data)
+            container.get_blob_client('blob3').upload_blob(data)
+
+            blob_ref = blob.get_blob_properties()
+
+            parts = container.set_standard_blob_tier_blobs(
+                tier,
+                blob_ref,
+                'blob2',
+                'blob3',
+                timeout=5
             )
 
             parts = list(parts)


### PR DESCRIPTION
Here is the list that batch operation doesn’t work in Python track2 this pr is to address them

Batch Authenticate using sas
Batch delete/set tier for blob with special characters in name
Batch delete/set tier for blobs in different containers
Batch delete snapshot
Batch Delete leased blobs,
Batch Delete blob with matching condition 
Set batch operation timeout in sub request/ main request