### PR TITLE
[ServiceBus] Remove unneeded mgmt properties

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Sending a message twice will no longer result in a MessageAlreadySettled exception.
 * `ServiceBusClient.close()` now closes spawned senders and receivers.
 * Attempting to initialize a sender or receiver with a different connection string entity and specified entity (e.g. `queue_name`) will result in an AuthenticationError
+* Remove `is_anonymous_accessible` from management entities.
+* Remove `support_ordering` from `create_queue` and `QueueProperties`
+* Remove `enable_subscription_partitioning` from `create_topic` and `TopicProperties`
 
 ## 7.0.0b5 (2020-08-10)
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
@@ -198,9 +198,6 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         :keyword enable_partitioning: A value that indicates whether the queue is to be partitioned
          across multiple message brokers.
         :type enable_partitioning: bool
-        :keyword is_anonymous_accessible: A value indicating if the resource can be accessed without
-         authorization.
-        :type is_anonymous_accessible: bool
         :keyword lock_duration: ISO 8601 timespan duration of a peek-lock; that is, the amount of time
          that the message is locked for other receivers. The maximum value for LockDuration is 5
          minutes; the default value is 1 minute.
@@ -223,8 +220,6 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         :keyword user_metadata: Custom metdata that user can associate with the description. Max length
          is 1024 chars.
         :type user_metadata: str
-        :keyword support_ordering: A value that indicates whether the queue supports ordering.
-        :type support_ordering: bool
         :keyword forward_dead_lettered_messages_to: The name of the recipient entity to which all the
          dead-lettered messages of this subscription are forwarded to.
         :type forward_dead_lettered_messages_to: str
@@ -242,14 +237,12 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             enable_batched_operations=kwargs.pop("enable_batched_operations", None),
             enable_express=kwargs.pop("enable_express", None),
             enable_partitioning=kwargs.pop("enable_partitioning", None),
-            is_anonymous_accessible=kwargs.pop("is_anonymous_accessible", None),
             lock_duration=kwargs.pop("lock_duration", None),
             max_delivery_count=kwargs.pop("max_delivery_count", None),
             max_size_in_megabytes=kwargs.pop("max_size_in_megabytes", None),
             requires_duplicate_detection=kwargs.pop("requires_duplicate_detection", None),
             requires_session=kwargs.pop("requires_session", None),
             status=kwargs.pop("status", None),
-            support_ordering=kwargs.pop("support_ordering", None),
             forward_to=kwargs.pop("forward_to", None),
             forward_dead_lettered_messages_to=kwargs.pop("forward_dead_lettered_messages_to", None),
             user_metadata=kwargs.pop("user_metadata", None)
@@ -413,9 +406,6 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         :type size_in_bytes: int
         :keyword filtering_messages_before_publishing: Filter messages before publishing.
         :type filtering_messages_before_publishing: bool
-        :keyword is_anonymous_accessible: A value indicating if the resource can be accessed without
-         authorization.
-        :type is_anonymous_accessible: bool
         :keyword authorization_rules: Authorization rules for resource.
         :type authorization_rules:
          list[~azure.servicebus.management.AuthorizationRule]
@@ -427,9 +417,6 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
         :keyword enable_partitioning: A value that indicates whether the topic is to be partitioned
          across multiple message brokers.
         :type enable_partitioning: bool
-        :keyword enable_subscription_partitioning: A value that indicates whether the topic's
-         subscription is to be partitioned.
-        :type enable_subscription_partitioning: bool
         :keyword enable_express: A value that indicates whether Express Entities are enabled. An express
          queue holds a message in memory temporarily before writing it to persistent storage.
         :type enable_express: bool
@@ -447,14 +434,12 @@ class ServiceBusManagementClient:  #pylint:disable=too-many-public-methods
             duplicate_detection_history_time_window=kwargs.pop("duplicate_detection_history_time_window", None),
             enable_batched_operations=kwargs.pop("enable_batched_operations", None),
             size_in_bytes=kwargs.pop("size_in_bytes", None),
-            is_anonymous_accessible=kwargs.pop("is_anonymous_accessible", None),
             authorization_rules=kwargs.pop("authorization_rules", None),
             status=kwargs.pop("status", None),
             support_ordering=kwargs.pop("support_ordering", None),
             auto_delete_on_idle=kwargs.pop("auto_delete_on_idle", None),
             enable_partitioning=kwargs.pop("enable_partitioning", None),
             entity_availability_status=kwargs.pop("entity_availability_status", None),
-            enable_subscription_partitioning=kwargs.pop("enable_subscription_partitioning", None),
             enable_express=kwargs.pop("enable_express", None),
             user_metadata=kwargs.pop("user_metadata", None)
         )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
@@ -193,9 +193,6 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         :keyword enable_partitioning: A value that indicates whether the queue is to be partitioned
          across multiple message brokers.
         :type enable_partitioning: bool
-        :keyword is_anonymous_accessible: A value indicating if the resource can be accessed without
-         authorization.
-        :type is_anonymous_accessible: bool
         :keyword lock_duration: ISO 8601 timespan duration of a peek-lock; that is, the amount of time
          that the message is locked for other receivers. The maximum value for LockDuration is 5
          minutes; the default value is 1 minute.
@@ -218,8 +215,6 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         :keyword user_metadata: Custom metdata that user can associate with the description. Max length
          is 1024 chars.
         :type user_metadata: str
-        :keyword support_ordering: A value that indicates whether the queue supports ordering.
-        :type support_ordering: bool
         :keyword forward_dead_lettered_messages_to: The name of the recipient entity to which all the
          dead-lettered messages of this subscription are forwarded to.
         :type forward_dead_lettered_messages_to: str
@@ -237,14 +232,12 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             enable_batched_operations=kwargs.pop("enable_batched_operations", None),
             enable_express=kwargs.pop("enable_express", None),
             enable_partitioning=kwargs.pop("enable_partitioning", None),
-            is_anonymous_accessible=kwargs.pop("is_anonymous_accessible", None),
             lock_duration=kwargs.pop("lock_duration", None),
             max_delivery_count=kwargs.pop("max_delivery_count", None),
             max_size_in_megabytes=kwargs.pop("max_size_in_megabytes", None),
             requires_duplicate_detection=kwargs.pop("requires_duplicate_detection", None),
             requires_session=kwargs.pop("requires_session", None),
             status=kwargs.pop("status", None),
-            support_ordering=kwargs.pop("support_ordering", None),
             forward_to=kwargs.pop("forward_to", None),
             forward_dead_lettered_messages_to=kwargs.pop("forward_dead_lettered_messages_to", None),
             user_metadata=kwargs.pop("user_metadata", None)
@@ -417,9 +410,6 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         :type size_in_bytes: int
         :keyword filtering_messages_before_publishing: Filter messages before publishing.
         :type filtering_messages_before_publishing: bool
-        :keyword is_anonymous_accessible: A value indicating if the resource can be accessed without
-         authorization.
-        :type is_anonymous_accessible: bool
         :keyword authorization_rules: Authorization rules for resource.
         :type authorization_rules:
          list[~azure.servicebus.management.AuthorizationRule]
@@ -431,9 +421,6 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
         :keyword enable_partitioning: A value that indicates whether the topic is to be partitioned
          across multiple message brokers.
         :type enable_partitioning: bool
-        :keyword enable_subscription_partitioning: A value that indicates whether the topic's
-         subscription is to be partitioned.
-        :type enable_subscription_partitioning: bool
         :keyword enable_express: A value that indicates whether Express Entities are enabled. An express
          queue holds a message in memory temporarily before writing it to persistent storage.
         :type enable_express: bool
@@ -450,14 +437,12 @@ class ServiceBusManagementClient:  # pylint:disable=too-many-public-methods
             duplicate_detection_history_time_window=kwargs.pop("duplicate_detection_history_time_window", None),
             enable_batched_operations=kwargs.pop("enable_batched_operations", None),
             size_in_bytes=kwargs.pop("size_in_bytes", None),
-            is_anonymous_accessible=kwargs.pop("is_anonymous_accessible", None),
             authorization_rules=kwargs.pop("authorization_rules", None),
             status=kwargs.pop("status", None),
             support_ordering=kwargs.pop("support_ordering", None),
             auto_delete_on_idle=kwargs.pop("auto_delete_on_idle", None),
             enable_partitioning=kwargs.pop("enable_partitioning", None),
             entity_availability_status=kwargs.pop("entity_availability_status", None),
-            enable_subscription_partitioning=kwargs.pop("enable_subscription_partitioning", None),
             enable_express=kwargs.pop("enable_express", None),
             user_metadata=kwargs.pop("user_metadata", None)
         )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_models.py
@@ -125,9 +125,6 @@ class QueueProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
     :ivar enable_partitioning: A value that indicates whether the queue is to be partitioned
      across multiple message brokers.
     :type enable_partitioning: bool
-    :ivar is_anonymous_accessible: A value indicating if the resource can be accessed without
-     authorization.
-    :type is_anonymous_accessible: bool
     :ivar lock_duration: ISO 8601 timespan duration of a peek-lock; that is, the amount of time
      that the message is locked for other receivers. The maximum value for LockDuration is 5
      minutes; the default value is 1 minute.
@@ -153,8 +150,6 @@ class QueueProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
     :ivar user_metadata: Custom metdata that user can associate with the description. Max length
      is 1024 chars.
     :type user_metadata: str
-    :ivar support_ordering: A value that indicates whether the queue supports ordering.
-    :type support_ordering: bool
     :ivar forward_dead_lettered_messages_to: The name of the recipient entity to which all the
      dead-lettered messages of this subscription are forwarded to.
     :type forward_dead_lettered_messages_to: str
@@ -181,14 +176,12 @@ class QueueProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
         self.enable_batched_operations = extract_kwarg('enable_batched_operations')
         self.enable_express = extract_kwarg('enable_express')
         self.enable_partitioning = extract_kwarg('enable_partitioning')
-        self.is_anonymous_accessible = extract_kwarg('is_anonymous_accessible')
         self.lock_duration = extract_kwarg('lock_duration')
         self.max_delivery_count = extract_kwarg('max_delivery_count')
         self.max_size_in_megabytes = extract_kwarg('max_size_in_megabytes')
         self.requires_duplicate_detection = extract_kwarg('requires_duplicate_detection')
         self.requires_session = extract_kwarg('requires_session')
         self.status = extract_kwarg('status')
-        self.support_ordering = extract_kwarg('support_ordering')
         self.forward_to = extract_kwarg('forward_to')
         self.user_metadata = extract_kwarg('user_metadata')
         self.forward_dead_lettered_messages_to = extract_kwarg('forward_dead_lettered_messages_to')
@@ -210,14 +203,12 @@ class QueueProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
             enable_batched_operations=internal_qd.enable_batched_operations,
             enable_express=internal_qd.enable_express,
             enable_partitioning=internal_qd.enable_partitioning,
-            is_anonymous_accessible=internal_qd.is_anonymous_accessible,
             lock_duration=internal_qd.lock_duration,
             max_delivery_count=internal_qd.max_delivery_count,
             max_size_in_megabytes=internal_qd.max_size_in_megabytes,
             requires_duplicate_detection=internal_qd.requires_duplicate_detection,
             requires_session=internal_qd.requires_session,
             status=internal_qd.status,
-            support_ordering=internal_qd.support_ordering,
             forward_to=internal_qd.forward_to,
             forward_dead_lettered_messages_to=internal_qd.forward_dead_lettered_messages_to,
             user_metadata=internal_qd.user_metadata
@@ -239,14 +230,12 @@ class QueueProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
         self._internal_qd.enable_batched_operations = self.enable_batched_operations
         self._internal_qd.enable_express = self.enable_express
         self._internal_qd.enable_partitioning = self.enable_partitioning
-        self._internal_qd.is_anonymous_accessible = self.is_anonymous_accessible
         self._internal_qd.lock_duration = self.lock_duration
         self._internal_qd.max_delivery_count = self.max_delivery_count
         self._internal_qd.max_size_in_megabytes = self.max_size_in_megabytes
         self._internal_qd.requires_duplicate_detection = self.requires_duplicate_detection
         self._internal_qd.requires_session = self.requires_session
         self._internal_qd.status = self.status
-        self._internal_qd.support_ordering = self.support_ordering
         self._internal_qd.forward_to = self.forward_to
         self._internal_qd.forward_dead_lettered_messages_to = self.forward_dead_lettered_messages_to
         self._internal_qd.user_metadata = self.user_metadata
@@ -386,9 +375,6 @@ class TopicProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
     :type size_in_bytes: int
     :ivar filtering_messages_before_publishing: Filter messages before publishing.
     :type filtering_messages_before_publishing: bool
-    :ivar is_anonymous_accessible: A value indicating if the resource can be accessed without
-     authorization.
-    :type is_anonymous_accessible: bool
     :ivar authorization_rules: Authorization rules for resource.
     :type authorization_rules:
      list[~azure.servicebus.management.AuthorizationRule]
@@ -407,9 +393,6 @@ class TopicProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
      "Available", "Limited", "Renaming", "Restoring", "Unknown".
     :type entity_availability_status: str or
      ~azure.servicebus.management.EntityAvailabilityStatus
-    :ivar enable_subscription_partitioning: A value that indicates whether the topic's
-     subscription is to be partitioned.
-    :type enable_subscription_partitioning: bool
     :ivar enable_express: A value that indicates whether Express Entities are enabled. An express
      queue holds a message in memory temporarily before writing it to persistent storage.
     :type enable_express: bool
@@ -434,14 +417,12 @@ class TopicProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
         self.duplicate_detection_history_time_window = extract_kwarg('duplicate_detection_history_time_window')
         self.enable_batched_operations = extract_kwarg('enable_batched_operations')
         self.size_in_bytes = extract_kwarg('size_in_bytes')
-        self.is_anonymous_accessible = extract_kwarg('is_anonymous_accessible')
         self.authorization_rules = extract_kwarg('authorization_rules')
         self.status = extract_kwarg('status')
         self.support_ordering = extract_kwarg('support_ordering')
         self.auto_delete_on_idle = extract_kwarg('auto_delete_on_idle')
         self.enable_partitioning = extract_kwarg('enable_partitioning')
         self.entity_availability_status = extract_kwarg('entity_availability_status')
-        self.enable_subscription_partitioning = extract_kwarg('enable_subscription_partitioning')
         self.enable_express = extract_kwarg('enable_express')
         self.user_metadata = extract_kwarg('user_metadata')
 
@@ -458,14 +439,12 @@ class TopicProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
             duplicate_detection_history_time_window=internal_td.duplicate_detection_history_time_window,
             enable_batched_operations=internal_td.enable_batched_operations,
             size_in_bytes=internal_td.size_in_bytes,
-            is_anonymous_accessible=internal_td.is_anonymous_accessible,
             authorization_rules=internal_td.authorization_rules,
             status=internal_td.status,
             support_ordering=internal_td.support_ordering,
             auto_delete_on_idle=internal_td.auto_delete_on_idle,
             enable_partitioning=internal_td.enable_partitioning,
             entity_availability_status=internal_td.entity_availability_status,
-            enable_subscription_partitioning=internal_td.enable_subscription_partitioning,
             enable_express=internal_td.enable_express,
             user_metadata=internal_td.user_metadata
         )
@@ -482,14 +461,12 @@ class TopicProperties(DictMixin):  # pylint:disable=too-many-instance-attributes
         self._internal_td.duplicate_detection_history_time_window = self.duplicate_detection_history_time_window
         self._internal_td.enable_batched_operations = self.enable_batched_operations
         self._internal_td.size_in_bytes = self.size_in_bytes
-        self._internal_td.is_anonymous_accessible = self.is_anonymous_accessible
         self._internal_td.authorization_rules = self.authorization_rules
         self._internal_td.status = self.status
         self._internal_td.support_ordering = self.support_ordering
         self._internal_td.auto_delete_on_idle = self.auto_delete_on_idle
         self._internal_td.enable_partitioning = self.enable_partitioning
         self._internal_td.entity_availability_status = self.entity_availability_status
-        self._internal_td.enable_subscription_partitioning = self.enable_subscription_partitioning
         self._internal_td.enable_express = self.enable_express
         self._internal_td.user_metadata = self.user_metadata
 

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_queues_async.py
@@ -231,13 +231,11 @@ class ServiceBusManagementClientQueueAsyncTests(AzureMgmtTestCase):
                                                     enable_batched_operations=True,
                                                     enable_express=True,
                                                     enable_partitioning=True,
-                                                    is_anonymous_accessible=True,
                                                     lock_duration=datetime.timedelta(seconds=13),
                                                     max_delivery_count=14,
                                                     max_size_in_megabytes=3072,
                                                     #requires_duplicate_detection=True, 
-                                                    requires_session=True,
-                                                    support_ordering=True
+                                                    requires_session=True
                                                     )
         try:
             queue = await mgmt_service.get_queue(queue_name)
@@ -249,13 +247,11 @@ class ServiceBusManagementClientQueueAsyncTests(AzureMgmtTestCase):
             assert queue.enable_batched_operations == True
             assert queue.enable_express == True
             assert queue.enable_partitioning == True
-            assert queue.is_anonymous_accessible == True
             assert queue.lock_duration == datetime.timedelta(seconds=13)
             assert queue.max_delivery_count == 14
             assert queue.max_size_in_megabytes % 3072 == 0
             #assert queue.requires_duplicate_detection == True
             assert queue.requires_session == True
-            assert queue.support_ordering == True
         finally:
             await mgmt_service.delete_queue(queue_name)
 
@@ -295,13 +291,11 @@ class ServiceBusManagementClientQueueAsyncTests(AzureMgmtTestCase):
             queue_description.enable_batched_operations = True
             queue_description.enable_express = True
             #queue_description.enable_partitioning = True # Cannot be changed after creation
-            queue_description.is_anonymous_accessible = True
             queue_description.lock_duration = datetime.timedelta(seconds=13)
             queue_description.max_delivery_count = 14
             queue_description.max_size_in_megabytes = 3072
             #queue_description.requires_duplicate_detection = True # Read only
             #queue_description.requires_session = True # Cannot be changed after creation
-            queue_description.support_ordering = True
 
             await mgmt_service.update_queue(queue_description)
             queue_description = await mgmt_service.get_queue(queue_name)
@@ -313,13 +307,11 @@ class ServiceBusManagementClientQueueAsyncTests(AzureMgmtTestCase):
             assert queue_description.enable_batched_operations == True
             assert queue_description.enable_express == True
             #assert queue_description.enable_partitioning == True
-            assert queue_description.is_anonymous_accessible == True
             assert queue_description.lock_duration == datetime.timedelta(seconds=13)
             assert queue_description.max_delivery_count == 14
             assert queue_description.max_size_in_megabytes == 3072
             #assert queue_description.requires_duplicate_detection == True
             #assert queue_description.requires_session == True
-            assert queue_description.support_ordering == True
         finally:
             await mgmt_service.delete_queue(queue_name)
 

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_topics_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_topics_async.py
@@ -56,8 +56,6 @@ class ServiceBusManagementClientTopicAsyncTests(AzureMgmtTestCase):
                 enable_batched_operations=True,
                 enable_express=True,
                 enable_partitioning=True,
-                enable_subscription_partitioning=True,
-                is_anonymous_accessible=True,
                 max_size_in_megabytes=3072
             )
             topic = await mgmt_service.get_topic(topic_name)
@@ -68,8 +66,6 @@ class ServiceBusManagementClientTopicAsyncTests(AzureMgmtTestCase):
             assert topic.enable_batched_operations
             assert topic.enable_express
             assert topic.enable_partitioning
-            assert topic.enable_subscription_partitioning
-            assert topic.is_anonymous_accessible
             assert topic.max_size_in_megabytes % 3072 == 0
         finally:
             await mgmt_service.delete_topic(topic_name)
@@ -109,7 +105,6 @@ class ServiceBusManagementClientTopicAsyncTests(AzureMgmtTestCase):
             topic_description.enable_batched_operations = True
             topic_description.enable_express = True
             # topic_description.enable_partitioning = True # Cannot be changed after creation
-            topic_description.is_anonymous_accessible = True
             topic_description.max_size_in_megabytes = 3072
             # topic_description.requires_duplicate_detection = True # Read only
             # topic_description.requires_session = True # Cannot be changed after creation
@@ -124,7 +119,6 @@ class ServiceBusManagementClientTopicAsyncTests(AzureMgmtTestCase):
             assert topic_description.enable_batched_operations == True
             assert topic_description.enable_express == True
             # assert topic_description.enable_partitioning == True
-            assert topic_description.is_anonymous_accessible == True
             assert topic_description.max_size_in_megabytes == 3072
             # assert topic_description.requires_duplicate_detection == True
             # assert topic_description.requires_session == True

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_queues.py
@@ -245,13 +245,11 @@ class ServiceBusManagementClientQueueTests(AzureMgmtTestCase):
             enable_batched_operations=True,
             enable_express=True,
             enable_partitioning=True,
-            is_anonymous_accessible=True,
             lock_duration=datetime.timedelta(seconds=13),
             max_delivery_count=14,
             max_size_in_megabytes=3072,
             #requires_duplicate_detection=True,
-            requires_session=True,
-            support_ordering=True
+            requires_session=True
         )
         try:
             queue = mgmt_service.get_queue(queue_name)
@@ -263,7 +261,6 @@ class ServiceBusManagementClientQueueTests(AzureMgmtTestCase):
             assert queue.enable_batched_operations == True
             assert queue.enable_express == True
             assert queue.enable_partitioning == True
-            assert queue.is_anonymous_accessible == True
             assert queue.lock_duration == datetime.timedelta(seconds=13)
             assert queue.max_delivery_count == 14
             assert queue.max_size_in_megabytes % 3072 == 0  # TODO: In my local test, I don't see a multiple of the input number. To confirm
@@ -272,7 +269,6 @@ class ServiceBusManagementClientQueueTests(AzureMgmtTestCase):
             # To know more visit https://aka.ms/sbResourceMgrExceptions. 
             #assert queue.requires_duplicate_detection == True
             assert queue.requires_session == True
-            assert queue.support_ordering == True
         finally:
             mgmt_service.delete_queue(queue_name)
 
@@ -314,13 +310,11 @@ class ServiceBusManagementClientQueueTests(AzureMgmtTestCase):
             queue_description.enable_batched_operations = True
             queue_description.enable_express = True
             #queue_description.enable_partitioning = True # Cannot be changed after creation
-            queue_description.is_anonymous_accessible = True
             queue_description.lock_duration = datetime.timedelta(seconds=13)
             queue_description.max_delivery_count = 14
             queue_description.max_size_in_megabytes = 3072
             #queue_description.requires_duplicate_detection = True # Read only
             #queue_description.requires_session = True # Cannot be changed after creation
-            queue_description.support_ordering = True
 
             mgmt_service.update_queue(queue_description)
             queue_description = mgmt_service.get_queue(queue_name)
@@ -332,13 +326,11 @@ class ServiceBusManagementClientQueueTests(AzureMgmtTestCase):
             assert queue_description.enable_batched_operations == True
             assert queue_description.enable_express == True
             #assert queue_description.enable_partitioning == True
-            assert queue_description.is_anonymous_accessible == True
             assert queue_description.lock_duration == datetime.timedelta(seconds=13)
             assert queue_description.max_delivery_count == 14
             assert queue_description.max_size_in_megabytes == 3072
             #assert queue_description.requires_duplicate_detection == True
             #assert queue_description.requires_session == True
-            assert queue_description.support_ordering == True
         finally:
             mgmt_service.delete_queue(queue_name)
 

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_topics.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_topics.py
@@ -55,8 +55,6 @@ class ServiceBusManagementClientTopicTests(AzureMgmtTestCase):
                 enable_batched_operations=True,
                 enable_express=True,
                 enable_partitioning=True,
-                enable_subscription_partitioning=True,
-                is_anonymous_accessible=True,
                 max_size_in_megabytes=3072
             )
             topic = mgmt_service.get_topic(topic_name)
@@ -67,8 +65,6 @@ class ServiceBusManagementClientTopicTests(AzureMgmtTestCase):
             assert topic.enable_batched_operations
             assert topic.enable_express
             assert topic.enable_partitioning
-            assert topic.enable_subscription_partitioning
-            assert topic.is_anonymous_accessible
             assert topic.max_size_in_megabytes % 3072 == 0
         finally:
             mgmt_service.delete_topic(topic_name)
@@ -109,7 +105,6 @@ class ServiceBusManagementClientTopicTests(AzureMgmtTestCase):
             topic_description.enable_batched_operations = True
             topic_description.enable_express = True
             # topic_description.enable_partitioning = True # Cannot be changed after creation
-            topic_description.is_anonymous_accessible = True
             topic_description.max_size_in_megabytes = 3072
             # topic_description.requires_duplicate_detection = True # Read only
             # topic_description.requires_session = True # Cannot be changed after creation
@@ -124,7 +119,6 @@ class ServiceBusManagementClientTopicTests(AzureMgmtTestCase):
             assert topic_description.enable_batched_operations == True
             assert topic_description.enable_express == True
             # assert topic_description.enable_partitioning == True
-            assert topic_description.is_anonymous_accessible == True
             assert topic_description.max_size_in_megabytes == 3072
             # assert topic_description.requires_duplicate_detection == True
             # assert topic_description.requires_session == True


### PR DESCRIPTION
* Remove `is_anonymous_accessible` from management entities.
* Remove `support_ordering` from `create_queue` and `QueueProperties`
* Remove `enable_subscription_partitioning` from `create_topic` and `TopicProperties`