### PR TITLE
Let the transport handles bad urls

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bug fixes
 
 - `AzureKeyCredentialPolicy` will now accept (and ignore) passed in kwargs  #11963
+- Better error messages if passed endpoint is incorrect  #12106
 
 ## 1.6.0 (2020-06-03)
 

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
@@ -730,7 +730,13 @@ class PipelineClientBase(object):
             parsed = urlparse(url)
             if not parsed.scheme or not parsed.netloc:
                 url = url.lstrip("/")
-                base = _format_url_section(self._base_url, **kwargs).rstrip("/")
+                try:
+                    base = self._base_url.format(**kwargs).rstrip("/")
+                except KeyError as key:
+                    raise ValueError(
+                        "The value provided for the url part {} was incorrect, and resulted in an invalid url".format(key.args[0])
+                    )
+
                 url = _urljoin(base, url)
         else:
             url = self._base_url.format(**kwargs)

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
@@ -733,9 +733,8 @@ class PipelineClientBase(object):
                 try:
                     base = self._base_url.format(**kwargs).rstrip("/")
                 except KeyError as key:
-                    raise ValueError(
-                        "The value provided for the url part {} was incorrect, and resulted in an invalid url".format(key.args[0])
-                    )
+                    err_msg = "The value provided for the url part {} was incorrect, and resulted in an invalid url"
+                    raise ValueError(err_msg.format(key.args[0]))
 
                 url = _urljoin(base, url)
         else:

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
@@ -112,6 +112,18 @@ def _case_insensitive_dict(*args, **kwargs):
 
 
 def _format_url_section(template, **kwargs):
+    """String format the template with the kwargs, auto-skip sections of the template that are NOT in the kwargs.
+
+    By default in Python, "format" will raise a KeyError if a template element if not found. Here the section between
+    the slashes will be removed from the template instead.
+
+    This is used for API like Storage, where when Swagger has template section not defined as parameter.
+
+    :param str template: a string template to fill
+    :param dict[str,str] kwargs: Template values as string
+    :rtype: str
+    :returns: Template
+    """
     components = template.split("/")
     while components:
         try:
@@ -718,7 +730,7 @@ class PipelineClientBase(object):
             parsed = urlparse(url)
             if not parsed.scheme or not parsed.netloc:
                 url = url.lstrip("/")
-                base = self._base_url.format(**kwargs).rstrip("/")
+                base = _format_url_section(self._base_url, **kwargs).rstrip("/")
                 url = _urljoin(base, url)
         else:
             url = self._base_url.format(**kwargs)

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
@@ -114,7 +114,7 @@ def _case_insensitive_dict(*args, **kwargs):
 def _format_url_section(template, **kwargs):
     """String format the template with the kwargs, auto-skip sections of the template that are NOT in the kwargs.
 
-    By default in Python, "format" will raise a KeyError if a template element if not found. Here the section between
+    By default in Python, "format" will raise a KeyError if a template element is not found. Here the section between
     the slashes will be removed from the template instead.
 
     This is used for API like Storage, where when Swagger has template section not defined as parameter.
@@ -122,7 +122,7 @@ def _format_url_section(template, **kwargs):
     :param str template: a string template to fill
     :param dict[str,str] kwargs: Template values as string
     :rtype: str
-    :returns: Template
+    :returns: Template completed
     """
     components = template.split("/")
     while components:

--- a/sdk/core/azure-core/tests/test_pipeline.py
+++ b/sdk/core/azure-core/tests/test_pipeline.py
@@ -204,6 +204,12 @@ class TestClientPipelineURLFormatting(unittest.TestCase):
         formatted = client.format_url("https://google.com/subpath/{foo}", foo="bar")
         assert formatted == "https://google.com/subpath/bar"
 
+    def test_format_incorrect_endpoint(self):
+        # https://github.com/Azure/azure-sdk-for-python/pull/12106
+        client = PipelineClientBase('{Endpoint}/text/analytics/v3.0')
+        formatted = client.format_url("foo/bar")
+        # We don't care about the value, we care it doesn't fail
+        assert formatted is not None
 
 class TestClientRequest(unittest.TestCase):
     def test_request_json(self):

--- a/sdk/core/azure-core/tests/test_pipeline.py
+++ b/sdk/core/azure-core/tests/test_pipeline.py
@@ -207,9 +207,9 @@ class TestClientPipelineURLFormatting(unittest.TestCase):
     def test_format_incorrect_endpoint(self):
         # https://github.com/Azure/azure-sdk-for-python/pull/12106
         client = PipelineClientBase('{Endpoint}/text/analytics/v3.0')
-        formatted = client.format_url("foo/bar")
-        # We don't care about the value, we care it doesn't fail
-        assert formatted is not None
+        with pytest.raises(ValueError) as exp:
+            client.format_url("foo/bar")
+        assert str(exp.value) == "The value provided for the url part Endpoint was incorrect, and resulted in an invalid url"
 
 class TestClientRequest(unittest.TestCase):
     def test_request_json(self):


### PR DESCRIPTION
See https://github.com/Azure/azure-sdk-for-python/issues/11048

If a bad combination of parametrized host + incorrect client creation happen, do not crash while trying to build the Url, but build something, and let the transport decides what to do.

For requests, the new trace is now:
```python
  File "c:\users\lmazuel\git\azure-sdk-for-python\sdk\core\azure-core\azure\core\pipeline\transport\_requests_basic.py", line 284, in send
    raise error
azure.core.exceptions.ServiceRequestError: Invalid URL 'text/analytics/v3.0/krpratic-textanalytics.cognitiveservices.azure.com//text/analytics/v3.0/sentiment?showStats=false': No schema supplied. Perhaps you meant http://text/analytics/v3.0/krpratic-textanalytics.cognitiveservices.azure.com//text/analytics/v3.0/sentiment?showStats=false?
```

For aiohttp:
```python
aiohttp.client_exceptions.InvalidURL: text/analytics/v3.0/krpratic-textanalytics.cognitiveservices.azure.com//text/analytics/v3.0/sentiment?showStats=false
```

which is way better than the current error you can see on issue #11048 
```python
File "C:\Users\krpratic\azure-sdk-for-python\env\lib\site-packages\azure\core\pipeline\transport\_base.py", line 695, in format_url
    base = self._base_url.format(**kwargs).rstrip("/")
KeyError: 'Endpoint'
```

EDIT: Will now raise an exception 
>"The value provided for the url part Endpoint was incorrect, and resulted in an invalid url"