### PR TITLE
Verifychangelog

### DIFF
--- a/eng/common/scripts/modules/Package-Properties.psm1
+++ b/eng/common/scripts/modules/Package-Properties.psm1
@@ -106,7 +106,7 @@ function Extract-PythonPkgProps ($pkgPath, $serviceName, $pkgName)
     {
         $setupLocation = $pkgPath.Replace('\','/')
         pushd $RepoRoot
-        $setupProps = (python -c "import scripts.devops_tasks.common_tasks; obj=scripts.devops_tasks.common_tasks.parse_setup('$setupLocation'); print('{0},{1}'.format(obj[0], obj[1]));") -split ","
+        $setupProps = (python -c "import sys; import os; sys.path.append(os.path.join('scripts', 'devops_tasks')); from common_tasks import parse_setup; obj=parse_setup('$setupLocation'); print('{0},{1}'.format(obj[0], obj[1]));") -split ","
         popd
         if (($setupProps -ne $null) -and ($setupProps[0] -eq $pkgName))
         {

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -28,6 +28,13 @@ stages:
                 deploy:
                   steps:
                     - checkout: self
+                    
+                    - task: UsePythonVersion@0
+
+                    - script: |
+                        pip install -r /eng/ci_tools.txt
+                      displayName: 'Setup Python Environment'
+
                     - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
                       parameters:
                         PackageName: ${{artifact.name}}


### PR DESCRIPTION
Python ci required packages are required to execute script in ci_tools. Installing this req before running change log check.