### PR TITLE
[ServiceBus] Enable Async Unittest

### DIFF
--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -1103,7 +1103,6 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
                 assert len(messages) == 1
                 await messages[0].complete()
 
-    @pytest.mark.liveTest
     @pytest.mark.asyncio
     async def test_async_queue_mock_no_reusing_auto_lock_renew(self):
         class MockReceivedMessage:

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -1103,6 +1103,8 @@ class ServiceBusQueueAsyncTests(AzureMgmtTestCase):
                 assert len(messages) == 1
                 await messages[0].complete()
 
+    @pytest.mark.liveTest
+    @pytest.mark.asyncio
     async def test_async_queue_mock_no_reusing_auto_lock_renew(self):
         class MockReceivedMessage:
             def __init__(self):


### PR DESCRIPTION
Need to add annotation @pytest.mark.asyncio so that async unit test doesn't get skipped.