### PR TITLE
[text analytics] add --pre suffix to pip install

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/README.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/README.md
@@ -68,7 +68,9 @@ Install the Azure Text Analytics client library for Python with [pip][pip]:
 pip install azure-ai-textanalytics --pre
 ```
 
-> Note: This version of the client library supports the v3.0 version of the Text Analytics service
+> Note: This version of the client library supports both the v3.0 version, and the preview versions of the v3.1 version of the Text Analytics service. If you do not specify the `--pre` flag when installing the package, you will download version 5.0.0 of the library, which will only
+include support of the services v3.0 version. Specifying the `--pre` flag will give you the latest beta release of this library, which includes
+support of all preview versions of v3.1, and also continuing support of the service's v3.0 version.
 
 ### Authenticate the client
 #### Get the endpoint

--- a/sdk/textanalytics/azure-ai-textanalytics/README.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/README.md
@@ -67,10 +67,13 @@ Install the Azure Text Analytics client library for Python with [pip][pip]:
 ```bash
 pip install azure-ai-textanalytics --pre
 ```
+> This table shows the relationship between SDK versions and supported API versions of the service
+>| SDK version      | Supported API version of service |
+>| ----------- | ----------- |
+>| Latest GA release (can be installed by removing the `--pre` flag)      | 3.0       |
+>| Latest release (beta)   | 3.0, 3.1-preview        |
 
-> Note: This version of the client library supports both the v3.0 version, and the preview versions of the v3.1 version of the Text Analytics service. If you do not specify the `--pre` flag when installing the package, you will download version 5.0.0 of the library, which will only
-include support of the services v3.0 version. Specifying the `--pre` flag will give you the latest beta release of this library, which includes
-support of all preview versions of v3.1, and also continuing support of the service's v3.0 version.
+
 
 ### Authenticate the client
 #### Get the endpoint

--- a/sdk/textanalytics/azure-ai-textanalytics/README.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/README.md
@@ -65,7 +65,7 @@ For example, `https://<my-custom-subdomain>.cognitiveservices.azure.com/`.
 Install the Azure Text Analytics client library for Python with [pip][pip]:
 
 ```bash
-pip install azure-ai-textanalytics
+pip install azure-ai-textanalytics --pre
 ```
 
 > Note: This version of the client library supports the v3.0 version of the Text Analytics service


### PR DESCRIPTION
Should include the `--pre` specification when installing from pip, since there are both GA and preview versions of this library