### PR TITLE
Add stress tests for max batch size/prefetch, and for unsettled message receipt.

### DIFF
--- a/sdk/servicebus/azure-servicebus/tests/stress_tests/test_stress_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/stress_tests/test_stress_queues.py
@@ -114,3 +114,43 @@ class ServiceBusQueueStressTests(AzureMgmtTestCase):
         result = stress_test.Run()
         assert(result.total_sent > 0)
         assert(result.total_received > 0)
+
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedResourceGroupPreparer(name_prefix='servicebustest')
+    @ServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest')
+    def test_stress_queue_unsettled_messages(self, servicebus_namespace_connection_string, servicebus_queue):
+        sb_client = ServiceBusClient.from_connection_string(
+            servicebus_namespace_connection_string, debug=False)
+
+        stress_test = StressTestRunner(senders = [sb_client.get_queue_sender(servicebus_queue.name)],
+                                       receivers = [sb_client.get_queue_receiver(servicebus_queue.name)],
+                                       duration = timedelta(seconds=350),
+                                       should_complete_messages = False)
+
+        result = stress_test.Run()
+        # This test is prompted by reports of an issue where enough unsettled messages saturate a service-side cache
+        # and prevent further receipt.
+        assert(result.total_sent > 2500)
+        assert(result.total_received > 2500)
+
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedResourceGroupPreparer(name_prefix='servicebustest')
+    @ServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest')
+    def test_stress_queue_receive_large_batch_size(self, servicebus_namespace_connection_string, servicebus_queue):
+        sb_client = ServiceBusClient.from_connection_string(
+            servicebus_namespace_connection_string, debug=False)
+
+        stress_test = StressTestRunner(senders = [sb_client.get_queue_sender(servicebus_queue.name)],
+                                       receivers = [sb_client.get_queue_receiver(servicebus_queue.name, prefetch=50)],
+                                       duration = timedelta(seconds=60),
+                                       max_batch_size = 50)
+
+        result = stress_test.Run()
+        assert(result.total_sent > 0)
+        assert(result.total_received > 0)


### PR DESCRIPTION
To enable this, add capability to not auto-complete and adjust max_batch_size into the base stress tester.