### PR TITLE
Update FormRecognizer Tests.yml to auto-narrow when running against canary

### DIFF
--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -1,43 +1,41 @@
 trigger: none
 
-# this is a specific request from the formrecognizer service team
-# their claim is that the full matrix ends up stress-testing their tests.
-variables:
-  ${{ if contains(variables['Build.DefinitionName'], 'prod') }}:
-    DefaultMatrix:
-      Linux_Python35:
-        OSVmImage: 'ubuntu-18.04'
-        PythonVersion: '3.5'
-      MacOs_Python37:
-        OSVmImage: 'macOS-10.15'
-        PythonVersion: '3.7'
-      Windows_Python27:
-        OSVmImage: 'windows-2019'
-        PythonVersion: '2.7'
-      Linux_PyPy3:
-        OSVmImage: 'ubuntu-18.04'
-        PythonVersion: 'pypy3'
-      Linux_Python38:
-        OSVmImage: 'ubuntu-18.04'
-        PythonVersion: '3.8'
-  ${{ if not(contains(variables['Build.DefinitionName'], 'prod')) }}:
-    DefaultMatrix:
-      Linux_Python35:
-        OSVmImage: 'ubuntu-18.04'
-        PythonVersion: '3.5'
-      Windows_Python27:
-        OSVmImage: 'windows-2019'
-        PythonVersion: '2.7'
-      Linux_Python38:
-        OSVmImage: 'ubuntu-18.04'
-        PythonVersion: '3.8'
 
 jobs:
   - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
     parameters:
       BuildTargetingString: azure-ai-formrecognizer
       ServiceDirectory: formrecognizer
-      Matrix: ${{ variables.DefaultMatrix }}
+      # this is a specific request from the formrecognizer service team
+      # their claim is that the full matrix ends up stress-testing their tests.
+      ${{ if contains(variables['Build.DefinitionName'], 'prod') }}:
+        Matrix:
+          Linux_Python35:
+            OSVmImage: 'ubuntu-18.04'
+            PythonVersion: '3.5'
+          MacOs_Python37:
+            OSVmImage: 'macOS-10.15'
+            PythonVersion: '3.7'
+          Windows_Python27:
+            OSVmImage: 'windows-2019'
+            PythonVersion: '2.7'
+          Linux_PyPy3:
+            OSVmImage: 'ubuntu-18.04'
+            PythonVersion: 'pypy3'
+          Linux_Python38:
+            OSVmImage: 'ubuntu-18.04'
+            PythonVersion: '3.8'
+      ${{ if not(contains(variables['Build.DefinitionName'], 'prod')) }}:
+        Matrix:
+          Linux_Python35:
+            OSVmImage: 'ubuntu-18.04'
+            PythonVersion: '3.5'
+          Windows_Python27:
+            OSVmImage: 'windows-2019'
+            PythonVersion: '2.7'
+          Linux_Python38:
+            OSVmImage: 'ubuntu-18.04'
+            PythonVersion: '3.8'
       EnvVars:
         AZURE_SUBSCRIPTION_ID: $(provisioner-subscription)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -1,13 +1,12 @@
 trigger: none
 
-
 jobs:
   - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
     parameters:
       BuildTargetingString: azure-ai-formrecognizer
       ServiceDirectory: formrecognizer
       # this is a specific request from the formrecognizer service team
-      # their claim is that the full matrix ends up stress-testing their tests.
+      # their claim is that the full matrix ends up stress-testing their service.
       ${{ if contains(variables['Build.DefinitionName'], 'prod') }}:
         Matrix:
           Linux_Python35:

--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -1,10 +1,41 @@
 trigger: none
 
+variables:
+  ${{ if contains(variables['Build.DefinitionName'], 'prod') }}:
+    DefaultMatrix:
+      Linux_Python35:
+        OSVmImage: 'ubuntu-18.04'
+        PythonVersion: '3.5'
+      MacOs_Python37:
+        OSVmImage: 'macOS-10.15'
+        PythonVersion: '3.7'
+      Windows_Python27:
+        OSVmImage: 'windows-2019'
+        PythonVersion: '2.7'
+      Linux_PyPy3:
+        OSVmImage: 'ubuntu-18.04'
+        PythonVersion: 'pypy3'
+      Linux_Python38:
+        OSVmImage: 'ubuntu-18.04'
+        PythonVersion: '3.8'
+  ${{ if not contains(variables['Build.DefinitionName'], 'prod') }}:
+    DefaultMatrix:
+      Linux_Python35:
+        OSVmImage: 'ubuntu-18.04'
+        PythonVersion: '3.5'
+      Windows_Python27:
+        OSVmImage: 'windows-2019'
+        PythonVersion: '2.7'
+      Linux_Python38:
+        OSVmImage: 'ubuntu-18.04'
+        PythonVersion: '3.8'
+
 jobs:
   - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
     parameters:
       BuildTargetingString: azure-ai-formrecognizer
       ServiceDirectory: formrecognizer
+      Matrix: ${{ variables.DefaultMatrix }}
       EnvVars:
         AZURE_SUBSCRIPTION_ID: $(provisioner-subscription)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -1,5 +1,7 @@
 trigger: none
 
+# this is a specific request from the formrecognizer service team
+# their claim is that the full matrix ends up stress-testing their tests.
 variables:
   ${{ if contains(variables['Build.DefinitionName'], 'prod') }}:
     DefaultMatrix:
@@ -18,7 +20,7 @@ variables:
       Linux_Python38:
         OSVmImage: 'ubuntu-18.04'
         PythonVersion: '3.8'
-  ${{ if not contains(variables['Build.DefinitionName'], 'prod') }}:
+  ${{ if not(contains(variables['Build.DefinitionName'], 'prod')) }}:
     DefaultMatrix:
       Linux_Python35:
         OSVmImage: 'ubuntu-18.04'

--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -5,8 +5,9 @@ jobs:
     parameters:
       BuildTargetingString: azure-ai-formrecognizer
       ServiceDirectory: formrecognizer
-      # this is a specific request from the formrecognizer service team
-      # their claim is that the full matrix ends up stress-testing their service.
+      # This is a specific request from the formrecognizer service team
+      # their claim is that the full matrix ends up stress-testing their service. 
+      # As such, the canary test runs should run on a reduced matrix.
       ${{ if contains(variables['Build.DefinitionName'], 'prod') }}:
         Matrix:
           Linux_Python35:


### PR DESCRIPTION
Service team asked @kristapratico to narrow it. This PR adds some build magic to do this based on the definition name.