### PR TITLE
SharedTokenCacheCredential updates

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -32,6 +32,8 @@ class SharedTokenCacheCredential(SharedTokenCacheBase):
         tokens for multiple identities.
     :keyword AuthenticationRecord authentication_record: an authentication record returned by a user credential such as
         :class:`DeviceCodeCredential` or :class:`InteractiveBrowserCredential`
+    :keyword bool allow_unencrypted_cache: if True, the credential will fall back to a plaintext cache when encryption
+        is unavailable. Defaults to False.
     """
 
     @wrap_exceptions

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -61,6 +61,10 @@ class SharedTokenCacheCredential(SharedTokenCacheBase):
 
         account = self._get_account(self._username, self._tenant_id)
 
+        token = self._get_cached_access_token(scopes, account)
+        if token:
+            return token
+
         # try each refresh token, returning the first access token acquired
         for refresh_token in self._get_refresh_tokens(account):
             token = self._client.obtain_token_by_refresh_token(scopes, refresh_token)

--- a/sdk/identity/azure-identity/azure/identity/_internal/aad_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aad_client.py
@@ -12,7 +12,6 @@ from azure.core.pipeline.policies import (
     RetryPolicy,
     ProxyPolicy,
     UserAgentPolicy,
-    ContentDecodePolicy,
     DistributedTracingPolicy,
     HttpLoggingPolicy,
 )
@@ -39,32 +38,28 @@ class AadClient(AadClientBase):
         )
         now = int(time.time())
         response = self._pipeline.run(request, stream=False, **kwargs)
-        content = ContentDecodePolicy.deserialize_from_http_generics(response.http_response)
-        return self._process_response(response=content, scopes=scopes, now=now)
+        return self._process_response(response, now)
 
     def obtain_token_by_client_certificate(self, scopes, certificate, **kwargs):
         # type: (Sequence[str], AadClientCertificate, **Any) -> AccessToken
         request = self._get_client_certificate_request(scopes, certificate)
         now = int(time.time())
         response = self._pipeline.run(request, stream=False, **kwargs)
-        content = ContentDecodePolicy.deserialize_from_http_generics(response.http_response)
-        return self._process_response(response=content, scopes=scopes, now=now)
+        return self._process_response(response, now)
 
     def obtain_token_by_client_secret(self, scopes, secret, **kwargs):
         # type: (Sequence[str], str, **Any) -> AccessToken
         request = self._get_client_secret_request(scopes, secret)
         now = int(time.time())
         response = self._pipeline.run(request, stream=False, **kwargs)
-        content = ContentDecodePolicy.deserialize_from_http_generics(response.http_response)
-        return self._process_response(response=content, scopes=scopes, now=now)
+        return self._process_response(response, now)
 
     def obtain_token_by_refresh_token(self, scopes, refresh_token, **kwargs):
         # type: (Sequence[str], str, **Any) -> AccessToken
         request = self._get_refresh_token_request(scopes, refresh_token)
         now = int(time.time())
         response = self._pipeline.run(request, stream=False, **kwargs)
-        content = ContentDecodePolicy.deserialize_from_http_generics(response.http_response)
-        return self._process_response(response=content, scopes=scopes, now=now)
+        return self._process_response(response, now)
 
     # pylint:disable=no-self-use
     def _build_pipeline(self, config=None, policies=None, transport=None, **kwargs):

--- a/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
@@ -213,6 +213,7 @@ class AadClientBase(ABC):
             "refresh_token": refresh_token,
             "scope": " ".join(scopes),
             "client_id": self._client_id,
+            "client_info": 1,  # request AAD include home_account_id in its response
         }
         request = HttpRequest(
             "POST", self._token_endpoint, headers={"Content-Type": "application/x-www-form-urlencoded"}, data=data

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -193,8 +193,11 @@ class SharedTokenCacheBase(ABC):
         raise CredentialUnavailableError(message=message)
 
     def _get_refresh_tokens(self, account):
+        if "home_account_id" not in account:
+            return None
+
         cache_entries = self._cache.find(
-            TokenCache.CredentialType.REFRESH_TOKEN, query={"home_account_id": account.get("home_account_id")}
+            TokenCache.CredentialType.REFRESH_TOKEN, query={"home_account_id": account["home_account_id"]}
         )
         return (token["secret"] for token in cache_entries if "secret" in token)
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -5,7 +5,6 @@
 import abc
 import time
 
-from azure.core.credentials import AccessToken
 from msal import TokenCache
 from six.moves.urllib_parse import urlparse
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
@@ -31,6 +31,8 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncCredentialBase):
         tokens for multiple identities.
     :keyword AuthenticationRecord authentication_record: an authentication record returned by a user credential such as
         :class:`DeviceCodeCredential` or :class:`InteractiveBrowserCredential`
+    :keyword bool allow_unencrypted_cache: if True, the credential will fall back to a plaintext cache when encryption
+        is unavailable. Defaults to False.
     """
 
     async def __aenter__(self):

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
@@ -70,6 +70,10 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncCredentialBase):
 
         account = self._get_account(self._username, self._tenant_id)
 
+        token = self._get_cached_access_token(scopes, account)
+        if token:
+            return token
+
         # try each refresh token, returning the first access token acquired
         for refresh_token in self._get_refresh_tokens(account):
             token = await self._client.obtain_token_by_refresh_token(scopes, refresh_token)

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/aad_client.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/aad_client.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 from azure.core.configuration import Configuration
 from azure.core.pipeline import AsyncPipeline
 from azure.core.pipeline.policies import (
-    ContentDecodePolicy,
     ProxyPolicy,
     NetworkTraceLoggingPolicy,
     AsyncRetryPolicy,
@@ -56,16 +55,14 @@ class AadClient(AadClientBase):
         )
         now = int(time.time())
         response = await self._pipeline.run(request, **kwargs)
-        content = ContentDecodePolicy.deserialize_from_http_generics(response.http_response)
-        return self._process_response(response=content, scopes=scopes, now=now)
+        return self._process_response(response, now)
 
     async def obtain_token_by_client_certificate(self, scopes, certificate, **kwargs):
         # type: (Sequence[str], AadClientCertificate, **Any) -> AccessToken
         request = self._get_client_certificate_request(scopes, certificate)
         now = int(time.time())
         response = await self._pipeline.run(request, stream=False, **kwargs)
-        content = ContentDecodePolicy.deserialize_from_http_generics(response.http_response)
-        return self._process_response(response=content, scopes=scopes, now=now)
+        return self._process_response(response, now)
 
     async def obtain_token_by_client_secret(
         self, scopes: "Sequence[str]", secret: str, **kwargs: "Any"
@@ -73,8 +70,7 @@ class AadClient(AadClientBase):
         request = self._get_client_secret_request(scopes, secret)
         now = int(time.time())
         response = await self._pipeline.run(request, **kwargs)
-        content = ContentDecodePolicy.deserialize_from_http_generics(response.http_response)
-        return self._process_response(response=content, scopes=scopes, now=now)
+        return self._process_response(response, now)
 
     async def obtain_token_by_refresh_token(
         self, scopes: "Sequence[str]", refresh_token: str, **kwargs: "Any"
@@ -82,8 +78,7 @@ class AadClient(AadClientBase):
         request = self._get_refresh_token_request(scopes, refresh_token)
         now = int(time.time())
         response = await self._pipeline.run(request, **kwargs)
-        content = ContentDecodePolicy.deserialize_from_http_generics(response.http_response)
-        return self._process_response(response=content, scopes=scopes, now=now)
+        return self._process_response(response, now)
 
     # pylint:disable=no-self-use
     def _build_pipeline(

--- a/sdk/identity/azure-identity/tests/test_aad_client.py
+++ b/sdk/identity/azure-identity/tests/test_aad_client.py
@@ -8,9 +8,10 @@ from azure.core.exceptions import ClientAuthenticationError
 from azure.identity._constants import EnvironmentVariables
 from azure.identity._internal.aad_client import AadClient
 import pytest
+from msal import TokenCache
 from six.moves.urllib_parse import urlparse
 
-from helpers import mock_response
+from helpers import build_aad_response, mock_response
 
 try:
     from unittest.mock import Mock, patch
@@ -172,3 +173,31 @@ def test_refresh_token():
 
     assert token.token == access_token
     assert transport.send.call_count == 1
+
+
+def test_evicts_invalid_refresh_token():
+    """when AAD rejects a refresh token, the client should evict that token from its cache"""
+
+    tenant_id = "tenant-id"
+    client_id = "client-id"
+    invalid_token = "invalid-refresh-token"
+
+    cache = TokenCache()
+    cache.add({"response": build_aad_response(uid="id1", utid="tid1", access_token="*", refresh_token=invalid_token)})
+    cache.add({"response": build_aad_response(uid="id2", utid="tid2", access_token="*", refresh_token="...")})
+    assert len(cache.find(TokenCache.CredentialType.REFRESH_TOKEN)) == 2
+    assert len(cache.find(TokenCache.CredentialType.REFRESH_TOKEN, query={"secret": invalid_token})) == 1
+
+    def send(request, **_):
+        assert request.data["refresh_token"] == invalid_token
+        return mock_response(json_payload={"error": "invalid_grant"}, status_code=400)
+
+    transport = Mock(send=Mock(wraps=send))
+
+    client = AadClient(tenant_id, client_id, transport=transport, cache=cache)
+    with pytest.raises(ClientAuthenticationError):
+        client.obtain_token_by_refresh_token(scopes=("scope",), refresh_token=invalid_token)
+
+    assert transport.send.call_count == 1
+    assert len(cache.find(TokenCache.CredentialType.REFRESH_TOKEN)) == 1
+    assert len(cache.find(TokenCache.CredentialType.REFRESH_TOKEN, query={"secret": invalid_token})) == 0

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
@@ -9,7 +9,7 @@ from azure.identity import (
     CredentialUnavailableError,
     SharedTokenCacheCredential,
 )
-from azure.identity._constants import EnvironmentVariables
+from azure.identity._constants import AZURE_CLI_CLIENT_ID, EnvironmentVariables
 from azure.identity._internal.shared_token_cache import (
     KNOWN_ALIASES,
     MULTIPLE_ACCOUNTS,
@@ -598,6 +598,125 @@ def test_auth_record_multiple_accounts_for_username():
     assert token.token == expected_access_token
 
 
+@patch("azure.identity._internal.persistent_cache.sys.platform", "linux2")
+@patch("azure.identity._internal.persistent_cache.msal_extensions")
+def test_allow_unencrypted_cache(mock_extensions):
+    """The credential should use an unencrypted cache when encryption is unavailable and the user explicitly allows it.
+
+    This test was written when Linux was the only platform on which encryption may not be available.
+    """
+
+    # the credential should prefer an encrypted cache even when the user allows an unencrypted one
+    SharedTokenCacheCredential(allow_unencrypted_cache=True)
+    assert mock_extensions.PersistedTokenCache.called_with(mock_extensions.LibsecretPersistence)
+    mock_extensions.PersistedTokenCache.reset_mock()
+
+    # (when LibsecretPersistence's dependencies aren't available, constructing it raises ImportError)
+    mock_extensions.LibsecretPersistence = Mock(side_effect=ImportError)
+
+    # encryption unavailable, no opt in to unencrypted cache -> credential should be unavailable
+    with pytest.raises(CredentialUnavailableError):
+        SharedTokenCacheCredential().get_token("scope")
+    assert mock_extensions.PersistedTokenCache.call_count == 0
+
+    # still no encryption, but now we allow the unencrypted fallback
+    SharedTokenCacheCredential(allow_unencrypted_cache=True)
+    assert mock_extensions.PersistedTokenCache.called_with(mock_extensions.FilePersistence)
+
+
+def test_writes_to_cache():
+    """the credential should write tokens it acquires to the cache"""
+
+    scope = "scope"
+    expected_access_token = "access token"
+    first_refresh_token = "first refresh token"
+    second_refresh_token = "second refresh token"
+
+    username = "me"
+    uid = "uid"
+    utid = "utid"
+    account = get_account_event(username=username, uid=uid, utid=utid, refresh_token=first_refresh_token)
+    cache = TokenCache()
+    cache.add(account)
+
+    transport = validating_transport(
+        requests=[Request(required_data={"refresh_token": first_refresh_token})],  # credential redeems refresh token
+        responses=[
+            mock_response(
+                json_payload=build_aad_response(  # AAD responds with an access token and new refresh token
+                    uid=uid,
+                    utid=utid,
+                    access_token=expected_access_token,
+                    refresh_token=second_refresh_token,
+                    id_token=build_id_token(aud=AZURE_CLI_CLIENT_ID, object_id=uid, tenant_id=utid, username=username),
+                )
+            )
+        ],
+    )
+    credential = SharedTokenCacheCredential(_cache=cache, transport=transport)
+    token = credential.get_token(scope)
+    assert token.token == expected_access_token
+
+    # access token should be in the cache, and another instance should retrieve it
+    credential = SharedTokenCacheCredential(
+        _cache=cache, transport=Mock(send=Mock(side_effect=Exception("the credential should return a cached token")))
+    )
+    token = credential.get_token(scope)
+    assert token.token == expected_access_token
+
+    # and the credential should have updated the cached refresh token
+    second_access_token = "second access token"
+    transport = validating_transport(
+        requests=[Request(required_data={"refresh_token": second_refresh_token})],
+        responses=[mock_response(json_payload=build_aad_response(access_token=second_access_token))],
+    )
+    credential = SharedTokenCacheCredential(_cache=cache, transport=transport)
+    token = credential.get_token("some other " + scope)
+    assert token.token == second_access_token
+
+    # verify the credential didn't add a new cache entry
+    assert len(cache.find(TokenCache.CredentialType.REFRESH_TOKEN)) == 1
+
+
+def test_access_token_caching():
+    """'get_token' shouldn't return other users' access tokens"""
+
+    scope = "scope"
+    forbidden_access_token = "don't use me"
+    expected_access_token = "access token"
+    my_refresh_token = "my refresh token"
+    your_refresh_token = "your refresh token"
+
+    me = "me"
+    uid = "uidme"
+    utid = "utidme"
+    cache = TokenCache()
+    cache.add(
+        get_account_event(
+            username=me,
+            uid=uid,
+            utid=utid,
+            refresh_token=my_refresh_token,
+            access_token=forbidden_access_token,
+            scopes=[scope],
+        )
+    )
+
+    you = "you"
+    uid = "uidyou"
+    utid = "utidyou"
+    cache.add(
+        get_account_event(
+            username=you,
+            uid=uid,
+            utid=utid,
+            refresh_token=your_refresh_token,
+            access_token=expected_access_token,
+            scopes=[scope],
+        )
+    )
+
+
 def test_authentication_record_authenticating_tenant():
     """when given a record and 'tenant_id', the credential should authenticate in the latter"""
 
@@ -613,7 +732,7 @@ def test_authentication_record_authenticating_tenant():
 
 
 def get_account_event(
-    username, uid, utid, authority=None, client_id="client-id", refresh_token="refresh-token", scopes=None
+    username, uid, utid, authority=None, client_id="client-id", refresh_token="refresh-token", scopes=None, **kwargs
 ):
     if authority:
         endpoint = "https://" + "/".join((authority, utid, "path",))
@@ -627,6 +746,7 @@ def get_account_event(
             refresh_token=refresh_token,
             id_token=build_id_token(aud=client_id, preferred_username=username),
             foci="1",
+            **kwargs
         ),
         "client_id": client_id,
         "token_endpoint": endpoint,


### PR DESCRIPTION
Changes to make `SharedTokenCacheCredential` more useful and correct (correctness being defined by MSAL's behavior):
- load the cache on all platforms, with optional unprotected fallback
- write acquired tokens to the cache
  - evict invalid refresh tokens
- use cached access tokens

Closes #11636 