### PR TITLE
Skip pypy3 for service bus CI pipeline

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -7,6 +7,7 @@ parameters:
   ToxEnvParallel: '--tenvparallel'
   InjectedPackages: ''
   BuildDocs: true
+  SkipPyPyTest: false
   TestMatrix:
     Linux_Python27:
       OSVmImage: 'ubuntu-18.04'
@@ -92,8 +93,10 @@ jobs:
       matrix:
         ${{ each matrixEntry in parameters.TestMatrix }}:
           ${{ if or(eq(matrixEntry.value.RunForPR, 'true'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-            ${{ matrixEntry.key }}:
-              ${{ insert }}: ${{ matrixEntry.value }}
+            # Skip pypy3 if any specific service has opted out
+            ${{ if or(ne(matrixEntry.value.PythonVersion, 'pypy3'), ne(parameters.SkipPyPYTest, 'true')) }}:
+              ${{ matrixEntry.key }}:
+                ${{ insert }}: ${{ matrixEntry.value }}
         
     pool:
       vmImage: '$(OSVmImage)'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -7,7 +7,7 @@ parameters:
   ToxEnvParallel: '--tenvparallel'
   InjectedPackages: ''
   BuildDocs: true
-  SkipPyPyTest: false
+  SkipPythonVersion: ''
   TestMatrix:
     Linux_Python27:
       OSVmImage: 'ubuntu-18.04'
@@ -93,8 +93,8 @@ jobs:
       matrix:
         ${{ each matrixEntry in parameters.TestMatrix }}:
           ${{ if or(eq(matrixEntry.value.RunForPR, 'true'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-            # Skip pypy3 if any specific service has opted out
-            ${{ if or(ne(matrixEntry.value.PythonVersion, 'pypy3'), ne(parameters.SkipPyPYTest, 'true')) }}:
+            # Skip python version if any specific service has opted out
+            ${{ if not(contains(parameters.SkipPythonVersion, matrixEntry.value.PythonVersion)) }}:
               ${{ matrixEntry.key }}:
                 ${{ insert }}: ${{ matrixEntry.value }}
         

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -94,7 +94,7 @@ jobs:
         ${{ each matrixEntry in parameters.TestMatrix }}:
           ${{ if or(eq(matrixEntry.value.RunForPR, 'true'), ne(variables['Build.Reason'], 'PullRequest')) }}:
             # Skip python version if any specific service has opted out
-            ${{ if not(contains(parameters.SkipPythonVersion, matrixEntry.value.PythonVersion)) }}:
+            ${{ if ne(parameters.SkipPythonVersion, matrixEntry.value.PythonVersion) }}:
               ${{ matrixEntry.key }}:
                 ${{ insert }}: ${{ matrixEntry.value }}
         

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -20,6 +20,9 @@ parameters:
 - name: TargetDocRepoName
   type: string
   default: azure-docs-sdk-python
+- name: SkipPyPyTest
+  type: boolean
+  default: false
 
 stages:
   - stage: Build
@@ -30,6 +33,7 @@ stages:
         ToxEnvParallel: ${{parameters.ToxEnvParallel}}
         BuildDocs: ${{parameters.BuildDocs}}
         InjectedPackages: ${{parameters.InjectedPackages}}
+        SkipPyPyTest: ${{parameters.SkipPyPyTest}}
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
@@ -41,4 +45,4 @@ stages:
         ArtifactName: packages
         DocArtifact: documentation
         TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
-        TargetDocRepoName: ${{parameters.TargetDocRepoName}} 
+        TargetDocRepoName: ${{parameters.TargetDocRepoName}}

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -20,9 +20,9 @@ parameters:
 - name: TargetDocRepoName
   type: string
   default: azure-docs-sdk-python
-- name: SkipPyPyTest
-  type: boolean
-  default: false
+- name: SkipPythonVersion
+  type: string
+  default: ''
 
 stages:
   - stage: Build
@@ -33,7 +33,7 @@ stages:
         ToxEnvParallel: ${{parameters.ToxEnvParallel}}
         BuildDocs: ${{parameters.BuildDocs}}
         InjectedPackages: ${{parameters.InjectedPackages}}
-        SkipPyPyTest: ${{parameters.SkipPyPyTest}}
+        SkipPythonVersion: ${{parameters.SkipPythonVersion}}
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:

--- a/sdk/servicebus/ci.yml
+++ b/sdk/servicebus/ci.yml
@@ -33,3 +33,5 @@ extends:
       safeName: azuremgmtservicebus
     - name: azure_servicebus
       safeName: azureservicebus
+    SkipPyPyTest: true
+

--- a/sdk/servicebus/ci.yml
+++ b/sdk/servicebus/ci.yml
@@ -33,5 +33,5 @@ extends:
       safeName: azuremgmtservicebus
     - name: azure_servicebus
       safeName: azureservicebus
-    SkipPyPyTest: true
+    SkipPythonVersion: 'pypy3'
 


### PR DESCRIPTION
Servicebus has a requirement of uamqp and this package doesn't run on pypy3. Live test for service bus is already configured not to run on pypy3. New tests that were added for CI also doesn't run on pypy3. Python team has asked to remove pypy3 from test matrix for service bus. 

Just fyi. @KieranBrantnerMagee, @yunhaoling  