### PR TITLE
[ServiceBus] remove settled property on PeekMessage and ReceivedMessage

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -20,7 +20,8 @@
   - Removed instance variable `header`.
 
 * Removed several properties and instance variables on PeekMessage and ReceivedMessage.
-  - Removed proeprty `partition_id` on both type.
+  - Removed property `partition_id` on both type.
+  - Removed property `settled` on both type.
   - Removed instance variable `received_timestamp_utc` on both type.
   - Removed property `settled` on `PeekMessage`.
   - Removed property `expired` on `ReceivedMessage`.

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/message.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/message.py
@@ -878,16 +878,6 @@ class ReceivedMessageBase(PeekMessage):
             self._expiry = utc_from_timestamp(expiry_in_seconds)
         return self._expiry
 
-    @property
-    def settled(self):
-        # type: () -> bool
-        """Whether the message has been settled.
-        This will aways be `True` for a message received using ReceiveAndDelete mode,
-        otherwise it will be `False` until the message is completed or otherwise settled.
-        :rtype: bool
-        """
-        return self._settled
-
 
 class ReceivedMessage(ReceivedMessageBase):
     def _settle_message(


### PR DESCRIPTION
we decided to remove the property in preview 5 and may bring it back as post-GA feature, see issue: https://github.com/Azure/azure-sdk-for-python/issues/12849