### PR TITLE
[formrecognizer] Capitalize enum values

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.0.0b5 (Unreleased)
 
+**Breaking Changes**
+
+- Values are now capitalized for enums `FormContentType`, `LengthUnit`, `TrainingStatus`, and `CustomFormModelStatus`
 
 ## 1.0.0b4 (2020-07-07)
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
@@ -80,36 +80,36 @@ class LengthUnit(str, Enum):
     For images, the unit is "pixel". For PDF, the unit is "inch".
     """
 
-    pixel = "pixel"
-    inch = "inch"
+    PIXEL = "pixel"
+    INCH = "inch"
 
 
 class TrainingStatus(str, Enum):
     """Status of the training operation.
     """
 
-    succeeded = "succeeded"
-    partially_succeeded = "partiallySucceeded"
-    failed = "failed"
+    SUCCEEDED = "succeeded"
+    PARTIALLY_SUCCEEDED = "partiallySucceeded"
+    FAILED = "failed"
 
 
 class CustomFormModelStatus(str, Enum):
     """Status indicating the model's readiness for use.
     """
 
-    creating = "creating"
-    ready = "ready"
-    invalid = "invalid"
+    CREATING = "creating"
+    READY = "ready"
+    INVALID = "invalid"
 
 
 class FormContentType(str, Enum):
     """Content type for upload
     """
 
-    application_pdf = "application/pdf"  #: Content Type 'application/pdf'.
-    image_jpeg = "image/jpeg"  #: Content Type 'image/jpeg'.
-    image_png = "image/png"  #: Content Type 'image/png'.
-    image_tiff = "image/tiff"  #: Content Type 'image/tiff'.
+    APPLICATION_PDF = "application/pdf"  #: Content Type 'application/pdf'.
+    IMAGE_JPEG = "image/jpeg"  #: Content Type 'image/jpeg'.
+    IMAGE_PNG = "image/png"  #: Content Type 'image/png'.
+    IMAGE_TIFF = "image/tiff"  #: Content Type 'image/tiff'.
 
 
 class Point(namedtuple("Point", "x y")):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_content.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_content.py
@@ -50,7 +50,7 @@ class TestContentFromStream(FormRecognizerTest):
             myfile = fd.read()
         poller = client.begin_recognize_content(
             myfile,
-            content_type=FormContentType.application_pdf
+            content_type=FormContentType.APPLICATION_PDF
         )
         result = poller.result()
         self.assertIsNotNone(result)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_content_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_content_async.py
@@ -54,7 +54,7 @@ class TestContentFromStreamAsync(AsyncFormRecognizerTest):
             myfile = fd.read()
         poller = await client.begin_recognize_content(
             myfile,
-            content_type=FormContentType.application_pdf
+            content_type=FormContentType.APPLICATION_PDF
         )
         result = await poller.result()
         self.assertIsNotNone(result)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms.py
@@ -133,7 +133,7 @@ class TestCustomForms(FormRecognizerTest):
             poller = fr_client.begin_recognize_custom_forms(
                 model.model_id,
                 stream,
-                content_type=FormContentType.image_jpeg
+                content_type=FormContentType.IMAGE_JPEG
             )
         form = poller.result()
 
@@ -158,7 +158,7 @@ class TestCustomForms(FormRecognizerTest):
             poller = fr_client.begin_recognize_custom_forms(
                 model.model_id,
                 stream,
-                content_type=FormContentType.application_pdf
+                content_type=FormContentType.APPLICATION_PDF
             )
         forms = poller.result()
 
@@ -188,7 +188,7 @@ class TestCustomForms(FormRecognizerTest):
         with open(self.form_jpg, "rb") as fd:
             myfile = fd.read()
 
-        poller = fr_client.begin_recognize_custom_forms(model.model_id, myfile, content_type=FormContentType.image_jpeg)
+        poller = fr_client.begin_recognize_custom_forms(model.model_id, myfile, content_type=FormContentType.IMAGE_JPEG)
         form = poller.result()
 
         self.assertEqual(form[0].form_type, "form-"+model.model_id)
@@ -216,7 +216,7 @@ class TestCustomForms(FormRecognizerTest):
         poller = fr_client.begin_recognize_custom_forms(
             model.model_id,
             myfile,
-            content_type=FormContentType.application_pdf
+            content_type=FormContentType.APPLICATION_PDF
         )
         forms = poller.result()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_custom_forms_async.py
@@ -140,7 +140,7 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
         with open(self.form_jpg, "rb") as fd:
             myfile = fd.read()
 
-        poller = await fr_client.begin_recognize_custom_forms(model.model_id, myfile, content_type=FormContentType.image_jpeg)
+        poller = await fr_client.begin_recognize_custom_forms(model.model_id, myfile, content_type=FormContentType.IMAGE_JPEG)
         form = await poller.result()
         self.assertEqual(form[0].form_type, "form-0")
         self.assertFormPagesHasValues(form[0].pages)
@@ -165,7 +165,7 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
         poller = await fr_client.begin_recognize_custom_forms(
             model.model_id,
             myfile,
-            content_type=FormContentType.application_pdf
+            content_type=FormContentType.APPLICATION_PDF
         )
         forms = await poller.result()
 
@@ -192,7 +192,7 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
         with open(self.form_jpg, "rb") as fd:
             myfile = fd.read()
 
-        poller = await fr_client.begin_recognize_custom_forms(model.model_id, myfile, content_type=FormContentType.image_jpeg)
+        poller = await fr_client.begin_recognize_custom_forms(model.model_id, myfile, content_type=FormContentType.IMAGE_JPEG)
         form = await poller.result()
 
         self.assertEqual(form[0].form_type, "form-"+model.model_id)
@@ -220,7 +220,7 @@ class TestCustomFormsAsync(AsyncFormRecognizerTest):
         poller = await fr_client.begin_recognize_custom_forms(
             model.model_id,
             myfile,
-            content_type=FormContentType.application_pdf
+            content_type=FormContentType.APPLICATION_PDF
         )
         forms = await poller.result()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt.py
@@ -51,7 +51,7 @@ class TestReceiptFromStream(FormRecognizerTest):
             myfile = fd.read()
         poller = client.begin_recognize_receipts(
             myfile,
-            content_type=FormContentType.image_png
+            content_type=FormContentType.IMAGE_PNG
         )
         result = poller.result()
         self.assertIsNotNone(result)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_async.py
@@ -55,7 +55,7 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
             myfile = fd.read()
         poller = await client.begin_recognize_receipts(
             myfile,
-            content_type=FormContentType.image_png
+            content_type=FormContentType.IMAGE_PNG
         )
         result = await poller.result()
         self.assertIsNotNone(result)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_repr.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_repr.py
@@ -88,7 +88,7 @@ def page_range():
 
 @pytest.fixture
 def form_page(form_table, form_line):
-    model = _models.FormPage(page_number=1, text_angle=180, width=5, height=5.5, unit=_models.LengthUnit.pixel, tables=[form_table[0]], lines=[form_line[0]])
+    model = _models.FormPage(page_number=1, text_angle=180, width=5, height=5.5, unit=_models.LengthUnit.PIXEL, tables=[form_table[0]], lines=[form_line[0]])
     model_repr = "FormPage(page_number=1, text_angle=180, width=5, height=5.5, unit=pixel, tables=[{}], lines=[{}])".format(
             form_table[1], form_line[1]
         )[:1024]
@@ -118,7 +118,7 @@ def form_recognizer_error():
 
 @pytest.fixture
 def training_document_info(form_recognizer_error):
-    model = _models.TrainingDocumentInfo(document_name="document_name", status=_models.TrainingStatus.partially_succeeded, page_count=5, errors=[form_recognizer_error[0]])
+    model = _models.TrainingDocumentInfo(document_name="document_name", status=_models.TrainingStatus.PARTIALLY_SUCCEEDED, page_count=5, errors=[form_recognizer_error[0]])
     model_repr = "TrainingDocumentInfo(document_name=document_name, status=partiallySucceeded, page_count=5, errors=[{}])".format(form_recognizer_error[1])[:1024]
     assert repr(model) == model_repr
     return model, model_repr
@@ -137,7 +137,7 @@ class TestRepr():
     def test_custom_form_model(self, custom_form_sub_model, form_recognizer_error, training_document_info):
         model = _models.CustomFormModel(
             model_id=1,
-            status=_models.CustomFormModelStatus.creating,
+            status=_models.CustomFormModelStatus.CREATING,
             training_started_on=datetime.datetime(1, 1, 1),
             training_completed_on=datetime.datetime(1, 1, 1),
             submodels=[custom_form_sub_model[0], custom_form_sub_model[0]],
@@ -154,7 +154,7 @@ class TestRepr():
 
     def test_custom_form_model_info(self):
         model = _models.CustomFormModelInfo(
-            model_id=1, status=_models.CustomFormModelStatus.ready, training_started_on=datetime.datetime(1, 1, 1), training_completed_on=datetime.datetime(1, 1, 1)
+            model_id=1, status=_models.CustomFormModelStatus.READY, training_started_on=datetime.datetime(1, 1, 1), training_completed_on=datetime.datetime(1, 1, 1)
         )
         model_repr = "CustomFormModelInfo(model_id=1, status=ready, training_started_on=0001-01-01 00:00:00, training_completed_on=0001-01-01 00:00:00)"[:1024]
         assert repr(model) == model_repr


### PR DESCRIPTION
Autorest now generates with all uppercase enum values. Per discussion with @iscai-msft, this is more pythonic naming convention.