### PR TITLE
Revert "Resolve Pip Related Errors (#12157)", Pin VirtualEnv

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -1,7 +1,6 @@
 # requirements leveraged by ci tools
 setuptools==44.1.0; python_version == '2.7'
 setuptools==45.1.0; python_version >= '3.5'
-virtualenv==20.0.24
 wheel==0.34.2 
 Jinja2==2.11.1
 packaging==20.4
@@ -31,5 +30,6 @@ pytest-cov==2.8.1
 # local dev packages
 ./tools/azure-devtools
 ./tools/azure-sdk-tools
+
 
 

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -1,6 +1,7 @@
 # requirements leveraged by ci tools
 setuptools==44.1.0; python_version == '2.7'
 setuptools==45.1.0; python_version >= '3.5'
+virtualenv==20.0.23
 wheel==0.34.2 
 Jinja2==2.11.1
 packaging==20.4

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -26,27 +26,27 @@ steps:
   - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
 
   - script: |
-      python -m pip install -r eng/ci_tools.txt
-      mkdir $(Build.SourcesDirectory)/env
-      python -m virtualenv $(Build.SourcesDirectory)/env 
+      python -m pip install pip == 20.1
+      pip install -r eng/ci_tools.txt
+      pip --version
     displayName: 'Prep Environment'
 
   - ${{ parameters.BeforeTestSteps }}
 
-  - pwsh: |
-      $env:Path = "$(Build.SourcesDirectory)/env;" + $env:Path
-      python -m pip install pip==20.1
-      python -m pip install -r eng/ci_tools.txt
-      python -m pip --version
-
-      $env:PYTHON_HOME = ""
-      $env:VIRTUAL_ENV = "$(Build.SourcesDirectory)/env"
-
-      Write-Host 'python ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}"'
-      python ./scripts/devops_tasks/setup_execute_tests.py "${{ parameters.BuildTargetingString }}" ${{ parameters.AdditionalTestArgs }} ${{ parameters.CoverageArg }} --mark_arg="${{ parameters.TestMarkArgument }}" --service="${{ parameters.ServiceDirectory }}" --toxenv="${{ parameters.ToxTestEnv }}" --injected-packages="${{ parameters.InjectedPackages }}" ${{ parameters.ToxEnvParallel }}
-      
-    env: ${{ parameters.EnvVars }}
+  - task: PythonScript@0
     displayName: 'Run Tests'
+    inputs:
+      scriptPath: 'scripts/devops_tasks/setup_execute_tests.py'
+      arguments: >-
+        "${{ parameters.BuildTargetingString }}"
+        ${{ parameters.AdditionalTestArgs }}
+        ${{ parameters.CoverageArg }}
+        --mark_arg="${{ parameters.TestMarkArgument }}"
+        --service="${{ parameters.ServiceDirectory }}"
+        --toxenv="${{ parameters.ToxTestEnv }}"
+        --injected-packages="${{ parameters.InjectedPackages }}"
+        ${{ parameters.ToxEnvParallel }}
+    env: ${{ parameters.EnvVars }}
 
   - ${{ parameters.AfterTestSteps }}
 


### PR DESCRIPTION
This reverts commit c5ca969e5ffa4dbd5d91dfa646fb3fc29b29adc2.

Essentially, a  new version of `virtualenv` (because tox has a dep on it) was added. the behavior of this bug was accidentally bypassed with the commit that this PR reverts.

Essentially, we create multiple environments in parallel. `virtualenv` released a new package yesterday morning that REGRESSED some behavior here. They released a new patch TODAY that adds a lock to avoid these weird errors!

https://virtualenv.pypa.io/en/latest/changelog.html

In a follow-up PR, I will run `pip freeze` PRIOR to invoking `tox`. None of the deps WITHIN the tox environments changed. `virtualenv` is OUTSIDE the tox environments. 
