### PR TITLE
policy_id for a SAS token should match an existing policy_id

### DIFF
--- a/sdk/storage/azure-storage-blob/samples/blob_samples_containers_async.py
+++ b/sdk/storage/azure-storage-blob/samples/blob_samples_containers_async.py
@@ -131,7 +131,7 @@ class ContainerSamplesAsync(object):
                                             expiry=datetime.utcnow() + timedelta(hours=1),
                                             start=datetime.utcnow() - timedelta(minutes=1))
 
-                identifiers = {'test': access_policy}
+                identifiers = {'my-access-policy-id': access_policy}
 
                 # Set the access policy on the container
                 await container_client.set_container_access_policy(signed_identifiers=identifiers)


### PR DESCRIPTION
Having spent a day trying to work out why my code based on this example didn't work, it'd be cool if the example worked!