### PR TITLE
Suppress errors in anomoly detector for now.

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -95,6 +95,7 @@ known_content_issues:
   - ['sdk/storage/azure-storage-queue/swagger/README.md', '#4554']
   - ['sdk/storage/README.md', '#4554']
   - ['sdk/textanalytics/azure-ai-textanalytics/samples/README.md', '#4554']
+  - ['sdk/anomalydetector/azure-ai-anomalydetector/README.md', '#4554']
 
   # nspckg and common.
   - ['sdk/appconfiguration/azure-appconfiguration/README.md', 'nspkg and common']


### PR DESCRIPTION
Python pipelines are broken due to a bad README.md file, this suppresses that issue for now.