### PR TITLE
Fix pip version requirement in build-test.yml

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -26,7 +26,7 @@ steps:
   - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
 
   - script: |
-      python -m pip install pip == 20.1
+      python -m pip install pip==20.1
       pip install -r eng/ci_tools.txt
       pip --version
     displayName: 'Prep Environment'


### PR DESCRIPTION
While debugging Key Vault CI problems, I noticed this script attempts to pin a `pip` version but fails because it uses invalid syntax.