### PR TITLE
[metricsadvisor] rename for alert config property

### DIFF
--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/azure/ai/metricsadvisor/models/_models.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/azure/ai/metricsadvisor/models/_models.py
@@ -536,8 +536,8 @@ class MetricAlertConfiguration(object):
     :type detection_configuration_id: str
     :param alert_scope: Required. Anomaly scope.
     :type alert_scope: ~azure.ai.metricsadvisor.models.MetricAnomalyAlertScope
-    :keyword use_detection_result_to_filter_anomalies: Negation operation.
-    :paramtype use_detection_result_to_filter_anomalies: bool
+    :keyword negation_operation: Negation operation.
+    :paramtype negation_operation: bool
     :keyword alert_conditions:
     :paramtype alert_conditions: ~azure.ai.metricsadvisor.models.MetricAnomalyAlertConditions
     :keyword alert_snooze_condition:
@@ -547,7 +547,7 @@ class MetricAlertConfiguration(object):
         # type: (str, MetricAnomalyAlertScope, Any) -> None
         self.detection_configuration_id = detection_configuration_id
         self.alert_scope = alert_scope
-        self.use_detection_result_to_filter_anomalies = kwargs.get("use_detection_result_to_filter_anomalies", None)
+        self.negation_operation = kwargs.get("negation_operation", None)
         self.alert_conditions = kwargs.get("alert_conditions", None)
         self.alert_snooze_condition = kwargs.get("alert_snooze_condition", None)
 
@@ -556,7 +556,7 @@ class MetricAlertConfiguration(object):
         return cls(
             detection_configuration_id=config.anomaly_detection_configuration_id,
             alert_scope=MetricAnomalyAlertScope._from_generated(config),
-            use_detection_result_to_filter_anomalies=config.negation_operation,
+            negation_operation=config.negation_operation,
             alert_snooze_condition=MetricAnomalyAlertSnoozeCondition(
                 auto_snooze=config.snooze_filter.auto_snooze,
                 snooze_scope=config.snooze_filter.snooze_scope,
@@ -588,7 +588,7 @@ class MetricAlertConfiguration(object):
                 period=self.alert_scope.top_n_group_in_scope.period,
                 min_top_count=self.alert_scope.top_n_group_in_scope.min_top_count,
             ) if self.alert_scope.top_n_group_in_scope else None,
-            negation_operation=self.use_detection_result_to_filter_anomalies,
+            negation_operation=self.negation_operation,
             severity_filter=_SeverityCondition(
                 max_alert_severity=self.alert_conditions.severity_condition.max_alert_severity,
                 min_alert_severity=self.alert_conditions.severity_condition.min_alert_severity

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_anomaly_alert_config_async.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_anomaly_alert_config_async.py
@@ -58,7 +58,7 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorAdministrati
                 self.assertIsNotNone(alert_config.name)
                 self.assertEqual(len(alert_config.metric_alert_configurations), 1)
                 self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-                self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+                self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "TopN")
                 self.assertEqual(
                     alert_config.metric_alert_configurations[0].alert_scope.top_n_group_in_scope.min_top_count, 9)
@@ -120,7 +120,7 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorAdministrati
                 self.assertIsNotNone(alert_config.name)
                 self.assertEqual(len(alert_config.metric_alert_configurations), 1)
                 self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-                self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+                self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "TopN")
                 self.assertEqual(
                     alert_config.metric_alert_configurations[0].alert_scope.top_n_group_in_scope.min_top_count, 9)
@@ -182,7 +182,7 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorAdministrati
                 self.assertIsNotNone(alert_config.name)
                 self.assertEqual(len(alert_config.metric_alert_configurations), 1)
                 self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-                self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+                self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "TopN")
                 self.assertEqual(
                     alert_config.metric_alert_configurations[0].alert_scope.top_n_group_in_scope.min_top_count, 9)
@@ -243,7 +243,7 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorAdministrati
                 self.assertIsNotNone(alert_config.name)
                 self.assertEqual(len(alert_config.metric_alert_configurations), 1)
                 self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-                self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+                self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "TopN")
                 self.assertEqual(
                     alert_config.metric_alert_configurations[0].alert_scope.top_n_group_in_scope.min_top_count, 9)
@@ -297,7 +297,7 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorAdministrati
                 self.assertIsNotNone(alert_config.name)
                 self.assertEqual(len(alert_config.metric_alert_configurations), 1)
                 self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-                self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+                self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "TopN")
                 self.assertEqual(
                     alert_config.metric_alert_configurations[0].alert_scope.top_n_group_in_scope.min_top_count, 9)
@@ -350,7 +350,7 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorAdministrati
                 self.assertIsNotNone(alert_config.name)
                 self.assertEqual(len(alert_config.metric_alert_configurations), 1)
                 self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-                self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+                self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "WholeSeries")
                 self.assertIsNotNone(
                     alert_config.metric_alert_configurations[0].alert_conditions.metric_boundary_condition.companion_metric_id)
@@ -403,7 +403,7 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorAdministrati
                 self.assertIsNotNone(alert_config.name)
                 self.assertEqual(len(alert_config.metric_alert_configurations), 1)
                 self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-                self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+                self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "WholeSeries")
                 self.assertIsNotNone(
                     alert_config.metric_alert_configurations[0].alert_conditions.metric_boundary_condition.companion_metric_id)
@@ -456,7 +456,7 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorAdministrati
                 self.assertIsNotNone(alert_config.name)
                 self.assertEqual(len(alert_config.metric_alert_configurations), 1)
                 self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-                self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+                self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "WholeSeries")
                 self.assertIsNotNone(
                     alert_config.metric_alert_configurations[0].alert_conditions.metric_boundary_condition.companion_metric_id)
@@ -508,7 +508,7 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorAdministrati
                 self.assertIsNotNone(alert_config.name)
                 self.assertEqual(len(alert_config.metric_alert_configurations), 1)
                 self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-                self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+                self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "WholeSeries")
                 self.assertEqual(
                     alert_config.metric_alert_configurations[0].alert_conditions.severity_condition.min_alert_severity, "Low")
@@ -557,7 +557,7 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorAdministrati
                 self.assertIsNotNone(alert_config.name)
                 self.assertEqual(len(alert_config.metric_alert_configurations), 1)
                 self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-                self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+                self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "SeriesGroup")
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.series_group_in_scope, {'city': 'Shenzhen'})
                 self.assertIsNotNone(
@@ -612,7 +612,7 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorAdministrati
                 self.assertIsNotNone(alert_config.name)
                 self.assertEqual(len(alert_config.metric_alert_configurations), 1)
                 self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-                self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+                self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "SeriesGroup")
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.series_group_in_scope, {'city': 'Shenzhen'})
                 self.assertIsNotNone(
@@ -667,7 +667,7 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorAdministrati
                 self.assertIsNotNone(alert_config.name)
                 self.assertEqual(len(alert_config.metric_alert_configurations), 1)
                 self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-                self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+                self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "SeriesGroup")
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.series_group_in_scope, {'city': 'Shenzhen'})
                 self.assertIsNotNone(
@@ -721,7 +721,7 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorAdministrati
                 self.assertIsNotNone(alert_config.name)
                 self.assertEqual(len(alert_config.metric_alert_configurations), 1)
                 self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-                self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+                self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "SeriesGroup")
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.series_group_in_scope, {'city': 'Shenzhen'})
                 self.assertEqual(
@@ -801,7 +801,7 @@ class TestMetricsAdvisorAdministrationClientAsync(TestMetricsAdvisorAdministrati
                 self.assertIsNotNone(alert_config.name)
                 self.assertEqual(len(alert_config.metric_alert_configurations), 3)
                 self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-                self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+                self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
                 self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "TopN")
                 self.assertEqual(
                     alert_config.metric_alert_configurations[0].alert_scope.top_n_group_in_scope.min_top_count, 9)

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_anomaly_alert_config.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_anomaly_alert_config.py
@@ -57,7 +57,7 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorAdministrationCli
             self.assertIsNotNone(alert_config.name)
             self.assertEqual(len(alert_config.metric_alert_configurations), 1)
             self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-            self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+            self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "TopN")
             self.assertEqual(
                 alert_config.metric_alert_configurations[0].alert_scope.top_n_group_in_scope.min_top_count, 9)
@@ -117,7 +117,7 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorAdministrationCli
             self.assertIsNotNone(alert_config.name)
             self.assertEqual(len(alert_config.metric_alert_configurations), 1)
             self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-            self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+            self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "TopN")
             self.assertEqual(
                 alert_config.metric_alert_configurations[0].alert_scope.top_n_group_in_scope.min_top_count, 9)
@@ -177,7 +177,7 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorAdministrationCli
             self.assertIsNotNone(alert_config.name)
             self.assertEqual(len(alert_config.metric_alert_configurations), 1)
             self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-            self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+            self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "TopN")
             self.assertEqual(
                 alert_config.metric_alert_configurations[0].alert_scope.top_n_group_in_scope.min_top_count, 9)
@@ -236,7 +236,7 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorAdministrationCli
             self.assertIsNotNone(alert_config.name)
             self.assertEqual(len(alert_config.metric_alert_configurations), 1)
             self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-            self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+            self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "TopN")
             self.assertEqual(
                 alert_config.metric_alert_configurations[0].alert_scope.top_n_group_in_scope.min_top_count, 9)
@@ -288,7 +288,7 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorAdministrationCli
             self.assertIsNotNone(alert_config.name)
             self.assertEqual(len(alert_config.metric_alert_configurations), 1)
             self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-            self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+            self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "TopN")
             self.assertEqual(
                 alert_config.metric_alert_configurations[0].alert_scope.top_n_group_in_scope.min_top_count, 9)
@@ -339,7 +339,7 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorAdministrationCli
             self.assertIsNotNone(alert_config.name)
             self.assertEqual(len(alert_config.metric_alert_configurations), 1)
             self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-            self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+            self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "WholeSeries")
             self.assertIsNotNone(
                 alert_config.metric_alert_configurations[0].alert_conditions.metric_boundary_condition.companion_metric_id)
@@ -390,7 +390,7 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorAdministrationCli
             self.assertIsNotNone(alert_config.name)
             self.assertEqual(len(alert_config.metric_alert_configurations), 1)
             self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-            self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+            self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "WholeSeries")
             self.assertIsNotNone(
                 alert_config.metric_alert_configurations[0].alert_conditions.metric_boundary_condition.companion_metric_id)
@@ -441,7 +441,7 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorAdministrationCli
             self.assertIsNotNone(alert_config.name)
             self.assertEqual(len(alert_config.metric_alert_configurations), 1)
             self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-            self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+            self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "WholeSeries")
             self.assertIsNotNone(
                 alert_config.metric_alert_configurations[0].alert_conditions.metric_boundary_condition.companion_metric_id)
@@ -491,7 +491,7 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorAdministrationCli
             self.assertIsNotNone(alert_config.name)
             self.assertEqual(len(alert_config.metric_alert_configurations), 1)
             self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-            self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+            self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "WholeSeries")
             self.assertEqual(
                 alert_config.metric_alert_configurations[0].alert_conditions.severity_condition.min_alert_severity, "Low")
@@ -538,7 +538,7 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorAdministrationCli
             self.assertIsNotNone(alert_config.name)
             self.assertEqual(len(alert_config.metric_alert_configurations), 1)
             self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-            self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+            self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "SeriesGroup")
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.series_group_in_scope, {'city': 'Shenzhen'})
             self.assertIsNotNone(
@@ -591,7 +591,7 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorAdministrationCli
             self.assertIsNotNone(alert_config.name)
             self.assertEqual(len(alert_config.metric_alert_configurations), 1)
             self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-            self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+            self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "SeriesGroup")
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.series_group_in_scope, {'city': 'Shenzhen'})
             self.assertIsNotNone(
@@ -644,7 +644,7 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorAdministrationCli
             self.assertIsNotNone(alert_config.name)
             self.assertEqual(len(alert_config.metric_alert_configurations), 1)
             self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-            self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+            self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "SeriesGroup")
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.series_group_in_scope, {'city': 'Shenzhen'})
             self.assertIsNotNone(
@@ -696,7 +696,7 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorAdministrationCli
             self.assertIsNotNone(alert_config.name)
             self.assertEqual(len(alert_config.metric_alert_configurations), 1)
             self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-            self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+            self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "SeriesGroup")
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.series_group_in_scope, {'city': 'Shenzhen'})
             self.assertEqual(
@@ -774,7 +774,7 @@ class TestMetricsAdvisorAdministrationClient(TestMetricsAdvisorAdministrationCli
             self.assertIsNotNone(alert_config.name)
             self.assertEqual(len(alert_config.metric_alert_configurations), 3)
             self.assertIsNotNone(alert_config.metric_alert_configurations[0].detection_configuration_id)
-            self.assertFalse(alert_config.metric_alert_configurations[0].use_detection_result_to_filter_anomalies)
+            self.assertFalse(alert_config.metric_alert_configurations[0].negation_operation)
             self.assertEqual(alert_config.metric_alert_configurations[0].alert_scope.scope_type, "TopN")
             self.assertEqual(
                 alert_config.metric_alert_configurations[0].alert_scope.top_n_group_in_scope.min_top_count, 9)


### PR DESCRIPTION
Renaming `use_detection_result_to_filter_anomalies` back to the service naming - `negation_operation` to align with Java