### PR TITLE
[Service Bus] Use swagger file in azure-rest-api-specs/sb_dataplane_namespace

### DIFF
--- a/sdk/servicebus/azure-servicebus/swagger/README.md
+++ b/sdk/servicebus/azure-servicebus/swagger/README.md
@@ -2,28 +2,18 @@
 
 > see https://aka.ms/autorest
 
-### Setup
-```ps
-cd C:\work
-git clone --recursive https://github.com/Azure/autorest.python.git
-cd autorest.python
-git checkout azure-core
-npm install
-```
 ### Generation
 ```ps
 cd C:\Work\ServiceBus\
-autorest --use=@autorest/python@5.0.0-preview.6
+autorest --v3 --python --use=@autorest/python@5.0.0-preview.6
 ```
 ### Settings
 ``` yaml
-input-file: https://raw.githubusercontent.com/YijunXieMS/azure-rest-api-specs-pr/servicebus_mgmt/specification/servicebus/data-plane/servicebus-swagger.json?token=ALQFVABEGSXQX2IEVU26V2K7AYZ4K
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/sb_dataplane_namespace/specification/servicebus/data-plane/servicebus-swagger.json
 output-folder: ../azure/servicebus/management/_generated
 namespace: azure.servicebus.management._generated
 no-namespace-folders: true
 license-header: MICROSOFT_MIT_NO_VERSION
-enable-xml: false
-vanilla: true
 clear-output-folder: true
 python: true
 package-version: "2017-04"


### PR DESCRIPTION
1. Moved the swagger file from repo `azure-rest-api-specs-pr` to `azure-rest-api-specs` so everyone can see it.
2. Cleaned swagger/README.md. The setup section is removed because it's obsolete. `enable-xml`  and `vanilla` are not used in Python code gen.
3. No impact to generated code.