### PR TITLE
remove v1 form recognizer from CI

### DIFF
--- a/sdk/cognitiveservices/ci.yml
+++ b/sdk/cognitiveservices/ci.yml
@@ -30,8 +30,6 @@ extends:
     Artifacts:
     - name: azure_cognitiveservices_anomalydetector
       safeName: azurecognitiveservicesanomalydetector
-    - name: azure_cognitiveservices_formrecognizer
-      safeName: azurecognitiveservicesformrecognizer
     - name: azure_cognitiveservices_knowledge_nspkg
       safeName: azurecognitiveservicesknowledgenspkg
     - name: azure_cognitiveservices_knowledge_qnamaker


### PR DESCRIPTION
Package is deprecated and has been re-released with note about deprecation and breadcrumb to track 2. Remove from CI to save a bit on time