### PR TITLE
Added more docstring context and sample code for `receive_messages()`

### DIFF
--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
@@ -500,8 +500,8 @@ class QueueClient(StorageAccountHostsMixin):
             messages to retrieve from the queue, up to a maximum of 32. If
             fewer are visible, the visible messages are returned. By default,
             a single message is retrieved from the queue with this operation.
-            When retrieving these pages it is important to pass the output to `by_page()`.
-            These pages and their content can be iterated through using `next()`.
+            `by_page()` can be used to provide a page iterator on the AsyncItemPaged if messages_per_page is set.
+            `next()` can be used to get the next page.
             .. admonition:: Example:
 
                 .. literalinclude:: ../samples/queue_samples_message.py

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
@@ -500,6 +500,17 @@ class QueueClient(StorageAccountHostsMixin):
             messages to retrieve from the queue, up to a maximum of 32. If
             fewer are visible, the visible messages are returned. By default,
             a single message is retrieved from the queue with this operation.
+            When retrieving these pages it is important to pass the output to `by_page()`.
+            These pages and their content can be iterated through using `next()`.
+            .. admonition:: Example:
+
+                .. literalinclude:: ../samples/queue_samples_message.py
+                    :start-after: [START receive_messages_listing]
+                    :end-before: [END receive_messages_listing]
+                    :language: python
+                    :dedent: 12
+                    :caption: List pages and corresponding messages from the queue.
+
         :keyword int visibility_timeout:
             If not specified, the default value is 0. Specifies the
             new visibility timeout value, in seconds, relative to server time.

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
@@ -502,6 +502,7 @@ class QueueClient(StorageAccountHostsMixin):
             a single message is retrieved from the queue with this operation.
             `by_page()` can be used to provide a page iterator on the AsyncItemPaged if messages_per_page is set.
             `next()` can be used to get the next page.
+            
             .. admonition:: Example:
 
                 .. literalinclude:: ../samples/queue_samples_message.py

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
@@ -502,15 +502,14 @@ class QueueClient(StorageAccountHostsMixin):
             a single message is retrieved from the queue with this operation.
             `by_page()` can be used to provide a page iterator on the AsyncItemPaged if messages_per_page is set.
             `next()` can be used to get the next page.
-            
-            .. admonition:: Example:
+        .. admonition:: Example:
 
-                .. literalinclude:: ../samples/queue_samples_message.py
-                    :start-after: [START receive_messages_listing]
-                    :end-before: [END receive_messages_listing]
-                    :language: python
-                    :dedent: 12
-                    :caption: List pages and corresponding messages from the queue.
+            .. literalinclude:: ../samples/queue_samples_message.py
+                :start-after: [START receive_messages_listing]
+                :end-before: [END receive_messages_listing]
+                :language: python
+                :dedent: 12
+                :caption: List pages and corresponding messages from the queue.
 
         :keyword int visibility_timeout:
             If not specified, the default value is 0. Specifies the

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
@@ -419,6 +419,7 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase):
             messages to retrieve from the queue, up to a maximum of 32. If
             fewer are visible, the visible messages are returned. By default,
             a single message is retrieved from the queue with this operation.
+            When retrieving these pages it is important to pass the output to `by_page()`.
         :keyword int visibility_timeout:
             If not specified, the default value is 0. Specifies the
             new visibility timeout value, in seconds, relative to server time.

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
@@ -419,7 +419,8 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase):
             messages to retrieve from the queue, up to a maximum of 32. If
             fewer are visible, the visible messages are returned. By default,
             a single message is retrieved from the queue with this operation.
-            When retrieving these pages it is important to pass the output to `by_page()`.
+            `by_page()` can be used to provide a page iterator on the AsyncItemPaged if messages_per_page is set.
+            `next()` can be used to get the next page.
         :keyword int visibility_timeout:
             If not specified, the default value is 0. Specifies the
             new visibility timeout value, in seconds, relative to server time.

--- a/sdk/storage/azure-storage-queue/samples/queue_samples_message.py
+++ b/sdk/storage/azure-storage-queue/samples/queue_samples_message.py
@@ -160,18 +160,20 @@ class QueueMessageSamples(object):
             queue.send_message(u"message3")
             queue.send_message(u"message4")
             queue.send_message(u"message5")
-            queue.send_message(u"message6", visibility_timeout=30)
+            queue.send_message(u"message6")
 
             # [START receive_messages_listing]
             # Store two messages in each page
-            messages = queue.receive_messages(messages_per_page=2).by_page()
+            message_batches = queue.receive_messages(messages_per_page=2).by_page()
 
             # Iterate through the page lists
-            print(list(next(messages)))
-            print(list(next(messages)))
+            print(list(next(message_batches)))
+            print(list(next(message_batches)))
 
-            # Third list has one message since `message6` is still invisible
-            print(list(next(messages)))
+            # There are two iterations in the last page as well.
+            last_page = next(message_batches)
+            for message in last_page:
+                print(message)
             # [END receive_messages_listing]
 
         finally:

--- a/sdk/storage/azure-storage-queue/samples/queue_samples_message.py
+++ b/sdk/storage/azure-storage-queue/samples/queue_samples_message.py
@@ -273,10 +273,10 @@ class QueueMessageSamples(object):
 
 if __name__ == '__main__':
     sample = QueueMessageSamples()
-    #sample.set_access_policy()
-    #sample.queue_metadata()
-    #sample.send_and_receive_messages()
+    sample.set_access_policy()
+    sample.queue_metadata()
+    sample.send_and_receive_messages()
     sample.list_message_pages()
-    #sample.delete_and_clear_messages()
-    #sample.peek_messages()
-    #sample.update_message()
+    sample.delete_and_clear_messages()
+    sample.peek_messages()
+    sample.update_message()

--- a/sdk/storage/azure-storage-queue/samples/queue_samples_message.py
+++ b/sdk/storage/azure-storage-queue/samples/queue_samples_message.py
@@ -146,10 +146,41 @@ class QueueMessageSamples(object):
             # Delete the queue
             queue.delete_queue()
 
-    def delete_and_clear_messages(self):
+    def list_message_pages(self):
         # Instantiate a queue client
         from azure.storage.queue import QueueClient
         queue = QueueClient.from_connection_string(self.connection_string, "myqueue4")
+
+        # Create the queue
+        queue.create_queue()
+
+        try:
+            queue.send_message(u"message1")
+            queue.send_message(u"message2")
+            queue.send_message(u"message3")
+            queue.send_message(u"message4")
+            queue.send_message(u"message5")
+            queue.send_message(u"message6", visibility_timeout=30)
+
+            # [START receive_messages_listing]
+            # Store two messages in each page
+            messages = queue.receive_messages(messages_per_page=2).by_page()
+
+            # Iterate through the page lists
+            print(list(next(messages)))
+            print(list(next(messages)))
+
+            # Third list has one message since `message6` is still invisible
+            print(list(next(messages)))
+            # [END receive_messages_listing]
+
+        finally:
+            queue.delete_queue()
+
+    def delete_and_clear_messages(self):
+        # Instantiate a queue client
+        from azure.storage.queue import QueueClient
+        queue = QueueClient.from_connection_string(self.connection_string, "myqueue5")
 
         # Create the queue
         queue.create_queue()
@@ -181,7 +212,7 @@ class QueueMessageSamples(object):
     def peek_messages(self):
         # Instantiate a queue client
         from azure.storage.queue import QueueClient
-        queue = QueueClient.from_connection_string(self.connection_string, "myqueue5")
+        queue = QueueClient.from_connection_string(self.connection_string, "myqueue6")
 
         # Create the queue
         queue.create_queue()
@@ -213,7 +244,7 @@ class QueueMessageSamples(object):
     def update_message(self):
         # Instantiate a queue client
         from azure.storage.queue import QueueClient
-        queue = QueueClient.from_connection_string(self.connection_string, "myqueue6")
+        queue = QueueClient.from_connection_string(self.connection_string, "myqueue7")
 
         # Create the queue
         queue.create_queue()
@@ -242,9 +273,10 @@ class QueueMessageSamples(object):
 
 if __name__ == '__main__':
     sample = QueueMessageSamples()
-    sample.set_access_policy()
-    sample.queue_metadata()
-    sample.send_and_receive_messages()
-    sample.delete_and_clear_messages()
-    sample.peek_messages()
-    sample.update_message()
+    #sample.set_access_policy()
+    #sample.queue_metadata()
+    #sample.send_and_receive_messages()
+    sample.list_message_pages()
+    #sample.delete_and_clear_messages()
+    #sample.peek_messages()
+    #sample.update_message()


### PR DESCRIPTION
This PR resolves https://github.com/Azure/azure-sdk-for-python/issues/11784
The usage of the page iterators from `receive_messages` is sometimes unclear to users. This PR adds extra docstrings and sample.