### PR TITLE
SharedTokenCacheCredential lazily loads the cache

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -55,6 +55,9 @@ class SharedTokenCacheCredential(SharedTokenCacheBase):
         if not scopes:
             raise ValueError("'get_token' requires at least one scope")
 
+        if not self._initialized:
+            self._initialize()
+
         if not self._client:
             raise CredentialUnavailableError(message="Shared token cache unavailable")
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import abc
+import platform
 import time
 
 from msal import TokenCache
@@ -236,12 +237,4 @@ class SharedTokenCacheBase(ABC):
 
         :rtype: bool
         """
-        try:
-            load_user_cache(allow_unencrypted=False)
-        except NotImplementedError:
-            return False
-        except ValueError:
-            # cache is supported but can't be encrypted
-            pass
-
-        return True
+        return platform.system() in {"Darwin", "Linux", "Windows"}

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -114,8 +114,11 @@ class SharedTokenCacheBase(ABC):
         self._initialized = False
 
     def _initialize(self):
+        if self._initialized:
+            return
+
         if not self._cache and self.supported():
-            allow_unencrypted = self._client_kwargs.pop("allow_unencrypted_cache", False)
+            allow_unencrypted = self._client_kwargs.get("allow_unencrypted_cache", False)
             try:
                 self._cache = load_user_cache(allow_unencrypted)
             except Exception:  # pylint:disable=broad-except

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -108,20 +108,26 @@ class SharedTokenCacheBase(ABC):
             self._tenant_id = kwargs.pop("tenant_id", None)
 
         self._cache = kwargs.pop("_cache", None)
-        if not self._cache:
-            allow_unencrypted = kwargs.pop("allow_unencrypted_cache", False)
+        self._client = None  # type: Optional[AadClientBase]
+        self._client_kwargs = kwargs
+        self._client_kwargs["tenant_id"] = authenticating_tenant
+        self._initialized = False
+
+    def _initialize(self):
+        if self._initialized:
+            return
+
+        if not self._cache and self.supported():
+            allow_unencrypted = self._client_kwargs.pop("allow_unencrypted_cache", False)
             try:
                 self._cache = load_user_cache(allow_unencrypted)
             except Exception:  # pylint:disable=broad-except
                 pass
 
         if self._cache:
-            self._client = self._get_auth_client(
-                authority=self._authority, cache=self._cache, tenant_id=authenticating_tenant, **kwargs
-            )  # type: Optional[AadClientBase]
-        else:
-            # couldn't load the cache -> credential will be unavailable
-            self._client = None
+            self._client = self._get_auth_client(authority=self._authority, cache=self._cache, **self._client_kwargs)
+
+        self._initialized = True
 
     @abc.abstractmethod
     def _get_auth_client(self, **kwargs):

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -114,9 +114,6 @@ class SharedTokenCacheBase(ABC):
         self._initialized = False
 
     def _initialize(self):
-        if self._initialized:
-            return
-
         if not self._cache and self.supported():
             allow_unencrypted = self._client_kwargs.pop("allow_unencrypted_cache", False)
             try:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
@@ -63,6 +63,9 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncCredentialBase):
         if not scopes:
             raise ValueError("'get_token' requires at least one scope")
 
+        if not self._initialized:
+            self._initialize()
+
         if not self._client:
             raise CredentialUnavailableError(message="Shared token cache unavailable")
 


### PR DESCRIPTION
When we try to load the persistent cache on Linux and PyGObject isn't available, `msal-extensions` logs an error message. The message is only relevant to someone who wants to use the encrypted shared cache. However, because `SharedTokenCacheCredential.__init__()` and `.supported()` attempt to load the cache, `DefaultAzureCredential()` does as well. Many users will therefore see an alarming irrelevant log message (see #12152). This PR limits the alarm by having `SharedTokenCacheCredential` attempt to load the cache only when `get_token` is called for the first time.