### PR TITLE
Resolve aggregate-reports relative path errors

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -19,13 +19,13 @@ variables:
 jobs:
 - job: 'ValidateDependencies'
   variables:
-  - template: ./variables/globals.yml
+  - template: ./templates/variables/globals.yml
 
   pool:
     vmImage: 'windows-2019'
 
   steps:
-  - template: ./steps/analyze.yml
+  - template: ./templates/steps/analyze.yml
 
   - task: AzureFileCopy@2
     displayName: 'Upload dependency report'

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -14,17 +14,18 @@ pr: none
 variables:
   Skip.MyPy: true
   Skip.Pylint: true
+  Skip.ApiStubGen: true
 
 jobs:
 - job: 'ValidateDependencies'
   variables:
-  - template: ../variables/globals.yml
+  - template: ./variables/globals.yml
 
   pool:
     vmImage: 'windows-2019'
 
   steps:
-  - template: ../steps/analyze.yml
+  - template: ./steps/analyze.yml
 
   - task: AzureFileCopy@2
     displayName: 'Upload dependency report'


### PR DESCRIPTION
I absolutely [confirmed](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=414186&view=results) that my previous PR to aggregate-reports actually worked.

Unfortunately, due to the fact that it was a PR, the merge commit hid the fact that the relative paths wouldn't work. This PR resolves those.

[Another Test Run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=421270&view=logs&j=0874ffeb-2919-5b4b-20de-16a97970b94c)