### PR TITLE
Remove OSName Variable

### DIFF
--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -7,19 +7,15 @@ jobs:
       ServiceDirectory: eventhub
       Matrix:
         Linux_Python35:
-          OSName: 'Linux'
           OSVmImage: 'ubuntu-18.04'
           PythonVersion: '3.5'
         Linux_Python38:
-          OSName: 'Linux'
           OSVmImage: 'ubuntu-18.04'
           PythonVersion: '3.8'
         Windows_Python27:
-          OSName: 'Windows'
           OSVmImage: 'windows-2019'
           PythonVersion: '2.7'
         MacOs_Python37:
-          OSName: 'MacOS'
           OSVmImage: 'macOS-10.15'
           PythonVersion: '3.7'
       EnvVars:

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -14,18 +14,14 @@ jobs:
         AZURE_TEST_RUN_LIVE: 'true'
       Matrix:
         Linux_Python35:
-          OSName: 'Linux'
           OSVmImage: 'ubuntu-18.04'
           PythonVersion: '3.5'
         MacOs_Python37:
-          OSName: 'MacOS'
           OSVmImage: 'macOS-10.15'
           PythonVersion: '3.7'
         Windows_Python27:
-          OSName: 'Windows'
           OSVmImage: 'windows-2019'
           PythonVersion: '2.7'
         Linux_Python38:
-          OSName: 'Linux'
           OSVmImage: 'ubuntu-18.04'
           PythonVersion: '3.8'


### PR DESCRIPTION
Remove OSName since it is being set [here](https://github.com/Azure/azure-sdk-for-python/blob/4fef4d76774529b6ac03f63b0ec26bb5708e8c84/eng/common/pipelines/templates/steps/verify-agent-os.yml#L36)