### PR TITLE
[formrecognizer] remove test code that works around service bug (fixed)

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
@@ -23,23 +23,20 @@ def adjust_confidence(score):
 def get_elements(field, read_result):
     text_elements = []
 
-    try:
-        for item in field.elements:
-            nums = [int(s) for s in re.findall(r"\d+", item)]
-            read = nums[0]
-            line = nums[1]
-            if len(nums) == 3:
-                word = nums[2]
-                ocr_word = read_result[read].lines[line].words[word]
-                extracted_word = FormWord._from_generated(ocr_word, page=read + 1)
-                text_elements.append(extracted_word)
-                continue
-            ocr_line = read_result[read].lines[line]
-            extracted_line = FormLine._from_generated(ocr_line, page=read + 1)
-            text_elements.append(extracted_line)
-        return text_elements
-    except IndexError:
-        return None  # https://github.com/Azure/azure-sdk-for-python/issues/11014
+    for item in field.elements:
+        nums = [int(s) for s in re.findall(r"\d+", item)]
+        read = nums[0]
+        line = nums[1]
+        if len(nums) == 3:
+            word = nums[2]
+            ocr_word = read_result[read].lines[line].words[word]
+            extracted_word = FormWord._from_generated(ocr_word, page=read + 1)
+            text_elements.append(extracted_word)
+            continue
+        ocr_line = read_result[read].lines[line]
+        extracted_line = FormLine._from_generated(ocr_line, page=read + 1)
+        text_elements.append(extracted_line)
+    return text_elements
 
 
 def get_field_value(field, value, read_result):  # pylint: disable=too-many-return-statements

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms.py
@@ -257,12 +257,12 @@ class TestCustomForms(FormRecognizerTest):
         read_results = actual.analyze_result.read_results
         page_results = actual.analyze_result.page_results
 
-        self.assertFormPagesTransformCorrect(recognized_form, read_results, page_results, bug_skip_text_content=True)
+        self.assertFormPagesTransformCorrect(recognized_form, read_results, page_results)
 
         for form, actual in zip(recognized_form, page_results):
             self.assertEqual(form.page_range.first_page_number, actual.page)
             self.assertEqual(form.page_range.last_page_number, actual.page)
-            self.assertUnlabeledFormFieldDictTransformCorrect(form.fields, actual.key_value_pairs, read_results, bug_skip_text_content=True)
+            self.assertUnlabeledFormFieldDictTransformCorrect(form.fields, actual.key_value_pairs, read_results)
 
     @GlobalFormRecognizerAccountPreparer()
     @GlobalTrainingAccountPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_async.py
@@ -261,13 +261,12 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
         read_results = actual.analyze_result.read_results
         page_results = actual.analyze_result.page_results
 
-        # bug_skip_text_content should be removed after bug fix: https://github.com/Azure/azure-sdk-for-python/issues/11014
-        self.assertFormPagesTransformCorrect(recognized_form, read_results, page_results, bug_skip_text_content=True)
+        self.assertFormPagesTransformCorrect(recognized_form, read_results, page_results)
 
         for form, actual in zip(recognized_form, page_results):
             self.assertEqual(form.page_range.first_page_number, actual.page)
             self.assertEqual(form.page_range.last_page_number, actual.page)
-            self.assertUnlabeledFormFieldDictTransformCorrect(form.fields, actual.key_value_pairs, read_results, bug_skip_text_content=True)
+            self.assertUnlabeledFormFieldDictTransformCorrect(form.fields, actual.key_value_pairs, read_results)
 
 
     @GlobalFormRecognizerAccountPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_from_url.py
@@ -231,12 +231,12 @@ class TestCustomFormsFromUrl(FormRecognizerTest):
         read_results = actual.analyze_result.read_results
         page_results = actual.analyze_result.page_results
 
-        self.assertFormPagesTransformCorrect(recognized_form, read_results, page_results, bug_skip_text_content=True)
+        self.assertFormPagesTransformCorrect(recognized_form, read_results, page_results)
 
         for form, actual in zip(recognized_form, page_results):
             self.assertEqual(form.page_range.first_page_number, actual.page)
             self.assertEqual(form.page_range.last_page_number, actual.page)
-            self.assertUnlabeledFormFieldDictTransformCorrect(form.fields, actual.key_value_pairs, read_results, bug_skip_text_content=True)
+            self.assertUnlabeledFormFieldDictTransformCorrect(form.fields, actual.key_value_pairs, read_results)
 
 
     @GlobalFormRecognizerAccountPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_from_url_async.py
@@ -236,12 +236,12 @@ class TestCustomFormsFromUrlAsync(AsyncFormRecognizerTest):
         read_results = actual.analyze_result.read_results
         page_results = actual.analyze_result.page_results
 
-        self.assertFormPagesTransformCorrect(recognized_form, read_results, page_results, bug_skip_text_content=True)
+        self.assertFormPagesTransformCorrect(recognized_form, read_results, page_results)
 
         for form, actual in zip(recognized_form, page_results):
             self.assertEqual(form.page_range.first_page_number, actual.page)
             self.assertEqual(form.page_range.last_page_number, actual.page)
-            self.assertUnlabeledFormFieldDictTransformCorrect(form.fields, actual.key_value_pairs, read_results, bug_skip_text_content=True)
+            self.assertUnlabeledFormFieldDictTransformCorrect(form.fields, actual.key_value_pairs, read_results)
 
     @GlobalFormRecognizerAccountPreparer()
     @GlobalTrainingAccountPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/testcase.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/testcase.py
@@ -214,14 +214,14 @@ class FormRecognizerTest(AzureTestCase):
                     read_results
                 )
 
-    def assertUnlabeledFormFieldDictTransformCorrect(self, form_fields, actual_fields, read_results=None, **kwargs):
+    def assertUnlabeledFormFieldDictTransformCorrect(self, form_fields, actual_fields, read_results=None):
         if actual_fields is None:
             return
         for idx, a in enumerate(actual_fields):
             self.assertEqual(a.confidence, form_fields["field-"+str(idx)].confidence if a.confidence is not None else 1.0)
             self.assertEqual(a.key.text, form_fields["field-"+str(idx)].label_data.text)
             self.assertBoundingBoxTransformCorrect(form_fields["field-"+str(idx)].label_data.bounding_box, a.key.bounding_box)
-            if read_results and not kwargs.get("bug_skip_text_content", False):
+            if read_results:
                 self.assertTextContentTransformCorrect(
                     form_fields["field-"+str(idx)].label_data.text_content,
                     a.key.elements,
@@ -229,7 +229,7 @@ class FormRecognizerTest(AzureTestCase):
                 )
             self.assertEqual(a.value.text, form_fields["field-" + str(idx)].value_data.text)
             self.assertBoundingBoxTransformCorrect(form_fields["field-" + str(idx)].value_data.bounding_box, a.value.bounding_box)
-            if read_results and not kwargs.get("bug_skip_text_content", False):
+            if read_results:
                 self.assertTextContentTransformCorrect(
                     form_fields["field-"+str(idx)].value_data.text_content,
                     a.value.elements,
@@ -287,8 +287,7 @@ class FormRecognizerTest(AzureTestCase):
                 self.assertEqual(cell.is_header, actual_cell.is_header if actual_cell.is_header is not None else False)
                 self.assertEqual(cell.is_footer, actual_cell.is_footer if actual_cell.is_footer is not None else False)
                 self.assertBoundingBoxTransformCorrect(cell.bounding_box, actual_cell.bounding_box)
-                if not kwargs.get("bug_skip_text_content", False):
-                    self.assertTextContentTransformCorrect(cell.text_content, actual_cell.elements, read_results)
+                self.assertTextContentTransformCorrect(cell.text_content, actual_cell.elements, read_results)
 
     def assertReceiptItemsHasValues(self, items, page_number, include_text_content):
         for item in items:
@@ -537,7 +536,6 @@ def form_recognizer_account():
         name_prefix='pycog',
         location="westcentralus"
     )
-    time.sleep(60)  # current ask until race condition bug fixed
 
     try:
         rg_name, rg_kwargs = rg_preparer._prepare_create_resource(test_case)
@@ -545,6 +543,8 @@ def form_recognizer_account():
         try:
             form_recognizer_name, form_recognizer_kwargs = form_recognizer_preparer._prepare_create_resource(
                 test_case, **rg_kwargs)
+            if test_case.is_live:
+                time.sleep(60)  # current ask until race condition bug fixed
             FormRecognizerTest._FORM_RECOGNIZER_ACCOUNT = form_recognizer_kwargs['cognitiveservices_account']
             FormRecognizerTest._FORM_RECOGNIZER_KEY = form_recognizer_kwargs['cognitiveservices_account_key']
             FormRecognizerTest._FORM_RECOGNIZER_NAME = form_recognizer_name


### PR DESCRIPTION
Resolves #11014 

This bug was fixed in the latest release of FR so now we can remove the code that worked around it.