### PR TITLE
Restore user authentication API

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release History
 
-## 1.4.1 (Unreleased)
-
-
+## 1.5.0b1 (Unreleased)
+### Added
+- Application authentication APIs from 1.4.0b7
+ 
 ## 1.4.0 (2020-08-10)
 ### Added
 - `DefaultAzureCredential` uses the value of environment variable

--- a/sdk/identity/azure-identity/MANIFEST.in
+++ b/sdk/identity/azure-identity/MANIFEST.in
@@ -1,3 +1,4 @@
+recursive-include samples *.py
 recursive-include tests *.py
 include *.md
 include azure/__init__.py

--- a/sdk/identity/azure-identity/azure/identity/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/__init__.py
@@ -4,7 +4,8 @@
 # ------------------------------------
 """Credentials for Azure SDK clients."""
 
-from ._exceptions import CredentialUnavailableError
+from ._auth_record import AuthenticationRecord
+from ._exceptions import AuthenticationRequiredError, CredentialUnavailableError
 from ._constants import AzureAuthorityHosts, KnownAuthorities
 from ._credentials import (
     AzureCliCredential,
@@ -24,6 +25,8 @@ from ._credentials import (
 
 
 __all__ = [
+    "AuthenticationRecord",
+    "AuthenticationRequiredError",
     "AuthorizationCodeCredential",
     "AzureAuthorityHosts",
     "AzureCliCredential",

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -36,6 +36,13 @@ class InteractiveBrowserCredential(InteractiveCredential):
           authenticate work or school accounts.
     :keyword str client_id: Client ID of the Azure Active Directory application users will sign in to. If
           unspecified, the Azure CLI's ID will be used.
+    :keyword AuthenticationRecord authentication_record: :class:`AuthenticationRecord` returned by :func:`authenticate`
+    :keyword bool disable_automatic_authentication: if True, :func:`get_token` will raise
+          :class:`AuthenticationRequiredError` when user interaction is required to acquire a token. Defaults to False.
+    :keyword bool enable_persistent_cache: if True, the credential will store tokens in a persistent cache shared by
+         other user credentials. Defaults to False.
+    :keyword bool allow_unencrypted_cache: if True, the credential will fall back to a plaintext cache on platforms
+          where encryption is unavailable. Default to False. Has no effect when `enable_persistent_cache` is False.
     :keyword int timeout: seconds to wait for the user to complete authentication. Defaults to 300 (5 minutes).
     """
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/certificate.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/certificate.py
@@ -25,6 +25,10 @@ class CertificateCredential(CertificateCredentialBase):
     :keyword password: The certificate's password. If a unicode string, it will be encoded as UTF-8. If the certificate
           requires a different encoding, pass appropriately encoded bytes instead.
     :paramtype password: str or bytes
+    :keyword bool enable_persistent_cache: if True, the credential will store tokens in a persistent cache. Defaults to
+          False.
+    :keyword bool allow_unencrypted_cache: if True, the credential will fall back to a plaintext cache when encryption
+          is unavailable. Default to False. Has no effect when `enable_persistent_cache` is False.
     """
 
     @log_get_token("CertificateCredential")

--- a/sdk/identity/azure-identity/azure/identity/_credentials/client_secret.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/client_secret.py
@@ -26,6 +26,10 @@ class ClientSecretCredential(ClientSecretCredentialBase):
     :keyword str authority: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
           the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
           defines authorities for other clouds.
+    :keyword bool enable_persistent_cache: if True, the credential will store tokens in a persistent cache. Defaults to
+          False.
+    :keyword bool allow_unencrypted_cache: if True, the credential will fall back to a plaintext cache when encryption
+          is unavailable. Default to False. Has no effect when `enable_persistent_cache` is False.
     """
 
     @log_get_token("ClientSecretCredential")

--- a/sdk/identity/azure-identity/azure/identity/_credentials/device_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/device_code.py
@@ -46,6 +46,13 @@ class DeviceCodeCredential(InteractiveCredential):
             - ``expires_on`` (datetime.datetime) the UTC time at which the code will expire
           If this argument isn't provided, the credential will print instructions to stdout.
     :paramtype prompt_callback: Callable[str, str, ~datetime.datetime]
+    :keyword AuthenticationRecord authentication_record: :class:`AuthenticationRecord` returned by :func:`authenticate`
+    :keyword bool disable_automatic_authentication: if True, :func:`get_token` will raise
+          :class:`AuthenticationRequiredError` when user interaction is required to acquire a token. Defaults to False.
+    :keyword bool enable_persistent_cache: if True, the credential will store tokens in a persistent cache shared by
+         other user credentials. Defaults to False.
+    :keyword bool allow_unencrypted_cache: if True, the credential will fall back to a plaintext cache on platforms
+          where encryption is unavailable. Default to False. Has no effect when `enable_persistent_cache` is False.
     """
 
     def __init__(self, client_id, **kwargs):

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -44,6 +44,10 @@ class ManagedIdentityCredential(object):
     the keyword arguments.
 
     :keyword str client_id: a user-assigned identity's client ID. This is supported in all hosting environments.
+    :keyword identity_config: a mapping ``{parameter_name: value}`` specifying a user-assigned identity by its object
+      or resource ID, for example ``{"object_id": "..."}``. Check the documentation for your hosting environment to
+      learn what values it expects.
+    :paramtype identity_config: Mapping[str, str]
     """
 
     def __init__(self, **kwargs):
@@ -76,7 +80,7 @@ class ManagedIdentityCredential(object):
 class _ManagedIdentityBase(object):
     def __init__(self, endpoint, client_cls, config=None, client_id=None, **kwargs):
         # type: (str, Type, Optional[Configuration], Optional[str], **Any) -> None
-        self._identity_config = kwargs.pop("_identity_config", None) or {}
+        self._identity_config = kwargs.pop("identity_config", None) or {}
         if client_id:
             if os.environ.get(EnvironmentVariables.MSI_ENDPOINT) and os.environ.get(EnvironmentVariables.MSI_SECRET):
                 # App Service: version 2017-09-1 accepts client ID as parameter "clientid"

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -31,6 +31,10 @@ class SharedTokenCacheCredential(SharedTokenCacheBase):
         defines authorities for other clouds.
     :keyword str tenant_id: an Azure Active Directory tenant ID. Used to select an account when the cache contains
         tokens for multiple identities.
+    :keyword AuthenticationRecord authentication_record: an authentication record returned by a user credential such as
+        :class:`DeviceCodeCredential` or :class:`InteractiveBrowserCredential`
+    :keyword bool allow_unencrypted_cache: if True, the credential will fall back to a plaintext cache when encryption
+        is unavailable. Defaults to False.
     """
 
     @log_get_token("SharedTokenCacheCredential")

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user_password.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user_password.py
@@ -33,6 +33,10 @@ class UsernamePasswordCredential(InteractiveCredential):
           defines authorities for other clouds.
     :keyword str tenant_id: tenant ID or a domain associated with a tenant. If not provided, defaults to the
           'organizations' tenant, which supports only Azure Active Directory work or school accounts.
+    :keyword bool enable_persistent_cache: if True, the credential will store tokens in a persistent cache shared by
+         other user credentials. Defaults to False.
+    :keyword bool allow_unencrypted_cache: if True, the credential will fall back to a plaintext cache on platforms
+          where encryption is unavailable. Default to False. Has no effect when `enable_persistent_cache` is False.
     """
 
     def __init__(self, client_id, username, password, **kwargs):
@@ -42,7 +46,7 @@ class UsernamePasswordCredential(InteractiveCredential):
         # first time it's asked for a token. However, we want to ensure this first authentication is not silent, to
         # validate the given password. This class therefore doesn't document the authentication_record argument, and we
         # discard it here.
-        kwargs.pop("_authentication_record", None)
+        kwargs.pop("authentication_record", None)
         super(UsernamePasswordCredential, self).__init__(client_id=client_id, **kwargs)
         self._username = username
         self._password = password

--- a/sdk/identity/azure-identity/azure/identity/_internal/certificate_credential_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/certificate_credential_base.py
@@ -44,9 +44,9 @@ class CertificateCredentialBase(ABC):
 
         self._certificate = AadClientCertificate(pem_bytes, password=password)
 
-        enable_persistent_cache = kwargs.pop("_enable_persistent_cache", False)
+        enable_persistent_cache = kwargs.pop("enable_persistent_cache", False)
         if enable_persistent_cache:
-            allow_unencrypted = kwargs.pop("_allow_unencrypted_cache", False)
+            allow_unencrypted = kwargs.pop("allow_unencrypted_cache", False)
             cache = load_service_principal_cache(allow_unencrypted)
         else:
             cache = TokenCache()

--- a/sdk/identity/azure-identity/azure/identity/_internal/client_secret_credential_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/client_secret_credential_base.py
@@ -31,9 +31,9 @@ class ClientSecretCredentialBase(ABC):
                 "tenant_id should be an Azure Active Directory tenant's id (also called its 'directory id')"
             )
 
-        enable_persistent_cache = kwargs.pop("_enable_persistent_cache", False)
+        enable_persistent_cache = kwargs.pop("enable_persistent_cache", False)
         if enable_persistent_cache:
-            allow_unencrypted = kwargs.pop("_allow_unencrypted_cache", False)
+            allow_unencrypted = kwargs.pop("allow_unencrypted_cache", False)
             cache = load_service_principal_cache(allow_unencrypted)
         else:
             cache = TokenCache()

--- a/sdk/identity/azure-identity/azure/identity/_internal/interactive.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/interactive.py
@@ -71,8 +71,8 @@ def _build_auth_record(response):
 
 class InteractiveCredential(MsalCredential):
     def __init__(self, **kwargs):
-        self._disable_automatic_authentication = kwargs.pop("_disable_automatic_authentication", False)
-        self._auth_record = kwargs.pop("_authentication_record", None)  # type: Optional[AuthenticationRecord]
+        self._disable_automatic_authentication = kwargs.pop("disable_automatic_authentication", False)
+        self._auth_record = kwargs.pop("authentication_record", None)  # type: Optional[AuthenticationRecord]
         if self._auth_record:
             kwargs.pop("client_id", None)  # authentication_record overrides client_id argument
             tenant_id = kwargs.pop("tenant_id", None) or self._auth_record.tenant_id
@@ -97,6 +97,8 @@ class InteractiveCredential(MsalCredential):
           required data, state, or platform support
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The error's ``message``
           attribute gives a reason.
+        :raises AuthenticationRequiredError: user interaction is necessary to acquire a token, and the credential is
+          configured not to begin this automatically. Call :func:`authenticate` to begin interactive authentication.
         """
         if not scopes:
             message = "'get_token' requires at least one scope"
@@ -138,7 +140,7 @@ class InteractiveCredential(MsalCredential):
         _LOGGER.info("%s.get_token succeeded", self.__class__.__name__)
         return AccessToken(result["access_token"], now + int(result["expires_in"]))
 
-    def _authenticate(self, **kwargs):
+    def authenticate(self, **kwargs):
         # type: (**Any) -> AuthenticationRecord
         """Interactively authenticate a user.
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
@@ -40,8 +40,8 @@ class MsalCredential(ABC):
 
         self._cache = kwargs.pop("_cache", None)  # internal, for use in tests
         if not self._cache:
-            if kwargs.pop("_enable_persistent_cache", False):
-                allow_unencrypted = kwargs.pop("_allow_unencrypted_cache", False)
+            if kwargs.pop("enable_persistent_cache", False):
+                allow_unencrypted = kwargs.pop("allow_unencrypted_cache", False)
                 self._cache = load_user_cache(allow_unencrypted)
             else:
                 self._cache = msal.TokenCache()

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     # pylint:disable=unused-import,ungrouped-imports
     from typing import Any, Iterable, List, Mapping, Optional
     from .._internal import AadClientBase
-    from azure.identity._auth_record import AuthenticationRecord
+    from azure.identity import AuthenticationRecord
 
     CacheItem = Mapping[str, str]
 
@@ -90,7 +90,7 @@ class SharedTokenCacheBase(ABC):
     def __init__(self, username=None, **kwargs):  # pylint:disable=unused-argument
         # type: (Optional[str], **Any) -> None
 
-        self._auth_record = kwargs.pop("_authentication_record", None)  # type: Optional[AuthenticationRecord]
+        self._auth_record = kwargs.pop("authentication_record", None)  # type: Optional[AuthenticationRecord]
         if self._auth_record:
             # authenticate in the tenant that produced the record unless 'tenant_id' specifies another
             authenticating_tenant = kwargs.pop("tenant_id", None) or self._auth_record.tenant_id
@@ -118,7 +118,7 @@ class SharedTokenCacheBase(ABC):
             return
 
         if not self._cache and self.supported():
-            allow_unencrypted = self._client_kwargs.get("_allow_unencrypted_cache", True)
+            allow_unencrypted = self._client_kwargs.get("allow_unencrypted_cache", False)
             try:
                 self._cache = load_user_cache(allow_unencrypted)
             except Exception:  # pylint:disable=broad-except

--- a/sdk/identity/azure-identity/azure/identity/_version.py
+++ b/sdk/identity/azure-identity/azure/identity/_version.py
@@ -2,4 +2,4 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-VERSION = "1.4.1"
+VERSION = "1.5.0b1"

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_secret.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_secret.py
@@ -24,6 +24,10 @@ class ClientSecretCredential(AsyncCredentialBase, ClientSecretCredentialBase):
     :keyword str authority: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
           the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
           defines authorities for other clouds.
+    :keyword bool enable_persistent_cache: if True, the credential will store tokens in a persistent cache. Defaults to
+          False.
+    :keyword bool allow_unencrypted_cache: if True, the credential will fall back to a plaintext cache when encryption
+          is unavailable. Default to False. Has no effect when `enable_persistent_cache` is False.
     """
 
     async def __aenter__(self):

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -32,6 +32,10 @@ class ManagedIdentityCredential(AsyncCredentialBase):
     the keyword arguments.
 
     :keyword str client_id: a user-assigned identity's client ID. This is supported in all hosting environments.
+    :keyword identity_config: a mapping ``{parameter_name: value}`` specifying a user-assigned identity by its object
+      or resource ID, for example ``{"object_id": "..."}``. Check the documentation for your hosting environment to
+      learn what values it expects.
+    :paramtype identity_config: Mapping[str, str]
     """
 
     def __init__(self, **kwargs: "Any") -> None:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
@@ -29,6 +29,10 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncCredentialBase):
         defines authorities for other clouds.
     :keyword str tenant_id: an Azure Active Directory tenant ID. Used to select an account when the cache contains
         tokens for multiple identities.
+    :keyword AuthenticationRecord authentication_record: an authentication record returned by a user credential such as
+        :class:`DeviceCodeCredential` or :class:`InteractiveBrowserCredential`
+    :keyword bool allow_unencrypted_cache: if True, the credential will fall back to a plaintext cache when encryption
+        is unavailable. Defaults to False.
     """
 
     async def __aenter__(self):

--- a/sdk/identity/azure-identity/samples/README.md
+++ b/sdk/identity/azure-identity/samples/README.md
@@ -1,0 +1,37 @@
+---
+page_type: sample
+languages:
+  - python
+products:
+  - azure
+  - azure-identity
+urlFragment: identity-samples
+---
+
+# Azure Identity Library Python Samples
+
+## Prerequisites
+
+You must have an [Azure subscription](https://azure.microsoft.com/free) and an
+[Azure Key Vault](https://azure.microsoft.com/en-us/services/key-vault/) to run
+these samples. You can create a Key Vault in the
+[Azure Portal](https://portal.azure.com/#create/Microsoft.KeyVault) or with the
+[Azure CLI](https://docs.microsoft.com/en-us/azure/key-vault/secrets/quick-create-cli).
+
+Azure Key Vault is used only to demonstrate authentication. Azure Identity has
+the same API for all compatible client libraries.
+
+## Setup
+
+To run these samples, first install the Azure Identity and Key Vault Secrets
+client libraries:
+
+```commandline
+pip install azure-identity azure-keyvault-secrets
+```
+
+## Contents
+| File | Description |
+|-------------|-------------|
+| control_interactive_prompts.py | demonstrates controlling when interactive credentials prompt for user interaction |
+| user_authentication.py | demonstrates user authentication API for applications |

--- a/sdk/identity/azure-identity/samples/control_interactive_prompts.py
+++ b/sdk/identity/azure-identity/samples/control_interactive_prompts.py
@@ -1,0 +1,38 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+"""Demonstrates controlling the timing of interactive authentication using InteractiveBrowserCredential.
+
+DeviceCodeCredential supports the same API.
+"""
+
+import os
+import sys
+from azure.identity import AuthenticationRequiredError, InteractiveBrowserCredential
+from azure.keyvault.secrets import SecretClient
+
+
+# This sample uses Key Vault only for demonstration. Any client accepting azure-identity credentials will work the same.
+VAULT_URL = os.environ.get("VAULT_URL")
+if not VAULT_URL:
+    print("This sample expects environment variable 'VAULT_URL' to be set with the URL of a Key Vault.")
+    sys.exit(1)
+
+
+# If it's important for your application to prompt for authentication only at certain times,
+# create the credential with disable_automatic_authentication=True. This configures the credential to raise
+# when interactive authentication is required, instead of immediately beginning that authentication.
+credential = InteractiveBrowserCredential(disable_automatic_authentication=True)
+client = SecretClient(VAULT_URL, credential)
+
+try:
+    secret_names = [s.name for s in client.list_properties_of_secrets()]
+except AuthenticationRequiredError as ex:
+    # Interactive authentication is necessary to authorize the client's request. The exception carries the
+    # requested authentication scopes. If you pass these to 'authenticate', it will cache an access token
+    # for those scopes.
+    credential.authenticate(scopes=ex.scopes)
+
+# the client operation should now succeed
+secret_names = [s.name for s in client.list_properties_of_secrets()]

--- a/sdk/identity/azure-identity/samples/user_authentication.py
+++ b/sdk/identity/azure-identity/samples/user_authentication.py
@@ -1,0 +1,43 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+"""Demonstrates user authentication using InteractiveBrowserCredential. DeviceCodeCredential supports the same API."""
+
+import os
+import sys
+from azure.identity import AuthenticationRecord, InteractiveBrowserCredential
+from azure.keyvault.secrets import SecretClient
+
+
+# This sample uses Key Vault only for demonstration. Any client accepting azure-identity credentials will work the same.
+VAULT_URL = os.environ.get("VAULT_URL")
+if not VAULT_URL:
+    print("This sample expects environment variable 'VAULT_URL' to be set with the URL of a Key Vault.")
+    sys.exit(1)
+
+
+# Persistent caching is optional. By default, interactive credentials cache in memory only.
+credential = InteractiveBrowserCredential(enable_persistent_cache=True)
+
+# The 'authenticate' method begins interactive authentication. Call it whenever it's convenient
+# for your application to authenticate a user. It returns a record of the authentication.
+record = credential.authenticate()
+
+# The record contains no authentication secrets. You can serialize it to JSON for storage.
+record_json = record.serialize()
+
+# An authenticated credential is ready for use with a client. This request should succeed
+# without prompting for authentication again.
+client = SecretClient(VAULT_URL, credential)
+secret_names = [s.name for s in client.list_properties_of_secrets()]
+
+# With persistent caching enabled, an authentication record stored by your application enables
+# credentials to access data from past authentications. If the cache contains sufficient data,
+# this eliminates the need for your application to prompt for authentication every time it runs.
+deserialized_record = AuthenticationRecord.deserialize(record_json)
+new_credential = InteractiveBrowserCredential(enable_persistent_cache=True, authentication_record=deserialized_record)
+
+# This request should also succeed without prompting for authentication.
+client = SecretClient(VAULT_URL, new_credential)
+secret_names = [s.name for s in client.list_properties_of_secrets()]

--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -51,7 +51,7 @@ setup(
     author_email="azpysdkhelp@microsoft.com",
     url="https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/identity/azure-identity",
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 4 - Beta",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",

--- a/sdk/identity/azure-identity/tests/test_auth_record.py
+++ b/sdk/identity/azure-identity/tests/test_auth_record.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import json
 
-from azure.identity._auth_record import AuthenticationRecord
+from azure.identity import AuthenticationRecord
 
 
 def test_serialization():

--- a/sdk/identity/azure-identity/tests/test_browser_credential.py
+++ b/sdk/identity/azure-identity/tests/test_browser_credential.py
@@ -10,8 +10,7 @@ import time
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.pipeline.policies import SansIOHTTPPolicy
-from azure.identity import CredentialUnavailableError, InteractiveBrowserCredential
-from azure.identity._exceptions import AuthenticationRequiredError
+from azure.identity import AuthenticationRequiredError, CredentialUnavailableError, InteractiveBrowserCredential
 from azure.identity._internal import AuthCodeRedirectServer
 from azure.identity._internal.user_agent import USER_AGENT
 from msal import TokenCache
@@ -82,7 +81,7 @@ def test_authenticate():
                 tenant_id=tenant_id,
                 transport=transport,
             )
-            record = credential._authenticate(scopes=(scope,))
+            record = credential.authenticate(scopes=(scope,))
 
     assert record.authority == environment
     assert record.home_account_id == object_id + "." + home_tenant
@@ -101,7 +100,7 @@ def test_disable_automatic_authentication():
     empty_cache = TokenCache()  # empty cache makes silent auth impossible
     transport = Mock(send=Mock(side_effect=Exception("no request should be sent")))
     credential = InteractiveBrowserCredential(
-        _disable_automatic_authentication=True, transport=transport, _cache=empty_cache
+        disable_automatic_authentication=True, transport=transport, _cache=empty_cache
     )
 
     with patch(WEBBROWSER_OPEN, Mock(side_effect=Exception("credential shouldn't try interactive authentication"))):

--- a/sdk/identity/azure-identity/tests/test_certificate_credential.py
+++ b/sdk/identity/azure-identity/tests/test_certificate_credential.py
@@ -157,20 +157,20 @@ def test_enable_persistent_cache(cert_path, cert_password):
         CertificateCredential(*required_arguments, password=cert_password)
 
         # allowing an unencrypted cache doesn't count as opting in to the persistent cache
-        CertificateCredential(*required_arguments, password=cert_password, _allow_unencrypted_cache=True)
+        CertificateCredential(*required_arguments, password=cert_password, allow_unencrypted_cache=True)
 
     # keyword argument opts in to persistent cache
     with patch(persistent_cache + ".msal_extensions") as mock_extensions:
-        CertificateCredential(*required_arguments, password=cert_password, _enable_persistent_cache=True)
+        CertificateCredential(*required_arguments, password=cert_password, enable_persistent_cache=True)
     assert mock_extensions.PersistedTokenCache.call_count == 1
 
     # opting in on an unsupported platform raises an exception
     with patch(persistent_cache + ".sys.platform", "commodore64"):
         with pytest.raises(NotImplementedError):
-            CertificateCredential(*required_arguments, password=cert_password, _enable_persistent_cache=True)
+            CertificateCredential(*required_arguments, password=cert_password, enable_persistent_cache=True)
         with pytest.raises(NotImplementedError):
             CertificateCredential(
-                *required_arguments, password=cert_password, _enable_persistent_cache=True, _allow_unencrypted_cache=True
+                *required_arguments, password=cert_password, enable_persistent_cache=True, allow_unencrypted_cache=True
             )
 
 
@@ -187,7 +187,7 @@ def test_persistent_cache_linux(mock_extensions, cert_path, cert_password):
 
     # the credential should prefer an encrypted cache even when the user allows an unencrypted one
     CertificateCredential(
-        *required_arguments, password=cert_password, _enable_persistent_cache=True, _allow_unencrypted_cache=True
+        *required_arguments, password=cert_password, enable_persistent_cache=True, allow_unencrypted_cache=True
     )
     assert mock_extensions.PersistedTokenCache.called_with(mock_extensions.LibsecretPersistence)
     mock_extensions.PersistedTokenCache.reset_mock()
@@ -197,10 +197,10 @@ def test_persistent_cache_linux(mock_extensions, cert_path, cert_password):
 
     # encryption unavailable, no opt in to unencrypted cache -> credential should raise
     with pytest.raises(ValueError):
-        CertificateCredential(*required_arguments, password=cert_password, _enable_persistent_cache=True)
+        CertificateCredential(*required_arguments, password=cert_password, enable_persistent_cache=True)
 
     CertificateCredential(
-        *required_arguments, password=cert_password, _enable_persistent_cache=True, _allow_unencrypted_cache=True
+        *required_arguments, password=cert_password, enable_persistent_cache=True, allow_unencrypted_cache=True
     )
     assert mock_extensions.PersistedTokenCache.called_with(mock_extensions.FilePersistence)
 
@@ -222,11 +222,11 @@ def test_persistent_cache_multiple_clients(cert_path, cert_password):
     with patch("azure.identity._internal.persistent_cache._load_persistent_cache") as mock_cache_loader:
         mock_cache_loader.return_value = Mock(wraps=cache)
         credential_a = CertificateCredential(
-            "tenant", "client-a", cert_path, password=cert_password, _enable_persistent_cache=True, transport=transport_a
+            "tenant", "client-a", cert_path, password=cert_password, enable_persistent_cache=True, transport=transport_a
         )
         assert mock_cache_loader.call_count == 1, "credential should load the persistent cache"
         credential_b = CertificateCredential(
-            "tenant", "client-b", cert_path, password=cert_password, _enable_persistent_cache=True, transport=transport_b
+            "tenant", "client-b", cert_path, password=cert_password, enable_persistent_cache=True, transport=transport_b
         )
         assert mock_cache_loader.call_count == 2, "credential should load the persistent cache"
 

--- a/sdk/identity/azure-identity/tests/test_certificate_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_certificate_credential_async.py
@@ -149,20 +149,20 @@ def test_enable_persistent_cache(cert_path, cert_password):
         CertificateCredential(*required_arguments, password=cert_password)
 
         # allowing an unencrypted cache doesn't count as opting in to the persistent cache
-        CertificateCredential(*required_arguments, password=cert_password, _allow_unencrypted_cache=True)
+        CertificateCredential(*required_arguments, password=cert_password, allow_unencrypted_cache=True)
 
     # keyword argument opts in to persistent cache
     with patch(persistent_cache + ".msal_extensions") as mock_extensions:
-        CertificateCredential(*required_arguments, password=cert_password, _enable_persistent_cache=True)
+        CertificateCredential(*required_arguments, password=cert_password, enable_persistent_cache=True)
     assert mock_extensions.PersistedTokenCache.call_count == 1
 
     # opting in on an unsupported platform raises an exception
     with patch(persistent_cache + ".sys.platform", "commodore64"):
         with pytest.raises(NotImplementedError):
-            CertificateCredential(*required_arguments, password=cert_password, _enable_persistent_cache=True)
+            CertificateCredential(*required_arguments, password=cert_password, enable_persistent_cache=True)
         with pytest.raises(NotImplementedError):
             CertificateCredential(
-                *required_arguments, password=cert_password, _enable_persistent_cache=True, _allow_unencrypted_cache=True
+                *required_arguments, password=cert_password, enable_persistent_cache=True, allow_unencrypted_cache=True
             )
 
 
@@ -179,7 +179,7 @@ def test_persistent_cache_linux(mock_extensions, cert_path, cert_password):
 
     # the credential should prefer an encrypted cache even when the user allows an unencrypted one
     CertificateCredential(
-        *required_arguments, password=cert_password, _enable_persistent_cache=True, _allow_unencrypted_cache=True
+        *required_arguments, password=cert_password, enable_persistent_cache=True, allow_unencrypted_cache=True
     )
     assert mock_extensions.PersistedTokenCache.called_with(mock_extensions.LibsecretPersistence)
     mock_extensions.PersistedTokenCache.reset_mock()
@@ -189,10 +189,10 @@ def test_persistent_cache_linux(mock_extensions, cert_path, cert_password):
 
     # encryption unavailable, no opt in to unencrypted cache -> credential should raise
     with pytest.raises(ValueError):
-        CertificateCredential(*required_arguments, password=cert_password, _enable_persistent_cache=True)
+        CertificateCredential(*required_arguments, password=cert_password, enable_persistent_cache=True)
 
     CertificateCredential(
-        *required_arguments, password=cert_password, _enable_persistent_cache=True, _allow_unencrypted_cache=True
+        *required_arguments, password=cert_password, enable_persistent_cache=True, allow_unencrypted_cache=True
     )
     assert mock_extensions.PersistedTokenCache.called_with(mock_extensions.FilePersistence)
 
@@ -215,11 +215,11 @@ async def test_persistent_cache_multiple_clients(cert_path, cert_password):
     with patch("azure.identity._internal.persistent_cache._load_persistent_cache") as mock_cache_loader:
         mock_cache_loader.return_value = Mock(wraps=cache)
         credential_a = CertificateCredential(
-            "tenant", "client-a", cert_path, password=cert_password, _enable_persistent_cache=True, transport=transport_a
+            "tenant", "client-a", cert_path, password=cert_password, enable_persistent_cache=True, transport=transport_a
         )
         assert mock_cache_loader.call_count == 1, "credential should load the persistent cache"
         credential_b = CertificateCredential(
-            "tenant", "client-b", cert_path, password=cert_password, _enable_persistent_cache=True, transport=transport_b
+            "tenant", "client-b", cert_path, password=cert_password, enable_persistent_cache=True, transport=transport_b
         )
         assert mock_cache_loader.call_count == 2, "credential should load the persistent cache"
 

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential.py
@@ -158,19 +158,19 @@ def test_enable_persistent_cache():
         ClientSecretCredential(*required_arguments)
 
         # allowing an unencrypted cache doesn't count as opting in to the persistent cache
-        ClientSecretCredential(*required_arguments, _allow_unencrypted_cache=True)
+        ClientSecretCredential(*required_arguments, allow_unencrypted_cache=True)
 
     # keyword argument opts in to persistent cache
     with patch(persistent_cache + ".msal_extensions") as mock_extensions:
-        ClientSecretCredential(*required_arguments, _enable_persistent_cache=True)
+        ClientSecretCredential(*required_arguments, enable_persistent_cache=True)
     assert mock_extensions.PersistedTokenCache.call_count == 1
 
     # opting in on an unsupported platform raises an exception
     with patch(persistent_cache + ".sys.platform", "commodore64"):
         with pytest.raises(NotImplementedError):
-            ClientSecretCredential(*required_arguments, _enable_persistent_cache=True)
+            ClientSecretCredential(*required_arguments, enable_persistent_cache=True)
         with pytest.raises(NotImplementedError):
-            ClientSecretCredential(*required_arguments, _enable_persistent_cache=True, _allow_unencrypted_cache=True)
+            ClientSecretCredential(*required_arguments, enable_persistent_cache=True, allow_unencrypted_cache=True)
 
 
 @patch("azure.identity._internal.persistent_cache.sys.platform", "linux2")
@@ -184,7 +184,7 @@ def test_persistent_cache_linux(mock_extensions):
     required_arguments = ("tenant-id", "client-id", "secret")
 
     # the credential should prefer an encrypted cache even when the user allows an unencrypted one
-    ClientSecretCredential(*required_arguments, _enable_persistent_cache=True, _allow_unencrypted_cache=True)
+    ClientSecretCredential(*required_arguments, enable_persistent_cache=True, allow_unencrypted_cache=True)
     assert mock_extensions.PersistedTokenCache.called_with(mock_extensions.LibsecretPersistence)
     mock_extensions.PersistedTokenCache.reset_mock()
 
@@ -193,9 +193,9 @@ def test_persistent_cache_linux(mock_extensions):
 
     # encryption unavailable, no opt in to unencrypted cache -> credential should raise
     with pytest.raises(ValueError):
-        ClientSecretCredential(*required_arguments, _enable_persistent_cache=True)
+        ClientSecretCredential(*required_arguments, enable_persistent_cache=True)
 
-    ClientSecretCredential(*required_arguments, _enable_persistent_cache=True, _allow_unencrypted_cache=True)
+    ClientSecretCredential(*required_arguments, enable_persistent_cache=True, allow_unencrypted_cache=True)
     assert mock_extensions.PersistedTokenCache.called_with(mock_extensions.FilePersistence)
 
 
@@ -215,11 +215,11 @@ def test_persistent_cache_multiple_clients():
     with patch("azure.identity._internal.persistent_cache._load_persistent_cache") as mock_cache_loader:
         mock_cache_loader.return_value = Mock(wraps=cache)
         credential_a = ClientSecretCredential(
-            "tenant-id", "client-a", "...", _enable_persistent_cache=True, transport=transport_a
+            "tenant-id", "client-a", "...", enable_persistent_cache=True, transport=transport_a
         )
         assert mock_cache_loader.call_count == 1, "credential should load the persistent cache"
         credential_b = ClientSecretCredential(
-            "tenant-id", "client-b", "...", _enable_persistent_cache=True, transport=transport_b
+            "tenant-id", "client-b", "...", enable_persistent_cache=True, transport=transport_b
         )
         assert mock_cache_loader.call_count == 2, "credential should load the persistent cache"
 

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential_async.py
@@ -184,19 +184,19 @@ def test_enable_persistent_cache():
         ClientSecretCredential(*required_arguments)
 
         # allowing an unencrypted cache doesn't count as opting in to the persistent cache
-        ClientSecretCredential(*required_arguments, _allow_unencrypted_cache=True)
+        ClientSecretCredential(*required_arguments, allow_unencrypted_cache=True)
 
     # keyword argument opts in to persistent cache
     with patch(persistent_cache + ".msal_extensions") as mock_extensions:
-        ClientSecretCredential(*required_arguments, _enable_persistent_cache=True)
+        ClientSecretCredential(*required_arguments, enable_persistent_cache=True)
     assert mock_extensions.PersistedTokenCache.call_count == 1
 
     # opting in on an unsupported platform raises an exception
     with patch(persistent_cache + ".sys.platform", "commodore64"):
         with pytest.raises(NotImplementedError):
-            ClientSecretCredential(*required_arguments, _enable_persistent_cache=True)
+            ClientSecretCredential(*required_arguments, enable_persistent_cache=True)
         with pytest.raises(NotImplementedError):
-            ClientSecretCredential(*required_arguments, _enable_persistent_cache=True, _allow_unencrypted_cache=True)
+            ClientSecretCredential(*required_arguments, enable_persistent_cache=True, allow_unencrypted_cache=True)
 
 
 @patch("azure.identity._internal.persistent_cache.sys.platform", "linux2")
@@ -210,7 +210,7 @@ def test_persistent_cache_linux(mock_extensions):
     required_arguments = ("tenant-id", "client-id", "secret")
 
     # the credential should prefer an encrypted cache even when the user allows an unencrypted one
-    ClientSecretCredential(*required_arguments, _enable_persistent_cache=True, _allow_unencrypted_cache=True)
+    ClientSecretCredential(*required_arguments, enable_persistent_cache=True, allow_unencrypted_cache=True)
     assert mock_extensions.PersistedTokenCache.called_with(mock_extensions.LibsecretPersistence)
     mock_extensions.PersistedTokenCache.reset_mock()
 
@@ -219,9 +219,9 @@ def test_persistent_cache_linux(mock_extensions):
 
     # encryption unavailable, no opt in to unencrypted cache -> credential should raise
     with pytest.raises(ValueError):
-        ClientSecretCredential(*required_arguments, _enable_persistent_cache=True)
+        ClientSecretCredential(*required_arguments, enable_persistent_cache=True)
 
-    ClientSecretCredential(*required_arguments, _enable_persistent_cache=True, _allow_unencrypted_cache=True)
+    ClientSecretCredential(*required_arguments, enable_persistent_cache=True, allow_unencrypted_cache=True)
     assert mock_extensions.PersistedTokenCache.called_with(mock_extensions.FilePersistence)
 
 
@@ -242,11 +242,11 @@ async def test_persistent_cache_multiple_clients():
     with patch("azure.identity._internal.persistent_cache._load_persistent_cache") as mock_cache_loader:
         mock_cache_loader.return_value = Mock(wraps=cache)
         credential_a = ClientSecretCredential(
-            "tenant-id", "client-a", "...", _enable_persistent_cache=True, transport=transport_a
+            "tenant-id", "client-a", "...", enable_persistent_cache=True, transport=transport_a
         )
         assert mock_cache_loader.call_count == 1, "credential should load the persistent cache"
         credential_b = ClientSecretCredential(
-            "tenant-id", "client-b", "...", _enable_persistent_cache=True, transport=transport_b
+            "tenant-id", "client-b", "...", enable_persistent_cache=True, transport=transport_b
         )
         assert mock_cache_loader.call_count == 2, "credential should load the persistent cache"
 

--- a/sdk/identity/azure-identity/tests/test_device_code_credential.py
+++ b/sdk/identity/azure-identity/tests/test_device_code_credential.py
@@ -6,8 +6,7 @@ import datetime
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.pipeline.policies import SansIOHTTPPolicy
-from azure.identity import DeviceCodeCredential
-from azure.identity._exceptions import AuthenticationRequiredError
+from azure.identity import AuthenticationRequiredError, DeviceCodeCredential
 from azure.identity._internal.user_agent import USER_AGENT
 from msal import TokenCache
 import pytest
@@ -78,7 +77,7 @@ def test_authenticate():
         tenant_id=tenant_id,
         _cache=TokenCache(),
     )
-    record = credential._authenticate(scopes=(scope,))
+    record = credential.authenticate(scopes=(scope,))
     assert record.authority == environment
     assert record.home_account_id == object_id + "." + home_tenant
     assert record.tenant_id == home_tenant
@@ -94,7 +93,7 @@ def test_disable_automatic_authentication():
 
     empty_cache = TokenCache()  # empty cache makes silent auth impossible
     transport = Mock(send=Mock(side_effect=Exception("no request should be sent")))
-    credential = DeviceCodeCredential("client-id", _disable_automatic_authentication=True, transport=transport, _cache=empty_cache)
+    credential = DeviceCodeCredential("client-id", disable_automatic_authentication=True, transport=transport, _cache=empty_cache)
 
     with pytest.raises(AuthenticationRequiredError):
         credential.get_token("scope")

--- a/sdk/identity/azure-identity/tests/test_imds_credential.py
+++ b/sdk/identity/azure-identity/tests/test_imds_credential.py
@@ -169,7 +169,7 @@ def test_identity_config():
         ],
     )
 
-    credential = ImdsCredential(_identity_config={param_name: param_value}, transport=transport)
+    credential = ImdsCredential(identity_config={param_name: param_value}, transport=transport)
     token = credential.get_token(scope)
 
     assert token == expected_token

--- a/sdk/identity/azure-identity/tests/test_imds_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_imds_credential_async.py
@@ -198,7 +198,7 @@ async def test_identity_config():
         ],
     )
 
-    credential = ImdsCredential(client_id=client_id, _identity_config={param_name: param_value}, transport=transport)
+    credential = ImdsCredential(client_id=client_id, identity_config={param_name: param_value}, transport=transport)
     token = await credential.get_token(scope)
 
     assert token == expected_token

--- a/sdk/identity/azure-identity/tests/test_msi_credential.py
+++ b/sdk/identity/azure-identity/tests/test_msi_credential.py
@@ -68,7 +68,7 @@ def test_identity_config_app_service():
         {EnvironmentVariables.MSI_ENDPOINT: endpoint, EnvironmentVariables.MSI_SECRET: secret},
         clear=True,
     ):
-        credential = MsiCredential(_identity_config={param_name: param_value}, transport=transport)
+        credential = MsiCredential(identity_config={param_name: param_value}, transport=transport)
         token = credential.get_token(scope)
 
     assert token == expected_token
@@ -107,7 +107,7 @@ def test_identity_config_cloud_shell():
     with mock.patch.dict(
         MsiCredential.__module__ + ".os.environ", {EnvironmentVariables.MSI_ENDPOINT: endpoint}, clear=True
     ):
-        credential = MsiCredential(_identity_config={param_name: param_value}, transport=transport)
+        credential = MsiCredential(identity_config={param_name: param_value}, transport=transport)
         token = credential.get_token(scope)
 
     assert token == expected_token

--- a/sdk/identity/azure-identity/tests/test_msi_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_msi_credential_async.py
@@ -96,7 +96,7 @@ async def test_identity_config_app_service():
         {EnvironmentVariables.MSI_ENDPOINT: endpoint, EnvironmentVariables.MSI_SECRET: secret},
         clear=True,
     ):
-        credential = MsiCredential(_identity_config={param_name: param_value}, transport=transport)
+        credential = MsiCredential(identity_config={param_name: param_value}, transport=transport)
         token = await credential.get_token(scope)
 
     assert token == expected_token
@@ -135,7 +135,7 @@ async def test_identity_config_cloud_shell():
     with mock.patch.dict(
         MsiCredential.__module__ + ".os.environ", {EnvironmentVariables.MSI_ENDPOINT: endpoint}, clear=True
     ):
-        credential = MsiCredential(_identity_config={param_name: param_value}, transport=transport)
+        credential = MsiCredential(identity_config={param_name: param_value}, transport=transport)
         token = await credential.get_token(scope)
 
     assert token == expected_token

--- a/sdk/identity/azure-identity/tests/test_username_password_credential.py
+++ b/sdk/identity/azure-identity/tests/test_username_password_credential.py
@@ -125,7 +125,7 @@ def test_authenticate():
         tenant_id=tenant_id,
         transport=transport,
     )
-    record = credential._authenticate(scopes=(scope,))
+    record = credential.authenticate(scopes=(scope,))
     assert record.authority == environment
     assert record.home_account_id == object_id + "." + home_tenant
     assert record.tenant_id == home_tenant


### PR DESCRIPTION
Reverting #12788, restoring the user authentication API of 1.4.0b7. Also updating packaging metadata for 1.5.0b1.