### PR TITLE
Add azure-ai-anomalydetector to error code 5 ignored list

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -48,6 +48,7 @@ known_content_issues:
   - ['sdk/synapse/azure-synapse-spark/README.md', '#4554']
   - ['sdk/synapse/azure-synapse-artifacts/README.md', '#4554']
   - ['sdk/synapse/azure-synapse-nspkg/README.md', '#4554']
+  - ['sdk/anomalydetector/azure-ai-anomalydetector/README.md', '#4554']
   - ['sdk/applicationinsights/azure-applicationinsights/README.md', '#4554']
   - ['sdk/batch/azure-batch/README.md', '#4554']
   - ['sdk/cognitiveservices/azure-cognitiveservices-anomalydetector/README.md', '#4554']

--- a/eng/tox/allowed_pylint_failures.py
+++ b/eng/tox/allowed_pylint_failures.py
@@ -47,4 +47,5 @@ PYLINT_ACCEPTABLE_FAILURES = [
     "azure-synapse-spark",
     "azure-synapse-accesscontrol",
     "azure-synapse-nspkg",
+    "azure-ai-anomalydetector",
 ]

--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -48,7 +48,8 @@ MANAGEMENT_PACKAGE_IDENTIFIERS = [
     "azure-servicefabric",
     "nspkg",
     "azure-keyvault",
-    "azure-synapse"
+    "azure-synapse",
+    "azure-ai-anomalydetector",
 ]
 META_PACKAGES = ["azure", "azure-mgmt", "azure-keyvault"]
 REGRESSION_EXCLUDED_PACKAGES = [

--- a/sdk/anomalydetector/ci.yml
+++ b/sdk/anomalydetector/ci.yml
@@ -33,3 +33,4 @@ extends:
     Artifacts:
     - name: azure_ai_anomalydetector
       safeName: azureaianomalydetector
+

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -156,3 +156,4 @@ opentelemetry-api==0.10b0
 #override azure-synapse-spark azure-core>=1.6.0,<2.0.0
 #override azure-synapse-artifacts azure-core>=1.6.0,<2.0.0
 #override azure-data-tables msrest>=0.6.10
+#override azure-ai-anomalydetector azure-core>=1.6.0,<2.0.0


### PR DESCRIPTION
Azure-ai-anomalydetector is autogenerated code so it doesn't have any tests. pytest returns error code 5 when no test is present and we need to ignore error code 5 for these packages.

