### PR TITLE
AzureCliCredential correctly invokes /bin/sh

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
 ## 1.4.0b6 (Unreleased)
-
+- The async `AzureCliCredential` correctly invokes `/bin/sh`
+  ([#12048](https://github.com/Azure/azure-sdk-for-python/issues/12048))
 
 ## 1.4.0b5 (2020-06-12)
 - Prevent an error on importing `AzureCliCredential` on Windows caused by a bug

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -62,7 +62,7 @@ async def _run_command(command):
     if sys.platform.startswith("win"):
         args = ("cmd", "/c " + command)
     else:
-        args = ("/bin/sh", "-c " + command)
+        args = ("/bin/sh", "-c", command)
 
     working_directory = get_safe_working_dir()
 


### PR DESCRIPTION
As detailed in #12048, the async `AzureCliCredential` passes malformed arguments to `/bin/sh`, provoking an exception:
```
azure.core.exceptions.ClientAuthenticationError: /bin/sh: - : invalid option
```