### PR TITLE
Update KeyVaultPreparer with track 2 mgmt changes

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/keyvault_preparer.py
+++ b/tools/azure-sdk-tools/devtools_testutils/keyvault_preparer.py
@@ -103,7 +103,7 @@ class KeyVaultPreparer(AzureMgmtPreparer):
             retries = 4
             for i in range(retries):
                 try:
-                    vault = self.client.vaults.create_or_update(group, name, parameters).result()
+                    vault = self.client.vaults.begin_create_or_update(group, name, parameters).result()
                     break
                 except Exception as ex:
                     if "VaultAlreadyExists" in str(ex):


### PR DESCRIPTION
Key Vault live tests install `azure-mgmt-keyvault` from the master branch. #11484 regenerated that library with a new version of autorest, making some breaking changes.