### PR TITLE
[EventHubs] Update extensions.__init__.py in EventHubs and EHCheckpointstoreblob to the right nspkg format

### DIFF
--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/__init__.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/__init__.py
@@ -2,3 +2,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/__init__.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/__init__.py
@@ -1,0 +1,5 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/__init__.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/__init__.py
@@ -2,9 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
-
 from uamqp import constants
 from ._common import EventData, EventDataBatch
 from ._version import VERSION


### PR DESCRIPTION
The change is based on the conclusion for namespace package in eh and checkpointstoreblob: 
https://gist.github.com/yunhaoling/e59c4e95905c628472f43b7e7d09d061#gistcomment-3453972

TODO:

- [x] local smoke test
  - [x] install using the generated whls and try import
  - [x] check extensions.__init__.py being excluded in checkpointstoreblob(-aio)
  - [ ] check user issue (doesn't break installation into different dirs)
    - we need to bump the EH dependency, otherwise it would still try to install 5.2.0 from pypi when trying to install into different dirs