### PR TITLE
Minimize packages installed for depends test

### DIFF
--- a/eng/tox/sanitize_setup.py
+++ b/eng/tox/sanitize_setup.py
@@ -14,13 +14,14 @@ import logging
 import glob
 from packaging.specifiers import SpecifierSet
 from pkg_resources import Requirement
-from pypi_tools.pypi import PyPIClient
 
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", ".."))
 setup_parser_path = os.path.abspath(os.path.join(root_dir, "eng", "versioning"))
+pypi_tools_path = os.path.join(root_dir, "tools", "azure-sdk-tools", "pypi_tools")
 
-sys.path.append(setup_parser_path)
+sys.path += [setup_parser_path, pypi_tools_path]
 from setup_parser import get_install_requires, parse_setup
+from pypi import PyPIClient
 
 DEV_BUILD_IDENTIFIER = ".dev"
 

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -135,14 +135,13 @@ commands =
 
 
 [testenv:depends]
-pre-deps =
-  {[packaging]pkgs}
 platform = linux: linux
            macos: darwin
            windows: win32
 changedir = {toxinidir}
 deps =
-  {[tools]deps}
+  {[packaging]pkgs}
+  requests
 commands =
     {envbindir}/python {toxinidir}/../../../eng/tox/sanitize_setup.py -t {toxinidir}
     {envbindir}/python {toxinidir}/../../../eng/tox/create_package_and_install.py \


### PR DESCRIPTION
Closes #12990 by removing unnecessary packages from the depends environment.