### PR TITLE
Update release stage condition

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -8,7 +8,7 @@ parameters:
   TargetDocRepoName: ''
 
 stages:
-  - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
+  - ${{if and(or(eq(variables['TestPipeline'], 'true'), eq(variables['Build.Reason'], 'Manual')), eq(variables['System.TeamProject'], 'internal'))}}:
     - ${{ each artifact in parameters.Artifacts }}:
       - stage: Release_${{artifact.safeName}}
         displayName: 'Release: ${{artifact.name}}'

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -44,7 +44,7 @@ stages:
         DevFeedName: ${{parameters.DevFeedName}}
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
-  - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
+  - ${{if and(or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['TestPipeline'], 'true')), eq(variables['System.TeamProject'], 'internal'))}}:
     - template: archetype-python-release.yml
       parameters:
         DependsOn: Build


### PR DESCRIPTION
Update release stage condition to always allow template runs from internal pipeline.
This is intended to help facilitate testing of common EngSys tools in the `eng/common` directory.