### PR TITLE
fixed bug in querying by page using continuation token

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -1,3 +1,7 @@
+**Bug fixes**
+- Fixed bug where continuation token is not honored when query_iterable is used to get results by page. Issue #13265.
+
+
 ## 4.1.0 (2020-08-10)
 
 - Added deprecation warning for "lazy" indexing mode. The backend no longer allows creating containers with this mode and will set them to consistent instead.

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 4.1.1 (unreleased)
+
 **Bug fixes**
 - Fixed bug where continuation token is not honored when query_iterable is used to get results by page. Issue #13265.
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/base_execution_context.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/base_execution_context.py
@@ -52,7 +52,7 @@ class _QueryExecutionContextBase(object):
     def _get_initial_continuation(self):
         if "continuation" in self._options:
             if "enableCrossPartitionQuery" in self._options:
-                raise AttributeError("continuation tokens are not supported for cross-partition queries.")
+                raise ValueError("continuation tokens are not supported for cross-partition queries.")
             return self._options["continuation"]
         return None
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/base_execution_context.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/base_execution_context.py
@@ -44,7 +44,7 @@ class _QueryExecutionContextBase(object):
         self._options = options
         self._is_change_feed = "changeFeed" in options and options["changeFeed"] is True
         self._continuation = None
-        if "continuation" in options and self._is_change_feed:
+        if "continuation" in options:
             self._continuation = options["continuation"]
         self._has_started = False
         self._has_finished = False

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/base_execution_context.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/base_execution_context.py
@@ -24,9 +24,9 @@ database service.
 """
 
 from collections import deque
+import copy
 from .. import _retry_utility
 from .. import http_constants
-import copy
 
 # pylint: disable=protected-access
 
@@ -53,8 +53,7 @@ class _QueryExecutionContextBase(object):
         if "continuation" in self._options:
             if "enableCrossPartitionQuery" in self._options:
                 raise AttributeError("continuation tokens are not supported for cross-partition queries.")
-            else:
-                return self._options["continuation"]
+            return self._options["continuation"]
         return None
 
     def _has_more_pages(self):

--- a/sdk/cosmos/azure-cosmos/test/test_query.py
+++ b/sdk/cosmos/azure-cosmos/test/test_query.py
@@ -546,6 +546,18 @@ class QueryTest(unittest.TestCase):
 
         self.assertEqual(second_page['id'], second_page_fetched_with_continuation_token['id'])
 
+    def test_cross_partition_query_with_continuation_token_fails(self):
+        created_collection = self.config.create_multi_partition_collection_with_custom_pk_if_not_exist(self.client)
+        query = 'SELECT * from c'
+        query_iterable = created_collection.query_items(
+            query=query,
+            enable_cross_partition_query=True,
+            max_item_count=1,
+        )
+
+        with self.assertRaises(AttributeError):
+            pager = query_iterable.by_page("fake_continuation_token")
+
     def _validate_distinct_on_different_types_and_field_orders(self, collection, query, expected_results, get_mock_result):
         self.count = 0
         self.get_mock_result = get_mock_result

--- a/sdk/cosmos/azure-cosmos/test/test_query.py
+++ b/sdk/cosmos/azure-cosmos/test/test_query.py
@@ -522,6 +522,30 @@ class QueryTest(unittest.TestCase):
         _QueryExecutionContextBase.__next__ = self.OriginalExecuteFunction
         _QueryExecutionContextBase.next = self.OriginalExecuteFunction
 
+    def test_paging_with_continuation_token(self):
+        created_collection = self.config.create_multi_partition_collection_with_custom_pk_if_not_exist(self.client)
+
+        document_definition = {'pk': 'pk', 'id': '1'}
+        created_collection.create_item(body=document_definition)
+        document_definition = {'pk': 'pk', 'id': '2'}
+        created_collection.create_item(body=document_definition)
+
+        query = 'SELECT * from c'
+        query_iterable = created_collection.query_items(
+            query=query,
+            partition_key='pk',
+            max_item_count=1
+        )
+        pager = query_iterable.by_page()
+        pager.next()
+        token = pager.continuation_token
+        second_page = list(pager.next())[0]
+
+        pager = query_iterable.by_page(token)
+        second_page_fetched_with_continuation_token = list(pager.next())[0]
+
+        self.assertEqual(second_page['id'], second_page_fetched_with_continuation_token['id'])
+
     def _validate_distinct_on_different_types_and_field_orders(self, collection, query, expected_results, get_mock_result):
         self.count = 0
         self.get_mock_result = get_mock_result

--- a/sdk/cosmos/azure-cosmos/test/test_query.py
+++ b/sdk/cosmos/azure-cosmos/test/test_query.py
@@ -555,7 +555,7 @@ class QueryTest(unittest.TestCase):
             max_item_count=1,
         )
 
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(ValueError):
             pager = query_iterable.by_page("fake_continuation_token")
 
     def _validate_distinct_on_different_types_and_field_orders(self, collection, query, expected_results, get_mock_result):


### PR DESCRIPTION
Earlier, the base_execution_context checked if the feed operation being performed is change_feed, and if so, passed on the continuation token header to the rest call. This fix ensures that continuation token is passed on for all feed operations.