### PR TITLE
[formrecognizer] update how value_data is set on FormField to align with other languages

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
@@ -16,6 +16,8 @@
 **Fixes and improvements**
 
 - Fixes a bug where error code and message weren't being returned on `HttpResponseError` if operation failed during polling
+- `FormField` property `value_data` is now set to `None` if no values are returned on its `FieldData`.
+Previously `value_data` returned a `FieldData` with all its attributes set to `None` in the above case.
 
 
 ## 1.0.0b4 (2020-07-07)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
@@ -264,8 +264,8 @@ class FormField(object):
 
 
 class FieldData(FormElement):
-    """Represents the text that is part of a form field. This includes
-    the location of the text in the form and a collection of the
+    """Contains the data for the form field. This includes the text,
+    location of the text on the form, and a collection of the
     elements that make up the text.
 
     :ivar int page_number:

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
@@ -9,7 +9,6 @@
 from enum import Enum
 from collections import namedtuple
 import re
-import six
 
 
 def adjust_value_type(value_type):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
@@ -240,7 +240,7 @@ class FormField(object):
     def _from_generated(cls, field, value, read_result):
         return cls(
             value_type=adjust_value_type(value.type) if value else None,
-            label_data=FieldData._from_generated(field, read_result),
+            label_data=None,  # not returned with receipt/supervised
             value_data=FieldData._from_generated(value, read_result),
             value=get_field_value(field, value, read_result),
             name=field,
@@ -290,7 +290,7 @@ class FieldData(FormElement):
 
     @classmethod
     def _from_generated(cls, field, read_result):
-        if field is None or isinstance(field, six.string_types):
+        if field is None or all(field_data is None for field_data in [field.page, field.text, field.bounding_box]):
             return None
         return cls(
             page_number=field.page,

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_response_handlers.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_response_handlers.py
@@ -25,14 +25,6 @@ def prepare_receipt(response):
     form_page = FormPage._from_generated(read_result)
 
     for page in document_result:
-        if page.fields is None:
-            receipt = RecognizedForm(
-                page_range=FormPageRange(first_page_number=page.page_range[0], last_page_number=page.page_range[1]),
-                pages=form_page[page.page_range[0]-1:page.page_range[1]],
-                form_type=page.doc_type,
-            )
-            receipts.append(receipt)
-            continue
         receipt = RecognizedForm(
             page_range=FormPageRange(
                 first_page_number=page.page_range[0], last_page_number=page.page_range[1]
@@ -42,7 +34,7 @@ def prepare_receipt(response):
             fields={
                 key: FormField._from_generated(key, value, read_result)
                 for key, value in page.fields.items()
-            }
+            } if page.fields else None
         )
 
         receipts.append(receipt)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt.py
@@ -309,7 +309,7 @@ class TestReceiptFromStream(FormRecognizerTest):
         self.assertFormPagesHasValues(receipt.pages)
 
         for name, field in receipt.fields.items():
-            if field.value_type not in ["list", "dictionary"] and name != "ReceiptType":
+            if field.value_type not in ["list", "dictionary"] and name != "ReceiptType":  # receipt cases where value_data is None
                 self.assertFieldElementsHasValues(field.value_data.field_elements, receipt.page_range.first_page_number)
 
     @GlobalFormRecognizerAccountPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt.py
@@ -307,13 +307,10 @@ class TestReceiptFromStream(FormRecognizerTest):
         receipt = result[0]
 
         self.assertFormPagesHasValues(receipt.pages)
-        for field, value in receipt.__dict__.items():
-            if field not in ["receipt_items", "page_range", "pages", "fields", "form_type"]:
-                form_field = getattr(receipt, field)
-                self.assertFieldElementsHasValues(form_field.value_data.field_elements, receipt.page_range.first_page_number)
 
-        for field, value in receipt.fields.items():
-            self.assertFieldElementsHasValues(value.value_data.field_elements, receipt.page_range.first_page_number)
+        for name, field in receipt.fields.items():
+            if field.value_type not in ["list", "dictionary"] and name != "ReceiptType":
+                self.assertFieldElementsHasValues(field.value_data.field_elements, receipt.page_range.first_page_number)
 
     @GlobalFormRecognizerAccountPreparer()
     @GlobalClientPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_async.py
@@ -335,13 +335,10 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
         receipt = result[0]
 
         self.assertFormPagesHasValues(receipt.pages)
-        for field, value in receipt.__dict__.items():
-            if field not in ["receipt_items", "page_range", "pages", "fields", "form_type"]:
-                form_field = getattr(receipt, field)
-                self.assertFieldElementsHasValues(form_field.value_data.field_elements, receipt.page_range.first_page_number)
 
-        for field, value in receipt.fields.items():
-            self.assertFieldElementsHasValues(value.value_data.field_elements, receipt.page_range.first_page_number)
+        for name, field in receipt.fields.items():
+            if field.value_type not in ["list", "dictionary"] and name != "ReceiptType":
+                self.assertFieldElementsHasValues(field.value_data.field_elements, receipt.page_range.first_page_number)
 
     @GlobalFormRecognizerAccountPreparer()
     @GlobalClientPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_async.py
@@ -337,7 +337,7 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
         self.assertFormPagesHasValues(receipt.pages)
 
         for name, field in receipt.fields.items():
-            if field.value_type not in ["list", "dictionary"] and name != "ReceiptType":
+            if field.value_type not in ["list", "dictionary"] and name != "ReceiptType":  # receipt cases where value_data is None
                 self.assertFieldElementsHasValues(field.value_data.field_elements, receipt.page_range.first_page_number)
 
     @GlobalFormRecognizerAccountPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url.py
@@ -198,13 +198,10 @@ class TestReceiptFromUrl(FormRecognizerTest):
         receipt = result[0]
 
         self.assertFormPagesHasValues(receipt.pages)
-        for field, value in receipt.__dict__.items():
-            if field not in ["receipt_items", "page_range", "pages", "fields", "form_type"]:
-                field = getattr(receipt, field)
-                self.assertFieldElementsHasValues(field.value_data.field_elements, receipt.page_range.first_page_number)
 
-        for field, value in receipt.fields.items():
-            self.assertFieldElementsHasValues(value.value_data.field_elements, receipt.page_range.first_page_number)
+        for name, field in receipt.fields.items():
+            if field.value_type not in ["list", "dictionary"] and name != "ReceiptType":
+                self.assertFieldElementsHasValues(field.value_data.field_elements, receipt.page_range.first_page_number)
 
     @GlobalFormRecognizerAccountPreparer()
     @GlobalClientPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url.py
@@ -200,7 +200,7 @@ class TestReceiptFromUrl(FormRecognizerTest):
         self.assertFormPagesHasValues(receipt.pages)
 
         for name, field in receipt.fields.items():
-            if field.value_type not in ["list", "dictionary"] and name != "ReceiptType":
+            if field.value_type not in ["list", "dictionary"] and name != "ReceiptType":  # receipt cases where value_data is None
                 self.assertFieldElementsHasValues(field.value_data.field_elements, receipt.page_range.first_page_number)
 
     @GlobalFormRecognizerAccountPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url_async.py
@@ -225,13 +225,10 @@ class TestReceiptFromUrlAsync(AsyncFormRecognizerTest):
         receipt = result[0]
 
         self.assertFormPagesHasValues(receipt.pages)
-        for field, value in receipt.__dict__.items():
-            if field not in ["page_range", "pages", "fields", "form_type"]:
-                field = getattr(receipt, field)
-                self.assertFieldElementsHasValues(field.value_data.field_elements, receipt.page_range.first_page_number)
 
-        for field, value in receipt.fields.items():
-            self.assertFieldElementsHasValues(value.value_data.field_elements, receipt.page_range.first_page_number)
+        for name, field in receipt.fields.items():
+            if field.value_type not in ["list", "dictionary"] and name != "ReceiptType":
+                self.assertFieldElementsHasValues(field.value_data.field_elements, receipt.page_range.first_page_number)
 
     @GlobalFormRecognizerAccountPreparer()
     @GlobalClientPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url_async.py
@@ -227,7 +227,7 @@ class TestReceiptFromUrlAsync(AsyncFormRecognizerTest):
         self.assertFormPagesHasValues(receipt.pages)
 
         for name, field in receipt.fields.items():
-            if field.value_type not in ["list", "dictionary"] and name != "ReceiptType":
+            if field.value_type not in ["list", "dictionary"] and name != "ReceiptType":  # receipt cases where value_data is None
                 self.assertFieldElementsHasValues(field.value_data.field_elements, receipt.page_range.first_page_number)
 
     @GlobalFormRecognizerAccountPreparer()


### PR DESCRIPTION
Resolves #12840 

Sets `value_data` to None on `FormField` if none of `bounding_box`, `text`, or `page` is returned on `FieldData`. As described in this Teams [chat](https://teams.microsoft.com/l/message/19:88f2d9dea2344075b5d4bc34d82a3d1c@thread.skype/1586470046196?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1586210857171&teamName=Azure%20SDK&channelName=Service%20-%20Form%20Recognizer&createdTime=1586470046196), but somehow missed in implementation.
