### PR TITLE
Identity release notes

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.5.0b1 (Unreleased)
+## 1.5.0b1 (2020-09-08)
 ### Added
 - Application authentication APIs from 1.4.0b7
 - `ManagedIdentityCredential` supports the latest version of App Service
@@ -13,6 +13,14 @@
   (`azure.identity.aio.CertificateCredential`) will support this in a
   future version.
   ([#10816](https://github.com/Azure/azure-sdk-for-python/issues/10816))
+- Credentials in `azure.identity` support ADFS authorities, excepting
+  `VisualStudioCodeCredential`. To configure a credential for this, configure
+  the credential with `authority` and `tenant_id="adfs"` keyword arguments, for
+  example
+  `ClientSecretCredential(authority="<your ADFS URI>", tenant_id="adfs")` 
+  Async credentials (those in `azure.identity.aio`) will support ADFS in a
+  future release.
+  ([#12696](https://github.com/Azure/azure-sdk-for-python/issues/12696))
 
 ## 1.4.0 (2020-08-10)
 ### Added

--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -73,7 +73,7 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.0.0",
         "cryptography>=2.1.4",
-        "msal<1.5.0,>=1.3.0",
+        "msal<1.6.0,>=1.3.0",
         "msal-extensions~=0.2.2",
         "six>=1.6",
     ],

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -98,7 +98,7 @@ futures
 mock
 typing
 typing-extensions
-msal<1.5.0,>=1.3.0
+msal<1.6.0,>=1.3.0
 msal-extensions~=0.2.2
 msrest>=0.5.0
 msrestazure<2.0.0,>=0.4.32


### PR DESCRIPTION
Also raising the upper bound on `msal` because we need 1.5.0 but 1.6.0 may be incompatible.