### PR TITLE
Remove unnecessary coroutine declaration

### DIFF
--- a/sdk/identity/azure-identity/tests/test_authn_client_async.py
+++ b/sdk/identity/azure-identity/tests/test_authn_client_async.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-import asyncio
 import time
 from unittest.mock import Mock, patch
 from urllib.parse import urlparse
@@ -39,7 +38,7 @@ async def test_request_url(authority):
         await client.request_token(("scope",))
 
 
-async def test_should_refresh():
+def test_should_refresh():
     client = AsyncAuthnClient(endpoint="http://foo")
     now = int(time.time())
 


### PR DESCRIPTION
`pytest` doesn't execute this test because it's a coroutine but not marked as such. It doesn't `await` anything, so I just removed the `async` declaration.