### PR TITLE
Build AuthenticationRecords from ADFS identity tokens

### DIFF
--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -14,24 +14,7 @@ except ImportError:  # python < 3.3
     import mock  # type: ignore
 
 
-# build_* lifted from msal tests
 def build_id_token(
-    iss="issuer",
-    sub="subject",
-    aud="client-id",
-    username="username",
-    tenant_id="tenant",
-    object_id="object id",
-    **claims
-):
-    token_claims = id_token_claims(
-        iss=iss, sub=sub, aud=aud, tenant_id=tenant_id, object_id=object_id, preferred_username=username, **claims
-    )
-    jwt_payload = base64.b64encode(json.dumps(token_claims).encode()).decode("utf-8")
-    return "header.{}.signature".format(jwt_payload)
-
-
-def build_adfs_id_token(
     iss="issuer",
     sub="subject",
     aud="client-id",
@@ -41,23 +24,21 @@ def build_adfs_id_token(
     **claims
 ):
     token_claims = id_token_claims(
-        iss=iss, sub=sub, aud=aud, tenant_id=tenant_id, object_id=object_id, upn=username, **claims
+        iss=iss, sub=sub, aud=aud, tid=tenant_id, oid=object_id, preferred_username=username, **claims
     )
     jwt_payload = base64.b64encode(json.dumps(token_claims).encode()).decode("utf-8")
     return "header.{}.signature".format(jwt_payload)
 
 
-def id_token_claims(iss, sub, aud, tenant_id, object_id, exp=None, iat=None, **claims):
+def build_adfs_id_token(iss="issuer", sub="subject", aud="client-id", username="username", **claims):
+    token_claims = id_token_claims(iss=iss, sub=sub, aud=aud, upn=username, **claims)
+    jwt_payload = base64.b64encode(json.dumps(token_claims).encode()).decode("utf-8")
+    return "header.{}.signature".format(jwt_payload)
+
+
+def id_token_claims(iss, sub, aud, exp=None, iat=None, **claims):
     return dict(
-        {
-            "iss": iss,
-            "sub": sub,
-            "aud": aud,
-            "exp": exp or int(time.time()) + 3600,
-            "iat": iat or int(time.time()),
-            "tid": tenant_id,
-            "oid": object_id,
-        },
+        {"iss": iss, "sub": sub, "aud": aud, "exp": exp or int(time.time()) + 3600, "iat": iat or int(time.time())},
         **claims
     )
 

--- a/sdk/identity/azure-identity/tests/test_browser_credential.py
+++ b/sdk/identity/azure-identity/tests/test_browser_credential.py
@@ -111,10 +111,13 @@ def test_disable_automatic_authentication():
 @patch("azure.identity._credentials.browser.webbrowser.open", lambda _: True)
 def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
-
+    client_id = "client-id"
     transport = validating_transport(
         requests=[Request()] * 2,
-        responses=[get_discovery_response(), mock_response(json_payload=build_aad_response(access_token="**"))],
+        responses=[
+            get_discovery_response(),
+            mock_response(json_payload=build_aad_response(access_token="**", id_token=build_id_token(aud=client_id))),
+        ],
     )
 
     # mock local server fakes successful authentication by immediately returning a well-formed response
@@ -123,7 +126,7 @@ def test_policies_configurable():
     server_class = Mock(return_value=Mock(wait_for_redirect=lambda: auth_code_response))
 
     credential = InteractiveBrowserCredential(
-        policies=[policy], transport=transport, server_class=server_class, _cache=TokenCache()
+        policies=[policy], client_id=client_id, transport=transport, server_class=server_class, _cache=TokenCache()
     )
 
     with patch("azure.identity._credentials.browser.uuid.uuid4", lambda: oauth_state):
@@ -134,9 +137,13 @@ def test_policies_configurable():
 
 @patch("azure.identity._credentials.browser.webbrowser.open", lambda _: True)
 def test_user_agent():
+    client_id = "client-id"
     transport = validating_transport(
         requests=[Request(), Request(required_headers={"User-Agent": USER_AGENT})],
-        responses=[get_discovery_response(), mock_response(json_payload=build_aad_response(access_token="**"))],
+        responses=[
+            get_discovery_response(),
+            mock_response(json_payload=build_aad_response(access_token="**", id_token=build_id_token(aud=client_id))),
+        ],
     )
 
     # mock local server fakes successful authentication by immediately returning a well-formed response
@@ -144,7 +151,9 @@ def test_user_agent():
     auth_code_response = {"code": "authorization-code", "state": [oauth_state]}
     server_class = Mock(return_value=Mock(wait_for_redirect=lambda: auth_code_response))
 
-    credential = InteractiveBrowserCredential(transport=transport, server_class=server_class, _cache=TokenCache())
+    credential = InteractiveBrowserCredential(
+        client_id=client_id, transport=transport, server_class=server_class, _cache=TokenCache()
+    )
 
     with patch("azure.identity._credentials.browser.uuid.uuid4", lambda: oauth_state):
         credential.get_token("scope")
@@ -284,7 +293,7 @@ def test_redirect_server():
     thread.start()
 
     # send a request, verify the server exposes the query
-    url = "http://127.0.0.1:{}/?{}={}".format(port, expected_param, expected_value) # nosec
+    url = "http://127.0.0.1:{}/?{}={}".format(port, expected_param, expected_value)  # nosec
     response = urllib.request.urlopen(url)  # nosec
 
     assert response.code == 200

--- a/sdk/identity/azure-identity/tests/test_interactive_credential.py
+++ b/sdk/identity/azure-identity/tests/test_interactive_credential.py
@@ -21,6 +21,20 @@ except ImportError:  # python < 3.3
 from helpers import build_aad_response, build_id_token, id_token_claims
 
 
+# fake object for tests which need to exercise request_token but don't care about its return value
+REQUEST_TOKEN_RESULT = build_aad_response(
+    access_token="***",
+    id_token_claims=id_token_claims(
+        aud="...",
+        iss="http://localhost/tenant",
+        sub="subject",
+        preferred_username="...",
+        tenant_id="...",
+        object_id="...",
+    ),
+)
+
+
 class MockCredential(InteractiveCredential):
     """Test class to drive InteractiveCredential.
 
@@ -132,7 +146,7 @@ def test_scopes_round_trip():
 
     def validate_scopes(*scopes, **_):
         assert scopes == (scope,)
-        return {"access_token": "**", "expires_in": 42}
+        return REQUEST_TOKEN_RESULT
 
     request_token = Mock(wraps=validate_scopes)
     credential = MockCredential(disable_automatic_authentication=True, request_token=request_token)
@@ -158,7 +172,7 @@ def test_authenticate_default_scopes(authority, expected_scope):
 
     def validate_scopes(*scopes):
         assert scopes == (expected_scope,)
-        return {"access_token": "**", "expires_in": 42}
+        return REQUEST_TOKEN_RESULT
 
     request_token = Mock(wraps=validate_scopes)
     MockCredential(authority=authority, request_token=request_token).authenticate()
@@ -176,7 +190,7 @@ def test_authenticate_unknown_cloud():
 def test_authenticate_ignores_disable_automatic_authentication(option):
     """authenticate should prompt for authentication regardless of the credential's configuration"""
 
-    request_token = Mock(return_value={"access_token": "**", "expires_in": 42})
+    request_token = Mock(return_value=REQUEST_TOKEN_RESULT)
     MockCredential(request_token=request_token, disable_automatic_authentication=option).authenticate()
     assert request_token.call_count == 1, "credential didn't begin interactive authentication"
 

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
@@ -769,7 +769,7 @@ def get_account_event(
             uid=uid,
             utid=utid,
             refresh_token=refresh_token,
-            id_token=build_id_token(aud=client_id, preferred_username=username),
+            id_token=build_id_token(aud=client_id, username=username),
             foci="1",
             **kwargs
         ),

--- a/sdk/identity/azure-identity/tests/test_username_password_credential.py
+++ b/sdk/identity/azure-identity/tests/test_username_password_credential.py
@@ -35,7 +35,8 @@ def test_policies_configurable():
 
     transport = validating_transport(
         requests=[Request()] * 3,
-        responses=[get_discovery_response()] * 2 + [mock_response(json_payload=build_aad_response(access_token="**"))],
+        responses=[get_discovery_response()] * 2
+        + [mock_response(json_payload=build_aad_response(access_token="**", id_token=build_id_token()))],
     )
     credential = UsernamePasswordCredential("client-id", "username", "password", policies=[policy], transport=transport)
 
@@ -47,7 +48,8 @@ def test_policies_configurable():
 def test_user_agent():
     transport = validating_transport(
         requests=[Request()] * 2 + [Request(required_headers={"User-Agent": USER_AGENT})],
-        responses=[get_discovery_response()] * 2 + [mock_response(json_payload=build_aad_response(access_token="**"))],
+        responses=[get_discovery_response()] * 2
+        + [mock_response(json_payload=build_aad_response(access_token="**", id_token=build_id_token()))],
     )
 
     credential = UsernamePasswordCredential("client-id", "username", "password", transport=transport)
@@ -57,6 +59,7 @@ def test_user_agent():
 
 def test_username_password_credential():
     expected_token = "access-token"
+    client_id = "client-id"
     transport = validating_transport(
         requests=[Request()] * 3,  # not validating requests because they're formed by MSAL
         responses=[
@@ -66,18 +69,13 @@ def test_username_password_credential():
             mock_response(json_payload={}),
             # token request
             mock_response(
-                json_payload={
-                    "access_token": expected_token,
-                    "expires_in": 42,
-                    "token_type": "Bearer",
-                    "ext_expires_in": 42,
-                }
+                json_payload=build_aad_response(access_token=expected_token, id_token=build_id_token(aud=client_id))
             ),
         ],
     )
 
     credential = UsernamePasswordCredential(
-        client_id="some-guid",
+        client_id=client_id,
         username="user@azure",
         password="secret_password",
         transport=transport,


### PR DESCRIPTION
ADFS identity tokens have different claims than do AAD identity tokens. This change ensures credentials can build a correct `AuthenticationRecord` from either authority's tokens.