### PR TITLE
Resolve Pip Related Errors

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -1,6 +1,7 @@
 # requirements leveraged by ci tools
 setuptools==44.1.0; python_version == '2.7'
 setuptools==45.1.0; python_version >= '3.5'
+virtualenv==20.0.24
 wheel==0.34.2 
 Jinja2==2.11.1
 packaging==20.4
@@ -30,6 +31,5 @@ pytest-cov==2.8.1
 # local dev packages
 ./tools/azure-devtools
 ./tools/azure-sdk-tools
-
 
 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -26,7 +26,7 @@ steps:
   - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
 
   - script: |
-      python -m pip install pip == 20.1
+      python -m pip install pip==20.1
       pip install -r eng/ci_tools.txt
       pip --version
     displayName: 'Prep Environment'

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -26,6 +26,7 @@ steps:
   - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
 
   - script: |
+      python -m pip install venv
       python -m venv ./env
       ls -l .
       ls -l ./venv

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -29,8 +29,10 @@ steps:
       python -m pip install pip==20.1
       pip install -r eng/ci_tools.txt
       pip --version
-      Get-ChildItem Env:
     displayName: 'Prep Environment'
+
+  - pwsh: |
+      Get-ChildItem Env:
 
   - ${{ parameters.BeforeTestSteps }}
 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -43,7 +43,8 @@ steps:
       $env:VIRTUAL_ENV = "$(Build.SourcesDirectory)/env"
 
       Write-Host 'python ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}"'
-      python ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}"
+      python ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}
+      
     env: ${{ parameters.EnvVars }}
     displayName: 'Run Tests'
 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -42,10 +42,24 @@ steps:
       python -m pip install pip==20.1
       python -m pip install -r eng/ci_tools.txt
       python -m pip --version
-      python ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}
+
+      Write-Host 'python ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}"'
+
+      Write-Host "TEST SESSION BEGINS"
+
+      python ./scripts/devops_tasks/setup_execute_tests.py `
+        "${{ parameters.BuildTargetingString }}" `
+        ${{ parameters.AdditionalTestArgs }} `
+        ${{ parameters.CoverageArg }} `
+        --mark_arg="${{ parameters.TestMarkArgument }}" `
+        --service="${{ parameters.ServiceDirectory }}" `
+        --toxenv="${{ parameters.ToxTestEnv }}" `
+        --injected-packages="${{ parameters.InjectedPackages }}" `
+        ${{ parameters.ToxEnvParallel }}
     env: 
       PYTHON_HOME: ""
       VIRTUAL_ENV: $(Build.SourcesDirectory)/env
+      ${{ insert }}: ${{ parameters.EnvVars }}
     displayName: 'Run Tests'
 
   - ${{ parameters.AfterTestSteps }}

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -26,7 +26,9 @@ steps:
   - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
 
   - script: |
-      python -m venv env
+      python -m venv ./env
+      ls -l .
+      ls -l ./venv
       ./env/scripts/activate
       python -m pip install pip==20.1
       pip install -r eng/ci_tools.txt

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -26,36 +26,23 @@ steps:
   - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
 
   - script: |
-      python -m pip install --upgrade setuptools virtualenv wheel
+      python -m pip install -r eng/ci_tools.txt
       mkdir $(Build.SourcesDirectory)/env
       python -m virtualenv $(Build.SourcesDirectory)/env 
-
     displayName: 'Prep Environment'
-
-  - pwsh: |
-      Get-ChildItem Env:
 
   - ${{ parameters.BeforeTestSteps }}
 
   - pwsh: |
+      # prepend path and install ci requirements
       $env:Path = "$(Build.SourcesDirectory)/env;" + $env:Path
       python -m pip install pip==20.1
       python -m pip install -r eng/ci_tools.txt
       python -m pip --version
 
+      # execute tests
       Write-Host 'python ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}"'
-
-      Write-Host "TEST SESSION BEGINS"
-
-      python ./scripts/devops_tasks/setup_execute_tests.py `
-        "${{ parameters.BuildTargetingString }}" `
-        ${{ parameters.AdditionalTestArgs }} `
-        ${{ parameters.CoverageArg }} `
-        --mark_arg="${{ parameters.TestMarkArgument }}" `
-        --service="${{ parameters.ServiceDirectory }}" `
-        --toxenv="${{ parameters.ToxTestEnv }}" `
-        --injected-packages="${{ parameters.InjectedPackages }}" `
-        ${{ parameters.ToxEnvParallel }}
+      python ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}"
     env: 
       PYTHON_HOME: ""
       VIRTUAL_ENV: $(Build.SourcesDirectory)/env

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -29,6 +29,7 @@ steps:
       python -m pip install pip==20.1
       pip install -r eng/ci_tools.txt
       pip --version
+      Get-ChildItem Env:
     displayName: 'Prep Environment'
 
   - ${{ parameters.BeforeTestSteps }}

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -34,13 +34,11 @@ steps:
   - ${{ parameters.BeforeTestSteps }}
 
   - pwsh: |
-      # prepend path and install ci requirements
       $env:Path = "$(Build.SourcesDirectory)/env;" + $env:Path
       python -m pip install pip==20.1
       python -m pip install -r eng/ci_tools.txt
       python -m pip --version
 
-      # execute tests
       Write-Host 'python ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}"'
       python ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}"
     env: 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -39,12 +39,12 @@ steps:
       python -m pip install -r eng/ci_tools.txt
       python -m pip --version
 
+      $env:PYTHON_HOME = ""
+      $env:VIRTUAL_ENV = "$(Build.SourcesDirectory)/env"
+
       Write-Host 'python ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}"'
       python ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}"
-    env: 
-      PYTHON_HOME: ""
-      VIRTUAL_ENV: "$(Build.SourcesDirectory)/env"
-      ${{ insert }}: ${{ parameters.EnvVars }}
+    env: ${{ parameters.EnvVars }}
     displayName: 'Run Tests'
 
   - ${{ parameters.AfterTestSteps }}

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -26,6 +26,8 @@ steps:
   - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
 
   - script: |
+      python -m venv env
+      ./env/scripts/activate
       python -m pip install pip==20.1
       pip install -r eng/ci_tools.txt
       pip --version
@@ -36,20 +38,11 @@ steps:
 
   - ${{ parameters.BeforeTestSteps }}
 
-  - task: PythonScript@0
-    displayName: 'Run Tests'
-    inputs:
-      scriptPath: 'scripts/devops_tasks/setup_execute_tests.py'
-      arguments: >-
-        "${{ parameters.BuildTargetingString }}"
-        ${{ parameters.AdditionalTestArgs }}
-        ${{ parameters.CoverageArg }}
-        --mark_arg="${{ parameters.TestMarkArgument }}"
-        --service="${{ parameters.ServiceDirectory }}"
-        --toxenv="${{ parameters.ToxTestEnv }}"
-        --injected-packages="${{ parameters.InjectedPackages }}"
-        ${{ parameters.ToxEnvParallel }}
+  - pwsh: |
+      ./env/scripts/activate
+      ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}
     env: ${{ parameters.EnvVars }}
+    displayName: 'Run Tests'
 
   - ${{ parameters.AfterTestSteps }}
 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -26,14 +26,10 @@ steps:
   - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
 
   - script: |
-      python -m pip install venv
-      python -m venv ./env
-      ls -l .
-      ls -l ./venv
-      ./env/scripts/activate
-      python -m pip install pip==20.1
-      pip install -r eng/ci_tools.txt
-      pip --version
+      python -m pip install --upgrade setuptools virtualenv wheel
+      mkdir $(Build.SourcesDirectory)/env
+      python -m virtualenv $(Build.SourcesDirectory)/env 
+
     displayName: 'Prep Environment'
 
   - pwsh: |
@@ -42,9 +38,14 @@ steps:
   - ${{ parameters.BeforeTestSteps }}
 
   - pwsh: |
-      ./env/scripts/activate
-      ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}
-    env: ${{ parameters.EnvVars }}
+      $env:Path = "$(Build.SourcesDirectory)/env;" + $env:Path
+      python -m pip install pip==20.1
+      python -m pip install -r eng/ci_tools.txt
+      python -m pip --version
+      python ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}
+    env: 
+      PYTHON_HOME: ""
+      VIRTUAL_ENV: $(Build.SourcesDirectory)/env
     displayName: 'Run Tests'
 
   - ${{ parameters.AfterTestSteps }}

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -43,7 +43,7 @@ steps:
       python ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}"
     env: 
       PYTHON_HOME: ""
-      VIRTUAL_ENV: $(Build.SourcesDirectory)/env
+      VIRTUAL_ENV: "$(Build.SourcesDirectory)/env"
       ${{ insert }}: ${{ parameters.EnvVars }}
     displayName: 'Run Tests'
 

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -25,6 +25,8 @@ ignore_args=--ignore=.tox --ignore=build --ignore=.eggs
 default_pytest_params = --junitxml={toxinidir}/test-junit-{envname}.xml --verbose --durations=10 --ignore=azure {[testenv]ignore_args}
 parallel_show_output =True
 pre-deps =
+  setuptools==44.1.0; python_version == '2.7'
+  setuptools==45.1.0; python_version >= '3.5'
   wheel
 skip_install = true
 skipsdist = true

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -25,8 +25,6 @@ ignore_args=--ignore=.tox --ignore=build --ignore=.eggs
 default_pytest_params = --junitxml={toxinidir}/test-junit-{envname}.xml --verbose --durations=10 --ignore=azure {[testenv]ignore_args}
 parallel_show_output =True
 pre-deps =
-  setuptools==44.1.0; python_version == '2.7'
-  setuptools==45.1.0; python_version >= '3.5'
   wheel
 skip_install = true
 skipsdist = true


### PR DESCRIPTION
I don't fully understand why the current storm of build errors is occurring.  However, based on some inferences from mike's repros, we know it has something to do with the global python install.

- There has not been agent updates 
   - Agent Versions and Task Versions between success and failing are the same
- The installed dependencies have not changed (seriously I diffed the `pip freeze` results)

This PR addresses the bulk of the errors, specifically the inability to access some `pip` private components. My thoughts are that there are permission issues with the globalally installed `pip` folder.

I'm still seeing some issues with STDIO not closing on windows, but that is a different error that I will address in a further PR. 

@iscai-msft 
@lmazuel 
@mikeharder 
@Azure/azure-sdk-eng 