### PR TITLE
[DataLake] Fix PathProperties __init__

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_models.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_models.py
@@ -230,9 +230,7 @@ class PathProperties(object):
     :ivar content_length: the size of file if the path is a file.
     """
     def __init__(self, **kwargs):
-        super(PathProperties, self).__init__(
-            **kwargs
-        )
+        super(PathProperties, self).__init__()
         self.name = kwargs.pop('name', None)
         self.owner = kwargs.get('owner', None)
         self.group = kwargs.get('group', None)

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_models.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_models.py
@@ -230,7 +230,6 @@ class PathProperties(object):
     :ivar content_length: the size of file if the path is a file.
     """
     def __init__(self, **kwargs):
-        super(PathProperties, self).__init__()
         self.name = kwargs.pop('name', None)
         self.owner = kwargs.get('owner', None)
         self.group = kwargs.get('group', None)


### PR DESCRIPTION
Since PathProperties inherits from object, it would throw an exception if
PathProperties were created with any kwargs