### PR TITLE
msrestazure is a holdover from track1; can be deprecated 

### DIFF
--- a/sdk/servicebus/azure-servicebus/setup.py
+++ b/sdk/servicebus/azure-servicebus/setup.py
@@ -79,7 +79,6 @@ setup(
     ]),
     install_requires=[
         'uamqp>=1.2.10,<2.0.0',
-        'msrestazure>=0.4.32,<2.0.0',
         'azure-common~=1.1',
         'msrest>=0.6.17,<2.0.0',
         'azure-core<2.0.0,>=1.6.0',


### PR DESCRIPTION
This is likely in light of control client removal.