### PR TITLE
Quick fix for broken log analytics pipeline.

### DIFF
--- a/sdk/loganalytics/ci.yml
+++ b/sdk/loganalytics/ci.yml
@@ -7,6 +7,7 @@ resources:
       type: github
       name: Azure/azure-sdk-tools
       endpoint: azure
+      ref: 0aedb8f2c152440e22d49317ad417c7c1d10a67c
     - repository: azure-sdk-build-tools
       type: git
       name: internal/azure-sdk-build-tools


### PR DESCRIPTION
@praveenkuttappan this is the ref trick I was talking about. I've just applied it to the loganalytics ```ci.yml``` file. This should unblock the team and is very surgical, however we should probably go through and change all of the ci.yml files to pin them to the latest known good tagged version of ```azure-sdk-tools```. @chidozieononiwu has been doing some work in this space recently.