### PR TITLE
Clean-up excess includes for triggers.

### DIFF
--- a/sdk/anomalydetector/ci.yml
+++ b/sdk/anomalydetector/ci.yml
@@ -11,7 +11,6 @@ trigger:
   paths:
     include:
     - sdk/anomalydetector/
-    - sdk/core/
 
 pr:
   branches:
@@ -24,7 +23,6 @@ pr:
   paths:
     include:
     - sdk/anomalydetector/
-    - sdk/core/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/appconfiguration/ci.yml
+++ b/sdk/appconfiguration/ci.yml
@@ -10,9 +10,6 @@ trigger:
   paths:
     include:
     - sdk/appconfiguration/
-    - sdk/core/
-    - tools/
-    - eng/
 
 pr:
   branches:
@@ -25,9 +22,6 @@ pr:
   paths:
     include:
     - sdk/appconfiguration/
-    - sdk/core/
-    - tools/
-    - eng/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/cosmos/ci.yml
+++ b/sdk/cosmos/ci.yml
@@ -9,7 +9,6 @@ trigger:
   paths:
     include:
     - sdk/cosmos/
-    - sdk/core/
 
 pr:
   branches:
@@ -22,7 +21,6 @@ pr:
   paths:
     include:
     - sdk/cosmos/
-    - sdk/core/
 
 extends:
   template: ../../eng/pipelines/templates/stages/cosmos-sdk-client.yml

--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -10,9 +10,6 @@ trigger:
   paths:
     include:
     - sdk/eventhub/
-    - sdk/core/
-    - tools/
-    - eng/
 
 pr:
   branches:
@@ -25,9 +22,6 @@ pr:
   paths:
     include:
     - sdk/eventhub/
-    - sdk/core/
-    - tools/
-    - eng/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/formrecognizer/ci.yml
+++ b/sdk/formrecognizer/ci.yml
@@ -10,7 +10,6 @@ trigger:
   paths:
     include:
     - sdk/formrecognizer/
-    - sdk/core/
 
 pr:
   branches:
@@ -22,7 +21,6 @@ pr:
   paths:
     include:
     - sdk/formrecognizer/
-    - sdk/core/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -10,7 +10,6 @@ trigger:
   paths:
     include:
     - sdk/identity/
-    - sdk/core/
 
 pr:
   branches:
@@ -23,7 +22,6 @@ pr:
   paths:
     include:
     - sdk/identity/
-    - sdk/core/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/keyvault/ci.yml
+++ b/sdk/keyvault/ci.yml
@@ -10,9 +10,6 @@ trigger:
   paths:
     include:
     - sdk/keyvault/
-    - sdk/core/
-    - tools/
-    - eng/
 
 pr:
   branches:
@@ -25,9 +22,6 @@ pr:
   paths:
     include:
     - sdk/keyvault/
-    - sdk/core/
-    - tools/
-    - eng/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -10,9 +10,6 @@ trigger:
   paths:
     include:
     - sdk/storage/
-    - sdk/core/
-    - tools/
-    - eng/
 
 pr:
   branches:
@@ -25,9 +22,6 @@ pr:
   paths:
     include:
     - sdk/storage/
-    - sdk/core/
-    - tools/
-    - eng/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/streamanalytics/ci.yml
+++ b/sdk/streamanalytics/ci.yml
@@ -10,9 +10,6 @@ trigger:
   paths:
     include:
     - sdk/streamanalytics/
-    - sdk/core/
-    - tools/
-    - eng/
 
 pr:
   branches:
@@ -25,9 +22,6 @@ pr:
   paths:
     include:
     - sdk/streamanalytics/
-    - sdk/core/
-    - tools/
-    - eng/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/tables/ci.yml
+++ b/sdk/tables/ci.yml
@@ -10,9 +10,6 @@ trigger:
   paths:
     include:
     - sdk/tables/
-    - sdk/core/
-    - tools/
-    - eng/
 
 pr:
   branches:
@@ -25,10 +22,6 @@ pr:
   paths:
     include:
     - sdk/tables/
-    - sdk/core/
-    - tools/
-    - eng/
-
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/textanalytics/ci.yml
+++ b/sdk/textanalytics/ci.yml
@@ -10,7 +10,6 @@ trigger:
   paths:
     include:
     - sdk/textanalytics/
-    - sdk/core/
 
 pr:
   branches:
@@ -23,7 +22,6 @@ pr:
   paths:
     include:
     - sdk/textanalytics/
-    - sdk/core/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
This PR is more for discussion than anything else at this point. I was helping out the management plane team with a new pipeline an observed that the ```ci.yml``` file they were using had some extra path filters for ```tools/```, ```sdk/core/```, and ```eng/```. It wasn't for all service directories and it got me thinking if it was intentional or not.

Do we still need these triggers, especially on ```eng/```. When sync PRs are pushed this has the potential to really hammer the build pools with this broader coverage created by the triggers.