### PR TITLE
Remove Dependency Install from azure-sdk-tools test_tools install

### DIFF
--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -27,4 +27,4 @@ pylint==1.8.4; python_version < '3.4'
 pylint==2.5.2; python_version >= '3.4'
 
 ../../../tools/azure-devtools
-../../../tools/azure-sdk-tools
+../../../tools/azure-sdk-tools --no-dependencies

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -27,4 +27,4 @@ pylint==1.8.4; python_version < '3.4'
 pylint==2.5.2; python_version >= '3.4'
 
 ../../../tools/azure-devtools
-../../../tools/azure-sdk-tools --no-dependencies
+--no-dependencies ../../../tools/azure-sdk-tools


### PR DESCRIPTION
We do use common functionality from this package. I *believe* this should work, but we'll see where core blows up.