### PR TITLE
Extend `UsePythonVersion` Task to allow download from gh-actions version manifest

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -39,6 +39,11 @@ parameters:
       PythonVersion: 'pypy3'
       CoverageArg: '--disablecov'
       RunForPR: false
+    Linux_Python39rc2:
+      OSVmImage: 'ubuntu-18.04'
+      PythonVersion: '3.9.0-rc.2'
+      CoverageArg: ''
+      RunForPR: true
   AdditionalTestMatrix: []
   DevFeedName: 'public/azure-sdk-for-python'
 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -19,9 +19,8 @@ steps:
   - pwsh: |
       gci -r $(Build.ArtifactStagingDirectory)
 
-  - task: UsePythonVersion@0
-    displayName: 'Use Python ${{ parameters.PythonVersion }}'
-    inputs:
+  - template: /eng/pipelines/templates/steps/wrapped-use-python.yml
+    parameters:
       versionSpec: '${{ parameters.PythonVersion }}'
 
   - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml

--- a/eng/pipelines/templates/steps/wrapped-use-python.yml
+++ b/eng/pipelines/templates/steps/wrapped-use-python.yml
@@ -1,0 +1,60 @@
+parameters:
+  versionSpec: ''
+
+steps:
+  # use python 3.8 for tooling. packaging. platform.
+  - task: UsePythonVersion@0
+    displayName: "Use Python 3.8"
+    inputs:
+      versionSpec: 3.8
+
+  - pwsh: |
+      pip install packaging
+    displayName: Prep Environment
+
+  # select the appropriate version from manifest if present
+  - task: PythonScript@0
+    displayName: 'Check Version Spec Against Known Versions'
+    inputs:
+     scriptPath: 'scripts/devops_tasks/resolve_installer_location.py'
+     arguments: '${{ parameters.versionSpec }}'
+
+  # install from location discovered in manifest
+  - pwsh: |
+      $installerFolder = "../_installer"
+      $uri = $(_PythonInstallerLocation)
+
+      if ([Environment]::GetEnvironmentVariable("Agent.OS") == "Windows_NT") {
+        $outFile = "local.zip"
+      }
+      else {
+        $outFile = "local.tar.gz"
+      }
+
+      mkdir $installerFolder
+
+      Invoke-WebRequest -Method GET `
+        -Uri $uri `
+        -OutFile "$installerFolder/$outFile"
+
+      Push-Location $installerFolder
+
+      # unzip and install
+      if ([Environment]::GetEnvironmentVariable("Agent.OS") == "Windows_NT") {
+        Expand-Archive -Path "local.zip" -DestinationPath .
+        ./setup.ps1
+      }
+      else {
+        tar -xvf "local.tar.gz"
+        sh setup.sh
+      }
+
+      Pop-Location
+    displayName: 'Install Py ${{ parameters.versionSpec }}'
+    condition: eq($(_PythonNeedsInstall), 'true')
+
+  # use
+  - task: UsePythonVersion@0
+    displayName: "Use Python $(PythonVersion)"
+    inputs:
+      versionSpec: ${{ parameters.versionSpec }}

--- a/eng/pipelines/templates/steps/wrapped-use-python.yml
+++ b/eng/pipelines/templates/steps/wrapped-use-python.yml
@@ -51,7 +51,7 @@ steps:
 
       Pop-Location
     displayName: 'Install Py ${{ parameters.versionSpec }}'
-    condition: eq($(_PythonNeedsInstall), 'true')
+    condition: eq(variables['_PythonNeedsInstall'], 'true')
 
   # use
   - task: UsePythonVersion@0

--- a/scripts/devops_tasks/resolve_installer_location.py
+++ b/scripts/devops_tasks/resolve_installer_location.py
@@ -56,8 +56,8 @@ if __name__ == "__main__":
         print("Requested version {} is newer than versions pre-cached on agent. Invoking.")
         print("##vso[task.setvariable variable=_PythonNeedsInstall;]true")
 
-        version_url = get_installer_url(args.versionSpec, version_dict)
-        print("##vso[task.setvariable variable=_PythonInstallerLocation;]{}".format(version_url))
+        install_file_details = get_installer_url(args.versionSpec, version_dict)
+        print("##vso[task.setvariable variable=_PythonInstallerLocation;]{}".format(install_file_details["download_url"]))
     else:
         print("##vso[task.setvariable variable=_PythonNeedsInstall;]false")
 

--- a/scripts/devops_tasks/resolve_installer_location.py
+++ b/scripts/devops_tasks/resolve_installer_location.py
@@ -1,0 +1,56 @@
+import platform
+import json
+import argparse
+import urllib
+from urllib.request import urlopen
+from packaging.version import Version
+from packaging.version import parse
+import pdb
+
+MANIFEST_LOCATION = "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json"
+
+
+def get_installer_url(requested_version, version_manifest):
+    if version_manifest[requested_version]:
+        found_installers = version_manifest[requested_version].files
+
+        # filter anything that's not x64
+        x64_installers = [file_def for file_def in found_installers if file_def["arch"] == "x64"]
+
+        # if we're on linux, we should go after the one that aligns with our platform version.
+        
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Takes the incoming request and attempts to resolve the versionspec"
+    )
+
+    parser.add_argument(
+        "versionSpec",
+        nargs="?",
+        help=(
+            "The version specifier passed in to the UsePythonVersion extended task."
+        ),
+    )
+
+    args = parser.parse_args()
+    max_precached_version = Version('3.8.6')
+    version_from_spec = Version(args.versionSpec)
+
+    with urllib.request.urlopen(MANIFEST_LOCATION) as url:
+        version_manifest = json.load(url)
+
+    version_dict = { i['version'] : i for i in version_manifest }
+
+    if version_from_spec > max_precached_version:
+        print("Requested version {} is newer than versions pre-cached on agent. Invoking.")
+        print("##vso[task.setvariable variable=_PythonNeedsInstall;]true")
+
+        version_url = get_installer_url(args.versionSpec, version_dict)
+        print("##vso[task.setvariable variable=_PythonInstallerLocation;]{}".format(version_url))
+    else:
+        print("##vso[task.setvariable variable=_PythonNeedsInstall;]false")
+
+
+

--- a/scripts/devops_tasks/resolve_installer_location.py
+++ b/scripts/devops_tasks/resolve_installer_location.py
@@ -27,7 +27,7 @@ def get_installer_url(requested_version, version_manifest):
         elif current_plat == "darwin":
             return [windows_installer for installer in x64_installers if installer["platform"] == current_plat][0]
         else:
-            pass
+            return [windows_installer for installer in x64_installers if installer["platform"] == "linux" and installer["platform_version"] =="18.04" ][0]
 
 
 if __name__ == "__main__":

--- a/scripts/devops_tasks/resolve_installer_location.py
+++ b/scripts/devops_tasks/resolve_installer_location.py
@@ -7,18 +7,27 @@ from packaging.version import Version
 from packaging.version import parse
 import pdb
 
+# SOURCE OF THIS FILE: https://github.com/actions/python-versions
+# this is the official mapping file for gh-actions to retrieve python installers
 MANIFEST_LOCATION = "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json"
 
-
 def get_installer_url(requested_version, version_manifest):
+    current_plat = platform.system().tolower()
+
+    print("Current Platform Is {}".format(platform.platform()))
+
     if version_manifest[requested_version]:
         found_installers = version_manifest[requested_version].files
 
-        # filter anything that's not x64
+        # filter anything that's not x64. we don't care.
         x64_installers = [file_def for file_def in found_installers if file_def["arch"] == "x64"]
 
-        # if we're on linux, we should go after the one that aligns with our platform version.
-        
+        if current_plat == "windows":
+            return [windows_installer for installer in x64_installers if installer["platform"] == "win32"][0]
+        elif current_plat == "darwin":
+            return [windows_installer for installer in x64_installers if installer["platform"] == current_plat][0]
+        else:
+            pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I am a HUGE FAN of the installers provided by gh-actions. They are _already set up_ to be used with the images.

@lmazuel here is as close to `official` support for pre-GA python versions as AZDO will give us. I honestly expect this to fail given all the missing crypto dependencies.
