### PR TITLE
Fixed QueueClient type declaration

### DIFF
--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
@@ -158,7 +158,7 @@ class QueueClient(StorageAccountHostsMixin):
             credential=None,  # type: Any
             **kwargs  # type: Any
         ):
-        # type: (...) -> None
+        # type: (...) -> QueueClient
         """Create QueueClient from a Connection String.
 
         :param str conn_str:


### PR DESCRIPTION
This PR resolves https://github.com/Azure/azure-sdk-for-python/issues/11392. The method `from_connection_string` had the wrong return type which may cause typing errors.