### PR TITLE
Convert QueueRuntimeInfo to QueueRuntimeProperties

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
@@ -33,7 +33,7 @@ from ...management._generated.aio._service_bus_management_client_async import Se
     as ServiceBusManagementClientImpl
 from ...management import _constants as constants
 from ._shared_key_policy_async import AsyncServiceBusSharedKeyCredentialPolicy
-from ...management._models import QueueRuntimeInfo, QueueDescription, TopicDescription, TopicRuntimeInfo, \
+from ...management._models import QueueRuntimeProperties, QueueDescription, TopicDescription, TopicRuntimeInfo, \
     SubscriptionDescription, SubscriptionRuntimeInfo, RuleDescription
 from ...management._xml_workaround_policy import ServiceBusXMLWorkaroundPolicy
 from ...management._handle_response_error import _handle_response_error
@@ -157,17 +157,17 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             entry.content.queue_description)
         return queue_description
 
-    async def get_queue_runtime_info(self, queue_name: str, **kwargs) -> QueueRuntimeInfo:
+    async def get_queue_runtime_info(self, queue_name: str, **kwargs) -> QueueRuntimeProperties:
         """Get the runtime information of a queue.
 
         :param str queue_name: The name of the queue.
-        :rtype: ~azure.servicebus.management.QueueRuntimeInfo
+        :rtype: ~azure.servicebus.management.QueueRuntimeProperties
         """
         entry_ele = await self._get_entity_element(queue_name, **kwargs)
         entry = QueueDescriptionEntry.deserialize(entry_ele)
         if not entry.content:
             raise ResourceNotFoundError("Queue {} does not exist".format(queue_name))
-        runtime_info = QueueRuntimeInfo._from_internal_entity(queue_name,
+        runtime_info = QueueRuntimeProperties._from_internal_entity(queue_name,
             entry.content.queue_description)
         return runtime_info
 
@@ -294,15 +294,15 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         return AsyncItemPaged(
             get_next, extract_data)
 
-    def list_queues_runtime_info(self, **kwargs) -> AsyncItemPaged[QueueRuntimeInfo]:
+    def list_queues_runtime_info(self, **kwargs) -> AsyncItemPaged[QueueRuntimeProperties]:
         """List the runtime information of the queues in a ServiceBus namespace.
 
-        :returns: An iterable (auto-paging) response of QueueRuntimeInfo.
-        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.servicebus.management.QueueRuntimeInfo]
+        :returns: An iterable (auto-paging) response of QueueRuntimeProperties.
+        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.servicebus.management.QueueRuntimeProperties]
         """
 
         def entry_to_qr(entry):
-            qd = QueueRuntimeInfo._from_internal_entity(entry.title, entry.content.queue_description)
+            qd = QueueRuntimeProperties._from_internal_entity(entry.title, entry.content.queue_description)
             return qd
 
         extract_data = functools.partial(

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/__init__.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/__init__.py
@@ -8,7 +8,7 @@ from ._generated.models import AuthorizationRule, MessageCountDetails, \
     AccessRights, EntityAvailabilityStatus, EntityStatus, \
     NamespaceProperties, MessagingSku, NamespaceType
 
-from ._models import QueueRuntimeInfo, QueueDescription, TopicRuntimeInfo, TopicDescription, \
+from ._models import QueueRuntimeProperties, QueueDescription, TopicRuntimeInfo, TopicDescription, \
     SubscriptionDescription, SubscriptionRuntimeInfo, RuleDescription, \
     TrueRuleFilter, FalseRuleFilter, SqlRuleFilter, CorrelationRuleFilter, \
     SqlRuleAction
@@ -18,7 +18,7 @@ __all__ = [
     'AuthorizationRule',
     'MessageCountDetails',
     'QueueDescription',
-    'QueueRuntimeInfo',
+    'QueueRuntimeProperties',
     'TopicDescription',
     'TopicRuntimeInfo',
     'SubscriptionDescription',

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
@@ -35,7 +35,7 @@ from ._generated._configuration import ServiceBusManagementClientConfiguration
 from ._generated._service_bus_management_client import ServiceBusManagementClient as ServiceBusManagementClientImpl
 from ._model_workaround import avoid_timedelta_overflow
 from . import _constants as constants
-from ._models import QueueRuntimeInfo, QueueDescription, TopicDescription, TopicRuntimeInfo, \
+from ._models import QueueRuntimeProperties, QueueDescription, TopicDescription, TopicRuntimeInfo, \
     SubscriptionDescription, SubscriptionRuntimeInfo, RuleDescription
 from ._handle_response_error import _handle_response_error
 
@@ -152,17 +152,17 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         return queue_description
 
     def get_queue_runtime_info(self, queue_name, **kwargs):
-        # type: (str, Any) -> QueueRuntimeInfo
+        # type: (str, Any) -> QueueRuntimeProperties
         """Get the runtime information of a queue.
 
         :param str queue_name: The name of the queue.
-        :rtype: ~azure.servicebus.management.QueueRuntimeInfo
+        :rtype: ~azure.servicebus.management.QueueRuntimeProperties
         """
         entry_ele = self._get_entity_element(queue_name, **kwargs)
         entry = QueueDescriptionEntry.deserialize(entry_ele)
         if not entry.content:
             raise ResourceNotFoundError("Queue {} does not exist".format(queue_name))
-        runtime_info = QueueRuntimeInfo._from_internal_entity(queue_name, entry.content.queue_description)
+        runtime_info = QueueRuntimeProperties._from_internal_entity(queue_name, entry.content.queue_description)
         return runtime_info
 
     def create_queue(self, queue, **kwargs):
@@ -289,15 +289,15 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             get_next, extract_data)
 
     def list_queues_runtime_info(self, **kwargs):
-        # type: (Any) -> ItemPaged[QueueRuntimeInfo]
+        # type: (Any) -> ItemPaged[QueueRuntimeProperties]
         """List the runtime information of the queues in a ServiceBus namespace.
 
-        :returns: An iterable (auto-paging) response of QueueRuntimeInfo.
-        :rtype: ~azure.core.paging.ItemPaged[~azure.servicebus.management.QueueRuntimeInfo]
+        :returns: An iterable (auto-paging) response of QueueRuntimeProperties.
+        :rtype: ~azure.core.paging.ItemPaged[~azure.servicebus.management.QueueRuntimeProperties]
         """
 
         def entry_to_qr(entry):
-            qd = QueueRuntimeInfo._from_internal_entity(entry.title, entry.content.queue_description)
+            qd = QueueRuntimeProperties._from_internal_entity(entry.title, entry.content.queue_description)
             return qd
 
         extract_data = functools.partial(

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
@@ -182,7 +182,7 @@ class QueueDescription(object):  # pylint:disable=too-many-instance-attributes
         return self._internal_qd
 
 
-class QueueRuntimeInfo(object):
+class QueueRuntimeProperties(object):
     """Service Bus queue metrics.
 
     :ivar name: Name of the queue.
@@ -196,10 +196,18 @@ class QueueRuntimeInfo(object):
     :type updated_at: ~datetime.datetime
     :ivar size_in_bytes: The size of the queue, in bytes.
     :type size_in_bytes: int
-    :ivar message_count: The number of messages in the queue.
-    :type message_count: int
-    :ivar message_count_details: Details about the message counts in entity.
-    :type message_count_details: ~azure.servicebus.management.MessageCountDetails
+    :ivar total_message_count: The total number of messages in the queue.
+    :type total_message_count: int
+    :ivar active_message_count: The number of active messages in the queue.
+    :type active_message_count: int
+    :ivar dead_letter_message_count: The number of messages in the dead-letter sub-queue.
+    :type dead_letter_message_count: int
+    :ivar scheduled_message_count: The number of scheduled messages in the queue.
+    :type scheduled_message_count: int
+    :ivar transfer_dead_letter_message_count: The number of messages transferred into dead-letter.
+    :type transfer_dead_letter_message_count: int
+    :ivar transfer_message_count: Number of messages transferred to another queue, topic, or subscription.
+    :type transfer_message_count: int
     """
 
     def __init__(
@@ -211,25 +219,34 @@ class QueueRuntimeInfo(object):
         self.name = name
         self._internal_qr = None  # type: Optional[InternalQueueDescription]
 
-        self.accessed_at = kwargs.get('accessed_at', None)
-        self.created_at = kwargs.get('created_at', None)
-        self.updated_at = kwargs.get('updated_at', None)
-        self.size_in_bytes = kwargs.get('size_in_bytes', None)
-        self.message_count = kwargs.get('message_count', None)
-        self.message_count_details = kwargs.get('message_count_details', None)
+        self.accessed_at = kwargs.get('accessed_at')
+        self.created_at = kwargs.get('created_at')
+        self.updated_at = kwargs.get('updated_at')
+        self.size_in_bytes = kwargs.get('size_in_bytes')
+        self.total_message_count = kwargs.get('total_message_count')
+        # We want to flatten these properties to make them more discoverable
+        self.active_message_count = kwargs.get('active_message_count')
+        self.dead_letter_message_count = kwargs.get('dead_letter_message_count')
+        self.scheduled_message_count = kwargs.get('scheduled_message_count')
+        self.transfer_dead_letter_message_count = kwargs.get('transfer_dead_letter_message_count')
+        self.transfer_message_count = kwargs.get('transfer_message_count')
 
     @classmethod
     def _from_internal_entity(cls, name, internal_qr):
         # type: (str, InternalQueueDescription) -> QueueRuntimeInfo
-        qr = cls(name)
+        qr = cls(name,
+                 accessed_at = internal_qr.accessed_at,
+                 created_at = internal_qr.created_at,
+                 updated_at = internal_qr.updated_at,
+                 size_in_bytes = internal_qr.size_in_bytes,
+                 total_message_count = internal_qr.message_count,
+                 active_message_count = internal_qr.message_count_details.active_message_count,
+                 dead_letter_message_count = internal_qr.message_count_details.dead_letter_message_count,
+                 scheduled_message_count = internal_qr.message_count_details.scheduled_message_count,
+                 transfer_dead_letter_message_count = internal_qr.message_count_details.transfer_dead_letter_message_count,
+                 transfer_message_count = internal_qr.message_count_details.transfer_message_count
+                 )
         qr._internal_qr = deepcopy(internal_qr)  # pylint:disable=protected-access
-
-        qr.accessed_at = internal_qr.accessed_at
-        qr.created_at = internal_qr.created_at
-        qr.updated_at = internal_qr.updated_at
-        qr.size_in_bytes = internal_qr.size_in_bytes
-        qr.message_count = internal_qr.message_count
-        qr.message_count_details = internal_qr.message_count_details
 
         return qr
 

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_queues_async.py
@@ -394,14 +394,13 @@ class ServiceBusManagementClientQueueAsyncTests(AzureMgmtTestCase):
         assert info.size_in_bytes == 0
         assert info.accessed_at is not None
         assert info.updated_at is not None
-        assert info.message_count == 0
+        assert info.total_message_count == 0
 
-        assert info.message_count_details
-        assert info.message_count_details.active_message_count == 0
-        assert info.message_count_details.dead_letter_message_count == 0
-        assert info.message_count_details.transfer_dead_letter_message_count == 0
-        assert info.message_count_details.transfer_message_count == 0
-        assert info.message_count_details.scheduled_message_count == 0
+        assert info.active_message_count == 0
+        assert info.dead_letter_message_count == 0
+        assert info.transfer_dead_letter_message_count == 0
+        assert info.transfer_message_count == 0
+        assert info.scheduled_message_count == 0
 
         await mgmt_service.delete_queue("test_queue")
         queues_infos = await async_pageable_to_list(mgmt_service.list_queues_runtime_info())
@@ -435,14 +434,13 @@ class ServiceBusManagementClientQueueAsyncTests(AzureMgmtTestCase):
         assert queue_runtime_info.created_at is not None
         assert queue_runtime_info.accessed_at is not None
         assert queue_runtime_info.updated_at is not None
-        assert queue_runtime_info.message_count == 0
+        assert queue_runtime_info.total_message_count == 0
 
-        assert queue_runtime_info.message_count_details
-        assert queue_runtime_info.message_count_details.active_message_count == 0
-        assert queue_runtime_info.message_count_details.dead_letter_message_count == 0
-        assert queue_runtime_info.message_count_details.transfer_dead_letter_message_count == 0
-        assert queue_runtime_info.message_count_details.transfer_message_count == 0
-        assert queue_runtime_info.message_count_details.scheduled_message_count == 0
+        assert queue_runtime_info.active_message_count == 0
+        assert queue_runtime_info.dead_letter_message_count == 0
+        assert queue_runtime_info.transfer_dead_letter_message_count == 0
+        assert queue_runtime_info.transfer_message_count == 0
+        assert queue_runtime_info.scheduled_message_count == 0
         await mgmt_service.delete_queue("test_queue")
 
     @CachedResourceGroupPreparer(name_prefix='servicebustest')

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_queues.py
@@ -409,14 +409,13 @@ class ServiceBusManagementClientQueueTests(AzureMgmtTestCase):
         assert info.size_in_bytes == 0
         assert info.accessed_at is not None
         assert info.updated_at is not None
-        assert info.message_count == 0
+        assert info.total_message_count == 0
 
-        assert info.message_count_details
-        assert info.message_count_details.active_message_count == 0
-        assert info.message_count_details.dead_letter_message_count == 0
-        assert info.message_count_details.transfer_dead_letter_message_count == 0
-        assert info.message_count_details.transfer_message_count == 0
-        assert info.message_count_details.scheduled_message_count == 0
+        assert info.active_message_count == 0
+        assert info.dead_letter_message_count == 0
+        assert info.transfer_dead_letter_message_count == 0
+        assert info.transfer_message_count == 0
+        assert info.scheduled_message_count == 0
 
         mgmt_service.delete_queue("test_queue")
         queues_infos = list(mgmt_service.list_queues_runtime_info())
@@ -451,14 +450,13 @@ class ServiceBusManagementClientQueueTests(AzureMgmtTestCase):
             assert queue_runtime_info.created_at is not None
             assert queue_runtime_info.accessed_at is not None
             assert queue_runtime_info.updated_at is not None
-            assert queue_runtime_info.message_count == 0
+            assert queue_runtime_info.total_message_count == 0
 
-            assert queue_runtime_info.message_count_details
-            assert queue_runtime_info.message_count_details.active_message_count == 0
-            assert queue_runtime_info.message_count_details.dead_letter_message_count == 0
-            assert queue_runtime_info.message_count_details.transfer_dead_letter_message_count == 0
-            assert queue_runtime_info.message_count_details.transfer_message_count == 0
-            assert queue_runtime_info.message_count_details.scheduled_message_count == 0
+            assert queue_runtime_info.active_message_count == 0
+            assert queue_runtime_info.dead_letter_message_count == 0
+            assert queue_runtime_info.transfer_dead_letter_message_count == 0
+            assert queue_runtime_info.transfer_message_count == 0
+            assert queue_runtime_info.scheduled_message_count == 0
         finally:
             mgmt_service.delete_queue("test_queue")
 


### PR DESCRIPTION
* Flattening message details for easier discoverability
* renaming message count -> total_message_count
* adjusting tests.

@annatisch as with the other consistency PR, this is the example of what will spread across the other entities assuming no major issues with this pattern. (figured it'd potentially save time to review one of the verticals first rather than propagating changes across all of them)