### PR TITLE
Test preparer region config loader (and DeleteAfter fixes)

### DIFF
--- a/sdk/eventhub/azure-eventhub/conftest.py
+++ b/sdk/eventhub/azure-eventhub/conftest.py
@@ -18,6 +18,7 @@ from azure.eventhub import EventHubProducerClient
 from uamqp import ReceiveClient
 from uamqp.authentication import SASTokenAuth
 
+from devtools_testutils import get_region_override
 
 # Ignore async tests for Python < 3.5
 collect_ignore = []
@@ -32,7 +33,7 @@ RES_GROUP_PREFIX = "eh-res-group"
 NAMESPACE_PREFIX = "eh-ns"
 EVENTHUB_PREFIX = "eh"
 EVENTHUB_DEFAULT_AUTH_RULE_NAME = 'RootManageSharedAccessKey'
-LOCATION = "westus"
+LOCATION = get_region_override("westus")
 
 
 def pytest_addoption(parser):

--- a/sdk/servicebus/azure-servicebus/tests/servicebus_preparer.py
+++ b/sdk/servicebus/azure-servicebus/tests/servicebus_preparer.py
@@ -9,7 +9,7 @@ from azure.mgmt.servicebus.models import SBQueue, SBSubscription, AccessRights
 from azure_devtools.scenario_tests.exceptions import AzureTestError
 
 from devtools_testutils import (
-    ResourceGroupPreparer, AzureMgmtPreparer, FakeResource
+    ResourceGroupPreparer, AzureMgmtPreparer, FakeResource, get_region_override
 )
 
 from devtools_testutils.resource_testcase import RESOURCE_GROUP_PARAM
@@ -27,7 +27,7 @@ class ServiceBusNamespacePreparer(AzureMgmtPreparer):
     def __init__(self,
                  name_prefix='',
                  use_cache=False,
-                 sku='Standard', location='westus',
+                 sku='Standard', location=get_region_override('westus'),
                  parameter_name=SERVICEBUS_NAMESPACE_PARAM,
                  resource_group_parameter_name=RESOURCE_GROUP_PARAM,
                  disable_recording=True, playback_fake_resource=None,

--- a/tools/azure-sdk-tools/devtools_testutils/__init__.py
+++ b/tools/azure-sdk-tools/devtools_testutils/__init__.py
@@ -1,5 +1,5 @@
 from .mgmt_testcase import (AzureMgmtTestCase, AzureMgmtPreparer)
-from .azure_testcase import AzureTestCase, is_live
+from .azure_testcase import AzureTestCase, is_live, get_region_override
 from .resource_testcase import (FakeResource, ResourceGroupPreparer, RandomNameResourceGroupPreparer, CachedResourceGroupPreparer)
 from .storage_testcase import (FakeStorageAccount, StorageAccountPreparer)
 from .keyvault_preparer import KeyVaultPreparer
@@ -8,7 +8,7 @@ __all__ = [
     'AzureMgmtTestCase', 'AzureMgmtPreparer',
     'FakeResource', 'ResourceGroupPreparer',
     'FakeStorageAccount', 'StorageAccountPreparer',
-    'AzureTestCase', 'is_live',
+    'AzureTestCase', 'is_live', 'get_region_override',
     'KeyVaultPreparer', 'RandomNameResourceGroupPreparer',
     'CachedResourceGroupPreparer'
 ]

--- a/tools/azure-sdk-tools/devtools_testutils/azure_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/azure_testcase.py
@@ -65,6 +65,10 @@ def is_live():
     return is_live._cache
 
 
+def get_region_override(default='westus'):
+    return os.environ.get('RESOURCE_REGION', default) or 'westus'
+
+
 def _is_autorest_v3(client_class):
     """ IS this client a autorestv3/track2 one?.
     Could be refined later if necessary.

--- a/tools/azure-sdk-tools/devtools_testutils/azure_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/azure_testcase.py
@@ -66,7 +66,10 @@ def is_live():
 
 
 def get_region_override(default='westus'):
-    return os.environ.get('RESOURCE_REGION', default) or 'westus'
+    region = os.environ.get('RESOURCE_REGION', None) or default
+    if not region:
+        raise ValueError('Region should not be None; set a non-empty-string region to either the RESOURCE_REGION environment variable or the default parameter to this function.')
+    return region
 
 
 def _is_autorest_v3(client_class):

--- a/tools/azure-sdk-tools/devtools_testutils/resource_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/resource_testcase.py
@@ -60,7 +60,7 @@ class ResourceGroupPreparer(AzureMgmtPreparer):
             parameters = {'location': self.location}
             if self.delete_after_tag_timedelta:
                 expiry = datetime.datetime.utcnow() + self.delete_after_tag_timedelta
-                parameters['tags'] = {'DeleteAfter': expiry.isoformat()}
+                parameters['tags'] = {'DeleteAfter': expiry.replace(microsecond=0).isoformat()}
             try:
                 self.resource = self.client.resource_groups.create_or_update(
                     name, parameters


### PR DESCRIPTION
Adds a helper to fetch a potential region override from the test config matrix.
Puts this in place for Event Hubs and Service Bus.
Additionally truncates DeleteAfter to 2 digits after observing that RGs weren't being picked up for autodeletion.  @danieljurek  you'll have to let me know if the format being parsed for is even more strict, I had been given the breadcrumb "iso format."