### PR TITLE
Run only analyse dependency step for aggregate report

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -1,10 +1,6 @@
 trigger: none
 pr: none
 
-variables:
-  Skip.MyPy: true
-  Skip.Pylint: true
-  Skip.ApiStubGen: true
 
 jobs:
 - job: 'ValidateDependencies'

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -15,7 +15,7 @@ jobs:
     parameters:
       Directory: ""
 
-  - template: ./templates/steps/analyze.yml
+  - template: /eng/pipelines/templates/steps/analyze_dependency.yml
 
   - task: AzureFileCopy@2
     displayName: 'Upload dependency report'

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -5,7 +5,7 @@ parameters:
   AdditionalTestArgs: ''
 
 steps:
-  - template: ./templates/steps/analyze_dependency.yml
+  - template: /eng/common/pipelines/templates/steps/analyze_dependency.yml
 
   - task: PythonScript@0
     displayName: 'Verify Change Log'

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -5,7 +5,7 @@ parameters:
   AdditionalTestArgs: ''
 
 steps:
-  - template: /eng/common/pipelines/templates/steps/analyze_dependency.yml
+  - template: /eng/pipelines/templates/steps/analyze_dependency.yml
 
   - task: PythonScript@0
     displayName: 'Verify Change Log'

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -5,31 +5,7 @@ parameters:
   AdditionalTestArgs: ''
 
 steps:
-  - task: UsePythonVersion@0
-    displayName: 'Use Python $(PythonVersion)'
-    inputs:
-     versionSpec: '$(PythonVersion)'
-
-  - task: DownloadPipelineArtifact@0
-    inputs:
-      artifactName: 'artifacts'
-      targetPath: $(Build.ArtifactStagingDirectory)
-
-  - script: |
-     pip install -r eng/ci_tools.txt
-     ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/eng/.docsettings.yml
-    displayName: 'Verify Readmes'
-
-  - pwsh: |
-      mkdir "$(Build.ArtifactStagingDirectory)/reports"
-      Copy-Item -Path "$(Build.SourcesDirectory)/eng/common/InterdependencyGraph.html" -Destination "$(Build.ArtifactStagingDirectory)/reports/InterdependencyGraph.html"
-    displayName: 'Populate Reports Staging Folder'
-
-  - task: PythonScript@0
-    displayName: 'Analyze dependencies'
-    inputs:
-     scriptPath: 'scripts/analyze_deps.py'
-     arguments: '--verbose --out "$(Build.ArtifactStagingDirectory)/reports/dependencies.html" --dump "$(Build.ArtifactStagingDirectory)/reports/data.js"'
+  - template: ./templates/steps/analyze_dependency.yml
 
   - task: PythonScript@0
     displayName: 'Verify Change Log'
@@ -96,6 +72,12 @@ steps:
       ServiceDirectory: ${{ parameters.ServiceDirectory }}
       BuildTargetingString: ${{ parameters.BuildTargetingString }}
       TestMarkArgument: ${{ parameters.TestMarkArgument }}
+
+  - task: DownloadPipelineArtifact@0
+    condition: ne(variables['Skip.ApiStubGen'],'true')
+    inputs:
+      artifactName: 'artifacts'
+      targetPath: $(Build.ArtifactStagingDirectory)
 
   - template: ../steps/run_apistub.yml
     parameters:

--- a/eng/pipelines/templates/steps/analyze_dependency.yml
+++ b/eng/pipelines/templates/steps/analyze_dependency.yml
@@ -1,9 +1,3 @@
-parameters:
-  BuildTargetingString: 'azure-*'
-  ServiceDirectory: ''
-  TestMarkArgument: ''
-  AdditionalTestArgs: ''
-
 steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python $(PythonVersion)'

--- a/eng/pipelines/templates/steps/analyze_dependency.yml
+++ b/eng/pipelines/templates/steps/analyze_dependency.yml
@@ -1,0 +1,27 @@
+parameters:
+  BuildTargetingString: 'azure-*'
+  ServiceDirectory: ''
+  TestMarkArgument: ''
+  AdditionalTestArgs: ''
+
+steps:
+  - task: UsePythonVersion@0
+    displayName: 'Use Python $(PythonVersion)'
+    inputs:
+     versionSpec: '$(PythonVersion)'
+
+  - script: |
+     pip install -r eng/ci_tools.txt
+     ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/eng/.docsettings.yml
+    displayName: 'Verify Readmes'
+
+  - pwsh: |
+      mkdir "$(Build.ArtifactStagingDirectory)/reports"
+      Copy-Item -Path "$(Build.SourcesDirectory)/eng/common/InterdependencyGraph.html" -Destination "$(Build.ArtifactStagingDirectory)/reports/InterdependencyGraph.html"
+    displayName: 'Populate Reports Staging Folder'
+
+  - task: PythonScript@0
+    displayName: 'Analyze dependencies'
+    inputs:
+     scriptPath: 'scripts/analyze_deps.py'
+     arguments: '--verbose --out "$(Build.ArtifactStagingDirectory)/reports/dependencies.html" --dump "$(Build.ArtifactStagingDirectory)/reports/data.js"'


### PR DESCRIPTION
Aggregate reports pipeline runs all steps in analyze.yml with few steps disabled. This makes it necessary to add more variables to disable those steps when any new step is added. This has caused a new breakage when download artifact step was added in analyze step and aggregate-reports pipeline doesn't have any artifact to download. Below changes are done in order to fix this issue.

1. Split Analyze.yml to isolate steps that run dependency check into different template and run that template only from aggregate report pipeline.
2. Run download artifact only when running apistubgen. 