### PR TITLE
Handle missing certs model properties in 2016-10-01

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/tests/recordings/test_certificates_client.test_2016_10_01_models.yaml
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/recordings/test_certificates_client.test_2016_10_01_models.yaml
@@ -1,0 +1,395 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/certificates/certb81a116d/create?api-version=2016-10-01
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
+        or PoP token."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '87'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 14 Aug 2020 21:57:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.31.4
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"policy": {"x509_props": {"subject": "CN=DefaultPolicy", "sans": {}},
+      "issuer": {"name": "Self"}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/certificates/certb81a116d/create?api-version=2016-10-01
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/certificates/certb81a116d/pending","issuer":{"name":"Self"},"csr":"MIICqDCCAZACAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALc5ApOeeyu064QOivTm9mgpsMkTqEjegjgKj6Bav+6rmgr0GS976w+Or+4EpHhTxNSax9C3Pyw8PKrJU45OBdTQn+5h5Y7N2MumREvBsMFnycKOU0vMe2uxPOcXlXTJj+t6j3it54hk/ExdlQG7oYPlxw2RmSW+ZVO5ZCphgThVBozNINcE8bQV8KciuUQKUyCQx/wdkikPaq1qnEuQ883HdofoBQJ9rvPoNcKEE/x+WTB1NA52d5WOwAOgpf92ro82XZWajGzjY9pkiPrb+u89fX1g6fczvjqXRp3FPSsrzTR1oZ8zc1NR2ZQbKkCISF2uWrpx3jjoc2KjxhhAcGECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAXY6j0agUrOsfsfWcsEsp6Quu27klwfgEhELa2HUvSMPtay5QARrSSsTwmx09Hw9ayyERi4E6eVhEufxdLLamvjbOqRJUlY7m0pbusKr1xgCmoggXPJDl/5L7rU49dCjP+YXXxzEaTkkD27sePXqptNWB4rODrHZ/5Akup6YadX0ntOd2nIxO0qhM8tt0TXHArCMjBsjzOXwOq5PR6cU2lYEylHzQkSaL9qLi6s4u1pDTug3xaaJLPdZBKBZ0z2X+wzgAHBXigx+k2In7lsZKAXbbiH1TRusxUf5qrYsq0P7HI1RyIzuLKkG07AQ4ORlhPyEsStVh/LBBlC3McuBae","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"36abd634c44a425db54e971c3cc52011"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1302'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 14 Aug 2020 21:57:38 GMT
+      expires:
+      - '-1'
+      location:
+      - https://vaultname.vault.azure.net/certificates/certb81a116d/pending?api-version=2016-10-01&request_id=36abd634c44a425db54e971c3cc52011
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.31.4
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/certificates/certb81a116d/pending?api-version=2016-10-01
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/certificates/certb81a116d/pending","issuer":{"name":"Self"},"csr":"MIICqDCCAZACAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALc5ApOeeyu064QOivTm9mgpsMkTqEjegjgKj6Bav+6rmgr0GS976w+Or+4EpHhTxNSax9C3Pyw8PKrJU45OBdTQn+5h5Y7N2MumREvBsMFnycKOU0vMe2uxPOcXlXTJj+t6j3it54hk/ExdlQG7oYPlxw2RmSW+ZVO5ZCphgThVBozNINcE8bQV8KciuUQKUyCQx/wdkikPaq1qnEuQ883HdofoBQJ9rvPoNcKEE/x+WTB1NA52d5WOwAOgpf92ro82XZWajGzjY9pkiPrb+u89fX1g6fczvjqXRp3FPSsrzTR1oZ8zc1NR2ZQbKkCISF2uWrpx3jjoc2KjxhhAcGECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAXY6j0agUrOsfsfWcsEsp6Quu27klwfgEhELa2HUvSMPtay5QARrSSsTwmx09Hw9ayyERi4E6eVhEufxdLLamvjbOqRJUlY7m0pbusKr1xgCmoggXPJDl/5L7rU49dCjP+YXXxzEaTkkD27sePXqptNWB4rODrHZ/5Akup6YadX0ntOd2nIxO0qhM8tt0TXHArCMjBsjzOXwOq5PR6cU2lYEylHzQkSaL9qLi6s4u1pDTug3xaaJLPdZBKBZ0z2X+wzgAHBXigx+k2In7lsZKAXbbiH1TRusxUf5qrYsq0P7HI1RyIzuLKkG07AQ4ORlhPyEsStVh/LBBlC3McuBae","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"36abd634c44a425db54e971c3cc52011"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1302'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 14 Aug 2020 21:57:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.31.4
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/certificates/certb81a116d/pending?api-version=2016-10-01
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/certificates/certb81a116d/pending","issuer":{"name":"Self"},"csr":"MIICqDCCAZACAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALc5ApOeeyu064QOivTm9mgpsMkTqEjegjgKj6Bav+6rmgr0GS976w+Or+4EpHhTxNSax9C3Pyw8PKrJU45OBdTQn+5h5Y7N2MumREvBsMFnycKOU0vMe2uxPOcXlXTJj+t6j3it54hk/ExdlQG7oYPlxw2RmSW+ZVO5ZCphgThVBozNINcE8bQV8KciuUQKUyCQx/wdkikPaq1qnEuQ883HdofoBQJ9rvPoNcKEE/x+WTB1NA52d5WOwAOgpf92ro82XZWajGzjY9pkiPrb+u89fX1g6fczvjqXRp3FPSsrzTR1oZ8zc1NR2ZQbKkCISF2uWrpx3jjoc2KjxhhAcGECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAXY6j0agUrOsfsfWcsEsp6Quu27klwfgEhELa2HUvSMPtay5QARrSSsTwmx09Hw9ayyERi4E6eVhEufxdLLamvjbOqRJUlY7m0pbusKr1xgCmoggXPJDl/5L7rU49dCjP+YXXxzEaTkkD27sePXqptNWB4rODrHZ/5Akup6YadX0ntOd2nIxO0qhM8tt0TXHArCMjBsjzOXwOq5PR6cU2lYEylHzQkSaL9qLi6s4u1pDTug3xaaJLPdZBKBZ0z2X+wzgAHBXigx+k2In7lsZKAXbbiH1TRusxUf5qrYsq0P7HI1RyIzuLKkG07AQ4ORlhPyEsStVh/LBBlC3McuBae","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"36abd634c44a425db54e971c3cc52011"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1302'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 14 Aug 2020 21:57:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.31.4
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/certificates/certb81a116d/pending?api-version=2016-10-01
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/certificates/certb81a116d/pending","issuer":{"name":"Self"},"csr":"MIICqDCCAZACAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALc5ApOeeyu064QOivTm9mgpsMkTqEjegjgKj6Bav+6rmgr0GS976w+Or+4EpHhTxNSax9C3Pyw8PKrJU45OBdTQn+5h5Y7N2MumREvBsMFnycKOU0vMe2uxPOcXlXTJj+t6j3it54hk/ExdlQG7oYPlxw2RmSW+ZVO5ZCphgThVBozNINcE8bQV8KciuUQKUyCQx/wdkikPaq1qnEuQ883HdofoBQJ9rvPoNcKEE/x+WTB1NA52d5WOwAOgpf92ro82XZWajGzjY9pkiPrb+u89fX1g6fczvjqXRp3FPSsrzTR1oZ8zc1NR2ZQbKkCISF2uWrpx3jjoc2KjxhhAcGECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAXY6j0agUrOsfsfWcsEsp6Quu27klwfgEhELa2HUvSMPtay5QARrSSsTwmx09Hw9ayyERi4E6eVhEufxdLLamvjbOqRJUlY7m0pbusKr1xgCmoggXPJDl/5L7rU49dCjP+YXXxzEaTkkD27sePXqptNWB4rODrHZ/5Akup6YadX0ntOd2nIxO0qhM8tt0TXHArCMjBsjzOXwOq5PR6cU2lYEylHzQkSaL9qLi6s4u1pDTug3xaaJLPdZBKBZ0z2X+wzgAHBXigx+k2In7lsZKAXbbiH1TRusxUf5qrYsq0P7HI1RyIzuLKkG07AQ4ORlhPyEsStVh/LBBlC3McuBae","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"36abd634c44a425db54e971c3cc52011"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1302'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 14 Aug 2020 21:57:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.31.4
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/certificates/certb81a116d/pending?api-version=2016-10-01
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/certificates/certb81a116d/pending","issuer":{"name":"Self"},"csr":"MIICqDCCAZACAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALc5ApOeeyu064QOivTm9mgpsMkTqEjegjgKj6Bav+6rmgr0GS976w+Or+4EpHhTxNSax9C3Pyw8PKrJU45OBdTQn+5h5Y7N2MumREvBsMFnycKOU0vMe2uxPOcXlXTJj+t6j3it54hk/ExdlQG7oYPlxw2RmSW+ZVO5ZCphgThVBozNINcE8bQV8KciuUQKUyCQx/wdkikPaq1qnEuQ883HdofoBQJ9rvPoNcKEE/x+WTB1NA52d5WOwAOgpf92ro82XZWajGzjY9pkiPrb+u89fX1g6fczvjqXRp3FPSsrzTR1oZ8zc1NR2ZQbKkCISF2uWrpx3jjoc2KjxhhAcGECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAXY6j0agUrOsfsfWcsEsp6Quu27klwfgEhELa2HUvSMPtay5QARrSSsTwmx09Hw9ayyERi4E6eVhEufxdLLamvjbOqRJUlY7m0pbusKr1xgCmoggXPJDl/5L7rU49dCjP+YXXxzEaTkkD27sePXqptNWB4rODrHZ/5Akup6YadX0ntOd2nIxO0qhM8tt0TXHArCMjBsjzOXwOq5PR6cU2lYEylHzQkSaL9qLi6s4u1pDTug3xaaJLPdZBKBZ0z2X+wzgAHBXigx+k2In7lsZKAXbbiH1TRusxUf5qrYsq0P7HI1RyIzuLKkG07AQ4ORlhPyEsStVh/LBBlC3McuBae","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"36abd634c44a425db54e971c3cc52011"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1302'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 14 Aug 2020 21:57:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.31.4
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/certificates/certb81a116d/pending?api-version=2016-10-01
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/certificates/certb81a116d/pending","issuer":{"name":"Self"},"csr":"MIICqDCCAZACAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALc5ApOeeyu064QOivTm9mgpsMkTqEjegjgKj6Bav+6rmgr0GS976w+Or+4EpHhTxNSax9C3Pyw8PKrJU45OBdTQn+5h5Y7N2MumREvBsMFnycKOU0vMe2uxPOcXlXTJj+t6j3it54hk/ExdlQG7oYPlxw2RmSW+ZVO5ZCphgThVBozNINcE8bQV8KciuUQKUyCQx/wdkikPaq1qnEuQ883HdofoBQJ9rvPoNcKEE/x+WTB1NA52d5WOwAOgpf92ro82XZWajGzjY9pkiPrb+u89fX1g6fczvjqXRp3FPSsrzTR1oZ8zc1NR2ZQbKkCISF2uWrpx3jjoc2KjxhhAcGECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAXY6j0agUrOsfsfWcsEsp6Quu27klwfgEhELa2HUvSMPtay5QARrSSsTwmx09Hw9ayyERi4E6eVhEufxdLLamvjbOqRJUlY7m0pbusKr1xgCmoggXPJDl/5L7rU49dCjP+YXXxzEaTkkD27sePXqptNWB4rODrHZ/5Akup6YadX0ntOd2nIxO0qhM8tt0TXHArCMjBsjzOXwOq5PR6cU2lYEylHzQkSaL9qLi6s4u1pDTug3xaaJLPdZBKBZ0z2X+wzgAHBXigx+k2In7lsZKAXbbiH1TRusxUf5qrYsq0P7HI1RyIzuLKkG07AQ4ORlhPyEsStVh/LBBlC3McuBae","cancellation_requested":false,"status":"completed","target":"https://vaultname.vault.azure.net/certificates/certb81a116d","request_id":"36abd634c44a425db54e971c3cc52011"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1223'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 14 Aug 2020 21:57:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.31.4
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/certificates/certb81a116d/?api-version=2016-10-01
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/certificates/certb81a116d/c90ec48f3d15432682bcdda7b91e24d2","kid":"https://vaultname.vault.azure.net/keys/certb81a116d/c90ec48f3d15432682bcdda7b91e24d2","sid":"https://vaultname.vault.azure.net/secrets/certb81a116d/c90ec48f3d15432682bcdda7b91e24d2","x5t":"YB8hpzNuUUnBts670ui4x8obRTw","cer":"MIIDNjCCAh6gAwIBAgIQHHHqA9RgRC6fan+r1SdguDANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIwMDgxNDIxNDc1NloXDTIxMDgxNDIxNTc1NlowGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALc5ApOeeyu064QOivTm9mgpsMkTqEjegjgKj6Bav+6rmgr0GS976w+Or+4EpHhTxNSax9C3Pyw8PKrJU45OBdTQn+5h5Y7N2MumREvBsMFnycKOU0vMe2uxPOcXlXTJj+t6j3it54hk/ExdlQG7oYPlxw2RmSW+ZVO5ZCphgThVBozNINcE8bQV8KciuUQKUyCQx/wdkikPaq1qnEuQ883HdofoBQJ9rvPoNcKEE/x+WTB1NA52d5WOwAOgpf92ro82XZWajGzjY9pkiPrb+u89fX1g6fczvjqXRp3FPSsrzTR1oZ8zc1NR2ZQbKkCISF2uWrpx3jjoc2KjxhhAcGECAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFEZdbqwP8jT7Ty3ub84SE7TljkYyMB0GA1UdDgQWBBRGXW6sD/I0+08t7m/OEhO05Y5GMjANBgkqhkiG9w0BAQsFAAOCAQEAmKxQTPGTVuoizDx/tPKShFGZPOiZ8ieDfm2UNEkpBs79Hw/Svf+/CXLLJVbm1y0OJ/LBPgXWgdKYyaZhva++zS8ebHCnb2+apM5sDe1D6woUkOfo0i7LZ2u24zFeGNSSjSi5yJRoK52aZqxZYHWNnkrZVAlLVIuPMvQpcHUn/AWpjtkmzwhDS6D5EmyQiRn9q1OsbiKT0Pr7bRYDuR6wcZF5KXQI04B6qqgc4GtgfNAA/We91y+C+1hQYK7PhPKXUKDOKkj0tBG/EgSWQbzfg99owkHq0YnsOJ73/wGKoI6CsxkVLjFmlM0E42xrRvZN9gBr/UQiCLVZaHUhqv2UOw==","attributes":{"enabled":true,"nbf":1597441676,"exp":1628978276,"created":1597442276,"updated":1597442276,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://vaultname.vault.azure.net/certificates/certb81a116d/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=DefaultPolicy","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1597442258,"updated":1597442258}},"pending":{"id":"https://vaultname.vault.azure.net/certificates/certb81a116d/pending"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2366'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 14 Aug 2020 21:57:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.31.4
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
@@ -11,6 +11,7 @@ from azure_devtools.scenario_tests import RecordingProcessor, RequestUrlNormaliz
 
 from azure.keyvault.certificates import (
     AdministratorContact,
+    ApiVersion,
     CertificateClient,
     CertificateContact,
     CertificatePolicyAction,
@@ -621,6 +622,19 @@ class CertificateClientTests(KeyVaultTestCase):
                 except (ValueError, KeyError):
                     # this means the message is not JSON or has no kty property
                     pass
+
+    @ResourceGroupPreparer(random_name_enabled=True)
+    @KeyVaultPreparer()
+    @KeyVaultClientPreparer(client_kwargs={"api_version": ApiVersion.V2016_10_01})
+    def test_2016_10_01_models(self, client, **kwargs):
+        """The client should correctly deserialize version 2016-10-01 models"""
+
+        cert_name = self.get_resource_name("cert")
+        cert = client.begin_create_certificate(cert_name, CertificatePolicy.get_default()).result()
+
+        # these properties don't exist in version 2016-10-01
+        assert cert.policy.key_curve_name is None
+        assert cert.policy.certificate_transparency is None
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @KeyVaultPreparer()


### PR DESCRIPTION
In Key Vault API version 2016-10-01, two models are missing attributes added in version 7.0:
- IssuerParameters.certificate_transparency
- KeyProperties.curve

Code for wrapping generated models in hand-written ones doesn't handle this gracefully, raising `AttributeError`. This PR makes the code tolerant of these missing attributes and adds a test to exercise it. The test is a medium-term thing. For the long run we need a better way to test multiple versions, something like `pytest.mark.parametrize` that runs test cases with a client for each supported service version.

There's at least one other issue preventing `CertificateClient` from fully supporting 2016-10-01: #13122.