### PR TITLE
[formrecognizer] arch board feedback renames

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - Remove `RecognizedReceipts` Class.
 - `begin_recognize_receipts` and `begin_recognize_receipts_from_url` now return `RecognizedForm`.
+- `requested_on` renamed to `training_started_on` and `completed_on` renamed to `training_completed_on` on `CustomFormModel`
+and `CustomFormModelInfo`
 
 ## 1.0.0b3 (2020-06-10)
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/README.md
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/README.md
@@ -260,8 +260,8 @@ model = poller.result()
 # Custom model information
 print("Model ID: {}".format(model.model_id))
 print("Status: {}".format(model.status))
-print("Requested on: {}".format(model.requested_on))
-print("Completed on: {}".format(model.completed_on))
+print("Training started on: {}".format(model.training_started_on))
+print("Training completed on: {}".format(model.training_completed_on))
 
 print("Recognized fields:")
 # looping through the submodels, which contains the fields they were trained on
@@ -309,8 +309,8 @@ model_id = "<model id from the Train a Model sample>"
 custom_model = form_training_client.get_custom_model(model_id=model_id)
 print("Model ID: {}".format(custom_model.model_id))
 print("Status: {}".format(custom_model.status))
-print("Requested on: {}".format(custom_model.requested_on))
-print("Completed on: {}".format(custom_model.completed_on))
+print("Training started on: {}".format(custom_model.training_started_on))
+print("Training completed on: {}".format(custom_model.training_completed_on))
 
 # Finally, we will delete this model by ID
 form_training_client.delete_model(model_id=custom_model.model_id)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
@@ -517,9 +517,9 @@ class CustomFormModel(object):
         Status indicating the model's readiness for use,
         :class:`~azure.ai.formrecognizer.CustomFormModelStatus`.
         Possible values include: 'creating', 'ready', 'invalid'.
-    :ivar ~datetime.datetime requested_on:
+    :ivar ~datetime.datetime training_started_on:
         The date and time (UTC) when model training was requested.
-    :ivar ~datetime.datetime completed_on:
+    :ivar ~datetime.datetime training_completed_on:
         Date and time (UTC) when model training completed.
     :ivar list[~azure.ai.formrecognizer.CustomFormSubmodel] submodels:
         A list of submodels that are part of this model, each of
@@ -533,8 +533,8 @@ class CustomFormModel(object):
     def __init__(self, **kwargs):
         self.model_id = kwargs.get("model_id", None)
         self.status = kwargs.get("status", None)
-        self.requested_on = kwargs.get("requested_on", None)
-        self.completed_on = kwargs.get("completed_on", None)
+        self.training_started_on = kwargs.get("training_started_on", None)
+        self.training_completed_on = kwargs.get("training_completed_on", None)
         self.submodels = kwargs.get("submodels", None)
         self.errors = kwargs.get("errors", None)
         self.training_documents = kwargs.get("training_documents", [])
@@ -544,8 +544,8 @@ class CustomFormModel(object):
         return cls(
             model_id=model.model_info.model_id,
             status=model.model_info.status,
-            requested_on=model.model_info.created_date_time,
-            completed_on=model.model_info.last_updated_date_time,
+            training_started_on=model.model_info.created_date_time,
+            training_completed_on=model.model_info.last_updated_date_time,
             submodels=CustomFormSubmodel._from_generated_unlabeled(model)
             if model.keys else CustomFormSubmodel._from_generated_labeled(model),
             errors=FormRecognizerError._from_generated(model.train_result.errors) if model.train_result else None,
@@ -554,11 +554,10 @@ class CustomFormModel(object):
         )
 
     def __repr__(self):
-        return "CustomFormModel(model_id={}, status={}, requested_on={}, completed_on={}, submodels={}, " \
-                "errors={}, training_documents={})".format(
-                    self.model_id, self.status, self.requested_on, self.completed_on, repr(self.submodels),
-                    repr(self.errors), repr(self.training_documents)
-                )[:1024]
+        return "CustomFormModel(model_id={}, status={}, training_started_on={}, training_completed_on={}, " \
+               "submodels={}, errors={}, training_documents={})".format(
+                    self.model_id, self.status, self.training_started_on, self.training_completed_on,
+                    repr(self.submodels), repr(self.errors), repr(self.training_documents))[:1024]
 
 
 class CustomFormSubmodel(object):
@@ -698,17 +697,17 @@ class CustomFormModelInfo(object):
     :ivar str status:
         The status of the model, :class:`~azure.ai.formrecognizer.CustomFormModelStatus`.
         Possible values include: 'creating', 'ready', 'invalid'.
-    :ivar ~datetime.datetime requested_on:
+    :ivar ~datetime.datetime training_started_on:
         Date and time (UTC) when model training was requested.
-    :ivar ~datetime.datetime completed_on:
+    :ivar ~datetime.datetime training_completed_on:
         Date and time (UTC) when model training completed.
     """
 
     def __init__(self, **kwargs):
         self.model_id = kwargs.get("model_id", None)
         self.status = kwargs.get("status", None)
-        self.requested_on = kwargs.get("requested_on", None)
-        self.completed_on = kwargs.get("completed_on", None)
+        self.training_started_on = kwargs.get("training_started_on", None)
+        self.training_completed_on = kwargs.get("training_completed_on", None)
 
     @classmethod
     def _from_generated(cls, model, model_id=None):
@@ -717,13 +716,13 @@ class CustomFormModelInfo(object):
         return cls(
             model_id=model_id if model_id else model.model_id,
             status=model.status,
-            requested_on=model.created_date_time,
-            completed_on=model.last_updated_date_time
+            training_started_on=model.created_date_time,
+            training_completed_on=model.last_updated_date_time
         )
 
     def __repr__(self):
-        return "CustomFormModelInfo(model_id={}, status={}, requested_on={}, completed_on={})".format(
-            self.model_id, self.status, self.requested_on, self.completed_on
+        return "CustomFormModelInfo(model_id={}, status={}, training_started_on={}, training_completed_on={})".format(
+            self.model_id, self.status, self.training_started_on, self.training_completed_on
         )[:1024]
 
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
@@ -518,7 +518,7 @@ class CustomFormModel(object):
         :class:`~azure.ai.formrecognizer.CustomFormModelStatus`.
         Possible values include: 'creating', 'ready', 'invalid'.
     :ivar ~datetime.datetime training_started_on:
-        The date and time (UTC) when model training was requested.
+        The date and time (UTC) when model training was started.
     :ivar ~datetime.datetime training_completed_on:
         Date and time (UTC) when model training completed.
     :ivar list[~azure.ai.formrecognizer.CustomFormSubmodel] submodels:
@@ -698,7 +698,7 @@ class CustomFormModelInfo(object):
         The status of the model, :class:`~azure.ai.formrecognizer.CustomFormModelStatus`.
         Possible values include: 'creating', 'ready', 'invalid'.
     :ivar ~datetime.datetime training_started_on:
-        Date and time (UTC) when model training was requested.
+        Date and time (UTC) when model training was started.
     :ivar ~datetime.datetime training_completed_on:
         Date and time (UTC) when model training completed.
     """

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_manage_custom_models_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_manage_custom_models_async.py
@@ -65,8 +65,8 @@ class ManageCustomModelsSampleAsync(object):
             custom_model = await form_training_client.get_custom_model(model_id=first_model.model_id)
             print("Model ID: {}".format(custom_model.model_id))
             print("Status: {}".format(custom_model.status))
-            print("Requested on: {}".format(custom_model.requested_on))
-            print("Completed on: {}".format(custom_model.completed_on))
+            print("Training started on: {}".format(custom_model.training_started_on))
+            print("Training completed on: {}".format(custom_model.training_completed_on))
             # [END get_custom_model_async]
 
             # Finally, we will delete this model by ID

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_train_model_with_labels_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_train_model_with_labels_async.py
@@ -51,8 +51,8 @@ class TrainModelWithLabelsSampleAsync(object):
             # Custom model information
             print("Model ID: {}".format(model.model_id))
             print("Status: {}".format(model.status))
-            print("Requested on: {}".format(model.requested_on))
-            print("Completed on: {}".format(model.completed_on))
+            print("Training started on: {}".format(model.training_started_on))
+            print("Training completed on: {}".format(model.training_completed_on))
 
             print("Recognized fields:")
             # looping through the submodels, which contains the fields they were trained on

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_train_model_without_labels_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_train_model_without_labels_async.py
@@ -48,8 +48,8 @@ class TrainModelWithoutLabelsSampleAsync(object):
             # Custom model information
             print("Model ID: {}".format(model.model_id))
             print("Status: {}".format(model.status))
-            print("Requested on: {}".format(model.requested_on))
-            print("Completed on: {}".format(model.completed_on))
+            print("Training started on: {}".format(model.training_started_on))
+            print("Training completed on: {}".format(model.training_completed_on))
 
             print("Recognized fields:")
             # Looping through the submodels, which contains the fields they were trained on

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_manage_custom_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_manage_custom_models.py
@@ -61,8 +61,8 @@ class ManageCustomModelsSample(object):
         custom_model = form_training_client.get_custom_model(model_id=first_model.model_id)
         print("Model ID: {}".format(custom_model.model_id))
         print("Status: {}".format(custom_model.status))
-        print("Requested on: {}".format(custom_model.requested_on))
-        print("Completed on: {}".format(custom_model.completed_on))
+        print("Training started on: {}".format(custom_model.training_started_on))
+        print("Training completed on: {}".format(custom_model.training_completed_on))
         # [END get_custom_model]
 
         # Finally, we will delete this model by ID

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_train_model_with_labels.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_train_model_with_labels.py
@@ -46,8 +46,8 @@ class TrainModelWithLabelsSample(object):
         # Custom model information
         print("Model ID: {}".format(model.model_id))
         print("Status: {}".format(model.status))
-        print("Requested on: {}".format(model.requested_on))
-        print("Completed on: {}".format(model.completed_on))
+        print("Training started on: {}".format(model.training_started_on))
+        print("Training completed on: {}".format(model.training_completed_on))
 
         print("Recognized fields:")
         # looping through the submodels, which contains the fields they were trained on

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_train_model_without_labels.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_train_model_without_labels.py
@@ -44,8 +44,8 @@ class TrainModelWithoutLabelsSample(object):
         # Custom model information
         print("Model ID: {}".format(model.model_id))
         print("Status: {}".format(model.status))
-        print("Requested on: {}".format(model.requested_on))
-        print("Completed on: {}".format(model.completed_on))
+        print("Training started on: {}".format(model.training_started_on))
+        print("Training completed on: {}".format(model.training_completed_on))
 
         print("Recognized fields:")
         # Looping through the submodels, which contains the fields they were trained on

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_copy_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_copy_model.py
@@ -46,8 +46,8 @@ class TestCopyModel(FormRecognizerTest):
         copied_model = client.get_custom_model(copy.model_id)
 
         self.assertEqual(copy.status, "ready")
-        self.assertIsNotNone(copy.requested_on)
-        self.assertIsNotNone(copy.completed_on)
+        self.assertIsNotNone(copy.training_started_on)
+        self.assertIsNotNone(copy.training_completed_on)
         self.assertEqual(target["modelId"], copy.model_id)
         self.assertNotEqual(target["modelId"], model.model_id)
         self.assertIsNotNone(copied_model)
@@ -103,9 +103,9 @@ class TestCopyModel(FormRecognizerTest):
 
         actual = raw_response[0]
         copy = raw_response[1]
-        self.assertEqual(copy.requested_on, actual.created_date_time)
+        self.assertEqual(copy.training_started_on, actual.created_date_time)
         self.assertEqual(copy.status, actual.status)
-        self.assertEqual(copy.completed_on, actual.last_updated_date_time)
+        self.assertEqual(copy.training_completed_on, actual.last_updated_date_time)
         self.assertEqual(copy.model_id, target["modelId"])
 
     @GlobalFormRecognizerAccountPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_copy_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_copy_model_async.py
@@ -47,8 +47,8 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
         copied_model = await client.get_custom_model(copy.model_id)
 
         self.assertEqual(copy.status, "ready")
-        self.assertIsNotNone(copy.requested_on)
-        self.assertIsNotNone(copy.completed_on)
+        self.assertIsNotNone(copy.training_started_on)
+        self.assertIsNotNone(copy.training_completed_on)
         self.assertEqual(target["modelId"], copy.model_id)
         self.assertNotEqual(target["modelId"], model.model_id)
         self.assertIsNotNone(copied_model)
@@ -104,9 +104,9 @@ class TestCopyModelAsync(AsyncFormRecognizerTest):
 
         actual = raw_response[0]
         copy = raw_response[1]
-        self.assertEqual(copy.requested_on, actual.created_date_time)
+        self.assertEqual(copy.training_started_on, actual.created_date_time)
         self.assertEqual(copy.status, actual.status)
-        self.assertEqual(copy.completed_on, actual.last_updated_date_time)
+        self.assertEqual(copy.training_completed_on, actual.last_updated_date_time)
         self.assertEqual(copy.model_id, target["modelId"])
 
     @GlobalFormRecognizerAccountPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_mgmt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_mgmt.py
@@ -87,8 +87,8 @@ class TestManagement(FormRecognizerTest):
 
         self.assertEqual(labeled_model_from_train.model_id, labeled_model_from_get.model_id)
         self.assertEqual(labeled_model_from_train.status, labeled_model_from_get.status)
-        self.assertEqual(labeled_model_from_train.requested_on, labeled_model_from_get.requested_on)
-        self.assertEqual(labeled_model_from_train.completed_on, labeled_model_from_get.completed_on)
+        self.assertEqual(labeled_model_from_train.training_started_on, labeled_model_from_get.training_started_on)
+        self.assertEqual(labeled_model_from_train.training_completed_on, labeled_model_from_get.training_completed_on)
         self.assertEqual(labeled_model_from_train.errors, labeled_model_from_get.errors)
         for a, b in zip(labeled_model_from_train.training_documents, labeled_model_from_get.training_documents):
             self.assertEqual(a.document_name, b.document_name)
@@ -104,8 +104,8 @@ class TestManagement(FormRecognizerTest):
         for model in models_list:
             self.assertIsNotNone(model.model_id)
             self.assertIsNotNone(model.status)
-            self.assertIsNotNone(model.requested_on)
-            self.assertIsNotNone(model.completed_on)
+            self.assertIsNotNone(model.training_started_on)
+            self.assertIsNotNone(model.training_completed_on)
 
         client.delete_model(labeled_model_from_train.model_id)
 
@@ -123,8 +123,8 @@ class TestManagement(FormRecognizerTest):
 
         self.assertEqual(unlabeled_model_from_train.model_id, unlabeled_model_from_get.model_id)
         self.assertEqual(unlabeled_model_from_train.status, unlabeled_model_from_get.status)
-        self.assertEqual(unlabeled_model_from_train.requested_on, unlabeled_model_from_get.requested_on)
-        self.assertEqual(unlabeled_model_from_train.completed_on, unlabeled_model_from_get.completed_on)
+        self.assertEqual(unlabeled_model_from_train.training_started_on, unlabeled_model_from_get.training_started_on)
+        self.assertEqual(unlabeled_model_from_train.training_completed_on, unlabeled_model_from_get.training_completed_on)
         self.assertEqual(unlabeled_model_from_train.errors, unlabeled_model_from_get.errors)
         for a, b in zip(unlabeled_model_from_train.training_documents, unlabeled_model_from_get.training_documents):
             self.assertEqual(a.document_name, b.document_name)
@@ -139,8 +139,8 @@ class TestManagement(FormRecognizerTest):
         for model in models_list:
             self.assertIsNotNone(model.model_id)
             self.assertIsNotNone(model.status)
-            self.assertIsNotNone(model.requested_on)
-            self.assertIsNotNone(model.completed_on)
+            self.assertIsNotNone(model.training_started_on)
+            self.assertIsNotNone(model.training_completed_on)
 
         client.delete_model(unlabeled_model_from_train.model_id)
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_mgmt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_mgmt_async.py
@@ -97,8 +97,8 @@ class TestManagementAsync(AsyncFormRecognizerTest):
 
         self.assertEqual(labeled_model_from_train.model_id, labeled_model_from_get.model_id)
         self.assertEqual(labeled_model_from_train.status, labeled_model_from_get.status)
-        self.assertEqual(labeled_model_from_train.requested_on, labeled_model_from_get.requested_on)
-        self.assertEqual(labeled_model_from_train.completed_on, labeled_model_from_get.completed_on)
+        self.assertEqual(labeled_model_from_train.training_started_on, labeled_model_from_get.training_started_on)
+        self.assertEqual(labeled_model_from_train.training_completed_on, labeled_model_from_get.training_completed_on)
         self.assertEqual(labeled_model_from_train.errors, labeled_model_from_get.errors)
         for a, b in zip(labeled_model_from_train.training_documents, labeled_model_from_get.training_documents):
             self.assertEqual(a.document_name, b.document_name)
@@ -114,8 +114,8 @@ class TestManagementAsync(AsyncFormRecognizerTest):
         async for model in models_list:
             self.assertIsNotNone(model.model_id)
             self.assertIsNotNone(model.status)
-            self.assertIsNotNone(model.requested_on)
-            self.assertIsNotNone(model.completed_on)
+            self.assertIsNotNone(model.training_started_on)
+            self.assertIsNotNone(model.training_completed_on)
 
         await client.delete_model(labeled_model_from_train.model_id)
 
@@ -131,8 +131,8 @@ class TestManagementAsync(AsyncFormRecognizerTest):
 
         self.assertEqual(unlabeled_model_from_train.model_id, unlabeled_model_from_get.model_id)
         self.assertEqual(unlabeled_model_from_train.status, unlabeled_model_from_get.status)
-        self.assertEqual(unlabeled_model_from_train.requested_on, unlabeled_model_from_get.requested_on)
-        self.assertEqual(unlabeled_model_from_train.completed_on, unlabeled_model_from_get.completed_on)
+        self.assertEqual(unlabeled_model_from_train.training_started_on, unlabeled_model_from_get.training_started_on)
+        self.assertEqual(unlabeled_model_from_train.training_completed_on, unlabeled_model_from_get.training_completed_on)
         self.assertEqual(unlabeled_model_from_train.errors, unlabeled_model_from_get.errors)
         for a, b in zip(unlabeled_model_from_train.training_documents, unlabeled_model_from_get.training_documents):
             self.assertEqual(a.document_name, b.document_name)
@@ -147,8 +147,8 @@ class TestManagementAsync(AsyncFormRecognizerTest):
         async for model in models_list:
             self.assertIsNotNone(model.model_id)
             self.assertIsNotNone(model.status)
-            self.assertIsNotNone(model.requested_on)
-            self.assertIsNotNone(model.completed_on)
+            self.assertIsNotNone(model.training_started_on)
+            self.assertIsNotNone(model.training_completed_on)
 
         await client.delete_model(unlabeled_model_from_train.model_id)
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_repr.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_repr.py
@@ -138,15 +138,15 @@ class TestRepr():
         model = _models.CustomFormModel(
             model_id=1,
             status=_models.CustomFormModelStatus.creating,
-            requested_on=datetime.datetime(1, 1, 1),
-            completed_on=datetime.datetime(1, 1, 1),
+            training_started_on=datetime.datetime(1, 1, 1),
+            training_completed_on=datetime.datetime(1, 1, 1),
             submodels=[custom_form_sub_model[0], custom_form_sub_model[0]],
             errors=[form_recognizer_error[0]],
             training_documents=[training_document_info[0], training_document_info[0]]
         )
 
-        model_repr = "CustomFormModel(model_id=1, status=creating, requested_on=0001-01-01 00:00:00, " \
-            "completed_on=0001-01-01 00:00:00, submodels=[{}, {}], errors=[{}], training_documents=[{}, {}])".format(
+        model_repr = "CustomFormModel(model_id=1, status=creating, training_started_on=0001-01-01 00:00:00, " \
+            "training_completed_on=0001-01-01 00:00:00, submodels=[{}, {}], errors=[{}], training_documents=[{}, {}])".format(
                 custom_form_sub_model[1], custom_form_sub_model[1], form_recognizer_error[1], training_document_info[1], training_document_info[1]
             )[:1024]
 
@@ -154,9 +154,9 @@ class TestRepr():
 
     def test_custom_form_model_info(self):
         model = _models.CustomFormModelInfo(
-            model_id=1, status=_models.CustomFormModelStatus.ready, requested_on=datetime.datetime(1, 1, 1), completed_on=datetime.datetime(1, 1, 1)
+            model_id=1, status=_models.CustomFormModelStatus.ready, training_started_on=datetime.datetime(1, 1, 1), training_completed_on=datetime.datetime(1, 1, 1)
         )
-        model_repr = "CustomFormModelInfo(model_id=1, status=ready, requested_on=0001-01-01 00:00:00, completed_on=0001-01-01 00:00:00)"[:1024]
+        model_repr = "CustomFormModelInfo(model_id=1, status=ready, training_started_on=0001-01-01 00:00:00, training_completed_on=0001-01-01 00:00:00)"[:1024]
         assert repr(model) == model_repr
 
     def test_account_properties(self):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_training.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_training.py
@@ -61,8 +61,8 @@ class TestTraining(FormRecognizerTest):
         model = poller.result()
 
         self.assertIsNotNone(model.model_id)
-        self.assertIsNotNone(model.requested_on)
-        self.assertIsNotNone(model.completed_on)
+        self.assertIsNotNone(model.training_started_on)
+        self.assertIsNotNone(model.training_completed_on)
         self.assertEqual(model.errors, [])
         self.assertEqual(model.status, "ready")
         for doc in model.training_documents:
@@ -84,8 +84,8 @@ class TestTraining(FormRecognizerTest):
         model = poller.result()
 
         self.assertIsNotNone(model.model_id)
-        self.assertIsNotNone(model.requested_on)
-        self.assertIsNotNone(model.completed_on)
+        self.assertIsNotNone(model.training_started_on)
+        self.assertIsNotNone(model.training_completed_on)
         self.assertEqual(model.errors, [])
         self.assertEqual(model.status, "ready")
         for doc in model.training_documents:
@@ -145,8 +145,8 @@ class TestTraining(FormRecognizerTest):
         model = poller.result()
 
         self.assertIsNotNone(model.model_id)
-        self.assertIsNotNone(model.requested_on)
-        self.assertIsNotNone(model.completed_on)
+        self.assertIsNotNone(model.training_started_on)
+        self.assertIsNotNone(model.training_completed_on)
         self.assertEqual(model.errors, [])
         self.assertEqual(model.status, "ready")
         for doc in model.training_documents:
@@ -169,8 +169,8 @@ class TestTraining(FormRecognizerTest):
         model = poller.result()
 
         self.assertIsNotNone(model.model_id)
-        self.assertIsNotNone(model.requested_on)
-        self.assertIsNotNone(model.completed_on)
+        self.assertIsNotNone(model.training_started_on)
+        self.assertIsNotNone(model.training_completed_on)
         self.assertEqual(model.errors, [])
         self.assertEqual(model.status, "ready")
         for doc in model.training_documents:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_training_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_training_async.py
@@ -65,8 +65,8 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
         model = await poller.result()
 
         self.assertIsNotNone(model.model_id)
-        self.assertIsNotNone(model.requested_on)
-        self.assertIsNotNone(model.completed_on)
+        self.assertIsNotNone(model.training_started_on)
+        self.assertIsNotNone(model.training_completed_on)
         self.assertEqual(model.errors, [])
         self.assertEqual(model.status, "ready")
         for doc in model.training_documents:
@@ -88,8 +88,8 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
         model = await poller.result()
 
         self.assertIsNotNone(model.model_id)
-        self.assertIsNotNone(model.requested_on)
-        self.assertIsNotNone(model.completed_on)
+        self.assertIsNotNone(model.training_started_on)
+        self.assertIsNotNone(model.training_completed_on)
         self.assertEqual(model.errors, [])
         self.assertEqual(model.status, "ready")
         for doc in model.training_documents:
@@ -152,8 +152,8 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
         model = await poller.result()
 
         self.assertIsNotNone(model.model_id)
-        self.assertIsNotNone(model.requested_on)
-        self.assertIsNotNone(model.completed_on)
+        self.assertIsNotNone(model.training_started_on)
+        self.assertIsNotNone(model.training_completed_on)
         self.assertEqual(model.errors, [])
         self.assertEqual(model.status, "ready")
         for doc in model.training_documents:
@@ -175,8 +175,8 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
         model = await poller.result()
 
         self.assertIsNotNone(model.model_id)
-        self.assertIsNotNone(model.requested_on)
-        self.assertIsNotNone(model.completed_on)
+        self.assertIsNotNone(model.training_started_on)
+        self.assertIsNotNone(model.training_completed_on)
         self.assertEqual(model.errors, [])
         self.assertEqual(model.status, "ready")
         for doc in model.training_documents:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/testcase.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/testcase.py
@@ -132,8 +132,8 @@ class FormRecognizerTest(AzureTestCase):
 
     def assertModelTransformCorrect(self, model, actual, unlabeled=False):
         self.assertEqual(model.model_id, actual.model_info.model_id)
-        self.assertEqual(model.requested_on, actual.model_info.created_date_time)
-        self.assertEqual(model.completed_on, actual.model_info.last_updated_date_time)
+        self.assertEqual(model.training_started_on, actual.model_info.created_date_time)
+        self.assertEqual(model.training_completed_on, actual.model_info.last_updated_date_time)
         self.assertEqual(model.status, actual.model_info.status)
         self.assertEqual(model.errors, actual.train_result.errors)
         for m, a in zip(model.training_documents, actual.train_result.training_documents):


### PR DESCRIPTION
Item on #11881 

- `requested_on` -> `training_started_on`
- `completed_on` -> `training_completed_on`
