### PR TITLE
Resolve Failing SchemaRegistry Regressions

### DIFF
--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -27,6 +27,7 @@ from pkg_resources import parse_version, parse_requirements, Requirement, Workin
 # this assumes the presence of "packaging"
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
+from packaging.version import parse
 
 
 DEV_REQ_FILE = "dev_requirements.txt"
@@ -340,13 +341,15 @@ def find_whl(package_name, version, whl_directory):
         logging.error("Whl directory is incorrect")
         exit(1)
 
-    logging.info("Searching whl for package {}".format(package_name))
-    whl_name = "{0}-{1}*.whl".format(package_name.replace("-", "_"), version)
+    parsed_version = parse(version)
+
+    logging.info("Searching whl for package {0}-{1}".format(package_name, parsed_version.base_version))
+    whl_name = "{0}-{1}*.whl".format(package_name.replace("-", "_"), parsed_version.base_version)
     paths = glob.glob(os.path.join(whl_directory, whl_name))
     if not paths:
         logging.error(
-            "whl is not found in whl directory {0} for package {1}".format(
-                whl_directory, package_name
+            "whl is not found in whl directory {0} for package {1}-{2}".format(
+                whl_directory, package_name, parsed_version.base_version
             )
         )
         exit(1)

--- a/scripts/devops_tasks/git_helper.py
+++ b/scripts/devops_tasks/git_helper.py
@@ -23,6 +23,7 @@ EXCLUDED_PACKAGE_VERSIONS = {
     'azure-cosmos': '3.2.0',
     'azure-servicebus': '0.50.3',
     'azure-eventgrid': '1.3.0',
+    'azure-schemaregistry-avroserializer': '1.0.0'
 }
 
 # This method identifies release tag for latest or oldest released version of a given package

--- a/scripts/devops_tasks/git_helper.py
+++ b/scripts/devops_tasks/git_helper.py
@@ -23,7 +23,7 @@ EXCLUDED_PACKAGE_VERSIONS = {
     'azure-cosmos': '3.2.0',
     'azure-servicebus': '0.50.3',
     'azure-eventgrid': '1.3.0',
-    'azure-schemaregistry-avroserializer': '1.0.0'
+    'azure-schemaregistry-avroserializer': '1.0.0b1'
 }
 
 # This method identifies release tag for latest or oldest released version of a given package


### PR DESCRIPTION
To be completely clear, this is _not_ related to any code that @yunhaoling committed.

This is merely a symptom of [this](https://github.com/Azure/azure-sdk-for-python/pull/13500/files)
![image](https://user-images.githubusercontent.com/45376673/93381729-f49aaa80-f815-11ea-96ca-4996fa41149c.png)

update that had a slight gap that I missed.

The `regression` stage of the nightly build locates dependencies based on the following glob match in the `artifacts` directory:

What this looks for is essentially `*<packagename>-<packageversion>*`

And that was FINE when we had `<version>.dev<buildId`. But now we've swapped to `<base_version>a<buildId>` where the difference is the following.

Old: `1.0.0b1.dev20200916`
New: `1.0.0a20200916`

This means that when we're dealing with a `preview` package, 1.0.0b1* won't match the DEV versioned package! This is why the build error is tossing back `not found`.

We simply needed to adjust the search a bit to take the above facts into account.