### PR TITLE
azure-identity 1.4.0b6

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.4.0b6 (Unreleased)
+## 1.4.0b6 (2020-07-07)
 - `AzureCliCredential` no longer raises an exception due to unexpected output
   from the CLI when run by PyCharm (thanks @NVolcz)
   ([#11362](https://github.com/Azure/azure-sdk-for-python/pull/11362))

--- a/sdk/identity/azure-identity/dev_requirements.txt
+++ b/sdk/identity/azure-identity/dev_requirements.txt
@@ -1,3 +1,4 @@
 ../../core/azure-core
 aiohttp;python_full_version>="3.5.3"
+mock;python_version<"3.3"
 typing_extensions>=3.7.2

--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -79,7 +79,6 @@ setup(
     ],
     extras_require={
         ":python_version<'3.0'": ["azure-nspkg"],
-        ":python_version<'3.3'": ["mock"],
         ":python_version<'3.5'": ["typing"],
     },
 )


### PR DESCRIPTION
Putting a date in the changelog and removing a vestigial dependency from `setup.py`.