### PR TITLE
AzureCliCredential is unavailable when no account is logged in

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
 
 ## 1.4.0b4 (Unreleased)
+- `AzureCliCredential` raises `CredentialUnavailableError` when no user is
+  logged in to the Azure CLI.
+  ([#11819](https://github.com/Azure/azure-sdk-for-python/issues/11819))
 - `AzureCliCredential` and `VSCodeCredential`, which enable authenticating as
   the identity signed in to the Azure CLI and Visual Studio Code, respectively,
   can be imported from `azure.identity` and `azure.identity.aio`.

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
 CLI_NOT_FOUND = "Azure CLI not found on path"
 COMMAND_LINE = "az account get-access-token --output json --resource {}"
+NOT_LOGGED_IN = "Please run 'az login' to set up an account"
 
 # CLI's "expiresOn" is naive, so we use this naive datetime for the epoch to calculate expires_on in UTC
 EPOCH = datetime.fromtimestamp(0)
@@ -116,6 +117,8 @@ def _run_command(command):
         # non-zero return from shell
         if ex.returncode == 127 or ex.output.startswith("'az' is not recognized"):
             error = CredentialUnavailableError(message=CLI_NOT_FOUND)
+        elif "az login" in ex.output or "az account set" in ex.output:
+            error = CredentialUnavailableError(message=NOT_LOGGED_IN)
         else:
             # return code is from the CLI -> propagate its output
             if ex.output:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -13,6 +13,7 @@ from ..._credentials.azure_cli import (
     CLI_NOT_FOUND,
     COMMAND_LINE,
     get_safe_working_dir,
+    NOT_LOGGED_IN,
     parse_token,
     sanitize_output,
 )
@@ -82,6 +83,9 @@ async def _run_command(command):
 
     if proc.returncode == 127 or output.startswith("'az' is not recognized"):
         raise CredentialUnavailableError(CLI_NOT_FOUND)
+
+    if "az login" in output or "az account set" in output:
+        raise CredentialUnavailableError(message=NOT_LOGGED_IN)
 
     message = sanitize_output(output) if output else "Failed to invoke Azure CLI"
     raise ClientAuthenticationError(message=message)

--- a/sdk/identity/azure-identity/tests/test_cli_credential.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import json
 
 from azure.identity import AzureCliCredential, CredentialUnavailableError
-from azure.identity._credentials.azure_cli import CLI_NOT_FOUND
+from azure.identity._credentials.azure_cli import CLI_NOT_FOUND, NOT_LOGGED_IN
 from azure.core.exceptions import ClientAuthenticationError
 
 import subprocess
@@ -98,10 +98,19 @@ def test_cannot_execute_shell():
 
 
 def test_not_logged_in():
-    """When the CLI isn't logged in, the credential should raise an error containing the CLI's output"""
+    """When the CLI isn't logged in, the credential should raise CredentialUnavailableError"""
 
     output = "ERROR: Please run 'az login' to setup account."
     with mock.patch(CHECK_OUTPUT, raise_called_process_error(1, output)):
+        with pytest.raises(CredentialUnavailableError, match=NOT_LOGGED_IN):
+            AzureCliCredential().get_token("scope")
+
+
+def test_unexpected_error():
+    """When the CLI returns an unexpected error, the credential should raise an error containing the CLI's output"""
+
+    output = "something went wrong"
+    with mock.patch(CHECK_OUTPUT, raise_called_process_error(42, output)):
         with pytest.raises(ClientAuthenticationError, match=output):
             AzureCliCredential().get_token("scope")
 


### PR DESCRIPTION
This fixes #11819 by ensuring the credential raises `CredentialUnavailableError` when no account is logged in to the CLI, prompting `ChainedTokenCredential` to continue to its next credential.