### PR TITLE
Raise msal-extensions dependency to ~=0.3.0

### DIFF
--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -74,7 +74,7 @@ setup(
         "azure-core<2.0.0,>=1.0.0",
         "cryptography>=2.1.4",
         "msal<1.6.0,>=1.3.0",
-        "msal-extensions~=0.2.2",
+        "msal-extensions~=0.3.0",
         "six>=1.6",
     ],
     extras_require={

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -100,7 +100,7 @@ mock
 typing
 typing-extensions
 msal<1.6.0,>=1.3.0
-msal-extensions~=0.2.2
+msal-extensions~=0.3.0
 msrest>=0.5.0
 msrestazure<2.0.0,>=0.4.32
 azure-mgmt-core<2.0.0,>=1.0.0


### PR DESCRIPTION
0.3.0 includes a fix for #13107 