### PR TITLE
SAS credential replicated "/" fix

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
@@ -147,7 +147,9 @@ def _urljoin(base_url, stub_url):
     :rtype: str
     """
     parsed = urlparse(base_url)
-    parsed = parsed._replace(path=parsed.path + "/" + stub_url)
+    parsed = (parsed._replace(
+        path=parsed.path + "/" + stub_url) if parsed.path[-1:] != "/" else parsed._replace(
+        path=parsed.path + stub_url))
     return parsed.geturl()
 
 

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
@@ -147,9 +147,7 @@ def _urljoin(base_url, stub_url):
     :rtype: str
     """
     parsed = urlparse(base_url)
-    parsed = (parsed._replace(
-        path=parsed.path + "/" + stub_url) if parsed.path[-1:] != "/" else parsed._replace(
-        path=parsed.path + stub_url))
+    parsed = parsed._replace(path=parsed.path.rstrip("/") + "/" + stub_url)
     return parsed.geturl()
 
 

--- a/sdk/core/azure-core/tests/test_basic_transport.py
+++ b/sdk/core/azure-core/tests/test_basic_transport.py
@@ -14,7 +14,7 @@ except ImportError:
     import mock
 
 from azure.core.pipeline.transport import HttpRequest, HttpResponse, RequestsTransport
-from azure.core.pipeline.transport._base import HttpClientTransportResponse, HttpTransport, _deserialize_response
+from azure.core.pipeline.transport._base import HttpClientTransportResponse, HttpTransport, _deserialize_response, _urljoin
 from azure.core.pipeline.policies import HeadersPolicy
 from azure.core.pipeline import Pipeline
 import logging
@@ -86,6 +86,13 @@ def test_http_request_serialization():
         b'I am groot'
     )
     assert serialized == expected
+
+
+def test_url_join():
+    assert _urljoin('devstoreaccount1', '') == 'devstoreaccount1/'
+    assert _urljoin('devstoreaccount1', 'testdir/') == 'devstoreaccount1/testdir/'
+    assert _urljoin('devstoreaccount1/', '') == 'devstoreaccount1/'
+    assert _urljoin('devstoreaccount1/', 'testdir/') == 'devstoreaccount1/testdir/'
 
 
 def test_http_client_response():


### PR DESCRIPTION
This PR aims to resolve https://github.com/Azure/azure-sdk-for-python/issues/11941.
The issue involves `path` found in the `urlparse` object which will some times contain a `/` suffix (for example when `credential` is not `None`), when that happens a hardcoded `/` was added (and hence a duplicate occurs). Instead now a simple check is made before adding the `/`.