### PR TITLE
Fix name error in workflow triggers operations.

### DIFF
--- a/sdk/logic/azure-mgmt-logic/azure/mgmt/logic/operations/workflow_triggers_operations.py
+++ b/sdk/logic/azure-mgmt-logic/azure/mgmt/logic/operations/workflow_triggers_operations.py
@@ -10,6 +10,7 @@
 # --------------------------------------------------------------------------
 
 import uuid
+from msrest.exceptions import HttpOperationError
 from msrest.pipeline import ClientRawResponse
 from msrestazure.azure_exceptions import CloudError
 


### PR DESCRIPTION
WorkflowTriggersOperations.run [refers to HttpOperationError](https://github.com/Azure/azure-sdk-for-python/blob/7d7fbcbee8e3827c5726a0d085ae10e1e5bb244c/sdk/logic/azure-mgmt-logic/azure/mgmt/logic/operations/workflow_triggers_operations.py#L288) but it is not imported.