### PR TITLE
Adding one more item to the limitations list

### DIFF
--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -89,8 +89,9 @@ As of August 2020 the features below are not yet supported.
 * Group By queries
 * Direct TCP Mode access
 * Language Native async i/o
+* Continuation token for cross partitions queries
 
-## Limitations Workaround
+## Bult processing limitations workaround
 
 If you want to use Python SDK to perform bulk inserts to Cosmos DB, the best alternative is to use [stored procedures](https://docs.microsoft.com/azure/cosmos-db/how-to-write-stored-procedures-triggers-udfs) to write multiple items with the same partition key.
 

--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -83,12 +83,12 @@ For more information about these resources, see [Working with Azure Cosmos datab
 
 ## Limitations
 
-As of August 2020 the features below are **not yet supported**.
+As of August 2020 the features below are **not supported**.
 
+* Group By queries (in roadmap for 2021)
+* Language Native async i/o (in roadmap for 2021)
 * Bulk/Transactional batch processing
-* Group By queries
 * Direct TCP Mode access
-* Language Native async i/o
 * Continuation token for cross partitions queries
 * Change Feed: Processor
 * Change Feed: Read multiple partitions key values
@@ -99,7 +99,8 @@ As of August 2020 the features below are **not yet supported**.
 * Create User
 * Create Geospatial Index
 * Provision Autoscale DBs or containers
-* Cross-partition ORDER BY for mixed types 
+* Cross-partition ORDER BY for mixed types
+* Get the connection string
 
 ## Bulk processing limitation workaround
 

--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -91,7 +91,7 @@ As of August 2020 the features below are not yet supported.
 * Language Native async i/o
 * Continuation token for cross partitions queries
 
-## Bult processing limitations workaround
+## Bulk processing limitation workaround
 
 If you want to use Python SDK to perform bulk inserts to Cosmos DB, the best alternative is to use [stored procedures](https://docs.microsoft.com/azure/cosmos-db/how-to-write-stored-procedures-triggers-udfs) to write multiple items with the same partition key.
 

--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -99,6 +99,7 @@ As of August 2020 the features below are **not yet supported**.
 * Create User
 * Create Geospatial Index
 * Provision Autoscale DBs or containers
+* Cross-partition ORDER BY for mixed types 
 
 ## Bulk processing limitation workaround
 

--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -83,13 +83,22 @@ For more information about these resources, see [Working with Azure Cosmos datab
 
 ## Limitations
 
-As of August 2020 the features below are not yet supported.
+As of August 2020 the features below are **not yet supported**.
 
-* Bulk/Batch processing
+* Bulk/Transactional batch processing
 * Group By queries
 * Direct TCP Mode access
 * Language Native async i/o
 * Continuation token for cross partitions queries
+* Change Feed: Processor
+* Change Feed: Read multiple partitions key values
+* Change Feed: Read specific time 
+* Change Feed: Read from the beggining
+* Change Feed: Pull model
+* Get CollectionSizeUsage, DatabaseUsage, and DocumentUsage metrics
+* Create User
+* Create Geospatial Index
+* Provision Autoscale DBs or containers
 
 ## Bulk processing limitation workaround
 


### PR DESCRIPTION
Python only supports continuation token for queries against a single partition key. It is not supported for cross partition query.