### PR TITLE
seg fault on debian

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/linux_vscode_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/linux_vscode_adapter.py
@@ -101,7 +101,5 @@ def get_credentials():
         environment_name = _get_user_settings()
         credentials = _get_refresh_token(VSCODE_CREDENTIALS_SECTION, environment_name)
         return credentials
-    except NotImplementedError:  # pylint:disable=try-except-raise
-        raise
     except Exception:  # pylint: disable=broad-except
         return None

--- a/sdk/identity/azure-identity/azure/identity/_credentials/linux_vscode_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/linux_vscode_adapter.py
@@ -69,8 +69,7 @@ def _get_refresh_token(service_name, account_name):
     try:
         import platform
         distro = platform.uname()
-        if sys.version_info[0] == 3 and sys.version_info[1] == 8 \
-                and not (distro[1] == "redhat" or distro[1] == "ubuntu"):
+        if sys.version_info >= (3, 8) and not ("redhat" in distro or "ubuntu" in distro):
             raise NotImplementedError("Not supported")
     except Exception:  # pylint: disable=broad-except
         raise NotImplementedError("Not supported")

--- a/sdk/identity/azure-identity/azure/identity/_credentials/linux_vscode_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/linux_vscode_adapter.py
@@ -66,6 +66,15 @@ def _get_refresh_token(service_name, account_name):
     if sys.version_info[0] < 3:
         raise NotImplementedError("Not supported on Python 2.7")
 
+    try:
+        import platform
+        distro = platform.uname()
+        if sys.version_info[0] == 3 and sys.version_info[1] == 8 \
+                and not (distro[1] == "redhat" or distro[1] == "ubuntu"):
+            raise NotImplementedError("Not supported")
+    except Exception:  # pylint: disable=broad-except
+        raise NotImplementedError("Not supported")
+
     err = ct.c_int()
     schema = _libsecret.secret_schema_new(
         _c_str("org.freedesktop.Secret.Generic"), 2, _c_str("service"), 0, _c_str("account"), 0, None

--- a/sdk/identity/azure-identity/tests/test_vscode_credential.py
+++ b/sdk/identity/azure-identity/tests/test_vscode_credential.py
@@ -104,6 +104,35 @@ def test_no_obtain_token_if_cached():
         assert mock_client.obtain_token_by_refresh_token.call_count == 0
 
 
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="This test only runs on Linux")
+def test_distro():
+    from azure.identity._credentials.linux_vscode_adapter import _get_refresh_token
+    expected_token = AccessToken("token", 42)
+
+    mock_client = mock.Mock(spec=object)
+    mock_client.obtain_token_by_refresh_token = mock.Mock(return_value=expected_token)
+    mock_client.get_cached_access_token = mock.Mock(return_value="VALUE")
+
+    with mock.patch("sys.version_info", return_value=(3, 8, 3, 'final', 0)):
+        with mock.patch("platform.uname",
+                        return_value=('Linux', 'redhat', '4.18.0-193.el8.x86_64',
+                                      '#1 SMP Fri Mar 27 14:35:58 UTC 2020', 'x86_64', 'x86_64')):
+            credential = VSCodeCredential(_client=mock_client)
+            token = credential.get_token("scope")
+
+        with mock.patch("platform.uname",
+                        return_value=('Linux', 'ubuntu', '5.3.0-1022-azure',
+                                      '#23~18.04.1-Ubuntu SMP Mon May 11 11:55:56 UTC 2020', 'x86_64', 'x86_64')):
+            credential = VSCodeCredential(_client=mock_client)
+            token = credential.get_token("scope")
+
+        with mock.patch("platform.uname",
+                        return_value=('Linux', 'deb', '4.19.0-9-cloud-amd64',
+                                      '#1 SMP Debian 4.19.118-2 (2020-04-29)', 'x86_64', '')):
+            with pytest.raises(NotImplementedError):
+                credential = _get_refresh_token("test", "test")
+
+
 @pytest.mark.skipif(not sys.platform.startswith("darwin"), reason="This test only runs on MacOS")
 def test_mac_keychain_valid_value():
     with mock.patch("msal_extensions.osx.Keychain.get_generic_password", return_value="VALUE"):

--- a/sdk/identity/azure-identity/tests/test_vscode_credential.py
+++ b/sdk/identity/azure-identity/tests/test_vscode_credential.py
@@ -113,24 +113,23 @@ def test_distro():
     mock_client.obtain_token_by_refresh_token = mock.Mock(return_value=expected_token)
     mock_client.get_cached_access_token = mock.Mock(return_value="VALUE")
 
-    with mock.patch("sys.version_info", return_value=(3, 8, 3, 'final', 0)):
-        with mock.patch("platform.uname",
-                        return_value=('Linux', 'redhat', '4.18.0-193.el8.x86_64',
-                                      '#1 SMP Fri Mar 27 14:35:58 UTC 2020', 'x86_64', 'x86_64')):
-            credential = VSCodeCredential(_client=mock_client)
-            token = credential.get_token("scope")
+    with mock.patch("platform.uname",
+                    return_value=('Linux', 'redhat', '4.18.0-193.el8.x86_64',
+                                  '#1 SMP Fri Mar 27 14:35:58 UTC 2020', 'x86_64', 'x86_64')):
+        credential = VSCodeCredential(_client=mock_client)
+        token = credential.get_token("scope")
 
-        with mock.patch("platform.uname",
-                        return_value=('Linux', 'ubuntu', '5.3.0-1022-azure',
-                                      '#23~18.04.1-Ubuntu SMP Mon May 11 11:55:56 UTC 2020', 'x86_64', 'x86_64')):
-            credential = VSCodeCredential(_client=mock_client)
-            token = credential.get_token("scope")
+    with mock.patch("platform.uname",
+                    return_value=('Linux', 'ubuntu', '5.3.0-1022-azure',
+                                  '#23~18.04.1-Ubuntu SMP Mon May 11 11:55:56 UTC 2020', 'x86_64', 'x86_64')):
+        credential = VSCodeCredential(_client=mock_client)
+        token = credential.get_token("scope")
 
-        with mock.patch("platform.uname",
-                        return_value=('Linux', 'deb', '4.19.0-9-cloud-amd64',
-                                      '#1 SMP Debian 4.19.118-2 (2020-04-29)', 'x86_64', '')):
-            with pytest.raises(NotImplementedError):
-                credential = _get_refresh_token("test", "test")
+    with mock.patch("platform.uname",
+                    return_value=('Linux', 'deb', '4.19.0-9-cloud-amd64',
+                                  '#1 SMP Debian 4.19.118-2 (2020-04-29)', 'x86_64', '')):
+        with pytest.raises(NotImplementedError):
+            credential = _get_refresh_token("test", "test")
 
 
 @pytest.mark.skipif(not sys.platform.startswith("darwin"), reason="This test only runs on MacOS")

--- a/sdk/identity/azure-identity/tests/test_vscode_credential.py
+++ b/sdk/identity/azure-identity/tests/test_vscode_credential.py
@@ -129,7 +129,7 @@ def test_distro():
                     return_value=('Linux', 'deb', '4.19.0-9-cloud-amd64',
                                   '#1 SMP Debian 4.19.118-2 (2020-04-29)', 'x86_64', '')):
         if sys.version_info[0] == 3 and sys.version_info[1] == 8:
-            with pytest.raises(CredentialUnavailableError):
+            with pytest.raises(NotImplementedError):
                 credential = _get_refresh_token("test", "test")
 
 

--- a/sdk/identity/azure-identity/tests/test_vscode_credential.py
+++ b/sdk/identity/azure-identity/tests/test_vscode_credential.py
@@ -128,8 +128,9 @@ def test_distro():
     with mock.patch("platform.uname",
                     return_value=('Linux', 'deb', '4.19.0-9-cloud-amd64',
                                   '#1 SMP Debian 4.19.118-2 (2020-04-29)', 'x86_64', '')):
-        with pytest.raises(NotImplementedError):
-            credential = _get_refresh_token("test", "test")
+        if sys.version_info[0] == 3 and sys.version_info[1] == 8:
+            with pytest.raises(NotImplementedError):
+                credential = _get_refresh_token("test", "test")
 
 
 @pytest.mark.skipif(not sys.platform.startswith("darwin"), reason="This test only runs on MacOS")

--- a/sdk/identity/azure-identity/tests/test_vscode_credential.py
+++ b/sdk/identity/azure-identity/tests/test_vscode_credential.py
@@ -129,7 +129,7 @@ def test_distro():
                     return_value=('Linux', 'deb', '4.19.0-9-cloud-amd64',
                                   '#1 SMP Debian 4.19.118-2 (2020-04-29)', 'x86_64', '')):
         if sys.version_info[0] == 3 and sys.version_info[1] == 8:
-            with pytest.raises(NotImplementedError):
+            with pytest.raises(CredentialUnavailableError):
                 credential = _get_refresh_token("test", "test")
 
 


### PR DESCRIPTION
VS code credential raises seg fault on debian 3.8.3. It kills python process and user cannot catch the exception. Disable it on debian 3.8.3 for now to unblock user.