### PR TITLE
VSCodeCredential supports Python 2.7 on Windows

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_internal/linux_vscode_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/linux_vscode_adapter.py
@@ -4,8 +4,11 @@
 # ------------------------------------
 import os
 import json
+import logging
 import ctypes as ct
 from .._constants import VSCODE_CREDENTIALS_SECTION
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _c_str(string):
@@ -96,5 +99,8 @@ def get_credentials():
         environment_name = _get_user_settings()
         credentials = _get_refresh_token(VSCODE_CREDENTIALS_SECTION, environment_name)
         return credentials
-    except Exception:  # pylint: disable=broad-except
+    except Exception as ex:  # pylint: disable=broad-except
+        _LOGGER.debug(
+            'Exception retrieving VS Code credentials: "%s"', ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG)
+        )
         return None

--- a/sdk/identity/azure-identity/azure/identity/_internal/macos_vscode_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/macos_vscode_adapter.py
@@ -4,8 +4,11 @@
 # ------------------------------------
 import os
 import json
+import logging
 from msal_extensions.osx import Keychain, KeychainError
 from .._constants import VSCODE_CREDENTIALS_SECTION
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _get_user_settings_path():
@@ -37,5 +40,8 @@ def get_credentials():
         environment_name = _get_user_settings()
         credentials = _get_refresh_token(VSCODE_CREDENTIALS_SECTION, environment_name)
         return credentials
-    except Exception:  # pylint: disable=broad-except
+    except Exception as ex:  # pylint: disable=broad-except
+        _LOGGER.debug(
+            'Exception retrieving VS Code credentials: "%s"', ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG)
+        )
         return None

--- a/sdk/identity/azure-identity/azure/identity/_internal/win_vscode_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/win_vscode_adapter.py
@@ -49,8 +49,7 @@ def _read_credential(service_name, account_name):
     if _advapi.CredReadW(target, 1, 0, ct.byref(cred_ptr)):
         cred_blob = cred_ptr.contents.CredentialBlob
         cred_blob_size = cred_ptr.contents.CredentialBlobSize
-        password_as_list = [int.from_bytes(cred_blob[pos : pos + 1], "little") for pos in range(0, cred_blob_size)]
-        cred = "".join(map(chr, password_as_list))
+        cred = "".join(map(chr, cred_blob[:cred_blob_size]))
         _advapi.CredFree(cred_ptr)
         return cred
     return None

--- a/sdk/identity/azure-identity/azure/identity/_internal/win_vscode_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/win_vscode_adapter.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 import os
 import json
+import logging
 import ctypes as ct
 from .._constants import VSCODE_CREDENTIALS_SECTION
 
@@ -12,6 +13,7 @@ try:
 except (IOError, ValueError):
     pass
 
+_LOGGER = logging.getLogger(__name__)
 
 SUPPORTED_CREDKEYS = set(("Type", "TargetName", "Persist", "UserName", "Comment", "CredentialBlob"))
 
@@ -80,5 +82,8 @@ def get_credentials():
         environment_name = _get_user_settings()
         credentials = _get_refresh_token(VSCODE_CREDENTIALS_SECTION, environment_name)
         return credentials
-    except Exception:  # pylint: disable=broad-except
+    except Exception as ex:  # pylint: disable=broad-except
+        _LOGGER.debug(
+            'Exception retrieving VS Code credentials: "%s"', ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG)
+        )
         return None


### PR DESCRIPTION
The credential was failing on 2.7 because `int.from_bytes` was added in 3.2. I added debug logging of the exception so future failures like this are less silent.