### PR TITLE
More accurate type annotation for scopes

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -9,7 +9,7 @@ from .._internal.aad_client import AadClient
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
-    from typing import Any, Optional, Sequence
+    from typing import Any, Iterable, Optional
     from azure.core.credentials import AccessToken
 
 
@@ -73,7 +73,7 @@ class AuthorizationCodeCredential(object):
         return token
 
     def _redeem_refresh_token(self, scopes, **kwargs):
-        # type: (Sequence[str], **Any) -> Optional[AccessToken]
+        # type: (Iterable[str], **Any) -> Optional[AccessToken]
         for refresh_token in self._client.get_cached_refresh_tokens(scopes):
             if "secret" not in refresh_token:
                 continue

--- a/sdk/identity/azure-identity/azure/identity/_exceptions.py
+++ b/sdk/identity/azure-identity/azure/identity/_exceptions.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from azure.core.exceptions import ClientAuthenticationError
 
 if TYPE_CHECKING:
-    from typing import Any, Optional, Sequence
+    from typing import Any, Iterable, Optional
 
 
 class CredentialUnavailableError(ClientAuthenticationError):
@@ -18,7 +18,7 @@ class AuthenticationRequiredError(CredentialUnavailableError):
     """Interactive authentication is required to acquire a token."""
 
     def __init__(self, scopes, message=None, error_details=None, **kwargs):
-        # type: (Sequence[str], Optional[str], Optional[str], **Any) -> None
+        # type: (Iterable[str], Optional[str], Optional[str], **Any) -> None
         self._scopes = scopes
         self._error_details = error_details
         if not message:
@@ -27,7 +27,7 @@ class AuthenticationRequiredError(CredentialUnavailableError):
 
     @property
     def scopes(self):
-        # type: () -> Sequence[str]
+        # type: () -> Iterable[str]
         """Scopes requested during the failed authentication"""
         return self._scopes
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/aad_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aad_client.py
@@ -21,7 +21,7 @@ from .user_agent import USER_AGENT
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
-    from typing import Any, List, Optional, Sequence, Union
+    from typing import Any, Iterable, List, Optional, Union
     from azure.core.credentials import AccessToken
     from azure.core.pipeline.policies import HTTPPolicy, SansIOHTTPPolicy
     from azure.core.pipeline.transport import HttpTransport
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 class AadClient(AadClientBase):
     def obtain_token_by_authorization_code(self, scopes, code, redirect_uri, client_secret=None, **kwargs):
-        # type: (Sequence[str], str, str, Optional[str], **Any) -> AccessToken
+        # type: (Iterable[str], str, str, Optional[str], **Any) -> AccessToken
         request = self._get_auth_code_request(
             scopes=scopes, code=code, redirect_uri=redirect_uri, client_secret=client_secret
         )
@@ -41,21 +41,21 @@ class AadClient(AadClientBase):
         return self._process_response(response, now)
 
     def obtain_token_by_client_certificate(self, scopes, certificate, **kwargs):
-        # type: (Sequence[str], AadClientCertificate, **Any) -> AccessToken
+        # type: (Iterable[str], AadClientCertificate, **Any) -> AccessToken
         request = self._get_client_certificate_request(scopes, certificate)
         now = int(time.time())
         response = self._pipeline.run(request, stream=False, **kwargs)
         return self._process_response(response, now)
 
     def obtain_token_by_client_secret(self, scopes, secret, **kwargs):
-        # type: (Sequence[str], str, **Any) -> AccessToken
+        # type: (Iterable[str], str, **Any) -> AccessToken
         request = self._get_client_secret_request(scopes, secret)
         now = int(time.time())
         response = self._pipeline.run(request, stream=False, **kwargs)
         return self._process_response(response, now)
 
     def obtain_token_by_refresh_token(self, scopes, refresh_token, **kwargs):
-        # type: (Sequence[str], str, **Any) -> AccessToken
+        # type: (Iterable[str], str, **Any) -> AccessToken
         request = self._get_refresh_token_request(scopes, refresh_token)
         now = int(time.time())
         response = self._pipeline.run(request, stream=False, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
@@ -29,7 +29,7 @@ except AttributeError:  # Python 2.7, abc exists, but not ABC
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
-    from typing import Any, Optional, Sequence, Union
+    from typing import Any, Iterable, List, Optional, Union
     from azure.core.pipeline import AsyncPipeline, Pipeline, PipelineResponse
     from azure.core.pipeline.policies import AsyncHTTPPolicy, HTTPPolicy, SansIOHTTPPolicy
     from azure.core.pipeline.transport import AsyncHttpTransport, HttpTransport
@@ -50,7 +50,7 @@ class AadClientBase(ABC):
         self._pipeline = self._build_pipeline(**kwargs)
 
     def get_cached_access_token(self, scopes, query=None):
-        # type: (Sequence[str], Optional[dict]) -> Optional[AccessToken]
+        # type: (Iterable[str], Optional[dict]) -> Optional[AccessToken]
         tokens = self._cache.find(TokenCache.CredentialType.ACCESS_TOKEN, target=list(scopes), query=query)
         for token in tokens:
             expires_on = int(token["expires_on"])
@@ -59,7 +59,7 @@ class AadClientBase(ABC):
         return None
 
     def get_cached_refresh_tokens(self, scopes):
-        # type: (Sequence[str]) -> Sequence[dict]
+        # type: (Iterable[str]) -> List[dict]
         """Assumes all cached refresh tokens belong to the same user"""
         return self._cache.find(TokenCache.CredentialType.REFRESH_TOKEN, target=list(scopes))
 
@@ -136,7 +136,7 @@ class AadClientBase(ABC):
         return token
 
     def _get_auth_code_request(self, scopes, code, redirect_uri, client_secret=None):
-        # type: (Sequence[str], str, str, Optional[str]) -> HttpRequest
+        # type: (Iterable[str], str, str, Optional[str]) -> HttpRequest
         data = {
             "client_id": self._client_id,
             "code": code,
@@ -153,7 +153,7 @@ class AadClientBase(ABC):
         return request
 
     def _get_client_certificate_request(self, scopes, certificate):
-        # type: (Sequence[str], AadClientCertificate) -> HttpRequest
+        # type: (Iterable[str], AadClientCertificate) -> HttpRequest
         assertion = self._get_jwt_assertion(certificate)
         data = {
             "client_assertion": assertion,
@@ -169,7 +169,7 @@ class AadClientBase(ABC):
         return request
 
     def _get_client_secret_request(self, scopes, secret):
-        # type: (Sequence[str], str) -> HttpRequest
+        # type: (Iterable[str], str) -> HttpRequest
         data = {
             "client_id": self._client_id,
             "client_secret": secret,
@@ -207,7 +207,7 @@ class AadClientBase(ABC):
         return jwt_bytes.decode("utf-8")
 
     def _get_refresh_token_request(self, scopes, refresh_token):
-        # type: (Sequence[str], str) -> HttpRequest
+        # type: (Iterable[str], str) -> HttpRequest
         data = {
             "grant_type": "refresh_token",
             "refresh_token": refresh_token,

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
@@ -200,7 +200,7 @@ class InteractiveCredential(PublicClientCredential):
         # type: (**Any) -> AuthenticationRecord
         """Interactively authenticate a user.
 
-        :keyword Sequence[str] scopes: scopes to request during authentication, such as those provided by
+        :keyword Iterable[str] scopes: scopes to request during authentication, such as those provided by
           :func:`AuthenticationRequiredError.scopes`. If provided, successful authentication will cache an access token
           for these scopes.
         :rtype: ~azure.identity.AuthenticationRecord

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -28,7 +28,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
-    from typing import Any, Iterable, List, Mapping, Optional, Sequence
+    from typing import Any, Iterable, List, Mapping, Optional
     from .._internal import AadClientBase
     from azure.identity import AuthenticationRecord
 
@@ -203,7 +203,7 @@ class SharedTokenCacheBase(ABC):
         raise CredentialUnavailableError(message=message)
 
     def _get_cached_access_token(self, scopes, account):
-        # type: (Sequence[str], CacheItem) -> Optional[AccessToken]
+        # type: (Iterable[str], CacheItem) -> Optional[AccessToken]
         if "home_account_id" not in account:
             return None
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -10,7 +10,7 @@ from .._internal import AadClient
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
-    from typing import Any, Optional, Sequence
+    from typing import Any, Iterable, Optional
     from azure.core.credentials import AccessToken
 
 
@@ -88,7 +88,7 @@ class AuthorizationCodeCredential(AsyncCredentialBase):
 
         return token
 
-    async def _redeem_refresh_token(self, scopes: "Sequence[str]", **kwargs: "Any") -> "Optional[AccessToken]":
+    async def _redeem_refresh_token(self, scopes: "Iterable[str]", **kwargs: "Any") -> "Optional[AccessToken]":
         for refresh_token in self._client.get_cached_refresh_tokens(scopes):
             if "secret" not in refresh_token:
                 continue

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/aad_client.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/aad_client.py
@@ -20,7 +20,7 @@ from ..._internal.user_agent import USER_AGENT
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
-    from typing import Any, List, Optional, Sequence, Union
+    from typing import Any, Iterable, List, Optional, Union
     from azure.core.credentials import AccessToken
     from azure.core.pipeline.policies import AsyncHTTPPolicy, SansIOHTTPPolicy
     from azure.core.pipeline.transport import AsyncHttpTransport
@@ -45,7 +45,7 @@ class AadClient(AadClientBase):
 
     async def obtain_token_by_authorization_code(
         self,
-        scopes: "Sequence[str]",
+        scopes: "Iterable[str]",
         code: str,
         redirect_uri: str,
         client_secret: "Optional[str]" = None,
@@ -59,14 +59,14 @@ class AadClient(AadClientBase):
         return self._process_response(response, now)
 
     async def obtain_token_by_client_certificate(self, scopes, certificate, **kwargs):
-        # type: (Sequence[str], AadClientCertificate, **Any) -> AccessToken
+        # type: (Iterable[str], AadClientCertificate, **Any) -> AccessToken
         request = self._get_client_certificate_request(scopes, certificate)
         now = int(time.time())
         response = await self._pipeline.run(request, stream=False, **kwargs)
         return self._process_response(response, now)
 
     async def obtain_token_by_client_secret(
-        self, scopes: "Sequence[str]", secret: str, **kwargs: "Any"
+        self, scopes: "Iterable[str]", secret: str, **kwargs: "Any"
     ) -> "AccessToken":
         request = self._get_client_secret_request(scopes, secret)
         now = int(time.time())
@@ -74,7 +74,7 @@ class AadClient(AadClientBase):
         return self._process_response(response, now)
 
     async def obtain_token_by_refresh_token(
-        self, scopes: "Sequence[str]", refresh_token: str, **kwargs: "Any"
+        self, scopes: "Iterable[str]", refresh_token: str, **kwargs: "Any"
     ) -> "AccessToken":
         request = self._get_refresh_token_request(scopes, refresh_token)
         now = int(time.time())


### PR DESCRIPTION
Throughout the library we have `scopes` annotated as `Sequence[str]`. We only need `scopes` to be unpackable though, so the simpler `Iterable[str]` is more accurate.