### PR TITLE
[keyvault] add continuation token for secrets polling

### DIFF
--- a/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 4.2.0b3 (Unreleased)
+- All long running operation methods now accept a `continuation_token` keyword argument
+to restart the poller from a saved state
+
 ## 4.2.0b2 (Unreleased)
 - Values of `x-ms-keyvault-region` and `x-ms-keyvault-service-version` headers
   are no longer redacted in logging output.

--- a/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 4.2.0b3 (Unreleased)
-- All long running operation methods now accept a `continuation_token` keyword argument
+- All sync long running operation methods now accept a `continuation_token` keyword argument
 to restart the poller from a saved state
 
 ## 4.2.0b2 (Unreleased)

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
@@ -329,7 +329,7 @@ class SecretClient(KeyVaultClientBase):
             polling_interval = 2
 
         if continuation_token:
-            deleted_secret = pickle.loads(base64.b64decode(continuation_token))
+            deleted_secret = pickle.loads(base64.b64decode(continuation_token))  # nosec
         else:
             deleted_secret = DeletedSecret._from_deleted_secret_bundle(
                 self._client.delete_secret(self.vault_url, name, error_map=_error_map, **kwargs)
@@ -462,7 +462,7 @@ class SecretClient(KeyVaultClientBase):
             polling_interval = 2
 
         if continuation_token:
-            recovered_secret = pickle.loads(base64.b64decode(continuation_token))
+            recovered_secret = pickle.loads(base64.b64decode(continuation_token))  # nosec
         else:
             recovered_secret = SecretProperties._from_secret_bundle(
                 self._client.recover_deleted_secret(self.vault_url, name, error_map=_error_map, **kwargs)

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
@@ -303,7 +303,8 @@ class SecretClient(KeyVaultClientBase):
         with soft-delete enabled. This method therefore returns a poller enabling you to wait for deletion to complete.
 
         :param str name: Name of the secret to delete.
-        :keyword str continuation_token: A continuation token to restart the poller from a saved state.
+        :keyword str continuation_token: A continuation token to restart the poller from a saved state. To get the
+         continuation token from your poller, call `continuation_token()` on the poller.
         :returns: A poller for the delete operation. The poller's `result` method returns the
          :class:`~azure.keyvault.secrets.DeletedSecret` without waiting for deletion to complete. If the vault has
          soft-delete enabled and you want to permanently delete the secret with :func:`purge_deleted_secret`, call the
@@ -439,7 +440,8 @@ class SecretClient(KeyVaultClientBase):
         Requires the secrets/recover permission.
 
         :param str name: Name of the deleted secret to recover
-        :keyword str continuation_token: A continuation token to restart the poller from a saved state.
+        :keyword str continuation_token: A continuation token to restart the poller from a saved state. To get the
+         continuation token from your poller, call `continuation_token()` on the poller.
         :returns: A poller for the recovery operation. The poller's `result` method returns the recovered
          :class:`~azure.keyvault.secrets.Secret` without waiting for recovery to complete. If you want to use the
          recovered secret immediately, call the poller's `wait` method, which blocks until the secret is ready to use.

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/__init__.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/__init__.py
@@ -15,6 +15,7 @@ from .client_base import KeyVaultClientBase
 from .http_challenge import HttpChallenge
 from . import http_challenge_cache as HttpChallengeCache
 
+VaultId = namedtuple("VaultId", ["vault_url", "collection", "name", "version"])
 
 __all__ = [
     "ChallengeAuthPolicy",
@@ -22,9 +23,8 @@ __all__ = [
     "HttpChallenge",
     "HttpChallengeCache",
     "KeyVaultClientBase",
+    "VaultId",
 ]
-
-_VaultId = namedtuple("VaultId", ["vault_url", "collection", "name", "version"])
 
 
 def parse_vault_id(url):
@@ -40,7 +40,7 @@ def parse_vault_id(url):
     if len(path) < 2 or len(path) > 3:
         raise ValueError("'{}' is not not a valid vault url".format(url))
 
-    return _VaultId(
+    return VaultId(
         vault_url="{}://{}".format(parsed_uri.scheme, parsed_uri.hostname),
         collection=path[0],
         name=path[1],

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/_polling.py
@@ -6,6 +6,7 @@ import logging
 import time
 import threading
 import uuid
+import base64
 from typing import TYPE_CHECKING
 
 from azure.core.polling import PollingMethod, LROPoller, NoPolling
@@ -32,7 +33,7 @@ class KeyVaultOperationPoller(LROPoller):
 
     # pylint: disable=arguments-differ
     def __init__(self, polling_method):
-        # type: (PollingMethod) -> None
+        # type: (DeleteRecoverPollingMethod) -> None
         super(KeyVaultOperationPoller, self).__init__(None, None, None, NoPolling())
         self._polling_method = polling_method
 
@@ -75,6 +76,10 @@ class KeyVaultOperationPoller(LROPoller):
         except TypeError:  # Was None
             pass
 
+    @classmethod
+    def from_continuation_token(cls, polling_method, **kwargs):
+        # type: (DeleteRecoverPollingMethod, Any) -> KeyVaultOperationPoller
+        return cls(polling_method)
 
 class DeleteRecoverPollingMethod(PollingMethod):
     """Poller for deleting resources, and recovering deleted resources, in vaults with soft-delete enabled.
@@ -133,3 +138,8 @@ class DeleteRecoverPollingMethod(PollingMethod):
     def status(self):
         # type: () -> str
         return "finished" if self._finished else "polling"
+
+    def get_continuation_token(self):
+        # type() -> str
+        import pickle
+        return base64.b64encode(pickle.dumps(self._resource)).decode('ascii')

--- a/sdk/keyvault/azure-keyvault-secrets/tests/recordings/test_secrets_client.test_continuation_token.yaml
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/recordings/test_secrets_client.test_continuation_token.yaml
@@ -15,7 +15,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
     method: PUT
-    uri: https://vaultname.vault.azure.net/secrets/crud-secret?api-version=7.1
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret888911df?api-version=7.1
   response:
     body:
       string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
@@ -28,7 +28,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 05 Aug 2020 17:37:31 GMT
+      - Thu, 06 Aug 2020 16:07:40 GMT
       expires:
       - '-1'
       pragma:
@@ -69,19 +69,19 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
     method: PUT
-    uri: https://vaultname.vault.azure.net/secrets/crud-secret?api-version=7.1
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret888911df?api-version=7.1
   response:
     body:
-      string: '{"value":"crud_secret_value888911df","id":"https://vaultname.vault.azure.net/secrets/crud-secret/279d92f9533743f7b4376625ca065fe3","attributes":{"enabled":true,"created":1596649051,"updated":1596649051,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"value":"crud_secret_value888911df","id":"https://vaultname.vault.azure.net/secrets/crud-secret888911df/069c7a61348847289e0d25a0465f60bf","attributes":{"enabled":true,"created":1596730061,"updated":1596730061,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '279'
+      - '287'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 05 Aug 2020 17:37:31 GMT
+      - Thu, 06 Aug 2020 16:07:41 GMT
       expires:
       - '-1'
       pragma:
@@ -117,19 +117,19 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
     method: DELETE
-    uri: https://vaultname.vault.azure.net/secrets/crud-secret?api-version=7.1
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret888911df?api-version=7.1
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedsecrets/crud-secret","deletedDate":1596649051,"scheduledPurgeDate":1604425051,"id":"https://vaultname.vault.azure.net/secrets/crud-secret/279d92f9533743f7b4376625ca065fe3","attributes":{"enabled":true,"created":1596649051,"updated":1596649051,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedsecrets/crud-secret888911df","deletedDate":1596730062,"scheduledPurgeDate":1604506062,"id":"https://vaultname.vault.azure.net/secrets/crud-secret888911df/069c7a61348847289e0d25a0465f60bf","attributes":{"enabled":true,"created":1596730061,"updated":1596730061,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '391'
+      - '407'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 05 Aug 2020 17:37:31 GMT
+      - Thu, 06 Aug 2020 16:07:41 GMT
       expires:
       - '-1'
       pragma:
@@ -163,20 +163,20 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
     method: GET
-    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret888911df?api-version=7.1
   response:
     body:
       string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
-        crud-secret"}}'
+        crud-secret888911df"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '85'
+      - '93'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 05 Aug 2020 17:37:31 GMT
+      - Thu, 06 Aug 2020 16:07:41 GMT
       expires:
       - '-1'
       pragma:
@@ -210,20 +210,20 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
     method: GET
-    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret888911df?api-version=7.1
   response:
     body:
       string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
-        crud-secret"}}'
+        crud-secret888911df"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '85'
+      - '93'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 05 Aug 2020 17:37:34 GMT
+      - Thu, 06 Aug 2020 16:07:43 GMT
       expires:
       - '-1'
       pragma:
@@ -257,20 +257,20 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
     method: GET
-    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret888911df?api-version=7.1
   response:
     body:
       string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
-        crud-secret"}}'
+        crud-secret888911df"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '85'
+      - '93'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 05 Aug 2020 17:37:36 GMT
+      - Thu, 06 Aug 2020 16:07:45 GMT
       expires:
       - '-1'
       pragma:
@@ -304,20 +304,20 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
     method: GET
-    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret888911df?api-version=7.1
   response:
     body:
       string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
-        crud-secret"}}'
+        crud-secret888911df"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '85'
+      - '93'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 05 Aug 2020 17:37:38 GMT
+      - Thu, 06 Aug 2020 16:07:47 GMT
       expires:
       - '-1'
       pragma:
@@ -351,20 +351,20 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
     method: GET
-    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret888911df?api-version=7.1
   response:
     body:
       string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
-        crud-secret"}}'
+        crud-secret888911df"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '85'
+      - '93'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 05 Aug 2020 17:37:40 GMT
+      - Thu, 06 Aug 2020 16:07:49 GMT
       expires:
       - '-1'
       pragma:
@@ -398,20 +398,20 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
     method: GET
-    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret888911df?api-version=7.1
   response:
     body:
       string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
-        crud-secret"}}'
+        crud-secret888911df"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '85'
+      - '93'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 05 Aug 2020 17:37:42 GMT
+      - Thu, 06 Aug 2020 16:07:51 GMT
       expires:
       - '-1'
       pragma:
@@ -445,20 +445,20 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
     method: GET
-    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret888911df?api-version=7.1
   response:
     body:
       string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
-        crud-secret"}}'
+        crud-secret888911df"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '85'
+      - '93'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 05 Aug 2020 17:37:44 GMT
+      - Thu, 06 Aug 2020 16:07:54 GMT
       expires:
       - '-1'
       pragma:
@@ -492,20 +492,20 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
     method: GET
-    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret888911df?api-version=7.1
   response:
     body:
       string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
-        crud-secret"}}'
+        crud-secret888911df"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '85'
+      - '93'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 05 Aug 2020 17:37:46 GMT
+      - Thu, 06 Aug 2020 16:07:56 GMT
       expires:
       - '-1'
       pragma:
@@ -539,20 +539,20 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
     method: GET
-    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret888911df?api-version=7.1
   response:
     body:
       string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
-        crud-secret"}}'
+        crud-secret888911df"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '85'
+      - '93'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 05 Aug 2020 17:37:48 GMT
+      - Thu, 06 Aug 2020 16:07:58 GMT
       expires:
       - '-1'
       pragma:
@@ -586,20 +586,20 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
     method: GET
-    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret888911df?api-version=7.1
   response:
     body:
       string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
-        crud-secret"}}'
+        crud-secret888911df"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '85'
+      - '93'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 05 Aug 2020 17:37:50 GMT
+      - Thu, 06 Aug 2020 16:08:00 GMT
       expires:
       - '-1'
       pragma:
@@ -633,19 +633,113 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
     method: GET
-    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret888911df?api-version=7.1
   response:
     body:
-      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedsecrets/crud-secret","deletedDate":1596649051,"scheduledPurgeDate":1604425051,"id":"https://vaultname.vault.azure.net/secrets/crud-secret/279d92f9533743f7b4376625ca065fe3","attributes":{"enabled":true,"created":1596649051,"updated":1596649051,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
+        crud-secret888911df"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '391'
+      - '93'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 05 Aug 2020 17:37:52 GMT
+      - Thu, 06 Aug 2020 16:08:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret888911df?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
+        crud-secret888911df"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '93'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 06 Aug 2020 16:08:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret888911df?api-version=7.1
+  response:
+    body:
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedsecrets/crud-secret888911df","deletedDate":1596730062,"scheduledPurgeDate":1604506062,"id":"https://vaultname.vault.azure.net/secrets/crud-secret888911df/069c7a61348847289e0d25a0465f60bf","attributes":{"enabled":true,"created":1596730061,"updated":1596730061,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '407'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 06 Aug 2020 16:08:07 GMT
       expires:
       - '-1'
       pragma:
@@ -681,19 +775,650 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
     method: POST
-    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret/recover?api-version=7.1
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret888911df/recover?api-version=7.1
   response:
     body:
-      string: '{"id":"https://vaultname.vault.azure.net/secrets/crud-secret/279d92f9533743f7b4376625ca065fe3","attributes":{"enabled":true,"created":1596649051,"updated":1596649051,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+      string: '{"id":"https://vaultname.vault.azure.net/secrets/crud-secret888911df/069c7a61348847289e0d25a0465f60bf","attributes":{"enabled":true,"created":1596730061,"updated":1596730061,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '243'
+      - '251'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 05 Aug 2020 17:37:52 GMT
+      - Thu, 06 Aug 2020 16:08:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret888911df/?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"A secret with (name/id)
+        crud-secret888911df was not found in this key vault. If you recently deleted
+        this secret you may be able to recover it using the correct recovery command.
+        For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '316'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 06 Aug 2020 16:08:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret888911df/?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"A secret with (name/id)
+        crud-secret888911df was not found in this key vault. If you recently deleted
+        this secret you may be able to recover it using the correct recovery command.
+        For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '316'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 06 Aug 2020 16:08:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret888911df/?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"A secret with (name/id)
+        crud-secret888911df was not found in this key vault. If you recently deleted
+        this secret you may be able to recover it using the correct recovery command.
+        For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '316'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 06 Aug 2020 16:08:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret888911df/?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"A secret with (name/id)
+        crud-secret888911df was not found in this key vault. If you recently deleted
+        this secret you may be able to recover it using the correct recovery command.
+        For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '316'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 06 Aug 2020 16:08:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret888911df/?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"A secret with (name/id)
+        crud-secret888911df was not found in this key vault. If you recently deleted
+        this secret you may be able to recover it using the correct recovery command.
+        For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '316'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 06 Aug 2020 16:08:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret888911df/?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"A secret with (name/id)
+        crud-secret888911df was not found in this key vault. If you recently deleted
+        this secret you may be able to recover it using the correct recovery command.
+        For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '316'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 06 Aug 2020 16:08:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret888911df/?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"A secret with (name/id)
+        crud-secret888911df was not found in this key vault. If you recently deleted
+        this secret you may be able to recover it using the correct recovery command.
+        For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '316'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 06 Aug 2020 16:08:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret888911df/?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"A secret with (name/id)
+        crud-secret888911df was not found in this key vault. If you recently deleted
+        this secret you may be able to recover it using the correct recovery command.
+        For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '316'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 06 Aug 2020 16:08:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret888911df/?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"A secret with (name/id)
+        crud-secret888911df was not found in this key vault. If you recently deleted
+        this secret you may be able to recover it using the correct recovery command.
+        For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '316'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 06 Aug 2020 16:08:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret888911df/?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"A secret with (name/id)
+        crud-secret888911df was not found in this key vault. If you recently deleted
+        this secret you may be able to recover it using the correct recovery command.
+        For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '316'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 06 Aug 2020 16:08:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret888911df/?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"A secret with (name/id)
+        crud-secret888911df was not found in this key vault. If you recently deleted
+        this secret you may be able to recover it using the correct recovery command.
+        For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '316'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 06 Aug 2020 16:08:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret888911df/?api-version=7.1
+  response:
+    body:
+      string: '{"value":"crud_secret_value888911df","id":"https://vaultname.vault.azure.net/secrets/crud-secret888911df/069c7a61348847289e0d25a0465f60bf","attributes":{"enabled":true,"created":1596730061,"updated":1596730061,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '287'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 06 Aug 2020 16:08:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret888911df/?api-version=7.1
+  response:
+    body:
+      string: '{"value":"crud_secret_value888911df","id":"https://vaultname.vault.azure.net/secrets/crud-secret888911df/069c7a61348847289e0d25a0465f60bf","attributes":{"enabled":true,"created":1596730061,"updated":1596730061,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '287'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 06 Aug 2020 16:08:30 GMT
       expires:
       - '-1'
       pragma:

--- a/sdk/keyvault/azure-keyvault-secrets/tests/recordings/test_secrets_client.test_continuation_token.yaml
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/recordings/test_secrets_client.test_continuation_token.yaml
@@ -1,0 +1,718 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: PUT
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
+        or PoP token."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '87'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 17:37:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"value": "crud_secret_value888911df"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: PUT
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret?api-version=7.1
+  response:
+    body:
+      string: '{"value":"crud_secret_value888911df","id":"https://vaultname.vault.azure.net/secrets/crud-secret/279d92f9533743f7b4376625ca065fe3","attributes":{"enabled":true,"created":1596649051,"updated":1596649051,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '279'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 17:37:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: DELETE
+    uri: https://vaultname.vault.azure.net/secrets/crud-secret?api-version=7.1
+  response:
+    body:
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedsecrets/crud-secret","deletedDate":1596649051,"scheduledPurgeDate":1604425051,"id":"https://vaultname.vault.azure.net/secrets/crud-secret/279d92f9533743f7b4376625ca065fe3","attributes":{"enabled":true,"created":1596649051,"updated":1596649051,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '391'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 17:37:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
+        crud-secret"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '85'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 17:37:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
+        crud-secret"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '85'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 17:37:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
+        crud-secret"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '85'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 17:37:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
+        crud-secret"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '85'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 17:37:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
+        crud-secret"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '85'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 17:37:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
+        crud-secret"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '85'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 17:37:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
+        crud-secret"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '85'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 17:37:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
+        crud-secret"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '85'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 17:37:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
+        crud-secret"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '85'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 17:37:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"SecretNotFound","message":"Deleted Secret not found:
+        crud-secret"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '85'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 17:37:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: GET
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret?api-version=7.1
+  response:
+    body:
+      string: '{"recoveryId":"https://vaultname.vault.azure.net/deletedsecrets/crud-secret","deletedDate":1596649051,"scheduledPurgeDate":1604425051,"id":"https://vaultname.vault.azure.net/secrets/crud-secret/279d92f9533743f7b4376625ca065fe3","attributes":{"enabled":true,"created":1596649051,"updated":1596649051,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '391'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 17:37:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.2.0b2 Python/3.7.7 (Darwin-17.7.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://vaultname.vault.azure.net/deletedsecrets/crud-secret/recover?api-version=7.1
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/secrets/crud-secret/279d92f9533743f7b4376625ca065fe3","attributes":{"enabled":true,"created":1596649051,"updated":1596649051,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '243'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 05 Aug 2020 17:37:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=73.135.72.237;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.10.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_client.py
@@ -350,3 +350,28 @@ class SecretClientTests(KeyVaultTestCase):
     @KeyVaultClientPreparer(client_kwargs={"custom_hook_policy": _CustomHookPolicy()})
     def test_custom_hook_policy(self, client, **kwargs):
         assert isinstance(client._client._config.custom_hook_policy, SecretClientTests._CustomHookPolicy)
+
+    @ResourceGroupPreparer(random_name_enabled=True)
+    @KeyVaultPreparer()
+    @KeyVaultClientPreparer()
+    def test_continuation_token(self, client, **kwargs):
+        secret_name = "crud-secret"
+        secret_value = self.get_resource_name("crud_secret_value")
+
+        # create secret
+        secret = client.set_secret(secret_name, secret_value)
+
+        # delete secret
+        initial_poller = client.begin_delete_secret(secret.name)
+        continuation_token = initial_poller.continuation_token()
+        poller = client.begin_delete_secret(secret.name, continuation_token=continuation_token)
+        deleted_secret = poller.result()
+        self.assertIsNotNone(deleted_secret)
+        poller.wait()
+
+        # recover deleted secret
+        initial_poller = client.begin_recover_deleted_secret(secret.name)
+        continuation_token = initial_poller.continuation_token()
+        poller = client.begin_recover_deleted_secret(secret.name, continuation_token=continuation_token)
+        recovered_secret = poller.result()
+        self.assertIsNotNone(recovered_secret)


### PR DESCRIPTION
fixes #12028

For context: this PR is adding a continuation token functionality, so users can pickle their pollers and restart the polling from the state where they left off. These two pollers in key vault are also quite unique, the reason being that
1. They're not defined as long running on the service side
2. When we make the initial call to the service, the final response object, i.e. a deleted secret is returned. However, it takes a while for the secret to be fully deleted on the service side, so we poll until the service has fully deleted the secret. We do allow users to immediately get the response object from the service though (our `result` function doesn't call `wait`)