### PR TITLE
added create_table_if_not_exists method to table service client

### DIFF
--- a/sdk/tables/azure-data-tables/azure/data/tables/_table_client.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_table_client.py
@@ -14,13 +14,22 @@ except ImportError:
     from urllib2 import unquote  # type: ignore
 
 from azure.core.paging import ItemPaged
-from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
+from azure.core.exceptions import (
+    HttpResponseError,
+    ResourceNotFoundError,
+    ResourceExistsError
+)
 from azure.core.tracing.decorator import distributed_trace
 
 from ._deserialize import _convert_to_entity
 from ._entity import TableEntity
 from ._generated import AzureTable
-from ._generated.models import AccessPolicy, SignedIdentifier, TableProperties, QueryOptions
+from ._generated.models import (
+    AccessPolicy,
+    SignedIdentifier,
+    TableProperties,
+    QueryOptions
+)
 from ._serialize import _get_match_headers, _add_entity_properties
 from ._base_client import parse_connection_str
 from ._table_client_base import TableClientBase

--- a/sdk/tables/azure-data-tables/azure/data/tables/_table_client.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_table_client.py
@@ -14,11 +14,7 @@ except ImportError:
     from urllib2 import unquote  # type: ignore
 
 from azure.core.paging import ItemPaged
-from azure.core.exceptions import (
-    HttpResponseError,
-    ResourceNotFoundError,
-    ResourceExistsError
-)
+from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from azure.core.tracing.decorator import distributed_trace
 
 from ._deserialize import _convert_to_entity

--- a/sdk/tables/azure-data-tables/azure/data/tables/_table_service_client.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_table_service_client.py
@@ -6,7 +6,7 @@
 
 import functools
 from typing import Any, Union
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from azure.core.paging import ItemPaged
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.pipeline import Pipeline
@@ -154,6 +154,30 @@ class TableServiceClient(TableServiceClientBase):
         """
         table = self.get_table_client(table_name=table_name)
         table.create_table(**kwargs)
+        return table
+
+    @distributed_trace
+    def create_table_if_not_exists(
+        self,
+        table_name, # type: str
+        **kwargs # type: Any
+    ):
+        # type: (...) -> TableClient
+        """Creates a new table if it does not currently exist.
+        If the table currently exists, the current table is
+        returned.
+
+        :param table_name: The Table name.
+        :type table_name: str
+        :return: TableClient
+        :rtype: ~azure.data.tables.TableClient
+        :raises: ~azure.core.exceptions.HttpResponseError
+        """
+        table = self.get_table_client(table_name=table_name)
+        try:
+            table.create_table(**kwargs)
+        except ResourceExistsError:
+            pass
         return table
 
     @distributed_trace

--- a/sdk/tables/azure-data-tables/azure/data/tables/aio/_table_service_client_async.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/aio/_table_service_client_async.py
@@ -197,7 +197,7 @@ class TableServiceClient(AsyncStorageAccountHostsMixin, TableServiceClientBase):
         await table.create_table(**kwargs)
         return table
 
-    @distributed_trace
+    @distributed_trace_async
     async def create_table_if_not_exists(
         self,
         table_name, # type: str
@@ -211,7 +211,7 @@ class TableServiceClient(AsyncStorageAccountHostsMixin, TableServiceClientBase):
         :param table_name: The Table name.
         :type table_name: str
         :return: TableClient
-        :rtype: ~azure.data.tables.TableClient
+        :rtype: ~azure.data.tables.aio.TableClient
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         table = self.get_table_client(table_name=table_name)

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table.test_create_table_if_exists.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table.test_create_table_if_exists.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"TableName": "pytablesync6d7c1113"}'
+    body: '{"TableName": "pytablesync2c5a0f7d"}'
     headers:
       Accept:
       - application/json;odata=minimalmetadata
@@ -15,27 +15,27 @@ interactions:
       DataServiceVersion:
       - '3.0'
       Date:
-      - Thu, 27 Aug 2020 21:28:19 GMT
+      - Thu, 27 Aug 2020 21:42:12 GMT
       User-Agent:
       - azsdk-python-data-tables/2019-07-07 Python/3.8.4 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 27 Aug 2020 21:28:19 GMT
+      - Thu, 27 Aug 2020 21:42:12 GMT
       x-ms-version:
       - '2019-07-07'
     method: POST
     uri: https://storagename.table.core.windows.net/Tables
   response:
     body:
-      string: '{"odata.metadata":"https://storagename.table.core.windows.net/$metadata#Tables/@Element","TableName":"pytablesync6d7c1113"}'
+      string: '{"odata.metadata":"https://storagename.table.core.windows.net/$metadata#Tables/@Element","TableName":"pytablesync2c5a0f7d"}'
     headers:
       cache-control:
       - no-cache
       content-type:
       - application/json;odata=minimalmetadata;streaming=true;charset=utf-8
       date:
-      - Thu, 27 Aug 2020 21:28:20 GMT
+      - Thu, 27 Aug 2020 21:42:12 GMT
       location:
-      - https://storagename.table.core.windows.net/Tables('pytablesync6d7c1113')
+      - https://storagename.table.core.windows.net/Tables('pytablesync2c5a0f7d')
       server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -48,7 +48,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"TableName": "pytablesync6d7c1113"}'
+    body: '{"TableName": "pytablesync2c5a0f7d"}'
     headers:
       Accept:
       - application/json;odata=minimalmetadata
@@ -63,11 +63,11 @@ interactions:
       DataServiceVersion:
       - '3.0'
       Date:
-      - Thu, 27 Aug 2020 21:28:20 GMT
+      - Thu, 27 Aug 2020 21:42:12 GMT
       User-Agent:
       - azsdk-python-data-tables/2019-07-07 Python/3.8.4 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 27 Aug 2020 21:28:20 GMT
+      - Thu, 27 Aug 2020 21:42:12 GMT
       x-ms-version:
       - '2019-07-07'
     method: POST
@@ -75,14 +75,14 @@ interactions:
   response:
     body:
       string: '{"odata.error":{"code":"TableAlreadyExists","message":{"lang":"en-US","value":"The
-        table specified already exists.\nRequestId:2e7b208e-d002-003b-7bb8-7c685f000000\nTime:2020-08-27T21:28:21.0100931Z"}}}'
+        table specified already exists.\nRequestId:64cfdefd-d002-0057-80ba-7c2831000000\nTime:2020-08-27T21:42:13.5449901Z"}}}'
     headers:
       cache-control:
       - no-cache
       content-type:
       - application/json;odata=minimalmetadata;streaming=true;charset=utf-8
       date:
-      - Thu, 27 Aug 2020 21:28:20 GMT
+      - Thu, 27 Aug 2020 21:42:13 GMT
       server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -106,15 +106,15 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Thu, 27 Aug 2020 21:28:20 GMT
+      - Thu, 27 Aug 2020 21:42:12 GMT
       User-Agent:
       - azsdk-python-data-tables/2019-07-07 Python/3.8.4 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 27 Aug 2020 21:28:20 GMT
+      - Thu, 27 Aug 2020 21:42:12 GMT
       x-ms-version:
       - '2019-07-07'
     method: DELETE
-    uri: https://storagename.table.core.windows.net/Tables('pytablesync6d7c1113')
+    uri: https://storagename.table.core.windows.net/Tables('pytablesync2c5a0f7d')
   response:
     body:
       string: ''
@@ -124,7 +124,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 27 Aug 2020 21:28:20 GMT
+      - Thu, 27 Aug 2020 21:42:13 GMT
       server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       x-content-type-options:

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table.test_create_table_if_exists_new_table.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table.test_create_table_if_exists_new_table.yaml
@@ -1,0 +1,90 @@
+interactions:
+- request:
+    body: '{"TableName": "pytablesyncdd9e138d"}'
+    headers:
+      Accept:
+      - application/json;odata=minimalmetadata
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/json;odata=nometadata
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 27 Aug 2020 21:42:13 GMT
+      User-Agent:
+      - azsdk-python-data-tables/2019-07-07 Python/3.8.4 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 27 Aug 2020 21:42:13 GMT
+      x-ms-version:
+      - '2019-07-07'
+    method: POST
+    uri: https://storagename.table.core.windows.net/Tables
+  response:
+    body:
+      string: '{"odata.metadata":"https://storagename.table.core.windows.net/$metadata#Tables/@Element","TableName":"pytablesyncdd9e138d"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-type:
+      - application/json;odata=minimalmetadata;streaming=true;charset=utf-8
+      date:
+      - Thu, 27 Aug 2020 21:42:13 GMT
+      location:
+      - https://storagename.table.core.windows.net/Tables('pytablesyncdd9e138d')
+      server:
+      - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-ms-version:
+      - '2019-07-07'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 27 Aug 2020 21:42:13 GMT
+      User-Agent:
+      - azsdk-python-data-tables/2019-07-07 Python/3.8.4 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 27 Aug 2020 21:42:13 GMT
+      x-ms-version:
+      - '2019-07-07'
+    method: DELETE
+    uri: https://storagename.table.core.windows.net/Tables('pytablesyncdd9e138d')
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 27 Aug 2020 21:42:13 GMT
+      server:
+      - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      x-content-type-options:
+      - nosniff
+      x-ms-version:
+      - '2019-07-07'
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table_async.test_create_table_if_exists.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table_async.test_create_table_if_exists.yaml
@@ -1,0 +1,103 @@
+interactions:
+- request:
+    body: '{"TableName": "pytableasync938b11fa"}'
+    headers:
+      Accept:
+      - application/json;odata=minimalmetadata
+      Content-Length:
+      - '37'
+      Content-Type:
+      - application/json;odata=nometadata
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 27 Aug 2020 21:49:52 GMT
+      User-Agent:
+      - azsdk-python-data-tables/2019-07-07 Python/3.8.4 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 27 Aug 2020 21:49:52 GMT
+      x-ms-version:
+      - '2019-07-07'
+    method: POST
+    uri: https://storagename.table.core.windows.net/Tables
+  response:
+    body:
+      string: '{"odata.metadata":"https://storagename.table.core.windows.net/$metadata#Tables/@Element","TableName":"pytableasync938b11fa"}'
+    headers:
+      cache-control: no-cache
+      content-type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8
+      date: Thu, 27 Aug 2020 21:49:53 GMT
+      location: https://storagename.table.core.windows.net/Tables('pytableasync938b11fa')
+      server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-content-type-options: nosniff
+      x-ms-version: '2019-07-07'
+    status:
+      code: 201
+      message: Created
+    url: https://pyacrstorageqqhkgfuuwjpy.table.core.windows.net/Tables
+- request:
+    body: '{"TableName": "pytableasync938b11fa"}'
+    headers:
+      Accept:
+      - application/json;odata=minimalmetadata
+      Content-Length:
+      - '37'
+      Content-Type:
+      - application/json;odata=nometadata
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 27 Aug 2020 21:49:53 GMT
+      User-Agent:
+      - azsdk-python-data-tables/2019-07-07 Python/3.8.4 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 27 Aug 2020 21:49:53 GMT
+      x-ms-version:
+      - '2019-07-07'
+    method: POST
+    uri: https://storagename.table.core.windows.net/Tables
+  response:
+    body:
+      string: '{"odata.error":{"code":"TableAlreadyExists","message":{"lang":"en-US","value":"The
+        table specified already exists.\nRequestId:6a7f283a-f002-0003-2dbb-7ccc9f000000\nTime:2020-08-27T21:49:54.0261635Z"}}}'
+    headers:
+      cache-control: no-cache
+      content-type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8
+      date: Thu, 27 Aug 2020 21:49:53 GMT
+      server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-content-type-options: nosniff
+      x-ms-version: '2019-07-07'
+    status:
+      code: 409
+      message: Conflict
+    url: https://pyacrstorageqqhkgfuuwjpy.table.core.windows.net/Tables
+- request:
+    body: null
+    headers:
+      Date:
+      - Thu, 27 Aug 2020 21:49:53 GMT
+      User-Agent:
+      - azsdk-python-data-tables/2019-07-07 Python/3.8.4 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 27 Aug 2020 21:49:53 GMT
+      x-ms-version:
+      - '2019-07-07'
+    method: DELETE
+    uri: https://storagename.table.core.windows.net/Tables('pytableasync938b11fa')
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control: no-cache
+      content-length: '0'
+      date: Thu, 27 Aug 2020 21:49:53 GMT
+      server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      x-content-type-options: nosniff
+      x-ms-version: '2019-07-07'
+    status:
+      code: 204
+      message: No Content
+    url: https://pyacrstorageqqhkgfuuwjpy.table.core.windows.net/Tables('pytableasync938b11fa')
+version: 1

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table_async.test_create_table_if_exists_new_table.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table_async.test_create_table_if_exists_new_table.yaml
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    body: '{"TableName": "pytableasync5dc0160a"}'
+    headers:
+      Accept:
+      - application/json;odata=minimalmetadata
+      Content-Length:
+      - '37'
+      Content-Type:
+      - application/json;odata=nometadata
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 27 Aug 2020 21:49:53 GMT
+      User-Agent:
+      - azsdk-python-data-tables/2019-07-07 Python/3.8.4 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 27 Aug 2020 21:49:53 GMT
+      x-ms-version:
+      - '2019-07-07'
+    method: POST
+    uri: https://storagename.table.core.windows.net/Tables
+  response:
+    body:
+      string: '{"odata.metadata":"https://storagename.table.core.windows.net/$metadata#Tables/@Element","TableName":"pytableasync5dc0160a"}'
+    headers:
+      cache-control: no-cache
+      content-type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8
+      date: Thu, 27 Aug 2020 21:49:54 GMT
+      location: https://storagename.table.core.windows.net/Tables('pytableasync5dc0160a')
+      server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-content-type-options: nosniff
+      x-ms-version: '2019-07-07'
+    status:
+      code: 201
+      message: Created
+    url: https://pyacrstorageqqhkgfuuwjpy.table.core.windows.net/Tables
+- request:
+    body: null
+    headers:
+      Date:
+      - Thu, 27 Aug 2020 21:49:53 GMT
+      User-Agent:
+      - azsdk-python-data-tables/2019-07-07 Python/3.8.4 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 27 Aug 2020 21:49:53 GMT
+      x-ms-version:
+      - '2019-07-07'
+    method: DELETE
+    uri: https://storagename.table.core.windows.net/Tables('pytableasync5dc0160a')
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control: no-cache
+      content-length: '0'
+      date: Thu, 27 Aug 2020 21:49:54 GMT
+      server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      x-content-type-options: nosniff
+      x-ms-version: '2019-07-07'
+    status:
+      code: 204
+      message: No Content
+    url: https://pyacrstorageqqhkgfuuwjpy.table.core.windows.net/Tables('pytableasync5dc0160a')
+version: 1

--- a/sdk/tables/azure-data-tables/tests/test_table.py
+++ b/sdk/tables/azure-data-tables/tests/test_table.py
@@ -133,17 +133,37 @@ class StorageTableTest(TableTestCase):
         # Arrange
         ts = TableServiceClient(self.account_url(storage_account, "table"), storage_account_key)
         table_name = self._get_table_reference()
-        # btable_client = ts.get_table_client(table_name)
 
         # Act
         created = ts.create_table(table_name)
         with self.assertRaises(ResourceExistsError):
             ts.create_table(table_name)
+        print(created)
 
         # Assert
-        self.assertTrue(created)
-        # existing = list(ts.query_tables(query_options=QueryOptions(filter="TableName eq '{}'".format(table_name))))
-        # self.assertEqual(existing[0], [table_name])
+        self.assertIsNotNone(created)
+        ts.delete_table(table_name)
+
+    @GlobalStorageAccountPreparer()
+    def test_create_table_if_exists(self, resource_group, location, storage_account, storage_account_key):
+        ts = TableServiceClient(self.account_url(storage_account, "table"), storage_account_key)
+        table_name = self._get_table_reference()
+
+        t0 = ts.create_table(table_name)
+        t1 = ts.create_table_if_not_exists(table_name)
+
+        self.assertIsNotNone(t0)
+        self.assertIsNotNone(t1)
+        ts.delete_table(table_name)
+
+    @GlobalStorageAccountPreparer()
+    def test_create_table_if_exists_new_table(self, resource_group, location, storage_account, storage_account_key):
+        ts = TableServiceClient(self.account_url(storage_account, "table"), storage_account_key)
+        table_name = self._get_table_reference()
+
+        t = ts.create_table_if_not_exists(table_name)
+
+        self.assertIsNotNone(t)
         ts.delete_table(table_name)
 
     @GlobalStorageAccountPreparer()

--- a/sdk/tables/azure-data-tables/tests/test_table.py
+++ b/sdk/tables/azure-data-tables/tests/test_table.py
@@ -154,7 +154,7 @@ class StorageTableTest(TableTestCase):
 
         self.assertIsNotNone(t0)
         self.assertIsNotNone(t1)
-        self.assertEqual(t0.name, t1.name)
+        self.assertEqual(t0.table_name, t1.table_name)
         ts.delete_table(table_name)
 
     @GlobalStorageAccountPreparer()
@@ -165,7 +165,7 @@ class StorageTableTest(TableTestCase):
         t = ts.create_table_if_not_exists(table_name)
 
         self.assertIsNotNone(t)
-        self.assertEqual(t.name, table_name)
+        self.assertEqual(t.table_name, table_name)
         ts.delete_table(table_name)
 
     @GlobalStorageAccountPreparer()

--- a/sdk/tables/azure-data-tables/tests/test_table.py
+++ b/sdk/tables/azure-data-tables/tests/test_table.py
@@ -154,6 +154,7 @@ class StorageTableTest(TableTestCase):
 
         self.assertIsNotNone(t0)
         self.assertIsNotNone(t1)
+        self.assertEqual(t0.name, t1.name)
         ts.delete_table(table_name)
 
     @GlobalStorageAccountPreparer()
@@ -164,6 +165,7 @@ class StorageTableTest(TableTestCase):
         t = ts.create_table_if_not_exists(table_name)
 
         self.assertIsNotNone(t)
+        self.assertEqual(t.name, table_name)
         ts.delete_table(table_name)
 
     @GlobalStorageAccountPreparer()

--- a/sdk/tables/azure-data-tables/tests/test_table_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_async.py
@@ -83,7 +83,7 @@ class TableTestAsync(AsyncTableTestCase):
 
         self.assertIsNotNone(t0)
         self.assertIsNotNone(t1)
-        self.assertEqual(t0.name, t1.name)
+        self.assertEqual(t0.table_name, t1.table_name)
         await ts.delete_table(table_name)
 
     @GlobalStorageAccountPreparer()
@@ -94,7 +94,7 @@ class TableTestAsync(AsyncTableTestCase):
         t = await ts.create_table_if_not_exists(table_name)
 
         self.assertIsNotNone(t)
-        self.assertEqual(t.name, table_name)
+        self.assertEqual(t.table_name, table_name)
         await ts.delete_table(table_name)
 
     @GlobalStorageAccountPreparer()

--- a/sdk/tables/azure-data-tables/tests/test_table_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_async.py
@@ -83,6 +83,7 @@ class TableTestAsync(AsyncTableTestCase):
 
         self.assertIsNotNone(t0)
         self.assertIsNotNone(t1)
+        self.assertEqual(t0.name, t1.name)
         await ts.delete_table(table_name)
 
     @GlobalStorageAccountPreparer()
@@ -93,6 +94,7 @@ class TableTestAsync(AsyncTableTestCase):
         t = await ts.create_table_if_not_exists(table_name)
 
         self.assertIsNotNone(t)
+        self.assertEqual(t.name, table_name)
         await ts.delete_table(table_name)
 
     @GlobalStorageAccountPreparer()

--- a/sdk/tables/azure-data-tables/tests/test_table_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_async.py
@@ -74,6 +74,28 @@ class TableTestAsync(AsyncTableTestCase):
         await ts.delete_table(table_name=table_name)
 
     @GlobalStorageAccountPreparer()
+    async def test_create_table_if_exists(self, resource_group, location, storage_account, storage_account_key):
+        ts = TableServiceClient(self.account_url(storage_account, "table"), storage_account_key)
+        table_name = self._get_table_reference()
+
+        t0 = await ts.create_table(table_name)
+        t1 = await ts.create_table_if_not_exists(table_name)
+
+        self.assertIsNotNone(t0)
+        self.assertIsNotNone(t1)
+        await ts.delete_table(table_name)
+
+    @GlobalStorageAccountPreparer()
+    async def test_create_table_if_exists_new_table(self, resource_group, location, storage_account, storage_account_key):
+        ts = TableServiceClient(self.account_url(storage_account, "table"), storage_account_key)
+        table_name = self._get_table_reference()
+
+        t = await ts.create_table_if_not_exists(table_name)
+
+        self.assertIsNotNone(t)
+        await ts.delete_table(table_name)
+
+    @GlobalStorageAccountPreparer()
     async def test_create_table_invalid_name(self, resource_group, location, storage_account, storage_account_key):
         # Arrange
         ts = TableServiceClient(self.account_url(storage_account, "table"), storage_account_key)


### PR DESCRIPTION
This adds a `create_table_if_not_exists` method to the `TableServiceClient`. If the table exists, the error is caught and a `TableClient` is caught. If the table does not exist it is created and a `TableClient` for the new table is returned. 

Asking for review on the implementation and whether it should be `TableServiceClient` or `TableClient` method.