### PR TITLE
GeneralNameReplacer safely decodes bytes bodies

### DIFF
--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/recording_processors.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
+import six
 
 from .utilities import is_text_payload, is_json_payload
 
@@ -177,7 +178,7 @@ class GeneralNameReplacer(RecordingProcessor):
             request.uri = request.uri.replace(old, new)
 
             if is_text_payload(request) and request.body:
-                body = str(request.body)
+                body = six.ensure_str(request.body)
                 if old in body:
                     request.body = body.replace(old, new)
 


### PR DESCRIPTION
When a request's body is `bytes`, `GeneralNameReplacer.process_request` corrupts it before recording because
```py
>>> str(b'{}')
"b'{}'"
```
Seeing that [vcr encodes bodies](https://github.com/kevin1024/vcrpy/blob/v3.0.0/vcr/request.py#L40), I'm surprised not to have encountered this before 😕 