### PR TITLE
Adding a clarification about Lazy Index Mode

### DIFF
--- a/sdk/cosmos/README.md
+++ b/sdk/cosmos/README.md
@@ -1,10 +1,8 @@
 # Azure Cosmos DB SQL API client SDKs for Python
 
-Azure Cosmos DB is a globally distributed, multi-model database service that supports document, key-value, wide-column, and graph databases.
+Azure Cosmos DB is a globally distributed, multi-model database service that supports document, key-value, wide-column, and graph databases. For more information, go to [https://www.gotcosmos.com/](https://www.gotcosmos.com/) .
 
-For more information, go to [https://www.gotcosmos.com/](https://www.gotcosmos.com/) .
-
-Use the Azure Cosmos DB SQL API SDKs for application development and database management.
+Use the Azure Cosmos DB SQL API SDKs for application development and database management. For all other APIs, please check the [documentation](https://docs.microsoft.com/en-us/azure/cosmos-db/introduction) to evaluate the best SDK for your project.
 
 ## Contents of this folder
 

--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -245,6 +245,7 @@ The container name must be unique within the database.""")
 
 ```
 ### Logging
+
 This library uses the standard
 [logging](https://docs.python.org/3.5/library/logging.html) library for logging.
 Basic information about HTTP sessions (URLs, headers, etc.) is logged at INFO
@@ -314,7 +315,7 @@ For more extensive documentation on the Cosmos DB service, see the [Azure Cosmos
 [venv]: https://docs.python.org/3/library/venv.html
 [virtualenv]: https://virtualenv.pypa.io
 
-# Contributing
+## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
@@ -133,16 +133,11 @@ class IndexingMode(object):
         operation.
 
         With lazy indexing, queries are eventually consistent. The index is
-        updated when the collection is idle.
+        updated when the collection is idle. In June 2020,
+        we introduced a change that no longer allows new
+        containers to be set to Lazy indexing mode.
+        Check the documentation for more details.
         
-        In June 2020, we introduced a change that no longer allows new 
-        containers to be set to Lazy indexing mode. 
-        If your Azure Cosmos DB account already contains at least 
-        one container with lazy indexing, this account is 
-        automatically exempt from the change.
-        
-        For more information, go to 
-        https://docs.microsoft.com/en-us/azure/cosmos-db/index-policy
     :ivar str NoIndex:
         No index is provided.
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
@@ -130,14 +130,10 @@ class IndexingMode(object):
         The index is always kept up to date with the data.
     :ivar str Lazy:
         Index is updated asynchronously with respect to a create or update
-        operation.
+        operation. Not supported for new containers since June/2020.
 
         With lazy indexing, queries are eventually consistent. The index is
-        updated when the collection is idle. In June 2020,
-        we introduced a change that no longer allows new
-        containers to be set to Lazy indexing mode.
-        Check the documentation for more details.
-        
+        updated when the collection is idle.    
     :ivar str NoIndex:
         No index is provided.
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
@@ -130,10 +130,7 @@ class IndexingMode(object):
         The index is always kept up to date with the data.
     :ivar str Lazy:
         Index is updated asynchronously with respect to a create or update
-        operation. Not supported for new containers since June/2020.
-
-        With lazy indexing, queries are eventually consistent. The index is
-        updated when the collection is idle.    
+        operation. Not supported for new containers since June/2020.  
     :ivar str NoIndex:
         No index is provided.
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
@@ -130,7 +130,10 @@ class IndexingMode(object):
         The index is always kept up to date with the data.
     :ivar str Lazy:
         Index is updated asynchronously with respect to a create or update
-        operation. Not supported for new containers since June/2020.  
+        operation. Not supported for new containers since June/2020.
+
+        With lazy indexing, queries are eventually consistent. The index is
+        updated when the collection is idle.
     :ivar str NoIndex:
         No index is provided.
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/documents.py
@@ -134,6 +134,15 @@ class IndexingMode(object):
 
         With lazy indexing, queries are eventually consistent. The index is
         updated when the collection is idle.
+        
+        In June 2020, we introduced a change that no longer allows new 
+        containers to be set to Lazy indexing mode. 
+        If your Azure Cosmos DB account already contains at least 
+        one container with lazy indexing, this account is 
+        automatically exempt from the change.
+        
+        For more information, go to 
+        https://docs.microsoft.com/en-us/azure/cosmos-db/index-policy
     :ivar str NoIndex:
         No index is provided.
 


### PR DESCRIPTION
In June 2020, we introduced a change that no longer allows new containers to be set to Lazy indexing mode. If your Azure Cosmos DB account already contains at least one container with lazy indexing, this account is automatically exempt from the change.

https://docs.microsoft.com/en-us/azure/cosmos-db/index-policy