### PR TITLE
Updated min dependency test version for azure-storage-blob to 12.3.1

### DIFF
--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -29,6 +29,7 @@ logging.getLogger().setLevel(logging.INFO)
 
 MINIMUM_VERSION_SUPPORTED_OVERRIDE = {
     'azure-common': '1.1.10',
+    'azure-storage-blob': '12.3.1',
 }
 
 def install_dependent_packages(setup_py_file_path, dependency_type, temp_dir):

--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -29,7 +29,6 @@ logging.getLogger().setLevel(logging.INFO)
 
 MINIMUM_VERSION_SUPPORTED_OVERRIDE = {
     'azure-common': '1.1.10',
-    'azure-storage-blob': '12.3.1',
 }
 
 def install_dependent_packages(setup_py_file_path, dependency_type, temp_dir):

--- a/sdk/storage/azure-storage-file-datalake/setup.py
+++ b/sdk/storage/azure-storage-file-datalake/setup.py
@@ -93,7 +93,7 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.6.0",
         "msrest>=0.6.10",
-        "azure-storage-blob~=12.0"
+        "azure-storage-blob>=12.3.1"
     ],
     extras_require={
         ":python_version<'3.0'": ['futures', 'azure-storage-nspkg<4.0.0,>=3.0.0'],

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -136,7 +136,7 @@ six>=1.6
 #override azure-storage-file-share msrest>=0.6.10
 #override azure-storage-file-datalake azure-core<2.0.0,>=1.6.0
 #override azure-storage-file-datalake msrest>=0.6.10
-#override azure-storage-file-datalake azure-storage-blob~=12.0
+#override azure-storage-file-datalake azure-storage-blob>=12.3.1
 opencensus>=0.6.0
 opencensus-ext-threading
 opencensus-ext-azure>=0.3.1


### PR DESCRIPTION
@annatisch , @xiafu-msft : As I mentioned earlier, this PR is to set minimum version of azure-storage-blob we use during dependency test to 12.3.1 to avoid failures due to encoding changes in recorded test.