### PR TITLE
Add wrapper class for exposing core AMQP properties

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **New Features**
 * Messages can now be sent twice in succession.
+* Internal AMQP message properties (header, footer, annotations, properties, etc) are now exposed via `Message.amqp_message`
 
 **Breaking Changes**
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_sender.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_sender.py
@@ -78,7 +78,8 @@ class SenderMixin(object):
                 message_data[MGMT_REQUEST_PARTITION_KEY] = message.partition_key
             if message.via_partition_key:
                 message_data[MGMT_REQUEST_VIA_PARTITION_KEY] = message.via_partition_key
-            message_data[MGMT_REQUEST_MESSAGE] = bytearray(message.message.encode_message())
+            message_data[MGMT_REQUEST_MESSAGE] = bytearray(
+                message._internal_message.encode_message()) # pylint: disable=protected-access
             request_body[MGMT_REQUEST_MESSAGES].append(message_data)
         return request_body
 
@@ -191,7 +192,7 @@ class ServiceBusSender(BaseHandler, SenderMixin):
         # type: (Message, Optional[float], Exception) -> None
         self._open()
         self._set_msg_timeout(timeout, last_exception)
-        self._handler.send_message(message.message)
+        self._handler.send_message(message._internal_message) # pylint: disable=protected-access
 
     def schedule_messages(self, messages, schedule_time_utc):
         # type: (Union[Message, List[Message]], datetime.datetime) -> List[int]

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_sender_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_sender_async.py
@@ -135,7 +135,7 @@ class ServiceBusSender(BaseHandler, SenderMixin):
     async def _send(self, message, timeout=None, last_exception=None):
         await self._open()
         self._set_msg_timeout(timeout, last_exception)
-        await self._handler.send_message_async(message.message)
+        await self._handler.send_message_async(message._internal_message)
 
     async def schedule_messages(self, messages, schedule_time_utc):
         # type: (Union[Message, List[Message]], datetime.datetime) -> List[int]

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -1892,6 +1892,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                     assert message.amqp_message.properties.subject == b"subject"
                     assert message.amqp_message.application_properties[b"application_properties"] == 1
                     assert message.amqp_message.annotations[b"annotations"] == 2
+                    # delivery_annotations and footer disabled pending uamqp bug https://github.com/Azure/azure-uamqp-python/issues/169
                     #assert message.amqp_message.delivery_annotations[b"delivery_annotations"] == 3
                     assert message.amqp_message.header.priority == 5
                     #assert message.amqp_message.footer[b"footer"] == 6

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -136,9 +136,9 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                 assert message.reply_to == 'reply_to'
                 assert message.sequence_number
                 assert message.enqueued_time_utc
-                assert message.message.delivery_tag is not None
-                assert message.lock_token == message.message.delivery_annotations.get(_X_OPT_LOCK_TOKEN)
-                assert message.lock_token == uuid.UUID(bytes_le=message.message.delivery_tag)
+                assert message._internal_message.delivery_tag is not None
+                assert message.lock_token == message._internal_message.delivery_annotations.get(_X_OPT_LOCK_TOKEN)
+                assert message.lock_token == uuid.UUID(bytes_le=message._internal_message.delivery_tag)
                 assert not message.scheduled_enqueue_time_utc
                 assert not message.time_to_live
                 assert not message.session_id
@@ -1289,7 +1289,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                         assert messages[0].reply_to == 'reply_to'
                         assert messages[0].sequence_number
                         assert messages[0].enqueued_time_utc
-                        assert messages[0].message.delivery_tag is not None
+                        assert messages[0]._internal_message.delivery_tag is not None
                         assert len(messages) == 2
                     finally:
                         for m in messages:
@@ -1857,3 +1857,41 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                                               max_wait_time="oij") as receiver:
             
                 assert receiver
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest')
+    def test_message_inner_amqp_properties(self, servicebus_namespace_connection_string, servicebus_queue, **kwargs):
+        
+        message = Message("body")
+
+        with pytest.raises(TypeError):
+            message.amqp_message.properties = {"properties":1}
+        message.amqp_message.properties.subject = "subject"
+
+        message.amqp_message.application_properties = {b"application_properties":1}
+
+        message.amqp_message.annotations = {b"annotations":2}
+        message.amqp_message.delivery_annotations = {b"delivery_annotations":3}
+
+        with pytest.raises(TypeError):
+            message.amqp_message.header = {"header":4}
+        message.amqp_message.header.priority = 5
+
+        message.amqp_message.footer = {b"footer":6}
+
+        with ServiceBusClient.from_connection_string(
+            servicebus_namespace_connection_string, logging_enable=False) as sb_client:
+
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                sender.send_messages(message)
+                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+                    message = receiver.receive_messages()[0]
+                    assert message.amqp_message.properties.subject == b"subject"
+                    assert message.amqp_message.application_properties[b"application_properties"] == 1
+                    assert message.amqp_message.annotations[b"annotations"] == 2
+                    #assert message.amqp_message.delivery_annotations[b"delivery_annotations"] == 3
+                    assert message.amqp_message.header.priority == 5
+                    #assert message.amqp_message.footer[b"footer"] == 6


### PR DESCRIPTION
Annotations, header/footer, properties.

Tests, changelog notes, docstrings, etc.

Currently test is partially disabled due to discovery of a uamqp bug that has been logged [here](https://github.com/Azure/azure-uamqp-python/issues/169).