### PR TITLE
Int32 serialization

### DIFF
--- a/sdk/tables/azure-data-tables/azure/data/tables/_deserialize.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_deserialize.py
@@ -162,10 +162,8 @@ def _convert_to_entity(entry_element):
         if type(value) is int:  # pylint:disable=C0123
             if value.bit_length() <= 32:
                 mtype = EdmType.INT32
-            elif value.bit_length() <= 64:
-                mtype = EdmType.INT64
             else:
-                mtype = EdmType.STRING
+                mtype = EdmType.INT64
 
         # no type info, property should parse automatically
         if not mtype:

--- a/sdk/tables/azure-data-tables/azure/data/tables/_deserialize.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_deserialize.py
@@ -160,7 +160,12 @@ def _convert_to_entity(entry_element):
 
         # Add type for Int32
         if type(value) is int:  # pylint:disable=C0123
-            mtype = EdmType.INT32
+            if value.bit_length() <= 32:
+                mtype = EdmType.INT32
+            elif value.bit_length() <= 64:
+                mtype = EdmType.INT64
+            else:
+                mtype = EdmType.STRING
 
         # no type info, property should parse automatically
         if not mtype:

--- a/sdk/tables/azure-data-tables/azure/data/tables/_entity.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_entity.py
@@ -103,10 +103,8 @@ class EntityProperty(object):
         elif isinstance(value, six.integer_types):
             if value.bit_length() <= 32:
                 self.type = EdmType.INT32
-            elif value.bit_length() <= 64:
-                self.type = EdmType.INT64
             else:
-                self.type = EdmType.STRING
+                self.type = EdmType.INT64
         elif isinstance(value, datetime):
             self.type = EdmType.DATETIME
         elif isinstance(value, float):

--- a/sdk/tables/azure-data-tables/azure/data/tables/_entity.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_entity.py
@@ -101,7 +101,12 @@ class EntityProperty(object):
         elif isinstance(value, bool):
             self.type = EdmType.BOOLEAN
         elif isinstance(value, six.integer_types):
-            self.type = EdmType.INT64
+            if value.bit_length() <= 32:
+                self.type = EdmType.INT32
+            elif value.bit_length() <= 64:
+                self.type = EdmType.INT64
+            else:
+                self.type = EdmType.STRING
         elif isinstance(value, datetime):
             self.type = EdmType.DATETIME
         elif isinstance(value, float):

--- a/sdk/tables/azure-data-tables/azure/data/tables/_serialize.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_serialize.py
@@ -133,6 +133,15 @@ def _to_entity_int64(value):
     return EdmType.INT64, str(value)
 
 
+def _to_entity_int(value):
+    ivalue = int(value)
+    if ivalue.bit_length() <= 32:
+        return _to_entity_int32(value)
+    elif ivalue.bit_length() <= 64:
+        return _to_entity_int64(value)
+    raise TypeError(_ERROR_VALUE_TOO_LARGE.format(str(value), EdmType.INT64))
+
+
 def _to_entity_str(value):
     return None, value
 
@@ -144,7 +153,7 @@ def _to_entity_none(value):  # pylint:disable=W0613
 # Conversion from Python type to a function which returns a tuple of the
 # type string and content string.
 _PYTHON_TO_ENTITY_CONVERSIONS = {
-    int: _to_entity_int64,
+    int: _to_entity_int,
     bool: _to_entity_bool,
     datetime: _to_entity_datetime,
     float: _to_entity_float,

--- a/sdk/tables/azure-data-tables/azure/data/tables/_serialize.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_serialize.py
@@ -137,7 +137,7 @@ def _to_entity_int(value):
     ivalue = int(value)
     if ivalue.bit_length() <= 32:
         return _to_entity_int32(value)
-    elif ivalue.bit_length() <= 64:
+    if ivalue.bit_length() <= 64:
         return _to_entity_int64(value)
     raise TypeError(_ERROR_VALUE_TOO_LARGE.format(str(value), EdmType.INT64))
 

--- a/sdk/tables/azure-data-tables/azure/data/tables/_table_client.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_table_client.py
@@ -27,7 +27,7 @@ from ._table_client_base import TableClientBase
 from ._serialize import serialize_iso
 from ._deserialize import _return_headers_and_deserialized
 from ._error import _process_table_error
-from ._models import TableEntityPropertiesPaged, UpdateMode, TableItem
+from ._models import TableEntityPropertiesPaged, UpdateMode
 
 
 class TableClient(TableClientBase):

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table_entity.test_insert_entity_with_large_int32_value_throws.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table_entity.test_insert_entity_with_large_int32_value_throws.yaml
@@ -15,13 +15,13 @@ interactions:
       DataServiceVersion:
       - '3.0'
       Date:
-      - Thu, 20 Aug 2020 20:16:40 GMT
+      - Mon, 31 Aug 2020 22:27:33 GMT
       User-Agent:
-      - azsdk-python-data-tables/2019-07-07 Python/3.8.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-data-tables/12.0.0b1 Python/3.8.4 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 20 Aug 2020 20:16:40 GMT
+      - Mon, 31 Aug 2020 22:27:33 GMT
       x-ms-version:
-      - '2019-07-07'
+      - '2019-02-02'
     method: POST
     uri: https://storagename.table.core.windows.net/Tables
   response:
@@ -33,7 +33,7 @@ interactions:
       content-type:
       - application/json;odata=minimalmetadata;streaming=true;charset=utf-8
       date:
-      - Thu, 20 Aug 2020 20:16:40 GMT
+      - Mon, 31 Aug 2020 22:27:30 GMT
       location:
       - https://storagename.table.core.windows.net/Tables('uttable8fac1b18')
       server:
@@ -43,7 +43,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-version:
-      - '2019-07-07'
+      - '2019-02-02'
     status:
       code: 201
       message: Created
@@ -59,13 +59,13 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Thu, 20 Aug 2020 20:16:40 GMT
+      - Mon, 31 Aug 2020 22:27:33 GMT
       User-Agent:
-      - azsdk-python-data-tables/2019-07-07 Python/3.8.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-data-tables/12.0.0b1 Python/3.8.4 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 20 Aug 2020 20:16:40 GMT
+      - Mon, 31 Aug 2020 22:27:33 GMT
       x-ms-version:
-      - '2019-07-07'
+      - '2019-02-02'
     method: DELETE
     uri: https://storagename.table.core.windows.net/Tables('uttable8fac1b18')
   response:
@@ -77,13 +77,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 20 Aug 2020 20:16:40 GMT
+      - Mon, 31 Aug 2020 22:27:30 GMT
       server:
       - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
       x-content-type-options:
       - nosniff
       x-ms-version:
-      - '2019-07-07'
+      - '2019-02-02'
     status:
       code: 204
       message: No Content

--- a/sdk/tables/azure-data-tables/tests/test_table_batch.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch.py
@@ -163,7 +163,7 @@ class StorageTableBatchTest(TableTestCase):
         entity.test5 = EntityProperty(u"stringystring")
         entity.test6 = EntityProperty(3.14159)
         entity.test7 = EntityProperty(100)
-        entity.test8 = EntityProperty(10, EdmType.INT32)
+        entity.test8 = EntityProperty(2 ** 33)
 
         # Assert
         self.assertEqual(entity.test.type, EdmType.BOOLEAN)
@@ -172,8 +172,8 @@ class StorageTableBatchTest(TableTestCase):
         self.assertEqual(entity.test4.type, EdmType.DATETIME)
         self.assertEqual(entity.test5.type, EdmType.STRING)
         self.assertEqual(entity.test6.type, EdmType.DOUBLE)
-        self.assertEqual(entity.test7.type, EdmType.INT64)
-        self.assertEqual(entity.test8.type, EdmType.INT32)
+        self.assertEqual(entity.test7.type, EdmType.INT32)
+        self.assertEqual(entity.test8.type, EdmType.INT64)
 
 
     @pytest.mark.skip("pending")

--- a/sdk/tables/azure-data-tables/tests/test_table_entity.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_entity.py
@@ -446,10 +446,6 @@ class StorageTableEntityTest(TableTestCase):
             dict32['large'] = EntityProperty(-(2 ** 31 + 1), EdmType.INT32)
             with self.assertRaises(TypeError):
                 self.table.create_entity(entity=dict32)
-
-            dict32['large'] = 2**100
-            with self.assertRaises(TypeError):
-                self.table.create_entity(entity=dict32)
         finally:
             self._tear_down()
 

--- a/sdk/tables/azure-data-tables/tests/test_table_entity.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_entity.py
@@ -160,7 +160,7 @@ class StorageTableEntityTest(TableTestCase):
         self.assertEqual(entity['birthday'], datetime(1970, 10, 4, tzinfo=tzutc()))
         self.assertEqual(entity['binary'].value, b'binary')
         self.assertIsInstance(entity['other'], EntityProperty)
-        self.assertEqual(entity['other'].type, EdmType.INT64)
+        self.assertEqual(entity['other'].type, EdmType.INT32)
         self.assertEqual(entity['other'].value, 20)
         self.assertEqual(entity['clsid'], uuid.UUID('c9da6455-213d-42c9-9a79-3e9149a57833'))
         # self.assertTrue('metadata' in entity.odata)
@@ -188,7 +188,7 @@ class StorageTableEntityTest(TableTestCase):
         self.assertEqual(entity['birthday'], datetime(1970, 10, 4, tzinfo=tzutc()))
         self.assertEqual(entity['binary'].value, b'binary')
         self.assertIsInstance(entity['other'], EntityProperty)
-        self.assertEqual(entity['other'].type, EdmType.INT64)
+        self.assertEqual(entity['other'].type, EdmType.INT32)
         self.assertEqual(entity['other'].value, 20)
         self.assertEqual(entity['clsid'], uuid.UUID('c9da6455-213d-42c9-9a79-3e9149a57833'))
         # self.assertTrue('metadata' in entity.odata)
@@ -222,7 +222,7 @@ class StorageTableEntityTest(TableTestCase):
         self.assertTrue(entity['birthday'].endswith('00Z'))
         self.assertEqual(entity['binary'], b64encode(b'binary').decode('utf-8'))
         self.assertIsInstance(entity['other'], EntityProperty)
-        self.assertEqual(entity['other'].type, EdmType.INT64)
+        self.assertEqual(entity['other'].type, EdmType.INT32)
         self.assertEqual(entity['other'].value, 20)
         self.assertEqual(entity['clsid'], 'c9da6455-213d-42c9-9a79-3e9149a57833')
         # self.assertIsNone(entity.odata)
@@ -273,7 +273,7 @@ class StorageTableEntityTest(TableTestCase):
         self.assertEqual(entity.Birthday, datetime(1973, 10, 4, tzinfo=tzutc()))
         self.assertEqual(entity.birthday, datetime(1991, 10, 4, tzinfo=tzutc()))
         self.assertIsInstance(entity.other, EntityProperty)
-        self.assertEqual(entity.other.type, EdmType.INT64)
+        self.assertEqual(entity.other.type, EdmType.INT32)
         self.assertEqual(entity.other.value, 20)
         self.assertIsInstance(entity.clsid, uuid.UUID)
         self.assertEqual(str(entity.clsid), 'c9da6455-213d-42c9-9a79-3e9149a57833')
@@ -444,6 +444,10 @@ class StorageTableEntityTest(TableTestCase):
                 self.table.create_entity(entity=dict32)
 
             dict32['large'] = EntityProperty(-(2 ** 31 + 1), EdmType.INT32)
+            with self.assertRaises(TypeError):
+                self.table.create_entity(entity=dict32)
+
+            dict32['large'] = 2**100
             with self.assertRaises(TypeError):
                 self.table.create_entity(entity=dict32)
         finally:

--- a/sdk/tables/azure-data-tables/tests/test_table_entity_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_entity_async.py
@@ -412,10 +412,6 @@ class StorageTableEntityTest(TableTestCase):
             dict32['large'] = EntityProperty(-(2 ** 31 + 1), EdmType.INT32)  # TODO: this is outside the range of int32
             with self.assertRaises(TypeError):
                 await self.table.create_entity(entity=dict32)
-
-            dict32['large'] = 2**100
-            with self.assertRaises(TypeError):
-                await self.table.create_entity(entity=dict32)
         finally:
             await self._tear_down()
 

--- a/sdk/tables/azure-data-tables/tests/test_table_entity_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_entity_async.py
@@ -161,7 +161,7 @@ class StorageTableEntityTest(TableTestCase):
         self.assertEqual(entity['birthday'], datetime(1970, 10, 4, tzinfo=tzutc()))
         self.assertEqual(entity['binary'].value, b'binary') # TODO: added the ".value" portion, verify this is correct
         self.assertIsInstance(entity['other'], EntityProperty)
-        self.assertEqual(entity['other'].type, EdmType.INT64)
+        self.assertEqual(entity['other'].type, EdmType.INT32)
         self.assertEqual(entity['other'].value, 20)
         self.assertEqual(entity['clsid'], uuid.UUID('c9da6455-213d-42c9-9a79-3e9149a57833'))
         # self.assertTrue('metadata' in entity.odata)
@@ -190,7 +190,7 @@ class StorageTableEntityTest(TableTestCase):
         self.assertEqual(entity['birthday'], datetime(1970, 10, 4, tzinfo=tzutc()))
         self.assertEqual(entity['binary'].value, b'binary')
         self.assertIsInstance(entity['other'], EntityProperty)
-        self.assertEqual(entity['other'].type, EdmType.INT64)
+        self.assertEqual(entity['other'].type, EdmType.INT32)
         self.assertEqual(entity['other'].value, 20)
         self.assertEqual(entity['clsid'], uuid.UUID('c9da6455-213d-42c9-9a79-3e9149a57833'))
         # self.assertTrue('metadata' in entity.odata)
@@ -225,7 +225,7 @@ class StorageTableEntityTest(TableTestCase):
         self.assertTrue(entity['birthday'].endswith('00Z'))
         self.assertEqual(entity['binary'], b64encode(b'binary').decode('utf-8'))
         self.assertIsInstance(entity['other'], EntityProperty)
-        self.assertEqual(entity['other'].type, EdmType.INT64)
+        self.assertEqual(entity['other'].type, EdmType.INT32)
         self.assertEqual(entity['other'].value, 20)
         self.assertEqual(entity['clsid'], 'c9da6455-213d-42c9-9a79-3e9149a57833')
         # self.assertIsNone(entity.odata)
@@ -275,7 +275,7 @@ class StorageTableEntityTest(TableTestCase):
         self.assertEqual(entity.Birthday, datetime(1973, 10, 4, tzinfo=tzutc()))
         self.assertEqual(entity.birthday, datetime(1991, 10, 4, tzinfo=tzutc()))
         self.assertIsInstance(entity.other, EntityProperty)
-        self.assertEqual(entity.other.type, EdmType.INT64)
+        self.assertEqual(entity.other.type, EdmType.INT32)
         self.assertEqual(entity.other.value, 20)
         self.assertIsInstance(entity.clsid, uuid.UUID)
         self.assertEqual(str(entity.clsid), 'c9da6455-213d-42c9-9a79-3e9149a57833')
@@ -410,6 +410,10 @@ class StorageTableEntityTest(TableTestCase):
                 await self.table.create_entity(entity=dict32)
 
             dict32['large'] = EntityProperty(-(2 ** 31 + 1), EdmType.INT32)  # TODO: this is outside the range of int32
+            with self.assertRaises(TypeError):
+                await self.table.create_entity(entity=dict32)
+
+            dict32['large'] = 2**100
             with self.assertRaises(TypeError):
                 await self.table.create_entity(entity=dict32)
         finally:


### PR DESCRIPTION
Partially addresses integer serialization issues raised in #13420. Changes the automatic serialization to int32 instead of int64 to stay consistent with other languages, casts to int64 if the integer is larger than 32 bits. If the integer is larger than 64 bits an error is thrown from the client stating so. 