### PR TITLE
Don't redact Key Vault header values in logs

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release History
 
 ## 4.2.0b2 (Unreleased)
+- Values of `x-ms-keyvault-region` and `x-ms-keyvault-service-version` headers
+  are no longer redacted in logging output.
 - Updated minimum `azure-core` version to 1.4.0
 
 ## 4.2.0b1 (2020-03-10)

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
@@ -27,7 +27,9 @@ if TYPE_CHECKING:
 
 def _get_policies(config, **kwargs):
     logging_policy = HttpLoggingPolicy(**kwargs)
-    logging_policy.allowed_header_names.add("x-ms-keyvault-network-info")
+    logging_policy.allowed_header_names.update(
+        {"x-ms-keyvault-network-info", "x-ms-keyvault-region", "x-ms-keyvault-service-version"}
+    )
 
     return [
         config.headers_policy,

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release History
 
 ## 4.2.0b2 (Unreleased)
+- Values of `x-ms-keyvault-region` and `x-ms-keyvault-service-version` headers
+  are no longer redacted in logging output.
 - Updated minimum `azure-core` version to 1.4.0
 - `CryptographyClient` will no longer perform encrypt or wrap operations when
   its key has expired or is not yet valid.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
@@ -27,7 +27,9 @@ if TYPE_CHECKING:
 
 def _get_policies(config, **kwargs):
     logging_policy = HttpLoggingPolicy(**kwargs)
-    logging_policy.allowed_header_names.add("x-ms-keyvault-network-info")
+    logging_policy.allowed_header_names.update(
+        {"x-ms-keyvault-network-info", "x-ms-keyvault-region", "x-ms-keyvault-service-version"}
+    )
 
     return [
         config.headers_policy,

--- a/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release History
 
 ## 4.2.0b2 (Unreleased)
+- Values of `x-ms-keyvault-region` and `x-ms-keyvault-service-version` headers
+  are no longer redacted in logging output.
 - Updated minimum `azure-core` version to 1.4.0
 
 ## 4.2.0b1 (2020-03-10)

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
@@ -27,7 +27,9 @@ if TYPE_CHECKING:
 
 def _get_policies(config, **kwargs):
     logging_policy = HttpLoggingPolicy(**kwargs)
-    logging_policy.allowed_header_names.add("x-ms-keyvault-network-info")
+    logging_policy.allowed_header_names.update(
+        {"x-ms-keyvault-network-info", "x-ms-keyvault-region", "x-ms-keyvault-service-version"}
+    )
 
     return [
         config.headers_policy,


### PR DESCRIPTION
Key Vault has a couple custom headers whose values we've been unwittingly redacting from logs. This configures `HttpLoggingPolicy` to log their values.