### PR TITLE
[keyvault] add continuation token for key polling

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 4.2.0b3 (Unreleased)
+- All long running operation methods now accept a `continuation_token` keyword argument
+to restart the poller from a saved state
+
 ## 4.2.0b2 (Unreleased)
 - Values of `x-ms-keyvault-region` and `x-ms-keyvault-service-version` headers
   are no longer redacted in logging output.

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 4.2.0b3 (Unreleased)
-- All long running operation methods now accept a `continuation_token` keyword argument
+- All sync long running operation methods now accept a `continuation_token` keyword argument
 to restart the poller from a saved state
 
 ## 4.2.0b2 (Unreleased)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -208,7 +208,7 @@ class KeyClient(KeyVaultClientBase):
             polling_interval = 2
 
         if continuation_token:
-            deleted_key = pickle.loads(base64.b64decode(continuation_token))
+            deleted_key = pickle.loads(base64.b64decode(continuation_token))  # nosec
         else:
             deleted_key = DeletedKey._from_deleted_key_bundle(
                 self._client.delete_key(self.vault_url, name, error_map=_error_map, **kwargs)
@@ -412,7 +412,7 @@ class KeyClient(KeyVaultClientBase):
             polling_interval = 2
 
         if continuation_token:
-            recovered_key = pickle.loads(base64.b64decode(continuation_token))
+            recovered_key = pickle.loads(base64.b64decode(continuation_token))  # nosec
         else:
             recovered_key = KeyVaultKey._from_key_bundle(
                 self._client.recover_deleted_key(

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import pickle
+import base64
 from functools import partial
 from azure.core.tracing.decorator import distributed_trace
 
@@ -181,6 +183,7 @@ class KeyClient(KeyVaultClientBase):
         with soft-delete enabled. This method therefore returns a poller enabling you to wait for deletion to complete.
 
         :param str name: The name of the key to delete.
+        :keyword str continuation_token: A continuation token to restart the poller from a saved state.
         :returns: A poller for the delete key operation. The poller's `result` method returns the
          :class:`~azure.keyvault.keys.DeletedKey` without waiting for deletion to complete. If the vault has
          soft-delete enabled and you want to permanently delete the key with :func:`purge_deleted_key`, call the
@@ -200,11 +203,16 @@ class KeyClient(KeyVaultClientBase):
                 :dedent: 8
         """
         polling_interval = kwargs.pop("_polling_interval", None)
+        continuation_token = kwargs.pop("continuation_token", None)
         if polling_interval is None:
             polling_interval = 2
-        deleted_key = DeletedKey._from_deleted_key_bundle(
-            self._client.delete_key(self.vault_url, name, error_map=_error_map, **kwargs)
-        )
+
+        if continuation_token:
+            deleted_key = pickle.loads(base64.b64decode(continuation_token))
+        else:
+            deleted_key = DeletedKey._from_deleted_key_bundle(
+                self._client.delete_key(self.vault_url, name, error_map=_error_map, **kwargs)
+            )
 
         command = partial(self.get_deleted_key, name=name, **kwargs)
         polling_method = DeleteRecoverPollingMethod(
@@ -214,6 +222,9 @@ class KeyClient(KeyVaultClientBase):
             final_resource=deleted_key,
             interval=polling_interval,
         )
+
+        if continuation_token:
+            return KeyVaultOperationPoller.from_continuation_token(polling_method)
         return KeyVaultOperationPoller(polling_method)
 
     @distributed_trace
@@ -379,6 +390,7 @@ class KeyClient(KeyVaultClientBase):
         you want to use the recovered key in another operation immediately.
 
         :param str name: The name of the deleted key to recover
+        :keyword str continuation_token: A continuation token to restart the poller from a saved state.
         :returns: A poller for the recovery operation. The poller's `result` method returns the recovered
          :class:`~azure.keyvault.keys.KeyVaultKey` without waiting for recovery to complete. If you want to use the
          recovered key immediately, call the poller's `wait` method, which blocks until the key is ready to use. The
@@ -395,17 +407,25 @@ class KeyClient(KeyVaultClientBase):
                 :dedent: 8
         """
         polling_interval = kwargs.pop("_polling_interval", None)
+        continuation_token = kwargs.pop("continuation_token", None)
         if polling_interval is None:
             polling_interval = 2
-        recovered_key = KeyVaultKey._from_key_bundle(
-            self._client.recover_deleted_key(
-                vault_base_url=self.vault_url, key_name=name, error_map=_error_map, **kwargs
+
+        if continuation_token:
+            recovered_key = pickle.loads(base64.b64decode(continuation_token))
+        else:
+            recovered_key = KeyVaultKey._from_key_bundle(
+                self._client.recover_deleted_key(
+                    vault_base_url=self.vault_url, key_name=name, error_map=_error_map, **kwargs
+                )
             )
-        )
         command = partial(self.get_key, name=name, **kwargs)
         polling_method = DeleteRecoverPollingMethod(
             finished=False, command=command, final_resource=recovered_key, interval=polling_interval,
         )
+
+        if continuation_token:
+            return KeyVaultOperationPoller.from_continuation_token(polling_method)
 
         return KeyVaultOperationPoller(polling_method)
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -183,7 +183,8 @@ class KeyClient(KeyVaultClientBase):
         with soft-delete enabled. This method therefore returns a poller enabling you to wait for deletion to complete.
 
         :param str name: The name of the key to delete.
-        :keyword str continuation_token: A continuation token to restart the poller from a saved state.
+        :keyword str continuation_token: A continuation token to restart the poller from a saved state. To get the
+         continuation token from your poller, call `continuation_token()` on the poller.
         :returns: A poller for the delete key operation. The poller's `result` method returns the
          :class:`~azure.keyvault.keys.DeletedKey` without waiting for deletion to complete. If the vault has
          soft-delete enabled and you want to permanently delete the key with :func:`purge_deleted_key`, call the
@@ -390,7 +391,8 @@ class KeyClient(KeyVaultClientBase):
         you want to use the recovered key in another operation immediately.
 
         :param str name: The name of the deleted key to recover
-        :keyword str continuation_token: A continuation token to restart the poller from a saved state.
+        :keyword str continuation_token: A continuation token to restart the poller from a saved state. To get the
+         continuation token from your poller, call `continuation_token()` on the poller.
         :returns: A poller for the recovery operation. The poller's `result` method returns the recovered
          :class:`~azure.keyvault.keys.KeyVaultKey` without waiting for recovery to complete. If you want to use the
          recovered key immediately, call the poller's `wait` method, which blocks until the key is ready to use. The

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/__init__.py
@@ -15,6 +15,7 @@ from .client_base import KeyVaultClientBase
 from .http_challenge import HttpChallenge
 from . import http_challenge_cache as HttpChallengeCache
 
+VaultId = namedtuple("VaultId", ["vault_url", "collection", "name", "version"])
 
 __all__ = [
     "ChallengeAuthPolicy",
@@ -22,9 +23,8 @@ __all__ = [
     "HttpChallenge",
     "HttpChallengeCache",
     "KeyVaultClientBase",
+    "VaultId",
 ]
-
-_VaultId = namedtuple("VaultId", ["vault_url", "collection", "name", "version"])
 
 
 def parse_vault_id(url):
@@ -40,7 +40,7 @@ def parse_vault_id(url):
     if len(path) < 2 or len(path) > 3:
         raise ValueError("'{}' is not not a valid vault url".format(url))
 
-    return _VaultId(
+    return VaultId(
         vault_url="{}://{}".format(parsed_uri.scheme, parsed_uri.hostname),
         collection=path[0],
         name=path[1],

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/_polling.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/_polling.py
@@ -6,6 +6,7 @@ import logging
 import time
 import threading
 import uuid
+import base64
 from typing import TYPE_CHECKING
 
 from azure.core.polling import PollingMethod, LROPoller, NoPolling
@@ -32,7 +33,7 @@ class KeyVaultOperationPoller(LROPoller):
 
     # pylint: disable=arguments-differ
     def __init__(self, polling_method):
-        # type: (PollingMethod) -> None
+        # type: (DeleteRecoverPollingMethod) -> None
         super(KeyVaultOperationPoller, self).__init__(None, None, None, NoPolling())
         self._polling_method = polling_method
 
@@ -75,6 +76,10 @@ class KeyVaultOperationPoller(LROPoller):
         except TypeError:  # Was None
             pass
 
+    @classmethod
+    def from_continuation_token(cls, polling_method, **kwargs):
+        # type: (DeleteRecoverPollingMethod, Any) -> KeyVaultOperationPoller
+        return cls(polling_method)
 
 class DeleteRecoverPollingMethod(PollingMethod):
     """Poller for deleting resources, and recovering deleted resources, in vaults with soft-delete enabled.
@@ -133,3 +138,8 @@ class DeleteRecoverPollingMethod(PollingMethod):
     def status(self):
         # type: () -> str
         return "finished" if self._finished else "polling"
+
+    def get_continuation_token(self):
+        # type() -> str
+        import pickle
+        return base64.b64encode(pickle.dumps(self._resource)).decode('ascii')

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_continuation_token.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_continuation_token.yaml
@@ -1,0 +1,662 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/ec-key/create?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
+        or PoP token."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '87'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 15:43:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"kty": "EC"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/ec-key/create?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-key/a0e525f7b37c48e8906484fd5378bccf","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"XInMv0owFPioKokwmPNOEQs2555ViKmoAog9F_ZxJvs","y":"aduS9AapF3SV4g7ZVY3xJE4FpeI9gDTyM746dzGpYK8"},"attributes":{"enabled":true,"created":1596642234,"updated":1596642234,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '397'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 15:43:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: DELETE
+    uri: https://vaultname.vault.azure.net/keys/ec-key?api-version=7.1
+  response:
+    body:
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/ec-key","deletedDate":1596642234,"scheduledPurgeDate":1604418234,"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-key/a0e525f7b37c48e8906484fd5378bccf","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"XInMv0owFPioKokwmPNOEQs2555ViKmoAog9F_ZxJvs","y":"aduS9AapF3SV4g7ZVY3xJE4FpeI9gDTyM746dzGpYK8"},"attributes":{"enabled":true,"created":1596642234,"updated":1596642234,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '537'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 15:43:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/ec-key?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: ec-key"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '74'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 15:43:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/ec-key?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: ec-key"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '74'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 15:43:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/ec-key?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: ec-key"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '74'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 15:43:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/ec-key?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: ec-key"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '74'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 15:44:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/ec-key?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: ec-key"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '74'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 15:44:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/ec-key?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: ec-key"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '74'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 15:44:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/ec-key?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"KeyNotFound","message":"Deleted Key not found: ec-key"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '74'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 15:44:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedkeys/ec-key?api-version=7.1
+  response:
+    body:
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedkeys/ec-key","deletedDate":1596642234,"scheduledPurgeDate":1604418234,"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-key/a0e525f7b37c48e8906484fd5378bccf","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"XInMv0owFPioKokwmPNOEQs2555ViKmoAog9F_ZxJvs","y":"aduS9AapF3SV4g7ZVY3xJE4FpeI9gDTyM746dzGpYK8"},"attributes":{"enabled":true,"created":1596642234,"updated":1596642234,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '537'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 15:44:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://vaultname.vault.azure.net/deletedkeys/ec-key/recover?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-key/a0e525f7b37c48e8906484fd5378bccf","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"XInMv0owFPioKokwmPNOEQs2555ViKmoAog9F_ZxJvs","y":"aduS9AapF3SV4g7ZVY3xJE4FpeI9gDTyM746dzGpYK8"},"attributes":{"enabled":true,"created":1596642234,"updated":1596642234,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '397'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 15:44:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/ec-key/?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-key/a0e525f7b37c48e8906484fd5378bccf","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"XInMv0owFPioKokwmPNOEQs2555ViKmoAog9F_ZxJvs","y":"aduS9AapF3SV4g7ZVY3xJE4FpeI9gDTyM746dzGpYK8"},"attributes":{"enabled":true,"created":1596642234,"updated":1596642234,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '397'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 15:44:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/ec-key/?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/ec-key/a0e525f7b37c48e8906484fd5378bccf","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"XInMv0owFPioKokwmPNOEQs2555ViKmoAog9F_ZxJvs","y":"aduS9AapF3SV4g7ZVY3xJE4FpeI9gDTyM746dzGpYK8"},"attributes":{"enabled":true,"created":1596642234,"updated":1596642234,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '397'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 15:44:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -433,7 +433,8 @@ class KeyClientTests(KeyVaultTestCase):
     @KeyVaultClientPreparer()
     def test_continuation_token(self, client, **kwargs):
         # create key
-        key = client.create_ec_key("ec-key")
+        key_name = self.create_random_name("ec-key")
+        key = client.create_ec_key(key_name)
 
         # delete key
         initial_poller = client.begin_delete_key(key.name)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -421,3 +421,29 @@ class KeyClientTests(KeyVaultTestCase):
     @KeyVaultClientPreparer(client_kwargs={"custom_hook_policy": _CustomHookPolicy()})
     def test_custom_hook_policy(self, client, **kwargs):
         assert isinstance(client._client._config.custom_hook_policy, KeyClientTests._CustomHookPolicy)
+
+    @ResourceGroupPreparer(random_name_enabled=True)
+    @KeyVaultPreparer()
+    @KeyVaultClientPreparer()
+    def test_continuation_token(self, client, **kwargs):
+        # create key
+        key = client.create_ec_key("ec-key")
+
+        # delete key
+        initial_poller = client.begin_delete_key(key.name)
+        continuation_token = initial_poller.continuation_token()
+        poller = client.begin_delete_key(key.name, continuation_token=continuation_token)
+        deleted_key = poller.result()
+        self.assertIsNotNone(deleted_key)
+        poller.wait()
+
+        # recover deleted key
+        initial_poller = client.begin_recover_deleted_key(key.name)
+        continuation_token = initial_poller.continuation_token()
+        poller = client.begin_recover_deleted_key(key.name, continuation_token=continuation_token)
+        recovered_key = poller.result()
+        self.assertIsNotNone(recovered_key)
+        poller.wait()
+
+        retrieved_key = client.get_key(key.name)
+        self.assertEqual(retrieved_key.name, recovered_key.name)


### PR DESCRIPTION
fixes #12027 

For context: this PR is adding a continuation token functionality, so users can pickle their pollers and restart the polling from the state where they left off. These two pollers in key vault are also quite unique, the reason being that
1. They're not defined as long running on the service side
2. When we make the initial call to the service, the final response object, i.e. a deleted key is returned. However, it takes a while for the key to be fully deleted on the service side, so we poll until the service has fully deleted the key. We do allow users to immediately get the response object from the service though (our `result` function doesn't call `wait`)