### PR TITLE
[Service Bus] Normalize management naming with other languages

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
@@ -232,7 +232,6 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
 
         :rtype: ~azure.servicebus.management.QueueProperties
         """
-        kwargs = dict(kwargs)
         queue = QueueProperties(name, **kwargs)
         for key in queue.keys():
             kwargs.pop(key, None)
@@ -420,7 +419,6 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         :rtype: ~azure.servicebus.management.TopicProperties
         """
 
-        kwargs = dict(kwargs)
         topic = TopicProperties(name, **kwargs)
         for key in topic.keys():
             kwargs.pop(key, None)
@@ -619,7 +617,6 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             topic_name = topic.name  # type: ignore
         except AttributeError:
             topic_name = topic
-        kwargs = dict(kwargs)
         subscription = SubscriptionProperties(name, **kwargs)
         for key in subscription.keys():
             kwargs.pop(key, None)
@@ -799,10 +796,10 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         :param name: Name of the rule.
         :type name: str
         :keyword filter: The filter of the rule.
-        :type filter: Union[~azure.servicebus.management.models.CorrelationRuleFilter,
-         ~azure.servicebus.management.models.SqlRuleFilter]
+        :type filter: Union[~azure.servicebus.management.CorrelationRuleFilter,
+         ~azure.servicebus.management.SqlRuleFilter]
         :keyword action: The action of the rule.
-        :type action: Optional[~azure.servicebus.management.models.SqlRuleAction]
+        :type action: Optional[~azure.servicebus.management.SqlRuleAction]
         :keyword created_at: The exact time the rule was created.
         :type created_at: ~datetime.datetime
 
@@ -816,7 +813,6 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             subscription_name = subscription.name  # type: ignore
         except AttributeError:
             subscription_name = subscription
-        kwargs = dict(kwargs)
         rule = RuleProperties(name, **kwargs)
         for key in rule.keys():
             kwargs.pop(key, None)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
@@ -258,11 +258,12 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
     async def update_queue(self, queue: QueueProperties, **kwargs) -> None:
         """Update a queue.
 
-        Before calling this method, you should use `get_queue` to get a `QueueProperties` instance, then update
-        the properties you want to update. Only a portion of properties can be updated.
-        Refer to https://docs.microsoft.com/en-us/rest/api/servicebus/update-queue.
+        Before calling this method, you should use `get_queue`, `create_queue` or `list_queues` to get a
+        `QueueProperties` instance, then update the properties. Only a portion of properties can
+        be updated. Refer to https://docs.microsoft.com/en-us/rest/api/servicebus/update-queue.
 
-        :param queue: The queue that is returned from `get_queue` and has the updated properties.
+        :param queue: The queue that is returned from `get_queue`, `create_queue` or `list_queues` and
+         has the updated properties.
         :type queue: ~azure.servicebus.management.QueueProperties
         :rtype: None
         """
@@ -444,11 +445,12 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
     async def update_topic(self, topic: TopicProperties, **kwargs) -> None:
         """Update a topic.
 
-        Before calling this method, you should use `get_topic` to get a `TopicProperties` instance, then
-        update the properties you want to update. Only a portion of properties can be updated.
+        Before calling this method, you should use `get_topic`, `create_topic` or `list_topics` to get a
+        `TopicProperties` instance, then update the properties. Only a portion of properties can be updated.
         Refer to https://docs.microsoft.com/en-us/rest/api/servicebus/update-topic.
 
-        :param topic: The topic that is returned from `get_topic` and has the updated properties.
+        :param topic: The topic that is returned from `get_topic`, `create_topic`, or `list_topics`
+         and has the updated properties.
         :type topic: ~azure.servicebus.management.TopicProperties
         :rtype: None
         """
@@ -647,12 +649,12 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
     ) -> None:
         """Update a subscription.
 
-        Before calling this method, you should use `get_subscription` to get a `SubscriptionProperties` instance,
-        then update the properties you want to update.
+        Before calling this method, you should use `get_subscription`, `update_subscription` or `list_subscription`
+        to get a `SubscriptionProperties` instance, then update the properties.
 
         :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
         :param ~azure.servicebus.management.SubscriptionProperties subscription: The subscription that is returned
-         from `get_subscription` and has the updated properties.
+         from `get_subscription`, `update_subscription` or `list_subscription` and has the updated properties.
         :rtype: None
         """
         try:
@@ -841,14 +843,14 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             rule: RuleProperties, **kwargs) -> None:
         """Update a rule.
 
-        Before calling this method, you should use `get_rule` to get a `RuleProperties` instance,
-        then update the properties you want to update.
+        Before calling this method, you should use `get_rule`, `create_rule` or `list_rules` to get a `RuleProperties`
+        instance, then update the properties.
 
         :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
         :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
          owns this rule.
-        :param ~azure.servicebus.management.RuleProperties rule: The rule that is returned
-         from `get_rule` and has the updated properties.
+        :param ~azure.servicebus.management.RuleProperties rule: The rule that is returned from `get_rule`,
+        `create_rule`, or `list_rules` and has the updated properties.
         :rtype: None
         """
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
@@ -802,8 +802,6 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             name: str, **kwargs) -> RuleProperties:
         """Create a rule for a topic subscription.
 
-        :param name: Name of the rule.
-        :type name: str
         :keyword filter: The filter of the rule.
         :type filter: Union[~azure.servicebus.management.models.CorrelationRuleFilter,
          ~azure.servicebus.management.models.SqlRuleFilter]

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
@@ -33,8 +33,8 @@ from ...management._generated.aio._service_bus_management_client_async import Se
     as ServiceBusManagementClientImpl
 from ...management import _constants as constants
 from ._shared_key_policy_async import AsyncServiceBusSharedKeyCredentialPolicy
-from ...management._models import QueueRuntimeInfo, QueueDescription, TopicDescription, TopicRuntimeInfo, \
-    SubscriptionDescription, SubscriptionRuntimeInfo, RuleDescription
+from ...management._models import QueueRuntimeProperties, QueueProperties, TopicProperties, TopicRuntimeProperties, \
+    SubscriptionProperties, SubscriptionRuntimeProperties, RuleProperties
 from ...management._xml_workaround_policy import ServiceBusXMLWorkaroundPolicy
 from ...management._handle_response_error import _handle_response_error
 from ...management._model_workaround import avoid_timedelta_overflow
@@ -143,42 +143,42 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             endpoint = endpoint[endpoint.index("//")+2:]
         return cls(endpoint, ServiceBusSharedKeyCredential(shared_access_key_name, shared_access_key), **kwargs)
 
-    async def get_queue(self, queue_name: str, **kwargs) -> QueueDescription:
+    async def get_queue(self, queue_name: str, **kwargs) -> QueueProperties:
         """Get the properties of a queue.
 
         :param str queue_name: The name of the queue.
-        :rtype: ~azure.servicebus.management.QueueDescription
+        :rtype: ~azure.servicebus.management.QueueProperties
         """
         entry_ele = await self._get_entity_element(queue_name, **kwargs)
         entry = QueueDescriptionEntry.deserialize(entry_ele)
         if not entry.content:
             raise ResourceNotFoundError("Queue '{}' does not exist".format(queue_name))
-        queue_description = QueueDescription._from_internal_entity(queue_name,
+        queue_description = QueueProperties._from_internal_entity(queue_name,
             entry.content.queue_description)
         return queue_description
 
-    async def get_queue_runtime_info(self, queue_name: str, **kwargs) -> QueueRuntimeInfo:
+    async def get_queue_runtime_info(self, queue_name: str, **kwargs) -> QueueRuntimeProperties:
         """Get the runtime information of a queue.
 
         :param str queue_name: The name of the queue.
-        :rtype: ~azure.servicebus.management.QueueRuntimeInfo
+        :rtype: ~azure.servicebus.management.QueueRuntimeProperties
         """
         entry_ele = await self._get_entity_element(queue_name, **kwargs)
         entry = QueueDescriptionEntry.deserialize(entry_ele)
         if not entry.content:
             raise ResourceNotFoundError("Queue {} does not exist".format(queue_name))
-        runtime_info = QueueRuntimeInfo._from_internal_entity(queue_name,
+        runtime_info = QueueRuntimeProperties._from_internal_entity(queue_name,
             entry.content.queue_description)
         return runtime_info
 
-    async def create_queue(self, queue: Union[str, QueueDescription], **kwargs) -> QueueDescription:
+    async def create_queue(self, queue: Union[str, QueueProperties], **kwargs) -> QueueProperties:
         """Create a queue.
 
-        :param queue: The queue name or a `QueueDescription` instance. When it's a str, it will be the name
+        :param queue: The queue name or a `QueueProperties` instance. When it's a str, it will be the name
          of the created queue. Other properties of the created queue will have default values as defined by the
-         service. Use a `QueueDescription` if you want to set queue properties other than the queue name.
-        :type queue: Union[str, ~azure.servicebus.management.QueueDescription]
-        :rtype: ~azure.servicebus.management.QueueDescription
+         service. Use a `QueueProperties` if you want to set queue properties other than the queue name.
+        :type queue: Union[str, ~azure.servicebus.management.QueueProperties]
+        :rtype: ~azure.servicebus.management.QueueProperties
         """
         try:
             queue_name = queue.name  # type: ignore
@@ -202,12 +202,12 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             )
 
         entry = QueueDescriptionEntry.deserialize(entry_ele)
-        result = QueueDescription._from_internal_entity(queue_name,
+        result = QueueProperties._from_internal_entity(queue_name,
             entry.content.queue_description)
         return result
 
     async def update_queue(
-            self, queue: QueueDescription,
+            self, queue: QueueProperties,
             *,
             default_message_time_to_live: timedelta = None,
             lock_duration: timedelta = None,
@@ -217,10 +217,10 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             **kwargs) -> None:
         """Update a queue.
 
-        :param queue: The properties of this `QueueDescription` will be applied to the queue in
+        :param queue: The properties of this `QueueProperties` will be applied to the queue in
          ServiceBus. Only a portion of properties can be updated.
          Refer to https://docs.microsoft.com/en-us/rest/api/servicebus/update-queue.
-        :type queue: ~azure.servicebus.management.QueueDescription
+        :type queue: ~azure.servicebus.management.QueueProperties
         :keyword timedelta default_message_time_to_live: The value you want to update to.
         :keyword timedelta lock_duration: The value you want to update to.
         :keyword bool dead_lettering_on_message_expiration: The value you want to update to.
@@ -258,11 +258,11 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
                 **kwargs
             )
 
-    async def delete_queue(self, queue: Union[str, QueueDescription], **kwargs) -> None:
+    async def delete_queue(self, queue: Union[str, QueueProperties], **kwargs) -> None:
         """Delete a queue.
 
-        :param Union[str, azure.servicebus.management.QueueDescription] queue: The name of the queue or
-         a `QueueDescription` with name.
+        :param Union[str, azure.servicebus.management.QueueProperties] queue: The name of the queue or
+         a `QueueProperties` with name.
         :rtype: None
         """
         try:
@@ -274,15 +274,15 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         with _handle_response_error():
             await self._impl.entity.delete(queue_name, api_version=constants.API_VERSION, **kwargs)
 
-    def list_queues(self, **kwargs) -> AsyncItemPaged[QueueDescription]:
+    def list_queues(self, **kwargs) -> AsyncItemPaged[QueueProperties]:
         """List the queues of a ServiceBus namespace.
 
-        :returns: An iterable (auto-paging) response of QueueDescription.
-        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.servicebus.management.QueueDescription]
+        :returns: An iterable (auto-paging) response of QueueProperties.
+        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.servicebus.management.QueueProperties]
         """
 
         def entry_to_qd(entry):
-            qd = QueueDescription._from_internal_entity(entry.title, entry.content.queue_description)
+            qd = QueueProperties._from_internal_entity(entry.title, entry.content.queue_description)
             return qd
 
         extract_data = functools.partial(
@@ -294,15 +294,15 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         return AsyncItemPaged(
             get_next, extract_data)
 
-    def list_queues_runtime_info(self, **kwargs) -> AsyncItemPaged[QueueRuntimeInfo]:
+    def list_queues_runtime_info(self, **kwargs) -> AsyncItemPaged[QueueRuntimeProperties]:
         """List the runtime information of the queues in a ServiceBus namespace.
 
-        :returns: An iterable (auto-paging) response of QueueRuntimeInfo.
-        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.servicebus.management.QueueRuntimeInfo]
+        :returns: An iterable (auto-paging) response of QueueRuntimeProperties.
+        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.servicebus.management.QueueRuntimeProperties]
         """
 
         def entry_to_qr(entry):
-            qd = QueueRuntimeInfo._from_internal_entity(entry.title, entry.content.queue_description)
+            qd = QueueRuntimeProperties._from_internal_entity(entry.title, entry.content.queue_description)
             return qd
 
         extract_data = functools.partial(
@@ -314,7 +314,7 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         return AsyncItemPaged(
             get_next, extract_data)
 
-    async def get_topic(self, topic_name: str, **kwargs) -> TopicDescription:
+    async def get_topic(self, topic_name: str, **kwargs) -> TopicProperties:
         """Get the properties of a topic.
 
         :param str topic_name: The name of the topic.
@@ -324,30 +324,30 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         entry = TopicDescriptionEntry.deserialize(entry_ele)
         if not entry.content:
             raise ResourceNotFoundError("Topic '{}' does not exist".format(topic_name))
-        topic_description = TopicDescription._from_internal_entity(topic_name, entry.content.topic_description)
+        topic_description = TopicProperties._from_internal_entity(topic_name, entry.content.topic_description)
         return topic_description
 
-    async def get_topic_runtime_info(self, topic_name: str, **kwargs) -> TopicRuntimeInfo:
+    async def get_topic_runtime_info(self, topic_name: str, **kwargs) -> TopicRuntimeProperties:
         """Get the runtime information of a topic.
 
         :param str topic_name: The name of the topic.
-        :rtype: ~azure.servicebus.management.TopicRuntimeInfo
+        :rtype: ~azure.servicebus.management.TopicRuntimeProperties
         """
         entry_ele = await self._get_entity_element(topic_name, **kwargs)
         entry = TopicDescriptionEntry.deserialize(entry_ele)
         if not entry.content:
             raise ResourceNotFoundError("Topic {} does not exist".format(topic_name))
-        topic_description = TopicRuntimeInfo._from_internal_entity(topic_name, entry.content.topic_description)
+        topic_description = TopicRuntimeProperties._from_internal_entity(topic_name, entry.content.topic_description)
         return topic_description
 
-    async def create_topic(self, topic: Union[str, TopicDescription], **kwargs) -> TopicDescription:
+    async def create_topic(self, topic: Union[str, TopicProperties], **kwargs) -> TopicProperties:
         """Create a topic.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic name or a `TopicDescription`
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic name or a `TopicProperties`
          instance. When it's a str, it will be the name of the created topic. Other properties of the created topic
          will have default values as defined by the service.
-         Use a `TopicDescription` if you want to set queue properties other than the queue name.
-        :rtype: ~azure.servicebus.management.TopicDescription
+         Use a `TopicProperties` if you want to set queue properties other than the queue name.
+        :rtype: ~azure.servicebus.management.TopicProperties
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -370,23 +370,23 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
                     request_body, api_version=constants.API_VERSION, **kwargs)
             )
         entry = TopicDescriptionEntry.deserialize(entry_ele)
-        result = TopicDescription._from_internal_entity(topic_name, entry.content.topic_description)
+        result = TopicProperties._from_internal_entity(topic_name, entry.content.topic_description)
         return result
 
     async def update_topic(
-            self, topic: TopicDescription,
+            self, topic: TopicProperties,
             *,
             default_message_time_to_live: timedelta = None,
             duplicate_detection_history_time_window: timedelta = None,
             **kwargs) -> None:
         """Update a topic.
 
-        Before calling this method, you should use `get_topic` to get a `TopicDescription` instance, then use the
+        Before calling this method, you should use `get_topic` to get a `TopicProperties` instance, then use the
         keyword arguments to update the properties you want to update.
         Only a portion of properties can be updated.
         Refer to https://docs.microsoft.com/en-us/rest/api/servicebus/update-topic.
 
-        :param ~azure.servicebus.management.TopicDescription topic: The topic to be updated.
+        :param ~azure.servicebus.management.TopicProperties topic: The topic to be updated.
         :keyword timedelta default_message_time_to_live: The value you want to update to.
         :keyword timedelta duplicate_detection_history_time_window: The value you want to update to.
         :rtype: None
@@ -417,10 +417,10 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
                 **kwargs
             )
 
-    async def delete_topic(self, topic: Union[str, TopicDescription], **kwargs) -> None:
+    async def delete_topic(self, topic: Union[str, TopicProperties], **kwargs) -> None:
         """Delete a topic.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic to be deleted.
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic to be deleted.
         :rtype: None
         """
         try:
@@ -429,14 +429,14 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             topic_name = topic
         await self._impl.entity.delete(topic_name, api_version=constants.API_VERSION, **kwargs)
 
-    def list_topics(self, **kwargs) -> AsyncItemPaged[TopicDescription]:
+    def list_topics(self, **kwargs) -> AsyncItemPaged[TopicProperties]:
         """List the topics of a ServiceBus namespace.
 
-        :returns: An iterable (auto-paging) response of TopicDescription.
-        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.servicebus.management.TopicDescription]
+        :returns: An iterable (auto-paging) response of TopicProperties.
+        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.servicebus.management.TopicProperties]
         """
         def entry_to_topic(entry):
-            topic = TopicDescription._from_internal_entity(entry.title, entry.content.topic_description)
+            topic = TopicProperties._from_internal_entity(entry.title, entry.content.topic_description)
             return topic
 
         extract_data = functools.partial(
@@ -448,14 +448,14 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         return AsyncItemPaged(
             get_next, extract_data)
 
-    def list_topics_runtime_info(self, **kwargs) -> AsyncItemPaged[TopicRuntimeInfo]:
+    def list_topics_runtime_info(self, **kwargs) -> AsyncItemPaged[TopicRuntimeProperties]:
         """List the topics runtime information of a ServiceBus namespace.
 
-        :returns: An iterable (auto-paging) response of TopicRuntimeInfo.
-        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.servicebus.management.TopicRuntimeInfo]
+        :returns: An iterable (auto-paging) response of TopicRuntimeProperties.
+        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.servicebus.management.TopicRuntimeProperties]
         """
         def entry_to_topic(entry):
-            topic = TopicRuntimeInfo._from_internal_entity(entry.title, entry.content.topic_description)
+            topic = TopicRuntimeProperties._from_internal_entity(entry.title, entry.content.topic_description)
             return topic
 
         extract_data = functools.partial(
@@ -468,13 +468,13 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             get_next, extract_data)
 
     async def get_subscription(
-            self, topic: Union[str, TopicDescription], subscription_name: str, **kwargs
-    ) -> SubscriptionDescription:
+            self, topic: Union[str, TopicProperties], subscription_name: str, **kwargs
+    ) -> SubscriptionProperties:
         """Get the properties of a topic subscription.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
         :param str subscription_name: name of the subscription.
-        :rtype: ~azure.servicebus.management.SubscriptionDescription
+        :rtype: ~azure.servicebus.management.SubscriptionProperties
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -485,18 +485,18 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         if not entry.content:
             raise ResourceNotFoundError(
                 "Subscription('Topic: {}, Subscription: {}') does not exist".format(subscription_name, topic_name))
-        subscription = SubscriptionDescription._from_internal_entity(
+        subscription = SubscriptionProperties._from_internal_entity(
             entry.title, entry.content.subscription_description)
         return subscription
 
     async def get_subscription_runtime_info(
-            self, topic: Union[str, TopicDescription], subscription_name: str, **kwargs
-    ) -> SubscriptionRuntimeInfo:
+            self, topic: Union[str, TopicProperties], subscription_name: str, **kwargs
+    ) -> SubscriptionRuntimeProperties:
         """Get a topic subscription runtime info.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
         :param str subscription_name: name of the subscription.
-        :rtype: ~azure.servicebus.management.SubscriptionRuntimeInfo
+        :rtype: ~azure.servicebus.management.SubscriptionRuntimeProperties
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -507,21 +507,21 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         if not entry.content:
             raise ResourceNotFoundError(
                 "Subscription('Topic: {}, Subscription: {}') does not exist".format(subscription_name, topic_name))
-        subscription = SubscriptionRuntimeInfo._from_internal_entity(
+        subscription = SubscriptionRuntimeProperties._from_internal_entity(
             entry.title, entry.content.subscription_description)
         return subscription
 
     async def create_subscription(
-            self, topic: Union[str, TopicDescription], subscription: Union[str, SubscriptionDescription], **kwargs
-    ) -> SubscriptionDescription:
+            self, topic: Union[str, TopicProperties], subscription: Union[str, SubscriptionProperties], **kwargs
+    ) -> SubscriptionProperties:
         """Create a topic subscription.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that will own the
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that will own the
          to-be-created subscription.
-        :param Union[str, ~azure.servicebus.management.SubscriptionDescription] subscription: The subscription name or a
-        `SubscriptionDescription` instance. When it's a str, it will be the name of the created subscription.
+        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription name or a
+        `SubscriptionProperties` instance. When it's a str, it will be the name of the created subscription.
          Other properties of the created subscription will have default values as defined by the service.
-        :rtype:  ~azure.servicebus.management.SubscriptionDescription
+        :rtype:  ~azure.servicebus.management.SubscriptionProperties
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -550,21 +550,21 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             )
 
         entry = SubscriptionDescriptionEntry.deserialize(entry_ele)
-        result = SubscriptionDescription._from_internal_entity(
+        result = SubscriptionProperties._from_internal_entity(
             subscription_name, entry.content.subscription_description)
         return result
 
     async def update_subscription(
-            self, topic: Union[str, TopicDescription], subscription: SubscriptionDescription, **kwargs
+            self, topic: Union[str, TopicProperties], subscription: SubscriptionProperties, **kwargs
     ) -> None:
         """Update a subscription.
 
-        Before calling this method, you should use `get_subscription` to get a `SubscriptionDescription` instance,
+        Before calling this method, you should use `get_subscription` to get a `SubscriptionProperties` instance,
         then update the related attributes and call this method.
         Only a portion of properties can be updated.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
-        :param ~azure.servicebus.management.SubscriptionDescription subscription: The subscription to be updated.
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
+        :param ~azure.servicebus.management.SubscriptionProperties subscription: The subscription to be updated.
         :rtype: None
         """
         try:
@@ -594,12 +594,12 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             )
 
     async def delete_subscription(
-            self, topic: Union[str, TopicDescription], subscription: Union[str, SubscriptionDescription], **kwargs
+            self, topic: Union[str, TopicProperties], subscription: Union[str, SubscriptionProperties], **kwargs
     ) -> None:
         """Delete a topic subscription.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
-        :param Union[str, ~azure.servicebus.management.SubscriptionDescription] subscription: The subscription
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
+        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription
          to be deleted.
         :rtype: None
         """
@@ -614,12 +614,12 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         await self._impl.subscription.delete(topic_name, subscription_name, api_version=constants.API_VERSION, **kwargs)
 
     def list_subscriptions(
-            self, topic: Union[str, TopicDescription], **kwargs) -> AsyncItemPaged[SubscriptionDescription]:
+            self, topic: Union[str, TopicProperties], **kwargs) -> AsyncItemPaged[SubscriptionProperties]:
         """List the subscriptions of a ServiceBus Topic.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
-        :returns: An iterable (auto-paging) response of SubscriptionDescription.
-        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.servicebus.management.SubscriptionDescription]
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
+        :returns: An iterable (auto-paging) response of SubscriptionProperties.
+        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.servicebus.management.SubscriptionProperties]
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -627,7 +627,7 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             topic_name = topic
 
         def entry_to_subscription(entry):
-            subscription = SubscriptionDescription._from_internal_entity(
+            subscription = SubscriptionProperties._from_internal_entity(
                 entry.title, entry.content.subscription_description)
             return subscription
 
@@ -641,12 +641,12 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             get_next, extract_data)
 
     def list_subscriptions_runtime_info(
-            self, topic: Union[str, TopicDescription], **kwargs) -> AsyncItemPaged[SubscriptionRuntimeInfo]:
+            self, topic: Union[str, TopicProperties], **kwargs) -> AsyncItemPaged[SubscriptionRuntimeProperties]:
         """List the subscriptions runtime information of a ServiceBus.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
-        :returns: An iterable (auto-paging) response of SubscriptionRuntimeInfo.
-        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.servicebus.management.SubscriptionRuntimeInfo]
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
+        :returns: An iterable (auto-paging) response of SubscriptionRuntimeProperties.
+        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.servicebus.management.SubscriptionRuntimeProperties]
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -654,7 +654,7 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             topic_name = topic
 
         def entry_to_subscription(entry):
-            subscription = SubscriptionRuntimeInfo._from_internal_entity(
+            subscription = SubscriptionRuntimeProperties._from_internal_entity(
                 entry.title, entry.content.subscription_description)
             return subscription
 
@@ -668,15 +668,15 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             get_next, extract_data)
 
     async def get_rule(
-            self, topic: Union[str, TopicDescription], subscription: Union[str, SubscriptionDescription],
-            rule_name: str, **kwargs) -> RuleDescription:
+            self, topic: Union[str, TopicProperties], subscription: Union[str, SubscriptionProperties],
+            rule_name: str, **kwargs) -> RuleProperties:
         """Get the properties of a topic subscription rule.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
-        :param Union[str, ~azure.servicebus.management.SubscriptionDescription] subscription: The subscription that
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
+        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
          owns the rule.
         :param str rule_name: Name of the rule.
-        :rtype: ~azure.servicebus.management.RuleDescription
+        :rtype: ~azure.servicebus.management.RuleProperties
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -692,22 +692,22 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             raise ResourceNotFoundError(
                 "Rule('Topic: {}, Subscription: {}, Rule {}') does not exist".format(
                     subscription_name, topic_name, rule_name))
-        rule_description = RuleDescription._from_internal_entity(rule_name, entry.content.rule_description)
+        rule_description = RuleProperties._from_internal_entity(rule_name, entry.content.rule_description)
         deserialize_rule_key_values(entry_ele, rule_description)  # to remove after #3535 is released.
         return rule_description
 
     async def create_rule(
-            self, topic: Union[str, TopicDescription], subscription: Union[str, SubscriptionDescription],
-            rule: RuleDescription, **kwargs) -> RuleDescription:
+            self, topic: Union[str, TopicProperties], subscription: Union[str, SubscriptionProperties],
+            rule: RuleProperties, **kwargs) -> RuleProperties:
         """Create a rule for a topic subscription.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that will own the
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that will own the
          to-be-created subscription rule.
-        :param Union[str, ~azure.servicebus.management.SubscriptionDescription] subscription: The subscription that
+        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
          will own the to-be-created rule.
-        :param ~azure.servicebus.management.RuleDescription rule: The rule to be created.
+        :param ~azure.servicebus.management.RuleProperties rule: The rule to be created.
          Other properties of the created rule will have default values as defined by the service.
-        :rtype: ~azure.servicebus.management.RuleDescription
+        :rtype: ~azure.servicebus.management.RuleProperties
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -734,23 +734,23 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
                 rule_name,
                 request_body, api_version=constants.API_VERSION, **kwargs)
         entry = RuleDescriptionEntry.deserialize(entry_ele)
-        result = RuleDescription._from_internal_entity(rule_name, entry.content.rule_description)
+        result = RuleProperties._from_internal_entity(rule_name, entry.content.rule_description)
         deserialize_rule_key_values(entry_ele, result)  # to remove after #3535 is released.
         return result
 
     async def update_rule(
-            self, topic: Union[str, TopicDescription], subscription: Union[str, SubscriptionDescription],
-            rule: RuleDescription, **kwargs) -> None:
+            self, topic: Union[str, TopicProperties], subscription: Union[str, SubscriptionProperties],
+            rule: RuleProperties, **kwargs) -> None:
         """Update a rule.
 
-        Before calling this method, you should use `get_rule` to get a `RuleDescription` instance,
+        Before calling this method, you should use `get_rule` to get a `RuleProperties` instance,
         then update the related attributes and call this method.
         Only a portion of properties can be updated.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
-        :param Union[str, ~azure.servicebus.management.SubscriptionDescription] subscription: The subscription that
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
+        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
          owns this rule.
-        :param ~azure.servicebus.management.RuleDescription rule: The rule to be updated.
+        :param ~azure.servicebus.management.RuleProperties rule: The rule to be updated.
         :rtype: None
         """
 
@@ -784,14 +784,14 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             )
 
     async def delete_rule(
-            self, topic: Union[str, TopicDescription], subscription: Union[str, SubscriptionDescription],
-            rule: Union[str, RuleDescription], **kwargs) -> None:
+            self, topic: Union[str, TopicProperties], subscription: Union[str, SubscriptionProperties],
+            rule: Union[str, RuleProperties], **kwargs) -> None:
         """Delete a topic subscription rule.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
-        :param Union[str, ~azure.servicebus.management.SubscriptionDescription] subscription: The subscription that
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
+        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
          owns the topic.
-        :param Union[str, ~azure.servicebus.management.RuleDescription] rule: The to-be-deleted rule.
+        :param Union[str, ~azure.servicebus.management.RuleProperties] rule: The to-be-deleted rule.
         :rtype: None
         """
         try:
@@ -810,15 +810,15 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             topic_name, subscription_name, rule_name, api_version=constants.API_VERSION, **kwargs)
 
     def list_rules(
-            self, topic: Union[str, TopicDescription], subscription: Union[str, SubscriptionDescription], **kwargs
-    ) -> AsyncItemPaged[RuleDescription]:
+            self, topic: Union[str, TopicProperties], subscription: Union[str, SubscriptionProperties], **kwargs
+    ) -> AsyncItemPaged[RuleProperties]:
         """List the rules of a topic subscription.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
-        :param Union[str, ~azure.servicebus.management.SubscriptionDescription] subscription: The subscription that
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
+        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
          owns the rules.
-        :returns: An iterable (auto-paging) response of RuleDescription.
-        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.servicebus.management.RuleDescription]
+        :returns: An iterable (auto-paging) response of RuleProperties.
+        :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.servicebus.management.RuleProperties]
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -834,7 +834,7 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             `ele` will be removed after #3535 is released.
             """
             rule = entry.content.rule_description
-            rule_description = RuleDescription._from_internal_entity(entry.title, rule)
+            rule_description = RuleProperties._from_internal_entity(entry.title, rule)
             deserialize_rule_key_values(ele, rule_description)  # to remove after #3535 is released.
             return rule_description
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
@@ -188,10 +188,6 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         :keyword duplicate_detection_history_time_window: ISO 8601 timeSpan structure that defines the
          duration of the duplicate detection history. The default value is 10 minutes.
         :type duplicate_detection_history_time_window: ~datetime.timedelta
-        :keyword entity_availability_status: Availibility status of the entity. Possible values include:
-         "Available", "Limited", "Renaming", "Restoring", "Unknown".
-        :type entity_availability_status: str or
-         ~azure.servicebus.management.EntityAvailabilityStatus
         :keyword enable_batched_operations: Value that indicates whether server-side batched operations
          are enabled.
         :type enable_batched_operations: bool
@@ -220,9 +216,6 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         :keyword requires_session: A value that indicates whether the queue supports the concept of
          sessions.
         :type requires_session: bool
-        :keyword status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
-         "Deleting", "Disabled", "ReceiveDisabled", "Renaming", "Restoring", "SendDisabled", "Unknown".
-        :type status: str or ~azure.servicebus.management.EntityStatus
         :keyword forward_to: The name of the recipient entity to which all the messages sent to the queue
          are forwarded to.
         :type forward_to: str
@@ -402,9 +395,6 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         :keyword authorization_rules: Authorization rules for resource.
         :type authorization_rules:
          list[~azure.servicebus.management.AuthorizationRule]
-        :keyword status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
-         "Deleting", "Disabled", "ReceiveDisabled", "Renaming", "Restoring", "SendDisabled", "Unknown".
-        :type status: str or ~azure.servicebus.management.models.EntityStatus
         :keyword support_ordering: A value that indicates whether the topic supports ordering.
         :type support_ordering: bool
         :keyword auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the topic is
@@ -413,10 +403,6 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         :keyword enable_partitioning: A value that indicates whether the topic is to be partitioned
          across multiple message brokers.
         :type enable_partitioning: bool
-        :keyword entity_availability_status: Availability status of the entity. Possible values include:
-         "Available", "Limited", "Renaming", "Restoring", "Unknown".
-        :type entity_availability_status: str or
-         ~azure.servicebus.management.models.EntityAvailabilityStatus
         :keyword enable_subscription_partitioning: A value that indicates whether the topic's
          subscription is to be partitioned.
         :type enable_subscription_partitioning: bool
@@ -605,9 +591,6 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         :keyword enable_batched_operations: Value that indicates whether server-side batched operations
          are enabled.
         :type enable_batched_operations: bool
-        :keyword status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
-         "Deleting", "Disabled", "ReceiveDisabled", "Renaming", "Restoring", "SendDisabled", "Unknown".
-        :type status: str or ~azure.servicebus.management.models.EntityStatus
         :keyword forward_to: The name of the recipient entity to which all the messages sent to the
          subscription are forwarded to.
         :type forward_to: str
@@ -620,10 +603,6 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         :keyword auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the subscription is
          automatically deleted. The minimum duration is 5 minutes.
         :type auto_delete_on_idle: ~datetime.timedelta
-        :keyword entity_availability_status: Availability status of the entity. Possible values include:
-         "Available", "Limited", "Renaming", "Restoring", "Unknown".
-        :type entity_availability_status: str or
-         ~azure.servicebus.management.models.EntityAvailabilityStatus
         :rtype:  ~azure.servicebus.management.SubscriptionProperties
         """
         try:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
@@ -206,40 +206,19 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             entry.content.queue_description)
         return result
 
-    async def update_queue(
-            self, queue: QueueProperties,
-            *,
-            default_message_time_to_live: timedelta = None,
-            lock_duration: timedelta = None,
-            dead_lettering_on_message_expiration: bool = None,
-            duplicate_detection_history_time_window: timedelta = None,
-            max_delivery_count: int = None,
-            **kwargs) -> None:
+    async def update_queue(self, queue: QueueProperties, **kwargs) -> None:
         """Update a queue.
 
-        :param queue: The properties of this `QueueProperties` will be applied to the queue in
-         ServiceBus. Only a portion of properties can be updated.
-         Refer to https://docs.microsoft.com/en-us/rest/api/servicebus/update-queue.
+        Before calling this method, you should use `get_queue` to get a `QueueProperties` instance, then update
+        the properties you want to update. Only a portion of properties can be updated.
+        Refer to https://docs.microsoft.com/en-us/rest/api/servicebus/update-queue.
+
+        :param queue: The queue that is returned from `get_queue` and has the updated properties.
         :type queue: ~azure.servicebus.management.QueueProperties
-        :keyword timedelta default_message_time_to_live: The value you want to update to.
-        :keyword timedelta lock_duration: The value you want to update to.
-        :keyword bool dead_lettering_on_message_expiration: The value you want to update to.
-        :keyword timedelta duplicate_detection_history_time_window: The value you want to update to.
-        :keyword int max_delivery_count: The value you want to update to.
         :rtype: None
         """
 
         to_update = queue._to_internal_entity()
-
-        to_update.default_message_time_to_live = default_message_time_to_live \
-                                                 or queue.default_message_time_to_live
-        to_update.lock_duration = lock_duration or queue.lock_duration
-        to_update.dead_lettering_on_message_expiration = dead_lettering_on_message_expiration \
-                                                         or queue.dead_lettering_on_message_expiration
-        to_update.duplicate_detection_history_time_window = duplicate_detection_history_time_window or \
-                                                            queue.duplicate_detection_history_time_window
-        to_update.max_delivery_count = max_delivery_count or queue.max_delivery_count
-
         to_update.default_message_time_to_live = avoid_timedelta_overflow(to_update.default_message_time_to_live)
         to_update.auto_delete_on_idle = avoid_timedelta_overflow(to_update.auto_delete_on_idle)
 
@@ -373,31 +352,19 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         result = TopicProperties._from_internal_entity(topic_name, entry.content.topic_description)
         return result
 
-    async def update_topic(
-            self, topic: TopicProperties,
-            *,
-            default_message_time_to_live: timedelta = None,
-            duplicate_detection_history_time_window: timedelta = None,
-            **kwargs) -> None:
+    async def update_topic(self, topic: TopicProperties, **kwargs) -> None:
         """Update a topic.
 
-        Before calling this method, you should use `get_topic` to get a `TopicProperties` instance, then use the
-        keyword arguments to update the properties you want to update.
-        Only a portion of properties can be updated.
+        Before calling this method, you should use `get_topic` to get a `TopicProperties` instance, then
+        update the properties you want to update. Only a portion of properties can be updated.
         Refer to https://docs.microsoft.com/en-us/rest/api/servicebus/update-topic.
 
-        :param ~azure.servicebus.management.TopicProperties topic: The topic to be updated.
-        :keyword timedelta default_message_time_to_live: The value you want to update to.
-        :keyword timedelta duplicate_detection_history_time_window: The value you want to update to.
+        :param topic: The topic that is returned from `get_topic` and has the updated properties.
+        :type topic: ~azure.servicebus.management.TopicProperties
         :rtype: None
         """
 
         to_update = topic._to_internal_entity()
-
-        to_update.default_message_time_to_live = default_message_time_to_live or \
-                                                 topic.default_message_time_to_live
-        to_update.duplicate_detection_history_time_window = duplicate_detection_history_time_window or \
-                                                            topic.duplicate_detection_history_time_window
 
         to_update.default_message_time_to_live = avoid_timedelta_overflow(to_update.default_message_time_to_live)
         to_update.auto_delete_on_idle = avoid_timedelta_overflow(to_update.auto_delete_on_idle)
@@ -560,11 +527,11 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         """Update a subscription.
 
         Before calling this method, you should use `get_subscription` to get a `SubscriptionProperties` instance,
-        then update the related attributes and call this method.
-        Only a portion of properties can be updated.
+        then update the properties you want to update.
 
         :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
-        :param ~azure.servicebus.management.SubscriptionProperties subscription: The subscription to be updated.
+        :param ~azure.servicebus.management.SubscriptionProperties subscription: The subscription that is returned
+         from `get_subscription` and has the updated properties.
         :rtype: None
         """
         try:
@@ -744,13 +711,13 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         """Update a rule.
 
         Before calling this method, you should use `get_rule` to get a `RuleProperties` instance,
-        then update the related attributes and call this method.
-        Only a portion of properties can be updated.
+        then update the properties you want to update.
 
         :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
         :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
          owns this rule.
-        :param ~azure.servicebus.management.RuleProperties rule: The rule to be updated.
+        :param ~azure.servicebus.management.RuleProperties rule: The rule that is returned
+         from `get_rule` and has the updated properties.
         :rtype: None
         """
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
@@ -173,6 +173,8 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
     async def create_queue(self, name: str, **kwargs) -> QueueProperties:
         """Create a queue.
 
+        :param name: Name of the queue.
+        :type name: str
         :keyword authorization_rules: Authorization rules for resource.
         :type authorization_rules: list[~azure.servicebus.management.AuthorizationRule]
         :keyword auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the queue is
@@ -230,6 +232,7 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
 
         :rtype: ~azure.servicebus.management.QueueProperties
         """
+        kwargs = dict(kwargs)
         queue = QueueProperties(name, **kwargs)
         for key in queue.keys():
             kwargs.pop(key, None)
@@ -369,6 +372,8 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
     async def create_topic(self, name: str, **kwargs) -> TopicProperties:
         """Create a topic.
 
+        :param name: Name of the topic.
+        :type name: str
         :keyword default_message_time_to_live: ISO 8601 default message timespan to live value. This is
          the duration after which the message expires, starting from when the message is sent to Service
          Bus. This is the default value used when TimeToLive is not set on a message itself.
@@ -415,6 +420,7 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         :rtype: ~azure.servicebus.management.TopicProperties
         """
 
+        kwargs = dict(kwargs)
         topic = TopicProperties(name, **kwargs)
         for key in topic.keys():
             kwargs.pop(key, None)
@@ -568,6 +574,10 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
     ) -> SubscriptionProperties:
         """Create a topic subscription.
 
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that will own the
+         to-be-created subscription.
+        :param name: Name of the subscription.
+        :type name: str
         :keyword lock_duration: ISO 8601 timespan duration of a peek-lock; that is, the amount of time
          that the message is locked for other receivers. The maximum value for LockDuration is 5
          minutes; the default value is 1 minute.
@@ -609,6 +619,7 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             topic_name = topic.name  # type: ignore
         except AttributeError:
             topic_name = topic
+        kwargs = dict(kwargs)
         subscription = SubscriptionProperties(name, **kwargs)
         for key in subscription.keys():
             kwargs.pop(key, None)
@@ -781,6 +792,12 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             name: str, **kwargs) -> RuleProperties:
         """Create a rule for a topic subscription.
 
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that will own the
+         to-be-created subscription rule.
+        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
+         will own the to-be-created rule.
+        :param name: Name of the rule.
+        :type name: str
         :keyword filter: The filter of the rule.
         :type filter: Union[~azure.servicebus.management.models.CorrelationRuleFilter,
          ~azure.servicebus.management.models.SqlRuleFilter]
@@ -799,6 +816,7 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             subscription_name = subscription.name  # type: ignore
         except AttributeError:
             subscription_name = subscription
+        kwargs = dict(kwargs)
         rule = RuleProperties(name, **kwargs)
         for key in rule.keys():
             kwargs.pop(key, None)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
@@ -232,9 +232,29 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
 
         :rtype: ~azure.servicebus.management.QueueProperties
         """
-        queue = QueueProperties(name, **kwargs)
-        for key in queue.keys():
-            kwargs.pop(key, None)
+        queue = QueueProperties(
+            name,
+            authorization_rules=kwargs.pop("authorization_rules", None),
+            auto_delete_on_idle=kwargs.pop("auto_delete_on_idle", None),
+            dead_lettering_on_message_expiration=kwargs.pop("dead_lettering_on_message_expiration", None),
+            default_message_time_to_live=kwargs.pop("default_message_time_to_live", None),
+            duplicate_detection_history_time_window=kwargs.pop("duplicate_detection_history_time_window", None),
+            entity_availability_status=kwargs.pop("entity_availability_status", None),
+            enable_batched_operations=kwargs.pop("enable_batched_operations", None),
+            enable_express=kwargs.pop("enable_express", None),
+            enable_partitioning=kwargs.pop("enable_partitioning", None),
+            is_anonymous_accessible=kwargs.pop("is_anonymous_accessible", None),
+            lock_duration=kwargs.pop("lock_duration", None),
+            max_delivery_count=kwargs.pop("max_delivery_count", None),
+            max_size_in_megabytes=kwargs.pop("max_size_in_megabytes", None),
+            requires_duplicate_detection=kwargs.pop("requires_duplicate_detection", None),
+            requires_session=kwargs.pop("requires_session", None),
+            status=kwargs.pop("status", None),
+            support_ordering=kwargs.pop("support_ordering", None),
+            forward_to=kwargs.pop("forward_to", None),
+            forward_dead_lettered_messages_to=kwargs.pop("forward_dead_lettered_messages_to", None),
+            user_metadata=kwargs.pop("user_metadata", None)
+        )
         to_create = queue._to_internal_entity()
         create_entity_body = CreateQueueBody(
             content=CreateQueueBodyContent(
@@ -420,9 +440,25 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         :rtype: ~azure.servicebus.management.TopicProperties
         """
 
-        topic = TopicProperties(name, **kwargs)
-        for key in topic.keys():
-            kwargs.pop(key, None)
+        topic = TopicProperties(
+            name,
+            default_message_time_to_live=kwargs.pop("default_message_time_to_live", None),
+            max_size_in_megabytes=kwargs.pop("max_size_in_megabytes", None),
+            requires_duplicate_detection=kwargs.pop("requires_duplicate_detection", None),
+            duplicate_detection_history_time_window=kwargs.pop("duplicate_detection_history_time_window", None),
+            enable_batched_operations=kwargs.pop("enable_batched_operations", None),
+            size_in_bytes=kwargs.pop("size_in_bytes", None),
+            is_anonymous_accessible=kwargs.pop("is_anonymous_accessible", None),
+            authorization_rules=kwargs.pop("authorization_rules", None),
+            status=kwargs.pop("status", None),
+            support_ordering=kwargs.pop("support_ordering", None),
+            auto_delete_on_idle=kwargs.pop("auto_delete_on_idle", None),
+            enable_partitioning=kwargs.pop("enable_partitioning", None),
+            entity_availability_status=kwargs.pop("entity_availability_status", None),
+            enable_subscription_partitioning=kwargs.pop("enable_subscription_partitioning", None),
+            enable_express=kwargs.pop("enable_express", None),
+            user_metadata=kwargs.pop("user_metadata", None)
+        )
         to_create = topic._to_internal_entity()
 
         create_entity_body = CreateTopicBody(
@@ -619,9 +655,23 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             topic_name = topic.name  # type: ignore
         except AttributeError:
             topic_name = topic
-        subscription = SubscriptionProperties(name, **kwargs)
-        for key in subscription.keys():
-            kwargs.pop(key, None)
+        subscription = SubscriptionProperties(
+            name,
+            lock_duration=kwargs.pop("lock_duration", None),
+            requires_session=kwargs.pop("requires_session", None),
+            default_message_time_to_live=kwargs.pop("default_message_time_to_live", None),
+            dead_lettering_on_message_expiration=kwargs.pop("dead_lettering_on_message_expiration", None),
+            dead_lettering_on_filter_evaluation_exceptions=
+            kwargs.pop("dead_lettering_on_filter_evaluation_exceptions", None),
+            max_delivery_count=kwargs.pop("max_delivery_count", None),
+            enable_batched_operations=kwargs.pop("enable_batched_operations", None),
+            status=kwargs.pop("status", None),
+            forward_to=kwargs.pop("forward_to", None),
+            user_metadata=kwargs.pop("user_metadata", None),
+            forward_dead_lettered_messages_to=kwargs.pop("forward_dead_lettered_messages_to", None),
+            auto_delete_on_idle=kwargs.pop("auto_delete_on_idle", None),
+            entity_availability_status=kwargs.pop("entity_availability_status", None),
+        )
         to_create = subscription._to_internal_entity()  # type: ignore  # pylint:disable=protected-access
 
         create_entity_body = CreateSubscriptionBody(
@@ -802,8 +852,6 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
          ~azure.servicebus.management.SqlRuleFilter]
         :keyword action: The action of the rule.
         :type action: Optional[~azure.servicebus.management.SqlRuleAction]
-        :keyword created_at: The exact time the rule was created.
-        :type created_at: ~datetime.datetime
 
         :rtype: ~azure.servicebus.management.RuleProperties
         """
@@ -815,9 +863,12 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             subscription_name = subscription.name  # type: ignore
         except AttributeError:
             subscription_name = subscription
-        rule = RuleProperties(name, **kwargs)
-        for key in rule.keys():
-            kwargs.pop(key, None)
+        rule = RuleProperties(
+            name,
+            filter=kwargs.pop("filter", None),
+            action=kwargs.pop("action", None),
+            created_at=None
+        )
         to_create = rule._to_internal_entity()
 
         create_entity_body = CreateRuleBody(

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 # pylint:disable=protected-access
 # pylint:disable=specify-parameter-names-in-call
+# pylint:disable=too-many-lines
 import functools
 from typing import TYPE_CHECKING, Any, Union, cast
 from xml.etree.ElementTree import ElementTree
@@ -20,8 +21,6 @@ from ...management._generated.models import QueueDescriptionFeed, TopicDescripti
     RuleDescriptionFeed, NamespacePropertiesEntry, CreateTopicBody, CreateTopicBodyContent, \
     TopicDescriptionFeed, CreateSubscriptionBody, CreateSubscriptionBodyContent, CreateRuleBody, \
     CreateRuleBodyContent, CreateQueueBody, CreateQueueBodyContent, \
-    QueueDescription as InternalQueueDescription, TopicDescription as InternalTopicDescription, \
-    SubscriptionDescription as InternalSubscriptionDescription, \
     NamespaceProperties
 
 from ..._common.utils import parse_conn_str

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
@@ -7,7 +7,6 @@
 import functools
 from typing import TYPE_CHECKING, Any, Union, cast
 from xml.etree.ElementTree import ElementTree
-from datetime import timedelta
 
 from azure.core.async_paging import AsyncItemPaged
 from azure.core.exceptions import ResourceNotFoundError
@@ -171,22 +170,77 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             entry.content.queue_description)
         return runtime_info
 
-    async def create_queue(self, queue: Union[str, QueueProperties], **kwargs) -> QueueProperties:
+    async def create_queue(self, name: str, **kwargs) -> QueueProperties:
         """Create a queue.
 
-        :param queue: The queue name or a `QueueProperties` instance. When it's a str, it will be the name
-         of the created queue. Other properties of the created queue will have default values as defined by the
-         service. Use a `QueueProperties` if you want to set queue properties other than the queue name.
-        :type queue: Union[str, ~azure.servicebus.management.QueueProperties]
+        :keyword authorization_rules: Authorization rules for resource.
+        :type authorization_rules: list[~azure.servicebus.management.AuthorizationRule]
+        :keyword auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the queue is
+         automatically deleted. The minimum duration is 5 minutes.
+        :type auto_delete_on_idle: ~datetime.timedelta
+        :keyword dead_lettering_on_message_expiration: A value that indicates whether this queue has dead
+         letter support when a message expires.
+        :type dead_lettering_on_message_expiration: bool
+        :keyword default_message_time_to_live: ISO 8601 default message timespan to live value. This is
+         the duration after which the message expires, starting from when the message is sent to Service
+         Bus. This is the default value used when TimeToLive is not set on a message itself.
+        :type default_message_time_to_live: ~datetime.timedelta
+        :keyword duplicate_detection_history_time_window: ISO 8601 timeSpan structure that defines the
+         duration of the duplicate detection history. The default value is 10 minutes.
+        :type duplicate_detection_history_time_window: ~datetime.timedelta
+        :keyword entity_availability_status: Availibility status of the entity. Possible values include:
+         "Available", "Limited", "Renaming", "Restoring", "Unknown".
+        :type entity_availability_status: str or
+         ~azure.servicebus.management.EntityAvailabilityStatus
+        :keyword enable_batched_operations: Value that indicates whether server-side batched operations
+         are enabled.
+        :type enable_batched_operations: bool
+        :keyword enable_express: A value that indicates whether Express Entities are enabled. An express
+         queue holds a message in memory temporarily before writing it to persistent storage.
+        :type enable_express: bool
+        :keyword enable_partitioning: A value that indicates whether the queue is to be partitioned
+         across multiple message brokers.
+        :type enable_partitioning: bool
+        :keyword is_anonymous_accessible: A value indicating if the resource can be accessed without
+         authorization.
+        :type is_anonymous_accessible: bool
+        :keyword lock_duration: ISO 8601 timespan duration of a peek-lock; that is, the amount of time
+         that the message is locked for other receivers. The maximum value for LockDuration is 5
+         minutes; the default value is 1 minute.
+        :type lock_duration: ~datetime.timedelta
+        :keyword max_delivery_count: The maximum delivery count. A message is automatically deadlettered
+         after this number of deliveries. Default value is 10.
+        :type max_delivery_count: int
+        :keyword max_size_in_megabytes: The maximum size of the queue in megabytes, which is the size of
+         memory allocated for the queue.
+        :type max_size_in_megabytes: int
+        :keyword requires_duplicate_detection: A value indicating if this queue requires duplicate
+         detection.
+        :type requires_duplicate_detection: bool
+        :keyword requires_session: A value that indicates whether the queue supports the concept of
+         sessions.
+        :type requires_session: bool
+        :keyword status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
+         "Deleting", "Disabled", "ReceiveDisabled", "Renaming", "Restoring", "SendDisabled", "Unknown".
+        :type status: str or ~azure.servicebus.management.EntityStatus
+        :keyword forward_to: The name of the recipient entity to which all the messages sent to the queue
+         are forwarded to.
+        :type forward_to: str
+        :keyword user_metadata: Custom metdata that user can associate with the description. Max length
+         is 1024 chars.
+        :type user_metadata: str
+        :keyword support_ordering: A value that indicates whether the queue supports ordering.
+        :type support_ordering: bool
+        :keyword forward_dead_lettered_messages_to: The name of the recipient entity to which all the
+         dead-lettered messages of this subscription are forwarded to.
+        :type forward_dead_lettered_messages_to: str
+
         :rtype: ~azure.servicebus.management.QueueProperties
         """
-        try:
-            queue_name = queue.name  # type: ignore
-            to_create = queue._to_internal_entity()  # type: ignore
-        except AttributeError:
-            queue_name = queue  # type: ignore
-            to_create = InternalQueueDescription()  # Use an empty queue description.
-
+        queue = QueueProperties(name, **kwargs)
+        for key in queue.keys():
+            kwargs.pop(key, None)
+        to_create = queue._to_internal_entity()
         create_entity_body = CreateQueueBody(
             content=CreateQueueBodyContent(
                 queue_description=to_create,  # type: ignore
@@ -197,12 +251,12 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             entry_ele = cast(
                 ElementTree,
                 await self._impl.entity.put(
-                    queue_name,  # type: ignore
+                    name,  # type: ignore
                     request_body, api_version=constants.API_VERSION, **kwargs)
             )
 
         entry = QueueDescriptionEntry.deserialize(entry_ele)
-        result = QueueProperties._from_internal_entity(queue_name,
+        result = QueueProperties._from_internal_entity(name,
             entry.content.queue_description)
         return result
 
@@ -319,21 +373,66 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         topic_description = TopicRuntimeProperties._from_internal_entity(topic_name, entry.content.topic_description)
         return topic_description
 
-    async def create_topic(self, topic: Union[str, TopicProperties], **kwargs) -> TopicProperties:
+    async def create_topic(self, name: str, **kwargs) -> TopicProperties:
         """Create a topic.
 
-        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic name or a `TopicProperties`
-         instance. When it's a str, it will be the name of the created topic. Other properties of the created topic
-         will have default values as defined by the service.
-         Use a `TopicProperties` if you want to set queue properties other than the queue name.
+        :keyword default_message_time_to_live: ISO 8601 default message timespan to live value. This is
+         the duration after which the message expires, starting from when the message is sent to Service
+         Bus. This is the default value used when TimeToLive is not set on a message itself.
+        :type default_message_time_to_live: ~datetime.timedelta
+        :keyword max_size_in_megabytes: The maximum size of the topic in megabytes, which is the size of
+         memory allocated for the topic.
+        :type max_size_in_megabytes: long
+        :keyword requires_duplicate_detection: A value indicating if this topic requires duplicate
+         detection.
+        :type requires_duplicate_detection: bool
+        :keyword duplicate_detection_history_time_window: ISO 8601 timeSpan structure that defines the
+         duration of the duplicate detection history. The default value is 10 minutes.
+        :type duplicate_detection_history_time_window: ~datetime.timedelta
+        :keyword enable_batched_operations: Value that indicates whether server-side batched operations
+         are enabled.
+        :type enable_batched_operations: bool
+        :keyword size_in_bytes: The size of the topic, in bytes.
+        :type size_in_bytes: int
+        :keyword filtering_messages_before_publishing: Filter messages before publishing.
+        :type filtering_messages_before_publishing: bool
+        :keyword is_anonymous_accessible: A value indicating if the resource can be accessed without
+         authorization.
+        :type is_anonymous_accessible: bool
+        :keyword authorization_rules: Authorization rules for resource.
+        :type authorization_rules:
+         list[~azure.servicebus.management.AuthorizationRule]
+        :keyword status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
+         "Deleting", "Disabled", "ReceiveDisabled", "Renaming", "Restoring", "SendDisabled", "Unknown".
+        :type status: str or ~azure.servicebus.management.models.EntityStatus
+        :keyword support_ordering: A value that indicates whether the topic supports ordering.
+        :type support_ordering: bool
+        :keyword auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the topic is
+         automatically deleted. The minimum duration is 5 minutes.
+        :type auto_delete_on_idle: ~datetime.timedelta
+        :keyword enable_partitioning: A value that indicates whether the topic is to be partitioned
+         across multiple message brokers.
+        :type enable_partitioning: bool
+        :keyword entity_availability_status: Availability status of the entity. Possible values include:
+         "Available", "Limited", "Renaming", "Restoring", "Unknown".
+        :type entity_availability_status: str or
+         ~azure.servicebus.management.models.EntityAvailabilityStatus
+        :keyword enable_subscription_partitioning: A value that indicates whether the topic's
+         subscription is to be partitioned.
+        :type enable_subscription_partitioning: bool
+        :keyword enable_express: A value that indicates whether Express Entities are enabled. An express
+         queue holds a message in memory temporarily before writing it to persistent storage.
+        :type enable_express: bool
+        :keyword user_metadata: Metadata associated with the topic.
+        :type user_metadata: str
+
         :rtype: ~azure.servicebus.management.TopicProperties
         """
-        try:
-            topic_name = topic.name  # type: ignore
-            to_create = topic._to_internal_entity()  # type: ignore
-        except AttributeError:
-            topic_name = topic  # type: ignore
-            to_create = InternalTopicDescription()  # Use an empty topic description.
+
+        topic = TopicProperties(name, **kwargs)
+        for key in topic.keys():
+            kwargs.pop(key, None)
+        to_create = topic._to_internal_entity()
 
         create_entity_body = CreateTopicBody(
             content=CreateTopicBodyContent(
@@ -345,11 +444,11 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             entry_ele = cast(
                 ElementTree,
                 await self._impl.entity.put(
-                    topic_name,  # type: ignore
+                    name,  # type: ignore
                     request_body, api_version=constants.API_VERSION, **kwargs)
             )
         entry = TopicDescriptionEntry.deserialize(entry_ele)
-        result = TopicProperties._from_internal_entity(topic_name, entry.content.topic_description)
+        result = TopicProperties._from_internal_entity(name, entry.content.topic_description)
         return result
 
     async def update_topic(self, topic: TopicProperties, **kwargs) -> None:
@@ -479,27 +578,62 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         return subscription
 
     async def create_subscription(
-            self, topic: Union[str, TopicProperties], subscription: Union[str, SubscriptionProperties], **kwargs
+            self, topic: Union[str, TopicProperties], name: str, **kwargs
     ) -> SubscriptionProperties:
         """Create a topic subscription.
 
-        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that will own the
-         to-be-created subscription.
-        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription name or a
-        `SubscriptionProperties` instance. When it's a str, it will be the name of the created subscription.
-         Other properties of the created subscription will have default values as defined by the service.
+        :keyword lock_duration: ISO 8601 timespan duration of a peek-lock; that is, the amount of time
+         that the message is locked for other receivers. The maximum value for LockDuration is 5
+         minutes; the default value is 1 minute.
+        :type lock_duration: ~datetime.timedelta
+        :keyword requires_session: A value that indicates whether the queue supports the concept of
+         sessions.
+        :type requires_session: bool
+        :keyword default_message_time_to_live: ISO 8601 default message timespan to live value. This is
+         the duration after which the message expires, starting from when the message is sent to Service
+         Bus. This is the default value used when TimeToLive is not set on a message itself.
+        :type default_message_time_to_live: ~datetime.timedelta
+        :keyword dead_lettering_on_message_expiration: A value that indicates whether this subscription
+         has dead letter support when a message expires.
+        :type dead_lettering_on_message_expiration: bool
+        :keyword dead_lettering_on_filter_evaluation_exceptions: A value that indicates whether this
+         subscription has dead letter support when a message expires.
+        :type dead_lettering_on_filter_evaluation_exceptions: bool
+        :keyword max_delivery_count: The maximum delivery count. A message is automatically deadlettered
+         after this number of deliveries. Default value is 10.
+        :type max_delivery_count: int
+        :keyword enable_batched_operations: Value that indicates whether server-side batched operations
+         are enabled.
+        :type enable_batched_operations: bool
+        :keyword status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
+         "Deleting", "Disabled", "ReceiveDisabled", "Renaming", "Restoring", "SendDisabled", "Unknown".
+        :type status: str or ~azure.servicebus.management.models.EntityStatus
+        :keyword forward_to: The name of the recipient entity to which all the messages sent to the
+         subscription are forwarded to.
+        :type forward_to: str
+        :keyword user_metadata: Metadata associated with the subscription. Maximum number of characters
+         is 1024.
+        :type user_metadata: str
+        :keyword forward_dead_lettered_messages_to: The name of the recipient entity to which all the
+         messages sent to the subscription are forwarded to.
+        :type forward_dead_lettered_messages_to: str
+        :keyword auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the subscription is
+         automatically deleted. The minimum duration is 5 minutes.
+        :type auto_delete_on_idle: ~datetime.timedelta
+        :keyword entity_availability_status: Availability status of the entity. Possible values include:
+         "Available", "Limited", "Renaming", "Restoring", "Unknown".
+        :type entity_availability_status: str or
+         ~azure.servicebus.management.models.EntityAvailabilityStatus
         :rtype:  ~azure.servicebus.management.SubscriptionProperties
         """
         try:
             topic_name = topic.name  # type: ignore
         except AttributeError:
             topic_name = topic
-        try:
-            subscription_name = subscription.name  # type: ignore
-            to_create = subscription._to_internal_entity()  # type: ignore
-        except AttributeError:
-            subscription_name = subscription  # type: ignore
-            to_create = InternalSubscriptionDescription()  # Use an empty queue description.
+        subscription = SubscriptionProperties(name, **kwargs)
+        for key in subscription.keys():
+            kwargs.pop(key, None)
+        to_create = subscription._to_internal_entity()  # type: ignore  # pylint:disable=protected-access
 
         create_entity_body = CreateSubscriptionBody(
             content=CreateSubscriptionBodyContent(
@@ -512,13 +646,13 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
                 ElementTree,
                 await self._impl.subscription.put(
                     topic_name,
-                    subscription_name,  # type: ignore
+                    name,  # type: ignore
                     request_body, api_version=constants.API_VERSION, **kwargs)
             )
 
         entry = SubscriptionDescriptionEntry.deserialize(entry_ele)
         result = SubscriptionProperties._from_internal_entity(
-            subscription_name, entry.content.subscription_description)
+            name, entry.content.subscription_description)
         return result
 
     async def update_subscription(
@@ -665,15 +799,19 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
 
     async def create_rule(
             self, topic: Union[str, TopicProperties], subscription: Union[str, SubscriptionProperties],
-            rule: RuleProperties, **kwargs) -> RuleProperties:
+            name: str, **kwargs) -> RuleProperties:
         """Create a rule for a topic subscription.
 
-        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that will own the
-         to-be-created subscription rule.
-        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
-         will own the to-be-created rule.
-        :param ~azure.servicebus.management.RuleProperties rule: The rule to be created.
-         Other properties of the created rule will have default values as defined by the service.
+        :param name: Name of the rule.
+        :type name: str
+        :keyword filter: The filter of the rule.
+        :type filter: Union[~azure.servicebus.management.models.CorrelationRuleFilter,
+         ~azure.servicebus.management.models.SqlRuleFilter]
+        :keyword action: The action of the rule.
+        :type action: Optional[~azure.servicebus.management.models.SqlRuleAction]
+        :keyword created_at: The exact time the rule was created.
+        :type created_at: ~datetime.datetime
+
         :rtype: ~azure.servicebus.management.RuleProperties
         """
         try:
@@ -684,7 +822,9 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             subscription_name = subscription.name  # type: ignore
         except AttributeError:
             subscription_name = subscription
-        rule_name = rule.name
+        rule = RuleProperties(name, **kwargs)
+        for key in rule.keys():
+            kwargs.pop(key, None)
         to_create = rule._to_internal_entity()
 
         create_entity_body = CreateRuleBody(
@@ -698,10 +838,10 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             entry_ele = await self._impl.rule.put(
                 topic_name,
                 subscription_name,  # type: ignore
-                rule_name,
+                name,
                 request_body, api_version=constants.API_VERSION, **kwargs)
         entry = RuleDescriptionEntry.deserialize(entry_ele)
-        result = RuleProperties._from_internal_entity(rule_name, entry.content.rule_description)
+        result = RuleProperties._from_internal_entity(name, entry.content.rule_description)
         deserialize_rule_key_values(entry_ele, result)  # to remove after #3535 is released.
         return result
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/__init__.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/__init__.py
@@ -8,8 +8,8 @@ from ._generated.models import AuthorizationRule, MessageCountDetails, \
     AccessRights, EntityAvailabilityStatus, EntityStatus, \
     NamespaceProperties, MessagingSku, NamespaceType
 
-from ._models import QueueRuntimeInfo, QueueDescription, TopicRuntimeInfo, TopicDescription, \
-    SubscriptionDescription, SubscriptionRuntimeInfo, RuleDescription, \
+from ._models import QueueRuntimeProperties, QueueProperties, TopicRuntimeProperties, TopicProperties, \
+    SubscriptionRuntimeProperties, SubscriptionProperties, RuleProperties, \
     TrueRuleFilter, FalseRuleFilter, SqlRuleFilter, CorrelationRuleFilter, \
     SqlRuleAction
 
@@ -17,16 +17,16 @@ __all__ = [
     'ServiceBusManagementClient',
     'AuthorizationRule',
     'MessageCountDetails',
-    'QueueDescription',
-    'QueueRuntimeInfo',
-    'TopicDescription',
-    'TopicRuntimeInfo',
-    'SubscriptionDescription',
-    'SubscriptionRuntimeInfo',
+    'QueueProperties',
+    'QueueRuntimeProperties',
+    'TopicProperties',
+    'TopicRuntimeProperties',
+    'SubscriptionProperties',
+    'SubscriptionRuntimeProperties',
     'AccessRights',
     'EntityAvailabilityStatus',
     'EntityStatus',
-    'RuleDescription',
+    'RuleProperties',
     'CorrelationRuleFilter', 'SqlRuleFilter', 'TrueRuleFilter', 'FalseRuleFilter',
     'SqlRuleAction',
     'NamespaceProperties', 'MessagingSku', 'NamespaceType',

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
@@ -19,8 +19,7 @@ from ._generated.models import QueueDescriptionFeed, TopicDescriptionEntry, \
     QueueDescriptionEntry, SubscriptionDescriptionFeed, SubscriptionDescriptionEntry, RuleDescriptionEntry, \
     RuleDescriptionFeed, NamespacePropertiesEntry, CreateTopicBody, CreateTopicBodyContent, \
     TopicDescriptionFeed, CreateSubscriptionBody, CreateSubscriptionBodyContent, CreateRuleBody, \
-    CreateRuleBodyContent, CreateQueueBody, CreateQueueBodyContent, NamespaceProperties, \
-    QueueDescription, TopicDescription, SubscriptionDescription, RuleDescription
+    CreateRuleBodyContent, CreateQueueBody, CreateQueueBodyContent, NamespaceProperties
 from ._utils import extract_data_template, get_next_template, deserialize_rule_key_values, serialize_rule_key_values, \
     extract_rule_data_template
 from ._xml_workaround_policy import ServiceBusXMLWorkaroundPolicy

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
@@ -225,7 +225,6 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
 
         :rtype: ~azure.servicebus.management.QueueProperties
         """
-        kwargs = dict(kwargs)
         queue = QueueProperties(name, **kwargs)
         for key in queue.keys():
             kwargs.pop(key, None)
@@ -421,7 +420,6 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
 
         :rtype: ~azure.servicebus.management.TopicProperties
         """
-        kwargs = dict(kwargs)
         topic = TopicProperties(name, **kwargs)
         for key in topic.keys():
             kwargs.pop(key, None)
@@ -626,7 +624,6 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             topic_name = topic.name  # type: ignore
         except AttributeError:
             topic_name = topic
-        kwargs = dict(kwargs)
         subscription = SubscriptionProperties(name, **kwargs)
         for key in subscription.keys():
             kwargs.pop(key, None)
@@ -802,10 +799,10 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         :param name: Name of the rule.
         :type name: str
         :keyword filter: The filter of the rule.
-        :type filter: Union[~azure.servicebus.management.models.CorrelationRuleFilter,
-         ~azure.servicebus.management.models.SqlRuleFilter]
+        :type filter: Union[~azure.servicebus.management.CorrelationRuleFilter,
+         ~azure.servicebus.management.SqlRuleFilter]
         :keyword action: The action of the rule.
-        :type action: Optional[~azure.servicebus.management.models.SqlRuleAction]
+        :type action: Optional[~azure.servicebus.management.SqlRuleAction]
         :keyword created_at: The exact time the rule was created.
         :type created_at: ~datetime.datetime
 
@@ -820,7 +817,6 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             subscription_name = subscription.name  # type: ignore
         except AttributeError:
             subscription_name = subscription
-        kwargs = dict(kwargs)
         rule = RuleProperties(name, **kwargs)
         for key in rule.keys():
             kwargs.pop(key, None)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
@@ -251,11 +251,12 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         # type: (QueueProperties, Any) -> None
         """Update a queue.
 
-        Before calling this method, you should use `get_queue` to get a `QueueProperties` instance, then update
-        the properties you want to update. Only a portion of properties can be updated.
-        Refer to https://docs.microsoft.com/en-us/rest/api/servicebus/update-queue.
+        Before calling this method, you should use `get_queue`, `create_queue` or `list_queues` to get a
+        `QueueProperties` instance, then update the properties. Only a portion of properties can
+        be updated. Refer to https://docs.microsoft.com/en-us/rest/api/servicebus/update-queue.
 
-        :param queue: The queue that is returned from `get_queue` and has the updated properties.
+        :param queue: The queue that is returned from `get_queue`, `create_queue` or `list_queues` and
+         has the updated properties.
         :type queue: ~azure.servicebus.management.QueueProperties
         :rtype: None
         """
@@ -446,11 +447,12 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         # type: (TopicProperties, Any) -> None
         """Update a topic.
 
-        Before calling this method, you should use `get_topic` to get a `TopicProperties` instance, then
-        update the properties you want to update. Only a portion of properties can be updated.
+        Before calling this method, you should use `get_topic`, `create_topic` or `list_topics` to get a
+        `TopicProperties` instance, then update the properties. Only a portion of properties can be updated.
         Refer to https://docs.microsoft.com/en-us/rest/api/servicebus/update-topic.
 
-        :param topic: The topic that is returned from `get_topic` and has the updated properties.
+        :param topic: The topic that is returned from `get_topic`, `create_topic`, or `list_topics`
+         and has the updated properties.
         :type topic: ~azure.servicebus.management.TopicProperties
         :rtype: None
         """
@@ -653,12 +655,12 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         # type: (Union[str, TopicProperties], SubscriptionProperties, Any) -> None
         """Update a subscription.
 
-        Before calling this method, you should use `get_subscription` to get a `SubscriptionProperties` instance,
-        then update the properties you want to update.
+        Before calling this method, you should use `get_subscription`, `update_subscription` or `list_subscription`
+        to get a `SubscriptionProperties` instance, then update the properties.
 
         :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
         :param ~azure.servicebus.management.SubscriptionProperties subscription: The subscription that is returned
-         from `get_subscription` and has the updated properties.
+         from `get_subscription`, `update_subscription` or `list_subscription` and has the updated properties.
         :rtype: None
         """
         try:
@@ -844,14 +846,14 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         # type: (Union[str, TopicProperties], Union[str, SubscriptionProperties], RuleProperties, Any) -> None
         """Update a rule.
 
-        Before calling this method, you should use `get_rule` to get a `RuleProperties` instance,
-        then update the properties you want to update.
+        Before calling this method, you should use `get_rule`, `create_rule` or `list_rules` to get a `RuleProperties`
+        instance, then update the properties.
 
         :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
         :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
          owns this rule.
-        :param ~azure.servicebus.management.RuleProperties rule: The rule that is returned
-         from `get_rule` and has the updated properties.
+        :param ~azure.servicebus.management.RuleProperties rule: The rule that is returned from `get_rule`,
+        `create_rule`, or `list_rules` and has the updated properties.
         :rtype: None
         """
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
@@ -19,7 +19,8 @@ from ._generated.models import QueueDescriptionFeed, TopicDescriptionEntry, \
     QueueDescriptionEntry, SubscriptionDescriptionFeed, SubscriptionDescriptionEntry, RuleDescriptionEntry, \
     RuleDescriptionFeed, NamespacePropertiesEntry, CreateTopicBody, CreateTopicBodyContent, \
     TopicDescriptionFeed, CreateSubscriptionBody, CreateSubscriptionBodyContent, CreateRuleBody, \
-    CreateRuleBodyContent, CreateQueueBody, CreateQueueBodyContent, NamespaceProperties
+    CreateRuleBodyContent, CreateQueueBody, CreateQueueBodyContent, NamespaceProperties, \
+    QueueDescription, TopicDescription, SubscriptionDescription, RuleDescription
 from ._utils import extract_data_template, get_next_template, deserialize_rule_key_values, serialize_rule_key_values, \
     extract_rule_data_template
 from ._xml_workaround_policy import ServiceBusXMLWorkaroundPolicy
@@ -225,9 +226,29 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
 
         :rtype: ~azure.servicebus.management.QueueProperties
         """
-        queue = QueueProperties(name, **kwargs)
-        for key in queue.keys():
-            kwargs.pop(key, None)
+        queue = QueueProperties(
+            name,
+            authorization_rules=kwargs.pop("authorization_rules", None),
+            auto_delete_on_idle=kwargs.pop("auto_delete_on_idle", None),
+            dead_lettering_on_message_expiration=kwargs.pop("dead_lettering_on_message_expiration", None),
+            default_message_time_to_live=kwargs.pop("default_message_time_to_live", None),
+            duplicate_detection_history_time_window=kwargs.pop("duplicate_detection_history_time_window", None),
+            entity_availability_status=kwargs.pop("entity_availability_status", None),
+            enable_batched_operations=kwargs.pop("enable_batched_operations", None),
+            enable_express=kwargs.pop("enable_express", None),
+            enable_partitioning=kwargs.pop("enable_partitioning", None),
+            is_anonymous_accessible=kwargs.pop("is_anonymous_accessible", None),
+            lock_duration=kwargs.pop("lock_duration", None),
+            max_delivery_count=kwargs.pop("max_delivery_count", None),
+            max_size_in_megabytes=kwargs.pop("max_size_in_megabytes", None),
+            requires_duplicate_detection=kwargs.pop("requires_duplicate_detection", None),
+            requires_session=kwargs.pop("requires_session", None),
+            status=kwargs.pop("status", None),
+            support_ordering=kwargs.pop("support_ordering", None),
+            forward_to=kwargs.pop("forward_to", None),
+            forward_dead_lettered_messages_to=kwargs.pop("forward_dead_lettered_messages_to", None),
+            user_metadata=kwargs.pop("user_metadata", None)
+        )
         to_create = queue._to_internal_entity()
         create_entity_body = CreateQueueBody(
             content=CreateQueueBodyContent(
@@ -421,9 +442,25 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
 
         :rtype: ~azure.servicebus.management.TopicProperties
         """
-        topic = TopicProperties(name, **kwargs)
-        for key in topic.keys():
-            kwargs.pop(key, None)
+        topic = TopicProperties(
+            name,
+            default_message_time_to_live=kwargs.pop("default_message_time_to_live", None),
+            max_size_in_megabytes=kwargs.pop("max_size_in_megabytes", None),
+            requires_duplicate_detection=kwargs.pop("requires_duplicate_detection", None),
+            duplicate_detection_history_time_window=kwargs.pop("duplicate_detection_history_time_window", None),
+            enable_batched_operations=kwargs.pop("enable_batched_operations", None),
+            size_in_bytes=kwargs.pop("size_in_bytes", None),
+            is_anonymous_accessible=kwargs.pop("is_anonymous_accessible", None),
+            authorization_rules=kwargs.pop("authorization_rules", None),
+            status=kwargs.pop("status", None),
+            support_ordering=kwargs.pop("support_ordering", None),
+            auto_delete_on_idle=kwargs.pop("auto_delete_on_idle", None),
+            enable_partitioning=kwargs.pop("enable_partitioning", None),
+            entity_availability_status=kwargs.pop("entity_availability_status", None),
+            enable_subscription_partitioning=kwargs.pop("enable_subscription_partitioning", None),
+            enable_express=kwargs.pop("enable_express", None),
+            user_metadata=kwargs.pop("user_metadata", None)
+        )
         to_create = topic._to_internal_entity()
 
         create_entity_body = CreateTopicBody(
@@ -626,9 +663,23 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             topic_name = topic.name  # type: ignore
         except AttributeError:
             topic_name = topic
-        subscription = SubscriptionProperties(name, **kwargs)
-        for key in subscription.keys():
-            kwargs.pop(key, None)
+        subscription = SubscriptionProperties(
+            name,
+            lock_duration=kwargs.pop("lock_duration", None),
+            requires_session=kwargs.pop("requires_session", None),
+            default_message_time_to_live=kwargs.pop("default_message_time_to_live", None),
+            dead_lettering_on_message_expiration=kwargs.pop("dead_lettering_on_message_expiration", None),
+            dead_lettering_on_filter_evaluation_exceptions=
+            kwargs.pop("dead_lettering_on_filter_evaluation_exceptions", None),
+            max_delivery_count=kwargs.pop("max_delivery_count", None),
+            enable_batched_operations=kwargs.pop("enable_batched_operations", None),
+            status=kwargs.pop("status", None),
+            forward_to=kwargs.pop("forward_to", None),
+            user_metadata=kwargs.pop("user_metadata", None),
+            forward_dead_lettered_messages_to=kwargs.pop("forward_dead_lettered_messages_to", None),
+            auto_delete_on_idle=kwargs.pop("auto_delete_on_idle", None),
+            entity_availability_status=kwargs.pop("entity_availability_status", None),
+        )
         to_create = subscription._to_internal_entity()  # type: ignore  # pylint:disable=protected-access
 
         create_entity_body = CreateSubscriptionBody(
@@ -805,8 +856,6 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
          ~azure.servicebus.management.SqlRuleFilter]
         :keyword action: The action of the rule.
         :type action: Optional[~azure.servicebus.management.SqlRuleAction]
-        :keyword created_at: The exact time the rule was created.
-        :type created_at: ~datetime.datetime
 
         :rtype: ~azure.servicebus.management.RuleProperties
         """
@@ -819,9 +868,12 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             subscription_name = subscription.name  # type: ignore
         except AttributeError:
             subscription_name = subscription
-        rule = RuleProperties(name, **kwargs)
-        for key in rule.keys():
-            kwargs.pop(key, None)
+        rule = RuleProperties(
+            name,
+            filter=kwargs.pop("filter", None),
+            action=kwargs.pop("action", None),
+            created_at=None
+        )
         to_create = rule._to_internal_entity()
 
         create_entity_body = CreateRuleBody(

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 # pylint:disable=protected-access
 # pylint:disable=specify-parameter-names-in-call
+# pylint:disable=too-many-lines
 import functools
 from typing import TYPE_CHECKING, Dict, Any, Union, cast
 from xml.etree.ElementTree import ElementTree

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
@@ -183,10 +183,6 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         :keyword duplicate_detection_history_time_window: ISO 8601 timeSpan structure that defines the
          duration of the duplicate detection history. The default value is 10 minutes.
         :type duplicate_detection_history_time_window: ~datetime.timedelta
-        :keyword entity_availability_status: Availibility status of the entity. Possible values include:
-         "Available", "Limited", "Renaming", "Restoring", "Unknown".
-        :type entity_availability_status: str or
-         ~azure.servicebus.management.EntityAvailabilityStatus
         :keyword enable_batched_operations: Value that indicates whether server-side batched operations
          are enabled.
         :type enable_batched_operations: bool
@@ -215,9 +211,6 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         :keyword requires_session: A value that indicates whether the queue supports the concept of
          sessions.
         :type requires_session: bool
-        :keyword status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
-         "Deleting", "Disabled", "ReceiveDisabled", "Renaming", "Restoring", "SendDisabled", "Unknown".
-        :type status: str or ~azure.servicebus.management.EntityStatus
         :keyword forward_to: The name of the recipient entity to which all the messages sent to the queue
          are forwarded to.
         :type forward_to: str
@@ -408,9 +401,6 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         :keyword authorization_rules: Authorization rules for resource.
         :type authorization_rules:
          list[~azure.servicebus.management.AuthorizationRule]
-        :keyword status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
-         "Deleting", "Disabled", "ReceiveDisabled", "Renaming", "Restoring", "SendDisabled", "Unknown".
-        :type status: str or ~azure.servicebus.management.models.EntityStatus
         :keyword support_ordering: A value that indicates whether the topic supports ordering.
         :type support_ordering: bool
         :keyword auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the topic is
@@ -419,10 +409,6 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         :keyword enable_partitioning: A value that indicates whether the topic is to be partitioned
          across multiple message brokers.
         :type enable_partitioning: bool
-        :keyword entity_availability_status: Availability status of the entity. Possible values include:
-         "Available", "Limited", "Renaming", "Restoring", "Unknown".
-        :type entity_availability_status: str or
-         ~azure.servicebus.management.models.EntityAvailabilityStatus
         :keyword enable_subscription_partitioning: A value that indicates whether the topic's
          subscription is to be partitioned.
         :type enable_subscription_partitioning: bool
@@ -621,9 +607,6 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         :keyword enable_batched_operations: Value that indicates whether server-side batched operations
          are enabled.
         :type enable_batched_operations: bool
-        :keyword status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
-         "Deleting", "Disabled", "ReceiveDisabled", "Renaming", "Restoring", "SendDisabled", "Unknown".
-        :type status: str or ~azure.servicebus.management.models.EntityStatus
         :keyword forward_to: The name of the recipient entity to which all the messages sent to the
          subscription are forwarded to.
         :type forward_to: str
@@ -636,10 +619,6 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         :keyword auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the subscription is
          automatically deleted. The minimum duration is 5 minutes.
         :type auto_delete_on_idle: ~datetime.timedelta
-        :keyword entity_availability_status: Availability status of the entity. Possible values include:
-         "Available", "Limited", "Renaming", "Restoring", "Unknown".
-        :type entity_availability_status: str or
-         ~azure.servicebus.management.models.EntityAvailabilityStatus
         :rtype:  ~azure.servicebus.management.SubscriptionProperties
         """
         try:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
@@ -225,6 +225,7 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
 
         :rtype: ~azure.servicebus.management.QueueProperties
         """
+        kwargs = dict(kwargs)
         queue = QueueProperties(name, **kwargs)
         for key in queue.keys():
             kwargs.pop(key, None)
@@ -420,7 +421,7 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
 
         :rtype: ~azure.servicebus.management.TopicProperties
         """
-
+        kwargs = dict(kwargs)
         topic = TopicProperties(name, **kwargs)
         for key in topic.keys():
             kwargs.pop(key, None)
@@ -625,6 +626,7 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             topic_name = topic.name  # type: ignore
         except AttributeError:
             topic_name = topic
+        kwargs = dict(kwargs)
         subscription = SubscriptionProperties(name, **kwargs)
         for key in subscription.keys():
             kwargs.pop(key, None)
@@ -790,9 +792,13 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         return rule_description
 
     def create_rule(self, topic, subscription, name, **kwargs):
-        # type: (Union[str, TopicProperties], Union[str, SubscriptionProperties], str, Any) -> RuleProperties  # pylint:disable=line-too-long
+        # type: (Union[str, TopicProperties], Union[str, SubscriptionProperties], str, Any) -> RuleProperties
         """Create a rule for a topic subscription.
 
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that will own the
+         to-be-created subscription rule.
+        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
+         will own the to-be-created rule.
         :param name: Name of the rule.
         :type name: str
         :keyword filter: The filter of the rule.
@@ -805,6 +811,7 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
 
         :rtype: ~azure.servicebus.management.RuleProperties
         """
+
         try:
             topic_name = topic.name  # type: ignore
         except AttributeError:
@@ -813,6 +820,7 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             subscription_name = subscription.name  # type: ignore
         except AttributeError:
             subscription_name = subscription
+        kwargs = dict(kwargs)
         rule = RuleProperties(name, **kwargs)
         for key in rule.keys():
             kwargs.pop(key, None)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
@@ -35,8 +35,8 @@ from ._generated._configuration import ServiceBusManagementClientConfiguration
 from ._generated._service_bus_management_client import ServiceBusManagementClient as ServiceBusManagementClientImpl
 from ._model_workaround import avoid_timedelta_overflow
 from . import _constants as constants
-from ._models import QueueRuntimeInfo, QueueDescription, TopicDescription, TopicRuntimeInfo, \
-    SubscriptionDescription, SubscriptionRuntimeInfo, RuleDescription
+from ._models import QueueRuntimeProperties, QueueProperties, TopicProperties, TopicRuntimeProperties, \
+    SubscriptionProperties, SubscriptionRuntimeProperties, RuleProperties
 from ._handle_response_error import _handle_response_error
 
 if TYPE_CHECKING:
@@ -138,42 +138,42 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         return cls(endpoint, ServiceBusSharedKeyCredential(shared_access_key_name, shared_access_key), **kwargs)
 
     def get_queue(self, queue_name, **kwargs):
-        # type: (str, Any) -> QueueDescription
+        # type: (str, Any) -> QueueProperties
         """Get the properties of a queue.
 
         :param str queue_name: The name of the queue.
-        :rtype: ~azure.servicebus.management.QueueDescription
+        :rtype: ~azure.servicebus.management.QueueProperties
         """
         entry_ele = self._get_entity_element(queue_name, **kwargs)
         entry = QueueDescriptionEntry.deserialize(entry_ele)
         if not entry.content:
             raise ResourceNotFoundError("Queue '{}' does not exist".format(queue_name))
-        queue_description = QueueDescription._from_internal_entity(queue_name, entry.content.queue_description)
+        queue_description = QueueProperties._from_internal_entity(queue_name, entry.content.queue_description)
         return queue_description
 
     def get_queue_runtime_info(self, queue_name, **kwargs):
-        # type: (str, Any) -> QueueRuntimeInfo
+        # type: (str, Any) -> QueueRuntimeProperties
         """Get the runtime information of a queue.
 
         :param str queue_name: The name of the queue.
-        :rtype: ~azure.servicebus.management.QueueRuntimeInfo
+        :rtype: ~azure.servicebus.management.QueueRuntimeProperties
         """
         entry_ele = self._get_entity_element(queue_name, **kwargs)
         entry = QueueDescriptionEntry.deserialize(entry_ele)
         if not entry.content:
             raise ResourceNotFoundError("Queue {} does not exist".format(queue_name))
-        runtime_info = QueueRuntimeInfo._from_internal_entity(queue_name, entry.content.queue_description)
+        runtime_info = QueueRuntimeProperties._from_internal_entity(queue_name, entry.content.queue_description)
         return runtime_info
 
     def create_queue(self, queue, **kwargs):
-        # type: (Union[str, QueueDescription], Any) -> QueueDescription
+        # type: (Union[str, QueueProperties], Any) -> QueueProperties
         """Create a queue.
 
-        :param queue: The queue name or a `QueueDescription` instance. When it's a str, it will be the name
+        :param queue: The queue name or a `QueueProperties` instance. When it's a str, it will be the name
          of the created queue. Other properties of the created queue will have default values as defined by the
-         service. Use a `QueueDescription` if you want to set queue properties other than the queue name.
-        :type queue: Union[str, ~azure.servicebus.management.QueueDescription]
-        :rtype: ~azure.servicebus.management.QueueDescription
+         service. Use a `QueueProperties` if you want to set queue properties other than the queue name.
+        :type queue: Union[str, ~azure.servicebus.management.QueueProperties]
+        :rtype: ~azure.servicebus.management.QueueProperties
         """
         try:
             queue_name = queue.name  # type: ignore
@@ -197,20 +197,20 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             )
 
         entry = QueueDescriptionEntry.deserialize(entry_ele)
-        result = QueueDescription._from_internal_entity(queue_name, entry.content.queue_description)
+        result = QueueProperties._from_internal_entity(queue_name, entry.content.queue_description)
         return result
 
     def update_queue(self, queue, **kwargs):
-        # type: (QueueDescription, Any) -> None
+        # type: (QueueProperties, Any) -> None
         """Update a queue.
 
-        Before calling this method, you should use `get_queue` to get a `QueueDescription` instance, then use the
+        Before calling this method, you should use `get_queue` to get a `QueueProperties` instance, then use the
         keyword arguments to update the properties you want to update.
         Only a portion of properties can be updated.
         Refer to https://docs.microsoft.com/en-us/rest/api/servicebus/update-queue.
 
         :param queue: The queue to be updated.
-        :type queue: ~azure.servicebus.management.QueueDescription
+        :type queue: ~azure.servicebus.management.QueueProperties
         :keyword timedelta default_message_time_to_live: The value you want to update to.
         :keyword timedelta lock_duration: The value you want to update to.
         :keyword bool dead_lettering_on_message_expiration: The value you want to update to.
@@ -249,11 +249,11 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             )
 
     def delete_queue(self, queue, **kwargs):
-        # type: (Union[str, QueueDescription], Any) -> None
+        # type: (Union[str, QueueProperties], Any) -> None
         """Delete a queue.
 
-        :param Union[str, azure.servicebus.management.QueueDescription] queue: The name of the queue or
-         a `QueueDescription` with name.
+        :param Union[str, azure.servicebus.management.QueueProperties] queue: The name of the queue or
+         a `QueueProperties` with name.
         :rtype: None
         """
         try:
@@ -268,15 +268,15 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
                 api_version=constants.API_VERSION, **kwargs)
 
     def list_queues(self, **kwargs):
-        # type: (Any) -> ItemPaged[QueueDescription]
+        # type: (Any) -> ItemPaged[QueueProperties]
         """List the queues of a ServiceBus namespace.
 
-        :returns: An iterable (auto-paging) response of QueueDescription.
-        :rtype: ~azure.core.paging.ItemPaged[~azure.servicebus.management.QueueDescription]
+        :returns: An iterable (auto-paging) response of QueueProperties.
+        :rtype: ~azure.core.paging.ItemPaged[~azure.servicebus.management.QueueProperties]
         """
 
         def entry_to_qd(entry):
-            qd = QueueDescription._from_internal_entity(entry.title, entry.content.queue_description)
+            qd = QueueProperties._from_internal_entity(entry.title, entry.content.queue_description)
             return qd
 
         extract_data = functools.partial(
@@ -289,15 +289,15 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             get_next, extract_data)
 
     def list_queues_runtime_info(self, **kwargs):
-        # type: (Any) -> ItemPaged[QueueRuntimeInfo]
+        # type: (Any) -> ItemPaged[QueueRuntimeProperties]
         """List the runtime information of the queues in a ServiceBus namespace.
 
-        :returns: An iterable (auto-paging) response of QueueRuntimeInfo.
-        :rtype: ~azure.core.paging.ItemPaged[~azure.servicebus.management.QueueRuntimeInfo]
+        :returns: An iterable (auto-paging) response of QueueRuntimeProperties.
+        :rtype: ~azure.core.paging.ItemPaged[~azure.servicebus.management.QueueRuntimeProperties]
         """
 
         def entry_to_qr(entry):
-            qd = QueueRuntimeInfo._from_internal_entity(entry.title, entry.content.queue_description)
+            qd = QueueRuntimeProperties._from_internal_entity(entry.title, entry.content.queue_description)
             return qd
 
         extract_data = functools.partial(
@@ -310,42 +310,42 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             get_next, extract_data)
 
     def get_topic(self, topic_name, **kwargs):
-        # type: (str, Any) -> TopicDescription
+        # type: (str, Any) -> TopicProperties
         """Get the properties of a topic.
 
         :param str topic_name: The name of the topic.
-        :rtype: ~azure.servicebus.management.TopicDescription
+        :rtype: ~azure.servicebus.management.TopicProperties
         """
         entry_ele = self._get_entity_element(topic_name, **kwargs)
         entry = TopicDescriptionEntry.deserialize(entry_ele)
         if not entry.content:
             raise ResourceNotFoundError("Topic '{}' does not exist".format(topic_name))
-        topic_description = TopicDescription._from_internal_entity(topic_name, entry.content.topic_description)
+        topic_description = TopicProperties._from_internal_entity(topic_name, entry.content.topic_description)
         return topic_description
 
     def get_topic_runtime_info(self, topic_name, **kwargs):
-        # type: (str, Any) -> TopicRuntimeInfo
+        # type: (str, Any) -> TopicRuntimeProperties
         """Get a the runtime information of a topic.
 
         :param str topic_name: The name of the topic.
-        :rtype: ~azure.servicebus.management.TopicRuntimeInfo
+        :rtype: ~azure.servicebus.management.TopicRuntimeProperties
         """
         entry_ele = self._get_entity_element(topic_name, **kwargs)
         entry = TopicDescriptionEntry.deserialize(entry_ele)
         if not entry.content:
             raise ResourceNotFoundError("Topic {} does not exist".format(topic_name))
-        topic_description = TopicRuntimeInfo._from_internal_entity(topic_name, entry.content.topic_description)
+        topic_description = TopicRuntimeProperties._from_internal_entity(topic_name, entry.content.topic_description)
         return topic_description
 
     def create_topic(self, topic, **kwargs):
-        # type: (Union[str, TopicDescription], Any) -> TopicDescription
+        # type: (Union[str, TopicProperties], Any) -> TopicProperties
         """Create a topic.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic name or a `TopicDescription`
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic name or a `TopicProperties`
          instance. When it's a str, it will be the name of the created topic. Other properties of the created topic
          will have default values as defined by the service.
-         Use a `TopicDescription` if you want to set queue properties other than the queue name.
-        :rtype: ~azure.servicebus.management.TopicDescription
+         Use a `TopicProperties` if you want to set queue properties other than the queue name.
+        :rtype: ~azure.servicebus.management.TopicProperties
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -368,19 +368,19 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
                     request_body, api_version=constants.API_VERSION, **kwargs)
             )
         entry = TopicDescriptionEntry.deserialize(entry_ele)
-        result = TopicDescription._from_internal_entity(topic_name, entry.content.topic_description)
+        result = TopicProperties._from_internal_entity(topic_name, entry.content.topic_description)
         return result
 
     def update_topic(self, topic, **kwargs):
-        # type: (TopicDescription, Any) -> None
+        # type: (TopicProperties, Any) -> None
         """Update a topic.
 
-        Before calling this method, you should use `get_topic` to get a `TopicDescription` instance, then use the
+        Before calling this method, you should use `get_topic` to get a `TopicProperties` instance, then use the
         keyword arguments to update the properties you want to update.
         Only a portion of properties can be updated.
         Refer to https://docs.microsoft.com/en-us/rest/api/servicebus/update-topic.
 
-        :param ~azure.servicebus.management.TopicDescription topic: The topic to be updated.
+        :param ~azure.servicebus.management.TopicProperties topic: The topic to be updated.
         :keyword timedelta default_message_time_to_live: The value you want to update to.
         :keyword timedelta duplicate_detection_history_time_window: The value you want to update to.
         :rtype: None
@@ -412,10 +412,10 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             )
 
     def delete_topic(self, topic, **kwargs):
-        # type: (Union[str, TopicDescription], Any) -> None
+        # type: (Union[str, TopicProperties], Any) -> None
         """Delete a topic.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic to be deleted.
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic to be deleted.
         :rtype: None
         """
         try:
@@ -425,14 +425,14 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         self._impl.entity.delete(topic_name, api_version=constants.API_VERSION, **kwargs)
 
     def list_topics(self, **kwargs):
-        # type: (Any) -> ItemPaged[TopicDescription]
+        # type: (Any) -> ItemPaged[TopicProperties]
         """List the topics of a ServiceBus namespace.
 
-        :returns: An iterable (auto-paging) response of TopicDescription.
-        :rtype: ~azure.core.paging.ItemPaged[~azure.servicebus.management.TopicDescription]
+        :returns: An iterable (auto-paging) response of TopicProperties.
+        :rtype: ~azure.core.paging.ItemPaged[~azure.servicebus.management.TopicProperties]
         """
         def entry_to_topic(entry):
-            topic = TopicDescription._from_internal_entity(entry.title, entry.content.topic_description)
+            topic = TopicProperties._from_internal_entity(entry.title, entry.content.topic_description)
             return topic
 
         extract_data = functools.partial(
@@ -445,14 +445,14 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             get_next, extract_data)
 
     def list_topics_runtime_info(self, **kwargs):
-        # type: (Any) -> ItemPaged[TopicRuntimeInfo]
+        # type: (Any) -> ItemPaged[TopicRuntimeProperties]
         """List the topics runtime information of a ServiceBus namespace.
 
-        :returns: An iterable (auto-paging) response of TopicRuntimeInfo.
-        :rtype: ~azure.core.paging.ItemPaged[~azure.servicebus.management.TopicRuntimeInfo]
+        :returns: An iterable (auto-paging) response of TopicRuntimeProperties.
+        :rtype: ~azure.core.paging.ItemPaged[~azure.servicebus.management.TopicRuntimeProperties]
         """
         def entry_to_topic(entry):
-            topic = TopicRuntimeInfo._from_internal_entity(entry.title, entry.content.topic_description)
+            topic = TopicRuntimeProperties._from_internal_entity(entry.title, entry.content.topic_description)
             return topic
 
         extract_data = functools.partial(
@@ -465,12 +465,12 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             get_next, extract_data)
 
     def get_subscription(self, topic, subscription_name, **kwargs):
-        # type: (Union[str, TopicDescription], str, Any) -> SubscriptionDescription
+        # type: (Union[str, TopicProperties], str, Any) -> SubscriptionProperties
         """Get the properties of a topic subscription.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
         :param str subscription_name: name of the subscription.
-        :rtype: ~azure.servicebus.management.SubscriptionDescription
+        :rtype: ~azure.servicebus.management.SubscriptionProperties
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -481,17 +481,17 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         if not entry.content:
             raise ResourceNotFoundError(
                 "Subscription('Topic: {}, Subscription: {}') does not exist".format(subscription_name, topic_name))
-        subscription = SubscriptionDescription._from_internal_entity(
+        subscription = SubscriptionProperties._from_internal_entity(
             entry.title, entry.content.subscription_description)
         return subscription
 
     def get_subscription_runtime_info(self, topic, subscription_name, **kwargs):
-        # type: (Union[str, TopicDescription], str, Any) -> SubscriptionRuntimeInfo
+        # type: (Union[str, TopicProperties], str, Any) -> SubscriptionRuntimeProperties
         """Get a topic subscription runtime info.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
         :param str subscription_name: name of the subscription.
-        :rtype: ~azure.servicebus.management.SubscriptionRuntimeInfo
+        :rtype: ~azure.servicebus.management.SubscriptionRuntimeProperties
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -502,20 +502,20 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         if not entry.content:
             raise ResourceNotFoundError(
                 "Subscription('Topic: {}, Subscription: {}') does not exist".format(subscription_name, topic_name))
-        subscription = SubscriptionRuntimeInfo._from_internal_entity(
+        subscription = SubscriptionRuntimeProperties._from_internal_entity(
             entry.title, entry.content.subscription_description)
         return subscription
 
     def create_subscription(self, topic, subscription, **kwargs):
-        # type: (Union[str, TopicDescription], Union[str, SubscriptionDescription], Any) -> SubscriptionDescription
+        # type: (Union[str, TopicProperties], Union[str, SubscriptionProperties], Any) -> SubscriptionProperties
         """Create a topic subscription.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that will own the
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that will own the
          to-be-created subscription.
-        :param Union[str, ~azure.servicebus.management.SubscriptionDescription] subscription: The subscription name or a
-        `SubscriptionDescription` instance. When it's a str, it will be the name of the created subscription.
+        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription name or a
+        `SubscriptionProperties` instance. When it's a str, it will be the name of the created subscription.
          Other properties of the created subscription will have default values as defined by the service.
-        :rtype:  ~azure.servicebus.management.SubscriptionDescription
+        :rtype:  ~azure.servicebus.management.SubscriptionProperties
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -544,20 +544,20 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             )
 
         entry = SubscriptionDescriptionEntry.deserialize(entry_ele)
-        result = SubscriptionDescription._from_internal_entity(
+        result = SubscriptionProperties._from_internal_entity(
             subscription_name, entry.content.subscription_description)
         return result
 
     def update_subscription(self, topic, subscription, **kwargs):
-        # type: (Union[str, TopicDescription], SubscriptionDescription, Any) -> None
+        # type: (Union[str, TopicProperties], SubscriptionProperties, Any) -> None
         """Update a subscription.
 
-        Before calling this method, you should use `get_subscription` to get a `SubscriptionDescription` instance,
+        Before calling this method, you should use `get_subscription` to get a `SubscriptionProperties` instance,
         then update the related attributes and call this method.
         Only a portion of properties can be updated.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
-        :param ~azure.servicebus.management.SubscriptionDescription subscription: The subscription to be updated.
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
+        :param ~azure.servicebus.management.SubscriptionProperties subscription: The subscription to be updated.
         :rtype: None
         """
         try:
@@ -587,11 +587,11 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             )
 
     def delete_subscription(self, topic, subscription, **kwargs):
-        # type: (Union[str, TopicDescription], Union[str, SubscriptionDescription], Any) -> None
+        # type: (Union[str, TopicProperties], Union[str, SubscriptionProperties], Any) -> None
         """Delete a topic subscription.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
-        :param Union[str, ~azure.servicebus.management.SubscriptionDescription] subscription: The subscription to
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
+        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription to
          be deleted.
         :rtype: None
         """
@@ -606,12 +606,12 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         self._impl.subscription.delete(topic_name, subscription_name, api_version=constants.API_VERSION, **kwargs)
 
     def list_subscriptions(self, topic, **kwargs):
-        # type: (Union[str, TopicDescription], Any) -> ItemPaged[SubscriptionDescription]
+        # type: (Union[str, TopicProperties], Any) -> ItemPaged[SubscriptionProperties]
         """List the subscriptions of a ServiceBus Topic.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
-        :returns: An iterable (auto-paging) response of SubscriptionDescription.
-        :rtype: ~azure.core.paging.ItemPaged[~azure.servicebus.management.SubscriptionDescription]
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
+        :returns: An iterable (auto-paging) response of SubscriptionProperties.
+        :rtype: ~azure.core.paging.ItemPaged[~azure.servicebus.management.SubscriptionProperties]
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -619,7 +619,7 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             topic_name = topic
 
         def entry_to_subscription(entry):
-            subscription = SubscriptionDescription._from_internal_entity(
+            subscription = SubscriptionProperties._from_internal_entity(
                 entry.title, entry.content.subscription_description)
             return subscription
 
@@ -633,12 +633,12 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             get_next, extract_data)
 
     def list_subscriptions_runtime_info(self, topic, **kwargs):
-        # type: (Union[str, TopicDescription], Any) -> ItemPaged[SubscriptionRuntimeInfo]
+        # type: (Union[str, TopicProperties], Any) -> ItemPaged[SubscriptionRuntimeProperties]
         """List the subscriptions runtime information of a ServiceBus Topic.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
-        :returns: An iterable (auto-paging) response of SubscriptionRuntimeInfo.
-        :rtype: ~azure.core.paging.ItemPaged[~azure.servicebus.management.SubscriptionRuntimeInfo]
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
+        :returns: An iterable (auto-paging) response of SubscriptionRuntimeProperties.
+        :rtype: ~azure.core.paging.ItemPaged[~azure.servicebus.management.SubscriptionRuntimeProperties]
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -646,7 +646,7 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             topic_name = topic
 
         def entry_to_subscription(entry):
-            subscription = SubscriptionRuntimeInfo._from_internal_entity(
+            subscription = SubscriptionRuntimeProperties._from_internal_entity(
                 entry.title, entry.content.subscription_description)
             return subscription
 
@@ -660,14 +660,14 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             get_next, extract_data)
 
     def get_rule(self, topic, subscription, rule_name, **kwargs):
-        # type: (Union[str, TopicDescription], Union[str, SubscriptionDescription], str, Any) -> RuleDescription
+        # type: (Union[str, TopicProperties], Union[str, SubscriptionProperties], str, Any) -> RuleProperties
         """Get the properties of a topic subscription rule.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
-        :param Union[str, ~azure.servicebus.management.SubscriptionDescription] subscription: The subscription that
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
+        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
          owns the rule.
         :param str rule_name: Name of the rule.
-        :rtype: ~azure.servicebus.management.RuleDescription
+        :rtype: ~azure.servicebus.management.RuleProperties
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -683,20 +683,20 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             raise ResourceNotFoundError(
                 "Rule('Topic: {}, Subscription: {}, Rule {}') does not exist".format(
                     subscription_name, topic_name, rule_name))
-        rule_description = RuleDescription._from_internal_entity(rule_name, entry.content.rule_description)
+        rule_description = RuleProperties._from_internal_entity(rule_name, entry.content.rule_description)
         deserialize_rule_key_values(entry_ele, rule_description)  # to remove after #3535 is released.
         return rule_description
 
     def create_rule(self, topic, subscription, rule, **kwargs):
-        # type: (Union[str, TopicDescription], Union[str, SubscriptionDescription], RuleDescription, Any) -> RuleDescription  # pylint:disable=line-too-long
+        # type: (Union[str, TopicProperties], Union[str, SubscriptionProperties], RuleProperties, Any) -> RuleProperties  # pylint:disable=line-too-long
         """Create a rule for a topic subscription.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that will own the
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that will own the
          to-be-created subscription rule.
-        :param Union[str, ~azure.servicebus.management.SubscriptionDescription] subscription: The subscription that
+        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
          will own the to-be-created rule.
-        :param azure.servicebus.management.RuleDescription rule: The rule to be created.
-        :rtype: ~azure.servicebus.management.RuleDescription
+        :param azure.servicebus.management.RuleProperties rule: The rule to be created.
+        :rtype: ~azure.servicebus.management.RuleProperties
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -723,22 +723,22 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
                 rule_name,
                 request_body, api_version=constants.API_VERSION, **kwargs)
         entry = RuleDescriptionEntry.deserialize(entry_ele)
-        result = RuleDescription._from_internal_entity(rule_name, entry.content.rule_description)
+        result = RuleProperties._from_internal_entity(rule_name, entry.content.rule_description)
         deserialize_rule_key_values(entry_ele, result)  # to remove after #3535 is released.
         return result
 
     def update_rule(self, topic, subscription, rule, **kwargs):
-        # type: (Union[str, TopicDescription], Union[str, SubscriptionDescription], RuleDescription, Any) -> None
+        # type: (Union[str, TopicProperties], Union[str, SubscriptionProperties], RuleProperties, Any) -> None
         """Update a rule.
 
-        Before calling this method, you should use `get_rule` to get a `RuleDescription` instance,
+        Before calling this method, you should use `get_rule` to get a `RuleProperties` instance,
         then update the related attributes and call this method.
         Only a portion of properties can be updated.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
-        :param Union[str, ~azure.servicebus.management.SubscriptionDescription] subscription: The subscription that
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
+        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
          owns this rule.
-        :param ~azure.servicebus.management.RuleDescription rule: The rule to be updated.
+        :param ~azure.servicebus.management.RuleProperties rule: The rule to be updated.
         :rtype: None
         """
 
@@ -772,13 +772,13 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             )
 
     def delete_rule(self, topic, subscription, rule, **kwargs):
-        # type: (Union[str, TopicDescription], Union[str, SubscriptionDescription], Union[str, RuleDescription], Any) -> None  # pylint:disable=line-too-long
+        # type: (Union[str, TopicProperties], Union[str, SubscriptionProperties], Union[str, RuleProperties], Any) -> None  # pylint:disable=line-too-long
         """Delete a topic subscription rule.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
-        :param Union[str, ~azure.servicebus.management.SubscriptionDescription] subscription: The subscription that
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
+        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
          owns the topic.
-        :param Union[str, ~azure.servicebus.management.RuleDescription] rule: The to-be-deleted rule.
+        :param Union[str, ~azure.servicebus.management.RuleProperties] rule: The to-be-deleted rule.
         :rtype: None
         """
         try:
@@ -796,14 +796,14 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         self._impl.rule.delete(topic_name, subscription_name, rule_name, api_version=constants.API_VERSION, **kwargs)
 
     def list_rules(self, topic, subscription, **kwargs):
-        # type: (Union[str, TopicDescription], Union[str, SubscriptionDescription], Any) -> ItemPaged[RuleDescription]
+        # type: (Union[str, TopicProperties], Union[str, SubscriptionProperties], Any) -> ItemPaged[RuleProperties]
         """List the rules of a topic subscription.
 
-        :param Union[str, ~azure.servicebus.management.TopicDescription] topic: The topic that owns the subscription.
-        :param Union[str, ~azure.servicebus.management.SubscriptionDescription] subscription: The subscription that
+        :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
+        :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
          owns the rules.
-        :returns: An iterable (auto-paging) response of RuleDescription.
-        :rtype: ~azure.core.paging.ItemPaged[~azure.servicebus.management.RuleDescription]
+        :returns: An iterable (auto-paging) response of RuleProperties.
+        :rtype: ~azure.core.paging.ItemPaged[~azure.servicebus.management.RuleProperties]
         """
         try:
             topic_name = topic.name  # type: ignore
@@ -819,7 +819,7 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             `ele` will be removed after https://github.com/Azure/autorest/issues/3535 is released.
             """
             rule = entry.content.rule_description
-            rule_description = RuleDescription._from_internal_entity(entry.title, rule)
+            rule_description = RuleProperties._from_internal_entity(entry.title, rule)
             deserialize_rule_key_values(ele, rule_description)  # to remove after #3535 is released.
             return rule_description
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
@@ -204,31 +204,16 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         # type: (QueueProperties, Any) -> None
         """Update a queue.
 
-        Before calling this method, you should use `get_queue` to get a `QueueProperties` instance, then use the
-        keyword arguments to update the properties you want to update.
-        Only a portion of properties can be updated.
+        Before calling this method, you should use `get_queue` to get a `QueueProperties` instance, then update
+        the properties you want to update. Only a portion of properties can be updated.
         Refer to https://docs.microsoft.com/en-us/rest/api/servicebus/update-queue.
 
-        :param queue: The queue to be updated.
+        :param queue: The queue that is returned from `get_queue` and has the updated properties.
         :type queue: ~azure.servicebus.management.QueueProperties
-        :keyword timedelta default_message_time_to_live: The value you want to update to.
-        :keyword timedelta lock_duration: The value you want to update to.
-        :keyword bool dead_lettering_on_message_expiration: The value you want to update to.
-        :keyword timedelta duplicate_detection_history_time_window: The value you want to update to.
-        :keyword int max_delivery_count: The value you want to update to.
         :rtype: None
         """
 
         to_update = queue._to_internal_entity()
-
-        to_update.default_message_time_to_live = kwargs.get(
-            "default_message_time_to_live") or queue.default_message_time_to_live
-        to_update.lock_duration = kwargs.get("lock_duration") or queue.lock_duration
-        to_update.dead_lettering_on_message_expiration = kwargs.get(
-            "dead_lettering_on_message_expiration") or queue.dead_lettering_on_message_expiration
-        to_update.duplicate_detection_history_time_window = kwargs.get(
-            "duplicate_detection_history_time_window") or queue.duplicate_detection_history_time_window
-        to_update.max_delivery_count = kwargs.get("max_delivery_count") or queue.max_delivery_count
 
         to_update.default_message_time_to_live = avoid_timedelta_overflow(to_update.default_message_time_to_live)
         to_update.auto_delete_on_idle = avoid_timedelta_overflow(to_update.auto_delete_on_idle)
@@ -375,14 +360,12 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         # type: (TopicProperties, Any) -> None
         """Update a topic.
 
-        Before calling this method, you should use `get_topic` to get a `TopicProperties` instance, then use the
-        keyword arguments to update the properties you want to update.
-        Only a portion of properties can be updated.
+        Before calling this method, you should use `get_topic` to get a `TopicProperties` instance, then
+        update the properties you want to update. Only a portion of properties can be updated.
         Refer to https://docs.microsoft.com/en-us/rest/api/servicebus/update-topic.
 
-        :param ~azure.servicebus.management.TopicProperties topic: The topic to be updated.
-        :keyword timedelta default_message_time_to_live: The value you want to update to.
-        :keyword timedelta duplicate_detection_history_time_window: The value you want to update to.
+        :param topic: The topic that is returned from `get_topic` and has the updated properties.
+        :type topic: ~azure.servicebus.management.TopicProperties
         :rtype: None
         """
 
@@ -553,11 +536,11 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         """Update a subscription.
 
         Before calling this method, you should use `get_subscription` to get a `SubscriptionProperties` instance,
-        then update the related attributes and call this method.
-        Only a portion of properties can be updated.
+        then update the properties you want to update.
 
         :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
-        :param ~azure.servicebus.management.SubscriptionProperties subscription: The subscription to be updated.
+        :param ~azure.servicebus.management.SubscriptionProperties subscription: The subscription that is returned
+         from `get_subscription` and has the updated properties.
         :rtype: None
         """
         try:
@@ -732,13 +715,13 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         """Update a rule.
 
         Before calling this method, you should use `get_rule` to get a `RuleProperties` instance,
-        then update the related attributes and call this method.
-        Only a portion of properties can be updated.
+        then update the properties you want to update.
 
         :param Union[str, ~azure.servicebus.management.TopicProperties] topic: The topic that owns the subscription.
         :param Union[str, ~azure.servicebus.management.SubscriptionProperties] subscription: The subscription that
          owns this rule.
-        :param ~azure.servicebus.management.RuleProperties rule: The rule to be updated.
+        :param ~azure.servicebus.management.RuleProperties rule: The rule that is returned
+         from `get_rule` and has the updated properties.
         :rtype: None
         """
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
@@ -353,7 +353,7 @@ class TopicProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
      list[~azure.servicebus.management.AuthorizationRule]
     :keyword status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
      "Deleting", "Disabled", "ReceiveDisabled", "Renaming", "Restoring", "SendDisabled", "Unknown".
-    :type status: str or ~azure.servicebus.management.models.EntityStatus
+    :type status: str or ~azure.servicebus.management.EntityStatus
     :keyword support_ordering: A value that indicates whether the topic supports ordering.
     :type support_ordering: bool
     :keyword auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the topic is
@@ -365,7 +365,7 @@ class TopicProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
     :keyword entity_availability_status: Availability status of the entity. Possible values include:
      "Available", "Limited", "Renaming", "Restoring", "Unknown".
     :type entity_availability_status: str or
-     ~azure.servicebus.management.models.EntityAvailabilityStatus
+     ~azure.servicebus.management.EntityAvailabilityStatus
     :keyword enable_subscription_partitioning: A value that indicates whether the topic's
      subscription is to be partitioned.
     :type enable_subscription_partitioning: bool
@@ -564,7 +564,7 @@ class SubscriptionProperties(DictMixin):  # pylint:disable=too-many-instance-att
     :type enable_batched_operations: bool
     :keyword status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
      "Deleting", "Disabled", "ReceiveDisabled", "Renaming", "Restoring", "SendDisabled", "Unknown".
-    :type status: str or ~azure.servicebus.management.models.EntityStatus
+    :type status: str or ~azure.servicebus.management.EntityStatus
     :keyword forward_to: The name of the recipient entity to which all the messages sent to the
      subscription are forwarded to.
     :type forward_to: str
@@ -580,7 +580,7 @@ class SubscriptionProperties(DictMixin):  # pylint:disable=too-many-instance-att
     :keyword entity_availability_status: Availability status of the entity. Possible values include:
      "Available", "Limited", "Renaming", "Restoring", "Unknown".
     :type entity_availability_status: str or
-     ~azure.servicebus.management.models.EntityAvailabilityStatus
+     ~azure.servicebus.management.EntityAvailabilityStatus
     """
     def __init__(self, name, **kwargs):
         # type: (str, Any) -> None
@@ -726,10 +726,10 @@ class RuleProperties(DictMixin):
     :param name: Name of the rule.
     :type name: str
     :keyword filter: The filter of the rule.
-    :type filter: Union[~azure.servicebus.management.models.CorrelationRuleFilter,
-     ~azure.servicebus.management.models.SqlRuleFilter]
+    :type filter: Union[~azure.servicebus.management.CorrelationRuleFilter,
+     ~azure.servicebus.management.SqlRuleFilter]
     :keyword action: The action of the rule.
-    :type action: Optional[~azure.servicebus.management.models.SqlRuleAction]
+    :type action: Optional[~azure.servicebus.management.SqlRuleAction]
     :keyword created_at: The exact time the rule was created.
     :type created_at: ~datetime.datetime
     """

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
@@ -235,31 +235,6 @@ class QueueProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
 
 class QueueRuntimeProperties(object):
     """Service Bus queue runtime properties.
-
-    :ivar name: Name of the queue.
-    :type name: str
-    :ivar accessed_at: Last time a message was sent, or the last time there was a receive request
-     to this queue.
-    :type accessed_at: ~datetime.datetime
-    :ivar created_at: The exact time the queue was created.
-    :type created_at: ~datetime.datetime
-    :ivar updated_at: The exact time a message was updated in the queue.
-    :type updated_at: ~datetime.datetime
-    :ivar size_in_bytes: The size of the queue, in bytes.
-    :type size_in_bytes: int
-    :ivar total_message_count: Total number of messages.
-    :type total_message_count: int
-    :ivar active_message_count: Number of active messages in the queue, topic, or subscription.
-    :type active_message_count: int
-    :ivar dead_letter_message_count: Number of messages that are dead lettered.
-    :type dead_letter_message_count: int
-    :ivar scheduled_message_count: Number of scheduled messages.
-    :type scheduled_message_count: int
-    :ivar transfer_dead_letter_message_count: Number of messages transferred into dead letters.
-    :type transfer_dead_letter_message_count: int
-    :ivar transfer_message_count: Number of messages transferred to another queue, topic, or
-     subscription.
-    :type transfer_message_count: int
     """
     def __init__(
         self,
@@ -277,46 +252,90 @@ class QueueRuntimeProperties(object):
 
     @property
     def name(self):
+        """Name of the queue.
+
+        :rtype: str
+        """
         return self._name
 
     @property
     def accessed_at(self):
+        """Last time a message was sent, or the last time there was a receive request to this queue.
+
+        :rtype:  ~datetime.datetime
+        """
         return self._internal_qr.accessed_at
 
     @property
     def created_at(self):
+        """The exact time the queue was created.
+
+        :rtype: ~datetime.datetime
+        """
         return self._internal_qr.created_at
 
     @property
     def updated_at(self):
+        """The exact the entity was updated.
+
+        :rtype: ~datetime.datetime
+        """
         return self._internal_qr.updated_at
 
     @property
     def size_in_bytes(self):
+        """The size of the queue, in bytes.
+
+        :rtype: int
+        """
         return self._internal_qr.size_in_bytes
 
     @property
     def total_message_count(self):
+        """Total number of messages.
+
+        :rtype: int
+        """
         return self._internal_qr.message_count
 
     @property
     def active_message_count(self):
+        """Number of active messages in the queue, topic, or subscription.
+
+        :rtype: int
+        """
         return self._internal_qr.message_count_details.active_message_count
 
     @property
     def dead_letter_message_count(self):
+        """Number of messages that are dead lettered.
+
+        :rtype: int
+        """
         return self._internal_qr.message_count_details.dead_letter_message_count
 
     @property
     def scheduled_message_count(self):
+        """Number of scheduled messages.
+
+        :rtype: int
+        """
         return self._internal_qr.message_count_details.scheduled_message_count
 
     @property
     def transfer_dead_letter_message_count(self):
+        """Number of messages transferred into dead letters.
+
+        :rtype: int
+        """
         return self._internal_qr.message_count_details.transfer_dead_letter_message_count
 
     @property
     def transfer_message_count(self):
+        """Number of messages transferred to another queue, topic, or subscription.
+
+        :rtype: int
+        """
         return self._internal_qr.message_count_details.transfer_message_count
 
 
@@ -452,28 +471,6 @@ class TopicProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
 
 class TopicRuntimeProperties(object):
     """Runtime properties of a Service Bus topic resource.
-
-    :ivar str name:
-    :ivar created_at: The exact time the queue was created.
-    :type created_at: ~datetime.datetime
-    :ivar updated_at: The exact time a message was updated in the queue.
-    :type updated_at: ~datetime.datetime
-    :ivar accessed_at: Last time a message was sent, or the last time there was a receive request
-     to this queue.
-    :type accessed_at: ~datetime.datetime
-    :ivar subscription_count: The number of subscriptions in the topic.
-    :type subscription_count: int
-    :ivar active_message_count: Number of active messages in the queue, topic, or subscription.
-    :type active_message_count: int
-    :ivar dead_letter_message_count: Number of messages that are dead lettered.
-    :type dead_letter_message_count: int
-    :ivar scheduled_message_count: Number of scheduled messages.
-    :type scheduled_message_count: int
-    :ivar transfer_dead_letter_message_count: Number of messages transferred into dead letters.
-    :type transfer_dead_letter_message_count: int
-    :ivar transfer_message_count: Number of messages transferred to another queue, topic, or
-     subscription.
-    :type transfer_message_count: int
     """
     def __init__(
         self,
@@ -491,47 +488,59 @@ class TopicRuntimeProperties(object):
 
     @property
     def name(self):
+        """The name of the topic.
+
+        :rtype: str
+        """
         return self._name
 
     @property
     def accessed_at(self):
+        """Last time a message was sent, or the last time there was a receive request
+
+        :rtype: ~datetime.datetime
+        """
         return self._internal_td.accessed_at
 
     @property
     def created_at(self):
+        """The exact time the queue was created.
+
+        :rtype: ~datetime.datetime
+        """
         return self._internal_td.created_at
 
     @property
     def updated_at(self):
+        """The exact time the entity was updated.
+
+        :rtype: ~datetime.datetime
+        """
         return self._internal_td.updated_at
 
     @property
     def size_in_bytes(self):
+        """The current size of the entity in bytes.
+
+        :rtype: int
+        """
         return self._internal_td.size_in_bytes
 
     @property
     def subscription_count(self):
+        """The number of subscriptions in the topic.
+
+        :rtype: int
+        """
         return self._internal_td.subscription_count
 
     @property
-    def active_message_count(self):
-        return self._internal_td.message_count_details.active_message_count
-
-    @property
-    def dead_letter_message_count(self):
-        return self._internal_td.message_count_details.dead_letter_message_count
-
-    @property
     def scheduled_message_count(self):
+        """Number of scheduled messages.
+
+        :rtype: int
+        """
         return self._internal_td.message_count_details.scheduled_message_count
-
-    @property
-    def transfer_dead_letter_message_count(self):
-        return self._internal_td.message_count_details.transfer_dead_letter_message_count
-
-    @property
-    def transfer_message_count(self):
-        return self._internal_td.message_count_details.transfer_message_count
 
 
 class SubscriptionProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
@@ -649,26 +658,6 @@ class SubscriptionProperties(DictMixin):  # pylint:disable=too-many-instance-att
 class SubscriptionRuntimeProperties(object):
     """Runtime properties of a Service Bus topic subscription resource.
 
-    :ivar str name:
-    :ivar created_at: The exact time the subscription was created.
-    :type created_at: ~datetime.datetime
-    :ivar updated_at: The exact time a message was updated in the queue.
-    :type updated_at: ~datetime.datetime
-    :ivar accessed_at: Last time a message was sent, or the last time there was a receive request
-     to this queue.
-    :type accessed_at: ~datetime.datetime
-    :ivar total_message_count: The number of messages in the subscription.
-    :type total_message_count: int
-    :ivar active_message_count: Number of active messages in the subscription.
-    :type active_message_count: int
-    :ivar dead_letter_message_count: Number of messages that are dead lettered.
-    :type dead_letter_message_count: int
-    :ivar transfer_dead_letter_message_count: Number of messages transferred into dead letters.
-    :type transfer_dead_letter_message_count: int
-    :ivar transfer_message_count: Number of messages transferred to another queue, topic, or
-     subscription.
-    :type transfer_message_count: int
-
     """
     def __init__(self):
         self._internal_sd = None  # type: Optional[InternalSubscriptionDescription]
@@ -685,38 +674,74 @@ class SubscriptionRuntimeProperties(object):
 
     @property
     def name(self):
+        """Name of subscription
+
+        :rtype: str
+        """
         return self._name
 
     @property
     def accessed_at(self):
+        """Last time a message was sent, or the last time there was a receive request
+
+        :rtype: ~datetime.datetime
+        """
         return self._internal_sd.accessed_at
 
     @property
     def created_at(self):
+        """The exact time the subscription was created.
+
+        :rtype: ~datetime.datetime
+        """
         return self._internal_sd.created_at
 
     @property
     def updated_at(self):
+        """The exact time the entity is updated.
+
+        :rtype: ~datetime.datetime
+        """
         return self._internal_sd.updated_at
 
     @property
     def total_message_count(self):
+        """The number of messages in the subscription.
+
+        :rtype: int
+        """
         return self._internal_sd.message_count
 
     @property
     def active_message_count(self):
+        """Number of active messages in the subscription.
+
+        :rtype: int
+        """
         return self._internal_sd.message_count_details.active_message_count
 
     @property
     def dead_letter_message_count(self):
+        """Number of messages that are dead lettered.
+
+        :rtype: int
+        """
         return self._internal_sd.message_count_details.dead_letter_message_count
 
     @property
     def transfer_dead_letter_message_count(self):
+        """Number of messages transferred into dead letters.
+
+        :rtype: int
+        """
         return self._internal_sd.message_count_details.transfer_dead_letter_message_count
 
     @property
     def transfer_message_count(self):
+        """Number of messages transferred to another queue, topic, or subscription.
+
+        :rtype: int
+        """
         return self._internal_sd.message_count_details.transfer_message_count
 
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
@@ -28,13 +28,10 @@ adjust_attribute_map()
 
 
 def extract_kwarg_template(self, kwargs, extraction_missing_args, name):
-    if getattr(self, '_require_all_args', False):
-        try:
-            return kwargs[name]
-        except KeyError:
-            extraction_missing_args.append(name)
-    else:
-        return kwargs.get(name, None)
+    try:
+        return kwargs[name]
+    except KeyError:
+        extraction_missing_args.append(name)
 
 
 def validate_extraction_missing_args(extraction_missing_args):
@@ -171,7 +168,6 @@ class QueueProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
         # type: (str, Any) -> None
         self.name = name
         self._internal_qd = None  # type: Optional[InternalQueueDescription]
-        self._require_all_args = True
 
         extraction_missing_args = []  # type: List[str]
         extract_kwarg = functools.partial(extract_kwarg_template, self, kwargs, extraction_missing_args)
@@ -427,7 +423,6 @@ class TopicProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
         # type: (str, Any) -> None
         self.name = name
         self._internal_td = None  # type: Optional[InternalTopicDescription]
-        self._require_all_args = True
 
         extraction_missing_args = []  # type: List[str]
         extract_kwarg = functools.partial(extract_kwarg_template, self, kwargs, extraction_missing_args)
@@ -626,7 +621,6 @@ class SubscriptionProperties(DictMixin):  # pylint:disable=too-many-instance-att
         # type: (str, Any) -> None
         self.name = name
         self._internal_sd = None  # type: Optional[InternalSubscriptionDescription]
-        self._require_all_args = True
 
         extraction_missing_args = []  # type: List[str]
         extract_kwarg = functools.partial(extract_kwarg_template, self, kwargs, extraction_missing_args)
@@ -802,7 +796,6 @@ class RuleProperties(DictMixin):
 
         self.name = name
         self._internal_rule = None  # type: Optional[InternalRuleDescription]
-        self._require_all_args = True
 
         extraction_missing_args = []  # type: List[str]
         extract_kwarg = functools.partial(extract_kwarg_template, self, kwargs, extraction_missing_args)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
@@ -79,67 +79,67 @@ class DictMixin(object):
 class QueueProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
     """Properties of a Service Bus queue resource.
 
-    :param name: Name of the queue.
+    :ivar name: Name of the queue.
     :type name: str
-    :keyword authorization_rules: Authorization rules for resource.
+    :ivar authorization_rules: Authorization rules for resource.
     :type authorization_rules: list[~azure.servicebus.management.AuthorizationRule]
-    :keyword auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the queue is
+    :ivar auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the queue is
      automatically deleted. The minimum duration is 5 minutes.
     :type auto_delete_on_idle: ~datetime.timedelta
-    :keyword dead_lettering_on_message_expiration: A value that indicates whether this queue has dead
+    :ivar dead_lettering_on_message_expiration: A value that indicates whether this queue has dead
      letter support when a message expires.
     :type dead_lettering_on_message_expiration: bool
-    :keyword default_message_time_to_live: ISO 8601 default message timespan to live value. This is
+    :ivar default_message_time_to_live: ISO 8601 default message timespan to live value. This is
      the duration after which the message expires, starting from when the message is sent to Service
      Bus. This is the default value used when TimeToLive is not set on a message itself.
     :type default_message_time_to_live: ~datetime.timedelta
-    :keyword duplicate_detection_history_time_window: ISO 8601 timeSpan structure that defines the
+    :ivar duplicate_detection_history_time_window: ISO 8601 timeSpan structure that defines the
      duration of the duplicate detection history. The default value is 10 minutes.
     :type duplicate_detection_history_time_window: ~datetime.timedelta
-    :keyword entity_availability_status: Availibility status of the entity. Possible values include:
+    :ivar entity_availability_status: Availibility status of the entity. Possible values include:
      "Available", "Limited", "Renaming", "Restoring", "Unknown".
     :type entity_availability_status: str or
      ~azure.servicebus.management.EntityAvailabilityStatus
-    :keyword enable_batched_operations: Value that indicates whether server-side batched operations
+    :ivar enable_batched_operations: Value that indicates whether server-side batched operations
      are enabled.
     :type enable_batched_operations: bool
-    :keyword enable_express: A value that indicates whether Express Entities are enabled. An express
+    :ivar enable_express: A value that indicates whether Express Entities are enabled. An express
      queue holds a message in memory temporarily before writing it to persistent storage.
     :type enable_express: bool
-    :keyword enable_partitioning: A value that indicates whether the queue is to be partitioned
+    :ivar enable_partitioning: A value that indicates whether the queue is to be partitioned
      across multiple message brokers.
     :type enable_partitioning: bool
-    :keyword is_anonymous_accessible: A value indicating if the resource can be accessed without
+    :ivar is_anonymous_accessible: A value indicating if the resource can be accessed without
      authorization.
     :type is_anonymous_accessible: bool
-    :keyword lock_duration: ISO 8601 timespan duration of a peek-lock; that is, the amount of time
+    :ivar lock_duration: ISO 8601 timespan duration of a peek-lock; that is, the amount of time
      that the message is locked for other receivers. The maximum value for LockDuration is 5
      minutes; the default value is 1 minute.
     :type lock_duration: ~datetime.timedelta
-    :keyword max_delivery_count: The maximum delivery count. A message is automatically deadlettered
+    :ivar max_delivery_count: The maximum delivery count. A message is automatically deadlettered
      after this number of deliveries. Default value is 10.
     :type max_delivery_count: int
-    :keyword max_size_in_megabytes: The maximum size of the queue in megabytes, which is the size of
+    :ivar max_size_in_megabytes: The maximum size of the queue in megabytes, which is the size of
      memory allocated for the queue.
     :type max_size_in_megabytes: int
-    :keyword requires_duplicate_detection: A value indicating if this queue requires duplicate
+    :ivar requires_duplicate_detection: A value indicating if this queue requires duplicate
      detection.
     :type requires_duplicate_detection: bool
-    :keyword requires_session: A value that indicates whether the queue supports the concept of
+    :ivar requires_session: A value that indicates whether the queue supports the concept of
      sessions.
     :type requires_session: bool
-    :keyword status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
+    :ivar status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
      "Deleting", "Disabled", "ReceiveDisabled", "Renaming", "Restoring", "SendDisabled", "Unknown".
     :type status: str or ~azure.servicebus.management.EntityStatus
-    :keyword forward_to: The name of the recipient entity to which all the messages sent to the queue
+    :ivar forward_to: The name of the recipient entity to which all the messages sent to the queue
      are forwarded to.
     :type forward_to: str
-    :keyword user_metadata: Custom metdata that user can associate with the description. Max length
+    :ivar user_metadata: Custom metdata that user can associate with the description. Max length
      is 1024 chars.
     :type user_metadata: str
-    :keyword support_ordering: A value that indicates whether the queue supports ordering.
+    :ivar support_ordering: A value that indicates whether the queue supports ordering.
     :type support_ordering: bool
-    :keyword forward_dead_lettered_messages_to: The name of the recipient entity to which all the
+    :ivar forward_dead_lettered_messages_to: The name of the recipient entity to which all the
      dead-lettered messages of this subscription are forwarded to.
     :type forward_dead_lettered_messages_to: str
     """
@@ -153,55 +153,55 @@ class QueueProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
         self.name = name
         self._internal_qd = None  # type: Optional[InternalQueueDescription]
 
-        self.authorization_rules = kwargs.get('authorization_rules', None)
-        self.auto_delete_on_idle = kwargs.get('auto_delete_on_idle', None)
-        self.dead_lettering_on_message_expiration = kwargs.get('dead_lettering_on_message_expiration', None)
-        self.default_message_time_to_live = kwargs.get('default_message_time_to_live', None)
-        self.duplicate_detection_history_time_window = kwargs.get('duplicate_detection_history_time_window', None)
-        self.entity_availability_status = kwargs.get('entity_availability_status', None)
-        self.enable_batched_operations = kwargs.get('enable_batched_operations', None)
-        self.enable_express = kwargs.get('enable_express', None)
-        self.enable_partitioning = kwargs.get('enable_partitioning', None)
-        self.is_anonymous_accessible = kwargs.get('is_anonymous_accessible', None)
-        self.lock_duration = kwargs.get('lock_duration', None)
-        self.max_delivery_count = kwargs.get('max_delivery_count', None)
-        self.max_size_in_megabytes = kwargs.get('max_size_in_megabytes', None)
-        self.requires_duplicate_detection = kwargs.get('requires_duplicate_detection', None)
-        self.requires_session = kwargs.get('requires_session', None)
-        self.status = kwargs.get('status', None)
-        self.support_ordering = kwargs.get('support_ordering', None)
-        self.forward_to = kwargs.get('forward_to', None)
-        self.user_metadata = kwargs.get('user_metadata', None)
-        self.forward_dead_lettered_messages_to = kwargs.get('forward_dead_lettered_messages_to', None)
+        self.authorization_rules = kwargs['authorization_rules']
+        self.auto_delete_on_idle = kwargs['auto_delete_on_idle']
+        self.dead_lettering_on_message_expiration = kwargs['dead_lettering_on_message_expiration']
+        self.default_message_time_to_live = kwargs['default_message_time_to_live']
+        self.duplicate_detection_history_time_window = kwargs['duplicate_detection_history_time_window']
+        self.entity_availability_status = kwargs['entity_availability_status']
+        self.enable_batched_operations = kwargs['enable_batched_operations']
+        self.enable_express = kwargs['enable_express']
+        self.enable_partitioning = kwargs['enable_partitioning']
+        self.is_anonymous_accessible = kwargs['is_anonymous_accessible']
+        self.lock_duration = kwargs['lock_duration']
+        self.max_delivery_count = kwargs['max_delivery_count']
+        self.max_size_in_megabytes = kwargs['max_size_in_megabytes']
+        self.requires_duplicate_detection = kwargs['requires_duplicate_detection']
+        self.requires_session = kwargs['requires_session']
+        self.status = kwargs['status']
+        self.support_ordering = kwargs['support_ordering']
+        self.forward_to = kwargs['forward_to']
+        self.user_metadata = kwargs['user_metadata']
+        self.forward_dead_lettered_messages_to = kwargs['forward_dead_lettered_messages_to']
 
 
     @classmethod
     def _from_internal_entity(cls, name, internal_qd):
         # type: (str, InternalQueueDescription) -> QueueProperties
-        qd = cls(name)
+        qd = cls(
+            name,
+            authorization_rules=internal_qd.authorization_rules,
+            auto_delete_on_idle=internal_qd.auto_delete_on_idle,
+            dead_lettering_on_message_expiration=internal_qd.dead_lettering_on_message_expiration,
+            default_message_time_to_live=internal_qd.default_message_time_to_live,
+            duplicate_detection_history_time_window=internal_qd.duplicate_detection_history_time_window,
+            entity_availability_status=internal_qd.entity_availability_status,
+            enable_batched_operations=internal_qd.enable_batched_operations,
+            enable_express=internal_qd.enable_express,
+            enable_partitioning=internal_qd.enable_partitioning,
+            is_anonymous_accessible=internal_qd.is_anonymous_accessible,
+            lock_duration=internal_qd.lock_duration,
+            max_delivery_count=internal_qd.max_delivery_count,
+            max_size_in_megabytes=internal_qd.max_size_in_megabytes,
+            requires_duplicate_detection=internal_qd.requires_duplicate_detection,
+            requires_session=internal_qd.requires_session,
+            status=internal_qd.status,
+            support_ordering=internal_qd.support_ordering,
+            forward_to=internal_qd.forward_to,
+            forward_dead_lettered_messages_to=internal_qd.forward_dead_lettered_messages_to,
+            user_metadata=internal_qd.user_metadata
+        )
         qd._internal_qd = deepcopy(internal_qd)  # pylint:disable=protected-access
-
-        qd.authorization_rules = internal_qd.authorization_rules
-        qd.auto_delete_on_idle = internal_qd.auto_delete_on_idle
-        qd.dead_lettering_on_message_expiration = internal_qd.dead_lettering_on_message_expiration
-        qd.default_message_time_to_live = internal_qd.default_message_time_to_live
-        qd.duplicate_detection_history_time_window = internal_qd.duplicate_detection_history_time_window
-        qd.entity_availability_status = internal_qd.entity_availability_status
-        qd.enable_batched_operations = internal_qd.enable_batched_operations
-        qd.enable_express = internal_qd.enable_express
-        qd.enable_partitioning = internal_qd.enable_partitioning
-        qd.is_anonymous_accessible = internal_qd.is_anonymous_accessible
-        qd.lock_duration = internal_qd.lock_duration
-        qd.max_delivery_count = internal_qd.max_delivery_count
-        qd.max_size_in_megabytes = internal_qd.max_size_in_megabytes
-        qd.requires_duplicate_detection = internal_qd.requires_duplicate_detection
-        qd.requires_session = internal_qd.requires_session
-        qd.status = internal_qd.status
-        qd.support_ordering = internal_qd.support_ordering
-        qd.forward_to = internal_qd.forward_to
-        qd.forward_dead_lettered_messages_to = internal_qd.forward_dead_lettered_messages_to
-        qd.user_metadata = internal_qd.user_metadata
-
         return qd
 
     def _to_internal_entity(self):
@@ -342,56 +342,56 @@ class QueueRuntimeProperties(object):
 class TopicProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
     """Properties of a Service Bus topic resource.
 
-    :param name: Name of the topic.
+    :ivar name: Name of the topic.
     :type name: str
-    :keyword default_message_time_to_live: ISO 8601 default message timespan to live value. This is
+    :ivar default_message_time_to_live: ISO 8601 default message timespan to live value. This is
      the duration after which the message expires, starting from when the message is sent to Service
      Bus. This is the default value used when TimeToLive is not set on a message itself.
     :type default_message_time_to_live: ~datetime.timedelta
-    :keyword max_size_in_megabytes: The maximum size of the topic in megabytes, which is the size of
+    :ivar max_size_in_megabytes: The maximum size of the topic in megabytes, which is the size of
      memory allocated for the topic.
     :type max_size_in_megabytes: long
-    :keyword requires_duplicate_detection: A value indicating if this topic requires duplicate
+    :ivar requires_duplicate_detection: A value indicating if this topic requires duplicate
      detection.
     :type requires_duplicate_detection: bool
-    :keyword duplicate_detection_history_time_window: ISO 8601 timeSpan structure that defines the
+    :ivar duplicate_detection_history_time_window: ISO 8601 timeSpan structure that defines the
      duration of the duplicate detection history. The default value is 10 minutes.
     :type duplicate_detection_history_time_window: ~datetime.timedelta
-    :keyword enable_batched_operations: Value that indicates whether server-side batched operations
+    :ivar enable_batched_operations: Value that indicates whether server-side batched operations
      are enabled.
     :type enable_batched_operations: bool
-    :keyword size_in_bytes: The size of the topic, in bytes.
+    :ivar size_in_bytes: The size of the topic, in bytes.
     :type size_in_bytes: int
-    :keyword filtering_messages_before_publishing: Filter messages before publishing.
+    :ivar filtering_messages_before_publishing: Filter messages before publishing.
     :type filtering_messages_before_publishing: bool
-    :keyword is_anonymous_accessible: A value indicating if the resource can be accessed without
+    :ivar is_anonymous_accessible: A value indicating if the resource can be accessed without
      authorization.
     :type is_anonymous_accessible: bool
-    :keyword authorization_rules: Authorization rules for resource.
+    :ivar authorization_rules: Authorization rules for resource.
     :type authorization_rules:
      list[~azure.servicebus.management.AuthorizationRule]
-    :keyword status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
+    :ivar status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
      "Deleting", "Disabled", "ReceiveDisabled", "Renaming", "Restoring", "SendDisabled", "Unknown".
     :type status: str or ~azure.servicebus.management.EntityStatus
-    :keyword support_ordering: A value that indicates whether the topic supports ordering.
+    :ivar support_ordering: A value that indicates whether the topic supports ordering.
     :type support_ordering: bool
-    :keyword auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the topic is
+    :ivar auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the topic is
      automatically deleted. The minimum duration is 5 minutes.
     :type auto_delete_on_idle: ~datetime.timedelta
-    :keyword enable_partitioning: A value that indicates whether the topic is to be partitioned
+    :ivar enable_partitioning: A value that indicates whether the topic is to be partitioned
      across multiple message brokers.
     :type enable_partitioning: bool
-    :keyword entity_availability_status: Availability status of the entity. Possible values include:
+    :ivar entity_availability_status: Availability status of the entity. Possible values include:
      "Available", "Limited", "Renaming", "Restoring", "Unknown".
     :type entity_availability_status: str or
      ~azure.servicebus.management.EntityAvailabilityStatus
-    :keyword enable_subscription_partitioning: A value that indicates whether the topic's
+    :ivar enable_subscription_partitioning: A value that indicates whether the topic's
      subscription is to be partitioned.
     :type enable_subscription_partitioning: bool
-    :keyword enable_express: A value that indicates whether Express Entities are enabled. An express
+    :ivar enable_express: A value that indicates whether Express Entities are enabled. An express
      queue holds a message in memory temporarily before writing it to persistent storage.
     :type enable_express: bool
-    :keyword user_metadata: Metadata associated with the topic.
+    :ivar user_metadata: Metadata associated with the topic.
     :type user_metadata: str
     """
     def __init__(
@@ -403,47 +403,47 @@ class TopicProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
         self.name = name
         self._internal_td = None  # type: Optional[InternalTopicDescription]
 
-        self.default_message_time_to_live = kwargs.get('default_message_time_to_live', None)
-        self.max_size_in_megabytes = kwargs.get('max_size_in_megabytes', None)
-        self.requires_duplicate_detection = kwargs.get('requires_duplicate_detection', None)
-        self.duplicate_detection_history_time_window = kwargs.get('duplicate_detection_history_time_window', None)
-        self.enable_batched_operations = kwargs.get('enable_batched_operations', None)
-        self.size_in_bytes = kwargs.get('size_in_bytes', None)
-        self.is_anonymous_accessible = kwargs.get('is_anonymous_accessible', None)
-        self.authorization_rules = kwargs.get('authorization_rules', None)
-        self.status = kwargs.get('status', None)
-        self.support_ordering = kwargs.get('support_ordering', None)
-        self.auto_delete_on_idle = kwargs.get('auto_delete_on_idle', None)
-        self.enable_partitioning = kwargs.get('enable_partitioning', None)
-        self.entity_availability_status = kwargs.get('entity_availability_status', None)
-        self.enable_subscription_partitioning = kwargs.get('enable_subscription_partitioning', None)
-        self.enable_express = kwargs.get('enable_express', None)
-        self.user_metadata = kwargs.get('user_metadata', None)
+        self.default_message_time_to_live = kwargs['default_message_time_to_live']
+        self.max_size_in_megabytes = kwargs['max_size_in_megabytes']
+        self.requires_duplicate_detection = kwargs['requires_duplicate_detection']
+        self.duplicate_detection_history_time_window = kwargs['duplicate_detection_history_time_window']
+        self.enable_batched_operations = kwargs['enable_batched_operations']
+        self.size_in_bytes = kwargs['size_in_bytes']
+        self.is_anonymous_accessible = kwargs['is_anonymous_accessible']
+        self.authorization_rules = kwargs['authorization_rules']
+        self.status = kwargs['status']
+        self.support_ordering = kwargs['support_ordering']
+        self.auto_delete_on_idle = kwargs['auto_delete_on_idle']
+        self.enable_partitioning = kwargs['enable_partitioning']
+        self.entity_availability_status = kwargs['entity_availability_status']
+        self.enable_subscription_partitioning = kwargs['enable_subscription_partitioning']
+        self.enable_express = kwargs['enable_express']
+        self.user_metadata = kwargs['user_metadata']
 
     @classmethod
     def _from_internal_entity(cls, name, internal_td):
         # type: (str, InternalTopicDescription) -> TopicProperties
-        qd = cls(name)
-        qd._internal_td = deepcopy(internal_td)
-
-        qd.default_message_time_to_live = internal_td.default_message_time_to_live
-        qd.max_size_in_megabytes = internal_td.max_size_in_megabytes
-        qd.requires_duplicate_detection = internal_td.requires_duplicate_detection
-        qd.duplicate_detection_history_time_window = internal_td.duplicate_detection_history_time_window
-        qd.enable_batched_operations = internal_td.enable_batched_operations
-        qd.size_in_bytes = internal_td.size_in_bytes
-        qd.is_anonymous_accessible = internal_td.is_anonymous_accessible
-        qd.authorization_rules = internal_td.authorization_rules
-        qd.status = internal_td.status
-        qd.support_ordering = internal_td.support_ordering
-        qd.auto_delete_on_idle = internal_td.auto_delete_on_idle
-        qd.enable_partitioning = internal_td.enable_partitioning
-        qd.entity_availability_status = internal_td.entity_availability_status
-        qd.enable_subscription_partitioning = internal_td.enable_subscription_partitioning
-        qd.enable_express = internal_td.enable_express
-        qd.user_metadata = internal_td.user_metadata
-
-        return qd
+        td = cls(
+            name,
+            default_message_time_to_live=internal_td.default_message_time_to_live,
+            max_size_in_megabytes=internal_td.max_size_in_megabytes,
+            requires_duplicate_detection=internal_td.requires_duplicate_detection,
+            duplicate_detection_history_time_window=internal_td.duplicate_detection_history_time_window,
+            enable_batched_operations=internal_td.enable_batched_operations,
+            size_in_bytes=internal_td.size_in_bytes,
+            is_anonymous_accessible=internal_td.is_anonymous_accessible,
+            authorization_rules=internal_td.authorization_rules,
+            status=internal_td.status,
+            support_ordering=internal_td.support_ordering,
+            auto_delete_on_idle=internal_td.auto_delete_on_idle,
+            enable_partitioning=internal_td.enable_partitioning,
+            entity_availability_status=internal_td.entity_availability_status,
+            enable_subscription_partitioning=internal_td.enable_subscription_partitioning,
+            enable_express=internal_td.enable_express,
+            user_metadata=internal_td.user_metadata
+        )
+        td._internal_td = deepcopy(internal_td)
+        return td
 
     def _to_internal_entity(self):
         # type: () -> InternalTopicDescription
@@ -546,47 +546,47 @@ class TopicRuntimeProperties(object):
 class SubscriptionProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
     """Properties of a Service Bus topic subscription resource.
 
-    :param name: Name of the subscription.
+    :ivar name: Name of the subscription.
     :type name: str
-    :keyword lock_duration: ISO 8601 timespan duration of a peek-lock; that is, the amount of time
+    :ivar lock_duration: ISO 8601 timespan duration of a peek-lock; that is, the amount of time
      that the message is locked for other receivers. The maximum value for LockDuration is 5
      minutes; the default value is 1 minute.
     :type lock_duration: ~datetime.timedelta
-    :keyword requires_session: A value that indicates whether the queue supports the concept of
+    :ivar requires_session: A value that indicates whether the queue supports the concept of
      sessions.
     :type requires_session: bool
-    :keyword default_message_time_to_live: ISO 8601 default message timespan to live value. This is
+    :ivar default_message_time_to_live: ISO 8601 default message timespan to live value. This is
      the duration after which the message expires, starting from when the message is sent to Service
      Bus. This is the default value used when TimeToLive is not set on a message itself.
     :type default_message_time_to_live: ~datetime.timedelta
-    :keyword dead_lettering_on_message_expiration: A value that indicates whether this subscription
+    :ivar dead_lettering_on_message_expiration: A value that indicates whether this subscription
      has dead letter support when a message expires.
     :type dead_lettering_on_message_expiration: bool
-    :keyword dead_lettering_on_filter_evaluation_exceptions: A value that indicates whether this
+    :ivar dead_lettering_on_filter_evaluation_exceptions: A value that indicates whether this
      subscription has dead letter support when a message expires.
     :type dead_lettering_on_filter_evaluation_exceptions: bool
-    :keyword max_delivery_count: The maximum delivery count. A message is automatically deadlettered
+    :ivar max_delivery_count: The maximum delivery count. A message is automatically deadlettered
      after this number of deliveries. Default value is 10.
     :type max_delivery_count: int
-    :keyword enable_batched_operations: Value that indicates whether server-side batched operations
+    :ivar enable_batched_operations: Value that indicates whether server-side batched operations
      are enabled.
     :type enable_batched_operations: bool
-    :keyword status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
+    :ivar status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
      "Deleting", "Disabled", "ReceiveDisabled", "Renaming", "Restoring", "SendDisabled", "Unknown".
     :type status: str or ~azure.servicebus.management.EntityStatus
-    :keyword forward_to: The name of the recipient entity to which all the messages sent to the
+    :ivar forward_to: The name of the recipient entity to which all the messages sent to the
      subscription are forwarded to.
     :type forward_to: str
-    :keyword user_metadata: Metadata associated with the subscription. Maximum number of characters
+    :ivar user_metadata: Metadata associated with the subscription. Maximum number of characters
      is 1024.
     :type user_metadata: str
-    :keyword forward_dead_lettered_messages_to: The name of the recipient entity to which all the
+    :ivar forward_dead_lettered_messages_to: The name of the recipient entity to which all the
      messages sent to the subscription are forwarded to.
     :type forward_dead_lettered_messages_to: str
-    :keyword auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the subscription is
+    :ivar auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the subscription is
      automatically deleted. The minimum duration is 5 minutes.
     :type auto_delete_on_idle: ~datetime.timedelta
-    :keyword entity_availability_status: Availability status of the entity. Possible values include:
+    :ivar entity_availability_status: Availability status of the entity. Possible values include:
      "Available", "Limited", "Renaming", "Restoring", "Unknown".
     :type entity_availability_status: str or
      ~azure.servicebus.management.EntityAvailabilityStatus
@@ -596,41 +596,42 @@ class SubscriptionProperties(DictMixin):  # pylint:disable=too-many-instance-att
         self.name = name
         self._internal_sd = None  # type: Optional[InternalSubscriptionDescription]
 
-        self.lock_duration = kwargs.get('lock_duration', None)
-        self.requires_session = kwargs.get('requires_session', None)
-        self.default_message_time_to_live = kwargs.get('default_message_time_to_live', None)
-        self.dead_lettering_on_message_expiration = kwargs.get('dead_lettering_on_message_expiration', None)
-        self.dead_lettering_on_filter_evaluation_exceptions = kwargs.get(
-            'dead_lettering_on_filter_evaluation_exceptions', None)
-        self.max_delivery_count = kwargs.get('max_delivery_count', None)
-        self.enable_batched_operations = kwargs.get('enable_batched_operations', None)
-        self.status = kwargs.get('status', None)
-        self.forward_to = kwargs.get('forward_to', None)
-        self.user_metadata = kwargs.get('user_metadata', None)
-        self.forward_dead_lettered_messages_to = kwargs.get('forward_dead_lettered_messages_to', None)
-        self.auto_delete_on_idle = kwargs.get('auto_delete_on_idle', None)
-        self.entity_availability_status = kwargs.get('entity_availability_status', None)
+        self.lock_duration = kwargs['lock_duration']
+        self.requires_session = kwargs['requires_session']
+        self.default_message_time_to_live = kwargs['default_message_time_to_live']
+        self.dead_lettering_on_message_expiration = kwargs['dead_lettering_on_message_expiration']
+        self.dead_lettering_on_filter_evaluation_exceptions = kwargs[
+            'dead_lettering_on_filter_evaluation_exceptions']
+        self.max_delivery_count = kwargs['max_delivery_count']
+        self.enable_batched_operations = kwargs['enable_batched_operations']
+        self.status = kwargs['status']
+        self.forward_to = kwargs['forward_to']
+        self.user_metadata = kwargs['user_metadata']
+        self.forward_dead_lettered_messages_to = kwargs['forward_dead_lettered_messages_to']
+        self.auto_delete_on_idle = kwargs['auto_delete_on_idle']
+        self.entity_availability_status = kwargs['entity_availability_status']
 
     @classmethod
     def _from_internal_entity(cls, name, internal_subscription):
         # type: (str, InternalSubscriptionDescription) -> SubscriptionProperties
-        subscription = cls(name)
+        subscription = cls(
+            name,
+            lock_duration=internal_subscription.lock_duration,
+            requires_session=internal_subscription.requires_session,
+            default_message_time_to_live=internal_subscription.default_message_time_to_live,
+            dead_lettering_on_message_expiration=internal_subscription.dead_lettering_on_message_expiration,
+            dead_lettering_on_filter_evaluation_exceptions=
+            internal_subscription.dead_lettering_on_filter_evaluation_exceptions,
+            max_delivery_count=internal_subscription.max_delivery_count,
+            enable_batched_operations=internal_subscription.enable_batched_operations,
+            status=internal_subscription.status,
+            forward_to=internal_subscription.forward_to,
+            user_metadata=internal_subscription.user_metadata,
+            forward_dead_lettered_messages_to=internal_subscription.forward_dead_lettered_messages_to,
+            auto_delete_on_idle=internal_subscription.auto_delete_on_idle,
+            entity_availability_status=internal_subscription.entity_availability_status
+        )
         subscription._internal_sd = deepcopy(internal_subscription)
-        subscription.lock_duration = internal_subscription.lock_duration
-        subscription.requires_session = internal_subscription.requires_session
-        subscription.default_message_time_to_live = internal_subscription.default_message_time_to_live
-        subscription.dead_lettering_on_message_expiration = internal_subscription.dead_lettering_on_message_expiration
-        subscription.dead_lettering_on_filter_evaluation_exceptions = \
-            internal_subscription.dead_lettering_on_filter_evaluation_exceptions
-        subscription.max_delivery_count = internal_subscription.max_delivery_count
-        subscription.enable_batched_operations = internal_subscription.enable_batched_operations
-        subscription.status = internal_subscription.status
-        subscription.forward_to = internal_subscription.forward_to
-        subscription.user_metadata = internal_subscription.user_metadata
-        subscription.forward_dead_lettered_messages_to = internal_subscription.forward_dead_lettered_messages_to
-        subscription.auto_delete_on_idle = internal_subscription.auto_delete_on_idle
-        subscription.entity_availability_status = internal_subscription.entity_availability_status
-
         return subscription
 
     def _to_internal_entity(self):
@@ -750,20 +751,20 @@ class RuleProperties(DictMixin):
 
     :param name: Name of the rule.
     :type name: str
-    :keyword filter: The filter of the rule.
+    :ivar filter: The filter of the rule.
     :type filter: Union[~azure.servicebus.management.CorrelationRuleFilter,
      ~azure.servicebus.management.SqlRuleFilter]
-    :keyword action: The action of the rule.
+    :ivar action: The action of the rule.
     :type action: Optional[~azure.servicebus.management.SqlRuleAction]
-    :keyword created_at: The exact time the rule was created.
+    :ivar created_at: The exact time the rule was created.
     :type created_at: ~datetime.datetime
     """
 
     def __init__(self, name, **kwargs):
         # type: (str, Any) -> None
-        self.filter = kwargs.get('filter', None)
-        self.action = kwargs.get('action', None)
-        self.created_at = kwargs.get('created_at', None)
+        self.filter = kwargs['filter']
+        self.action = kwargs['action']
+        self.created_at = kwargs['created_at']
         self.name = name
 
         self._internal_rule = None  # type: Optional[InternalRuleDescription]
@@ -771,15 +772,15 @@ class RuleProperties(DictMixin):
     @classmethod
     def _from_internal_entity(cls, name, internal_rule):
         # type: (str, InternalRuleDescription) -> RuleProperties
-        rule = cls(name)
+        rule = cls(
+            name,
+            filter=RULE_CLASS_MAPPING[type(internal_rule.filter)]._from_internal_entity(internal_rule.filter)
+            if internal_rule.filter and isinstance(internal_rule.filter, tuple(RULE_CLASS_MAPPING.keys())) else None,
+            action=RULE_CLASS_MAPPING[type(internal_rule.action)]._from_internal_entity(internal_rule.action)
+            if internal_rule.action and isinstance(internal_rule.action, tuple(RULE_CLASS_MAPPING.keys())) else None,
+            created_at=internal_rule.created_at
+        )
         rule._internal_rule = deepcopy(internal_rule)
-
-        rule.filter = RULE_CLASS_MAPPING[type(internal_rule.filter)]._from_internal_entity(internal_rule.filter) \
-            if internal_rule.filter and isinstance(internal_rule.filter, tuple(RULE_CLASS_MAPPING.keys())) else None
-        rule.action = RULE_CLASS_MAPPING[type(internal_rule.action)]._from_internal_entity(internal_rule.action) \
-            if internal_rule.action and isinstance(internal_rule.action, tuple(RULE_CLASS_MAPPING.keys())) else None
-        rule.created_at = internal_rule.created_at
-
         return rule
 
     def _to_internal_entity(self):

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
@@ -25,8 +25,8 @@ from ._constants import RULE_SQL_COMPATIBILITY_LEVEL
 adjust_attribute_map()
 
 
-class QueueDescription(object):  # pylint:disable=too-many-instance-attributes
-    """Description of a Service Bus queue resource.
+class QueueProperties(object):  # pylint:disable=too-many-instance-attributes
+    """Properties of a Service Bus queue resource.
 
     :param name: Name of the queue.
     :type name: str
@@ -126,7 +126,7 @@ class QueueDescription(object):  # pylint:disable=too-many-instance-attributes
 
     @classmethod
     def _from_internal_entity(cls, name, internal_qd):
-        # type: (str, InternalQueueDescription) -> QueueDescription
+        # type: (str, InternalQueueDescription) -> QueueProperties
         qd = cls(name)
         qd._internal_qd = deepcopy(internal_qd)  # pylint:disable=protected-access
 
@@ -182,8 +182,8 @@ class QueueDescription(object):  # pylint:disable=too-many-instance-attributes
         return self._internal_qd
 
 
-class QueueRuntimeInfo(object):
-    """Service Bus queue metrics.
+class QueueRuntimeProperties(object):
+    """Service Bus queue runtime properties.
 
     :ivar name: Name of the queue.
     :type name: str
@@ -196,46 +196,81 @@ class QueueRuntimeInfo(object):
     :type updated_at: ~datetime.datetime
     :ivar size_in_bytes: The size of the queue, in bytes.
     :type size_in_bytes: int
-    :ivar message_count: The number of messages in the queue.
-    :type message_count: int
-    :ivar message_count_details: Details about the message counts in entity.
-    :type message_count_details: ~azure.servicebus.management.MessageCountDetails
+    :ivar total_message_count: Total number of messages.
+    :type total_message_count: int
+    :ivar active_message_count: Number of active messages in the queue, topic, or subscription.
+    :type active_message_count: int
+    :ivar dead_letter_message_count: Number of messages that are dead lettered.
+    :type dead_letter_message_count: int
+    :ivar scheduled_message_count: Number of scheduled messages.
+    :type scheduled_message_count: int
+    :ivar transfer_dead_letter_message_count: Number of messages transferred into dead letters.
+    :type transfer_dead_letter_message_count: int
+    :ivar transfer_message_count: Number of messages transferred to another queue, topic, or
+     subscription.
+    :type transfer_message_count: int
     """
-
     def __init__(
         self,
-        name,
-        **kwargs
     ):
-        # type: (str, Any) -> None
-        self.name = name
+        self._name = None
         self._internal_qr = None  # type: Optional[InternalQueueDescription]
-
-        self.accessed_at = kwargs.get('accessed_at', None)
-        self.created_at = kwargs.get('created_at', None)
-        self.updated_at = kwargs.get('updated_at', None)
-        self.size_in_bytes = kwargs.get('size_in_bytes', None)
-        self.message_count = kwargs.get('message_count', None)
-        self.message_count_details = kwargs.get('message_count_details', None)
 
     @classmethod
     def _from_internal_entity(cls, name, internal_qr):
-        # type: (str, InternalQueueDescription) -> QueueRuntimeInfo
-        qr = cls(name)
+        # type: (str, InternalQueueDescription) -> QueueRuntimeProperties
+        qr = cls()
+        qr._name = name
         qr._internal_qr = deepcopy(internal_qr)  # pylint:disable=protected-access
-
-        qr.accessed_at = internal_qr.accessed_at
-        qr.created_at = internal_qr.created_at
-        qr.updated_at = internal_qr.updated_at
-        qr.size_in_bytes = internal_qr.size_in_bytes
-        qr.message_count = internal_qr.message_count
-        qr.message_count_details = internal_qr.message_count_details
-
         return qr
 
+    @property
+    def name(self):
+        return self._name
 
-class TopicDescription(object):  # pylint:disable=too-many-instance-attributes
-    """Description of a Service Bus topic resource.
+    @property
+    def accessed_at(self):
+        return self._internal_qr.accessed_at
+
+    @property
+    def created_at(self):
+        return self._internal_qr.created_at
+
+    @property
+    def updated_at(self):
+        return self._internal_qr.updated_at
+
+    @property
+    def size_in_bytes(self):
+        return self._internal_qr.size_in_bytes
+
+    @property
+    def total_message_count(self):
+        return self._internal_qr.message_count
+
+    @property
+    def active_message_count(self):
+        return self._internal_qr.message_count_details.active_message_count
+
+    @property
+    def dead_letter_message_count(self):
+        return self._internal_qr.message_count_details.dead_letter_message_count
+
+    @property
+    def scheduled_message_count(self):
+        return self._internal_qr.message_count_details.scheduled_message_count
+
+    @property
+    def transfer_dead_letter_message_count(self):
+        return self._internal_qr.message_count_details.transfer_dead_letter_message_count
+
+    @property
+    def transfer_message_count(self):
+        return self._internal_qr.message_count_details.transfer_message_count
+
+
+class TopicProperties(object):  # pylint:disable=too-many-instance-attributes
+    """Properties of a Service Bus topic resource.
 
     :param name: Name of the topic.
     :type name: str
@@ -317,7 +352,7 @@ class TopicDescription(object):  # pylint:disable=too-many-instance-attributes
 
     @classmethod
     def _from_internal_entity(cls, name, internal_td):
-        # type: (str, InternalTopicDescription) -> TopicDescription
+        # type: (str, InternalTopicDescription) -> TopicProperties
         qd = cls(name)
         qd._internal_td = deepcopy(internal_td)
 
@@ -364,8 +399,8 @@ class TopicDescription(object):  # pylint:disable=too-many-instance-attributes
         return self._internal_td
 
 
-class TopicRuntimeInfo(object):
-    """Description of a Service Bus topic resource.
+class TopicRuntimeProperties(object):
+    """Runtime properties of a Service Bus topic resource.
 
     :ivar str name:
     :ivar created_at: The exact time the queue was created.
@@ -375,42 +410,81 @@ class TopicRuntimeInfo(object):
     :ivar accessed_at: Last time a message was sent, or the last time there was a receive request
      to this queue.
     :type accessed_at: ~datetime.datetime
-    :ivar message_count_details: Details about the message counts in queue.
-    :type message_count_details: ~azure.servicebus.management._generated.models.MessageCountDetails
     :ivar subscription_count: The number of subscriptions in the topic.
     :type subscription_count: int
+    :ivar active_message_count: Number of active messages in the queue, topic, or subscription.
+    :type active_message_count: int
+    :ivar dead_letter_message_count: Number of messages that are dead lettered.
+    :type dead_letter_message_count: int
+    :ivar scheduled_message_count: Number of scheduled messages.
+    :type scheduled_message_count: int
+    :ivar transfer_dead_letter_message_count: Number of messages transferred into dead letters.
+    :type transfer_dead_letter_message_count: int
+    :ivar transfer_message_count: Number of messages transferred to another queue, topic, or
+     subscription.
+    :type transfer_message_count: int
     """
     def __init__(
         self,
-        name,
-        **kwargs
     ):
-        # type: (str, Any) -> None
-        self.name = name
+        self._name = None
         self._internal_td = None  # type: Optional[InternalTopicDescription]
-        self.created_at = kwargs.get('created_at', None)
-        self.updated_at = kwargs.get('updated_at', None)
-        self.accessed_at = kwargs.get('accessed_at', None)
-        self.message_count_details = kwargs.get('message_count_details', None)
-        self.subscription_count = kwargs.get('subscription_count', None)
 
     @classmethod
     def _from_internal_entity(cls, name, internal_td):
-        # type: (str, InternalTopicDescription) -> TopicRuntimeInfo
-        qd = cls(name)
+        # type: (str, InternalTopicDescription) -> TopicRuntimeProperties
+        qd = cls()
+        qd._name = name
         qd._internal_td = internal_td
-
-        qd.created_at = internal_td.created_at
-        qd.updated_at = internal_td.updated_at
-        qd.accessed_at = internal_td.accessed_at
-        qd.message_count_details = internal_td.message_count_details
-        qd.subscription_count = internal_td.subscription_count
-
         return qd
 
+    @property
+    def name(self):
+        return self._name
 
-class SubscriptionDescription(object):  # pylint:disable=too-many-instance-attributes
-    """Description of a Service Bus queue resource.
+    @property
+    def accessed_at(self):
+        return self._internal_td.accessed_at
+
+    @property
+    def created_at(self):
+        return self._internal_td.created_at
+
+    @property
+    def updated_at(self):
+        return self._internal_td.updated_at
+
+    @property
+    def size_in_bytes(self):
+        return self._internal_td.size_in_bytes
+
+    @property
+    def subscription_count(self):
+        return self._internal_td.subscription_count
+
+    @property
+    def active_message_count(self):
+        return self._internal_td.message_count_details.active_message_count
+
+    @property
+    def dead_letter_message_count(self):
+        return self._internal_td.message_count_details.dead_letter_message_count
+
+    @property
+    def scheduled_message_count(self):
+        return self._internal_td.message_count_details.scheduled_message_count
+
+    @property
+    def transfer_dead_letter_message_count(self):
+        return self._internal_td.message_count_details.transfer_dead_letter_message_count
+
+    @property
+    def transfer_message_count(self):
+        return self._internal_td.message_count_details.transfer_message_count
+
+
+class SubscriptionProperties(object):  # pylint:disable=too-many-instance-attributes
+    """Properties of a Service Bus topic subscription resource.
 
     :param name: Name of the subscription.
     :type name: str
@@ -479,7 +553,7 @@ class SubscriptionDescription(object):  # pylint:disable=too-many-instance-attri
 
     @classmethod
     def _from_internal_entity(cls, name, internal_subscription):
-        # type: (str, InternalSubscriptionDescription) -> SubscriptionDescription
+        # type: (str, InternalSubscriptionDescription) -> SubscriptionProperties
         subscription = cls(name)
         subscription._internal_sd = deepcopy(internal_subscription)
         subscription.lock_duration = internal_subscription.lock_duration
@@ -521,8 +595,8 @@ class SubscriptionDescription(object):  # pylint:disable=too-many-instance-attri
         return self._internal_sd
 
 
-class SubscriptionRuntimeInfo(object):
-    """Description of a Service Bus queue resource.
+class SubscriptionRuntimeProperties(object):
+    """Runtime properties of a Service Bus topic subscription resource.
 
     :ivar str name:
     :ivar created_at: The exact time the queue was created.
@@ -532,39 +606,77 @@ class SubscriptionRuntimeInfo(object):
     :ivar accessed_at: Last time a message was sent, or the last time there was a receive request
      to this queue.
     :type accessed_at: ~datetime.datetime
-    :ivar message_count: The number of messages in the subscription.
-    :type message_count: int
-    :ivar message_count_details: Details about the message counts in queue.
-    :type message_count_details: ~azure.servicebus.management._generated.models.MessageCountDetails
+    :ivar total_message_count: The number of messages in the subscription.
+    :type total_message_count: int
+    :ivar active_message_count: Number of active messages in the queue, topic, or subscription.
+    :type active_message_count: int
+    :ivar dead_letter_message_count: Number of messages that are dead lettered.
+    :type dead_letter_message_count: int
+    :ivar scheduled_message_count: Number of scheduled messages.
+    :type scheduled_message_count: int
+    :ivar transfer_dead_letter_message_count: Number of messages transferred into dead letters.
+    :type transfer_dead_letter_message_count: int
+    :ivar transfer_message_count: Number of messages transferred to another queue, topic, or
+     subscription.
+    :type transfer_message_count: int
 
     """
-    def __init__(self, name, **kwargs):
-        # type: (str, Any) -> None
+    def __init__(self):
         self._internal_sd = None  # type: Optional[InternalSubscriptionDescription]
-        self.name = name
-
-        self.message_count = kwargs.get('message_count', None)
-        self.created_at = kwargs.get('created_at', None)
-        self.updated_at = kwargs.get('updated_at', None)
-        self.accessed_at = kwargs.get('accessed_at', None)
-        self.message_count_details = kwargs.get('message_count_details', None)
+        self._name = None
 
     @classmethod
     def _from_internal_entity(cls, name, internal_subscription):
-        # type: (str, InternalSubscriptionDescription) -> SubscriptionRuntimeInfo
-        subscription = cls(name)
+        # type: (str, InternalSubscriptionDescription) -> SubscriptionRuntimeProperties
+        subscription = cls()
+        subscription._name = name
         subscription._internal_sd = internal_subscription
-        subscription.message_count = internal_subscription.message_count
-        subscription.created_at = internal_subscription.created_at
-        subscription.updated_at = internal_subscription.updated_at
-        subscription.accessed_at = internal_subscription.accessed_at
-        subscription.message_count_details = internal_subscription.message_count_details
 
         return subscription
 
+    @property
+    def name(self):
+        return self._name
 
-class RuleDescription(object):
-    """Description of a topic subscription rule.
+    @property
+    def accessed_at(self):
+        return self._internal_sd.accessed_at
+
+    @property
+    def created_at(self):
+        return self._internal_sd.created_at
+
+    @property
+    def updated_at(self):
+        return self._internal_sd.updated_at
+
+    @property
+    def total_message_count(self):
+        return self._internal_sd.message_count
+
+    @property
+    def active_message_count(self):
+        return self._internal_sd.message_count_details.active_message_count
+
+    @property
+    def dead_letter_message_count(self):
+        return self._internal_sd.message_count_details.dead_letter_message_count
+
+    @property
+    def scheduled_message_count(self):
+        return self._internal_sd.message_count_details.scheduled_message_count
+
+    @property
+    def transfer_dead_letter_message_count(self):
+        return self._internal_sd.message_count_details.transfer_dead_letter_message_count
+
+    @property
+    def transfer_message_count(self):
+        return self._internal_sd.message_count_details.transfer_message_count
+
+
+class RuleProperties(object):
+    """Properties of a topic subscription rule.
 
     :param name: Name of the rule.
     :type name: str
@@ -588,7 +700,7 @@ class RuleDescription(object):
 
     @classmethod
     def _from_internal_entity(cls, name, internal_rule):
-        # type: (str, InternalRuleDescription) -> RuleDescription
+        # type: (str, InternalRuleDescription) -> RuleProperties
         rule = cls(name)
         rule._internal_rule = deepcopy(internal_rule)
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
@@ -25,7 +25,58 @@ from ._constants import RULE_SQL_COMPATIBILITY_LEVEL
 adjust_attribute_map()
 
 
-class QueueProperties(object):  # pylint:disable=too-many-instance-attributes
+class DictMixin(object):
+
+    def __setitem__(self, key, item):
+        self.__dict__[key] = item
+
+    def __getitem__(self, key):
+        return self.__dict__[key]
+
+    def __repr__(self):
+        return str(self)
+
+    def __len__(self):
+        return len(self.keys())
+
+    def __delitem__(self, key):
+        self.__dict__[key] = None
+
+    def __eq__(self, other):
+        """Compare objects by comparing all attributes."""
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+    def __ne__(self, other):
+        """Compare objects by comparing all attributes."""
+        return not self.__eq__(other)
+
+    def __str__(self):
+        return str({k: v for k, v in self.__dict__.items() if not k.startswith('_')})
+
+    def has_key(self, k):
+        return k in self.__dict__
+
+    def update(self, *args, **kwargs):
+        return self.__dict__.update(*args, **kwargs)
+
+    def keys(self):
+        return [k for k in self.__dict__ if not k.startswith('_')]
+
+    def values(self):
+        return [v for k, v in self.__dict__.items() if not k.startswith('_')]
+
+    def items(self):
+        return [(k, v) for k, v in self.__dict__.items() if not k.startswith('_')]
+
+    def get(self, key, default=None):
+        if key in self.__dict__:
+            return self.__dict__[key]
+        return default
+
+
+class QueueProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
     """Properties of a Service Bus queue resource.
 
     :param name: Name of the queue.
@@ -269,7 +320,7 @@ class QueueRuntimeProperties(object):
         return self._internal_qr.message_count_details.transfer_message_count
 
 
-class TopicProperties(object):  # pylint:disable=too-many-instance-attributes
+class TopicProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
     """Properties of a Service Bus topic resource.
 
     :param name: Name of the topic.
@@ -299,10 +350,10 @@ class TopicProperties(object):  # pylint:disable=too-many-instance-attributes
     :type is_anonymous_accessible: bool
     :keyword authorization_rules: Authorization rules for resource.
     :type authorization_rules:
-     list[~azure.servicebus.management._generated.models.AuthorizationRule]
+     list[~azure.servicebus.management.AuthorizationRule]
     :keyword status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
      "Deleting", "Disabled", "ReceiveDisabled", "Renaming", "Restoring", "SendDisabled", "Unknown".
-    :type status: str or ~azure.servicebus.management._generated.models.EntityStatus
+    :type status: str or ~azure.servicebus.management.models.EntityStatus
     :keyword support_ordering: A value that indicates whether the topic supports ordering.
     :type support_ordering: bool
     :keyword auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the topic is
@@ -314,7 +365,7 @@ class TopicProperties(object):  # pylint:disable=too-many-instance-attributes
     :keyword entity_availability_status: Availability status of the entity. Possible values include:
      "Available", "Limited", "Renaming", "Restoring", "Unknown".
     :type entity_availability_status: str or
-     ~azure.servicebus.management._generated.models.EntityAvailabilityStatus
+     ~azure.servicebus.management.models.EntityAvailabilityStatus
     :keyword enable_subscription_partitioning: A value that indicates whether the topic's
      subscription is to be partitioned.
     :type enable_subscription_partitioning: bool
@@ -483,7 +534,7 @@ class TopicRuntimeProperties(object):
         return self._internal_td.message_count_details.transfer_message_count
 
 
-class SubscriptionProperties(object):  # pylint:disable=too-many-instance-attributes
+class SubscriptionProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
     """Properties of a Service Bus topic subscription resource.
 
     :param name: Name of the subscription.
@@ -513,7 +564,7 @@ class SubscriptionProperties(object):  # pylint:disable=too-many-instance-attrib
     :type enable_batched_operations: bool
     :keyword status: Status of a Service Bus resource. Possible values include: "Active", "Creating",
      "Deleting", "Disabled", "ReceiveDisabled", "Renaming", "Restoring", "SendDisabled", "Unknown".
-    :type status: str or ~azure.servicebus.management._generated.models.EntityStatus
+    :type status: str or ~azure.servicebus.management.models.EntityStatus
     :keyword forward_to: The name of the recipient entity to which all the messages sent to the
      subscription are forwarded to.
     :type forward_to: str
@@ -529,7 +580,7 @@ class SubscriptionProperties(object):  # pylint:disable=too-many-instance-attrib
     :keyword entity_availability_status: Availability status of the entity. Possible values include:
      "Available", "Limited", "Renaming", "Restoring", "Unknown".
     :type entity_availability_status: str or
-     ~azure.servicebus.management._generated.models.EntityAvailabilityStatus
+     ~azure.servicebus.management.models.EntityAvailabilityStatus
     """
     def __init__(self, name, **kwargs):
         # type: (str, Any) -> None
@@ -669,7 +720,7 @@ class SubscriptionRuntimeProperties(object):
         return self._internal_sd.message_count_details.transfer_message_count
 
 
-class RuleProperties(object):
+class RuleProperties(DictMixin):
     """Properties of a topic subscription rule.
 
     :param name: Name of the rule.

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
@@ -27,7 +27,7 @@ from ._constants import RULE_SQL_COMPATIBILITY_LEVEL
 adjust_attribute_map()
 
 
-def extract_kwarg_template(self, kwargs, extraction_missing_args, name):
+def extract_kwarg_template(kwargs, extraction_missing_args, name):
     try:
         return kwargs[name]
     except KeyError:
@@ -170,7 +170,7 @@ class QueueProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
         self._internal_qd = None  # type: Optional[InternalQueueDescription]
 
         extraction_missing_args = []  # type: List[str]
-        extract_kwarg = functools.partial(extract_kwarg_template, self, kwargs, extraction_missing_args)
+        extract_kwarg = functools.partial(extract_kwarg_template, kwargs, extraction_missing_args)
 
         self.authorization_rules = extract_kwarg('authorization_rules')
         self.auto_delete_on_idle = extract_kwarg('auto_delete_on_idle')
@@ -425,7 +425,7 @@ class TopicProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
         self._internal_td = None  # type: Optional[InternalTopicDescription]
 
         extraction_missing_args = []  # type: List[str]
-        extract_kwarg = functools.partial(extract_kwarg_template, self, kwargs, extraction_missing_args)
+        extract_kwarg = functools.partial(extract_kwarg_template, kwargs, extraction_missing_args)
 
         self.default_message_time_to_live = extract_kwarg('default_message_time_to_live')
         self.max_size_in_megabytes = extract_kwarg('max_size_in_megabytes')
@@ -623,7 +623,7 @@ class SubscriptionProperties(DictMixin):  # pylint:disable=too-many-instance-att
         self._internal_sd = None  # type: Optional[InternalSubscriptionDescription]
 
         extraction_missing_args = []  # type: List[str]
-        extract_kwarg = functools.partial(extract_kwarg_template, self, kwargs, extraction_missing_args)
+        extract_kwarg = functools.partial(extract_kwarg_template, kwargs, extraction_missing_args)
 
         self.lock_duration = extract_kwarg('lock_duration')
         self.requires_session = extract_kwarg('requires_session')
@@ -798,7 +798,7 @@ class RuleProperties(DictMixin):
         self._internal_rule = None  # type: Optional[InternalRuleDescription]
 
         extraction_missing_args = []  # type: List[str]
-        extract_kwarg = functools.partial(extract_kwarg_template, self, kwargs, extraction_missing_args)
+        extract_kwarg = functools.partial(extract_kwarg_template, kwargs, extraction_missing_args)
 
         self.filter = extract_kwarg('filter')
         self.action = extract_kwarg('action')

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 # pylint:disable=protected-access
+# pylint:disable=too-many-lines
 import functools
 from collections import OrderedDict
 from copy import deepcopy

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
@@ -3,10 +3,11 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 # pylint:disable=protected-access
+import functools
 from collections import OrderedDict
 from copy import deepcopy
 from datetime import datetime, timedelta
-from typing import Type, Dict, Any, Union, Optional
+from typing import Type, Dict, Any, Union, Optional, List
 from msrest.serialization import Model
 
 from ._generated.models import QueueDescription as InternalQueueDescription, \
@@ -23,6 +24,23 @@ from ._model_workaround import adjust_attribute_map
 from ._constants import RULE_SQL_COMPATIBILITY_LEVEL
 
 adjust_attribute_map()
+
+
+def extract_kwarg_template(self, kwargs, extraction_missing_args, name):
+    if getattr(self, '_require_all_args', False):
+        try:
+            return kwargs[name]
+        except KeyError:
+            extraction_missing_args.append(name)
+    else:
+        return kwargs.get(name, None)
+
+
+def validate_extraction_missing_args(extraction_missing_args):
+    if extraction_missing_args:
+        raise TypeError('__init__() missing {} required keyword arguments: {}'.format(
+            len(extraction_missing_args),
+            ' and '.join(["'" + e + "'" for e in extraction_missing_args])))
 
 
 class DictMixin(object):
@@ -152,27 +170,33 @@ class QueueProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
         # type: (str, Any) -> None
         self.name = name
         self._internal_qd = None  # type: Optional[InternalQueueDescription]
+        self._require_all_args = True
 
-        self.authorization_rules = kwargs['authorization_rules']
-        self.auto_delete_on_idle = kwargs['auto_delete_on_idle']
-        self.dead_lettering_on_message_expiration = kwargs['dead_lettering_on_message_expiration']
-        self.default_message_time_to_live = kwargs['default_message_time_to_live']
-        self.duplicate_detection_history_time_window = kwargs['duplicate_detection_history_time_window']
-        self.entity_availability_status = kwargs['entity_availability_status']
-        self.enable_batched_operations = kwargs['enable_batched_operations']
-        self.enable_express = kwargs['enable_express']
-        self.enable_partitioning = kwargs['enable_partitioning']
-        self.is_anonymous_accessible = kwargs['is_anonymous_accessible']
-        self.lock_duration = kwargs['lock_duration']
-        self.max_delivery_count = kwargs['max_delivery_count']
-        self.max_size_in_megabytes = kwargs['max_size_in_megabytes']
-        self.requires_duplicate_detection = kwargs['requires_duplicate_detection']
-        self.requires_session = kwargs['requires_session']
-        self.status = kwargs['status']
-        self.support_ordering = kwargs['support_ordering']
-        self.forward_to = kwargs['forward_to']
-        self.user_metadata = kwargs['user_metadata']
-        self.forward_dead_lettered_messages_to = kwargs['forward_dead_lettered_messages_to']
+        extraction_missing_args = []  # type: List[str]
+        extract_kwarg = functools.partial(extract_kwarg_template, self, kwargs, extraction_missing_args)
+
+        self.authorization_rules = extract_kwarg('authorization_rules')
+        self.auto_delete_on_idle = extract_kwarg('auto_delete_on_idle')
+        self.dead_lettering_on_message_expiration = extract_kwarg('dead_lettering_on_message_expiration')
+        self.default_message_time_to_live = extract_kwarg('default_message_time_to_live')
+        self.duplicate_detection_history_time_window = extract_kwarg('duplicate_detection_history_time_window')
+        self.entity_availability_status = extract_kwarg('entity_availability_status')
+        self.enable_batched_operations = extract_kwarg('enable_batched_operations')
+        self.enable_express = extract_kwarg('enable_express')
+        self.enable_partitioning = extract_kwarg('enable_partitioning')
+        self.is_anonymous_accessible = extract_kwarg('is_anonymous_accessible')
+        self.lock_duration = extract_kwarg('lock_duration')
+        self.max_delivery_count = extract_kwarg('max_delivery_count')
+        self.max_size_in_megabytes = extract_kwarg('max_size_in_megabytes')
+        self.requires_duplicate_detection = extract_kwarg('requires_duplicate_detection')
+        self.requires_session = extract_kwarg('requires_session')
+        self.status = extract_kwarg('status')
+        self.support_ordering = extract_kwarg('support_ordering')
+        self.forward_to = extract_kwarg('forward_to')
+        self.user_metadata = extract_kwarg('user_metadata')
+        self.forward_dead_lettered_messages_to = extract_kwarg('forward_dead_lettered_messages_to')
+
+        validate_extraction_missing_args(extraction_missing_args)
 
 
     @classmethod
@@ -402,23 +426,29 @@ class TopicProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
         # type: (str, Any) -> None
         self.name = name
         self._internal_td = None  # type: Optional[InternalTopicDescription]
+        self._require_all_args = True
 
-        self.default_message_time_to_live = kwargs['default_message_time_to_live']
-        self.max_size_in_megabytes = kwargs['max_size_in_megabytes']
-        self.requires_duplicate_detection = kwargs['requires_duplicate_detection']
-        self.duplicate_detection_history_time_window = kwargs['duplicate_detection_history_time_window']
-        self.enable_batched_operations = kwargs['enable_batched_operations']
-        self.size_in_bytes = kwargs['size_in_bytes']
-        self.is_anonymous_accessible = kwargs['is_anonymous_accessible']
-        self.authorization_rules = kwargs['authorization_rules']
-        self.status = kwargs['status']
-        self.support_ordering = kwargs['support_ordering']
-        self.auto_delete_on_idle = kwargs['auto_delete_on_idle']
-        self.enable_partitioning = kwargs['enable_partitioning']
-        self.entity_availability_status = kwargs['entity_availability_status']
-        self.enable_subscription_partitioning = kwargs['enable_subscription_partitioning']
-        self.enable_express = kwargs['enable_express']
-        self.user_metadata = kwargs['user_metadata']
+        extraction_missing_args = []  # type: List[str]
+        extract_kwarg = functools.partial(extract_kwarg_template, self, kwargs, extraction_missing_args)
+
+        self.default_message_time_to_live = extract_kwarg('default_message_time_to_live')
+        self.max_size_in_megabytes = extract_kwarg('max_size_in_megabytes')
+        self.requires_duplicate_detection = extract_kwarg('requires_duplicate_detection')
+        self.duplicate_detection_history_time_window = extract_kwarg('duplicate_detection_history_time_window')
+        self.enable_batched_operations = extract_kwarg('enable_batched_operations')
+        self.size_in_bytes = extract_kwarg('size_in_bytes')
+        self.is_anonymous_accessible = extract_kwarg('is_anonymous_accessible')
+        self.authorization_rules = extract_kwarg('authorization_rules')
+        self.status = extract_kwarg('status')
+        self.support_ordering = extract_kwarg('support_ordering')
+        self.auto_delete_on_idle = extract_kwarg('auto_delete_on_idle')
+        self.enable_partitioning = extract_kwarg('enable_partitioning')
+        self.entity_availability_status = extract_kwarg('entity_availability_status')
+        self.enable_subscription_partitioning = extract_kwarg('enable_subscription_partitioning')
+        self.enable_express = extract_kwarg('enable_express')
+        self.user_metadata = extract_kwarg('user_metadata')
+
+        validate_extraction_missing_args(extraction_missing_args)
 
     @classmethod
     def _from_internal_entity(cls, name, internal_td):
@@ -595,21 +625,27 @@ class SubscriptionProperties(DictMixin):  # pylint:disable=too-many-instance-att
         # type: (str, Any) -> None
         self.name = name
         self._internal_sd = None  # type: Optional[InternalSubscriptionDescription]
+        self._require_all_args = True
 
-        self.lock_duration = kwargs['lock_duration']
-        self.requires_session = kwargs['requires_session']
-        self.default_message_time_to_live = kwargs['default_message_time_to_live']
-        self.dead_lettering_on_message_expiration = kwargs['dead_lettering_on_message_expiration']
-        self.dead_lettering_on_filter_evaluation_exceptions = kwargs[
-            'dead_lettering_on_filter_evaluation_exceptions']
-        self.max_delivery_count = kwargs['max_delivery_count']
-        self.enable_batched_operations = kwargs['enable_batched_operations']
-        self.status = kwargs['status']
-        self.forward_to = kwargs['forward_to']
-        self.user_metadata = kwargs['user_metadata']
-        self.forward_dead_lettered_messages_to = kwargs['forward_dead_lettered_messages_to']
-        self.auto_delete_on_idle = kwargs['auto_delete_on_idle']
-        self.entity_availability_status = kwargs['entity_availability_status']
+        extraction_missing_args = []  # type: List[str]
+        extract_kwarg = functools.partial(extract_kwarg_template, self, kwargs, extraction_missing_args)
+
+        self.lock_duration = extract_kwarg('lock_duration')
+        self.requires_session = extract_kwarg('requires_session')
+        self.default_message_time_to_live = extract_kwarg('default_message_time_to_live')
+        self.dead_lettering_on_message_expiration = extract_kwarg('dead_lettering_on_message_expiration')
+        self.dead_lettering_on_filter_evaluation_exceptions = extract_kwarg(
+            'dead_lettering_on_filter_evaluation_exceptions')
+        self.max_delivery_count = extract_kwarg('max_delivery_count')
+        self.enable_batched_operations = extract_kwarg('enable_batched_operations')
+        self.status = extract_kwarg('status')
+        self.forward_to = extract_kwarg('forward_to')
+        self.user_metadata = extract_kwarg('user_metadata')
+        self.forward_dead_lettered_messages_to = extract_kwarg('forward_dead_lettered_messages_to')
+        self.auto_delete_on_idle = extract_kwarg('auto_delete_on_idle')
+        self.entity_availability_status = extract_kwarg('entity_availability_status')
+
+        validate_extraction_missing_args(extraction_missing_args)
 
     @classmethod
     def _from_internal_entity(cls, name, internal_subscription):
@@ -762,12 +798,19 @@ class RuleProperties(DictMixin):
 
     def __init__(self, name, **kwargs):
         # type: (str, Any) -> None
-        self.filter = kwargs['filter']
-        self.action = kwargs['action']
-        self.created_at = kwargs['created_at']
-        self.name = name
 
+        self.name = name
         self._internal_rule = None  # type: Optional[InternalRuleDescription]
+        self._require_all_args = True
+
+        extraction_missing_args = []  # type: List[str]
+        extract_kwarg = functools.partial(extract_kwarg_template, self, kwargs, extraction_missing_args)
+
+        self.filter = extract_kwarg('filter')
+        self.action = extract_kwarg('action')
+        self.created_at = extract_kwarg('created_at')
+
+        validate_extraction_missing_args(extraction_missing_args)
 
     @classmethod
     def _from_internal_entity(cls, name, internal_rule):

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
@@ -599,7 +599,7 @@ class SubscriptionRuntimeProperties(object):
     """Runtime properties of a Service Bus topic subscription resource.
 
     :ivar str name:
-    :ivar created_at: The exact time the queue was created.
+    :ivar created_at: The exact time the subscription was created.
     :type created_at: ~datetime.datetime
     :ivar updated_at: The exact time a message was updated in the queue.
     :type updated_at: ~datetime.datetime
@@ -608,12 +608,10 @@ class SubscriptionRuntimeProperties(object):
     :type accessed_at: ~datetime.datetime
     :ivar total_message_count: The number of messages in the subscription.
     :type total_message_count: int
-    :ivar active_message_count: Number of active messages in the queue, topic, or subscription.
+    :ivar active_message_count: Number of active messages in the subscription.
     :type active_message_count: int
     :ivar dead_letter_message_count: Number of messages that are dead lettered.
     :type dead_letter_message_count: int
-    :ivar scheduled_message_count: Number of scheduled messages.
-    :type scheduled_message_count: int
     :ivar transfer_dead_letter_message_count: Number of messages transferred into dead letters.
     :type transfer_dead_letter_message_count: int
     :ivar transfer_message_count: Number of messages transferred to another queue, topic, or
@@ -661,10 +659,6 @@ class SubscriptionRuntimeProperties(object):
     @property
     def dead_letter_message_count(self):
         return self._internal_sd.message_count_details.dead_letter_message_count
-
-    @property
-    def scheduled_message_count(self):
-        return self._internal_sd.message_count_details.scheduled_message_count
 
     @property
     def transfer_dead_letter_message_count(self):

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_queues_async.py
@@ -214,13 +214,8 @@ class ServiceBusManagementClientQueueAsyncTests(AzureMgmtTestCase):
             await mgmt_service.create_queue(Exception())
 
         with pytest.raises(msrest.exceptions.ValidationError):
-            await mgmt_service.create_queue(**QueueProperties(name=Exception()))
-
-        with pytest.raises(msrest.exceptions.ValidationError):
             await mgmt_service.create_queue('')
 
-        with pytest.raises(msrest.exceptions.ValidationError):
-            await mgmt_service.create_queue(**QueueProperties(name=''))
 
     @CachedResourceGroupPreparer(name_prefix='servicebustest')
     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
@@ -228,7 +223,7 @@ class ServiceBusManagementClientQueueAsyncTests(AzureMgmtTestCase):
         mgmt_service = ServiceBusManagementClient.from_connection_string(servicebus_namespace_connection_string)
         await clear_queues(mgmt_service)
         queue_name = "dkldf"
-        await mgmt_service.create_queue(**QueueProperties(name=queue_name,
+        await mgmt_service.create_queue(queue_name,
                                                     auto_delete_on_idle=datetime.timedelta(minutes=10),
                                                     dead_lettering_on_message_expiration=True, 
                                                     default_message_time_to_live=datetime.timedelta(minutes=11),
@@ -243,7 +238,7 @@ class ServiceBusManagementClientQueueAsyncTests(AzureMgmtTestCase):
                                                     #requires_duplicate_detection=True, 
                                                     requires_session=True,
                                                     support_ordering=True
-                                                    ))
+                                                    )
         try:
             queue = await mgmt_service.get_queue(queue_name)
             assert queue.name == queue_name

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_queues_async.py
@@ -9,7 +9,7 @@ import datetime
 import msrest
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError, ResourceExistsError
 from azure.servicebus.aio.management import ServiceBusManagementClient
-from azure.servicebus.management import QueueDescription
+from azure.servicebus.management import QueueProperties
 from azure.servicebus.aio import ServiceBusSharedKeyCredential
 from azure.servicebus._common.utils import utc_now
 
@@ -214,13 +214,13 @@ class ServiceBusManagementClientQueueAsyncTests(AzureMgmtTestCase):
             await mgmt_service.create_queue(Exception())
 
         with pytest.raises(msrest.exceptions.ValidationError):
-            await mgmt_service.create_queue(QueueDescription(name=Exception()))
+            await mgmt_service.create_queue(QueueProperties(name=Exception()))
 
         with pytest.raises(msrest.exceptions.ValidationError):
             await mgmt_service.create_queue('')
 
         with pytest.raises(msrest.exceptions.ValidationError):
-            await mgmt_service.create_queue(QueueDescription(name=''))
+            await mgmt_service.create_queue(QueueProperties(name=''))
 
     @CachedResourceGroupPreparer(name_prefix='servicebustest')
     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
@@ -228,7 +228,7 @@ class ServiceBusManagementClientQueueAsyncTests(AzureMgmtTestCase):
         mgmt_service = ServiceBusManagementClient.from_connection_string(servicebus_namespace_connection_string)
         await clear_queues(mgmt_service)
         queue_name = "dkldf"
-        await mgmt_service.create_queue(QueueDescription(name=queue_name,
+        await mgmt_service.create_queue(QueueProperties(name=queue_name,
                                                     auto_delete_on_idle=datetime.timedelta(minutes=10),
                                                     dead_lettering_on_message_expiration=True, 
                                                     default_message_time_to_live=datetime.timedelta(minutes=11),
@@ -392,16 +392,15 @@ class ServiceBusManagementClientQueueAsyncTests(AzureMgmtTestCase):
         info = queues_infos[0]
 
         assert info.size_in_bytes == 0
+        assert info.created_at is not None
         assert info.accessed_at is not None
         assert info.updated_at is not None
-        assert info.message_count == 0
-
-        assert info.message_count_details
-        assert info.message_count_details.active_message_count == 0
-        assert info.message_count_details.dead_letter_message_count == 0
-        assert info.message_count_details.transfer_dead_letter_message_count == 0
-        assert info.message_count_details.transfer_message_count == 0
-        assert info.message_count_details.scheduled_message_count == 0
+        assert info.total_message_count == 0
+        assert info.active_message_count == 0
+        assert info.dead_letter_message_count == 0
+        assert info.transfer_dead_letter_message_count == 0
+        assert info.transfer_message_count == 0
+        assert info.scheduled_message_count == 0
 
         await mgmt_service.delete_queue("test_queue")
         queues_infos = await async_pageable_to_list(mgmt_service.list_queues_runtime_info())
@@ -435,14 +434,12 @@ class ServiceBusManagementClientQueueAsyncTests(AzureMgmtTestCase):
         assert queue_runtime_info.created_at is not None
         assert queue_runtime_info.accessed_at is not None
         assert queue_runtime_info.updated_at is not None
-        assert queue_runtime_info.message_count == 0
-
-        assert queue_runtime_info.message_count_details
-        assert queue_runtime_info.message_count_details.active_message_count == 0
-        assert queue_runtime_info.message_count_details.dead_letter_message_count == 0
-        assert queue_runtime_info.message_count_details.transfer_dead_letter_message_count == 0
-        assert queue_runtime_info.message_count_details.transfer_message_count == 0
-        assert queue_runtime_info.message_count_details.scheduled_message_count == 0
+        assert queue_runtime_info.total_message_count == 0
+        assert queue_runtime_info.active_message_count == 0
+        assert queue_runtime_info.dead_letter_message_count == 0
+        assert queue_runtime_info.transfer_dead_letter_message_count == 0
+        assert queue_runtime_info.transfer_message_count == 0
+        assert queue_runtime_info.scheduled_message_count == 0
         await mgmt_service.delete_queue("test_queue")
 
     @CachedResourceGroupPreparer(name_prefix='servicebustest')

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_queues_async.py
@@ -214,13 +214,13 @@ class ServiceBusManagementClientQueueAsyncTests(AzureMgmtTestCase):
             await mgmt_service.create_queue(Exception())
 
         with pytest.raises(msrest.exceptions.ValidationError):
-            await mgmt_service.create_queue(QueueProperties(name=Exception()))
+            await mgmt_service.create_queue(**QueueProperties(name=Exception()))
 
         with pytest.raises(msrest.exceptions.ValidationError):
             await mgmt_service.create_queue('')
 
         with pytest.raises(msrest.exceptions.ValidationError):
-            await mgmt_service.create_queue(QueueProperties(name=''))
+            await mgmt_service.create_queue(**QueueProperties(name=''))
 
     @CachedResourceGroupPreparer(name_prefix='servicebustest')
     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
@@ -228,7 +228,7 @@ class ServiceBusManagementClientQueueAsyncTests(AzureMgmtTestCase):
         mgmt_service = ServiceBusManagementClient.from_connection_string(servicebus_namespace_connection_string)
         await clear_queues(mgmt_service)
         queue_name = "dkldf"
-        await mgmt_service.create_queue(QueueProperties(name=queue_name,
+        await mgmt_service.create_queue(**QueueProperties(name=queue_name,
                                                     auto_delete_on_idle=datetime.timedelta(minutes=10),
                                                     dead_lettering_on_message_expiration=True, 
                                                     default_message_time_to_live=datetime.timedelta(minutes=11),

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_rules_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_rules_async.py
@@ -48,21 +48,18 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
         sql_rule_action = SqlRuleAction(sql_expression="SET Priority = @param", parameters={
             "@param": datetime(2020, 7, 5, 11, 12, 13),
         })
-        rule_1 = RuleProperties(name=rule_name_1, filter=correlation_fitler, action=sql_rule_action)
 
         sql_filter = SqlRuleFilter("Priority = @param1", parameters={
             "@param1": "str1",
         })
-        rule_2 = RuleProperties(name=rule_name_2, filter=sql_filter)
 
         bool_filter = TrueRuleFilter()
-        rule_3 = RuleProperties(name=rule_name_3, filter=bool_filter)
 
         try:
             await mgmt_service.create_topic(topic_name)
             await mgmt_service.create_subscription(topic_name, subscription_name)
 
-            await mgmt_service.create_rule(topic_name, subscription_name, **rule_1)
+            await mgmt_service.create_rule(topic_name, subscription_name, rule_name_1, filter=correlation_fitler, action=sql_rule_action)
             rule_desc = await mgmt_service.get_rule(topic_name, subscription_name, rule_name_1)
             rule_properties = rule_desc.filter.properties
             assert type(rule_desc.filter) == CorrelationRuleFilter
@@ -76,13 +73,13 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
             assert rule_properties["key_datetime"] == datetime(2020, 7, 5, 11, 12, 13)
             assert rule_properties["key_duration"] == timedelta(days=1, hours=2, minutes=3)
 
-            await mgmt_service.create_rule(topic_name, subscription_name, **rule_2)
+            await mgmt_service.create_rule(topic_name, subscription_name, rule_name_2, filter=sql_filter)
             rule_desc = await mgmt_service.get_rule(topic_name, subscription_name, rule_name_2)
             assert type(rule_desc.filter) == SqlRuleFilter
             assert rule_desc.filter.sql_expression == "Priority = @param1"
             assert rule_desc.filter.parameters["@param1"] == "str1"
 
-            await mgmt_service.create_rule(topic_name, subscription_name, **rule_3)
+            await mgmt_service.create_rule(topic_name, subscription_name, rule_name_3, filter=bool_filter)
             rule_desc = await mgmt_service.get_rule(topic_name, subscription_name, rule_name_3)
             assert type(rule_desc.filter) == TrueRuleFilter
 
@@ -102,13 +99,12 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
         subscription_name = 'kkaqo'
         rule_name = 'rule'
         sql_filter = SqlRuleFilter("Priority = 'low'")
-        rule = RuleProperties(name=rule_name, filter=sql_filter)
         try:
             await mgmt_service.create_topic(topic_name)
             await mgmt_service.create_subscription(topic_name, subscription_name)
-            await mgmt_service.create_rule(topic_name, subscription_name, **rule)
+            await mgmt_service.create_rule(topic_name, subscription_name, rule_name, filter=sql_filter)
             with pytest.raises(ResourceExistsError):
-                await mgmt_service.create_rule(topic_name, subscription_name, **rule)
+                await mgmt_service.create_rule(topic_name, subscription_name, rule_name, filter=sql_filter)
         finally:
             await mgmt_service.delete_rule(topic_name, subscription_name, rule_name)
             await mgmt_service.delete_subscription(topic_name, subscription_name)
@@ -123,12 +119,11 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
         subscription_name = "eqkovc"
         rule_name = 'rule'
         sql_filter = SqlRuleFilter("Priority = 'low'")
-        rule = RuleProperties(name=rule_name, filter=sql_filter)
 
         try:
             topic_description = await mgmt_service.create_topic(topic_name)
             subscription_description = await mgmt_service.create_subscription(topic_description, subscription_name)
-            await mgmt_service.create_rule(topic_name, subscription_name, **rule)
+            await mgmt_service.create_rule(topic_name, subscription_name, rule_name, filter=sql_filter)
 
             rule_desc = await mgmt_service.get_rule(topic_name, subscription_name, rule_name)
 
@@ -161,12 +156,11 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
         subscription_name = "eqkovc"
         rule_name = 'rule'
         sql_filter = SqlRuleFilter("Priority = 'low'")
-        rule = RuleProperties(name=rule_name, filter=sql_filter)
 
         try:
             topic_description = await mgmt_service.create_topic(topic_name)
             subscription_description = await mgmt_service.create_subscription(topic_name, subscription_name)
-            await mgmt_service.create_rule(topic_name, subscription_name, **rule)
+            await mgmt_service.create_rule(topic_name, subscription_name, rule_name, filter=sql_filter)
 
             rule_desc = await mgmt_service.get_rule(topic_name, subscription_name, rule_name)
 
@@ -209,9 +203,6 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
         sql_filter_1 = SqlRuleFilter("Priority = 'low'")
         sql_filter_2 = SqlRuleFilter("Priority = 'middle'")
         sql_filter_3 = SqlRuleFilter("Priority = 'high'")
-        rule_1 = RuleProperties(name=rule_name_1, filter=sql_filter_1)
-        rule_2 = RuleProperties(name=rule_name_2, filter=sql_filter_2)
-        rule_3 = RuleProperties(name=rule_name_3, filter=sql_filter_3)
 
         try:
             await mgmt_service.create_topic(topic_name)
@@ -220,9 +211,9 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
             rules = await async_pageable_to_list(mgmt_service.list_rules(topic_name, subscription_name))
             assert len(rules) == 1  # by default there is a True filter
 
-            await mgmt_service.create_rule(topic_name, subscription_name, **rule_1)
-            await mgmt_service.create_rule(topic_name, subscription_name, **rule_2)
-            await mgmt_service.create_rule(topic_name, subscription_name, **rule_3)
+            await mgmt_service.create_rule(topic_name, subscription_name, rule_name_1, filter=sql_filter_1)
+            await mgmt_service.create_rule(topic_name, subscription_name, rule_name_2, filter=sql_filter_2)
+            await mgmt_service.create_rule(topic_name, subscription_name, rule_name_3, filter=sql_filter_3)
 
             rules = await async_pageable_to_list(mgmt_service.list_rules(topic_name, subscription_name))
             assert len(rules) == 3 + 1

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_rules_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_rules_async.py
@@ -10,7 +10,7 @@ import pytest
 
 import msrest
 from azure.servicebus.aio.management import ServiceBusManagementClient
-from azure.servicebus.management import RuleDescription, CorrelationRuleFilter, SqlRuleFilter, TrueRuleFilter, SqlRuleAction
+from azure.servicebus.management import RuleProperties, CorrelationRuleFilter, SqlRuleFilter, TrueRuleFilter, SqlRuleAction
 from azure.servicebus.management._constants import INT32_MAX_VALUE
 from utilities import get_logger
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
@@ -48,15 +48,15 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
         sql_rule_action = SqlRuleAction(sql_expression="SET Priority = @param", parameters={
             "@param": datetime(2020, 7, 5, 11, 12, 13),
         })
-        rule_1 = RuleDescription(name=rule_name_1, filter=correlation_fitler, action=sql_rule_action)
+        rule_1 = RuleProperties(name=rule_name_1, filter=correlation_fitler, action=sql_rule_action)
 
         sql_filter = SqlRuleFilter("Priority = @param1", parameters={
             "@param1": "str1",
         })
-        rule_2 = RuleDescription(name=rule_name_2, filter=sql_filter)
+        rule_2 = RuleProperties(name=rule_name_2, filter=sql_filter)
 
         bool_filter = TrueRuleFilter()
-        rule_3 = RuleDescription(name=rule_name_3, filter=bool_filter)
+        rule_3 = RuleProperties(name=rule_name_3, filter=bool_filter)
 
         try:
             await mgmt_service.create_topic(topic_name)
@@ -102,7 +102,7 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
         subscription_name = 'kkaqo'
         rule_name = 'rule'
         sql_filter = SqlRuleFilter("Priority = 'low'")
-        rule = RuleDescription(name=rule_name, filter=sql_filter)
+        rule = RuleProperties(name=rule_name, filter=sql_filter)
         try:
             await mgmt_service.create_topic(topic_name)
             await mgmt_service.create_subscription(topic_name, subscription_name)
@@ -123,7 +123,7 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
         subscription_name = "eqkovc"
         rule_name = 'rule'
         sql_filter = SqlRuleFilter("Priority = 'low'")
-        rule = RuleDescription(name=rule_name, filter=sql_filter)
+        rule = RuleProperties(name=rule_name, filter=sql_filter)
 
         try:
             topic_description = await mgmt_service.create_topic(topic_name)
@@ -161,7 +161,7 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
         subscription_name = "eqkovc"
         rule_name = 'rule'
         sql_filter = SqlRuleFilter("Priority = 'low'")
-        rule = RuleDescription(name=rule_name, filter=sql_filter)
+        rule = RuleProperties(name=rule_name, filter=sql_filter)
 
         try:
             topic_description = await mgmt_service.create_topic(topic_name)
@@ -209,9 +209,9 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
         sql_filter_1 = SqlRuleFilter("Priority = 'low'")
         sql_filter_2 = SqlRuleFilter("Priority = 'middle'")
         sql_filter_3 = SqlRuleFilter("Priority = 'high'")
-        rule_1 = RuleDescription(name=rule_name_1, filter=sql_filter_1)
-        rule_2 = RuleDescription(name=rule_name_2, filter=sql_filter_2)
-        rule_3 = RuleDescription(name=rule_name_3, filter=sql_filter_3)
+        rule_1 = RuleProperties(name=rule_name_1, filter=sql_filter_1)
+        rule_2 = RuleProperties(name=rule_name_2, filter=sql_filter_2)
+        rule_3 = RuleProperties(name=rule_name_3, filter=sql_filter_3)
 
         try:
             await mgmt_service.create_topic(topic_name)

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_rules_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_rules_async.py
@@ -62,7 +62,7 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
             await mgmt_service.create_topic(topic_name)
             await mgmt_service.create_subscription(topic_name, subscription_name)
 
-            await mgmt_service.create_rule(topic_name, subscription_name, rule_1)
+            await mgmt_service.create_rule(topic_name, subscription_name, **rule_1)
             rule_desc = await mgmt_service.get_rule(topic_name, subscription_name, rule_name_1)
             rule_properties = rule_desc.filter.properties
             assert type(rule_desc.filter) == CorrelationRuleFilter
@@ -76,13 +76,13 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
             assert rule_properties["key_datetime"] == datetime(2020, 7, 5, 11, 12, 13)
             assert rule_properties["key_duration"] == timedelta(days=1, hours=2, minutes=3)
 
-            await mgmt_service.create_rule(topic_name, subscription_name, rule_2)
+            await mgmt_service.create_rule(topic_name, subscription_name, **rule_2)
             rule_desc = await mgmt_service.get_rule(topic_name, subscription_name, rule_name_2)
             assert type(rule_desc.filter) == SqlRuleFilter
             assert rule_desc.filter.sql_expression == "Priority = @param1"
             assert rule_desc.filter.parameters["@param1"] == "str1"
 
-            await mgmt_service.create_rule(topic_name, subscription_name, rule_3)
+            await mgmt_service.create_rule(topic_name, subscription_name, **rule_3)
             rule_desc = await mgmt_service.get_rule(topic_name, subscription_name, rule_name_3)
             assert type(rule_desc.filter) == TrueRuleFilter
 
@@ -106,9 +106,9 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
         try:
             await mgmt_service.create_topic(topic_name)
             await mgmt_service.create_subscription(topic_name, subscription_name)
-            await mgmt_service.create_rule(topic_name, subscription_name, rule)
+            await mgmt_service.create_rule(topic_name, subscription_name, **rule)
             with pytest.raises(ResourceExistsError):
-                await mgmt_service.create_rule(topic_name, subscription_name, rule)
+                await mgmt_service.create_rule(topic_name, subscription_name, **rule)
         finally:
             await mgmt_service.delete_rule(topic_name, subscription_name, rule_name)
             await mgmt_service.delete_subscription(topic_name, subscription_name)
@@ -128,7 +128,7 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
         try:
             topic_description = await mgmt_service.create_topic(topic_name)
             subscription_description = await mgmt_service.create_subscription(topic_description, subscription_name)
-            await mgmt_service.create_rule(topic_name, subscription_name, rule)
+            await mgmt_service.create_rule(topic_name, subscription_name, **rule)
 
             rule_desc = await mgmt_service.get_rule(topic_name, subscription_name, rule_name)
 
@@ -166,7 +166,7 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
         try:
             topic_description = await mgmt_service.create_topic(topic_name)
             subscription_description = await mgmt_service.create_subscription(topic_name, subscription_name)
-            await mgmt_service.create_rule(topic_name, subscription_name, rule)
+            await mgmt_service.create_rule(topic_name, subscription_name, **rule)
 
             rule_desc = await mgmt_service.get_rule(topic_name, subscription_name, rule_name)
 
@@ -220,9 +220,9 @@ class ServiceBusManagementClientRuleAsyncTests(AzureMgmtTestCase):
             rules = await async_pageable_to_list(mgmt_service.list_rules(topic_name, subscription_name))
             assert len(rules) == 1  # by default there is a True filter
 
-            await mgmt_service.create_rule(topic_name, subscription_name, rule_1)
-            await mgmt_service.create_rule(topic_name, subscription_name, rule_2)
-            await mgmt_service.create_rule(topic_name, subscription_name, rule_3)
+            await mgmt_service.create_rule(topic_name, subscription_name, **rule_1)
+            await mgmt_service.create_rule(topic_name, subscription_name, **rule_2)
+            await mgmt_service.create_rule(topic_name, subscription_name, **rule_3)
 
             rules = await async_pageable_to_list(mgmt_service.list_rules(topic_name, subscription_name))
             assert len(rules) == 3 + 1

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_subscriptions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_subscriptions_async.py
@@ -9,7 +9,7 @@ import datetime
 
 import msrest
 from azure.servicebus.aio.management import ServiceBusManagementClient
-from azure.servicebus.management import SubscriptionDescription
+from azure.servicebus.management import SubscriptionProperties
 from utilities import get_logger
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 
@@ -55,7 +55,7 @@ class ServiceBusManagementClientSubscriptionAsyncTests(AzureMgmtTestCase):
             await mgmt_service.create_topic(topic_name)
             await mgmt_service.create_subscription(
                 topic_name,
-                SubscriptionDescription(
+                SubscriptionProperties(
                     name=subscription_name,
                     auto_delete_on_idle=datetime.timedelta(minutes=10),
                     dead_lettering_on_message_expiration=True,
@@ -257,13 +257,12 @@ class ServiceBusManagementClientSubscriptionAsyncTests(AzureMgmtTestCase):
 
         assert info.accessed_at is not None
         assert info.updated_at is not None
-
-        assert info.message_count_details
-        assert info.message_count_details.active_message_count == 0
-        assert info.message_count_details.dead_letter_message_count == 0
-        assert info.message_count_details.transfer_dead_letter_message_count == 0
-        assert info.message_count_details.transfer_message_count == 0
-        assert info.message_count_details.scheduled_message_count == 0
+        assert info.created_at is not None
+        assert info.total_message_count == 0
+        assert info.active_message_count == 0
+        assert info.dead_letter_message_count == 0
+        assert info.transfer_dead_letter_message_count == 0
+        assert info.transfer_message_count == 0
 
         await mgmt_service.delete_subscription(topic_name, subscription_name)
         subs_infos = await async_pageable_to_list(mgmt_service.list_subscriptions_runtime_info(topic_name))
@@ -288,13 +287,11 @@ class ServiceBusManagementClientSubscriptionAsyncTests(AzureMgmtTestCase):
         assert sub_runtime_info.created_at is not None
         assert sub_runtime_info.accessed_at is not None
         assert sub_runtime_info.updated_at is not None
-
-        assert sub_runtime_info.message_count_details
-        assert sub_runtime_info.message_count_details.active_message_count == 0
-        assert sub_runtime_info.message_count_details.dead_letter_message_count == 0
-        assert sub_runtime_info.message_count_details.transfer_dead_letter_message_count == 0
-        assert sub_runtime_info.message_count_details.transfer_message_count == 0
-        assert sub_runtime_info.message_count_details.scheduled_message_count == 0
+        assert sub_runtime_info.total_message_count == 0
+        assert sub_runtime_info.active_message_count == 0
+        assert sub_runtime_info.dead_letter_message_count == 0
+        assert sub_runtime_info.transfer_dead_letter_message_count == 0
+        assert sub_runtime_info.transfer_message_count == 0
 
         await mgmt_service.delete_subscription(topic_name, subscription_name)
         await mgmt_service.delete_topic(topic_name)

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_subscriptions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_subscriptions_async.py
@@ -55,7 +55,7 @@ class ServiceBusManagementClientSubscriptionAsyncTests(AzureMgmtTestCase):
             await mgmt_service.create_topic(topic_name)
             await mgmt_service.create_subscription(
                 topic_name,
-                SubscriptionProperties(
+                **SubscriptionProperties(
                     name=subscription_name,
                     auto_delete_on_idle=datetime.timedelta(minutes=10),
                     dead_lettering_on_message_expiration=True,

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_subscriptions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_subscriptions_async.py
@@ -55,16 +55,14 @@ class ServiceBusManagementClientSubscriptionAsyncTests(AzureMgmtTestCase):
             await mgmt_service.create_topic(topic_name)
             await mgmt_service.create_subscription(
                 topic_name,
-                **SubscriptionProperties(
-                    name=subscription_name,
-                    auto_delete_on_idle=datetime.timedelta(minutes=10),
-                    dead_lettering_on_message_expiration=True,
-                    default_message_time_to_live=datetime.timedelta(minutes=11),
-                    enable_batched_operations=True,
-                    lock_duration=datetime.timedelta(seconds=13),
-                    max_delivery_count=14,
-                    requires_session=True
-                )
+                name=subscription_name,
+                auto_delete_on_idle=datetime.timedelta(minutes=10),
+                dead_lettering_on_message_expiration=True,
+                default_message_time_to_live=datetime.timedelta(minutes=11),
+                enable_batched_operations=True,
+                lock_duration=datetime.timedelta(seconds=13),
+                max_delivery_count=14,
+                requires_session=True
             )
             subscription = await mgmt_service.get_subscription(topic_name, subscription_name)
             assert subscription.name == subscription_name

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_topics_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_topics_async.py
@@ -238,11 +238,7 @@ class ServiceBusManagementClientTopicAsyncTests(AzureMgmtTestCase):
         assert info.accessed_at is not None
         assert info.updated_at is not None
         assert info.subscription_count is 0
-
-        assert info.active_message_count == 0
-        assert info.dead_letter_message_count == 0
-        assert info.transfer_dead_letter_message_count == 0
-        assert info.transfer_message_count == 0
+        assert info.size_in_bytes == 0
         assert info.scheduled_message_count == 0
 
         await mgmt_service.delete_topic("test_topic")
@@ -264,10 +260,7 @@ class ServiceBusManagementClientTopicAsyncTests(AzureMgmtTestCase):
             assert topic_runtime_info.accessed_at is not None
             assert topic_runtime_info.updated_at is not None
             assert topic_runtime_info.subscription_count is 0
-            assert topic_runtime_info.active_message_count == 0
-            assert topic_runtime_info.dead_letter_message_count == 0
-            assert topic_runtime_info.transfer_dead_letter_message_count == 0
-            assert topic_runtime_info.transfer_message_count == 0
+            assert topic_runtime_info.size_in_bytes == 0
             assert topic_runtime_info.scheduled_message_count == 0
         finally:
             await mgmt_service.delete_topic("test_topic")

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_topics_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_topics_async.py
@@ -49,18 +49,16 @@ class ServiceBusManagementClientTopicAsyncTests(AzureMgmtTestCase):
         topic_name = "iweidk"
         try:
             await mgmt_service.create_topic(
-                **TopicProperties(
-                    name=topic_name,
-                    auto_delete_on_idle=datetime.timedelta(minutes=10),
-                    default_message_time_to_live=datetime.timedelta(minutes=11),
-                    duplicate_detection_history_time_window=datetime.timedelta(minutes=12),
-                    enable_batched_operations=True,
-                    enable_express=True,
-                    enable_partitioning=True,
-                    enable_subscription_partitioning=True,
-                    is_anonymous_accessible=True,
-                    max_size_in_megabytes=3072
-                )
+                name=topic_name,
+                auto_delete_on_idle=datetime.timedelta(minutes=10),
+                default_message_time_to_live=datetime.timedelta(minutes=11),
+                duplicate_detection_history_time_window=datetime.timedelta(minutes=12),
+                enable_batched_operations=True,
+                enable_express=True,
+                enable_partitioning=True,
+                enable_subscription_partitioning=True,
+                is_anonymous_accessible=True,
+                max_size_in_megabytes=3072
             )
             topic = await mgmt_service.get_topic(topic_name)
             assert topic.name == topic_name

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_topics_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_topics_async.py
@@ -9,7 +9,7 @@ import datetime
 
 import msrest
 from azure.servicebus.aio.management import ServiceBusManagementClient
-from azure.servicebus.management import TopicDescription
+from azure.servicebus.management import TopicProperties
 from utilities import get_logger
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 
@@ -49,7 +49,7 @@ class ServiceBusManagementClientTopicAsyncTests(AzureMgmtTestCase):
         topic_name = "iweidk"
         try:
             await mgmt_service.create_topic(
-                TopicDescription(
+                TopicProperties(
                     name=topic_name,
                     auto_delete_on_idle=datetime.timedelta(minutes=10),
                     default_message_time_to_live=datetime.timedelta(minutes=11),
@@ -239,12 +239,11 @@ class ServiceBusManagementClientTopicAsyncTests(AzureMgmtTestCase):
         assert info.updated_at is not None
         assert info.subscription_count is 0
 
-        assert info.message_count_details
-        assert info.message_count_details.active_message_count == 0
-        assert info.message_count_details.dead_letter_message_count == 0
-        assert info.message_count_details.transfer_dead_letter_message_count == 0
-        assert info.message_count_details.transfer_message_count == 0
-        assert info.message_count_details.scheduled_message_count == 0
+        assert info.active_message_count == 0
+        assert info.dead_letter_message_count == 0
+        assert info.transfer_dead_letter_message_count == 0
+        assert info.transfer_message_count == 0
+        assert info.scheduled_message_count == 0
 
         await mgmt_service.delete_topic("test_topic")
         topics_infos = await async_pageable_to_list(mgmt_service.list_topics_runtime_info())
@@ -265,12 +264,10 @@ class ServiceBusManagementClientTopicAsyncTests(AzureMgmtTestCase):
             assert topic_runtime_info.accessed_at is not None
             assert topic_runtime_info.updated_at is not None
             assert topic_runtime_info.subscription_count is 0
-
-            assert topic_runtime_info.message_count_details
-            assert topic_runtime_info.message_count_details.active_message_count == 0
-            assert topic_runtime_info.message_count_details.dead_letter_message_count == 0
-            assert topic_runtime_info.message_count_details.transfer_dead_letter_message_count == 0
-            assert topic_runtime_info.message_count_details.transfer_message_count == 0
-            assert topic_runtime_info.message_count_details.scheduled_message_count == 0
+            assert topic_runtime_info.active_message_count == 0
+            assert topic_runtime_info.dead_letter_message_count == 0
+            assert topic_runtime_info.transfer_dead_letter_message_count == 0
+            assert topic_runtime_info.transfer_message_count == 0
+            assert topic_runtime_info.scheduled_message_count == 0
         finally:
             await mgmt_service.delete_topic("test_topic")

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_topics_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_topics_async.py
@@ -49,7 +49,7 @@ class ServiceBusManagementClientTopicAsyncTests(AzureMgmtTestCase):
         topic_name = "iweidk"
         try:
             await mgmt_service.create_topic(
-                TopicProperties(
+                **TopicProperties(
                     name=topic_name,
                     auto_delete_on_idle=datetime.timedelta(minutes=10),
                     default_message_time_to_live=datetime.timedelta(minutes=11),

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_queues.py
@@ -11,7 +11,7 @@ import datetime
 import functools
 
 import msrest
-from azure.servicebus.management import ServiceBusManagementClient, QueueDescription
+from azure.servicebus.management import ServiceBusManagementClient, QueueProperties
 from azure.servicebus._common.utils import utc_now
 from utilities import get_logger
 from azure.core.exceptions import HttpResponseError, ServiceRequestError, ResourceNotFoundError, ResourceExistsError
@@ -222,13 +222,13 @@ class ServiceBusManagementClientQueueTests(AzureMgmtTestCase):
             mgmt_service.create_queue(Exception())
 
         with pytest.raises(msrest.exceptions.ValidationError):
-            mgmt_service.create_queue(QueueDescription(name=Exception()))
+            mgmt_service.create_queue(QueueProperties(name=Exception()))
 
         with pytest.raises(msrest.exceptions.ValidationError):
             mgmt_service.create_queue('')
 
         with pytest.raises(msrest.exceptions.ValidationError):
-            mgmt_service.create_queue(QueueDescription(name=''))
+            mgmt_service.create_queue(QueueProperties(name=''))
 
     @pytest.mark.liveTest
     @CachedResourceGroupPreparer(name_prefix='servicebustest')
@@ -238,9 +238,9 @@ class ServiceBusManagementClientQueueTests(AzureMgmtTestCase):
         clear_queues(mgmt_service)
         queue_name = "iweidk"
 
-        #TODO: Why don't we have an input model (queueOptions? as superclass of QueueDescription?) and output model to not show these params?
+        #TODO: Why don't we have an input model (queueOptions? as superclass of QueueProperties?) and output model to not show these params?
         #TODO: This fails with the following: E           msrest.exceptions.DeserializationError: Find several XML 'prefix:DeadLetteringOnMessageExpiration' where it was not expected .tox\whl\lib\site-packages\msrest\serialization.py:1262: DeserializationError
-        mgmt_service.create_queue(QueueDescription(name=queue_name,
+        mgmt_service.create_queue(QueueProperties(name=queue_name,
                                                     auto_delete_on_idle=datetime.timedelta(minutes=10),
                                                     dead_lettering_on_message_expiration=True,
                                                     default_message_time_to_live=datetime.timedelta(minutes=11),
@@ -409,14 +409,13 @@ class ServiceBusManagementClientQueueTests(AzureMgmtTestCase):
         assert info.size_in_bytes == 0
         assert info.accessed_at is not None
         assert info.updated_at is not None
-        assert info.message_count == 0
+        assert info.total_message_count == 0
 
-        assert info.message_count_details
-        assert info.message_count_details.active_message_count == 0
-        assert info.message_count_details.dead_letter_message_count == 0
-        assert info.message_count_details.transfer_dead_letter_message_count == 0
-        assert info.message_count_details.transfer_message_count == 0
-        assert info.message_count_details.scheduled_message_count == 0
+        assert info.active_message_count == 0
+        assert info.dead_letter_message_count == 0
+        assert info.transfer_dead_letter_message_count == 0
+        assert info.transfer_message_count == 0
+        assert info.scheduled_message_count == 0
 
         mgmt_service.delete_queue("test_queue")
         queues_infos = list(mgmt_service.list_queues_runtime_info())
@@ -451,14 +450,13 @@ class ServiceBusManagementClientQueueTests(AzureMgmtTestCase):
             assert queue_runtime_info.created_at is not None
             assert queue_runtime_info.accessed_at is not None
             assert queue_runtime_info.updated_at is not None
-            assert queue_runtime_info.message_count == 0
+            assert queue_runtime_info.total_message_count == 0
 
-            assert queue_runtime_info.message_count_details
-            assert queue_runtime_info.message_count_details.active_message_count == 0
-            assert queue_runtime_info.message_count_details.dead_letter_message_count == 0
-            assert queue_runtime_info.message_count_details.transfer_dead_letter_message_count == 0
-            assert queue_runtime_info.message_count_details.transfer_message_count == 0
-            assert queue_runtime_info.message_count_details.scheduled_message_count == 0
+            assert queue_runtime_info.active_message_count == 0
+            assert queue_runtime_info.dead_letter_message_count == 0
+            assert queue_runtime_info.transfer_dead_letter_message_count == 0
+            assert queue_runtime_info.transfer_message_count == 0
+            assert queue_runtime_info.scheduled_message_count == 0
         finally:
             mgmt_service.delete_queue("test_queue")
 

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_queues.py
@@ -222,13 +222,13 @@ class ServiceBusManagementClientQueueTests(AzureMgmtTestCase):
             mgmt_service.create_queue(Exception())
 
         with pytest.raises(msrest.exceptions.ValidationError):
-            mgmt_service.create_queue(QueueProperties(name=Exception()))
+            mgmt_service.create_queue(**QueueProperties(name=Exception()))
 
         with pytest.raises(msrest.exceptions.ValidationError):
             mgmt_service.create_queue('')
 
         with pytest.raises(msrest.exceptions.ValidationError):
-            mgmt_service.create_queue(QueueProperties(name=''))
+            mgmt_service.create_queue(**QueueProperties(name=''))
 
     @pytest.mark.liveTest
     @CachedResourceGroupPreparer(name_prefix='servicebustest')
@@ -240,7 +240,7 @@ class ServiceBusManagementClientQueueTests(AzureMgmtTestCase):
 
         #TODO: Why don't we have an input model (queueOptions? as superclass of QueueProperties?) and output model to not show these params?
         #TODO: This fails with the following: E           msrest.exceptions.DeserializationError: Find several XML 'prefix:DeadLetteringOnMessageExpiration' where it was not expected .tox\whl\lib\site-packages\msrest\serialization.py:1262: DeserializationError
-        mgmt_service.create_queue(QueueProperties(name=queue_name,
+        mgmt_service.create_queue(**QueueProperties(name=queue_name,
                                                     auto_delete_on_idle=datetime.timedelta(minutes=10),
                                                     dead_lettering_on_message_expiration=True,
                                                     default_message_time_to_live=datetime.timedelta(minutes=11),

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_queues.py
@@ -470,3 +470,6 @@ class ServiceBusManagementClientQueueTests(AzureMgmtTestCase):
         with pytest.raises(ResourceNotFoundError):
             mgmt_service.get_queue_runtime_info("non_existing_queue")
 
+    def test_queue_properties_constructor(self):
+        with pytest.raises(TypeError):
+            QueueProperties("randomname")

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_queues.py
@@ -221,14 +221,10 @@ class ServiceBusManagementClientQueueTests(AzureMgmtTestCase):
         with pytest.raises(msrest.exceptions.ValidationError):
             mgmt_service.create_queue(Exception())
 
-        with pytest.raises(msrest.exceptions.ValidationError):
-            mgmt_service.create_queue(**QueueProperties(name=Exception()))
 
         with pytest.raises(msrest.exceptions.ValidationError):
             mgmt_service.create_queue('')
 
-        with pytest.raises(msrest.exceptions.ValidationError):
-            mgmt_service.create_queue(**QueueProperties(name=''))
 
     @pytest.mark.liveTest
     @CachedResourceGroupPreparer(name_prefix='servicebustest')
@@ -240,22 +236,23 @@ class ServiceBusManagementClientQueueTests(AzureMgmtTestCase):
 
         #TODO: Why don't we have an input model (queueOptions? as superclass of QueueProperties?) and output model to not show these params?
         #TODO: This fails with the following: E           msrest.exceptions.DeserializationError: Find several XML 'prefix:DeadLetteringOnMessageExpiration' where it was not expected .tox\whl\lib\site-packages\msrest\serialization.py:1262: DeserializationError
-        mgmt_service.create_queue(**QueueProperties(name=queue_name,
-                                                    auto_delete_on_idle=datetime.timedelta(minutes=10),
-                                                    dead_lettering_on_message_expiration=True,
-                                                    default_message_time_to_live=datetime.timedelta(minutes=11),
-                                                    duplicate_detection_history_time_window=datetime.timedelta(minutes=12),
-                                                    enable_batched_operations=True,
-                                                    enable_express=True,
-                                                    enable_partitioning=True,
-                                                    is_anonymous_accessible=True,
-                                                    lock_duration=datetime.timedelta(seconds=13),
-                                                    max_delivery_count=14,
-                                                    max_size_in_megabytes=3072,
-                                                    #requires_duplicate_detection=True,
-                                                    requires_session=True,
-                                                    support_ordering=True
-                                                    ))
+        mgmt_service.create_queue(
+            queue_name,
+            auto_delete_on_idle=datetime.timedelta(minutes=10),
+            dead_lettering_on_message_expiration=True,
+            default_message_time_to_live=datetime.timedelta(minutes=11),
+            duplicate_detection_history_time_window=datetime.timedelta(minutes=12),
+            enable_batched_operations=True,
+            enable_express=True,
+            enable_partitioning=True,
+            is_anonymous_accessible=True,
+            lock_duration=datetime.timedelta(seconds=13),
+            max_delivery_count=14,
+            max_size_in_megabytes=3072,
+            #requires_duplicate_detection=True,
+            requires_session=True,
+            support_ordering=True
+        )
         try:
             queue = mgmt_service.get_queue(queue_name)
             assert queue.name == queue_name

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_rules.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_rules.py
@@ -60,7 +60,7 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
             mgmt_service.create_topic(topic_name)
             mgmt_service.create_subscription(topic_name, subscription_name)
 
-            mgmt_service.create_rule(topic_name, subscription_name, rule_1)
+            mgmt_service.create_rule(topic_name, subscription_name, **rule_1)
             rule_desc = mgmt_service.get_rule(topic_name, subscription_name, rule_name_1)
             rule_properties = rule_desc.filter.properties
             assert type(rule_desc.filter) == CorrelationRuleFilter
@@ -75,13 +75,13 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
             assert rule_properties["key_duration"] == timedelta(days=1, hours=2, minutes=3)
 
 
-            mgmt_service.create_rule(topic_name, subscription_name, rule_2)
+            mgmt_service.create_rule(topic_name, subscription_name, **rule_2)
             rule_desc = mgmt_service.get_rule(topic_name, subscription_name, rule_name_2)
             assert type(rule_desc.filter) == SqlRuleFilter
             assert rule_desc.filter.sql_expression == "Priority = @param1"
             assert rule_desc.filter.parameters["@param1"] == "str1"
 
-            mgmt_service.create_rule(topic_name, subscription_name, rule_3)
+            mgmt_service.create_rule(topic_name, subscription_name, **rule_3)
             rule_desc = mgmt_service.get_rule(topic_name, subscription_name, rule_name_3)
             assert type(rule_desc.filter) == TrueRuleFilter
 
@@ -121,9 +121,9 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
         try:
             mgmt_service.create_topic(topic_name)
             mgmt_service.create_subscription(topic_name, subscription_name)
-            mgmt_service.create_rule(topic_name, subscription_name, rule)
+            mgmt_service.create_rule(topic_name, subscription_name, **rule)
             with pytest.raises(ResourceExistsError):
-                mgmt_service.create_rule(topic_name, subscription_name, rule)
+                mgmt_service.create_rule(topic_name, subscription_name, **rule)
         finally:
             mgmt_service.delete_rule(topic_name, subscription_name, rule_name)
             mgmt_service.delete_subscription(topic_name, subscription_name)
@@ -143,7 +143,7 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
         try:
             topic_description = mgmt_service.create_topic(topic_name)
             subscription_description = mgmt_service.create_subscription(topic_description, subscription_name)
-            mgmt_service.create_rule(topic_name, subscription_name, rule)
+            mgmt_service.create_rule(topic_name, subscription_name, **rule)
 
             rule_desc = mgmt_service.get_rule(topic_name, subscription_name, rule_name)
 
@@ -181,7 +181,7 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
         try:
             topic_description = mgmt_service.create_topic(topic_name)
             subscription_description = mgmt_service.create_subscription(topic_name, subscription_name)
-            mgmt_service.create_rule(topic_name, subscription_name, rule)
+            mgmt_service.create_rule(topic_name, subscription_name, **rule)
 
             rule_desc = mgmt_service.get_rule(topic_name, subscription_name, rule_name)
 
@@ -235,9 +235,9 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
             rules = list(mgmt_service.list_rules(topic_name, subscription_name))
             assert len(rules) == 1  # by default there is a True filter
 
-            mgmt_service.create_rule(topic_name, subscription_name, rule_1)
-            mgmt_service.create_rule(topic_name, subscription_name, rule_2)
-            mgmt_service.create_rule(topic_name, subscription_name, rule_3)
+            mgmt_service.create_rule(topic_name, subscription_name, **rule_1)
+            mgmt_service.create_rule(topic_name, subscription_name, **rule_2)
+            mgmt_service.create_rule(topic_name, subscription_name, **rule_3)
 
             rules = list(mgmt_service.list_rules(topic_name, subscription_name))
             assert len(rules) == 3 + 1

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_rules.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_rules.py
@@ -253,3 +253,7 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
         finally:
             mgmt_service.delete_subscription(topic_name, subscription_name)
             mgmt_service.delete_topic(topic_name)
+
+    def test_rule_properties_constructor(self):
+        with pytest.raises(TypeError):
+            RuleProperties("randomname")

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_rules.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_rules.py
@@ -46,21 +46,18 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
         sql_rule_action = SqlRuleAction(sql_expression="SET Priority = @param", parameters={
             "@param": datetime(2020, 7, 5, 11, 12, 13),
         })
-        rule_1 = RuleProperties(name=rule_name_1, filter=correlation_fitler, action=sql_rule_action)
 
         sql_filter = SqlRuleFilter("Priority = @param1", parameters={
             "@param1": "str1",
         })
-        rule_2 = RuleProperties(name=rule_name_2, filter=sql_filter)
 
         bool_filter = TrueRuleFilter()
-        rule_3 = RuleProperties(name=rule_name_3, filter=bool_filter)
 
         try:
             mgmt_service.create_topic(topic_name)
             mgmt_service.create_subscription(topic_name, subscription_name)
 
-            mgmt_service.create_rule(topic_name, subscription_name, **rule_1)
+            mgmt_service.create_rule(topic_name, subscription_name, rule_name_1, filter=correlation_fitler, action=sql_rule_action)
             rule_desc = mgmt_service.get_rule(topic_name, subscription_name, rule_name_1)
             rule_properties = rule_desc.filter.properties
             assert type(rule_desc.filter) == CorrelationRuleFilter
@@ -75,13 +72,13 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
             assert rule_properties["key_duration"] == timedelta(days=1, hours=2, minutes=3)
 
 
-            mgmt_service.create_rule(topic_name, subscription_name, **rule_2)
+            mgmt_service.create_rule(topic_name, subscription_name, rule_name_2, filter=sql_filter)
             rule_desc = mgmt_service.get_rule(topic_name, subscription_name, rule_name_2)
             assert type(rule_desc.filter) == SqlRuleFilter
             assert rule_desc.filter.sql_expression == "Priority = @param1"
             assert rule_desc.filter.parameters["@param1"] == "str1"
 
-            mgmt_service.create_rule(topic_name, subscription_name, **rule_3)
+            mgmt_service.create_rule(topic_name, subscription_name, rule_name_3, filter=bool_filter)
             rule_desc = mgmt_service.get_rule(topic_name, subscription_name, rule_name_3)
             assert type(rule_desc.filter) == TrueRuleFilter
 
@@ -117,13 +114,12 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
         subscription_name = 'kkaqo'
         rule_name = 'rule'
         sql_filter = SqlRuleFilter("Priority = 'low'")
-        rule = RuleProperties(name=rule_name, filter=sql_filter)
         try:
             mgmt_service.create_topic(topic_name)
             mgmt_service.create_subscription(topic_name, subscription_name)
-            mgmt_service.create_rule(topic_name, subscription_name, **rule)
+            mgmt_service.create_rule(topic_name, subscription_name, rule_name, filter=sql_filter)
             with pytest.raises(ResourceExistsError):
-                mgmt_service.create_rule(topic_name, subscription_name, **rule)
+                mgmt_service.create_rule(topic_name, subscription_name, rule_name, filter=sql_filter)
         finally:
             mgmt_service.delete_rule(topic_name, subscription_name, rule_name)
             mgmt_service.delete_subscription(topic_name, subscription_name)
@@ -138,12 +134,11 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
         subscription_name = "eqkovc"
         rule_name = 'rule'
         sql_filter = SqlRuleFilter("Priority = 'low'")
-        rule = RuleProperties(name=rule_name, filter=sql_filter)
 
         try:
             topic_description = mgmt_service.create_topic(topic_name)
             subscription_description = mgmt_service.create_subscription(topic_description, subscription_name)
-            mgmt_service.create_rule(topic_name, subscription_name, **rule)
+            mgmt_service.create_rule(topic_name, subscription_name, rule_name, filter=sql_filter)
 
             rule_desc = mgmt_service.get_rule(topic_name, subscription_name, rule_name)
 
@@ -176,12 +171,11 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
         subscription_name = "eqkovc"
         rule_name = 'rule'
         sql_filter = SqlRuleFilter("Priority = 'low'")
-        rule = RuleProperties(name=rule_name, filter=sql_filter)
 
         try:
             topic_description = mgmt_service.create_topic(topic_name)
             subscription_description = mgmt_service.create_subscription(topic_name, subscription_name)
-            mgmt_service.create_rule(topic_name, subscription_name, **rule)
+            mgmt_service.create_rule(topic_name, subscription_name, rule_name, filter=sql_filter)
 
             rule_desc = mgmt_service.get_rule(topic_name, subscription_name, rule_name)
 
@@ -224,9 +218,6 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
         sql_filter_1 = SqlRuleFilter("Priority = 'low'")
         sql_filter_2 = SqlRuleFilter("Priority = 'middle'")
         sql_filter_3 = SqlRuleFilter("Priority = 'high'")
-        rule_1 = RuleProperties(name=rule_name_1, filter=sql_filter_1)
-        rule_2 = RuleProperties(name=rule_name_2, filter=sql_filter_2)
-        rule_3 = RuleProperties(name=rule_name_3, filter=sql_filter_3)
 
         try:
             mgmt_service.create_topic(topic_name)
@@ -235,9 +226,9 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
             rules = list(mgmt_service.list_rules(topic_name, subscription_name))
             assert len(rules) == 1  # by default there is a True filter
 
-            mgmt_service.create_rule(topic_name, subscription_name, **rule_1)
-            mgmt_service.create_rule(topic_name, subscription_name, **rule_2)
-            mgmt_service.create_rule(topic_name, subscription_name, **rule_3)
+            mgmt_service.create_rule(topic_name, subscription_name, rule_name_1, filter=sql_filter_1)
+            mgmt_service.create_rule(topic_name, subscription_name, rule_name_2, filter=sql_filter_2)
+            mgmt_service.create_rule(topic_name, subscription_name, rule_name_3, filter=sql_filter_3)
 
             rules = list(mgmt_service.list_rules(topic_name, subscription_name))
             assert len(rules) == 3 + 1

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_rules.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_rules.py
@@ -8,7 +8,7 @@ import pytest
 from datetime import datetime, timedelta
 
 import msrest
-from azure.servicebus.management import ServiceBusManagementClient, RuleDescription, CorrelationRuleFilter, SqlRuleFilter, TrueRuleFilter, FalseRuleFilter, SqlRuleAction
+from azure.servicebus.management import ServiceBusManagementClient, RuleProperties, CorrelationRuleFilter, SqlRuleFilter, TrueRuleFilter, FalseRuleFilter, SqlRuleAction
 from azure.servicebus.management._constants import INT32_MAX_VALUE
 from utilities import get_logger
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
@@ -46,15 +46,15 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
         sql_rule_action = SqlRuleAction(sql_expression="SET Priority = @param", parameters={
             "@param": datetime(2020, 7, 5, 11, 12, 13),
         })
-        rule_1 = RuleDescription(name=rule_name_1, filter=correlation_fitler, action=sql_rule_action)
+        rule_1 = RuleProperties(name=rule_name_1, filter=correlation_fitler, action=sql_rule_action)
 
         sql_filter = SqlRuleFilter("Priority = @param1", parameters={
             "@param1": "str1",
         })
-        rule_2 = RuleDescription(name=rule_name_2, filter=sql_filter)
+        rule_2 = RuleProperties(name=rule_name_2, filter=sql_filter)
 
         bool_filter = TrueRuleFilter()
-        rule_3 = RuleDescription(name=rule_name_3, filter=bool_filter)
+        rule_3 = RuleProperties(name=rule_name_3, filter=bool_filter)
 
         try:
             mgmt_service.create_topic(topic_name)
@@ -117,7 +117,7 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
         subscription_name = 'kkaqo'
         rule_name = 'rule'
         sql_filter = SqlRuleFilter("Priority = 'low'")
-        rule = RuleDescription(name=rule_name, filter=sql_filter)
+        rule = RuleProperties(name=rule_name, filter=sql_filter)
         try:
             mgmt_service.create_topic(topic_name)
             mgmt_service.create_subscription(topic_name, subscription_name)
@@ -138,7 +138,7 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
         subscription_name = "eqkovc"
         rule_name = 'rule'
         sql_filter = SqlRuleFilter("Priority = 'low'")
-        rule = RuleDescription(name=rule_name, filter=sql_filter)
+        rule = RuleProperties(name=rule_name, filter=sql_filter)
 
         try:
             topic_description = mgmt_service.create_topic(topic_name)
@@ -176,7 +176,7 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
         subscription_name = "eqkovc"
         rule_name = 'rule'
         sql_filter = SqlRuleFilter("Priority = 'low'")
-        rule = RuleDescription(name=rule_name, filter=sql_filter)
+        rule = RuleProperties(name=rule_name, filter=sql_filter)
 
         try:
             topic_description = mgmt_service.create_topic(topic_name)
@@ -224,9 +224,9 @@ class ServiceBusManagementClientRuleTests(AzureMgmtTestCase):
         sql_filter_1 = SqlRuleFilter("Priority = 'low'")
         sql_filter_2 = SqlRuleFilter("Priority = 'middle'")
         sql_filter_3 = SqlRuleFilter("Priority = 'high'")
-        rule_1 = RuleDescription(name=rule_name_1, filter=sql_filter_1)
-        rule_2 = RuleDescription(name=rule_name_2, filter=sql_filter_2)
-        rule_3 = RuleDescription(name=rule_name_3, filter=sql_filter_3)
+        rule_1 = RuleProperties(name=rule_name_1, filter=sql_filter_1)
+        rule_2 = RuleProperties(name=rule_name_2, filter=sql_filter_2)
+        rule_3 = RuleProperties(name=rule_name_3, filter=sql_filter_3)
 
         try:
             mgmt_service.create_topic(topic_name)

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_subscriptions.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_subscriptions.py
@@ -8,7 +8,7 @@ import pytest
 import datetime
 
 import msrest
-from azure.servicebus.management import ServiceBusManagementClient, SubscriptionDescription
+from azure.servicebus.management import ServiceBusManagementClient, SubscriptionProperties
 from utilities import get_logger
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 
@@ -54,7 +54,7 @@ class ServiceBusManagementClientSubscriptionTests(AzureMgmtTestCase):
             mgmt_service.create_topic(topic_name)
             mgmt_service.create_subscription(
                 topic_name,
-                SubscriptionDescription(
+                SubscriptionProperties(
                     name=subscription_name,
                     auto_delete_on_idle=datetime.timedelta(minutes=10),
                     dead_lettering_on_message_expiration=True,
@@ -257,12 +257,11 @@ class ServiceBusManagementClientSubscriptionTests(AzureMgmtTestCase):
         assert info.accessed_at is not None
         assert info.updated_at is not None
 
-        assert info.message_count_details
-        assert info.message_count_details.active_message_count == 0
-        assert info.message_count_details.dead_letter_message_count == 0
-        assert info.message_count_details.transfer_dead_letter_message_count == 0
-        assert info.message_count_details.transfer_message_count == 0
-        assert info.message_count_details.scheduled_message_count == 0
+        assert info.active_message_count == 0
+        assert info.dead_letter_message_count == 0
+        assert info.transfer_dead_letter_message_count == 0
+        assert info.transfer_message_count == 0
+        assert info.scheduled_message_count == 0
 
         mgmt_service.delete_subscription(topic_name, subscription_name)
         subs_infos = list(mgmt_service.list_subscriptions_runtime_info(topic_name))
@@ -288,12 +287,11 @@ class ServiceBusManagementClientSubscriptionTests(AzureMgmtTestCase):
         assert sub_runtime_info.accessed_at is not None
         assert sub_runtime_info.updated_at is not None
 
-        assert sub_runtime_info.message_count_details
-        assert sub_runtime_info.message_count_details.active_message_count == 0
-        assert sub_runtime_info.message_count_details.dead_letter_message_count == 0
-        assert sub_runtime_info.message_count_details.transfer_dead_letter_message_count == 0
-        assert sub_runtime_info.message_count_details.transfer_message_count == 0
-        assert sub_runtime_info.message_count_details.scheduled_message_count == 0
+        assert sub_runtime_info.active_message_count == 0
+        assert sub_runtime_info.dead_letter_message_count == 0
+        assert sub_runtime_info.transfer_dead_letter_message_count == 0
+        assert sub_runtime_info.transfer_message_count == 0
+        assert sub_runtime_info.scheduled_message_count == 0
 
         mgmt_service.delete_subscription(topic_name, subscription_name)
         mgmt_service.delete_topic(topic_name)

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_subscriptions.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_subscriptions.py
@@ -54,7 +54,7 @@ class ServiceBusManagementClientSubscriptionTests(AzureMgmtTestCase):
             mgmt_service.create_topic(topic_name)
             mgmt_service.create_subscription(
                 topic_name,
-                SubscriptionProperties(
+                **SubscriptionProperties(
                     name=subscription_name,
                     auto_delete_on_idle=datetime.timedelta(minutes=10),
                     dead_lettering_on_message_expiration=True,

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_subscriptions.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_subscriptions.py
@@ -261,7 +261,6 @@ class ServiceBusManagementClientSubscriptionTests(AzureMgmtTestCase):
         assert info.dead_letter_message_count == 0
         assert info.transfer_dead_letter_message_count == 0
         assert info.transfer_message_count == 0
-        assert info.scheduled_message_count == 0
 
         mgmt_service.delete_subscription(topic_name, subscription_name)
         subs_infos = list(mgmt_service.list_subscriptions_runtime_info(topic_name))
@@ -291,7 +290,6 @@ class ServiceBusManagementClientSubscriptionTests(AzureMgmtTestCase):
         assert sub_runtime_info.dead_letter_message_count == 0
         assert sub_runtime_info.transfer_dead_letter_message_count == 0
         assert sub_runtime_info.transfer_message_count == 0
-        assert sub_runtime_info.scheduled_message_count == 0
 
         mgmt_service.delete_subscription(topic_name, subscription_name)
         mgmt_service.delete_topic(topic_name)

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_subscriptions.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_subscriptions.py
@@ -291,3 +291,7 @@ class ServiceBusManagementClientSubscriptionTests(AzureMgmtTestCase):
 
         mgmt_service.delete_subscription(topic_name, subscription_name)
         mgmt_service.delete_topic(topic_name)
+
+    def test_subscription_properties_constructor(self):
+        with pytest.raises(TypeError):
+            SubscriptionProperties("randomname")

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_subscriptions.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_subscriptions.py
@@ -54,16 +54,14 @@ class ServiceBusManagementClientSubscriptionTests(AzureMgmtTestCase):
             mgmt_service.create_topic(topic_name)
             mgmt_service.create_subscription(
                 topic_name,
-                **SubscriptionProperties(
-                    name=subscription_name,
-                    auto_delete_on_idle=datetime.timedelta(minutes=10),
-                    dead_lettering_on_message_expiration=True,
-                    default_message_time_to_live=datetime.timedelta(minutes=11),
-                    enable_batched_operations=True,
-                    lock_duration=datetime.timedelta(seconds=13),
-                    max_delivery_count=14,
-                    requires_session=True
-                )
+                name=subscription_name,
+                auto_delete_on_idle=datetime.timedelta(minutes=10),
+                dead_lettering_on_message_expiration=True,
+                default_message_time_to_live=datetime.timedelta(minutes=11),
+                enable_batched_operations=True,
+                lock_duration=datetime.timedelta(seconds=13),
+                max_delivery_count=14,
+                requires_session=True
             )
             subscription = mgmt_service.get_subscription(topic_name, subscription_name)
             assert subscription.name == subscription_name

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_topics.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_topics.py
@@ -48,18 +48,16 @@ class ServiceBusManagementClientTopicTests(AzureMgmtTestCase):
         topic_name = "iweidk"
         try:
             mgmt_service.create_topic(
-                **TopicProperties(
-                    name=topic_name,
-                    auto_delete_on_idle=datetime.timedelta(minutes=10),
-                    default_message_time_to_live=datetime.timedelta(minutes=11),
-                    duplicate_detection_history_time_window=datetime.timedelta(minutes=12),
-                    enable_batched_operations=True,
-                    enable_express=True,
-                    enable_partitioning=True,
-                    enable_subscription_partitioning=True,
-                    is_anonymous_accessible=True,
-                    max_size_in_megabytes=3072
-                )
+                name=topic_name,
+                auto_delete_on_idle=datetime.timedelta(minutes=10),
+                default_message_time_to_live=datetime.timedelta(minutes=11),
+                duplicate_detection_history_time_window=datetime.timedelta(minutes=12),
+                enable_batched_operations=True,
+                enable_express=True,
+                enable_partitioning=True,
+                enable_subscription_partitioning=True,
+                is_anonymous_accessible=True,
+                max_size_in_megabytes=3072
             )
             topic = mgmt_service.get_topic(topic_name)
             assert topic.name == topic_name

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_topics.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_topics.py
@@ -261,3 +261,7 @@ class ServiceBusManagementClientTopicTests(AzureMgmtTestCase):
         assert topic_runtime_info.subscription_count is 0
         assert topic_runtime_info.scheduled_message_count == 0
         mgmt_service.delete_topic("test_topic")
+
+    def test_topic_properties_constructor(self):
+        with pytest.raises(TypeError):
+            TopicProperties("randomname")

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_topics.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_topics.py
@@ -48,7 +48,7 @@ class ServiceBusManagementClientTopicTests(AzureMgmtTestCase):
         topic_name = "iweidk"
         try:
             mgmt_service.create_topic(
-                TopicProperties(
+                **TopicProperties(
                     name=topic_name,
                     auto_delete_on_idle=datetime.timedelta(minutes=10),
                     default_message_time_to_live=datetime.timedelta(minutes=11),

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_topics.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_topics.py
@@ -8,7 +8,7 @@ import pytest
 import datetime
 
 import msrest
-from azure.servicebus.management import ServiceBusManagementClient, TopicDescription
+from azure.servicebus.management import ServiceBusManagementClient, TopicProperties
 from utilities import get_logger
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 
@@ -48,7 +48,7 @@ class ServiceBusManagementClientTopicTests(AzureMgmtTestCase):
         topic_name = "iweidk"
         try:
             mgmt_service.create_topic(
-                TopicDescription(
+                TopicProperties(
                     name=topic_name,
                     auto_delete_on_idle=datetime.timedelta(minutes=10),
                     default_message_time_to_live=datetime.timedelta(minutes=11),
@@ -239,12 +239,11 @@ class ServiceBusManagementClientTopicTests(AzureMgmtTestCase):
         assert info.updated_at is not None
         assert info.subscription_count is 0
 
-        assert info.message_count_details
-        assert info.message_count_details.active_message_count == 0
-        assert info.message_count_details.dead_letter_message_count == 0
-        assert info.message_count_details.transfer_dead_letter_message_count == 0
-        assert info.message_count_details.transfer_message_count == 0
-        assert info.message_count_details.scheduled_message_count == 0
+        assert info.active_message_count == 0
+        assert info.dead_letter_message_count == 0
+        assert info.transfer_dead_letter_message_count == 0
+        assert info.transfer_message_count == 0
+        assert info.scheduled_message_count == 0
 
         mgmt_service.delete_topic("test_topic")
         topics_infos = list(mgmt_service.list_topics_runtime_info())
@@ -265,10 +264,9 @@ class ServiceBusManagementClientTopicTests(AzureMgmtTestCase):
         assert topic_runtime_info.updated_at is not None
         assert topic_runtime_info.subscription_count is 0
 
-        assert topic_runtime_info.message_count_details
-        assert topic_runtime_info.message_count_details.active_message_count == 0
-        assert topic_runtime_info.message_count_details.dead_letter_message_count == 0
-        assert topic_runtime_info.message_count_details.transfer_dead_letter_message_count == 0
-        assert topic_runtime_info.message_count_details.transfer_message_count == 0
-        assert topic_runtime_info.message_count_details.scheduled_message_count == 0
+        assert topic_runtime_info.active_message_count == 0
+        assert topic_runtime_info.dead_letter_message_count == 0
+        assert topic_runtime_info.transfer_dead_letter_message_count == 0
+        assert topic_runtime_info.transfer_message_count == 0
+        assert topic_runtime_info.scheduled_message_count == 0
         mgmt_service.delete_topic("test_topic")

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_topics.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_topics.py
@@ -239,10 +239,7 @@ class ServiceBusManagementClientTopicTests(AzureMgmtTestCase):
         assert info.updated_at is not None
         assert info.subscription_count is 0
 
-        assert info.active_message_count == 0
-        assert info.dead_letter_message_count == 0
-        assert info.transfer_dead_letter_message_count == 0
-        assert info.transfer_message_count == 0
+        assert info.size_in_bytes == 0
         assert info.scheduled_message_count == 0
 
         mgmt_service.delete_topic("test_topic")
@@ -262,11 +259,7 @@ class ServiceBusManagementClientTopicTests(AzureMgmtTestCase):
         assert topic_runtime_info.created_at is not None
         assert topic_runtime_info.accessed_at is not None
         assert topic_runtime_info.updated_at is not None
+        assert topic_runtime_info.size_in_bytes == 0
         assert topic_runtime_info.subscription_count is 0
-
-        assert topic_runtime_info.active_message_count == 0
-        assert topic_runtime_info.dead_letter_message_count == 0
-        assert topic_runtime_info.transfer_dead_letter_message_count == 0
-        assert topic_runtime_info.transfer_message_count == 0
         assert topic_runtime_info.scheduled_message_count == 0
         mgmt_service.delete_topic("test_topic")


### PR DESCRIPTION
1. QueueDescription to QueueProperties and QueueRuntimeInfo to QueueRuntimeProperties (#12576 ). Same applies to Topic, Subscription and Rule 
2. Add scheduled_message_count to TopicRuntimeProperties and remove it from SubscriptionRuntimeProperties (#12707 )
3. Flatten MessageCountDetails and rename MessageCount -> TotalMessageCount
4. Removed updatable properties from **kwargs of update_queue method. Users should update the input queue object. Same applies to Topic, Subscription and Rule
5. create_queue now uses **kwargs instead of QueueProperties as input. Same for Topic, Subscription and Rule
6. Other small adjustment
