### PR TITLE
Disable a line throwing unused-import pylint warning

### DIFF
--- a/sdk/core/azure-core/azure/core/polling/_poller.py
+++ b/sdk/core/azure-core/azure/core/polling/_poller.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 
-from typing import Any, Callable, Union, List, Optional, TypeVar, Generic, Tuple
+from typing import Any, Callable, Union, List, Optional, Tuple, TypeVar, Generic
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.common import with_current_context
 

--- a/sdk/core/azure-core/azure/core/polling/_poller.py
+++ b/sdk/core/azure-core/azure/core/polling/_poller.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 
-from typing import Any, Callable, Union, List, Optional, Tuple, TypeVar, Generic
+from typing import Any, Callable, Union, List, Optional, TypeVar, Generic, Tuple
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.common import with_current_context
 

--- a/sdk/core/azure-core/azure/core/polling/_poller.py
+++ b/sdk/core/azure-core/azure/core/polling/_poller.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 
-from typing import Any, Callable, Union, List, Optional, Tuple, TypeVar, Generic
+from typing import Any, Callable, Union, List, Optional, Tuple, TypeVar, Generic # pylint: disable=unused-import
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.common import with_current_context
 


### PR DESCRIPTION
I currently have 0 idea as to why this fails in CI but not locally.

Checked
- [x] Python versions
- [x] Dependency versions compared to last succeed
- [x] Code Diff from last succeed

[This issue](https://github.com/Azure/azure-sdk-for-python/issues/11967) is filed to follow-up on why this is being thrown. We need to get CI unblocked on such a minor issue though.

EDIT: analyze now passing with the disable. swapping to PR