### PR TITLE
Pin to the same commit as loganalytics.

### DIFF
--- a/sdk/cosmos/ci.yml
+++ b/sdk/cosmos/ci.yml
@@ -7,6 +7,7 @@ resources:
       type: github
       name: Azure/azure-sdk-tools
       endpoint: azure
+      ref: 0aedb8f2c152440e22d49317ad417c7c1d10a67c
     - repository: azure-sdk-build-tools
       type: git
       name: internal/azure-sdk-build-tools


### PR DESCRIPTION
This PR pins the cosmos pipeline to use an old commit sha that is compatible with this long term servicing branch.