### PR TITLE
Filter authentication metadata requests during recording

### DIFF
--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/__init__.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/__init__.py
@@ -10,7 +10,7 @@ from .patches import mock_in_unit_test, patch_time_sleep_api, patch_long_run_ope
 from .preparers import AbstractPreparer, SingleValueReplacer
 from .recording_processors import (
     RecordingProcessor, SubscriptionRecordingProcessor,
-    LargeRequestBodyProcessor, LargeResponseBodyProcessor, LargeResponseBodyReplacer,
+    LargeRequestBodyProcessor, LargeResponseBodyProcessor, LargeResponseBodyReplacer, AuthenticationMetadataFilter,
     OAuthRequestResponsesFilter, DeploymentNameReplacer, GeneralNameReplacer, AccessTokenReplacer, RequestUrlNormalizer,
 )
 from .utilities import create_random_name, get_sha1_hash
@@ -21,7 +21,8 @@ __all__ = ['IntegrationTestBase', 'ReplayableTest', 'LiveTest',
            'AbstractPreparer', 'SingleValueReplacer', 'AllowLargeResponse',
            'RecordingProcessor', 'SubscriptionRecordingProcessor',
            'LargeRequestBodyProcessor', 'LargeResponseBodyProcessor', 'LargeResponseBodyReplacer',
-           'OAuthRequestResponsesFilter', 'DeploymentNameReplacer', 'GeneralNameReplacer',
+           'AuthenticationMetadataFilter', 'OAuthRequestResponsesFilter',
+           'DeploymentNameReplacer', 'GeneralNameReplacer',
            'AccessTokenReplacer', 'RequestUrlNormalizer',
            'live_only', 'record_only',
            'create_random_name', 'get_sha1_hash']

--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/recording_processors.py
@@ -127,6 +127,19 @@ class LargeResponseBodyReplacer(RecordingProcessor):
         return response
 
 
+class AuthenticationMetadataFilter(RecordingProcessor):
+    """Remove authority and tenant discovery requests and responses from recordings.
+
+    MSAL sends these requests to obtain non-secret metadata about the token authority. Recording them is unnecessary
+    because tests use fake credentials during playback that don't invoke MSAL.
+    """
+
+    def process_request(self, request):
+        if "/.well-known/openid-configuration" in request.uri or "/discovery/instance" in request.uri:
+            return None
+        return request
+
+
 class OAuthRequestResponsesFilter(RecordingProcessor):
     """Remove oauth authentication requests and responses from recording."""
 

--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/recording_processors.py
@@ -135,7 +135,7 @@ class AuthenticationMetadataFilter(RecordingProcessor):
     """
 
     def process_request(self, request):
-        if "/.well-known/openid-configuration" in request.uri or "/discovery/instance" in request.uri:
+        if "/.well-known/openid-configuration" in request.uri or "/common/discovery/instance" in request.uri:
             return None
         return request
 

--- a/tools/azure-sdk-tools/devtools_testutils/azure_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/azure_testcase.py
@@ -17,7 +17,7 @@ import pytest
 from azure_devtools.scenario_tests import (
     ReplayableTest, AzureTestError,
     GeneralNameReplacer, RequestUrlNormalizer,
-    OAuthRequestResponsesFilter
+    AuthenticationMetadataFilter, OAuthRequestResponsesFilter
 )
 from azure_devtools.scenario_tests.config import TestConfig
 
@@ -125,6 +125,7 @@ class AzureTestCase(ReplayableTest):
     def _get_recording_processors(self):
         return [
             self.scrubber,
+            AuthenticationMetadataFilter(),
             OAuthRequestResponsesFilter(),
             RequestUrlNormalizer()
         ]


### PR DESCRIPTION
Service principal credentials in azure-identity now use MSAL Python, which requests metadata from Azure AD. Recording these requests is unnecessary because tests use fake credentials during playback.