### PR TITLE
[Event Hubs] Fix a CheckpointStore bug that slows down retrieving checkpoint data if storage "File share soft delete" is enabled.

### DIFF
--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release History
 
-## 1.1.1 (Unreleased)
+## 1.1.1 (2020-09-08)
+**Bug fixes**
+- Fixed a bug that may gradually slow down retrieving checkpoint data from the storage blob if the storage account "File share soft delete" is enabled. #12836
 
 
 ## 1.1.0 (2020-03-09)

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_blobstoragecsaio.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_blobstoragecsaio.py
@@ -119,6 +119,7 @@ class BlobCheckpointStore(CheckpointStore):
         try:
             uploaded_blob_properties = await blob_client.set_blob_metadata(metadata, **etag_match)
         except ResourceNotFoundError:
+            logger.info("Upload ownership blob %r because it hasn't existed in the container yet.", blob_name)
             uploaded_blob_properties = await blob_client.upload_blob(
                 data=UPLOAD_DATA, overwrite=True, metadata=metadata, **etag_match
             )
@@ -228,6 +229,7 @@ class BlobCheckpointStore(CheckpointStore):
         try:
             await blob_client.set_blob_metadata(metadata)
         except ResourceNotFoundError:
+            logger.info("Upload checkpoint blob %r because it hasn't existed in the container yet.", blob_name)
             await blob_client.upload_blob(
                 data=UPLOAD_DATA, overwrite=True, metadata=metadata
             )

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_blobstoragecsaio.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_blobstoragecsaio.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 import asyncio
 from azure.eventhub.exceptions import OwnershipLostError  # type: ignore
 from azure.eventhub.aio import CheckpointStore  # type: ignore  # pylint: disable=no-name-in-module
-from azure.core.exceptions import ResourceModifiedError, ResourceExistsError  # type: ignore
+from azure.core.exceptions import ResourceModifiedError, ResourceExistsError, ResourceNotFoundError  # type: ignore
 from ._vendor.storage.blob.aio import ContainerClient, BlobClient
 from ._vendor.storage.blob._shared.base_client import parse_connection_str
 
@@ -115,9 +115,13 @@ class BlobCheckpointStore(CheckpointStore):
             ownership["partition_id"],
         )
         blob_name = blob_name.lower()
-        uploaded_blob_properties = await self._get_blob_client(blob_name).upload_blob(
-            data=UPLOAD_DATA, overwrite=True, metadata=metadata, **etag_match
-        )
+        blob_client = self._get_blob_client(blob_name)
+        try:
+            uploaded_blob_properties = await blob_client.set_blob_metadata(metadata, **etag_match)
+        except ResourceNotFoundError:
+            uploaded_blob_properties = await blob_client.upload_blob(
+                data=UPLOAD_DATA, overwrite=True, metadata=metadata, **etag_match
+            )
         ownership["etag"] = uploaded_blob_properties["etag"]
         ownership["last_modified_time"] = uploaded_blob_properties[
             "last_modified"
@@ -220,9 +224,13 @@ class BlobCheckpointStore(CheckpointStore):
             checkpoint["partition_id"],
         )
         blob_name = blob_name.lower()
-        await self._get_blob_client(blob_name).upload_blob(
-            data=UPLOAD_DATA, overwrite=True, metadata=metadata
-        )
+        blob_client = self._get_blob_client(blob_name)
+        try:
+            await blob_client.set_blob_metadata(metadata)
+        except ResourceNotFoundError:
+            await blob_client.upload_blob(
+                data=UPLOAD_DATA, overwrite=True, metadata=metadata
+            )
 
     async def list_checkpoints(
         self, fully_qualified_namespace, eventhub_name, consumer_group

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 1.1.1 (Unreleased)
-
+## 1.1.1 (2020-09-08)
+**Bug fixes**
+- Fixed a bug that may gradually slow down retrieving checkpoint data from the storage blob if the storage account "File share soft delete" is enabled. #12836
 
 ## 1.1.0 (2020-03-09)
 

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_blobstoragecs.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_blobstoragecs.py
@@ -140,6 +140,7 @@ class BlobCheckpointStore(CheckpointStore):
         try:
             uploaded_blob_properties = blob_client.set_blob_metadata(metadata, **etag_match)
         except ResourceNotFoundError:
+            logger.info("Upload ownership blob %r because it hasn't existed in the container yet.", blob_name)
             uploaded_blob_properties = blob_client.upload_blob(
                 data=UPLOAD_DATA, overwrite=True, metadata=metadata, **etag_match
             )
@@ -243,6 +244,7 @@ class BlobCheckpointStore(CheckpointStore):
         try:
             blob_client.set_blob_metadata(metadata)
         except ResourceNotFoundError:
+            logger.info("Upload checkpoint blob %r because it hasn't existed in the container yet.", blob_name)
             blob_client.upload_blob(
                 data=UPLOAD_DATA, overwrite=True, metadata=metadata
             )

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_blobstoragecs.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_blobstoragecs.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 
 from azure.eventhub import CheckpointStore  # type: ignore  # pylint: disable=no-name-in-module
 from azure.eventhub.exceptions import OwnershipLostError  # type: ignore
-from azure.core.exceptions import ResourceModifiedError, ResourceExistsError  # type: ignore
+from azure.core.exceptions import ResourceModifiedError, ResourceExistsError, ResourceNotFoundError  # type: ignore
 from ._vendor.storage.blob import BlobClient, ContainerClient
 from ._vendor.storage.blob._shared.base_client import parse_connection_str
 
@@ -136,9 +136,13 @@ class BlobCheckpointStore(CheckpointStore):
             ownership["partition_id"],
         )
         blob_name = blob_name.lower()
-        uploaded_blob_properties = self._get_blob_client(blob_name).upload_blob(
-            data=UPLOAD_DATA, overwrite=True, metadata=metadata, **etag_match
-        )
+        blob_client = self._get_blob_client(blob_name)
+        try:
+            uploaded_blob_properties = blob_client.set_blob_metadata(metadata, **etag_match)
+        except ResourceNotFoundError:
+            uploaded_blob_properties = blob_client.upload_blob(
+                data=UPLOAD_DATA, overwrite=True, metadata=metadata, **etag_match
+            )
         ownership["etag"] = uploaded_blob_properties["etag"]
         ownership["last_modified_time"] = _to_timestamp(
             uploaded_blob_properties["last_modified"]
@@ -235,9 +239,13 @@ class BlobCheckpointStore(CheckpointStore):
             checkpoint["partition_id"],
         )
         blob_name = blob_name.lower()
-        self._get_blob_client(blob_name).upload_blob(
-            data=UPLOAD_DATA, overwrite=True, metadata=metadata
-        )
+        blob_client = self._get_blob_client(blob_name)
+        try:
+            blob_client.set_blob_metadata(metadata)
+        except ResourceNotFoundError:
+            blob_client.upload_blob(
+                data=UPLOAD_DATA, overwrite=True, metadata=metadata
+            )
 
     def list_checkpoints(
         self, fully_qualified_namespace, eventhub_name, consumer_group


### PR DESCRIPTION
resolves #12836 