### PR TITLE
Enable the master replacement link feature in python

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -134,6 +134,7 @@ stages:
                           BlobSASKey: '$(azure-sdk-docs-prod-sas)'
                           BlobName: '$(azure-sdk-docs-prod-blob-name)'
                           TargetLanguage: 'python'
+                          ArtifactLocation: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}'
                           # we override the regular script path because we have cloned the build tools repo as a separate artifact.
                           ScriptPath: 'eng/common/scripts/copy-docs-to-blobstorage.ps1'
 


### PR DESCRIPTION
This is a follow up step of master link replacement work.

Tested in template: 
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=530466&view=logs&j=3c922a7d-1305-5297-ba3f-884e0ad84366&t=3c922a7d-1305-5297-ba3f-884e0ad84366

Retrieved release tag successfully:
![image](https://user-images.githubusercontent.com/48036328/92657821-4f7a5200-f2aa-11ea-82e4-d69c36ef379b.png)
