### PR TITLE
Bump template version

### DIFF
--- a/sdk/template/azure-template/CHANGELOG.md
+++ b/sdk/template/azure-template/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 0.0.18b3 (Unreleased)
+
+
 ## 0.0.18b2 (2020-09-04)
 - Testing release tag version
 

--- a/sdk/template/azure-template/CHANGELOG.md
+++ b/sdk/template/azure-template/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 0.0.13b2 (Unreleased)
+
+
 ## 0.0.13b1 (2020-08-27)
 - Testing out some alpha and beta versioning
 

--- a/sdk/template/azure-template/CHANGELOG.md
+++ b/sdk/template/azure-template/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
-## 0.0.13b2 (Unreleased)
-
+## 0.0.13b2 (2020-09-04)
+- Testing release tag version
 
 ## 0.0.13b1 (2020-08-27)
 - Testing out some alpha and beta versioning

--- a/sdk/template/azure-template/CHANGELOG.md
+++ b/sdk/template/azure-template/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.0.13b2 (2020-09-04)
+## 0.0.18b2 (2020-09-04)
 - Testing release tag version
 
 ## 0.0.13b1 (2020-08-27)

--- a/sdk/template/azure-template/azure/template/_version.py
+++ b/sdk/template/azure-template/azure/template/_version.py
@@ -1,2 +1,2 @@
 # matches SEMVER
-VERSION = "0.0.18b2"
+VERSION = "0.0.18b3"

--- a/sdk/template/azure-template/azure/template/_version.py
+++ b/sdk/template/azure-template/azure/template/_version.py
@@ -1,2 +1,2 @@
 # matches SEMVER
-VERSION = "0.0.13b2"
+VERSION = "0.0.18b2"

--- a/sdk/template/azure-template/azure/template/_version.py
+++ b/sdk/template/azure-template/azure/template/_version.py
@@ -1,2 +1,2 @@
 # matches SEMVER
-VERSION = "0.0.13b1"
+VERSION = "0.0.13b2"


### PR DESCRIPTION
Kick off the pipeline of template to test the release tag default setting. All passed, but release tag 0.0.18b2 has been used. Bump to a new one to 0.0.18b3.

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=525028&view=results