### PR TITLE
[EventHubs] Improve livetest stability on MacOS

### DIFF
--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_consumer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_consumer_client_async.py
@@ -89,7 +89,7 @@ async def test_receive_load_balancing_async(connstr_senders):
         await asyncio.sleep(3.3)
         task2 = asyncio.ensure_future(
             client2.receive(on_event, starting_position="-1"))
-        await asyncio.sleep(10)
+        await asyncio.sleep(20)
         assert len(client1._event_processors[("$default", ALL_PARTITIONS)]._tasks) == 1
         assert len(client2._event_processors[("$default", ALL_PARTITIONS)]._tasks) == 1
     await task1
@@ -139,7 +139,7 @@ async def test_receive_batch_no_max_wait_time_async(connstr_senders):
 
 
 @pytest.mark.parametrize("max_wait_time, sleep_time, expected_result",
-                         [(3, 6, []),
+                         [(3, 10, []),
                           (3, 2, None),
                           ])
 @pytest.mark.liveTest

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_consumer_client.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_consumer_client.py
@@ -100,7 +100,7 @@ def test_receive_load_balancing(connstr_senders):
         worker1.start()
         time.sleep(3.3)
         worker2.start()
-        time.sleep(10)
+        time.sleep(20)
         assert len(client1._event_processors[("$default", ALL_PARTITIONS)]._consumers) == 1
         assert len(client2._event_processors[("$default", ALL_PARTITIONS)]._consumers) == 1
 
@@ -147,7 +147,7 @@ def test_receive_batch_no_max_wait_time(connstr_senders):
 
 
 @pytest.mark.parametrize("max_wait_time, sleep_time, expected_result",
-                         [(3, 6, []),
+                         [(3, 10, []),
                           (3, 2, None),
                           ])
 def test_receive_batch_empty_with_max_wait_time(connection_str, max_wait_time, sleep_time, expected_result):


### PR DESCRIPTION
There're certain livetest cases failing on MacOS occasionally.
Based on analysis of the test case and previous experience, chances are high that the failure is receivers don't start up timely before the livetest end due to low MacOS performance.

One possible solution is to extend sleep time in the test case to give receiver enough time to open it self / load-balance algorithm stable.

This PR extend sleep time in two cases that usually fail on MacOS