### PR TITLE
Sb ci failure

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -95,10 +95,13 @@ jobs:
       matrix:
         ${{ each matrixEntry in parameters.TestMatrix }}:
           ${{ if or(eq(matrixEntry.value.RunForPR, 'true'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-            # Skip python version if any specific service has opted out
-            ${{ if ne(parameters.SkipPythonVersion, matrixEntry.value.PythonVersion) }}:
-              ${{ matrixEntry.key }}:
-                ${{ insert }}: ${{ matrixEntry.value }}
+            ${{ matrixEntry.key }}:
+              ${{ insert }}: ${{ matrixEntry.value }}
+
+        ${{ each matrixEntry in parameters.AdditionalTestMatrix }}:
+          ${{ if or(eq(matrixEntry.value.RunForPR, 'true'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+            ${{ matrixEntry.key }}:
+              ${{ insert }}: ${{ matrixEntry.value }}
 
         
     pool:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -39,7 +39,7 @@ parameters:
       PythonVersion: 'pypy3'
       CoverageArg: '--disablecov'
       RunForPR: false
-    AdditionalTestMatrix: []
+  AdditionalTestMatrix: []
 
 jobs:
   - job: 'Build'
@@ -95,8 +95,10 @@ jobs:
       matrix:
         ${{ each matrixEntry in parameters.TestMatrix }}:
           ${{ if or(eq(matrixEntry.value.RunForPR, 'true'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-            ${{ matrixEntry.key }}:
-              ${{ insert }}: ${{ matrixEntry.value }}
+            # Skip python version if any specific service has opted out
+            ${{ if ne(parameters.SkipPythonVersion, matrixEntry.value.PythonVersion) }}:
+              ${{ matrixEntry.key }}:
+                ${{ insert }}: ${{ matrixEntry.value }}
 
         ${{ each matrixEntry in parameters.AdditionalTestMatrix }}:
           ${{ if or(eq(matrixEntry.value.RunForPR, 'true'), ne(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -100,11 +100,6 @@ jobs:
               ${{ matrixEntry.key }}:
                 ${{ insert }}: ${{ matrixEntry.value }}
 
-        ${{ each matrixEntry in parameters.AdditionalTestMatrix }}:
-          ${{ if or(eq(matrixEntry.value.RunForPR, 'true'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-            ${{ matrixEntry.key }}:
-              ${{ insert }}: ${{ matrixEntry.value }}
-
         
     pool:
       vmImage: '$(OSVmImage)'


### PR DESCRIPTION
Fix YAML indentation. Still confused why this indentation is failing only for SB and works even for identity with additional matrix.

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=489172&view=logs&j=828acd67-1159-54af-ba3f-c65420d78475