### PR TITLE
Update Key Vault readme links

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/README.md
+++ b/sdk/keyvault/azure-keyvault-certificates/README.md
@@ -145,10 +145,10 @@ This section contains code snippets covering common tasks:
 * [Asynchronously list properties of Certificates](#asynchronously-list-properties-of-certificates "Asynchronously list properties of Certificates")
 
 ### Create a Certificate
-[begin_create_certificate](https://aka.ms/azsdk-python-keyvault-certificates-begincreatecert-ref) creates a certificate to be stored in the Azure Key Vault.
-If a certificate with the same name already exists, then a new version of the certificate is created.
-Before creating a certificate, a management policy for the certificate can be created or our default
-policy will be used. The [begin_create_certificate](https://aka.ms/azsdk-python-keyvault-certificates-begincreatecert-ref) operation returns a long running operation poller.
+[begin_create_certificate](https://aka.ms/azsdk/python/keyvault-certificates/docs#azure.keyvault.certificates.CertificateClient.begin_create_certificate)
+creates a certificate to be stored in the Azure Key Vault. If a certificate with the same name already exists, a new
+version of the certificate is created. Before creating a certificate, a management policy for the certificate can be
+created or our default policy will be used. This method returns a long running operation poller.
 ```python
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.certificates import CertificateClient, CertificatePolicy
@@ -163,11 +163,12 @@ create_certificate_poller = certificate_client.begin_create_certificate(
 print(create_certificate_poller.result())
 ```
 If you would like to check the status of your certificate creation, you can call `status()` on the poller or
-[get_certificate_operation](https://aka.ms/azsdk-python-keyvault-certificates-getcertop-ref) with the name of the certificate.
+[get_certificate_operation](https://aka.ms/azsdk/python/keyvault-certificates/docs#azure.keyvault.certificates.CertificateClient.get_certificate_operation)
+with the name of the certificate.
 
 ### Retrieve a Certificate
-[get_certificate](https://aka.ms/azsdk-python-keyvault-certificates-getcert-ref) retrieves a certificate previously stored in the Key Vault without
-having to specify version.
+[get_certificate](https://aka.ms/azsdk/python/keyvault-certificates/docs#azure.keyvault.certificates.CertificateClient.get_certificate)
+retrieves the latest version of a certificate previously stored in the Key Vault.
 ```python
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.certificates import CertificateClient
@@ -183,8 +184,8 @@ print(certificate.properties.version)
 print(certificate.policy.issuer_name)
 ```
 
-[get_certificate_version](https://aka.ms/azsdk-python-keyvault-certificates-getcertversion-ref) retrieves a certificate based on the certificate name and the version of the certificate.
-Version is required.
+[get_certificate_version](https://aka.ms/azsdk/python/keyvault-certificates/docs#azure.keyvault.certificates.CertificateClient.get_certificate_version)
+retrieves a specific version of a certificate.
 ```python
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.certificates import CertificateClient
@@ -199,7 +200,8 @@ print(certificate.properties.version)
 ```
 
 ### Update properties of an existing Certificate
-[update_certificate_properties](https://aka.ms/azsdk-python-keyvault-certificates-updatecertprops-ref) updates a certificate previously stored in the Key Vault.
+[update_certificate_properties](https://aka.ms/azsdk/python/keyvault-certificates/docs#azure.keyvault.certificates.CertificateClient.update_certificate_properties)
+updates a certificate previously stored in the Key Vault.
 ```python
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.certificates import CertificateClient
@@ -218,10 +220,11 @@ print(updated_certificate.properties.enabled)
 ```
 
 ### Delete a Certificate
-[begin_delete_certificate](https://aka.ms/azsdk-python-keyvault-certs-deletecert-ref) requests Key Vault delete a certificate, returning a poller which allows you to
-wait for the deletion to finish. Waiting is helpful when the vault has [soft-delete][soft_delete]
-enabled, and you want to purge (permanently delete) the certificate as soon as possible.
-When [soft-delete][soft_delete] is disabled, [begin_delete_certificate](https://aka.ms/azsdk-python-keyvault-certs-deletecert-ref) itself is permanent.
+[begin_delete_certificate](https://aka.ms/azsdk/python/keyvault-certificates/docs#azure.keyvault.certificates.CertificateClient.begin_delete_certificate)
+requests Key Vault delete a certificate, returning a poller which allows you to wait for the deletion to finish.
+Waiting is helpful when the vault has [soft-delete][soft_delete] enabled, and you want to purge
+(permanently delete) the certificate as soon as possible. When [soft-delete][soft_delete] is disabled,
+`begin_delete_certificate` itself is permanent.
 
 ```python
 from azure.identity import DefaultAzureCredential
@@ -237,7 +240,8 @@ print(deleted_certificate.name)
 print(deleted_certificate.deleted_on)
 ```
 ### List properties of Certificates
-[list_properties_of_certificates](https://aka.ms/azsdk-python-keyvault-certs-listcerts-ref) lists the properties of all certificates in the specified Key Vault.
+[list_properties_of_certificates](https://aka.ms/azsdk/python/keyvault-certificates/docs#azure.keyvault.certificates.CertificateClient.list_properties_of_certificates)
+lists the properties of all certificates in the specified Key Vault.
 ```python
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.certificates import CertificateClient
@@ -279,11 +283,13 @@ async with client:
 ```
 
 ### Asynchronously create a Certificate
-[create_certificate](https://aka.ms/azsdk-python-keyvault-certs-async-createcert) creates a certificate to be stored in the Azure Key Vault. If a certificate with the
-same name already exists, then a new version of the certificate is created.
-Before creating a certificate, a management policy for the certificate can be created or our default policy
-will be used. Awaiting the call to [create_certificate](https://aka.ms/azsdk-python-keyvault-certs-async-createcert) returns your created certificate if creation is successful,
-and a [CertificateOperation](https://aka.ms/azsdk-python-keyvault-certs-models-certop-ref) if creation is not.
+[create_certificate](https://aka.ms/azsdk/python/keyvault-certificates/aio/docs#azure.keyvault.certificates.aio.CertificateClient.create_certificate)
+creates a certificate to be stored in the Azure Key Vault. If a certificate with the same name already exists, a new
+version of the certificate is created. Before creating a certificate, a management policy for the certificate can be
+created or our default policy will be used. Awaiting `create_certificate` returns your created certificate if creation
+is successful, and a
+[CertificateOperation](https://aka.ms/azsdk/python/keyvault-certificates/docs#azure.keyvault.certificates.CertificateOperation)
+if it is not.
 ```python
 from azure.identity.aio import DefaultAzureCredential
 from azure.keyvault.certificates.aio import CertificateClient
@@ -300,8 +306,8 @@ print(create_certificate_result)
 ```
 
 ### Asynchronously list properties of Certificates
-[list_properties_of_certificates](https://aka.ms/azsdk-python-keyvault-certs-async-listcerts-ref) lists all the
-properties of the certificates in the client's vault:
+[list_properties_of_certificates](https://aka.ms/azsdk/python/keyvault-certificates/aio/docs#azure.keyvault.certificates.aio.CertificateClient.list_properties_of_certificates)
+lists all the properties of the certificates in the client's vault:
 ```python
 from azure.identity.aio import DefaultAzureCredential
 from azure.keyvault.certificates.aio import CertificateClient
@@ -395,8 +401,7 @@ This project has adopted the
 see the Code of Conduct FAQ or contact opencode@microsoft.com with any
 additional questions or comments.
 
-[asyncio_package]: https://docs.python.org/3/library/asyncio.html
-[default_cred_ref]: https://aka.ms/azsdk-python-identity-default-cred-ref
+[default_cred_ref]: https://aka.ms/azsdk/python/identity/docs#azure.identity.DefaultAzureCredential
 [azure_cloud_shell]: https://shell.azure.com/bash
 [azure_core_exceptions]: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/core/azure-core#azure-core-library-exceptions
 [azure_identity]: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/identity/azure-identity
@@ -418,12 +423,10 @@ additional questions or comments.
 [issuers_async_sample]: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/keyvault/azure-keyvault-certificates/samples/issuers_async.py
 [pip]: https://pypi.org/project/pip/
 [pypi_package_certificates]: https://pypi.org/project/azure-keyvault-certificates/
-[certificate_client_docs]: https://aka.ms/azsdk-python-keyvault-certificates-certificateclient-ref
-[reference_docs]: https://aka.ms/azsdk-python-keyvault-certificates-docs
+[certificate_client_docs]: https://aka.ms/azsdk/python/keyvault-certificates/docs#azure.keyvault.certificates.CertificateClient
+[reference_docs]: https://aka.ms/azsdk/python/keyvault-certificates/docs
 [certificates_client_src]: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates
 [certificates_samples]: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-certificates/samples
 [soft_delete]: https://docs.microsoft.com/en-us/azure/key-vault/key-vault-ovw-soft-delete
-[test_example_certificates]: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates.py
-[test_example_certificates_async]: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates_async.py
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-python%2Fsdk%2Fkeyvault%2Fazure-keyvault-certificates%2FFREADME.png)

--- a/sdk/keyvault/azure-keyvault-keys/README.md
+++ b/sdk/keyvault/azure-keyvault-keys/README.md
@@ -156,9 +156,9 @@ This section contains code snippets covering common tasks:
 * [Perform cryptographic operations](#cryptographic-operations)
 
 ### Create a Key
-[create_rsa_key](https://aka.ms/azsdk-python-keyvault-keys-create-rsa-key-ref) and
-[create_ec_key](https://aka.ms/azsdk-python-keyvault-keys-create-ec-key-rf) create RSA and elliptic curve keys in the
-vault, respectively. If a key with the same name already exists, a new version
+[create_rsa_key](https://aka.ms/azsdk/python/keyvault-keys/docs#azure.keyvault.keys.KeyClient.create_rsa_key) and
+[create_ec_key](https://aka.ms/azsdk/python/keyvault-keys/docs#azure.keyvault.keys.KeyClient.create_ec_key)
+create RSA and elliptic curve keys in the vault, respectively. If a key with the same name already exists, a new version
 of that key is created.
 
 ```python
@@ -181,7 +181,8 @@ print(ec_key.key_type)
 ```
 
 ### Retrieve a Key
-[get_key](https://aka.ms/azsdk-python-keyvault-keys-get-key-ref) retrieves a key previously stored in the vault.
+[get_key](https://aka.ms/azsdk/python/keyvault-keys/docs#azure.keyvault.keys.KeyClient.get_key) retrieves a key
+previously stored in the Vault.
 ```python
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.keys import KeyClient
@@ -194,7 +195,8 @@ print(key.name)
 ```
 
 ### Update an existing Key
-[update_key_properties](https://aka.ms/azsdk-python-keyvault-keys-update-key-ref) updates the properties of a key previously stored in the Key Vault.
+[update_key_properties](https://aka.ms/azsdk/python/keyvault-keys/docs#azure.keyvault.keys.KeyClient.update_key_properties)
+updates the properties of a key previously stored in the Key Vault.
 ```python
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.keys import KeyClient
@@ -211,10 +213,10 @@ print(updated_key.properties.enabled)
 ```
 
 ### Delete a Key
-[begin_delete_key](https://aka.ms/azsdk-python-keyvault-keys-begin-delete-key-ref) requests Key Vault delete a key, returning a poller which allows you to
-wait for the deletion to finish. Waiting is helpful when the vault has [soft-delete][soft_delete]
-enabled, and you want to purge (permanently delete) the key as soon as possible.
-When [soft-delete][soft_delete] is disabled, `begin_delete_key` itself is permanent.
+[begin_delete_key](https://aka.ms/azsdk/python/keyvault-keys/docs#azure.keyvault.keys.KeyClient.begin_delete_key)
+requests Key Vault delete a key, returning a poller which allows you to wait for the deletion to finish. Waiting is
+helpful when the vault has [soft-delete][soft_delete] enabled, and you want to purge (permanently delete) the key as
+soon as possible. When [soft-delete][soft_delete] is disabled, `begin_delete_key` itself is permanent.
 
 ```python
 from azure.identity import DefaultAzureCredential
@@ -229,8 +231,8 @@ print(deleted_key.name)
 print(deleted_key.deleted_date)
 ```
 ### List keys
-[list_properties_of_keys](https://aka.ms/azsdk-python-keyvault-keys-list-properties-keys-ref) lists the
-properties of all of the keys in the client's vault.
+[list_properties_of_keys](https://aka.ms/azsdk/python/keyvault-keys/docs#azure.keyvault.keys.KeyClient.list_properties_of_keys)
+lists the properties of all of the keys in the client's vault.
 
 ```python
 from azure.identity import DefaultAzureCredential
@@ -247,8 +249,8 @@ for key in keys:
 ```
 
 ### Cryptographic operations
-[CryptographyClient][crypto_client_docs] enables cryptographic operations (encrypt/decrypt,
-wrap/unwrap, sign/verify) using a particular key.
+[CryptographyClient](https://aka.ms/azsdk/python/keyvault-keys/crypto/docs#azure.keyvault.keys.crypto.CryptographyClient)
+enables cryptographic operations (encrypt/decrypt, wrap/unwrap, sign/verify) using a particular key.
 
 ```py
 from azure.identity import DefaultAzureCredential
@@ -267,7 +269,7 @@ decrypted = crypto_client.decrypt(result.algorithm, result.ciphertext)
 ```
 
 See the
-[package documentation](https://aka.ms/azsdk-python-keyvault-keys-crypto-ref)
+[package documentation][crypto_client_docs]
 for more details of the cryptography API.
 
 ### Async API
@@ -296,9 +298,10 @@ async with client:
 ```
 
 ### Asynchronously create a Key
-[create_rsa_key](https://aka.ms/azsdk-python-keyvault-keys-async-create-rsa-key-ref) and
-[create_ec_key](https://aka.ms/azsdk-python-keyvault-keys-async-create-ec-key-ref) create RSA and elliptic curve keys in the vault, respectively.
-If a key with the same name already exists, a new version of the key is created.
+[create_rsa_key](https://aka.ms/azsdk/python/keyvault-keys/aio/docs#azure.keyvault.keys.aio.KeyClient.create_rsa_key) and
+[create_ec_key](https://aka.ms/azsdk/python/keyvault-keys/aio/docs#azure.keyvault.keys.aio.KeyClient.create_ec_key)
+create RSA and elliptic curve keys in the vault, respectively. If a key with the same name already exists, a new
+version of the key is created.
 
 ```python
 from azure.identity.aio import DefaultAzureCredential
@@ -319,8 +322,8 @@ print(ec_key.key_type)
 ```
 
 ### Asynchronously list keys
-[list_properties_of_keys](https://aka.ms/azsdk-python-keyvault-keys-async-list-properties-keys-ref) lists the
-properties of all of the keys in the client's vault.
+[list_properties_of_keys](https://aka.ms/azsdk/python/keyvault-keys/aio/docs#azure.keyvault.keys.aio.KeyClient.list_properties_of_keys)
+lists the properties of all of the keys in the client's vault.
 
 ```python
 from azure.identity.aio import DefaultAzureCredential
@@ -426,7 +429,7 @@ additional questions or comments.
 [azure_identity]: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/identity/azure-identity
 [azure_identity_pypi]: https://pypi.org/project/azure-identity/
 [azure_sub]: https://azure.microsoft.com/free/
-[default_cred_ref]: https://aka.ms/azsdk-python-identity-default-cred-ref
+[default_cred_ref]: https://aka.ms/azsdk/python/identity/docs#azure.identity.DefaultAzureCredential
 [code_of_conduct]: https://opensource.microsoft.com/codeofconduct/
 [hello_world_sample]: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/keyvault/azure-keyvault-keys/samples/hello_world.py
 [hello_world_async_sample]: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/keyvault/azure-keyvault-keys/samples/hello_world_async.py
@@ -439,13 +442,11 @@ additional questions or comments.
 [keyvault_docs]: https://docs.microsoft.com/en-us/azure/key-vault/
 [pip]: https://pypi.org/project/pip/
 [pypi_package_keys]: https://pypi.org/project/azure-keyvault-keys/
-[reference_docs]: https://aka.ms/azsdk-python-keyvault-keys-docs
-[key_client_docs]: https://aka.ms/azsdk-python-keyvault-keys-keyclient
-[crypto_client_docs]: https://aka.ms/azsdk-python-keyvault-keys-cryptographyclient
+[reference_docs]: https://aka.ms/azsdk/python/keyvault-keys/docs
+[key_client_docs]: https://aka.ms/azsdk/python/keyvault-keys/docs#azure.keyvault.keys.KeyClient
+[crypto_client_docs]: https://aka.ms/azsdk/python/keyvault-keys/crypto/docs
 [key_client_src]: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys
 [key_samples]: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-keys/samples
 [soft_delete]: https://docs.microsoft.com/en-us/azure/key-vault/key-vault-ovw-soft-delete
-[test_examples_keys]: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
-[test_example_keys_async]: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-python%2Fsdk%2Fkeyvault%2Fazure-keyvault-keys%2FFREADME.png)

--- a/sdk/keyvault/azure-keyvault-secrets/README.md
+++ b/sdk/keyvault/azure-keyvault-secrets/README.md
@@ -156,8 +156,8 @@ This section contains code snippets covering common tasks:
 * [Asynchronously list Secrets](#asynchronously-list-secrets "Asynchronously list Secrets")
 
 ### Set a Secret
-[set_secret](https://aka.ms/azsdk-python-keyvault-secrets-set-secret) creates
-new secrets and changes the values of existing secrets. If no secret with the
+[set_secret](https://aka.ms/azsdk/python/keyvault-secrets/docs#azure.keyvault.secrets.SecretClient.set_secret)
+creates new secrets and changes the values of existing secrets. If no secret with the
 given name exists, `set_secret` creates a new secret with that name and the
 given value. If the given name is in use, `set_secret` creates a new version
 of that secret, with the given value.
@@ -177,7 +177,8 @@ print(secret.properties.version)
 ```
 
 ### Retrieve a Secret
-[get_secret](https://aka.ms/azsdk-python-keyvault-secrets-get-secret) retrieves a secret previously stored in the Key Vault.
+[get_secret](https://aka.ms/azsdk/python/keyvault-secrets/docs#azure.keyvault.secrets.SecretClient.get_secret)
+retrieves a secret previously stored in the Key Vault.
 
 ```python
 from azure.identity import DefaultAzureCredential
@@ -193,8 +194,9 @@ print(secret.value)
 ```
 
 ### Update Secret metadata
-[update_secret_properites](https://aka.ms/azsdk-python-keyvault-secrets-update-secret-ref) updates a secret's metadata. It cannot change the secret's
-value; use [set_secret](#set-a-secret) to set a secret's value.
+[update_secret_properites](https://aka.ms/azsdk/python/keyvault-secrets/docs#azure.keyvault.secrets.SecretClient.update_secret_properties)
+updates a secret's metadata. It cannot change the secret's value; use [set_secret](#set-a-secret) to set a secret's
+value.
 
 ```python
 from azure.identity import DefaultAzureCredential
@@ -217,10 +219,10 @@ print(updated_secret_properties.enabled)
 ```
 
 ### Delete a Secret
-[begin_delete_secret](https://aka.ms/azsdk-python-keyvault-secrets-begin-delete-secret-ref) requests Key Vault delete
-a secret, returning a poller which allows you to wait for the deletion to finish. Waiting is helpful when the vault has
-[soft-delete][soft_delete] enabled, and you want to purge (permanently delete) the secret as soon as possible.
-When [soft-delete][soft_delete] is disabled, `begin_delete_secret` itself is permanent.
+[begin_delete_secret](https://aka.ms/azsdk/python/keyvault-secrets/docs#azure.keyvault.secrets.SecretClient.begin_delete_secret)
+requests Key Vault delete a secret, returning a poller which allows you to wait for the deletion to finish. Waiting is
+helpful when the vault has [soft-delete][soft_delete] enabled, and you want to purge (permanently delete) the secret as
+soon as possible. When [soft-delete][soft_delete] is disabled, `begin_delete_secret` itself is permanent.
 
 ```python
 from azure.identity import DefaultAzureCredential
@@ -236,8 +238,8 @@ print(deleted_secret.deleted_date)
 ```
 
 ### List secrets
-[list_properties_of_secrets](https://aka.ms/azsdk-python-keyvault-secrets-list-properties-secrets-ref) lists the
-properties of all of the secrets in the client's vault. This list doesn't include the secret's values.
+[list_properties_of_secrets](https://aka.ms/azsdk/python/keyvault-secrets/docs#azure.keyvault.secrets.SecretClient.list_properties_of_secrets)
+lists the properties of all of the secrets in the client's vault. This list doesn't include the secret's values.
 
 ```python
 from azure.identity import DefaultAzureCredential
@@ -279,8 +281,8 @@ async with client:
 ```
 
 ### Asynchronously create a secret
-[set_secret](https://aka.ms/azsdk-python-keyvault-secrets-async-set-secret-ref) creates a secret in the Key Vault with the
-specified optional arguments.
+[set_secret](https://aka.ms/azsdk/python/keyvault-secrets/aio/docs#azure.keyvault.secrets.aio.SecretClient.set_secret)
+creates a secret in the Key Vault with the specified optional arguments.
 ```python
 from azure.identity.aio import DefaultAzureCredential
 from azure.keyvault.secrets.aio import SecretClient
@@ -296,8 +298,8 @@ print(secret.properties.version)
 ```
 
 ### Asynchronously list secrets
-[list_properties_of_secrets](https://aka.ms/azsdk-python-keyvault-secrets-async-list-properties-secrets-ref) lists the
-properties of all of the secrets in the client's vault.
+[list_properties_of_secrets](https://aka.ms/azsdk/python/keyvault-secrets/aio/docs#azure.keyvault.secrets.aio.SecretClient.list_properties_of_secrets)
+lists the properties of all of the secrets in the client's vault.
 
 ```python
 from azure.identity.aio import DefaultAzureCredential
@@ -406,7 +408,7 @@ additional questions or comments.
 [azure_identity_pypi]: https://pypi.org/project/azure-identity/
 [azure_sub]: https://azure.microsoft.com/free/
 [code_of_conduct]: https://opensource.microsoft.com/codeofconduct/
-[default_cred_ref]: https://aka.ms/azsdk-python-identity-default-cred-ref
+[default_cred_ref]: https://aka.ms/azsdk/python/identity/docs#azure.identity.DefaultAzureCredential
 [hello_world_sample]: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/keyvault/azure-keyvault-secrets/samples/hello_world.py
 [hello_world_async_sample]: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/keyvault/azure-keyvault-secrets/samples/hello_world_async.py
 [backup_operations_sample]: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/keyvault/azure-keyvault-secrets/samples/backup_restore_operations.py
@@ -418,12 +420,10 @@ additional questions or comments.
 [keyvault_docs]: https://docs.microsoft.com/en-us/azure/key-vault/
 [pip]: https://pypi.org/project/pip/
 [pypi_package_secrets]: https://pypi.org/project/azure-keyvault-secrets/
-[reference_docs]: https://aka.ms/azsdk-python-keyvault-secrets-ref
+[reference_docs]: https://aka.ms/azsdk/python/keyvault-secrets/docs
 [secret_client_src]: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets
-[secret_client_docs]: https://aka.ms/azsdk-python-keyvault-secrets-secretclient
+[secret_client_docs]: https://aka.ms/azsdk/python/keyvault-secrets/docs#azure.keyvault.secrets.SecretClient
 [secret_samples]: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-secrets/samples
 [soft_delete]: https://docs.microsoft.com/en-us/azure/key-vault/key-vault-ovw-soft-delete
-[test_examples_secrets]: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
-[test_example_secrets_async]: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-python%2Fsdk%2Fkeyvault%2Fazure-keyvault-secrets%2FFREADME.png)


### PR DESCRIPTION
Main goal is to use a minimal number of aka.ms links, and have those links meet our documentation guidelines.