### PR TITLE
CryptographyClient can decrypt and sign locally

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/__init__.py
@@ -3,8 +3,8 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from ._models import DecryptResult, EncryptResult, SignResult, WrapResult, VerifyResult, UnwrapResult
-from ._client import CryptographyClient
 from ._enums import EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
+from ._client import CryptographyClient
 
 
 __all__ = [

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
@@ -2,27 +2,27 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import logging
+from typing import TYPE_CHECKING
+
 import six
-from azure.core.exceptions import AzureError, HttpResponseError
+from azure.core.exceptions import HttpResponseError
 from azure.core.tracing.decorator import distributed_trace
 
 from . import DecryptResult, EncryptResult, SignResult, VerifyResult, UnwrapResult, WrapResult
-from ._nbf_exp import _enforce_nbf_exp
-from ._local_client import LocalCryptographyProvider
+from ._key_validity import raise_if_time_invalid
+from ._providers import get_local_cryptography_provider, NoLocalCryptography
+from .. import KeyOperation
 from .._models import KeyVaultKey
 from .._shared import KeyVaultClientBase, parse_vault_id
-
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import
     from typing import Any, Optional, Union
     from azure.core.credentials import TokenCredential
     from . import EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
-    from ._internal import Key as _Key
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class CryptographyClient(KeyVaultClientBase):
@@ -65,21 +65,18 @@ class CryptographyClient(KeyVaultClientBase):
         if isinstance(key, KeyVaultKey):
             self._key = key
             self._key_id = parse_vault_id(key.id)
-            self._allowed_ops = frozenset(self._key.key_operations)
         elif isinstance(key, six.string_types):
             self._key = None
             self._key_id = parse_vault_id(key)
             self._keys_get_forbidden = None  # type: Optional[bool]
-
-            # will be replaced with actual permissions before any local operations are attempted, if we can get the key
-            self._allowed_ops = frozenset()
         else:
             raise ValueError("'key' must be a KeyVaultKey instance or a key ID string including a version")
 
         if not self._key_id.version:
             raise ValueError("'key' must include a version")
 
-        self._internal_key = None  # type: Optional[_Key]
+        self._local_provider = NoLocalCryptography()
+        self._initialized = False
 
         super(CryptographyClient, self).__init__(vault_url=self._key_id.vault_url, credential=credential, **kwargs)
 
@@ -93,48 +90,29 @@ class CryptographyClient(KeyVaultClientBase):
         return "/".join(self._key_id)
 
     @distributed_trace
-    def _get_key(self, **kwargs):
-        # type: (**Any) -> Optional[KeyVaultKey]
-        """Get the client's :class:`~azure.keyvault.keys.KeyVaultKey`.
+    def _initialize(self, **kwargs):
+        # type: (**Any) -> None
+        if self._initialized:
+            return
 
-        Can be ``None``, if the client lacks keys/get permission.
-
-        :rtype: :class:`~azure.keyvault.keys.KeyVaultKey` or ``None``
-        """
-
+        # try to get the key material, if we don't have it and aren't forbidden to do so
         if not (self._key or self._keys_get_forbidden):
             try:
                 self._key = self._client.get_key(
                     self._key_id.vault_url, self._key_id.name, self._key_id.version, **kwargs
                 )
-                self._allowed_ops = frozenset(self._key.key_operations)
             except HttpResponseError as ex:
                 # if we got a 403, we don't have keys/get permission and won't try to get the key again
                 # (other errors may be transient)
                 self._keys_get_forbidden = ex.status_code == 403
-        return self._key
 
-    def _get_local_key(self, **kwargs):
-        # type: (**Any) -> Optional[_Key]
-        """Gets an object implementing local operations. Will be ``None``, if the client was instantiated with a key
-        id and lacks keys/get permission."""
-
-        if not self._internal_key:
-            key = self._get_key(**kwargs)
-            if not key:
-                return None
-
-            kty = key.key_type.lower()
-            if kty.startswith("ec"):
-                self._internal_key = EllipticCurveKey.from_jwk(key.key)
-            elif kty.startswith("rsa"):
-                self._internal_key = RsaKey.from_jwk(key.key)
-            elif kty == "oct":
-                self._internal_key = SymmetricKey.from_jwk(key.key)
-            else:
-                raise ValueError("Unsupported key type '{}'".format(key.key_type))
-
-        return self._internal_key
+        # if we have the key material, create a local crypto provider with it
+        if self._key:
+            self._local_provider = get_local_cryptography_provider(self._key)
+            self._initialized = True
+        else:
+            # try to get the key again next time unless we know we're forbidden to do so
+            self._initialized = self._keys_get_forbidden
 
     @distributed_trace
     def encrypt(self, algorithm, plaintext, **kwargs):
@@ -161,28 +139,23 @@ class CryptographyClient(KeyVaultClientBase):
             print(result.algorithm)
 
         """
+        self._initialize(**kwargs)
+        if self._local_provider.supports(KeyOperation.encrypt, algorithm):
+            raise_if_time_invalid(self._key)
+            try:
+                return self._local_provider.encrypt(algorithm, plaintext)
+            except Exception as ex:  # pylint:disable=broad-except
+                _LOGGER.warning("Local encrypt operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
 
-        local_key = self._get_local_key(**kwargs)
-        if local_key:
-            _enforce_nbf_exp(self._key)
-            if "encrypt" not in self._allowed_ops:
-                raise AzureError("This client doesn't have 'keys/encrypt' permission")
-            result = local_key.encrypt(plaintext, algorithm=algorithm.value)
-        else:
+        operation_result = self._client.encrypt(
+            vault_base_url=self._key_id.vault_url,
+            key_name=self._key_id.name,
+            key_version=self._key_id.version,
+            parameters=self._models.KeyOperationsParameters(algorithm=algorithm, value=plaintext),
+            **kwargs
+        )
 
-            parameters = self._models.KeyOperationsParameters(
-                algorithm=algorithm,
-                value=plaintext
-            )
-
-            result = self._client.encrypt(
-                vault_base_url=self._key_id.vault_url,
-                key_name=self._key_id.name,
-                key_version=self._key_id.version,
-                parameters=parameters,
-                **kwargs
-            ).result
-        return EncryptResult(key_id=self.key_id, algorithm=algorithm, ciphertext=result)
+        return EncryptResult(key_id=self.key_id, algorithm=algorithm, ciphertext=operation_result.result)
 
     @distributed_trace
     def decrypt(self, algorithm, ciphertext, **kwargs):
@@ -206,19 +179,22 @@ class CryptographyClient(KeyVaultClientBase):
             print(result.plaintext)
 
         """
+        self._initialize(**kwargs)
+        if self._local_provider.supports(KeyOperation.decrypt, algorithm):
+            try:
+                return self._local_provider.decrypt(algorithm, ciphertext)
+            except Exception as ex:  # pylint:disable=broad-except
+                _LOGGER.warning("Local decrypt operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
 
-        parameters = self._models.KeyOperationsParameters(
-            algorithm=algorithm,
-            value=ciphertext
-        )
-        result = self._client.decrypt(
+        operation_result = self._client.decrypt(
             vault_base_url=self._key_id.vault_url,
             key_name=self._key_id.name,
             key_version=self._key_id.version,
-            parameters=parameters,
+            parameters=self._models.KeyOperationsParameters(algorithm=algorithm, value=ciphertext),
             **kwargs
         )
-        return DecryptResult(key_id=self.key_id, algorithm=algorithm, plaintext=result.result)
+
+        return DecryptResult(key_id=self.key_id, algorithm=algorithm, plaintext=operation_result.result)
 
     @distributed_trace
     def wrap_key(self, algorithm, key, **kwargs):
@@ -243,26 +219,23 @@ class CryptographyClient(KeyVaultClientBase):
             print(result.algorithm)
 
         """
+        self._initialize(**kwargs)
+        if self._local_provider.supports(KeyOperation.wrap_key, algorithm):
+            raise_if_time_invalid(self._key)
+            try:
+                return self._local_provider.wrap_key(algorithm, key)
+            except Exception as ex:  # pylint:disable=broad-except
+                _LOGGER.warning("Local wrap operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
 
-        local_key = self._get_local_key(**kwargs)
-        if local_key:
-            _enforce_nbf_exp(self._key)
-            if "wrapKey" not in self._allowed_ops:
-                raise AzureError("This client doesn't have 'keys/wrapKey' permission")
-            result = local_key.wrap_key(key, algorithm=algorithm.value)
-        else:
-            parameters = self._models.KeyOperationsParameters(
-                algorithm=algorithm,
-                value=key,
-            )
-            result = self._client.wrap_key(
-                self._key_id.vault_url,
-                self._key_id.name,
-                self._key_id.version,
-                parameters=parameters
-            ).result
+        operation_result = self._client.wrap_key(
+            vault_base_url=self._key_id.vault_url,
+            key_name=self._key_id.name,
+            key_version=self._key_id.version,
+            parameters=self._models.KeyOperationsParameters(algorithm=algorithm, value=key),
+            **kwargs
+        )
 
-        return WrapResult(key_id=self.key_id, algorithm=algorithm, encrypted_key=result)
+        return WrapResult(key_id=self.key_id, algorithm=algorithm, encrypted_key=operation_result.result)
 
     @distributed_trace
     def unwrap_key(self, algorithm, encrypted_key, **kwargs):
@@ -284,26 +257,21 @@ class CryptographyClient(KeyVaultClientBase):
             key = result.key
 
         """
-        local_key = self._get_local_key(**kwargs)
-        if local_key and local_key.is_private_key():
-            if "unwrapKey" not in self._allowed_ops:
-                raise AzureError("This client doesn't have 'keys/unwrapKey' permission")
-            result = local_key.unwrap_key(encrypted_key, **kwargs)
-        else:
+        self._initialize(**kwargs)
+        if self._local_provider.supports(KeyOperation.unwrap_key, algorithm):
+            try:
+                return self._local_provider.unwrap_key(algorithm, encrypted_key)
+            except Exception as ex:  # pylint:disable=broad-except
+                _LOGGER.warning("Local unwrap operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
 
-            parameters = self._models.KeyOperationsParameters(
-                algorithm=algorithm,
-                value=encrypted_key
-            )
-
-            result = self._client.unwrap_key(
-                vault_base_url=self._key_id.vault_url,
-                key_name=self._key_id.name,
-                key_version=self._key_id.version,
-                parameters=parameters,
-                **kwargs
-            ).result
-        return UnwrapResult(key_id=self._key_id, algorithm=algorithm, key=result)
+        operation_result = self._client.unwrap_key(
+            vault_base_url=self._key_id.vault_url,
+            key_name=self._key_id.name,
+            key_version=self._key_id.version,
+            parameters=self._models.KeyOperationsParameters(algorithm=algorithm, value=encrypted_key),
+            **kwargs
+        )
+        return UnwrapResult(key_id=self._key_id, algorithm=algorithm, key=operation_result.result)
 
     @distributed_trace
     def sign(self, algorithm, digest, **kwargs):
@@ -333,20 +301,23 @@ class CryptographyClient(KeyVaultClientBase):
             print(result.algorithm)
 
         """
+        self._initialize(**kwargs)
+        if self._local_provider.supports(KeyOperation.sign, algorithm):
+            raise_if_time_invalid(self._key)
+            try:
+                return self._local_provider.sign(algorithm, digest)
+            except Exception as ex:  # pylint:disable=broad-except
+                _LOGGER.warning("Local sign operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
 
-        parameters = self._models.KeySignParameters(
-            algorithm=algorithm,
-            value=digest
-        )
-
-        result = self._client.sign(
+        operation_result = self._client.sign(
             vault_base_url=self._key_id.vault_url,
             key_name=self._key_id.name,
             key_version=self._key_id.version,
-            parameters=parameters,
+            parameters=self._models.KeySignParameters(algorithm=algorithm, value=digest),
             **kwargs
         )
-        return SignResult(key_id=self.key_id, algorithm=algorithm, signature=result.result)
+
+        return SignResult(key_id=self.key_id, algorithm=algorithm, signature=operation_result.result)
 
     @distributed_trace
     def verify(self, algorithm, digest, signature, **kwargs):
@@ -370,24 +341,19 @@ class CryptographyClient(KeyVaultClientBase):
             assert verified.is_valid
 
         """
+        self._initialize(**kwargs)
+        if self._local_provider.supports(KeyOperation.verify, algorithm):
+            try:
+                return self._local_provider.verify(algorithm, digest, signature)
+            except Exception as ex:  # pylint:disable=broad-except
+                _LOGGER.warning("Local verify operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
 
-        local_key = self._get_local_key(**kwargs)
-        if local_key:
-            if "verify" not in self._allowed_ops:
-                raise AzureError("This client doesn't have 'keys/verify' permission")
-            result = local_key.verify(digest, signature, algorithm=algorithm.value)
-        else:
-            parameters = self._models.KeyVerifyParameters(
-                algorithm=algorithm,
-                digest=digest,
-                signature=signature
-            )
+        operation_result = self._client.verify(
+            vault_base_url=self._key_id.vault_url,
+            key_name=self._key_id.name,
+            key_version=self._key_id.version,
+            parameters=self._models.KeyVerifyParameters(algorithm=algorithm, digest=digest, signature=signature),
+            **kwargs
+        )
 
-            result = self._client.verify(
-                vault_base_url=self._key_id.vault_url,
-                key_name=self._key_id.name,
-                key_version=self._key_id.version,
-                parameters=parameters,
-                **kwargs
-            ).value
-        return VerifyResult(key_id=self.key_id, algorithm=algorithm, is_valid=result)
+        return VerifyResult(key_id=self.key_id, algorithm=algorithm, is_valid=operation_result.value)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_key_validity.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_key_validity.py
@@ -1,0 +1,47 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from datetime import datetime, timedelta, tzinfo
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # pylint:disable=unused-import
+    from .. import KeyVaultKey
+
+
+class _UTC_TZ(tzinfo):
+    """from https://docs.python.org/2/library/datetime.html#tzinfo-objects"""
+
+    ZERO = timedelta(0)
+
+    def utcoffset(self, dt):
+        return self.__class__.ZERO
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return self.__class__.ZERO
+
+
+_UTC = _UTC_TZ()
+
+
+def raise_if_time_invalid(key):
+    # type: (KeyVaultKey) -> None
+    try:
+        nbf = key.properties.not_before
+        exp = key.properties.expires_on
+    except AttributeError:
+        # we consider the key valid because a user must have deliberately created it
+        # (if it came from Key Vault, it would have those attributes)
+        return
+
+    now = datetime.now(_UTC)
+    if (nbf and exp) and not nbf <= now <= exp:
+        raise ValueError("This client's key is useable only between {} and {} (UTC)".format(nbf, exp))
+    if nbf and nbf > now:
+        raise ValueError("This client's key is not useable until {} (UTC)".format(nbf))
+    if exp and exp <= now:
+        raise ValueError("This client's key expired at {} (UTC)".format(exp))

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/__init__.py
@@ -5,12 +5,12 @@
 from typing import TYPE_CHECKING
 
 from .ec import EllipticCurveCryptographyProvider
+from .local_provider import LocalCryptographyProvider
 from .rsa import RsaCryptographyProvider
 from .symmetric import SymmetricCryptographyProvider
 from ... import KeyType
 
 if TYPE_CHECKING:
-    from .local_provider import LocalCryptographyProvider
     from ... import KeyVaultKey
 
 
@@ -24,3 +24,14 @@ def get_local_cryptography_provider(key):
         return SymmetricCryptographyProvider(key)
 
     raise ValueError('Unsupported key type "{}"'.format(key.key_type))
+
+
+class NoLocalCryptography(LocalCryptographyProvider):
+    def __init__(self):  # pylint:disable=super-init-not-called
+        return
+
+    def supports(self, operation, algorithm):
+        return False
+
+    def _get_internal_key(self, key):
+        return None

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
@@ -2,26 +2,26 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from azure.core.exceptions import AzureError, HttpResponseError
+import logging
+from typing import TYPE_CHECKING
+
+from azure.core.exceptions import HttpResponseError
 from azure.core.tracing.decorator_async import distributed_trace_async
 
 from .. import DecryptResult, EncryptResult, SignResult, VerifyResult, UnwrapResult, WrapResult
-from .._internal import EllipticCurveKey, RsaKey, SymmetricKey
-from .._key_validity import enforce_nbf_exp
+from .._key_validity import raise_if_time_invalid
+from .._providers import get_local_cryptography_provider, NoLocalCryptography
+from ... import KeyOperation
 from ..._models import KeyVaultKey
 from ..._shared import AsyncKeyVaultClientBase, parse_vault_id
-
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import
     from typing import Any, Optional, Union
     from azure.core.credentials_async import AsyncTokenCredential
     from .. import EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
-    from .._internal import Key as _Key
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class CryptographyClient(AsyncKeyVaultClientBase):
@@ -62,21 +62,18 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         if isinstance(key, KeyVaultKey):
             self._key = key
             self._key_id = parse_vault_id(key.id)
-            self._allowed_ops = frozenset(self._key.key_operations)
         elif isinstance(key, str):
             self._key = None
             self._key_id = parse_vault_id(key)
             self._keys_get_forbidden = None  # type: Optional[bool]
-
-            # will be replaced with actual permissions before any local operations are attempted, if we can get the key
-            self._allowed_ops = frozenset()
         else:
             raise ValueError("'key' must be a KeyVaultKey instance or a key ID string including a version")
 
         if not self._key_id.version:
             raise ValueError("'key' must include a version")
 
-        self._internal_key = None  # type: Optional[_Key]
+        self._local_provider = NoLocalCryptography()
+        self._initialized = False
 
         super().__init__(vault_url=self._key_id.vault_url, credential=credential, **kwargs)
 
@@ -89,46 +86,29 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         return "/".join(self._key_id)
 
     @distributed_trace_async
-    async def _get_key(self, **kwargs: "Any") -> "Optional[KeyVaultKey]":
-        """Get the client's :class:`~azure.keyvault.keys.KeyVaultKey`.
+    async def _initialize(self, **kwargs):
+        # type: (**Any) -> None
+        if self._initialized:
+            return
 
-        Can be `None`, if the client lacks keys/get permission.
-
-        :rtype: :class:`~azure.keyvault.keys.KeyVaultKey` or None
-        """
-
+        # try to get the key material, if we don't have it and aren't forbidden to do so
         if not (self._key or self._keys_get_forbidden):
             try:
                 self._key = await self._client.get_key(
                     self._key_id.vault_url, self._key_id.name, self._key_id.version, **kwargs
                 )
-                self._allowed_ops = frozenset(self._key.key_operations)
             except HttpResponseError as ex:
                 # if we got a 403, we don't have keys/get permission and won't try to get the key again
                 # (other errors may be transient)
                 self._keys_get_forbidden = ex.status_code == 403
-        return self._key
 
-    async def _get_local_key(self, **kwargs: "Any") -> "Optional[_Key]":
-        """Gets an object implementing local operations. Will be ``None``, if the client was instantiated with a key
-        id and lacks keys/get permission."""
-
-        if not self._internal_key:
-            key = await self._get_key(**kwargs)
-            if not key:
-                return None
-
-            kty = key.key_type.lower()
-            if kty.startswith("ec"):
-                self._internal_key = EllipticCurveKey.from_jwk(key.key)
-            elif kty.startswith("rsa"):
-                self._internal_key = RsaKey.from_jwk(key.key)
-            elif kty == "oct":
-                self._internal_key = SymmetricKey.from_jwk(key.key)
-            else:
-                raise ValueError("Unsupported key type '{}'".format(key.key_type))
-
-        return self._internal_key
+        # if we have the key material, create a local crypto provider with it
+        if self._key:
+            self._local_provider = get_local_cryptography_provider(self._key)
+            self._initialized = True
+        else:
+            # try to get the key again next time unless we know we're forbidden to do so
+            self._initialized = self._keys_get_forbidden
 
     @distributed_trace_async
     async def encrypt(self, algorithm: "EncryptionAlgorithm", plaintext: bytes, **kwargs: "Any") -> EncryptResult:
@@ -154,24 +134,23 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             print(result.algorithm)
 
         """
+        await self._initialize(**kwargs)
+        if self._local_provider.supports(KeyOperation.encrypt, algorithm):
+            raise_if_time_invalid(self._key)
+            try:
+                return self._local_provider.encrypt(algorithm, plaintext)
+            except Exception as ex:  # pylint:disable=broad-except
+                _LOGGER.warning("Local encrypt operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
 
-        local_key = await self._get_local_key(**kwargs)
-        if local_key:
-            enforce_nbf_exp(self._key)
-            if "encrypt" not in self._allowed_ops:
-                raise AzureError("This client doesn't have 'keys/encrypt' permission")
-            result = local_key.encrypt(plaintext, algorithm=algorithm.value)
-        else:
-            parameters = self._models.KeyOperationsParameters(
-                algorithm=algorithm,
-                value=plaintext
-            )
+        operation_result = await self._client.encrypt(
+            vault_base_url=self._key_id.vault_url,
+            key_name=self._key_id.name,
+            key_version=self._key_id.version,
+            parameters=self._models.KeyOperationsParameters(algorithm=algorithm, value=plaintext),
+            **kwargs
+        )
 
-            operation = await self._client.encrypt(
-                self._key_id.vault_url, self._key_id.name, self._key_id.version, parameters=parameters, **kwargs
-            )
-            result = operation.result
-        return EncryptResult(key_id=self.key_id, algorithm=algorithm, ciphertext=result)
+        return EncryptResult(key_id=self.key_id, algorithm=algorithm, ciphertext=operation_result.result)
 
     @distributed_trace_async
     async def decrypt(self, algorithm: "EncryptionAlgorithm", ciphertext: bytes, **kwargs: "Any") -> DecryptResult:
@@ -194,20 +173,22 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             print(result.plaintext)
 
         """
+        await self._initialize(**kwargs)
+        if self._local_provider.supports(KeyOperation.decrypt, algorithm):
+            try:
+                return self._local_provider.decrypt(algorithm, ciphertext)
+            except Exception as ex:  # pylint:disable=broad-except
+                _LOGGER.warning("Local decrypt operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
 
-        parameters = self._models.KeyOperationsParameters(
-            algorithm=algorithm,
-            value=ciphertext
-        )
-
-        result = await self._client.decrypt(
+        operation_result = await self._client.decrypt(
             vault_base_url=self._key_id.vault_url,
             key_name=self._key_id.name,
             key_version=self._key_id.version,
-            parameters=parameters,
+            parameters=self._models.KeyOperationsParameters(algorithm=algorithm, value=ciphertext),
             **kwargs
         )
-        return DecryptResult(key_id=self.key_id, algorithm=algorithm, plaintext=result.result)
+
+        return DecryptResult(key_id=self.key_id, algorithm=algorithm, plaintext=operation_result.result)
 
     @distributed_trace_async
     async def wrap_key(self, algorithm: "KeyWrapAlgorithm", key: bytes, **kwargs: "Any") -> WrapResult:
@@ -231,28 +212,23 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             print(result.algorithm)
 
         """
+        await self._initialize(**kwargs)
+        if self._local_provider.supports(KeyOperation.wrap_key, algorithm):
+            raise_if_time_invalid(self._key)
+            try:
+                return self._local_provider.wrap_key(algorithm, key)
+            except Exception as ex:  # pylint:disable=broad-except
+                _LOGGER.warning("Local wrap operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
 
-        local_key = await self._get_local_key(**kwargs)
-        if local_key:
-            enforce_nbf_exp(self._key)
-            if "wrapKey" not in self._allowed_ops:
-                raise AzureError("This client doesn't have 'keys/wrapKey' permission")
-            result = local_key.wrap_key(key, algorithm=algorithm.value)
-        else:
-            parameters = self._models.KeyOperationsParameters(
-                algorithm=algorithm,
-                value=key
-            )
+        operation_result = await self._client.wrap_key(
+            vault_base_url=self._key_id.vault_url,
+            key_name=self._key_id.name,
+            key_version=self._key_id.version,
+            parameters=self._models.KeyOperationsParameters(algorithm=algorithm, value=key),
+            **kwargs
+        )
 
-            operation = await self._client.wrap_key(
-                self._key_id.vault_url,
-                self._key_id.name,
-                self._key_id.version,
-                parameters=parameters,
-                **kwargs
-            )
-            result = operation.result
-        return WrapResult(key_id=self.key_id, algorithm=algorithm, encrypted_key=result)
+        return WrapResult(key_id=self.key_id, algorithm=algorithm, encrypted_key=operation_result.result)
 
     @distributed_trace_async
     async def unwrap_key(self, algorithm: "KeyWrapAlgorithm", encrypted_key: bytes, **kwargs: "Any") -> UnwrapResult:
@@ -273,26 +249,22 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             key = result.key
 
         """
-        local_key = await self._get_local_key(**kwargs)
-        if local_key and local_key.is_private_key():
-            if "unwrapKey" not in self._allowed_ops:
-                raise AzureError("This client doesn't have 'keys/unwrapKey' permission")
-            result = local_key.unwrap_key(encrypted_key, **kwargs)
-        else:
-            parameters = self._models.KeyOperationsParameters(
-                algorithm=algorithm,
-                value=encrypted_key
-            )
+        await self._initialize(**kwargs)
+        if self._local_provider.supports(KeyOperation.unwrap_key, algorithm):
+            try:
+                return self._local_provider.unwrap_key(algorithm, encrypted_key)
+            except Exception as ex:  # pylint:disable=broad-except
+                _LOGGER.warning("Local unwrap operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
 
-            operation = await self._client.unwrap_key(
-                self._key_id.vault_url,
-                self._key_id.name,
-                self._key_id.version,
-                parameters=parameters,
-                **kwargs
-            )
-            result = operation.result
-        return UnwrapResult(key_id=self._key_id, algorithm=algorithm, key=result)
+        operation_result = await self._client.unwrap_key(
+            vault_base_url=self._key_id.vault_url,
+            key_name=self._key_id.name,
+            key_version=self._key_id.version,
+            parameters=self._models.KeyOperationsParameters(algorithm=algorithm, value=encrypted_key),
+            **kwargs
+        )
+
+        return UnwrapResult(key_id=self._key_id, algorithm=algorithm, key=operation_result.result)
 
     @distributed_trace_async
     async def sign(self, algorithm: "SignatureAlgorithm", digest: bytes, **kwargs: "Any") -> SignResult:
@@ -321,20 +293,23 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             print(result.algorithm)
 
         """
+        await self._initialize(**kwargs)
+        if self._local_provider.supports(KeyOperation.sign, algorithm):
+            raise_if_time_invalid(self._key)
+            try:
+                return self._local_provider.sign(algorithm, digest)
+            except Exception as ex:  # pylint:disable=broad-except
+                _LOGGER.warning("Local sign operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
 
-        parameters = self._models.KeySignParameters(
-            algorithm=algorithm,
-            value=digest
-        )
-
-        result = await self._client.sign(
+        operation_result = await self._client.sign(
             vault_base_url=self._key_id.vault_url,
             key_name=self._key_id.name,
             key_version=self._key_id.version,
-            parameters=parameters,
+            parameters=self._models.KeySignParameters(algorithm=algorithm, value=digest),
             **kwargs
         )
-        return SignResult(key_id=self.key_id, algorithm=algorithm, signature=result.result)
+
+        return SignResult(key_id=self.key_id, algorithm=algorithm, signature=operation_result.result)
 
     @distributed_trace_async
     async def verify(
@@ -359,26 +334,19 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             assert verified.is_valid
 
         """
+        await self._initialize(**kwargs)
+        if self._local_provider.supports(KeyOperation.verify, algorithm):
+            try:
+                return self._local_provider.verify(algorithm, digest, signature)
+            except Exception as ex:  # pylint:disable=broad-except
+                _LOGGER.warning("Local verify operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
 
-        local_key = await self._get_local_key(**kwargs)
-        if local_key:
-            if "verify" not in self._allowed_ops:
-                raise AzureError("This client doesn't have 'keys/verify' permission")
-            result = local_key.verify(digest, signature, algorithm=algorithm.value)
-        else:
-            parameters = self._models.KeyVerifyParameters(
-                algorithm=algorithm,
-                digest=digest,
-                signature=signature
-            )
+        operation_result = await self._client.verify(
+            vault_base_url=self._key_id.vault_url,
+            key_name=self._key_id.name,
+            key_version=self._key_id.version,
+            parameters=self._models.KeyVerifyParameters(algorithm=algorithm, digest=digest, signature=signature),
+            **kwargs
+        )
 
-            operation = await self._client.verify(
-                vault_base_url=self._key_id.vault_url,
-                key_name=self._key_id.name,
-                key_version=self._key_id.version,
-                parameters=parameters,
-                **kwargs
-            )
-            result = operation.value
-
-        return VerifyResult(key_id=self.key_id, algorithm=algorithm, is_valid=result)
+        return VerifyResult(key_id=self.key_id, algorithm=algorithm, is_valid=operation_result.value)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
@@ -7,7 +7,7 @@ from azure.core.tracing.decorator_async import distributed_trace_async
 
 from .. import DecryptResult, EncryptResult, SignResult, VerifyResult, UnwrapResult, WrapResult
 from .._internal import EllipticCurveKey, RsaKey, SymmetricKey
-from ...crypto._client import _enforce_nbf_exp
+from .._key_validity import enforce_nbf_exp
 from ..._models import KeyVaultKey
 from ..._shared import AsyncKeyVaultClientBase, parse_vault_id
 
@@ -157,7 +157,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
 
         local_key = await self._get_local_key(**kwargs)
         if local_key:
-            _enforce_nbf_exp(self._key)
+            enforce_nbf_exp(self._key)
             if "encrypt" not in self._allowed_ops:
                 raise AzureError("This client doesn't have 'keys/encrypt' permission")
             result = local_key.encrypt(plaintext, algorithm=algorithm.value)
@@ -234,7 +234,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
 
         local_key = await self._get_local_key(**kwargs)
         if local_key:
-            _enforce_nbf_exp(self._key)
+            enforce_nbf_exp(self._key)
             if "wrapKey" not in self._allowed_ops:
                 raise AzureError("This client doesn't have 'keys/wrapKey' permission")
             result = local_key.wrap_key(key, algorithm=algorithm.value)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from azure.core.credentials import AccessToken
 from azure.keyvault.keys import JsonWebKey, KeyClient, KeyCurveName, KeyVaultKey
 from azure.keyvault.keys.crypto import CryptographyClient, EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
-from azure.keyvault.keys.crypto._client import _UTC
+from azure.keyvault.keys.crypto._key_validity import _UTC
 from azure.mgmt.keyvault.models import KeyPermissions, Permissions
 from devtools_testutils import ResourceGroupPreparer, KeyVaultPreparer
 import pytest

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -3,13 +3,16 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import codecs
-import functools
 import hashlib
-import os
 from datetime import datetime
 
-from azure.core.credentials import AccessToken
-from azure.keyvault.keys import JsonWebKey, KeyClient, KeyCurveName, KeyVaultKey
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from azure.core.exceptions import HttpResponseError
+from azure.keyvault.keys import JsonWebKey, KeyCurveName, KeyVaultKey
 from azure.keyvault.keys.crypto import CryptographyClient, EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
 from azure.keyvault.keys.crypto._key_validity import _UTC
 from azure.mgmt.keyvault.models import KeyPermissions, Permissions
@@ -136,18 +139,6 @@ class CryptoClientTests(KeyVaultTestCase):
 
         result = crypto_client.unwrap_key(result.algorithm, result.encrypted_key)
         self.assertEqual(key_bytes, result.key)
-
-    def test_symmetric_wrap_and_unwrap_local(self, **kwargs):
-        jwk = {"k": os.urandom(32), "kty": "oct", "key_ops": ("unwrapKey", "wrapKey")}
-        key = KeyVaultKey(key_id="http://fake.test.vault/keys/key/version", jwk=jwk)
-
-        crypto_client = CryptographyClient(key, credential=lambda *_: None)
-
-        # Wrap a key with the created key, then unwrap it. The wrapped key's bytes should round-trip.
-        key_bytes = os.urandom(32)
-        wrap_result = crypto_client.wrap_key(KeyWrapAlgorithm.aes_256, key_bytes)
-        unwrap_result = crypto_client.unwrap_key(wrap_result.algorithm, wrap_result.encrypted_key)
-        self.assertEqual(unwrap_result.key, key_bytes)
 
     @ResourceGroupPreparer(random_name_enabled=True)
     @KeyVaultPreparer()
@@ -277,3 +268,141 @@ class CryptoClientTests(KeyVaultTestCase):
     @CryptoClientPreparer(client_kwargs={"custom_hook_policy": _CustomHookPolicy()})
     def test_custom_hook_policy(self, key_client, credential, **kwargs):
         assert isinstance(key_client._client._config.custom_hook_policy, CryptoClientTests._CustomHookPolicy)
+
+
+def test_initialization_given_key():
+    """If the client is given key material, it should not attempt to get this from the vault"""
+
+    mock_client = mock.Mock()
+    key = mock.Mock(spec=KeyVaultKey, id="https://localhost/fake/key/version")
+    client = CryptographyClient(key, mock.Mock())
+    client._client = mock_client
+
+    with mock.patch(CryptographyClient.__module__ + ".get_local_cryptography_provider") as get_provider:
+        client.verify(SignatureAlgorithm.rs256, b"...", b"...")
+    get_provider.assert_called_once_with(key)
+    assert mock_client.get_key.call_count == 0
+
+
+def test_initialization_get_key_successful():
+    """If the client is able to get key material, it shouldn't do so again"""
+
+    mock_client = mock.Mock()
+    mock_client.get_key.return_value = mock.Mock(spec=KeyVaultKey)
+    client = CryptographyClient("https://localhost/fake/key/version", mock.Mock())
+    client._client = mock_client
+    mock_key = mock.Mock()
+    mock_client.get_key.return_value = mock_key
+
+    assert mock_client.get_key.call_count == 0
+    with mock.patch(CryptographyClient.__module__ + ".get_local_cryptography_provider") as get_provider:
+        client.verify(SignatureAlgorithm.rs256, b"...", b"...")
+    get_provider.assert_called_once_with(mock_key)
+
+    for _ in range(3):
+        assert mock_client.get_key.call_count == 1
+        assert get_provider.call_count == 1
+        client.verify(SignatureAlgorithm.rs256, b"...", b"...")
+
+
+def test_initialization_forbidden_to_get_key():
+    """If the client is forbidden to get key material, it should try to do so exactly once"""
+
+    mock_client = mock.Mock()
+    mock_client.get_key.side_effect = HttpResponseError(response=mock.Mock(status_code=403))
+    client = CryptographyClient("https://localhost/fake/key/version", mock.Mock())
+    client._client = mock_client
+
+    assert mock_client.get_key.call_count == 0
+    for _ in range(3):
+        client.verify(SignatureAlgorithm.rs256, b"...", b"...")
+        assert mock_client.get_key.call_count == 1
+
+
+def test_initialization_transient_failure_getting_key():
+    """If the client is not forbidden to get key material, it should retry after failing to do so"""
+
+    mock_client = mock.Mock()
+    mock_client.get_key.side_effect = HttpResponseError(response=mock.Mock(status_code=500))
+    client = CryptographyClient("https://localhost/fake/key/version", mock.Mock())
+    client._client = mock_client
+
+    for i in range(3):
+        assert mock_client.get_key.call_count == i
+        client.verify(SignatureAlgorithm.rs256, b"...", b"...")
+
+
+def test_calls_service_for_operations_unsupported_locally():
+    """When an operation can't be performed locally, the client should request Key Vault perform it"""
+
+    mock_client = mock.Mock()
+    key = mock.Mock(spec=KeyVaultKey, id="https://localhost/fake/key/version")
+    client = CryptographyClient(key, mock.Mock())
+    client._client = mock_client
+
+    supports_nothing = mock.Mock(supports=mock.Mock(return_value=False))
+    with mock.patch(CryptographyClient.__module__ + ".get_local_cryptography_provider", lambda *_: supports_nothing):
+        client.decrypt(EncryptionAlgorithm.rsa_oaep, b"...")
+    assert mock_client.decrypt.call_count == 1
+    assert supports_nothing.decrypt.call_count == 0
+
+    client.encrypt(EncryptionAlgorithm.rsa_oaep, b"...")
+    assert mock_client.encrypt.call_count == 1
+    assert supports_nothing.encrypt.call_count == 0
+
+    client.sign(SignatureAlgorithm.rs256, b"...")
+    assert mock_client.sign.call_count == 1
+    assert supports_nothing.sign.call_count == 0
+
+    client.verify(SignatureAlgorithm.rs256, b"...", b"...")
+    assert mock_client.verify.call_count == 1
+    assert supports_nothing.verify.call_count == 0
+
+    client.unwrap_key(KeyWrapAlgorithm.rsa_oaep, b"...")
+    assert mock_client.unwrap_key.call_count == 1
+    assert supports_nothing.unwrap_key.call_count == 0
+
+    client.wrap_key(KeyWrapAlgorithm.rsa_oaep, b"...")
+    assert mock_client.wrap_key.call_count == 1
+    assert supports_nothing.wrap_key.call_count == 0
+
+
+def test_prefers_local_provider():
+    """The client should complete operations locally whenever possible"""
+
+    mock_client = mock.Mock()
+    key = mock.Mock(
+        spec=KeyVaultKey,
+        id="https://localhost/fake/key/version",
+        properties=mock.Mock(
+            not_before=datetime(2000, 1, 1, tzinfo=_UTC), expires_on=datetime(3000, 1, 1, tzinfo=_UTC)
+        ),
+    )
+    client = CryptographyClient(key, mock.Mock())
+    client._client = mock_client
+
+    supports_everything = mock.Mock(supports=mock.Mock(return_value=True))
+    with mock.patch(CryptographyClient.__module__ + ".get_local_cryptography_provider", lambda *_: supports_everything):
+        client.decrypt(EncryptionAlgorithm.rsa_oaep, b"...")
+    assert mock_client.decrypt.call_count == 0
+    assert supports_everything.decrypt.call_count == 1
+
+    client.encrypt(EncryptionAlgorithm.rsa_oaep, b"...")
+    assert mock_client.encrypt.call_count == 0
+    assert supports_everything.encrypt.call_count == 1
+
+    client.sign(SignatureAlgorithm.rs256, b"...")
+    assert mock_client.sign.call_count == 0
+    assert supports_everything.sign.call_count == 1
+
+    client.verify(SignatureAlgorithm.rs256, b"...", b"...")
+    assert mock_client.verify.call_count == 0
+    assert supports_everything.verify.call_count == 1
+
+    client.unwrap_key(KeyWrapAlgorithm.rsa_oaep, b"...")
+    assert mock_client.unwrap_key.call_count == 0
+    assert supports_everything.unwrap_key.call_count == 1
+
+    client.wrap_key(KeyWrapAlgorithm.rsa_oaep, b"...")
+    assert mock_client.wrap_key.call_count == 0
+    assert supports_everything.wrap_key.call_count == 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -6,7 +6,9 @@ import codecs
 from datetime import datetime
 import hashlib
 import os
+from unittest import mock
 
+from azure.core.exceptions import HttpResponseError
 from azure.keyvault.keys import JsonWebKey, KeyCurveName, KeyVaultKey
 from azure.keyvault.keys.crypto._key_validity import _UTC
 from azure.keyvault.keys.crypto.aio import CryptographyClient, EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
@@ -14,6 +16,7 @@ from azure.mgmt.keyvault.models import KeyPermissions, Permissions
 from devtools_testutils import ResourceGroupPreparer, KeyVaultPreparer
 import pytest
 
+from _shared.helpers_async  import get_completed_future
 from _shared.json_attribute_matcher import json_attribute_matcher
 from _shared.test_case_async import KeyVaultTestCase
 from crypto_client_preparer_async import CryptoClientPreparer
@@ -268,7 +271,7 @@ class CryptoClientTests(KeyVaultTestCase):
 @pytest.mark.asyncio
 async def test_symmetric_wrap_and_unwrap_local():
     key = KeyVaultKey(
-        key_id="http://fake.test.vault/keys/key/version", k=os.urandom(32), kty="oct", key_ops=["unwrapKey", "wrapKey"],
+        key_id="http://localhost/keys/key/version", k=os.urandom(32), kty="oct", key_ops=["unwrapKey", "wrapKey"],
     )
 
     crypto_client = CryptographyClient(key, credential=lambda *_: None)
@@ -278,3 +281,154 @@ async def test_symmetric_wrap_and_unwrap_local():
     wrap_result = await crypto_client.wrap_key(KeyWrapAlgorithm.aes_256, key_bytes)
     unwrap_result = await crypto_client.unwrap_key(wrap_result.algorithm, wrap_result.encrypted_key)
     assert unwrap_result.key == key_bytes
+
+
+@pytest.mark.asyncio
+async def test_initialization_given_key():
+    """If the client is given key material, it should not attempt to get this from the vault"""
+
+    mock_client = mock.Mock()
+    key = mock.Mock(spec=KeyVaultKey, id="https://localhost/fake/key/version")
+    client = CryptographyClient(key, mock.Mock())
+    client._client = mock_client
+    mock_client.get_key.return_value = get_completed_future()
+
+    with mock.patch(CryptographyClient.__module__ + ".get_local_cryptography_provider") as get_provider:
+        await client.verify(SignatureAlgorithm.rs256, b"...", b"...")
+    get_provider.assert_called_once_with(key)
+    assert mock_client.get_key.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_initialization_get_key_successful():
+    """If the client is able to get key material, it shouldn't do so again"""
+
+    mock_client = mock.Mock()
+    mock_client.get_key.return_value = mock.Mock(spec=KeyVaultKey)
+    client = CryptographyClient("https://localhost/fake/key/version", mock.Mock())
+    client._client = mock_client
+    mock_key = mock.Mock()
+    mock_client.get_key.return_value = get_completed_future(mock_key)
+
+    assert mock_client.get_key.call_count == 0
+    with mock.patch(CryptographyClient.__module__ + ".get_local_cryptography_provider") as get_provider:
+        await client.verify(SignatureAlgorithm.rs256, b"...", b"...")
+    get_provider.assert_called_once_with(mock_key)
+
+    for _ in range(3):
+        assert mock_client.get_key.call_count == 1
+        assert get_provider.call_count == 1
+        await client.verify(SignatureAlgorithm.rs256, b"...", b"...")
+
+
+@pytest.mark.asyncio
+async def test_initialization_forbidden_to_get_key():
+    """If the client is forbidden to get key material, it should try to do so exactly once"""
+
+    mock_client = mock.Mock()
+    mock_client.get_key.side_effect = HttpResponseError(response=mock.Mock(status_code=403))
+    mock_client.verify.return_value = get_completed_future(mock.Mock())
+    client = CryptographyClient("https://localhost/fake/key/version", mock.Mock())
+    client._client = mock_client
+
+    assert mock_client.get_key.call_count == 0
+    for _ in range(3):
+        await client.verify(SignatureAlgorithm.rs256, b"...", b"...")
+        assert mock_client.get_key.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_initialization_transient_failure_getting_key():
+    """If the client is not forbidden to get key material, it should retry after failing to do so"""
+
+    mock_client = mock.Mock()
+    mock_client.get_key.side_effect = HttpResponseError(response=mock.Mock(status_code=500))
+    mock_client.verify.return_value = get_completed_future(mock.Mock())
+    client = CryptographyClient("https://localhost/fake/key/version", mock.Mock())
+    client._client = mock_client
+
+    for i in range(3):
+        assert mock_client.get_key.call_count == i
+        await client.verify(SignatureAlgorithm.rs256, b"...", b"...")
+
+
+@pytest.mark.asyncio
+async def test_calls_service_for_operations_unsupported_locally():
+    """When an operation can't be performed locally, the client should request Key Vault perform it"""
+
+    class _AsyncMock(mock.Mock):
+        async def __call__(self, *args, **kwargs):
+            return super().__call__(*args, **kwargs)
+
+    mock_client = _AsyncMock()
+    key = mock.Mock(spec=KeyVaultKey, id="https://localhost/fake/key/version")
+    client = CryptographyClient(key, mock.Mock())
+    client._client = mock_client
+
+    supports_nothing = mock.Mock(supports=mock.Mock(return_value=False))
+    with mock.patch(CryptographyClient.__module__ + ".get_local_cryptography_provider", lambda *_: supports_nothing):
+        await client.decrypt(EncryptionAlgorithm.rsa_oaep, b"...")
+    assert mock_client.decrypt.call_count == 1
+    assert supports_nothing.decrypt.call_count == 0
+
+    await client.encrypt(EncryptionAlgorithm.rsa_oaep, b"...")
+    assert mock_client.encrypt.call_count == 1
+    assert supports_nothing.encrypt.call_count == 0
+
+    await client.sign(SignatureAlgorithm.rs256, b"...")
+    assert mock_client.sign.call_count == 1
+    assert supports_nothing.sign.call_count == 0
+
+    await client.verify(SignatureAlgorithm.rs256, b"...", b"...")
+    assert mock_client.verify.call_count == 1
+    assert supports_nothing.verify.call_count == 0
+
+    await client.unwrap_key(KeyWrapAlgorithm.rsa_oaep, b"...")
+    assert mock_client.unwrap_key.call_count == 1
+    assert supports_nothing.unwrap_key.call_count == 0
+
+    await client.wrap_key(KeyWrapAlgorithm.rsa_oaep, b"...")
+    assert mock_client.wrap_key.call_count == 1
+    assert supports_nothing.wrap_key.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_prefers_local_provider():
+    """The client should complete operations locally whenever possible"""
+
+    mock_client = mock.Mock()
+    key = mock.Mock(
+        spec=KeyVaultKey,
+        id="https://localhost/fake/key/version",
+        properties=mock.Mock(
+            not_before=datetime(2000, 1, 1, tzinfo=_UTC), expires_on=datetime(3000, 1, 1, tzinfo=_UTC)
+        ),
+    )
+    client = CryptographyClient(key, mock.Mock())
+    client._client = mock_client
+
+    supports_everything = mock.Mock(supports=mock.Mock(return_value=True))
+    with mock.patch(CryptographyClient.__module__ + ".get_local_cryptography_provider", lambda *_: supports_everything):
+        await client.decrypt(EncryptionAlgorithm.rsa_oaep, b"...")
+    assert mock_client.decrypt.call_count == 0
+    assert supports_everything.decrypt.call_count == 1
+
+    await client.encrypt(EncryptionAlgorithm.rsa_oaep, b"...")
+    assert mock_client.encrypt.call_count == 0
+    assert supports_everything.encrypt.call_count == 1
+
+    await client.sign(SignatureAlgorithm.rs256, b"...")
+    assert mock_client.sign.call_count == 0
+    assert supports_everything.sign.call_count == 1
+
+    await client.verify(SignatureAlgorithm.rs256, b"...", b"...")
+    assert mock_client.verify.call_count == 0
+    assert supports_everything.verify.call_count == 1
+
+    await client.unwrap_key(KeyWrapAlgorithm.rsa_oaep, b"...")
+    assert mock_client.unwrap_key.call_count == 0
+    assert supports_everything.unwrap_key.call_count == 1
+
+    await client.wrap_key(KeyWrapAlgorithm.rsa_oaep, b"...")
+    assert mock_client.wrap_key.call_count == 0
+    assert supports_everything.wrap_key.call_count == 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -8,7 +8,7 @@ import hashlib
 import os
 
 from azure.keyvault.keys import JsonWebKey, KeyCurveName, KeyVaultKey
-from azure.keyvault.keys.crypto._client import _UTC
+from azure.keyvault.keys.crypto._key_validity import _UTC
 from azure.keyvault.keys.crypto.aio import CryptographyClient, EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
 from azure.mgmt.keyvault.models import KeyPermissions, Permissions
 from devtools_testutils import ResourceGroupPreparer, KeyVaultPreparer


### PR DESCRIPTION
This is mostly internal refactoring to have `CryptographyClient` use the `LocalCryptographyProvider` added in #12490. That simplifies adding support for more algorithms locally, makes client initialization and behavior easier to reason about, and brings the client's local crypto capabilities to parity with other languages (closes #9754). Also included are a heap of tests to codify expected behavior and protect it from regression.

Public-facing `CryptographyClient` changes are:
- decrypt and sign can now be done locally
- the client logs a warning when a local operation unexpectedly fails, before falling back to a service request
- the client considers algorithm support when deciding whether to attempt an operation locally