### PR TITLE
Set version artificially for the test template runs

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -111,7 +111,15 @@ jobs:
     pool:
       vmImage: '$(OSVmImage)'
 
-    steps:    
+    steps:
+    - task: PowerShell@2
+      displayName: Prep template pipeline for release
+      condition: and(succeeded(),eq(variables['TestPipeline'],'true'))
+      inputs:
+        pwsh: true
+        workingDirectory: $(Build.SourcesDirectory)
+        filePath: eng/scripts/SetTestPipelineVersion.ps1
+
     - pwsh: |
         $toxenvvar = "whl,sdist"
         if (('$(Build.Reason)' -eq 'Schedule') -and ('$(System.TeamProject)' -eq 'internal')) {

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -28,6 +28,13 @@ stages:
                 deploy:
                   steps:
                     - checkout: self
+                    - task: PowerShell@2
+                      displayName: Prep template pipeline for release
+                      condition: and(succeeded(),eq(variables['TestPipeline'],'true'))
+                      inputs:
+                        pwsh: true
+                        workingDirectory: $(Build.SourcesDirectory)
+                        filePath: eng/scripts/SetTestPipelineVersion.ps1
                     - template: /eng/pipelines/templates/steps/stage-filtered-artifacts.yml
                       parameters:
                         SourceFolder: ${{parameters.ArtifactName}} 

--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -5,6 +5,14 @@ parameters:
   BuildDocs: true
 
 steps:
+  - task: PowerShell@2
+    displayName: Prep template pipeline for release
+    condition: and(succeeded(),eq(variables['TestPipeline'],'true'))
+    inputs:
+      pwsh: true
+      workingDirectory: $(Build.SourcesDirectory)
+      filePath: eng/scripts/SetTestPipelineVersion.ps1
+
   - script: |
       echo "##vso[build.addbuildtag]Scheduled"
     displayName: 'Tag scheduled builds'

--- a/eng/scripts/SetTestPipelineVersion.ps1
+++ b/eng/scripts/SetTestPipelineVersion.ps1
@@ -1,0 +1,39 @@
+# Overides the project file and CHANGELOG.md for the template project using the next publishable version
+# This is to help with testing the release pipeline.
+. "${PSScriptRoot}\..\common\scripts\common.ps1"
+$latestTags = git tag -l "azure-template_*"
+$semVars = @()
+
+$versionFile = "${PSScriptRoot}\..\..\sdk\template\azure-template\azure\template\_version.py"
+$changeLogFile = "${PSScriptRoot}\..\..\sdk\template\azure-template\CHANGELOG.md"
+
+Foreach ($tags in $latestTags)
+{
+  $semVars += $tags.Replace("azure-template_", "")
+}
+
+$semVarsSorted = [AzureEngSemanticVersion]::SortVersionStrings($semVars)
+LogDebug "Last Published Version $($semVarsSorted[0])"
+
+$newVersion = [AzureEngSemanticVersion]::ParsePythonVersionString($semVarsSorted[0])
+$newVersion.IncrementAndSetToPrerelease()
+LogDebug "Version to publish [ $($newVersion.ToString()) ]"
+
+$versionFileContent = Get-Content -Path $versionFile
+$newVersionFile = @()
+
+Foreach ($line in $versionFileContent)
+{
+    if($line.StartsWith("VERSION"))
+    {
+        $line = 'VERSION = "{0}"' -F $newVersion.ToString()
+    }
+    $newVersionFile += $line
+}
+
+Set-Content -Path $versionFile -Value $newVersionFile
+Set-Content -Path $changeLogFile -Value @"
+# Release History
+## $($newVersion.ToString()) ($(Get-Date -f "yyyy-MM-dd"))
+- Test Release Pipeline
+"@


### PR DESCRIPTION
This allows template (Test) run to go all the way to release with artificially generated versions.
Sample run https://dev.azure.com/azure-sdk/internal/_build/results?buildId=559373&view=results