### PR TITLE
Fixed issues with resource token

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Bug fixes**
 - Fixed bug where continuation token is not honored when query_iterable is used to get results by page. Issue #13265.
+- Fixed bug where resource tokens not being honored for document reads and deletes. Issue #13634.
 
 
 ## 4.1.0 (2020-08-10)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/auth.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/auth.py
@@ -27,7 +27,6 @@ from hashlib import sha256
 import hmac
 
 import six
-import six.moves.urllib.parse as url_parse
 
 from . import http_constants
 
@@ -119,7 +118,7 @@ def __GetAuthorizationTokenUsingResourceTokens(resource_tokens, path, resource_i
         # For database account access(through GetDatabaseAccount API), path and
         # resource_id_or_fullname are '', so in this case we return the first token to be
         # used for creating the auth header as the service will accept any token in this case
-        path = url_parse.unquote(path)
+        path = six.moves.urllib.parse.unquote(path)
         if not path and not resource_id_or_fullname:
             return next(six.itervalues(resource_tokens))
 

--- a/sdk/cosmos/azure-cosmos/test/test_crud.py
+++ b/sdk/cosmos/azure-cosmos/test/test_crud.py
@@ -531,21 +531,21 @@ class CRUDTests(unittest.TestCase):
     def test_partitioned_collection_permissions(self):
         created_db = self.databaseForTest
 
-        collection_id = 'test_partitioned_collection_permissions all collection'
+        collection_id = 'test_partitioned_collection_permissions all collection' + str(uuid.uuid4())
 
         all_collection = created_db.create_container(
             id=collection_id,
             partition_key=PartitionKey(path='/key', kind=documents.PartitionKind.Hash)
         )
 
-        collection_id = 'test_partitioned_collection_permissions read collection'
+        collection_id = 'test_partitioned_collection_permissions read collection' + str(uuid.uuid4())
 
         read_collection = created_db.create_container(
             id=collection_id,
             partition_key=PartitionKey(path='/key', kind=documents.PartitionKind.Hash)
         )
 
-        user = created_db.create_user(body={'id': 'user'})
+        user = created_db.create_user(body={'id': 'user' + str(uuid.uuid4())})
 
         permission_definition = {
             'id': 'all permission',
@@ -1315,7 +1315,7 @@ class CRUDTests(unittest.TestCase):
             )
 
             # create user
-            user = db.create_user(body={'id': 'user'})
+            user = db.create_user(body={'id': 'user' + str(uuid.uuid4())})
 
             # create permission for collection
             permission = {

--- a/sdk/cosmos/azure-cosmos/test/test_query.py
+++ b/sdk/cosmos/azure-cosmos/test/test_query.py
@@ -47,6 +47,7 @@ class QueryTest(unittest.TestCase):
         iter_list = list(query_iterable)
         self.assertEqual(iter_list[0]['id'], 'myId')
 
+
     def test_query_change_feed(self):
         created_collection = self.config.create_multi_partition_collection_with_custom_pk_if_not_exist(self.client)
         # The test targets partition #3

--- a/sdk/cosmos/azure-cosmos/test/test_query.py
+++ b/sdk/cosmos/azure-cosmos/test/test_query.py
@@ -47,7 +47,6 @@ class QueryTest(unittest.TestCase):
         iter_list = list(query_iterable)
         self.assertEqual(iter_list[0]['id'], 'myId')
 
-
     def test_query_change_feed(self):
         created_collection = self.config.create_multi_partition_collection_with_custom_pk_if_not_exist(self.client)
         # The test targets partition #3


### PR DESCRIPTION
- Earlier, the SDK was doing a comparison by id to check if the resource token was for a particular resource was passed to the client
- Now, we check for the entire path of the resource to be a key to the resource token passed to the client
- Changed existing tests to reflect this behavior.