### PR TITLE
Disable Changelog Verification

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -28,15 +28,6 @@ stages:
                 deploy:
                   steps:
                     - checkout: self
-                    - task: UsePythonVersion@0
-                    - script: |
-                        pip install -r eng/ci_tools.txt
-                      displayName: 'Setup Python Environment'
-                    - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
-                      parameters:
-                        PackageName: ${{artifact.name}}
-                        ServiceName: ${{parameters.ServiceDirectory}}
-                        ForRelease: true
                     - template: /eng/pipelines/templates/steps/stage-filtered-artifacts.yml
                       parameters:
                         SourceFolder: ${{parameters.ArtifactName}} 


### PR DESCRIPTION
This reverts commit b39c411ce5c203ee00881d62193e1a30b3ddd6ac.

Related to [these failures](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=450458&view=logs&j=7a9a3a09-f74e-5f55-65bc-59f7e8172950&t=2a4df810-d532-54f5-a55d-2385d43df013).

I've been digging for about 30 minutes trying to figure out where the `-` is getting injected, it's definitely not a parse problem!