### PR TITLE
[text analytics] remove batch prefix

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_request_handlers.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_request_handlers.py
@@ -13,7 +13,7 @@ from ._models import (
 )
 
 
-def _validate_batch_input(documents, hint, whole_batch_hint):
+def _validate_input(documents, hint, whole_input_hint):
     """Validate that batch input has either all string docs
     or dict/DetectLanguageInput/TextDocumentInput, not a mix of both.
     Assign country and language hints on a whole batch or per-item
@@ -39,26 +39,26 @@ def _validate_batch_input(documents, hint, whole_batch_hint):
     request_batch = []
     for idx, doc in enumerate(documents):
         if isinstance(doc, six.string_types):
-            if hint == "country_hint" and whole_batch_hint.lower() == "none":
-                whole_batch_hint = ""
-            document = {"id": str(idx), hint: whole_batch_hint, "text": doc}
+            if hint == "country_hint" and whole_input_hint.lower() == "none":
+                whole_input_hint = ""
+            document = {"id": str(idx), hint: whole_input_hint, "text": doc}
             request_batch.append(document)
         if isinstance(doc, dict):
             item_hint = doc.get(hint, None)
             if item_hint is None:
-                doc = {"id": doc.get("id", None), hint: whole_batch_hint, "text": doc.get("text", None)}
+                doc = {"id": doc.get("id", None), hint: whole_input_hint, "text": doc.get("text", None)}
             elif item_hint.lower() == "none":
                 doc = {"id": doc.get("id", None), hint: "", "text": doc.get("text", None)}
             request_batch.append(doc)
         if isinstance(doc, TextDocumentInput):
             item_hint = doc.language
             if item_hint is None:
-                doc = TextDocumentInput(id=doc.id, language=whole_batch_hint, text=doc.text)
+                doc = TextDocumentInput(id=doc.id, language=whole_input_hint, text=doc.text)
             request_batch.append(doc)
         if isinstance(doc, DetectLanguageInput):
             item_hint = doc.country_hint
             if item_hint is None:
-                doc = DetectLanguageInput(id=doc.id, country_hint=whole_batch_hint, text=doc.text)
+                doc = DetectLanguageInput(id=doc.id, country_hint=whole_input_hint, text=doc.text)
             elif item_hint.lower() == "none":
                 doc = DetectLanguageInput(id=doc.id, country_hint="", text=doc.text)
             request_batch.append(doc)

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_response_handlers.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_response_handlers.py
@@ -57,7 +57,7 @@ class CSODataV4Format(ODataV4Format):
             super(CSODataV4Format, self).__init__(odata_error)
 
 
-def process_batch_error(error):
+def process_http_response_error(error):
     """Raise detailed error message.
     """
     raise_error = HttpResponseError

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
@@ -17,7 +17,7 @@ from azure.core.exceptions import HttpResponseError
 from ._base_client import TextAnalyticsClientBase
 from ._request_handlers import _validate_input
 from ._response_handlers import (
-    process_batch_error,
+    process_http_response_error,
     entities_result,
     linked_entities_result,
     key_phrases_result,
@@ -157,7 +157,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                 **kwargs
             )
         except HttpResponseError as error:
-            process_batch_error(error)
+            process_http_response_error(error)
 
     @distributed_trace
     def recognize_entities(  # type: ignore
@@ -222,7 +222,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                 **kwargs
             )
         except HttpResponseError as error:
-            process_batch_error(error)
+            process_http_response_error(error)
 
     @distributed_trace
     def recognize_pii_entities(  # type: ignore
@@ -293,7 +293,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                 )
             raise error
         except HttpResponseError as error:
-            process_batch_error(error)
+            process_http_response_error(error)
 
     @distributed_trace
     def recognize_linked_entities(  # type: ignore
@@ -359,7 +359,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                 **kwargs
             )
         except HttpResponseError as error:
-            process_batch_error(error)
+            process_http_response_error(error)
 
     @distributed_trace
     def extract_key_phrases(  # type: ignore
@@ -425,7 +425,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                 **kwargs
             )
         except HttpResponseError as error:
-            process_batch_error(error)
+            process_http_response_error(error)
 
     @distributed_trace
     def analyze_sentiment(  # type: ignore
@@ -508,4 +508,4 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                 )
             raise error
         except HttpResponseError as error:
-            process_batch_error(error)
+            process_http_response_error(error)

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
@@ -137,8 +137,8 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         .. admonition:: Example:
 
             .. literalinclude:: ../samples/sample_detect_language.py
-                :start-after: [START batch_detect_language]
-                :end-before: [END batch_detect_language]
+                :start-after: [START detect_language]
+                :end-before: [END detect_language]
                 :language: python
                 :dedent: 8
                 :caption: Detecting language in a batch of documents.
@@ -202,8 +202,8 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         .. admonition:: Example:
 
             .. literalinclude:: ../samples/sample_recognize_entities.py
-                :start-after: [START batch_recognize_entities]
-                :end-before: [END batch_recognize_entities]
+                :start-after: [START recognize_entities]
+                :end-before: [END recognize_entities]
                 :language: python
                 :dedent: 8
                 :caption: Recognize entities in a batch of documents.
@@ -267,8 +267,8 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         .. admonition:: Example:
 
             .. literalinclude:: ../samples/sample_recognize_pii_entities.py
-                :start-after: [START batch_recognize_pii_entities]
-                :end-before: [END batch_recognize_pii_entities]
+                :start-after: [START recognize_pii_entities]
+                :end-before: [END recognize_pii_entities]
                 :language: python
                 :dedent: 8
                 :caption: Recognize personally identifiable information entities in a batch of documents.
@@ -339,8 +339,8 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         .. admonition:: Example:
 
             .. literalinclude:: ../samples/sample_recognize_linked_entities.py
-                :start-after: [START batch_recognize_linked_entities]
-                :end-before: [END batch_recognize_linked_entities]
+                :start-after: [START recognize_linked_entities]
+                :end-before: [END recognize_linked_entities]
                 :language: python
                 :dedent: 8
                 :caption: Recognize linked entities in a batch of documents.
@@ -405,8 +405,8 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         .. admonition:: Example:
 
             .. literalinclude:: ../samples/sample_extract_key_phrases.py
-                :start-after: [START batch_extract_key_phrases]
-                :end-before: [END batch_extract_key_phrases]
+                :start-after: [START extract_key_phrases]
+                :end-before: [END extract_key_phrases]
                 :language: python
                 :dedent: 8
                 :caption: Extract the key phrases in a batch of documents.
@@ -478,8 +478,8 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         .. admonition:: Example:
 
             .. literalinclude:: ../samples/sample_analyze_sentiment.py
-                :start-after: [START batch_analyze_sentiment]
-                :end-before: [END batch_analyze_sentiment]
+                :start-after: [START analyze_sentiment]
+                :end-before: [END analyze_sentiment]
                 :language: python
                 :dedent: 8
                 :caption: Analyze sentiment in a batch of documents.

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
@@ -15,7 +15,7 @@ from typing import (  # pylint: disable=unused-import
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.exceptions import HttpResponseError
 from ._base_client import TextAnalyticsClientBase
-from ._request_handlers import _validate_batch_input
+from ._request_handlers import _validate_input
 from ._response_handlers import (
     process_batch_error,
     entities_result,
@@ -145,7 +145,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         """
         country_hint_arg = kwargs.pop("country_hint", None)
         country_hint = country_hint_arg if country_hint_arg is not None else self._default_country_hint
-        docs = _validate_batch_input(documents, "country_hint", country_hint)
+        docs = _validate_input(documents, "country_hint", country_hint)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
         try:
@@ -210,7 +210,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         """
         language_arg = kwargs.pop("language", None)
         language = language_arg if language_arg is not None else self._default_language
-        docs = _validate_batch_input(documents, "language", language)
+        docs = _validate_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
         try:
@@ -275,7 +275,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         """
         language_arg = kwargs.pop("language", None)
         language = language_arg if language_arg is not None else self._default_language
-        docs = _validate_batch_input(documents, "language", language)
+        docs = _validate_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
         try:
@@ -347,7 +347,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         """
         language_arg = kwargs.pop("language", None)
         language = language_arg if language_arg is not None else self._default_language
-        docs = _validate_batch_input(documents, "language", language)
+        docs = _validate_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
         try:
@@ -413,7 +413,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         """
         language_arg = kwargs.pop("language", None)
         language = language_arg if language_arg is not None else self._default_language
-        docs = _validate_batch_input(documents, "language", language)
+        docs = _validate_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
         try:
@@ -486,7 +486,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         """
         language_arg = kwargs.pop("language", None)
         language = language_arg if language_arg is not None else self._default_language
-        docs = _validate_batch_input(documents, "language", language)
+        docs = _validate_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
         show_opinion_mining = kwargs.pop("show_opinion_mining", None)

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
@@ -17,7 +17,7 @@ from azure.core.exceptions import HttpResponseError
 from ._base_client_async import AsyncTextAnalyticsClientBase
 from .._request_handlers import _validate_input
 from .._response_handlers import (
-    process_batch_error,
+    process_http_response_error,
     entities_result,
     linked_entities_result,
     key_phrases_result,
@@ -161,7 +161,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                 **kwargs
             )
         except HttpResponseError as error:
-            process_batch_error(error)
+            process_http_response_error(error)
 
     @distributed_trace_async
     async def recognize_entities(  # type: ignore
@@ -225,7 +225,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                 **kwargs
             )
         except HttpResponseError as error:
-            process_batch_error(error)
+            process_http_response_error(error)
 
     @distributed_trace_async
     async def recognize_pii_entities(  # type: ignore
@@ -295,7 +295,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                 )
             raise error
         except HttpResponseError as error:
-            process_batch_error(error)
+            process_http_response_error(error)
 
     @distributed_trace_async
     async def recognize_linked_entities(  # type: ignore
@@ -360,7 +360,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                 **kwargs
             )
         except HttpResponseError as error:
-            process_batch_error(error)
+            process_http_response_error(error)
 
     @distributed_trace_async
     async def extract_key_phrases(  # type: ignore
@@ -425,7 +425,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                 **kwargs
             )
         except HttpResponseError as error:
-            process_batch_error(error)
+            process_http_response_error(error)
 
     @distributed_trace_async
     async def analyze_sentiment(  # type: ignore
@@ -508,4 +508,4 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                 )
             raise error
         except HttpResponseError as error:
-            process_batch_error(error)
+            process_http_response_error(error)

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
@@ -141,8 +141,8 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         .. admonition:: Example:
 
             .. literalinclude:: ../samples/async_samples/sample_detect_language_async.py
-                :start-after: [START batch_detect_language_async]
-                :end-before: [END batch_detect_language_async]
+                :start-after: [START detect_language_async]
+                :end-before: [END detect_language_async]
                 :language: python
                 :dedent: 8
                 :caption: Detecting language in a batch of documents.
@@ -205,8 +205,8 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         .. admonition:: Example:
 
             .. literalinclude:: ../samples/async_samples/sample_recognize_entities_async.py
-                :start-after: [START batch_recognize_entities_async]
-                :end-before: [END batch_recognize_entities_async]
+                :start-after: [START recognize_entities_async]
+                :end-before: [END recognize_entities_async]
                 :language: python
                 :dedent: 8
                 :caption: Recognize entities in a batch of documents.
@@ -269,8 +269,8 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         .. admonition:: Example:
 
             .. literalinclude:: ../samples/sample_recognize_pii_entities.py
-                :start-after: [START batch_recognize_pii_entities]
-                :end-before: [END batch_recognize_pii_entities]
+                :start-after: [START recognize_pii_entities]
+                :end-before: [END recognize_pii_entities]
                 :language: python
                 :dedent: 8
                 :caption: Recognize personally identifiable information entities in a batch of documents.
@@ -340,8 +340,8 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         .. admonition:: Example:
 
             .. literalinclude:: ../samples/async_samples/sample_recognize_linked_entities_async.py
-                :start-after: [START batch_recognize_linked_entities_async]
-                :end-before: [END batch_recognize_linked_entities_async]
+                :start-after: [START recognize_linked_entities_async]
+                :end-before: [END recognize_linked_entities_async]
                 :language: python
                 :dedent: 8
                 :caption: Recognize linked entities in a batch of documents.
@@ -405,8 +405,8 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         .. admonition:: Example:
 
             .. literalinclude:: ../samples/async_samples/sample_extract_key_phrases_async.py
-                :start-after: [START batch_extract_key_phrases_async]
-                :end-before: [END batch_extract_key_phrases_async]
+                :start-after: [START extract_key_phrases_async]
+                :end-before: [END extract_key_phrases_async]
                 :language: python
                 :dedent: 8
                 :caption: Extract the key phrases in a batch of documents.
@@ -477,8 +477,8 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         .. admonition:: Example:
 
             .. literalinclude:: ../samples/async_samples/sample_analyze_sentiment_async.py
-                :start-after: [START batch_analyze_sentiment_async]
-                :end-before: [END batch_analyze_sentiment_async]
+                :start-after: [START analyze_sentiment_async]
+                :end-before: [END analyze_sentiment_async]
                 :language: python
                 :dedent: 8
                 :caption: Analyze sentiment in a batch of documents.

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
@@ -15,7 +15,7 @@ from typing import (  # pylint: disable=unused-import
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.core.exceptions import HttpResponseError
 from ._base_client_async import AsyncTextAnalyticsClientBase
-from .._request_handlers import _validate_batch_input
+from .._request_handlers import _validate_input
 from .._response_handlers import (
     process_batch_error,
     entities_result,
@@ -149,7 +149,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         """
         country_hint_arg = kwargs.pop("country_hint", None)
         country_hint = country_hint_arg if country_hint_arg is not None else self._default_country_hint
-        docs = _validate_batch_input(documents, "country_hint", country_hint)
+        docs = _validate_input(documents, "country_hint", country_hint)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
         try:
@@ -213,7 +213,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         """
         language_arg = kwargs.pop("language", None)
         language = language_arg if language_arg is not None else self._default_language
-        docs = _validate_batch_input(documents, "language", language)
+        docs = _validate_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
         try:
@@ -277,7 +277,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         """
         language_arg = kwargs.pop("language", None)
         language = language_arg if language_arg is not None else self._default_language
-        docs = _validate_batch_input(documents, "language", language)
+        docs = _validate_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
         try:
@@ -348,7 +348,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         """
         language_arg = kwargs.pop("language", None)
         language = language_arg if language_arg is not None else self._default_language
-        docs = _validate_batch_input(documents, "language", language)
+        docs = _validate_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
         try:
@@ -413,7 +413,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         """
         language_arg = kwargs.pop("language", None)
         language = language_arg if language_arg is not None else self._default_language
-        docs = _validate_batch_input(documents, "language", language)
+        docs = _validate_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
         try:
@@ -485,7 +485,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         """
         language_arg = kwargs.pop("language", None)
         language = language_arg if language_arg is not None else self._default_language
-        docs = _validate_batch_input(documents, "language", language)
+        docs = _validate_input(documents, "language", language)
         model_version = kwargs.pop("model_version", None)
         show_stats = kwargs.pop("show_stats", False)
         show_opinion_mining = kwargs.pop("show_opinion_mining", None)

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_analyze_sentiment_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_analyze_sentiment_async.py
@@ -28,7 +28,7 @@ import asyncio
 class AnalyzeSentimentSampleAsync(object):
 
     async def analyze_sentiment_async(self):
-        # [START batch_analyze_sentiment_async]
+        # [START analyze_sentiment_async]
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.textanalytics.aio import TextAnalyticsClient
 
@@ -51,7 +51,7 @@ class AnalyzeSentimentSampleAsync(object):
         for idx, doc in enumerate(docs):
             print("Document text: {}".format(documents[idx]))
             print("Overall sentiment: {}".format(doc.sentiment))
-        # [END batch_analyze_sentiment_async]
+        # [END analyze_sentiment_async]
             print("Overall confidence scores: positive={}; neutral={}; negative={} \n".format(
                 doc.confidence_scores.positive,
                 doc.confidence_scores.neutral,

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_detect_language_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_detect_language_async.py
@@ -31,7 +31,7 @@ class DetectLanguageSampleAsync(object):
     key = os.environ["AZURE_TEXT_ANALYTICS_KEY"]
 
     async def detect_language_async(self):
-        # [START batch_detect_language_async]
+        # [START detect_language_async]
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.textanalytics.aio import TextAnalyticsClient
 
@@ -57,7 +57,7 @@ class DetectLanguageSampleAsync(object):
                 print("Confidence score: {}\n".format(doc.primary_language.confidence_score))
             if doc.is_error:
                 print(doc.id, doc.error)
-        # [END batch_detect_language_async]
+        # [END detect_language_async]
 
 
 async def main():

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_extract_key_phrases_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_extract_key_phrases_async.py
@@ -27,7 +27,7 @@ import asyncio
 class ExtractKeyPhrasesSampleAsync(object):
 
     async def extract_key_phrases_async(self):
-        # [START batch_extract_key_phrases_async]
+        # [START extract_key_phrases_async]
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.textanalytics.aio import TextAnalyticsClient
 
@@ -49,7 +49,7 @@ class ExtractKeyPhrasesSampleAsync(object):
                 print(doc.key_phrases)
             if doc.is_error:
                 print(doc.id, doc.error)
-        # [END batch_extract_key_phrases_async]
+        # [END extract_key_phrases_async]
 
 
 async def main():

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_entities_async.py
@@ -27,7 +27,7 @@ import asyncio
 class RecognizeEntitiesSampleAsync(object):
 
     async def recognize_entities_async(self):
-        # [START batch_recognize_entities_async]
+        # [START recognize_entities_async]
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.textanalytics.aio import TextAnalyticsClient
 
@@ -51,7 +51,7 @@ class RecognizeEntitiesSampleAsync(object):
             for entity in doc.entities:
                 print("Entity: \t", entity.text, "\tCategory: \t", entity.category,
                       "\tConfidence Score: \t", entity.confidence_score)
-        # [END batch_recognize_entities_async]
+        # [END recognize_entities_async]
 
 
 async def main():

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_linked_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_linked_entities_async.py
@@ -29,7 +29,7 @@ import asyncio
 class RecognizeLinkedEntitiesSampleAsync(object):
 
     async def recognize_linked_entities_async(self):
-        # [START batch_recognize_linked_entities_async]
+        # [START recognize_linked_entities_async]
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.textanalytics.aio import TextAnalyticsClient
 
@@ -58,7 +58,7 @@ class RecognizeLinkedEntitiesSampleAsync(object):
                     print("Confidence Score: {}".format(match.confidence_score))
                     print("Entity as appears in request: {}".format(match.text))
             print("------------------------------------------")
-        # [END batch_recognize_linked_entities_async]
+        # [END recognize_linked_entities_async]
 
 
 async def main():

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_pii_entities_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/async_samples/sample_recognize_pii_entities_async.py
@@ -28,7 +28,7 @@ import asyncio
 class RecognizePiiEntitiesSampleAsync(object):
 
     async def recognize_pii_entities_async(self):
-        # [START batch_recognize_pii_entities_async]
+        # [START recognize_pii_entities_async]
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.textanalytics import ApiVersion
         from azure.ai.textanalytics.aio import TextAnalyticsClient
@@ -56,7 +56,7 @@ class RecognizePiiEntitiesSampleAsync(object):
                 print("Entity: {}".format(entity.text))
                 print("Category: {}".format(entity.category))
                 print("Confidence Score: {}\n".format(entity.confidence_score))
-        # [END batch_recognize_pii_entities_async]
+        # [END recognize_pii_entities_async]
 
 
 async def main():

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_analyze_sentiment.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_analyze_sentiment.py
@@ -27,7 +27,7 @@ import os
 class AnalyzeSentimentSample(object):
 
     def analyze_sentiment(self):
-        # [START batch_analyze_sentiment]
+        # [START analyze_sentiment]
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.textanalytics import TextAnalyticsClient
 
@@ -48,7 +48,7 @@ class AnalyzeSentimentSample(object):
         for idx, doc in enumerate(docs):
             print("Document text: {}".format(documents[idx]))
             print("Overall sentiment: {}".format(doc.sentiment))
-        # [END batch_analyze_sentiment]
+        # [END analyze_sentiment]
             print("Overall confidence scores: positive={}; neutral={}; negative={} \n".format(
                 doc.confidence_scores.positive,
                 doc.confidence_scores.neutral,

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_detect_language.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_detect_language.py
@@ -27,7 +27,7 @@ import os
 class DetectLanguageSample(object):
 
     def detect_language(self):
-        # [START batch_detect_language]
+        # [START detect_language]
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.textanalytics import TextAnalyticsClient
 
@@ -53,7 +53,7 @@ class DetectLanguageSample(object):
                 print("Confidence score: {}\n".format(doc.primary_language.confidence_score))
             if doc.is_error:
                 print(doc.id, doc.error)
-        # [END batch_detect_language]
+        # [END detect_language]
 
 
 if __name__ == '__main__':

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_extract_key_phrases.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_extract_key_phrases.py
@@ -26,7 +26,7 @@ import os
 class ExtractKeyPhrasesSample(object):
 
     def extract_key_phrases(self):
-        # [START batch_extract_key_phrases]
+        # [START extract_key_phrases]
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.textanalytics import TextAnalyticsClient
 
@@ -46,7 +46,7 @@ class ExtractKeyPhrasesSample(object):
                 print(doc.key_phrases)
             if doc.is_error:
                 print(doc.id, doc.error)
-        # [END batch_extract_key_phrases]
+        # [END extract_key_phrases]
 
 
 if __name__ == '__main__':

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_entities.py
@@ -26,7 +26,7 @@ import os
 class RecognizeEntitiesSample(object):
 
     def recognize_entities(self):
-        # [START batch_recognize_entities]
+        # [START recognize_entities]
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.textanalytics import TextAnalyticsClient
 
@@ -48,7 +48,7 @@ class RecognizeEntitiesSample(object):
             for entity in doc.entities:
                 print("Entity: \t", entity.text, "\tCategory: \t", entity.category,
                       "\tConfidence Score: \t", entity.confidence_score)
-        # [END batch_recognize_entities]
+        # [END recognize_entities]
 
 
 if __name__ == '__main__':

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_linked_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_linked_entities.py
@@ -28,7 +28,7 @@ import os
 class RecognizeLinkedEntitiesSample(object):
 
     def recognize_linked_entities(self):
-        # [START batch_recognize_linked_entities]
+        # [START recognize_linked_entities]
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.textanalytics import TextAnalyticsClient
 
@@ -55,7 +55,7 @@ class RecognizeLinkedEntitiesSample(object):
                     print("Confidence Score: {}".format(match.confidence_score))
                     print("Entity as appears in request: {}".format(match.text))
             print("------------------------------------------")
-        # [END batch_recognize_linked_entities]
+        # [END recognize_linked_entities]
 
 
 if __name__ == '__main__':

--- a/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_pii_entities.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/samples/sample_recognize_pii_entities.py
@@ -27,7 +27,7 @@ import os
 class RecognizePiiEntitiesSample(object):
 
     def recognize_pii_entities(self):
-        # [START batch_recognize_pii_entities]
+        # [START recognize_pii_entities]
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.textanalytics import TextAnalyticsClient, ApiVersion
 
@@ -52,7 +52,7 @@ class RecognizePiiEntitiesSample(object):
                 print("Entity: {}".format(entity.text))
                 print("Category: {}".format(entity.category))
                 print("Confidence Score: {}\n".format(entity.confidence_score))
-        # [END batch_recognize_pii_entities]
+        # [END recognize_pii_entities]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fixes #12688 

I also took the liberty of renaming `validate_batch_input` and `process_batch_error`. I haven't renamed the tests since that seemed unnecessary. I've broken up each rename into its separate commit for easier viewing.

 Let me know if you disagree with any of my choices