### PR TITLE
[KeyVault] Add Status Methods to Query Backup and Restore Operations

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
@@ -93,3 +93,30 @@ class KeyVaultBackupClient(KeyVaultClientBase):
             polling=LROBasePolling(lro_algorithms=[KeyVaultBackupClientPolling()], timeout=polling_interval, **kwargs),
             **kwargs
         )
+
+    def full_backup_status(self, job_id, **kwargs):
+        """Returns the status of a full backup operation.
+
+        :param job_id: The job ID returned as part of the backup request.
+        :type job_id: str
+        :return: The full backup operation status as a :class:`BackupOperation`
+        :rtype: ~azure.keyvault.v7_2.models.FullBackupOperation
+        """
+        return self._client.full_backup_status(
+            vault_base_url=self._vault_url, 
+            job_id=job_id, 
+            **kwargs
+        )
+
+    def restore_status(self, job_id, **kwargs):
+        """Returns the status of a restore operation.
+
+        :param job_id: The job ID returned as part of the restore operation.
+        :type job_id: str
+        :return: The restore operation status as a :class:`RestoreOperation`
+        :rtype: ~azure.keyvault.v7_2.models.RestoreOperation
+        """
+        return self._client.restore_status(
+            vault_base_url=self.vault_url,
+            job_id=job_id
+        )

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
@@ -94,7 +94,7 @@ class KeyVaultBackupClient(KeyVaultClientBase):
             **kwargs
         )
 
-    def full_backup_status(self, job_id, **kwargs):
+    def get_backup_status(self, job_id, **kwargs):
         # type: (str, **Any) -> BackupOperation
         """Returns the status of a full backup operation.
 
@@ -110,7 +110,7 @@ class KeyVaultBackupClient(KeyVaultClientBase):
             **kwargs
         )
 
-    def restore_status(self, job_id, **kwargs):
+    def get_restore_status(self, job_id, **kwargs):
         # type: (str, **Any) -> RestoreOperation
         """Returns the status of a restore operation.
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
@@ -118,5 +118,6 @@ class KeyVaultBackupClient(KeyVaultClientBase):
         """
         return self._client.restore_status(
             vault_base_url=self.vault_url,
-            job_id=job_id
+            job_id=job_id,
+            **kwargs
         )

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
@@ -95,29 +95,33 @@ class KeyVaultBackupClient(KeyVaultClientBase):
         )
 
     def full_backup_status(self, job_id, **kwargs):
+        # type: (str, **Any) -> BackupOperation
         """Returns the status of a full backup operation.
 
-        :param job_id: The job ID returned as part of the backup request.
+        :param job_id: The job ID returned as part of the backup request
         :type job_id: str
         :return: The full backup operation status as a :class:`BackupOperation`
-        :rtype: ~azure.keyvault.v7_2.models.FullBackupOperation
+        :rtype: BackupOperation
         """
         return self._client.full_backup_status(
-            vault_base_url=self._vault_url, 
-            job_id=job_id, 
+            vault_base_url=self._vault_url,
+            job_id=job_id,
+            cls=BackupOperation._wrap_generated,
             **kwargs
         )
 
     def restore_status(self, job_id, **kwargs):
+        # type: (str, **Any) -> RestoreOperation
         """Returns the status of a restore operation.
 
-        :param job_id: The job ID returned as part of the restore operation.
+        :param job_id: The job ID returned as part of the restore request
         :type job_id: str
         :return: The restore operation status as a :class:`RestoreOperation`
-        :rtype: ~azure.keyvault.v7_2.models.RestoreOperation
+        :rtype: RestoreOperation
         """
         return self._client.restore_status(
             vault_base_url=self.vault_url,
             job_id=job_id,
+            cls=RestoreOperation._wrap_generated,
             **kwargs
         )

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
@@ -103,7 +103,7 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
             **kwargs
         )
 
-    async def full_backup_status(
+    async def get_backup_status(
         self, job_id: str, **kwargs: "Any"
     ) -> "BackupOperation":
         """Returns the status of a full backup operation.
@@ -119,7 +119,7 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
             **kwargs
         )
 
-    async def restore_status(
+    async def get_restore_status(
         self, job_id: str, **kwargs: "Any"
     ) -> "RestoreOperation":
         """Returns the status of a restore operation.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
@@ -102,3 +102,35 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
             ),
             **kwargs
         )
+
+    async def full_backup_status(
+        self, job_id: str, **kwargs: "Any"
+    ) -> "BackupOperation":
+        """Returns the status of a full backup operation.
+
+        :param str job_id: The job ID returned as part of the backup request
+        :returns: The full backup operation status as a :class:`BackupOperation`
+        :rtype: BackupOperation
+        """
+        return await self._client.full_backup_status(
+            vault_base_url=self._vault_url,
+            job_id=job_id,
+            cls=BackupOperation._wrap_generated,
+            **kwargs
+        )
+
+    async def restore_status(
+        self, job_id: str, **kwargs: "Any"
+    ) -> "RestoreOperation":
+        """Returns the status of a restore operation.
+
+        :param str job_id: The ID returned as part of the restore request
+        :returns: The restore operation status as a :class:`RestoreOperation`
+        :rtype: RestoreOperation
+        """
+        return await self._client.restore_status(
+            vault_base_url=self._vault_url,
+            job_id=job_id,
+            cls=RestoreOperation._wrap_generated,
+            **kwargs
+        )

--- a/sdk/keyvault/azure-keyvault-administration/tests/recordings/test_backup_client.test_full_backup_and_restore.yaml
+++ b/sdk/keyvault/azure-keyvault-administration/tests/recordings/test_backup_client.test_full_backup_and_restore.yaml
@@ -43,103 +43,8 @@ interactions:
       code: 401
       message: Unauthorized
 - request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-identity/1.5.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0/.well-known/openid-configuration
-  response:
-    body:
-      string: '{"token_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code
-        id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}'
-    headers:
-      access-control-allow-methods:
-      - GET, OPTIONS
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - max-age=86400, private
-      content-length:
-      - '1651'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 30 Sep 2020 23:58:33 GMT
-      p3p:
-      - CP="DSP CUR OTPi IND OTRi ONL FIN"
-      set-cookie:
-      - fpc=Atj-layKrThAm590nA75tDs; expires=Fri, 30-Oct-2020 23:58:33 GMT; path=/;
-        secure; HttpOnly; SameSite=None
-      - esctx=AQABAAAAAAB2UyzwtQEKR7-rWbgdcBZIdrHBkgdKkmA9xgym0OWrPyxdi56FsVdjQcA61oJCWHjUIZmIJOt9ADM8WOgSunmiUSJuJ-Qx3VDN-EnMVIbR9ccjx2duAvzPrPtizadgUN6zVZEE1EX7bAmkv3xsjIiz_1l9iEwAuVRhQkXWFTq6_TCfTWTFLjanPiks1cHq_gQgAA;
-        domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None
-      - x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly
-      - stsservicecookie=estsfd; path=/; secure; samesite=none; httponly
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ests-server:
-      - 2.1.11086.7 - SCUS ProdSlices
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - stsservicecookie=estsfd; x-ms-gateway-slice=estsfd; fpc=Atj-layKrThAm590nA75tDs;
-        esctx=AQABAAAAAAB2UyzwtQEKR7-rWbgdcBZIdrHBkgdKkmA9xgym0OWrPyxdi56FsVdjQcA61oJCWHjUIZmIJOt9ADM8WOgSunmiUSJuJ-Qx3VDN-EnMVIbR9ccjx2duAvzPrPtizadgUN6zVZEE1EX7bAmkv3xsjIiz_1l9iEwAuVRhQkXWFTq6_TCfTWTFLjanPiks1cHq_gQgAA
-      User-Agent:
-      - azsdk-python-identity/1.5.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=https://login.microsoftonline.com/common/oauth2/authorize
-  response:
-    body:
-      string: '{"tenant_discovery_endpoint":"https://login.microsoftonline.com/common/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}'
-    headers:
-      access-control-allow-methods:
-      - GET, OPTIONS
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - max-age=86400, private
-      content-length:
-      - '945'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 30 Sep 2020 23:58:33 GMT
-      p3p:
-      - CP="DSP CUR OTPi IND OTRi ONL FIN"
-      set-cookie:
-      - fpc=Atj-layKrThAm590nA75tDs; expires=Fri, 30-Oct-2020 23:58:33 GMT; path=/;
-        secure; HttpOnly; SameSite=None
-      - x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly
-      - stsservicecookie=estsfd; path=/; secure; samesite=none; httponly
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ests-server:
-      - 2.1.11086.7 - WUS2 ProdSlices
-    status:
-      code: 200
-      message: OK
-- request:
-    body: 'b''b\''b\\\''{"token": "redacted", "storageResourceUri": "https://storname.blob.core.windows.net/containerhl7ndvhj2hhrguq"}\\\''\'''''
+    body: '{"storageResourceUri": "https://storname.blob.core.windows.net/containertzdnut7zi4qw3kp",
+      "token": "redacted"}'
     headers:
       Accept:
       - application/json
@@ -148,7 +53,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '233'
+      - '235'
       Content-Type:
       - application/json
       User-Agent:
@@ -157,10 +62,10 @@ interactions:
     uri: https://managedhsm/backup?api-version=7.2-preview
   response:
     body:
-      string: '{"status":"InProgress","statusDetails":null,"error":{"code":null,"message":null,"innererror":null},"startTime":1601510314,"endTime":null,"jobId":"12e2c7c86b1c4ac0b41428a3ff67429f","azureStorageBlobContainerUri":null}'
+      string: '{"status":"InProgress","statusDetails":null,"error":{"code":null,"message":null,"innererror":null},"startTime":1601598856,"endTime":null,"jobId":"9f79064b49724b1c9896ebcd5222477d","azureStorageBlobContainerUri":null}'
     headers:
       azure-asyncoperation:
-      - https://managedhsm/backup/12e2c7c86b1c4ac0b41428a3ff67429f/pending
+      - https://managedhsm/backup/9f79064b49724b1c9896ebcd5222477d/pending
       cache-control:
       - no-cache
       content-length:
@@ -170,7 +75,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:58:33 GMT
+      - Fri, 02 Oct 2020 00:34:16 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -184,7 +89,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '661'
+      - '2444'
     status:
       code: 202
       message: ''
@@ -200,10 +105,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/backup/12e2c7c86b1c4ac0b41428a3ff67429f/pending?api-version=7.2-preview
+    uri: https://managedhsm/backup/9f79064b49724b1c9896ebcd5222477d/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"azureStorageBlobContainerUri":null,"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"12e2c7c86b1c4ac0b41428a3ff67429f","startTime":1601510314,"status":"InProgress","statusDetails":null}'
+      string: '{"azureStorageBlobContainerUri":null,"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"9f79064b49724b1c9896ebcd5222477d","startTime":1601598856,"status":"InProgress","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
@@ -214,7 +119,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:58:34 GMT
+      - Fri, 02 Oct 2020 00:34:17 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -230,7 +135,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '476'
+      - '1117'
     status:
       code: 200
       message: OK
@@ -246,10 +151,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/backup/12e2c7c86b1c4ac0b41428a3ff67429f/pending
+    uri: https://managedhsm/backup/9f79064b49724b1c9896ebcd5222477d/pending
   response:
     body:
-      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerhl7ndvhj2hhrguq/mhsm-chlowehsm-2020093023583440","endTime":1601510323,"error":null,"jobId":"12e2c7c86b1c4ac0b41428a3ff67429f","startTime":1601510314,"status":"Succeeded","statusDetails":null}'
+      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containertzdnut7zi4qw3kp/mhsm-chlowehsm-2020100200341740","endTime":1601598867,"error":null,"jobId":"9f79064b49724b1c9896ebcd5222477d","startTime":1601598856,"status":"Succeeded","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
@@ -260,7 +165,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:58:44 GMT
+      - Fri, 02 Oct 2020 00:34:27 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -276,7 +181,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '477'
+      - '1084'
     status:
       code: 200
       message: OK
@@ -292,10 +197,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/backup/12e2c7c86b1c4ac0b41428a3ff67429f/pending?api-version=7.2-preview
+    uri: https://managedhsm/backup/9f79064b49724b1c9896ebcd5222477d/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerhl7ndvhj2hhrguq/mhsm-chlowehsm-2020093023583440","endTime":1601510323,"error":null,"jobId":"12e2c7c86b1c4ac0b41428a3ff67429f","startTime":1601510314,"status":"Succeeded","statusDetails":null}'
+      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containertzdnut7zi4qw3kp/mhsm-chlowehsm-2020100200341740","endTime":1601598867,"error":null,"jobId":"9f79064b49724b1c9896ebcd5222477d","startTime":1601598856,"status":"Succeeded","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
@@ -306,7 +211,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:58:45 GMT
+      - Fri, 02 Oct 2020 00:34:28 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -322,13 +227,14 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '469'
+      - '515'
     status:
       code: 200
       message: OK
 - request:
-    body: 'b''b\''b\\\''{"folderToRestore": "mhsm-chlowehsm-2020093023583440", "sasTokenParameters":
-      {"token": "redacted", "storageResourceUri": "https://storname.blob.core.windows.net/containerhl7ndvhj2hhrguq"}}\\\''\'''''
+    body: '{"folderToRestore": "mhsm-chlowehsm-2020100200341740", "sasTokenParameters":
+      {"storageResourceUri": "https://storname.blob.core.windows.net/containertzdnut7zi4qw3kp",
+      "token": "redacted"}}'
     headers:
       Accept:
       - application/json
@@ -337,7 +243,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '311'
+      - '313'
       Content-Type:
       - application/json
       User-Agent:
@@ -346,10 +252,10 @@ interactions:
     uri: https://managedhsm/restore?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"90e115e27fc44f08ae7e689232a92b26","startTime":1601510326,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"08089b7944ef471ca45e77921ff1f5df","startTime":1601598870,"status":"InProgress","statusDetails":null}'
     headers:
       azure-asyncoperation:
-      - https://managedhsm/restore/90e115e27fc44f08ae7e689232a92b26/pending
+      - https://managedhsm/restore/08089b7944ef471ca45e77921ff1f5df/pending
       cache-control:
       - no-cache
       content-length:
@@ -359,7 +265,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:58:45 GMT
+      - Fri, 02 Oct 2020 00:34:29 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -373,7 +279,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '711'
+      - '1388'
     status:
       code: 202
       message: ''
@@ -389,10 +295,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/90e115e27fc44f08ae7e689232a92b26/pending?api-version=7.2-preview
+    uri: https://managedhsm/restore/08089b7944ef471ca45e77921ff1f5df/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"90e115e27fc44f08ae7e689232a92b26","startTime":1601510326,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"08089b7944ef471ca45e77921ff1f5df","startTime":1601598870,"status":"InProgress","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
@@ -403,7 +309,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:58:46 GMT
+      - Fri, 02 Oct 2020 00:34:30 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -419,7 +325,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '468'
+      - '985'
     status:
       code: 200
       message: OK
@@ -435,10 +341,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/90e115e27fc44f08ae7e689232a92b26/pending
+    uri: https://managedhsm/restore/08089b7944ef471ca45e77921ff1f5df/pending
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"90e115e27fc44f08ae7e689232a92b26","startTime":1601510326,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"08089b7944ef471ca45e77921ff1f5df","startTime":1601598870,"status":"InProgress","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
@@ -449,7 +355,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:58:57 GMT
+      - Fri, 02 Oct 2020 00:34:40 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -465,7 +371,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '558'
+      - '497'
     status:
       code: 200
       message: OK
@@ -481,10 +387,56 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/90e115e27fc44f08ae7e689232a92b26/pending
+    uri: https://managedhsm/restore/08089b7944ef471ca45e77921ff1f5df/pending
   response:
     body:
-      string: '{"endTime":1601510337,"error":null,"jobId":"90e115e27fc44f08ae7e689232a92b26","startTime":1601510326,"status":"Succeeded","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"08089b7944ef471ca45e77921ff1f5df","startTime":1601598870,"status":"InProgress","statusDetails":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '180'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 02 Oct 2020 00:34:45 GMT
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-build-version:
+      - 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info:
+      - addr=162.211.216.102
+      x-ms-keyvault-region:
+      - eastus2
+      x-ms-server-latency:
+      - '506'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/restore/08089b7944ef471ca45e77921ff1f5df/pending
+  response:
+    body:
+      string: '{"endTime":1601598887,"error":null,"jobId":"08089b7944ef471ca45e77921ff1f5df","startTime":1601598870,"status":"Succeeded","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
@@ -495,7 +447,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:59:03 GMT
+      - Fri, 02 Oct 2020 00:34:51 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -511,7 +463,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '1045'
+      - '472'
     status:
       code: 200
       message: OK
@@ -527,10 +479,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/90e115e27fc44f08ae7e689232a92b26/pending?api-version=7.2-preview
+    uri: https://managedhsm/restore/08089b7944ef471ca45e77921ff1f5df/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":1601510337,"error":null,"jobId":"90e115e27fc44f08ae7e689232a92b26","startTime":1601510326,"status":"Succeeded","statusDetails":null}'
+      string: '{"endTime":1601598887,"error":null,"jobId":"08089b7944ef471ca45e77921ff1f5df","startTime":1601598870,"status":"Succeeded","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
@@ -541,7 +493,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:59:04 GMT
+      - Fri, 02 Oct 2020 00:34:52 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -557,7 +509,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '749'
+      - '487'
     status:
       code: 200
       message: OK

--- a/sdk/keyvault/azure-keyvault-administration/tests/recordings/test_backup_client.test_full_backup_and_restore.yaml
+++ b/sdk/keyvault/azure-keyvault-administration/tests/recordings/test_backup_client.test_full_backup_and_restore.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://managedhsm/backup?api-version=7.2-preview
   response:
@@ -31,20 +31,115 @@ interactions:
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer authorization="https://login.windows-ppe.net/f686d426-8d16-42db-81b7-ab578e110ccd",
-        resource="https://managedhsm-int.azure-int.net"
+      - Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://managedhsm.azure.net"
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
       x-ms-server-latency:
-      - '2'
+      - '1'
     status:
       code: 401
       message: Unauthorized
 - request:
-    body: '{"storageResourceUri": "https://storname.blob.core.windows.net/containerlpibiggddqawmbw",
-      "token": "redacted"}'
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-identity/1.5.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0/.well-known/openid-configuration
+  response:
+    body:
+      string: '{"token_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code
+        id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}'
+    headers:
+      access-control-allow-methods:
+      - GET, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - max-age=86400, private
+      content-length:
+      - '1651'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 30 Sep 2020 23:58:33 GMT
+      p3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      set-cookie:
+      - fpc=Atj-layKrThAm590nA75tDs; expires=Fri, 30-Oct-2020 23:58:33 GMT; path=/;
+        secure; HttpOnly; SameSite=None
+      - esctx=AQABAAAAAAB2UyzwtQEKR7-rWbgdcBZIdrHBkgdKkmA9xgym0OWrPyxdi56FsVdjQcA61oJCWHjUIZmIJOt9ADM8WOgSunmiUSJuJ-Qx3VDN-EnMVIbR9ccjx2duAvzPrPtizadgUN6zVZEE1EX7bAmkv3xsjIiz_1l9iEwAuVRhQkXWFTq6_TCfTWTFLjanPiks1cHq_gQgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly
+      - stsservicecookie=estsfd; path=/; secure; samesite=none; httponly
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.11086.7 - SCUS ProdSlices
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - stsservicecookie=estsfd; x-ms-gateway-slice=estsfd; fpc=Atj-layKrThAm590nA75tDs;
+        esctx=AQABAAAAAAB2UyzwtQEKR7-rWbgdcBZIdrHBkgdKkmA9xgym0OWrPyxdi56FsVdjQcA61oJCWHjUIZmIJOt9ADM8WOgSunmiUSJuJ-Qx3VDN-EnMVIbR9ccjx2duAvzPrPtizadgUN6zVZEE1EX7bAmkv3xsjIiz_1l9iEwAuVRhQkXWFTq6_TCfTWTFLjanPiks1cHq_gQgAA
+      User-Agent:
+      - azsdk-python-identity/1.5.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=https://login.microsoftonline.com/common/oauth2/authorize
+  response:
+    body:
+      string: '{"tenant_discovery_endpoint":"https://login.microsoftonline.com/common/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}'
+    headers:
+      access-control-allow-methods:
+      - GET, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - max-age=86400, private
+      content-length:
+      - '945'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 30 Sep 2020 23:58:33 GMT
+      p3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      set-cookie:
+      - fpc=Atj-layKrThAm590nA75tDs; expires=Fri, 30-Oct-2020 23:58:33 GMT; path=/;
+        secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly
+      - stsservicecookie=estsfd; path=/; secure; samesite=none; httponly
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.11086.7 - WUS2 ProdSlices
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''b\''b\\\''{"token": "redacted", "storageResourceUri": "https://storname.blob.core.windows.net/containerhl7ndvhj2hhrguq"}\\\''\'''''
     headers:
       Accept:
       - application/json
@@ -53,19 +148,19 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '235'
+      - '233'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://managedhsm/backup?api-version=7.2-preview
   response:
     body:
-      string: '{"status":"InProgress","statusDetails":null,"error":{"code":null,"message":null,"innererror":null},"startTime":1599693259,"endTime":null,"jobId":"0c6890ada4cf411987b1c8fff2e8d20f","azureStorageBlobContainerUri":null}'
+      string: '{"status":"InProgress","statusDetails":null,"error":{"code":null,"message":null,"innererror":null},"startTime":1601510314,"endTime":null,"jobId":"12e2c7c86b1c4ac0b41428a3ff67429f","azureStorageBlobContainerUri":null}'
     headers:
       azure-asyncoperation:
-      - https://managedhsm/backup/0c6890ada4cf411987b1c8fff2e8d20f/pending
+      - https://managedhsm/backup/12e2c7c86b1c4ac0b41428a3ff67429f/pending
       cache-control:
       - no-cache
       content-length:
@@ -75,7 +170,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 09 Sep 2020 23:14:19 GMT
+      - Wed, 30 Sep 2020 23:58:33 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -85,14 +180,60 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-keyvault-network-info:
-      - addr=24.17.201.78
+      - addr=162.211.216.102
       x-ms-keyvault-region:
-      - EASTUS
+      - eastus2
       x-ms-server-latency:
-      - '962'
+      - '661'
     status:
       code: 202
       message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/backup/12e2c7c86b1c4ac0b41428a3ff67429f/pending?api-version=7.2-preview
+  response:
+    body:
+      string: '{"azureStorageBlobContainerUri":null,"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"12e2c7c86b1c4ac0b41428a3ff67429f","startTime":1601510314,"status":"InProgress","statusDetails":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '216'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 30 Sep 2020 23:58:34 GMT
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-build-version:
+      - 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info:
+      - addr=162.211.216.102
+      x-ms-keyvault-region:
+      - eastus2
+      x-ms-server-latency:
+      - '476'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -103,23 +244,23 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/backup/0c6890ada4cf411987b1c8fff2e8d20f/pending
+    uri: https://managedhsm/backup/12e2c7c86b1c4ac0b41428a3ff67429f/pending
   response:
     body:
-      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerlpibiggddqawmbw/mhsm-chriss-eu2-2020090923141950","endTime":1599693269,"error":null,"jobId":"0c6890ada4cf411987b1c8fff2e8d20f","startTime":1599693259,"status":"Succeeded","statusDetails":null}'
+      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerhl7ndvhj2hhrguq/mhsm-chlowehsm-2020093023583440","endTime":1601510323,"error":null,"jobId":"12e2c7c86b1c4ac0b41428a3ff67429f","startTime":1601510314,"status":"Succeeded","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '289'
+      - '288'
       content-security-policy:
       - default-src 'self'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 09 Sep 2020 23:14:29 GMT
+      - Wed, 30 Sep 2020 23:58:44 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -129,20 +270,65 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-build-version:
-      - 1.0.20200909-2-c73be597-develop
+      - 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info:
-      - addr=24.17.201.78
+      - addr=162.211.216.102
       x-ms-keyvault-region:
-      - EASTUS
+      - eastus2
       x-ms-server-latency:
-      - '599'
+      - '477'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"folderToRestore": "mhsm-chriss-eu2-2020090923141950", "sasTokenParameters":
-      {"storageResourceUri": "https://storname.blob.core.windows.net/containerlpibiggddqawmbw",
-      "token": "redacted"}}'
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/backup/12e2c7c86b1c4ac0b41428a3ff67429f/pending?api-version=7.2-preview
+  response:
+    body:
+      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerhl7ndvhj2hhrguq/mhsm-chlowehsm-2020093023583440","endTime":1601510323,"error":null,"jobId":"12e2c7c86b1c4ac0b41428a3ff67429f","startTime":1601510314,"status":"Succeeded","statusDetails":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '288'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 30 Sep 2020 23:58:45 GMT
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-build-version:
+      - 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info:
+      - addr=162.211.216.102
+      x-ms-keyvault-region:
+      - eastus2
+      x-ms-server-latency:
+      - '469'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''b\''b\\\''{"folderToRestore": "mhsm-chlowehsm-2020093023583440", "sasTokenParameters":
+      {"token": "redacted", "storageResourceUri": "https://storname.blob.core.windows.net/containerhl7ndvhj2hhrguq"}}\\\''\'''''
     headers:
       Accept:
       - application/json
@@ -151,19 +337,19 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '314'
+      - '311'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://managedhsm/restore?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"f45c5ed12efc498990690cc92ed43684","startTime":1599693271,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"90e115e27fc44f08ae7e689232a92b26","startTime":1601510326,"status":"InProgress","statusDetails":null}'
     headers:
       azure-asyncoperation:
-      - https://managedhsm/restore/f45c5ed12efc498990690cc92ed43684/pending
+      - https://managedhsm/restore/90e115e27fc44f08ae7e689232a92b26/pending
       cache-control:
       - no-cache
       content-length:
@@ -173,7 +359,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 09 Sep 2020 23:14:30 GMT
+      - Wed, 30 Sep 2020 23:58:45 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -183,11 +369,11 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-keyvault-network-info:
-      - addr=24.17.201.78
+      - addr=162.211.216.102
       x-ms-keyvault-region:
-      - EASTUS
+      - eastus2
       x-ms-server-latency:
-      - '812'
+      - '711'
     status:
       code: 202
       message: ''
@@ -195,18 +381,18 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/f45c5ed12efc498990690cc92ed43684/pending
+    uri: https://managedhsm/restore/90e115e27fc44f08ae7e689232a92b26/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"f45c5ed12efc498990690cc92ed43684","startTime":1599693271,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"90e115e27fc44f08ae7e689232a92b26","startTime":1601510326,"status":"InProgress","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
@@ -217,7 +403,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 09 Sep 2020 23:14:42 GMT
+      - Wed, 30 Sep 2020 23:58:46 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -227,13 +413,13 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-build-version:
-      - 1.0.20200909-2-c73be597-develop
+      - 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info:
-      - addr=24.17.201.78
+      - addr=162.211.216.102
       x-ms-keyvault-region:
-      - EASTUS
+      - eastus2
       x-ms-server-latency:
-      - '534'
+      - '468'
     status:
       code: 200
       message: OK
@@ -247,12 +433,58 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/f45c5ed12efc498990690cc92ed43684/pending
+    uri: https://managedhsm/restore/90e115e27fc44f08ae7e689232a92b26/pending
   response:
     body:
-      string: '{"endTime":1599693288,"error":null,"jobId":"f45c5ed12efc498990690cc92ed43684","startTime":1599693271,"status":"Succeeded","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"90e115e27fc44f08ae7e689232a92b26","startTime":1601510326,"status":"InProgress","statusDetails":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '180'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 30 Sep 2020 23:58:57 GMT
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-build-version:
+      - 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info:
+      - addr=162.211.216.102
+      x-ms-keyvault-region:
+      - eastus2
+      x-ms-server-latency:
+      - '558'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/restore/90e115e27fc44f08ae7e689232a92b26/pending
+  response:
+    body:
+      string: '{"endTime":1601510337,"error":null,"jobId":"90e115e27fc44f08ae7e689232a92b26","startTime":1601510326,"status":"Succeeded","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
@@ -263,7 +495,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 09 Sep 2020 23:14:50 GMT
+      - Wed, 30 Sep 2020 23:59:03 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -273,13 +505,59 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-build-version:
-      - 1.0.20200909-2-c73be597-develop
+      - 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info:
-      - addr=24.17.201.78
+      - addr=162.211.216.102
       x-ms-keyvault-region:
-      - EASTUS
+      - eastus2
       x-ms-server-latency:
-      - '656'
+      - '1045'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/restore/90e115e27fc44f08ae7e689232a92b26/pending?api-version=7.2-preview
+  response:
+    body:
+      string: '{"endTime":1601510337,"error":null,"jobId":"90e115e27fc44f08ae7e689232a92b26","startTime":1601510326,"status":"Succeeded","statusDetails":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '143'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 30 Sep 2020 23:59:04 GMT
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-build-version:
+      - 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info:
+      - addr=162.211.216.102
+      x-ms-keyvault-region:
+      - eastus2
+      x-ms-server-latency:
+      - '749'
     status:
       code: 200
       message: OK

--- a/sdk/keyvault/azure-keyvault-administration/tests/recordings/test_backup_client.test_selective_key_restore.yaml
+++ b/sdk/keyvault/azure-keyvault-administration/tests/recordings/test_backup_client.test_selective_key_restore.yaml
@@ -38,106 +38,10 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-server-latency:
-      - '0'
+      - '1'
     status:
       code: 401
       message: Unauthorized
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-identity/1.5.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0/.well-known/openid-configuration
-  response:
-    body:
-      string: '{"token_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code
-        id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}'
-    headers:
-      access-control-allow-methods:
-      - GET, OPTIONS
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - max-age=86400, private
-      content-length:
-      - '1651'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 30 Sep 2020 23:59:26 GMT
-      p3p:
-      - CP="DSP CUR OTPi IND OTRi ONL FIN"
-      set-cookie:
-      - fpc=AtS6j-8JgxlOtsKCNcrlGYE; expires=Fri, 30-Oct-2020 23:59:27 GMT; path=/;
-        secure; HttpOnly; SameSite=None
-      - esctx=AQABAAAAAAB2UyzwtQEKR7-rWbgdcBZINdETuzGiNEZtXAn6-n9vY-oEnVXg8gt-KQv7ccwKtW44OWB67TEYwsjl8vWsy5MegejCWYd8mb5uL37YWES4_C0VkolvW1AMGXp-bEvsYuT8DVpLqYbAyMOHBAf-22sRBHoAHeyj-VbbtCBwKKjqG-wwMAqK8RVMQIYM6jj09_wgAA;
-        domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None
-      - x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly
-      - stsservicecookie=estsfd; path=/; secure; samesite=none; httponly
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ests-server:
-      - 2.1.11086.7 - NCUS ProdSlices
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - stsservicecookie=estsfd; x-ms-gateway-slice=estsfd; fpc=AtS6j-8JgxlOtsKCNcrlGYE;
-        esctx=AQABAAAAAAB2UyzwtQEKR7-rWbgdcBZINdETuzGiNEZtXAn6-n9vY-oEnVXg8gt-KQv7ccwKtW44OWB67TEYwsjl8vWsy5MegejCWYd8mb5uL37YWES4_C0VkolvW1AMGXp-bEvsYuT8DVpLqYbAyMOHBAf-22sRBHoAHeyj-VbbtCBwKKjqG-wwMAqK8RVMQIYM6jj09_wgAA
-      User-Agent:
-      - azsdk-python-identity/1.5.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=https://login.microsoftonline.com/common/oauth2/authorize
-  response:
-    body:
-      string: '{"tenant_discovery_endpoint":"https://login.microsoftonline.com/common/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}'
-    headers:
-      access-control-allow-methods:
-      - GET, OPTIONS
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - max-age=86400, private
-      content-length:
-      - '945'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 30 Sep 2020 23:59:26 GMT
-      p3p:
-      - CP="DSP CUR OTPi IND OTRi ONL FIN"
-      set-cookie:
-      - fpc=AtS6j-8JgxlOtsKCNcrlGYE; expires=Fri, 30-Oct-2020 23:59:27 GMT; path=/;
-        secure; HttpOnly; SameSite=None
-      - x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly
-      - stsservicecookie=estsfd; path=/; secure; samesite=none; httponly
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ests-server:
-      - 2.1.11063.14 - SAN ProdSlices
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"kty": "RSA"}'
     headers:
@@ -157,7 +61,7 @@ interactions:
     uri: https://managedhsm/keys/selective-restore-test-keya85a1290/create?api-version=7.1
   response:
     body:
-      string: '{"attributes":{"created":1601510367,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601510367},"key":{"e":"AQAB","key_ops":["wrapKey","decrypt","encrypt","unwrapKey","sign","verify"],"kid":"https://managedhsm/keys/selective-restore-test-keya85a1290/ac499db56ba70fbe25ee3284d0fa42e2","kty":"RSA-HSM","n":"tZ9CLkaELpguZ3_oBCRHLHxpcfrctjxqqXzMruoK9d_OmpPArGNiWdn1bc6UxGM2ENM5AYFU_ejbDAFwRT88MkNBTvCrdfuHT1RPDZ5J4hA4yDkh4N2mvFDsnRKC8WQu-PsznL6kQOJ62afNjQhjmxcvE8IdfPx7cf0Yg3s806ETeMiWC_2q5n98rL5yZHBy5oCbqWQyOjNzKEw1GA5Lvh5iipKR3wRlutvdQmkGOwJXRj4h0l1D1XrsOohfA4N-rpZqqSgTEg5plLE5MVePHxTKsK1QM04KG7AhetEwcT3m_vd88bvzu4Ev_gmQ_oB7K4E9GY8tIXfxwdycHqcrFw"}}'
+      string: '{"attributes":{"created":1601598917,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601598917},"key":{"e":"AQAB","key_ops":["wrapKey","decrypt","encrypt","unwrapKey","sign","verify"],"kid":"https://managedhsm/keys/selective-restore-test-keya85a1290/aae82599cd7e46d995eaad3bb5a2e97b","kty":"RSA-HSM","n":"mUkI6IIEBBybDG2b-6_ohxZbYhCAsCoJy7Hd0j_8hsLR1QezRexuNXZXFWonjKCGJDjGE7SXgGqQB56B2mpME439HjywIN9nsGr1iwS0lyHtS8dgXVo1GROZg9HOazz4Gzq11Qp7v8zbwC4S8Zl7ifqB_D2U__AdI5AGRIGWHT5rpxtQeUGw9Tbo1qVV09ihFmOaI1Gl21Ufa4ynpEAHyyj_PkPC1ccfqZ70yihLG8iHzYQULv5jU2eQPO_oaD1YfBhOMSj0Jp1nAqVF-et1bRCcyTOhD2_QWUlLRKE99IWIlbENTIWoqITrwbg95z3qVw4un3YTYtzdbntreNK4ZQ"}}'
     headers:
       cache-control:
       - no-cache
@@ -178,108 +82,13 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '249'
+      - '257'
     status:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-identity/1.5.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0/.well-known/openid-configuration
-  response:
-    body:
-      string: '{"token_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code
-        id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}'
-    headers:
-      access-control-allow-methods:
-      - GET, OPTIONS
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - max-age=86400, private
-      content-length:
-      - '1651'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 30 Sep 2020 23:59:27 GMT
-      p3p:
-      - CP="DSP CUR OTPi IND OTRi ONL FIN"
-      set-cookie:
-      - fpc=AsaezQ0CVq5PsTboi3FFEW8; expires=Fri, 30-Oct-2020 23:59:28 GMT; path=/;
-        secure; HttpOnly; SameSite=None
-      - esctx=AQABAAAAAAB2UyzwtQEKR7-rWbgdcBZI7xEi_kjHA1k51lrOuZ9tRQo6C2EqbRQZkEVs5KmKFCtTJ0G1zdVf5uoZPa2m8MLCovz7FQI1oj9b_Z7K8660_QVqY3zfm9Ul7NmLNsJhuwG2C3UMhphmXkSuST5VdfPjXq6zlK2Dc4HAmWW3gbCScSVnWm0anDtzugmANuSIFf0gAA;
-        domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None
-      - x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly
-      - stsservicecookie=estsfd; path=/; secure; samesite=none; httponly
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ests-server:
-      - 2.1.11086.7 - WUS2 ProdSlices
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - stsservicecookie=estsfd; x-ms-gateway-slice=estsfd; fpc=AsaezQ0CVq5PsTboi3FFEW8;
-        esctx=AQABAAAAAAB2UyzwtQEKR7-rWbgdcBZI7xEi_kjHA1k51lrOuZ9tRQo6C2EqbRQZkEVs5KmKFCtTJ0G1zdVf5uoZPa2m8MLCovz7FQI1oj9b_Z7K8660_QVqY3zfm9Ul7NmLNsJhuwG2C3UMhphmXkSuST5VdfPjXq6zlK2Dc4HAmWW3gbCScSVnWm0anDtzugmANuSIFf0gAA
-      User-Agent:
-      - azsdk-python-identity/1.5.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=https://login.microsoftonline.com/common/oauth2/authorize
-  response:
-    body:
-      string: '{"tenant_discovery_endpoint":"https://login.microsoftonline.com/common/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}'
-    headers:
-      access-control-allow-methods:
-      - GET, OPTIONS
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - max-age=86400, private
-      content-length:
-      - '945'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 30 Sep 2020 23:59:27 GMT
-      p3p:
-      - CP="DSP CUR OTPi IND OTRi ONL FIN"
-      set-cookie:
-      - fpc=AsaezQ0CVq5PsTboi3FFEW8; expires=Fri, 30-Oct-2020 23:59:28 GMT; path=/;
-        secure; HttpOnly; SameSite=None
-      - x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly
-      - stsservicecookie=estsfd; path=/; secure; samesite=none; httponly
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ests-server:
-      - 2.1.11063.14 - SAN ProdSlices
-    status:
-      code: 200
-      message: OK
-- request:
-    body: 'b''b\''b\\\''{"token": "redacted", "storageResourceUri": "https://storname.blob.core.windows.net/containerhi3wxg7o76k25lb"}\\\''\'''''
+    body: '{"storageResourceUri": "https://storname.blob.core.windows.net/containerzychvl7fcjxrfa4",
+      "token": "redacted"}'
     headers:
       Accept:
       - application/json
@@ -288,7 +97,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '237'
+      - '235'
       Content-Type:
       - application/json
       User-Agent:
@@ -297,10 +106,10 @@ interactions:
     uri: https://managedhsm/backup?api-version=7.2-preview
   response:
     body:
-      string: '{"status":"InProgress","statusDetails":null,"error":{"code":null,"message":null,"innererror":null},"startTime":1601510369,"endTime":null,"jobId":"c8fb5200c65746a1809988333d59dd12","azureStorageBlobContainerUri":null}'
+      string: '{"status":"InProgress","statusDetails":null,"error":{"code":null,"message":null,"innererror":null},"startTime":1601598919,"endTime":null,"jobId":"90c79f44687046f9a9b8ef37d1f40455","azureStorageBlobContainerUri":null}'
     headers:
       azure-asyncoperation:
-      - https://managedhsm/backup/c8fb5200c65746a1809988333d59dd12/pending
+      - https://managedhsm/backup/90c79f44687046f9a9b8ef37d1f40455/pending
       cache-control:
       - no-cache
       content-length:
@@ -310,7 +119,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:59:29 GMT
+      - Fri, 02 Oct 2020 00:35:19 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -324,7 +133,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '627'
+      - '1753'
     status:
       code: 202
       message: ''
@@ -340,10 +149,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/backup/c8fb5200c65746a1809988333d59dd12/pending?api-version=7.2-preview
+    uri: https://managedhsm/backup/90c79f44687046f9a9b8ef37d1f40455/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"azureStorageBlobContainerUri":null,"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"c8fb5200c65746a1809988333d59dd12","startTime":1601510369,"status":"InProgress","statusDetails":null}'
+      string: '{"azureStorageBlobContainerUri":null,"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"90c79f44687046f9a9b8ef37d1f40455","startTime":1601598919,"status":"InProgress","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
@@ -354,7 +163,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:59:29 GMT
+      - Fri, 02 Oct 2020 00:35:21 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -370,7 +179,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '442'
+      - '1233'
     status:
       code: 200
       message: OK
@@ -386,10 +195,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/backup/c8fb5200c65746a1809988333d59dd12/pending
+    uri: https://managedhsm/backup/90c79f44687046f9a9b8ef37d1f40455/pending
   response:
     body:
-      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerhi3wxg7o76k25lb/mhsm-chlowehsm-2020093023592969","endTime":1601510378,"error":null,"jobId":"c8fb5200c65746a1809988333d59dd12","startTime":1601510369,"status":"Succeeded","statusDetails":null}'
+      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerzychvl7fcjxrfa4/mhsm-chlowehsm-2020100200352018","endTime":1601598929,"error":null,"jobId":"90c79f44687046f9a9b8ef37d1f40455","startTime":1601598919,"status":"Succeeded","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
@@ -400,7 +209,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:59:40 GMT
+      - Fri, 02 Oct 2020 00:35:31 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -416,7 +225,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '433'
+      - '776'
     status:
       code: 200
       message: OK
@@ -432,10 +241,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/backup/c8fb5200c65746a1809988333d59dd12/pending?api-version=7.2-preview
+    uri: https://managedhsm/backup/90c79f44687046f9a9b8ef37d1f40455/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerhi3wxg7o76k25lb/mhsm-chlowehsm-2020093023592969","endTime":1601510378,"error":null,"jobId":"c8fb5200c65746a1809988333d59dd12","startTime":1601510369,"status":"Succeeded","statusDetails":null}'
+      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerzychvl7fcjxrfa4/mhsm-chlowehsm-2020100200352018","endTime":1601598929,"error":null,"jobId":"90c79f44687046f9a9b8ef37d1f40455","startTime":1601598919,"status":"Succeeded","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
@@ -446,7 +255,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:59:40 GMT
+      - Fri, 02 Oct 2020 00:35:31 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -462,14 +271,13 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '500'
+      - '906'
     status:
       code: 200
       message: OK
 - request:
-    body: 'b''b\''b\\\''{"sasTokenParameters": {"token": "redacted", "storageResourceUri":
-      "https://storname.blob.core.windows.net/containerhi3wxg7o76k25lb"}, "folder":
-      "mhsm-chlowehsm-2020093023592969"}\\\''\'''''
+    body: '{"sasTokenParameters": {"storageResourceUri": "https://storname.blob.core.windows.net/containerzychvl7fcjxrfa4",
+      "token": "redacted"}, "folder": "mhsm-chlowehsm-2020100200352018"}'
     headers:
       Accept:
       - application/json
@@ -478,7 +286,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '306'
+      - '304'
       Content-Type:
       - application/json
       User-Agent:
@@ -487,10 +295,10 @@ interactions:
     uri: https://managedhsm/keys/selective-restore-test-keya85a1290/restore?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"126719305a0c48c7ac3b2ddcb6a5f3c8","startTime":1601510381,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"adb460788bad4654baa745e1268ddf37","startTime":1601598932,"status":"InProgress","statusDetails":null}'
     headers:
       azure-asyncoperation:
-      - https://managedhsm/restore/126719305a0c48c7ac3b2ddcb6a5f3c8/pending
+      - https://managedhsm/restore/adb460788bad4654baa745e1268ddf37/pending
       cache-control:
       - no-cache
       content-length:
@@ -500,7 +308,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:59:41 GMT
+      - Fri, 02 Oct 2020 00:35:32 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -514,7 +322,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '605'
+      - '1194'
     status:
       code: 202
       message: ''
@@ -530,10 +338,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/126719305a0c48c7ac3b2ddcb6a5f3c8/pending?api-version=7.2-preview
+    uri: https://managedhsm/restore/adb460788bad4654baa745e1268ddf37/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"126719305a0c48c7ac3b2ddcb6a5f3c8","startTime":1601510381,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"adb460788bad4654baa745e1268ddf37","startTime":1601598932,"status":"InProgress","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
@@ -544,7 +352,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:59:41 GMT
+      - Fri, 02 Oct 2020 00:35:33 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -560,7 +368,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '439'
+      - '671'
     status:
       code: 200
       message: OK
@@ -576,10 +384,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/126719305a0c48c7ac3b2ddcb6a5f3c8/pending
+    uri: https://managedhsm/restore/adb460788bad4654baa745e1268ddf37/pending
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"126719305a0c48c7ac3b2ddcb6a5f3c8","startTime":1601510381,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"adb460788bad4654baa745e1268ddf37","startTime":1601598932,"status":"InProgress","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
@@ -590,7 +398,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:59:52 GMT
+      - Fri, 02 Oct 2020 00:35:44 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -606,7 +414,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '903'
+      - '527'
     status:
       code: 200
       message: OK
@@ -622,12 +430,58 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/126719305a0c48c7ac3b2ddcb6a5f3c8/pending
+    uri: https://managedhsm/restore/adb460788bad4654baa745e1268ddf37/pending
   response:
     body:
-      string: '{"endTime":1601510392,"error":null,"jobId":"126719305a0c48c7ac3b2ddcb6a5f3c8","startTime":1601510381,"status":"Succeeded","statusDetails":"Number
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"adb460788bad4654baa745e1268ddf37","startTime":1601598932,"status":"InProgress","statusDetails":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '180'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 02 Oct 2020 00:35:48 GMT
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-build-version:
+      - 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info:
+      - addr=162.211.216.102
+      x-ms-keyvault-region:
+      - eastus2
+      x-ms-server-latency:
+      - '501'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/restore/adb460788bad4654baa745e1268ddf37/pending
+  response:
+    body:
+      string: '{"endTime":1601598949,"error":null,"jobId":"adb460788bad4654baa745e1268ddf37","startTime":1601598932,"status":"Succeeded","statusDetails":"Number
         of successful key versions restored: 0, Number of key versions could not overwrite:
-        3"}'
+        2"}'
     headers:
       cache-control:
       - no-cache
@@ -638,7 +492,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:59:58 GMT
+      - Fri, 02 Oct 2020 00:35:55 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -654,7 +508,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '719'
+      - '473'
     status:
       code: 200
       message: OK
@@ -670,12 +524,12 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/126719305a0c48c7ac3b2ddcb6a5f3c8/pending?api-version=7.2-preview
+    uri: https://managedhsm/restore/adb460788bad4654baa745e1268ddf37/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":1601510392,"error":null,"jobId":"126719305a0c48c7ac3b2ddcb6a5f3c8","startTime":1601510381,"status":"Succeeded","statusDetails":"Number
+      string: '{"endTime":1601598949,"error":null,"jobId":"adb460788bad4654baa745e1268ddf37","startTime":1601598932,"status":"Succeeded","statusDetails":"Number
         of successful key versions restored: 0, Number of key versions could not overwrite:
-        3"}'
+        2"}'
     headers:
       cache-control:
       - no-cache
@@ -686,7 +540,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 30 Sep 2020 23:59:59 GMT
+      - Fri, 02 Oct 2020 00:35:55 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -702,7 +556,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '814'
+      - '484'
     status:
       code: 200
       message: OK
@@ -723,7 +577,7 @@ interactions:
     uri: https://managedhsm/keys/selective-restore-test-keya85a1290?api-version=7.1
   response:
     body:
-      string: '{"attributes":{"created":1601510367,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601510367},"deletedDate":1601510399,"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","decrypt","encrypt"],"kid":"https://managedhsm/keys/selective-restore-test-keya85a1290/ac499db56ba70fbe25ee3284d0fa42e2","kty":"RSA-HSM","n":"tZ9CLkaELpguZ3_oBCRHLHxpcfrctjxqqXzMruoK9d_OmpPArGNiWdn1bc6UxGM2ENM5AYFU_ejbDAFwRT88MkNBTvCrdfuHT1RPDZ5J4hA4yDkh4N2mvFDsnRKC8WQu-PsznL6kQOJ62afNjQhjmxcvE8IdfPx7cf0Yg3s806ETeMiWC_2q5n98rL5yZHBy5oCbqWQyOjNzKEw1GA5Lvh5iipKR3wRlutvdQmkGOwJXRj4h0l1D1XrsOohfA4N-rpZqqSgTEg5plLE5MVePHxTKsK1QM04KG7AhetEwcT3m_vd88bvzu4Ev_gmQ_oB7K4E9GY8tIXfxwdycHqcrFw"},"recoveryId":"https://managedhsm/deletedkeys/selective-restore-test-keya85a1290","scheduledPurgeDate":1609286399}'
+      string: '{"attributes":{"created":1601598917,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601598917},"deletedDate":1601598956,"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","decrypt","encrypt"],"kid":"https://managedhsm/keys/selective-restore-test-keya85a1290/aae82599cd7e46d995eaad3bb5a2e97b","kty":"RSA-HSM","n":"mUkI6IIEBBybDG2b-6_ohxZbYhCAsCoJy7Hd0j_8hsLR1QezRexuNXZXFWonjKCGJDjGE7SXgGqQB56B2mpME439HjywIN9nsGr1iwS0lyHtS8dgXVo1GROZg9HOazz4Gzq11Qp7v8zbwC4S8Zl7ifqB_D2U__AdI5AGRIGWHT5rpxtQeUGw9Tbo1qVV09ihFmOaI1Gl21Ufa4ynpEAHyyj_PkPC1ccfqZ70yihLG8iHzYQULv5jU2eQPO_oaD1YfBhOMSj0Jp1nAqVF-et1bRCcyTOhD2_QWUlLRKE99IWIlbENTIWoqITrwbg95z3qVw4un3YTYtzdbntreNK4ZQ"},"recoveryId":"https://managedhsm/deletedkeys/selective-restore-test-keya85a1290","scheduledPurgeDate":1609374956}'
     headers:
       cache-control:
       - no-cache
@@ -744,7 +598,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '218'
+      - '183'
     status:
       code: 200
       message: OK
@@ -763,7 +617,7 @@ interactions:
     uri: https://managedhsm/deletedkeys/selective-restore-test-keya85a1290?api-version=7.1
   response:
     body:
-      string: '{"attributes":{"created":1601510367,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601510367},"deletedDate":1601510399,"key":{"e":"AQAB","key_ops":["encrypt","decrypt","unwrapKey","sign","verify","wrapKey"],"kid":"https://managedhsm/keys/selective-restore-test-keya85a1290/ac499db56ba70fbe25ee3284d0fa42e2","kty":"RSA-HSM","n":"tZ9CLkaELpguZ3_oBCRHLHxpcfrctjxqqXzMruoK9d_OmpPArGNiWdn1bc6UxGM2ENM5AYFU_ejbDAFwRT88MkNBTvCrdfuHT1RPDZ5J4hA4yDkh4N2mvFDsnRKC8WQu-PsznL6kQOJ62afNjQhjmxcvE8IdfPx7cf0Yg3s806ETeMiWC_2q5n98rL5yZHBy5oCbqWQyOjNzKEw1GA5Lvh5iipKR3wRlutvdQmkGOwJXRj4h0l1D1XrsOohfA4N-rpZqqSgTEg5plLE5MVePHxTKsK1QM04KG7AhetEwcT3m_vd88bvzu4Ev_gmQ_oB7K4E9GY8tIXfxwdycHqcrFw"},"recoveryId":"https://managedhsm/deletedkeys/selective-restore-test-keya85a1290","scheduledPurgeDate":1609286399}'
+      string: '{"attributes":{"created":1601598917,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601598917},"deletedDate":1601598956,"key":{"e":"AQAB","key_ops":["encrypt","decrypt","unwrapKey","sign","verify","wrapKey"],"kid":"https://managedhsm/keys/selective-restore-test-keya85a1290/aae82599cd7e46d995eaad3bb5a2e97b","kty":"RSA-HSM","n":"mUkI6IIEBBybDG2b-6_ohxZbYhCAsCoJy7Hd0j_8hsLR1QezRexuNXZXFWonjKCGJDjGE7SXgGqQB56B2mpME439HjywIN9nsGr1iwS0lyHtS8dgXVo1GROZg9HOazz4Gzq11Qp7v8zbwC4S8Zl7ifqB_D2U__AdI5AGRIGWHT5rpxtQeUGw9Tbo1qVV09ihFmOaI1Gl21Ufa4ynpEAHyyj_PkPC1ccfqZ70yihLG8iHzYQULv5jU2eQPO_oaD1YfBhOMSj0Jp1nAqVF-et1bRCcyTOhD2_QWUlLRKE99IWIlbENTIWoqITrwbg95z3qVw4un3YTYtzdbntreNK4ZQ"},"recoveryId":"https://managedhsm/deletedkeys/selective-restore-test-keya85a1290","scheduledPurgeDate":1609374956}'
     headers:
       cache-control:
       - no-cache
@@ -786,7 +640,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '70'
+      - '69'
     status:
       code: 200
       message: OK
@@ -828,7 +682,7 @@ interactions:
       x-ms-keyvault-region:
       - eastus2
       x-ms-server-latency:
-      - '236'
+      - '280'
     status:
       code: 204
       message: ''

--- a/sdk/keyvault/azure-keyvault-administration/tests/recordings/test_backup_client.test_selective_key_restore.yaml
+++ b/sdk/keyvault/azure-keyvault-administration/tests/recordings/test_backup_client.test_selective_key_restore.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://managedhsm/keys/selective-restore-test-keya85a1290/create?api-version=7.1
   response:
@@ -31,17 +31,113 @@ interactions:
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer authorization="https://login.windows-ppe.net/f686d426-8d16-42db-81b7-ab578e110ccd",
-        resource="https://managedhsm-int.azure-int.net"
+      - Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://managedhsm.azure.net"
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
       x-ms-server-latency:
-      - '1'
+      - '0'
     status:
       code: 401
       message: Unauthorized
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-identity/1.5.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0/.well-known/openid-configuration
+  response:
+    body:
+      string: '{"token_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code
+        id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}'
+    headers:
+      access-control-allow-methods:
+      - GET, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - max-age=86400, private
+      content-length:
+      - '1651'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 30 Sep 2020 23:59:26 GMT
+      p3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      set-cookie:
+      - fpc=AtS6j-8JgxlOtsKCNcrlGYE; expires=Fri, 30-Oct-2020 23:59:27 GMT; path=/;
+        secure; HttpOnly; SameSite=None
+      - esctx=AQABAAAAAAB2UyzwtQEKR7-rWbgdcBZINdETuzGiNEZtXAn6-n9vY-oEnVXg8gt-KQv7ccwKtW44OWB67TEYwsjl8vWsy5MegejCWYd8mb5uL37YWES4_C0VkolvW1AMGXp-bEvsYuT8DVpLqYbAyMOHBAf-22sRBHoAHeyj-VbbtCBwKKjqG-wwMAqK8RVMQIYM6jj09_wgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly
+      - stsservicecookie=estsfd; path=/; secure; samesite=none; httponly
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.11086.7 - NCUS ProdSlices
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - stsservicecookie=estsfd; x-ms-gateway-slice=estsfd; fpc=AtS6j-8JgxlOtsKCNcrlGYE;
+        esctx=AQABAAAAAAB2UyzwtQEKR7-rWbgdcBZINdETuzGiNEZtXAn6-n9vY-oEnVXg8gt-KQv7ccwKtW44OWB67TEYwsjl8vWsy5MegejCWYd8mb5uL37YWES4_C0VkolvW1AMGXp-bEvsYuT8DVpLqYbAyMOHBAf-22sRBHoAHeyj-VbbtCBwKKjqG-wwMAqK8RVMQIYM6jj09_wgAA
+      User-Agent:
+      - azsdk-python-identity/1.5.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=https://login.microsoftonline.com/common/oauth2/authorize
+  response:
+    body:
+      string: '{"tenant_discovery_endpoint":"https://login.microsoftonline.com/common/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}'
+    headers:
+      access-control-allow-methods:
+      - GET, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - max-age=86400, private
+      content-length:
+      - '945'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 30 Sep 2020 23:59:26 GMT
+      p3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      set-cookie:
+      - fpc=AtS6j-8JgxlOtsKCNcrlGYE; expires=Fri, 30-Oct-2020 23:59:27 GMT; path=/;
+        secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly
+      - stsservicecookie=estsfd; path=/; secure; samesite=none; httponly
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.11063.14 - SAN ProdSlices
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"kty": "RSA"}'
     headers:
@@ -56,17 +152,17 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://managedhsm/keys/selective-restore-test-keya85a1290/create?api-version=7.1
   response:
     body:
-      string: '{"attributes":{"created":1599693317,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1599693317},"key":{"e":"AQAB","key_ops":["wrapKey","decrypt","encrypt","unwrapKey","sign","verify"],"kid":"https://managedhsm/keys/selective-restore-test-keya85a1290/012b1544acb10c63b57eb1d95ebcf9c6","kty":"RSA-HSM","n":"i6Kf3a2-Jfv9735-DX9cAOONQ7OtSaKwgx84JgRs0wZFcfe1cIw7nyPnsZtHb5TJfp5oTXDj7_EZWUYIyUhwHEKpLSKK_nlAx1Y1izm_3_01nhGLtLMERg0GGQJlYCO7G8IGIKJ2XkC1EItj_LV1BNF3qozJziVOtYdycHckUpzwD5ij-VVegxwF9KeaMO8wmzVMgxyVDWctQVjuwB0-lbnZr_aJj9uo1ntEyNbpkiuxe6scJqKL3c8siu1gAeZ7K7Z0r8TEWYFEispB3NnX63AFkpMhRF8XjD4HyhTMMIU7JiBR-0h1CXrCaRb7Ys7Hpq1E5jcvdpspCbN94B3f1Q"}}'
+      string: '{"attributes":{"created":1601510367,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601510367},"key":{"e":"AQAB","key_ops":["wrapKey","decrypt","encrypt","unwrapKey","sign","verify"],"kid":"https://managedhsm/keys/selective-restore-test-keya85a1290/ac499db56ba70fbe25ee3284d0fa42e2","kty":"RSA-HSM","n":"tZ9CLkaELpguZ3_oBCRHLHxpcfrctjxqqXzMruoK9d_OmpPArGNiWdn1bc6UxGM2ENM5AYFU_ejbDAFwRT88MkNBTvCrdfuHT1RPDZ5J4hA4yDkh4N2mvFDsnRKC8WQu-PsznL6kQOJ62afNjQhjmxcvE8IdfPx7cf0Yg3s806ETeMiWC_2q5n98rL5yZHBy5oCbqWQyOjNzKEw1GA5Lvh5iipKR3wRlutvdQmkGOwJXRj4h0l1D1XrsOohfA4N-rpZqqSgTEg5plLE5MVePHxTKsK1QM04KG7AhetEwcT3m_vd88bvzu4Ev_gmQ_oB7K4E9GY8tIXfxwdycHqcrFw"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '753'
+      - '727'
       content-security-policy:
       - default-src 'self'
       content-type:
@@ -78,17 +174,112 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-keyvault-network-info:
-      - addr=24.17.201.78
+      - addr=162.211.216.102
       x-ms-keyvault-region:
-      - EASTUS
+      - eastus2
       x-ms-server-latency:
-      - '713'
+      - '249'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"storageResourceUri": "https://storname.blob.core.windows.net/containerr5j67u54ef7gqx7",
-      "token": "redacted"}'
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-identity/1.5.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0/.well-known/openid-configuration
+  response:
+    body:
+      string: '{"token_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code
+        id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"tenant_region_scope":"WW","cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}'
+    headers:
+      access-control-allow-methods:
+      - GET, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - max-age=86400, private
+      content-length:
+      - '1651'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 30 Sep 2020 23:59:27 GMT
+      p3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      set-cookie:
+      - fpc=AsaezQ0CVq5PsTboi3FFEW8; expires=Fri, 30-Oct-2020 23:59:28 GMT; path=/;
+        secure; HttpOnly; SameSite=None
+      - esctx=AQABAAAAAAB2UyzwtQEKR7-rWbgdcBZI7xEi_kjHA1k51lrOuZ9tRQo6C2EqbRQZkEVs5KmKFCtTJ0G1zdVf5uoZPa2m8MLCovz7FQI1oj9b_Z7K8660_QVqY3zfm9Ul7NmLNsJhuwG2C3UMhphmXkSuST5VdfPjXq6zlK2Dc4HAmWW3gbCScSVnWm0anDtzugmANuSIFf0gAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; secure; samesite=none; httponly
+      - stsservicecookie=estsfd; path=/; secure; samesite=none; httponly
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.11086.7 - WUS2 ProdSlices
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - stsservicecookie=estsfd; x-ms-gateway-slice=estsfd; fpc=AsaezQ0CVq5PsTboi3FFEW8;
+        esctx=AQABAAAAAAB2UyzwtQEKR7-rWbgdcBZI7xEi_kjHA1k51lrOuZ9tRQo6C2EqbRQZkEVs5KmKFCtTJ0G1zdVf5uoZPa2m8MLCovz7FQI1oj9b_Z7K8660_QVqY3zfm9Ul7NmLNsJhuwG2C3UMhphmXkSuST5VdfPjXq6zlK2Dc4HAmWW3gbCScSVnWm0anDtzugmANuSIFf0gAA
+      User-Agent:
+      - azsdk-python-identity/1.5.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=https://login.microsoftonline.com/common/oauth2/authorize
+  response:
+    body:
+      string: '{"tenant_discovery_endpoint":"https://login.microsoftonline.com/common/.well-known/openid-configuration","api-version":"1.1","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.windows.net","aliases":["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]},{"preferred_network":"login.partner.microsoftonline.cn","preferred_cache":"login.partner.microsoftonline.cn","aliases":["login.partner.microsoftonline.cn","login.chinacloudapi.cn"]},{"preferred_network":"login.microsoftonline.de","preferred_cache":"login.microsoftonline.de","aliases":["login.microsoftonline.de"]},{"preferred_network":"login.microsoftonline.us","preferred_cache":"login.microsoftonline.us","aliases":["login.microsoftonline.us","login.usgovcloudapi.net"]},{"preferred_network":"login-us.microsoftonline.com","preferred_cache":"login-us.microsoftonline.com","aliases":["login-us.microsoftonline.com"]}]}'
+    headers:
+      access-control-allow-methods:
+      - GET, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - max-age=86400, private
+      content-length:
+      - '945'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 30 Sep 2020 23:59:27 GMT
+      p3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      set-cookie:
+      - fpc=AsaezQ0CVq5PsTboi3FFEW8; expires=Fri, 30-Oct-2020 23:59:28 GMT; path=/;
+        secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly
+      - stsservicecookie=estsfd; path=/; secure; samesite=none; httponly
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.11063.14 - SAN ProdSlices
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''b\''b\\\''{"token": "redacted", "storageResourceUri": "https://storname.blob.core.windows.net/containerhi3wxg7o76k25lb"}\\\''\'''''
     headers:
       Accept:
       - application/json
@@ -97,19 +288,19 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '233'
+      - '237'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://managedhsm/backup?api-version=7.2-preview
   response:
     body:
-      string: '{"status":"InProgress","statusDetails":null,"error":{"code":null,"message":null,"innererror":null},"startTime":1599693320,"endTime":null,"jobId":"7161b3a9af704527b36d5a94c34d435c","azureStorageBlobContainerUri":null}'
+      string: '{"status":"InProgress","statusDetails":null,"error":{"code":null,"message":null,"innererror":null},"startTime":1601510369,"endTime":null,"jobId":"c8fb5200c65746a1809988333d59dd12","azureStorageBlobContainerUri":null}'
     headers:
       azure-asyncoperation:
-      - https://managedhsm/backup/7161b3a9af704527b36d5a94c34d435c/pending
+      - https://managedhsm/backup/c8fb5200c65746a1809988333d59dd12/pending
       cache-control:
       - no-cache
       content-length:
@@ -119,7 +310,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 09 Sep 2020 23:15:20 GMT
+      - Wed, 30 Sep 2020 23:59:29 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -129,14 +320,60 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-keyvault-network-info:
-      - addr=24.17.201.78
+      - addr=162.211.216.102
       x-ms-keyvault-region:
-      - EASTUS
+      - eastus2
       x-ms-server-latency:
-      - '878'
+      - '627'
     status:
       code: 202
       message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/backup/c8fb5200c65746a1809988333d59dd12/pending?api-version=7.2-preview
+  response:
+    body:
+      string: '{"azureStorageBlobContainerUri":null,"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"c8fb5200c65746a1809988333d59dd12","startTime":1601510369,"status":"InProgress","statusDetails":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '216'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 30 Sep 2020 23:59:29 GMT
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-build-version:
+      - 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info:
+      - addr=162.211.216.102
+      x-ms-keyvault-region:
+      - eastus2
+      x-ms-server-latency:
+      - '442'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -147,23 +384,23 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/backup/7161b3a9af704527b36d5a94c34d435c/pending
+    uri: https://managedhsm/backup/c8fb5200c65746a1809988333d59dd12/pending
   response:
     body:
-      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerr5j67u54ef7gqx7/mhsm-chriss-eu2-2020090923152045","endTime":1599693331,"error":null,"jobId":"7161b3a9af704527b36d5a94c34d435c","startTime":1599693320,"status":"Succeeded","statusDetails":null}'
+      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerhi3wxg7o76k25lb/mhsm-chlowehsm-2020093023592969","endTime":1601510378,"error":null,"jobId":"c8fb5200c65746a1809988333d59dd12","startTime":1601510369,"status":"Succeeded","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '289'
+      - '288'
       content-security-policy:
       - default-src 'self'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 09 Sep 2020 23:15:30 GMT
+      - Wed, 30 Sep 2020 23:59:40 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -173,20 +410,66 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-build-version:
-      - 1.0.20200909-2-c73be597-develop
+      - 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info:
-      - addr=24.17.201.78
+      - addr=162.211.216.102
       x-ms-keyvault-region:
-      - EASTUS
+      - eastus2
       x-ms-server-latency:
-      - '632'
+      - '433'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"folder": "mhsm-chriss-eu2-2020090923152045", "sasTokenParameters": {"storageResourceUri":
-      "https://storname.blob.core.windows.net/containerr5j67u54ef7gqx7", "token":
-      "redacted"}}'
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/backup/c8fb5200c65746a1809988333d59dd12/pending?api-version=7.2-preview
+  response:
+    body:
+      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerhi3wxg7o76k25lb/mhsm-chlowehsm-2020093023592969","endTime":1601510378,"error":null,"jobId":"c8fb5200c65746a1809988333d59dd12","startTime":1601510369,"status":"Succeeded","statusDetails":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '288'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 30 Sep 2020 23:59:40 GMT
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-build-version:
+      - 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info:
+      - addr=162.211.216.102
+      x-ms-keyvault-region:
+      - eastus2
+      x-ms-server-latency:
+      - '500'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''b\''b\\\''{"sasTokenParameters": {"token": "redacted", "storageResourceUri":
+      "https://storname.blob.core.windows.net/containerhi3wxg7o76k25lb"}, "folder":
+      "mhsm-chlowehsm-2020093023592969"}\\\''\'''''
     headers:
       Accept:
       - application/json
@@ -195,19 +478,19 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '303'
+      - '306'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://managedhsm/keys/selective-restore-test-keya85a1290/restore?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"a364959910264ceb91edb1df21290d87","startTime":1599693332,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"126719305a0c48c7ac3b2ddcb6a5f3c8","startTime":1601510381,"status":"InProgress","statusDetails":null}'
     headers:
       azure-asyncoperation:
-      - https://managedhsm/restore/a364959910264ceb91edb1df21290d87/pending
+      - https://managedhsm/restore/126719305a0c48c7ac3b2ddcb6a5f3c8/pending
       cache-control:
       - no-cache
       content-length:
@@ -217,7 +500,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 09 Sep 2020 23:15:32 GMT
+      - Wed, 30 Sep 2020 23:59:41 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -227,11 +510,11 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-keyvault-network-info:
-      - addr=24.17.201.78
+      - addr=162.211.216.102
       x-ms-keyvault-region:
-      - EASTUS
+      - eastus2
       x-ms-server-latency:
-      - '853'
+      - '605'
     status:
       code: 202
       message: ''
@@ -239,18 +522,18 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/a364959910264ceb91edb1df21290d87/pending
+    uri: https://managedhsm/restore/126719305a0c48c7ac3b2ddcb6a5f3c8/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"a364959910264ceb91edb1df21290d87","startTime":1599693332,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"126719305a0c48c7ac3b2ddcb6a5f3c8","startTime":1601510381,"status":"InProgress","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
@@ -261,7 +544,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 09 Sep 2020 23:15:43 GMT
+      - Wed, 30 Sep 2020 23:59:41 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -271,13 +554,13 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-build-version:
-      - 1.0.20200909-2-c73be597-develop
+      - 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info:
-      - addr=24.17.201.78
+      - addr=162.211.216.102
       x-ms-keyvault-region:
-      - EASTUS
+      - eastus2
       x-ms-server-latency:
-      - '654'
+      - '439'
     status:
       code: 200
       message: OK
@@ -291,12 +574,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/a364959910264ceb91edb1df21290d87/pending
+    uri: https://managedhsm/restore/126719305a0c48c7ac3b2ddcb6a5f3c8/pending
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"a364959910264ceb91edb1df21290d87","startTime":1599693332,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"126719305a0c48c7ac3b2ddcb6a5f3c8","startTime":1601510381,"status":"InProgress","statusDetails":null}'
     headers:
       cache-control:
       - no-cache
@@ -307,7 +590,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 09 Sep 2020 23:15:49 GMT
+      - Wed, 30 Sep 2020 23:59:52 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -317,13 +600,13 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-build-version:
-      - 1.0.20200909-2-c73be597-develop
+      - 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info:
-      - addr=24.17.201.78
+      - addr=162.211.216.102
       x-ms-keyvault-region:
-      - EASTUS
+      - eastus2
       x-ms-server-latency:
-      - '610'
+      - '903'
     status:
       code: 200
       message: OK
@@ -337,14 +620,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/a364959910264ceb91edb1df21290d87/pending
+    uri: https://managedhsm/restore/126719305a0c48c7ac3b2ddcb6a5f3c8/pending
   response:
     body:
-      string: '{"endTime":1599693349,"error":null,"jobId":"a364959910264ceb91edb1df21290d87","startTime":1599693332,"status":"Succeeded","statusDetails":"Number
+      string: '{"endTime":1601510392,"error":null,"jobId":"126719305a0c48c7ac3b2ddcb6a5f3c8","startTime":1601510381,"status":"Succeeded","statusDetails":"Number
         of successful key versions restored: 0, Number of key versions could not overwrite:
-        2"}'
+        3"}'
     headers:
       cache-control:
       - no-cache
@@ -355,7 +638,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 09 Sep 2020 23:15:54 GMT
+      - Wed, 30 Sep 2020 23:59:58 GMT
       server:
       - Kestrel
       strict-transport-security:
@@ -365,13 +648,61 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-build-version:
-      - 1.0.20200909-2-c73be597-develop
+      - 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info:
-      - addr=24.17.201.78
+      - addr=162.211.216.102
       x-ms-keyvault-region:
-      - EASTUS
+      - eastus2
       x-ms-server-latency:
-      - '616'
+      - '719'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/restore/126719305a0c48c7ac3b2ddcb6a5f3c8/pending?api-version=7.2-preview
+  response:
+    body:
+      string: '{"endTime":1601510392,"error":null,"jobId":"126719305a0c48c7ac3b2ddcb6a5f3c8","startTime":1601510381,"status":"Succeeded","statusDetails":"Number
+        of successful key versions restored: 0, Number of key versions could not overwrite:
+        3"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '233'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 30 Sep 2020 23:59:59 GMT
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-build-version:
+      - 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info:
+      - addr=162.211.216.102
+      x-ms-keyvault-region:
+      - eastus2
+      x-ms-server-latency:
+      - '814'
     status:
       code: 200
       message: OK
@@ -387,17 +718,17 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://managedhsm/keys/selective-restore-test-keya85a1290?api-version=7.1
   response:
     body:
-      string: '{"attributes":{"created":1599693317,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1599693317},"deletedDate":1599693356,"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","decrypt","encrypt"],"kid":"https://managedhsm/keys/selective-restore-test-keya85a1290/012b1544acb10c63b57eb1d95ebcf9c6","kty":"RSA-HSM","n":"i6Kf3a2-Jfv9735-DX9cAOONQ7OtSaKwgx84JgRs0wZFcfe1cIw7nyPnsZtHb5TJfp5oTXDj7_EZWUYIyUhwHEKpLSKK_nlAx1Y1izm_3_01nhGLtLMERg0GGQJlYCO7G8IGIKJ2XkC1EItj_LV1BNF3qozJziVOtYdycHckUpzwD5ij-VVegxwF9KeaMO8wmzVMgxyVDWctQVjuwB0-lbnZr_aJj9uo1ntEyNbpkiuxe6scJqKL3c8siu1gAeZ7K7Z0r8TEWYFEispB3NnX63AFkpMhRF8XjD4HyhTMMIU7JiBR-0h1CXrCaRb7Ys7Hpq1E5jcvdpspCbN94B3f1Q"},"recoveryId":"https://managedhsm/deletedkeys/selective-restore-test-keya85a1290","scheduledPurgeDate":1600298156}'
+      string: '{"attributes":{"created":1601510367,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601510367},"deletedDate":1601510399,"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","decrypt","encrypt"],"kid":"https://managedhsm/keys/selective-restore-test-keya85a1290/ac499db56ba70fbe25ee3284d0fa42e2","kty":"RSA-HSM","n":"tZ9CLkaELpguZ3_oBCRHLHxpcfrctjxqqXzMruoK9d_OmpPArGNiWdn1bc6UxGM2ENM5AYFU_ejbDAFwRT88MkNBTvCrdfuHT1RPDZ5J4hA4yDkh4N2mvFDsnRKC8WQu-PsznL6kQOJ62afNjQhjmxcvE8IdfPx7cf0Yg3s806ETeMiWC_2q5n98rL5yZHBy5oCbqWQyOjNzKEw1GA5Lvh5iipKR3wRlutvdQmkGOwJXRj4h0l1D1XrsOohfA4N-rpZqqSgTEg5plLE5MVePHxTKsK1QM04KG7AhetEwcT3m_vd88bvzu4Ev_gmQ_oB7K4E9GY8tIXfxwdycHqcrFw"},"recoveryId":"https://managedhsm/deletedkeys/selective-restore-test-keya85a1290","scheduledPurgeDate":1609286399}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '928'
+      - '885'
       content-security-policy:
       - default-src 'self'
       content-type:
@@ -409,11 +740,11 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-keyvault-network-info:
-      - addr=24.17.201.78
+      - addr=162.211.216.102
       x-ms-keyvault-region:
-      - EASTUS
+      - eastus2
       x-ms-server-latency:
-      - '485'
+      - '218'
     status:
       code: 200
       message: OK
@@ -427,17 +758,17 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://managedhsm/deletedkeys/selective-restore-test-keya85a1290?api-version=7.1
   response:
     body:
-      string: '{"attributes":{"created":1599693317,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1599693317},"deletedDate":1599693356,"key":{"e":"AQAB","key_ops":["encrypt","decrypt","unwrapKey","sign","verify","wrapKey"],"kid":"https://managedhsm/keys/selective-restore-test-keya85a1290/012b1544acb10c63b57eb1d95ebcf9c6","kty":"RSA-HSM","n":"i6Kf3a2-Jfv9735-DX9cAOONQ7OtSaKwgx84JgRs0wZFcfe1cIw7nyPnsZtHb5TJfp5oTXDj7_EZWUYIyUhwHEKpLSKK_nlAx1Y1izm_3_01nhGLtLMERg0GGQJlYCO7G8IGIKJ2XkC1EItj_LV1BNF3qozJziVOtYdycHckUpzwD5ij-VVegxwF9KeaMO8wmzVMgxyVDWctQVjuwB0-lbnZr_aJj9uo1ntEyNbpkiuxe6scJqKL3c8siu1gAeZ7K7Z0r8TEWYFEispB3NnX63AFkpMhRF8XjD4HyhTMMIU7JiBR-0h1CXrCaRb7Ys7Hpq1E5jcvdpspCbN94B3f1Q"},"recoveryId":"https://managedhsm/deletedkeys/selective-restore-test-keya85a1290","scheduledPurgeDate":1600298156}'
+      string: '{"attributes":{"created":1601510367,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601510367},"deletedDate":1601510399,"key":{"e":"AQAB","key_ops":["encrypt","decrypt","unwrapKey","sign","verify","wrapKey"],"kid":"https://managedhsm/keys/selective-restore-test-keya85a1290/ac499db56ba70fbe25ee3284d0fa42e2","kty":"RSA-HSM","n":"tZ9CLkaELpguZ3_oBCRHLHxpcfrctjxqqXzMruoK9d_OmpPArGNiWdn1bc6UxGM2ENM5AYFU_ejbDAFwRT88MkNBTvCrdfuHT1RPDZ5J4hA4yDkh4N2mvFDsnRKC8WQu-PsznL6kQOJ62afNjQhjmxcvE8IdfPx7cf0Yg3s806ETeMiWC_2q5n98rL5yZHBy5oCbqWQyOjNzKEw1GA5Lvh5iipKR3wRlutvdQmkGOwJXRj4h0l1D1XrsOohfA4N-rpZqqSgTEg5plLE5MVePHxTKsK1QM04KG7AhetEwcT3m_vd88bvzu4Ev_gmQ_oB7K4E9GY8tIXfxwdycHqcrFw"},"recoveryId":"https://managedhsm/deletedkeys/selective-restore-test-keya85a1290","scheduledPurgeDate":1609286399}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '928'
+      - '885'
       content-security-policy:
       - default-src 'self'
       content-type:
@@ -449,13 +780,13 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-build-version:
-      - 1.0.20200909-2-c73be597-develop
+      - 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info:
-      - addr=24.17.201.78
+      - addr=162.211.216.102
       x-ms-keyvault-region:
-      - EASTUS
+      - eastus2
       x-ms-server-latency:
-      - '183'
+      - '70'
     status:
       code: 200
       message: OK
@@ -471,7 +802,7 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://managedhsm/deletedkeys/selective-restore-test-keya85a1290?api-version=7.1
   response:
@@ -493,11 +824,11 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-ms-keyvault-network-info:
-      - addr=24.17.201.78
+      - addr=162.211.216.102
       x-ms-keyvault-region:
-      - EASTUS
+      - eastus2
       x-ms-server-latency:
-      - '506'
+      - '236'
     status:
       code: 204
       message: ''

--- a/sdk/keyvault/azure-keyvault-administration/tests/recordings/test_backup_client_async.test_full_backup_and_restore.yaml
+++ b/sdk/keyvault/azure-keyvault-administration/tests/recordings/test_backup_client_async.test_full_backup_and_restore.yaml
@@ -9,7 +9,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://managedhsm/backup?api-version=7.2-preview
   response:
@@ -21,17 +21,18 @@ interactions:
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
       strict-transport-security: max-age=31536000; includeSubDomains
-      www-authenticate: Bearer authorization="https://login.windows-ppe.net/f686d426-8d16-42db-81b7-ab578e110ccd",
-        resource="https://managedhsm-int.azure-int.net"
+      www-authenticate: Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://managedhsm.azure.net"
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
       x-ms-server-latency: '1'
     status:
       code: 401
       message: Unauthorized
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/backup?api-version=7.2-preview
+    url: https://chlowehsm.managedhsm.azure.net/backup?api-version=7.2-preview
 - request:
-    body: '{"token": "redacted", "storageResourceUri": "https://storname.blob.core.windows.net/containerukawv6vxixb3rhm"}'
+    body: 'b''b\''b\\\''{"storageResourceUri": "https://storname.blob.core.windows.net/containerkzplh4jvsi7ziqr",
+      "token": "redacted"}\\\''\'''''
     headers:
       Accept:
       - application/json
@@ -40,147 +41,268 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://managedhsm/backup?api-version=7.2-preview
   response:
     body:
-      string: '{"status":"InProgress","statusDetails":null,"error":{"code":null,"message":null,"innererror":null},"startTime":1599693526,"endTime":null,"jobId":"c41d7765beaa4c3eae7a1e6159f9efb2","azureStorageBlobContainerUri":null}'
+      string: '{"status":"InProgress","statusDetails":null,"error":{"code":null,"message":null,"innererror":null},"startTime":1601510004,"endTime":null,"jobId":"5dfce63b8e444a9a9cf187442c0ed628","azureStorageBlobContainerUri":null}'
     headers:
-      azure-asyncoperation: https://managedhsm/backup/c41d7765beaa4c3eae7a1e6159f9efb2/pending
+      azure-asyncoperation: https://managedhsm/backup/5dfce63b8e444a9a9cf187442c0ed628/pending
       cache-control: no-cache
       content-length: '216'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 09 Sep 2020 23:18:46 GMT
+      date: Wed, 30 Sep 2020 23:53:24 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-ms-keyvault-network-info: addr=24.17.201.78
-      x-ms-keyvault-region: EASTUS
-      x-ms-server-latency: '1033'
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '683'
     status:
       code: 202
-      message: null
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/backup?api-version=7.2-preview
+      message: ''
+    url: https://chlowehsm.managedhsm.azure.net/backup?api-version=7.2-preview
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/backup/5dfce63b8e444a9a9cf187442c0ed628/pending?api-version=7.2-preview
+  response:
+    body:
+      string: '{"azureStorageBlobContainerUri":null,"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"5dfce63b8e444a9a9cf187442c0ed628","startTime":1601510004,"status":"InProgress","statusDetails":null}'
+    headers:
+      cache-control: no-cache
+      content-length: '216'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      date: Wed, 30 Sep 2020 23:53:24 GMT
+      server: Kestrel
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '461'
+    status:
+      code: 200
+      message: OK
+    url: https://chlowehsm.managedhsm.azure.net/backup/5dfce63b8e444a9a9cf187442c0ed628/pending?api-version=7.2-preview
 - request:
     body: null
     headers:
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/backup/c41d7765beaa4c3eae7a1e6159f9efb2/pending
+    uri: https://managedhsm/backup/5dfce63b8e444a9a9cf187442c0ed628/pending
   response:
     body:
-      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerukawv6vxixb3rhm/mhsm-chriss-eu2-2020090923184683","endTime":1599693537,"error":null,"jobId":"c41d7765beaa4c3eae7a1e6159f9efb2","startTime":1599693526,"status":"Succeeded","statusDetails":null}'
+      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerkzplh4jvsi7ziqr/mhsm-chlowehsm-2020093023532454","endTime":1601510013,"error":null,"jobId":"5dfce63b8e444a9a9cf187442c0ed628","startTime":1601510004,"status":"Succeeded","statusDetails":null}'
     headers:
       cache-control: no-cache
-      content-length: '289'
+      content-length: '288'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 09 Sep 2020 23:18:57 GMT
+      date: Wed, 30 Sep 2020 23:53:35 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-ms-build-version: 1.0.20200909-2-c73be597-develop
-      x-ms-keyvault-network-info: addr=24.17.201.78
-      x-ms-keyvault-region: EASTUS
-      x-ms-server-latency: '641'
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '984'
     status:
       code: 200
       message: OK
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/backup/c41d7765beaa4c3eae7a1e6159f9efb2/pending
+    url: https://chlowehsm.managedhsm.azure.net/backup/5dfce63b8e444a9a9cf187442c0ed628/pending
 - request:
-    body: '{"folderToRestore": "mhsm-chriss-eu2-2020090923184683", "sasTokenParameters":
-      {"token": "redacted", "storageResourceUri": "https://storname.blob.core.windows.net/containerukawv6vxixb3rhm"}}'
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/backup/5dfce63b8e444a9a9cf187442c0ed628/pending?api-version=7.2-preview
+  response:
+    body:
+      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerkzplh4jvsi7ziqr/mhsm-chlowehsm-2020093023532454","endTime":1601510013,"error":null,"jobId":"5dfce63b8e444a9a9cf187442c0ed628","startTime":1601510004,"status":"Succeeded","statusDetails":null}'
+    headers:
+      cache-control: no-cache
+      content-length: '288'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      date: Wed, 30 Sep 2020 23:53:36 GMT
+      server: Kestrel
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '1208'
+    status:
+      code: 200
+      message: OK
+    url: https://chlowehsm.managedhsm.azure.net/backup/5dfce63b8e444a9a9cf187442c0ed628/pending?api-version=7.2-preview
+- request:
+    body: 'b''b\''b\\\''{"folderToRestore": "mhsm-chlowehsm-2020093023532454", "sasTokenParameters":
+      {"storageResourceUri": "https://storname.blob.core.windows.net/containerkzplh4jvsi7ziqr",
+      "token": "redacted"}}\\\''\'''''
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '312'
+      - '311'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://managedhsm/restore?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"e82968b7701143aeaddcc851525eca02","startTime":1599693539,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"acbf6c95750547d297a08b45b2a35d12","startTime":1601510018,"status":"InProgress","statusDetails":null}'
     headers:
-      azure-asyncoperation: https://managedhsm/restore/e82968b7701143aeaddcc851525eca02/pending
+      azure-asyncoperation: https://managedhsm/restore/acbf6c95750547d297a08b45b2a35d12/pending
       cache-control: no-cache
       content-length: '180'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 09 Sep 2020 23:18:59 GMT
+      date: Wed, 30 Sep 2020 23:53:39 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-ms-keyvault-network-info: addr=24.17.201.78
-      x-ms-keyvault-region: EASTUS
-      x-ms-server-latency: '932'
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '1370'
     status:
       code: 202
-      message: null
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/restore?api-version=7.2-preview
+      message: ''
+    url: https://chlowehsm.managedhsm.azure.net/restore?api-version=7.2-preview
 - request:
     body: null
     headers:
+      Accept:
+      - application/json
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/e82968b7701143aeaddcc851525eca02/pending
+    uri: https://managedhsm/restore/acbf6c95750547d297a08b45b2a35d12/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"e82968b7701143aeaddcc851525eca02","startTime":1599693539,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"acbf6c95750547d297a08b45b2a35d12","startTime":1601510018,"status":"InProgress","statusDetails":null}'
     headers:
       cache-control: no-cache
       content-length: '180'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 09 Sep 2020 23:19:10 GMT
+      date: Wed, 30 Sep 2020 23:53:39 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-ms-build-version: 1.0.20200909-2-c73be597-develop
-      x-ms-keyvault-network-info: addr=24.17.201.78
-      x-ms-keyvault-region: EASTUS
-      x-ms-server-latency: '675'
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '821'
     status:
       code: 200
       message: OK
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/restore/e82968b7701143aeaddcc851525eca02/pending
+    url: https://chlowehsm.managedhsm.azure.net/restore/acbf6c95750547d297a08b45b2a35d12/pending?api-version=7.2-preview
 - request:
     body: null
     headers:
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/e82968b7701143aeaddcc851525eca02/pending
+    uri: https://managedhsm/restore/acbf6c95750547d297a08b45b2a35d12/pending
   response:
     body:
-      string: '{"endTime":1599693551,"error":null,"jobId":"e82968b7701143aeaddcc851525eca02","startTime":1599693539,"status":"Succeeded","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"acbf6c95750547d297a08b45b2a35d12","startTime":1601510018,"status":"InProgress","statusDetails":null}'
+    headers:
+      cache-control: no-cache
+      content-length: '180'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      date: Wed, 30 Sep 2020 23:53:50 GMT
+      server: Kestrel
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '651'
+    status:
+      code: 200
+      message: OK
+    url: https://chlowehsm.managedhsm.azure.net/restore/acbf6c95750547d297a08b45b2a35d12/pending
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/restore/acbf6c95750547d297a08b45b2a35d12/pending
+  response:
+    body:
+      string: '{"endTime":1601510030,"error":null,"jobId":"acbf6c95750547d297a08b45b2a35d12","startTime":1601510018,"status":"Succeeded","statusDetails":null}'
     headers:
       cache-control: no-cache
       content-length: '143'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 09 Sep 2020 23:19:17 GMT
+      date: Wed, 30 Sep 2020 23:53:55 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-ms-build-version: 1.0.20200909-2-c73be597-develop
-      x-ms-keyvault-network-info: addr=24.17.201.78
-      x-ms-keyvault-region: EASTUS
-      x-ms-server-latency: '629'
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '493'
     status:
       code: 200
       message: OK
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/restore/e82968b7701143aeaddcc851525eca02/pending
+    url: https://chlowehsm.managedhsm.azure.net/restore/acbf6c95750547d297a08b45b2a35d12/pending
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/restore/acbf6c95750547d297a08b45b2a35d12/pending?api-version=7.2-preview
+  response:
+    body:
+      string: '{"endTime":1601510030,"error":null,"jobId":"acbf6c95750547d297a08b45b2a35d12","startTime":1601510018,"status":"Succeeded","statusDetails":null}'
+    headers:
+      cache-control: no-cache
+      content-length: '143'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      date: Wed, 30 Sep 2020 23:53:56 GMT
+      server: Kestrel
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '447'
+    status:
+      code: 200
+      message: OK
+    url: https://chlowehsm.managedhsm.azure.net/restore/acbf6c95750547d297a08b45b2a35d12/pending?api-version=7.2-preview
 version: 1

--- a/sdk/keyvault/azure-keyvault-administration/tests/recordings/test_backup_client_async.test_full_backup_and_restore.yaml
+++ b/sdk/keyvault/azure-keyvault-administration/tests/recordings/test_backup_client_async.test_full_backup_and_restore.yaml
@@ -25,19 +25,19 @@ interactions:
         resource="https://managedhsm.azure.net"
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-ms-server-latency: '1'
+      x-ms-server-latency: '0'
     status:
       code: 401
       message: Unauthorized
     url: https://chlowehsm.managedhsm.azure.net/backup?api-version=7.2-preview
 - request:
-    body: 'b''b\''b\\\''{"storageResourceUri": "https://storname.blob.core.windows.net/containerkzplh4jvsi7ziqr",
-      "token": "redacted"}\\\''\'''''
+    body: '{"storageResourceUri": "https://storname.blob.core.windows.net/containerbg7icm2wfp27ig3",
+      "token": "redacted"}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '233'
+      - '239'
       Content-Type:
       - application/json
       User-Agent:
@@ -46,21 +46,21 @@ interactions:
     uri: https://managedhsm/backup?api-version=7.2-preview
   response:
     body:
-      string: '{"status":"InProgress","statusDetails":null,"error":{"code":null,"message":null,"innererror":null},"startTime":1601510004,"endTime":null,"jobId":"5dfce63b8e444a9a9cf187442c0ed628","azureStorageBlobContainerUri":null}'
+      string: '{"status":"InProgress","statusDetails":null,"error":{"code":null,"message":null,"innererror":null},"startTime":1601591609,"endTime":null,"jobId":"294a2b2b05f14363a5880067f591e431","azureStorageBlobContainerUri":null}'
     headers:
-      azure-asyncoperation: https://managedhsm/backup/5dfce63b8e444a9a9cf187442c0ed628/pending
+      azure-asyncoperation: https://managedhsm/backup/294a2b2b05f14363a5880067f591e431/pending
       cache-control: no-cache
       content-length: '216'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:53:24 GMT
+      date: Thu, 01 Oct 2020 22:33:29 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '683'
+      x-ms-server-latency: '1733'
     status:
       code: 202
       message: ''
@@ -73,16 +73,16 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/backup/5dfce63b8e444a9a9cf187442c0ed628/pending?api-version=7.2-preview
+    uri: https://managedhsm/backup/294a2b2b05f14363a5880067f591e431/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"azureStorageBlobContainerUri":null,"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"5dfce63b8e444a9a9cf187442c0ed628","startTime":1601510004,"status":"InProgress","statusDetails":null}'
+      string: '{"azureStorageBlobContainerUri":null,"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"294a2b2b05f14363a5880067f591e431","startTime":1601591609,"status":"InProgress","statusDetails":null}'
     headers:
       cache-control: no-cache
       content-length: '216'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:53:24 GMT
+      date: Thu, 01 Oct 2020 22:33:31 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
@@ -90,27 +90,27 @@ interactions:
       x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '461'
+      x-ms-server-latency: '871'
     status:
       code: 200
       message: OK
-    url: https://chlowehsm.managedhsm.azure.net/backup/5dfce63b8e444a9a9cf187442c0ed628/pending?api-version=7.2-preview
+    url: https://chlowehsm.managedhsm.azure.net/backup/294a2b2b05f14363a5880067f591e431/pending?api-version=7.2-preview
 - request:
     body: null
     headers:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/backup/5dfce63b8e444a9a9cf187442c0ed628/pending
+    uri: https://managedhsm/backup/294a2b2b05f14363a5880067f591e431/pending
   response:
     body:
-      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerkzplh4jvsi7ziqr/mhsm-chlowehsm-2020093023532454","endTime":1601510013,"error":null,"jobId":"5dfce63b8e444a9a9cf187442c0ed628","startTime":1601510004,"status":"Succeeded","statusDetails":null}'
+      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerbg7icm2wfp27ig3/mhsm-chlowehsm-2020100122332997","endTime":1601591618,"error":null,"jobId":"294a2b2b05f14363a5880067f591e431","startTime":1601591609,"status":"Succeeded","statusDetails":null}'
     headers:
       cache-control: no-cache
       content-length: '288'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:53:35 GMT
+      date: Thu, 01 Oct 2020 22:33:41 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
@@ -118,11 +118,11 @@ interactions:
       x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '984'
+      x-ms-server-latency: '472'
     status:
       code: 200
       message: OK
-    url: https://chlowehsm.managedhsm.azure.net/backup/5dfce63b8e444a9a9cf187442c0ed628/pending
+    url: https://chlowehsm.managedhsm.azure.net/backup/294a2b2b05f14363a5880067f591e431/pending
 - request:
     body: null
     headers:
@@ -131,16 +131,16 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/backup/5dfce63b8e444a9a9cf187442c0ed628/pending?api-version=7.2-preview
+    uri: https://managedhsm/backup/294a2b2b05f14363a5880067f591e431/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerkzplh4jvsi7ziqr/mhsm-chlowehsm-2020093023532454","endTime":1601510013,"error":null,"jobId":"5dfce63b8e444a9a9cf187442c0ed628","startTime":1601510004,"status":"Succeeded","statusDetails":null}'
+      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerbg7icm2wfp27ig3/mhsm-chlowehsm-2020100122332997","endTime":1601591618,"error":null,"jobId":"294a2b2b05f14363a5880067f591e431","startTime":1601591609,"status":"Succeeded","statusDetails":null}'
     headers:
       cache-control: no-cache
       content-length: '288'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:53:36 GMT
+      date: Thu, 01 Oct 2020 22:33:42 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
@@ -148,20 +148,20 @@ interactions:
       x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '1208'
+      x-ms-server-latency: '447'
     status:
       code: 200
       message: OK
-    url: https://chlowehsm.managedhsm.azure.net/backup/5dfce63b8e444a9a9cf187442c0ed628/pending?api-version=7.2-preview
+    url: https://chlowehsm.managedhsm.azure.net/backup/294a2b2b05f14363a5880067f591e431/pending?api-version=7.2-preview
 - request:
-    body: 'b''b\''b\\\''{"folderToRestore": "mhsm-chlowehsm-2020093023532454", "sasTokenParameters":
-      {"storageResourceUri": "https://storname.blob.core.windows.net/containerkzplh4jvsi7ziqr",
-      "token": "redacted"}}\\\''\'''''
+    body: '{"folderToRestore": "mhsm-chlowehsm-2020100122332997", "sasTokenParameters":
+      {"storageResourceUri": "https://storname.blob.core.windows.net/containerbg7icm2wfp27ig3",
+      "token": "redacted"}}'
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '311'
+      - '317'
       Content-Type:
       - application/json
       User-Agent:
@@ -170,21 +170,21 @@ interactions:
     uri: https://managedhsm/restore?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"acbf6c95750547d297a08b45b2a35d12","startTime":1601510018,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"3004a649aa6844edb289a5f1bc0db202","startTime":1601591622,"status":"InProgress","statusDetails":null}'
     headers:
-      azure-asyncoperation: https://managedhsm/restore/acbf6c95750547d297a08b45b2a35d12/pending
+      azure-asyncoperation: https://managedhsm/restore/3004a649aa6844edb289a5f1bc0db202/pending
       cache-control: no-cache
       content-length: '180'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:53:39 GMT
+      date: Thu, 01 Oct 2020 22:33:42 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '1370'
+      x-ms-server-latency: '608'
     status:
       code: 202
       message: ''
@@ -197,102 +197,16 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/acbf6c95750547d297a08b45b2a35d12/pending?api-version=7.2-preview
+    uri: https://managedhsm/restore/3004a649aa6844edb289a5f1bc0db202/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"acbf6c95750547d297a08b45b2a35d12","startTime":1601510018,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"3004a649aa6844edb289a5f1bc0db202","startTime":1601591622,"status":"InProgress","statusDetails":null}'
     headers:
       cache-control: no-cache
       content-length: '180'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:53:39 GMT
-      server: Kestrel
-      strict-transport-security: max-age=31536000; includeSubDomains
-      x-content-type-options: nosniff
-      x-frame-options: SAMEORIGIN
-      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
-      x-ms-keyvault-network-info: addr=162.211.216.102
-      x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '821'
-    status:
-      code: 200
-      message: OK
-    url: https://chlowehsm.managedhsm.azure.net/restore/acbf6c95750547d297a08b45b2a35d12/pending?api-version=7.2-preview
-- request:
-    body: null
-    headers:
-      User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://managedhsm/restore/acbf6c95750547d297a08b45b2a35d12/pending
-  response:
-    body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"acbf6c95750547d297a08b45b2a35d12","startTime":1601510018,"status":"InProgress","statusDetails":null}'
-    headers:
-      cache-control: no-cache
-      content-length: '180'
-      content-security-policy: default-src 'self'
-      content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:53:50 GMT
-      server: Kestrel
-      strict-transport-security: max-age=31536000; includeSubDomains
-      x-content-type-options: nosniff
-      x-frame-options: SAMEORIGIN
-      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
-      x-ms-keyvault-network-info: addr=162.211.216.102
-      x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '651'
-    status:
-      code: 200
-      message: OK
-    url: https://chlowehsm.managedhsm.azure.net/restore/acbf6c95750547d297a08b45b2a35d12/pending
-- request:
-    body: null
-    headers:
-      User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://managedhsm/restore/acbf6c95750547d297a08b45b2a35d12/pending
-  response:
-    body:
-      string: '{"endTime":1601510030,"error":null,"jobId":"acbf6c95750547d297a08b45b2a35d12","startTime":1601510018,"status":"Succeeded","statusDetails":null}'
-    headers:
-      cache-control: no-cache
-      content-length: '143'
-      content-security-policy: default-src 'self'
-      content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:53:55 GMT
-      server: Kestrel
-      strict-transport-security: max-age=31536000; includeSubDomains
-      x-content-type-options: nosniff
-      x-frame-options: SAMEORIGIN
-      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
-      x-ms-keyvault-network-info: addr=162.211.216.102
-      x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '493'
-    status:
-      code: 200
-      message: OK
-    url: https://chlowehsm.managedhsm.azure.net/restore/acbf6c95750547d297a08b45b2a35d12/pending
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://managedhsm/restore/acbf6c95750547d297a08b45b2a35d12/pending?api-version=7.2-preview
-  response:
-    body:
-      string: '{"endTime":1601510030,"error":null,"jobId":"acbf6c95750547d297a08b45b2a35d12","startTime":1601510018,"status":"Succeeded","statusDetails":null}'
-    headers:
-      cache-control: no-cache
-      content-length: '143'
-      content-security-policy: default-src 'self'
-      content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:53:56 GMT
+      date: Thu, 01 Oct 2020 22:33:43 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
@@ -304,5 +218,91 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://chlowehsm.managedhsm.azure.net/restore/acbf6c95750547d297a08b45b2a35d12/pending?api-version=7.2-preview
+    url: https://chlowehsm.managedhsm.azure.net/restore/3004a649aa6844edb289a5f1bc0db202/pending?api-version=7.2-preview
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/restore/3004a649aa6844edb289a5f1bc0db202/pending
+  response:
+    body:
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"3004a649aa6844edb289a5f1bc0db202","startTime":1601591622,"status":"InProgress","statusDetails":null}'
+    headers:
+      cache-control: no-cache
+      content-length: '180'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      date: Thu, 01 Oct 2020 22:33:54 GMT
+      server: Kestrel
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '456'
+    status:
+      code: 200
+      message: OK
+    url: https://chlowehsm.managedhsm.azure.net/restore/3004a649aa6844edb289a5f1bc0db202/pending
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/restore/3004a649aa6844edb289a5f1bc0db202/pending
+  response:
+    body:
+      string: '{"endTime":1601591639,"error":null,"jobId":"3004a649aa6844edb289a5f1bc0db202","startTime":1601591622,"status":"Succeeded","statusDetails":null}'
+    headers:
+      cache-control: no-cache
+      content-length: '143'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      date: Thu, 01 Oct 2020 22:33:59 GMT
+      server: Kestrel
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '478'
+    status:
+      code: 200
+      message: OK
+    url: https://chlowehsm.managedhsm.azure.net/restore/3004a649aa6844edb289a5f1bc0db202/pending
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/restore/3004a649aa6844edb289a5f1bc0db202/pending?api-version=7.2-preview
+  response:
+    body:
+      string: '{"endTime":1601591639,"error":null,"jobId":"3004a649aa6844edb289a5f1bc0db202","startTime":1601591622,"status":"Succeeded","statusDetails":null}'
+    headers:
+      cache-control: no-cache
+      content-length: '143'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      date: Thu, 01 Oct 2020 22:34:00 GMT
+      server: Kestrel
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '440'
+    status:
+      code: 200
+      message: OK
+    url: https://chlowehsm.managedhsm.azure.net/restore/3004a649aa6844edb289a5f1bc0db202/pending?api-version=7.2-preview
 version: 1

--- a/sdk/keyvault/azure-keyvault-administration/tests/recordings/test_backup_client_async.test_selective_key_restore.yaml
+++ b/sdk/keyvault/azure-keyvault-administration/tests/recordings/test_backup_client_async.test_selective_key_restore.yaml
@@ -45,7 +45,7 @@ interactions:
     uri: https://managedhsm/keys/selective-restore-test-key20e5150d/create?api-version=7.1
   response:
     body:
-      string: '{"attributes":{"created":1601510060,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601510060},"key":{"e":"AQAB","key_ops":["wrapKey","decrypt","encrypt","unwrapKey","sign","verify"],"kid":"https://managedhsm/keys/selective-restore-test-key20e5150d/98f443829a3b4a559a01968c159d9a4e","kty":"RSA-HSM","n":"r80gA1lDz1hA5VQY5jY3iwYF8QCBotA_bRmuRIdqO3rYaEXZ4lQM6b0ouIrObPYQp0wpT3nbnNHB4Ho9VTB44Grqt1PFrdrCnR9mJ8VY7HwoDAciQH9qwjlbau-RBUUlN0dfFAZeb1ybrYX6vyuwFmvsJHUx3f1-7Jl1MkIhvhCWD6v6MzOHgHUsmeerJQ3hyX1337J3amiNMQcwYfZnB7IEfOSRWLj_lrjTQz-OQvw1eFkQaERiZnv2_mlUAXtJDgIj3zTVYNnfetoarq52zjYvoGD7CoKkwKeliS1jEL6du_7s7qXgvLLPUeZOQrAiucV06mSqTdUOipkaxg4D3w"}}'
+      string: '{"attributes":{"created":1601591665,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601591665},"key":{"e":"AQAB","key_ops":["wrapKey","decrypt","encrypt","unwrapKey","sign","verify"],"kid":"https://managedhsm/keys/selective-restore-test-key20e5150d/5cfeb43beec2485f1e716e7f905f9125","kty":"RSA-HSM","n":"rUiCMBpOm5LvgUekk5uws7D3MKrb6UWDLIwd1jxg9ntpPVbU-nVvGVwg4XwTPx7q5H_cTSaNnf3v1jIzA4kvqYPa21Lr4TRve9AeUcySCDz67N4hrVPncYWMQgQeAVgvkIiN2050-BpwQ6xI988HMwXX_8HTSRyvWw-ftavPFSvQwgAPbmpmLTdfq-zY8fW0tCps_xJnKyRk8kwcG8PMCuxnD_Mq6al3z_zcnjG5c6KSXxIc0_y9p2yHDJBSUYEspTNAxlz5ROU2XPxzrx7LvFA_yO-MJX2hIJoOxNBdNM4Qkjy16pgWcHQ1Dh6t5hX_GqCQGrWX0kCCCkDXeVPGPQ"}}'
     headers:
       cache-control: no-cache
       content-length: '727'
@@ -56,14 +56,14 @@ interactions:
       x-frame-options: SAMEORIGIN
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '228'
+      x-ms-server-latency: '280'
     status:
       code: 200
       message: OK
     url: https://chlowehsm.managedhsm.azure.net/keys/selective-restore-test-key20e5150d/create?api-version=7.1
 - request:
-    body: 'b''b\''b\\\''{"storageResourceUri": "https://storname.blob.core.windows.net/containerjxthg4xsxcvptdc",
-      "token": "redacted"}\\\''\'''''
+    body: '{"storageResourceUri": "https://storname.blob.core.windows.net/containerst5uppuukrzgyab",
+      "token": "redacted"}'
     headers:
       Accept:
       - application/json
@@ -77,21 +77,21 @@ interactions:
     uri: https://managedhsm/backup?api-version=7.2-preview
   response:
     body:
-      string: '{"status":"InProgress","statusDetails":null,"error":{"code":null,"message":null,"innererror":null},"startTime":1601510062,"endTime":null,"jobId":"ef13bc2e1bd74f51992e2c09d222726c","azureStorageBlobContainerUri":null}'
+      string: '{"status":"InProgress","statusDetails":null,"error":{"code":null,"message":null,"innererror":null},"startTime":1601591667,"endTime":null,"jobId":"089db62f03fc4f90b16b6ec1b0994fce","azureStorageBlobContainerUri":null}'
     headers:
-      azure-asyncoperation: https://managedhsm/backup/ef13bc2e1bd74f51992e2c09d222726c/pending
+      azure-asyncoperation: https://managedhsm/backup/089db62f03fc4f90b16b6ec1b0994fce/pending
       cache-control: no-cache
       content-length: '216'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:54:22 GMT
+      date: Thu, 01 Oct 2020 22:34:26 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '1085'
+      x-ms-server-latency: '615'
     status:
       code: 202
       message: ''
@@ -104,16 +104,16 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/backup/ef13bc2e1bd74f51992e2c09d222726c/pending?api-version=7.2-preview
+    uri: https://managedhsm/backup/089db62f03fc4f90b16b6ec1b0994fce/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"azureStorageBlobContainerUri":null,"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"ef13bc2e1bd74f51992e2c09d222726c","startTime":1601510062,"status":"InProgress","statusDetails":null}'
+      string: '{"azureStorageBlobContainerUri":null,"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"089db62f03fc4f90b16b6ec1b0994fce","startTime":1601591667,"status":"InProgress","statusDetails":null}'
     headers:
       cache-control: no-cache
       content-length: '216'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:54:23 GMT
+      date: Thu, 01 Oct 2020 22:34:27 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
@@ -121,27 +121,27 @@ interactions:
       x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '1233'
+      x-ms-server-latency: '457'
     status:
       code: 200
       message: OK
-    url: https://chlowehsm.managedhsm.azure.net/backup/ef13bc2e1bd74f51992e2c09d222726c/pending?api-version=7.2-preview
+    url: https://chlowehsm.managedhsm.azure.net/backup/089db62f03fc4f90b16b6ec1b0994fce/pending?api-version=7.2-preview
 - request:
     body: null
     headers:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/backup/ef13bc2e1bd74f51992e2c09d222726c/pending
+    uri: https://managedhsm/backup/089db62f03fc4f90b16b6ec1b0994fce/pending
   response:
     body:
-      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerjxthg4xsxcvptdc/mhsm-chlowehsm-2020093023542260","endTime":1601510071,"error":null,"jobId":"ef13bc2e1bd74f51992e2c09d222726c","startTime":1601510062,"status":"Succeeded","statusDetails":null}'
+      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerst5uppuukrzgyab/mhsm-chlowehsm-2020100122342733","endTime":1601591676,"error":null,"jobId":"089db62f03fc4f90b16b6ec1b0994fce","startTime":1601591667,"status":"Succeeded","statusDetails":null}'
     headers:
       cache-control: no-cache
       content-length: '288'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:54:34 GMT
+      date: Thu, 01 Oct 2020 22:34:37 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
@@ -149,11 +149,11 @@ interactions:
       x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '620'
+      x-ms-server-latency: '483'
     status:
       code: 200
       message: OK
-    url: https://chlowehsm.managedhsm.azure.net/backup/ef13bc2e1bd74f51992e2c09d222726c/pending
+    url: https://chlowehsm.managedhsm.azure.net/backup/089db62f03fc4f90b16b6ec1b0994fce/pending
 - request:
     body: null
     headers:
@@ -162,16 +162,16 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/backup/ef13bc2e1bd74f51992e2c09d222726c/pending?api-version=7.2-preview
+    uri: https://managedhsm/backup/089db62f03fc4f90b16b6ec1b0994fce/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerjxthg4xsxcvptdc/mhsm-chlowehsm-2020093023542260","endTime":1601510071,"error":null,"jobId":"ef13bc2e1bd74f51992e2c09d222726c","startTime":1601510062,"status":"Succeeded","statusDetails":null}'
+      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerst5uppuukrzgyab/mhsm-chlowehsm-2020100122342733","endTime":1601591676,"error":null,"jobId":"089db62f03fc4f90b16b6ec1b0994fce","startTime":1601591667,"status":"Succeeded","statusDetails":null}'
     headers:
       cache-control: no-cache
       content-length: '288'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:54:35 GMT
+      date: Thu, 01 Oct 2020 22:34:38 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
@@ -179,15 +179,14 @@ interactions:
       x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '776'
+      x-ms-server-latency: '491'
     status:
       code: 200
       message: OK
-    url: https://chlowehsm.managedhsm.azure.net/backup/ef13bc2e1bd74f51992e2c09d222726c/pending?api-version=7.2-preview
+    url: https://chlowehsm.managedhsm.azure.net/backup/089db62f03fc4f90b16b6ec1b0994fce/pending?api-version=7.2-preview
 - request:
-    body: 'b''b\''b\\\''{"folder": "mhsm-chlowehsm-2020093023542260", "sasTokenParameters":
-      {"storageResourceUri": "https://storname.blob.core.windows.net/containerjxthg4xsxcvptdc",
-      "token": "redacted"}}\\\''\'''''
+    body: '{"sasTokenParameters": {"storageResourceUri": "https://storname.blob.core.windows.net/containerst5uppuukrzgyab",
+      "token": "redacted"}, "folder": "mhsm-chlowehsm-2020100122342733"}'
     headers:
       Accept:
       - application/json
@@ -201,21 +200,21 @@ interactions:
     uri: https://managedhsm/keys/selective-restore-test-key20e5150d/restore?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"553f617274924a96856434b77330265c","startTime":1601510076,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"689318b514cc47dc93f41325ed3c15ac","startTime":1601591679,"status":"InProgress","statusDetails":null}'
     headers:
-      azure-asyncoperation: https://managedhsm/restore/553f617274924a96856434b77330265c/pending
+      azure-asyncoperation: https://managedhsm/restore/689318b514cc47dc93f41325ed3c15ac/pending
       cache-control: no-cache
       content-length: '180'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:54:36 GMT
+      date: Thu, 01 Oct 2020 22:34:39 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '1516'
+      x-ms-server-latency: '638'
     status:
       code: 202
       message: ''
@@ -228,16 +227,16 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/553f617274924a96856434b77330265c/pending?api-version=7.2-preview
+    uri: https://managedhsm/restore/689318b514cc47dc93f41325ed3c15ac/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"553f617274924a96856434b77330265c","startTime":1601510076,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"689318b514cc47dc93f41325ed3c15ac","startTime":1601591679,"status":"InProgress","statusDetails":null}'
     headers:
       cache-control: no-cache
       content-length: '180'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:54:37 GMT
+      date: Thu, 01 Oct 2020 22:34:39 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
@@ -245,27 +244,27 @@ interactions:
       x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '616'
+      x-ms-server-latency: '472'
     status:
       code: 200
       message: OK
-    url: https://chlowehsm.managedhsm.azure.net/restore/553f617274924a96856434b77330265c/pending?api-version=7.2-preview
+    url: https://chlowehsm.managedhsm.azure.net/restore/689318b514cc47dc93f41325ed3c15ac/pending?api-version=7.2-preview
 - request:
     body: null
     headers:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/553f617274924a96856434b77330265c/pending
+    uri: https://managedhsm/restore/689318b514cc47dc93f41325ed3c15ac/pending
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"553f617274924a96856434b77330265c","startTime":1601510076,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"689318b514cc47dc93f41325ed3c15ac","startTime":1601591679,"status":"InProgress","statusDetails":null}'
     headers:
       cache-control: no-cache
       content-length: '180'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:54:47 GMT
+      date: Thu, 01 Oct 2020 22:34:50 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
@@ -273,21 +272,21 @@ interactions:
       x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '447'
+      x-ms-server-latency: '443'
     status:
       code: 200
       message: OK
-    url: https://chlowehsm.managedhsm.azure.net/restore/553f617274924a96856434b77330265c/pending
+    url: https://chlowehsm.managedhsm.azure.net/restore/689318b514cc47dc93f41325ed3c15ac/pending
 - request:
     body: null
     headers:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/553f617274924a96856434b77330265c/pending
+    uri: https://managedhsm/restore/689318b514cc47dc93f41325ed3c15ac/pending
   response:
     body:
-      string: '{"endTime":1601510088,"error":null,"jobId":"553f617274924a96856434b77330265c","startTime":1601510076,"status":"Succeeded","statusDetails":"Number
+      string: '{"endTime":1601591696,"error":null,"jobId":"689318b514cc47dc93f41325ed3c15ac","startTime":1601591679,"status":"Succeeded","statusDetails":"Number
         of successful key versions restored: 0, Number of key versions could not overwrite:
         3"}'
     headers:
@@ -295,7 +294,7 @@ interactions:
       content-length: '233'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:54:53 GMT
+      date: Thu, 01 Oct 2020 22:34:56 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
@@ -303,11 +302,11 @@ interactions:
       x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '492'
+      x-ms-server-latency: '924'
     status:
       code: 200
       message: OK
-    url: https://chlowehsm.managedhsm.azure.net/restore/553f617274924a96856434b77330265c/pending
+    url: https://chlowehsm.managedhsm.azure.net/restore/689318b514cc47dc93f41325ed3c15ac/pending
 - request:
     body: null
     headers:
@@ -316,10 +315,10 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/553f617274924a96856434b77330265c/pending?api-version=7.2-preview
+    uri: https://managedhsm/restore/689318b514cc47dc93f41325ed3c15ac/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":1601510088,"error":null,"jobId":"553f617274924a96856434b77330265c","startTime":1601510076,"status":"Succeeded","statusDetails":"Number
+      string: '{"endTime":1601591696,"error":null,"jobId":"689318b514cc47dc93f41325ed3c15ac","startTime":1601591679,"status":"Succeeded","statusDetails":"Number
         of successful key versions restored: 0, Number of key versions could not overwrite:
         3"}'
     headers:
@@ -327,7 +326,7 @@ interactions:
       content-length: '233'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 30 Sep 2020 23:54:53 GMT
+      date: Thu, 01 Oct 2020 22:34:57 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
@@ -335,11 +334,11 @@ interactions:
       x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '492'
+      x-ms-server-latency: '711'
     status:
       code: 200
       message: OK
-    url: https://chlowehsm.managedhsm.azure.net/restore/553f617274924a96856434b77330265c/pending?api-version=7.2-preview
+    url: https://chlowehsm.managedhsm.azure.net/restore/689318b514cc47dc93f41325ed3c15ac/pending?api-version=7.2-preview
 - request:
     body: null
     headers:
@@ -351,7 +350,33 @@ interactions:
     uri: https://managedhsm/keys/selective-restore-test-key20e5150d?api-version=7.1
   response:
     body:
-      string: '{"attributes":{"created":1601510060,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601510060},"deletedDate":1601510095,"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","decrypt","encrypt"],"kid":"https://managedhsm/keys/selective-restore-test-key20e5150d/98f443829a3b4a559a01968c159d9a4e","kty":"RSA-HSM","n":"r80gA1lDz1hA5VQY5jY3iwYF8QCBotA_bRmuRIdqO3rYaEXZ4lQM6b0ouIrObPYQp0wpT3nbnNHB4Ho9VTB44Grqt1PFrdrCnR9mJ8VY7HwoDAciQH9qwjlbau-RBUUlN0dfFAZeb1ybrYX6vyuwFmvsJHUx3f1-7Jl1MkIhvhCWD6v6MzOHgHUsmeerJQ3hyX1337J3amiNMQcwYfZnB7IEfOSRWLj_lrjTQz-OQvw1eFkQaERiZnv2_mlUAXtJDgIj3zTVYNnfetoarq52zjYvoGD7CoKkwKeliS1jEL6du_7s7qXgvLLPUeZOQrAiucV06mSqTdUOipkaxg4D3w"},"recoveryId":"https://managedhsm/deletedkeys/selective-restore-test-key20e5150d","scheduledPurgeDate":1609286095}'
+      string: '{"error":{"code":"Conflict","message":"User triggered Restore operation
+        is in progress. Retry after the restore operation (Activity ID: d9c5d3c6-0335-11eb-b520-0242ac120008)"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '176'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-server-latency: '1'
+    status:
+      code: 409
+      message: ''
+    url: https://chlowehsm.managedhsm.azure.net/keys/selective-restore-test-key20e5150d?api-version=7.1
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: DELETE
+    uri: https://managedhsm/keys/selective-restore-test-key20e5150d?api-version=7.1
+  response:
+    body:
+      string: '{"attributes":{"created":1601591665,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601591665},"deletedDate":1601591701,"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","decrypt","encrypt"],"kid":"https://managedhsm/keys/selective-restore-test-key20e5150d/5cfeb43beec2485f1e716e7f905f9125","kty":"RSA-HSM","n":"rUiCMBpOm5LvgUekk5uws7D3MKrb6UWDLIwd1jxg9ntpPVbU-nVvGVwg4XwTPx7q5H_cTSaNnf3v1jIzA4kvqYPa21Lr4TRve9AeUcySCDz67N4hrVPncYWMQgQeAVgvkIiN2050-BpwQ6xI988HMwXX_8HTSRyvWw-ftavPFSvQwgAPbmpmLTdfq-zY8fW0tCps_xJnKyRk8kwcG8PMCuxnD_Mq6al3z_zcnjG5c6KSXxIc0_y9p2yHDJBSUYEspTNAxlz5ROU2XPxzrx7LvFA_yO-MJX2hIJoOxNBdNM4Qkjy16pgWcHQ1Dh6t5hX_GqCQGrWX0kCCCkDXeVPGPQ"},"recoveryId":"https://managedhsm/deletedkeys/selective-restore-test-key20e5150d","scheduledPurgeDate":1609367701}'
     headers:
       cache-control: no-cache
       content-length: '885'
@@ -362,7 +387,7 @@ interactions:
       x-frame-options: SAMEORIGIN
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '174'
+      x-ms-server-latency: '194'
     status:
       code: 200
       message: OK
@@ -378,7 +403,7 @@ interactions:
     uri: https://managedhsm/deletedkeys/selective-restore-test-key20e5150d?api-version=7.1
   response:
     body:
-      string: '{"attributes":{"created":1601510060,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601510060},"deletedDate":1601510095,"key":{"e":"AQAB","key_ops":["encrypt","decrypt","unwrapKey","sign","verify","wrapKey"],"kid":"https://managedhsm/keys/selective-restore-test-key20e5150d/98f443829a3b4a559a01968c159d9a4e","kty":"RSA-HSM","n":"r80gA1lDz1hA5VQY5jY3iwYF8QCBotA_bRmuRIdqO3rYaEXZ4lQM6b0ouIrObPYQp0wpT3nbnNHB4Ho9VTB44Grqt1PFrdrCnR9mJ8VY7HwoDAciQH9qwjlbau-RBUUlN0dfFAZeb1ybrYX6vyuwFmvsJHUx3f1-7Jl1MkIhvhCWD6v6MzOHgHUsmeerJQ3hyX1337J3amiNMQcwYfZnB7IEfOSRWLj_lrjTQz-OQvw1eFkQaERiZnv2_mlUAXtJDgIj3zTVYNnfetoarq52zjYvoGD7CoKkwKeliS1jEL6du_7s7qXgvLLPUeZOQrAiucV06mSqTdUOipkaxg4D3w"},"recoveryId":"https://managedhsm/deletedkeys/selective-restore-test-key20e5150d","scheduledPurgeDate":1609286095}'
+      string: '{"attributes":{"created":1601591665,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601591665},"deletedDate":1601591701,"key":{"e":"AQAB","key_ops":["encrypt","decrypt","unwrapKey","sign","verify","wrapKey"],"kid":"https://managedhsm/keys/selective-restore-test-key20e5150d/5cfeb43beec2485f1e716e7f905f9125","kty":"RSA-HSM","n":"rUiCMBpOm5LvgUekk5uws7D3MKrb6UWDLIwd1jxg9ntpPVbU-nVvGVwg4XwTPx7q5H_cTSaNnf3v1jIzA4kvqYPa21Lr4TRve9AeUcySCDz67N4hrVPncYWMQgQeAVgvkIiN2050-BpwQ6xI988HMwXX_8HTSRyvWw-ftavPFSvQwgAPbmpmLTdfq-zY8fW0tCps_xJnKyRk8kwcG8PMCuxnD_Mq6al3z_zcnjG5c6KSXxIc0_y9p2yHDJBSUYEspTNAxlz5ROU2XPxzrx7LvFA_yO-MJX2hIJoOxNBdNM4Qkjy16pgWcHQ1Dh6t5hX_GqCQGrWX0kCCCkDXeVPGPQ"},"recoveryId":"https://managedhsm/deletedkeys/selective-restore-test-key20e5150d","scheduledPurgeDate":1609367701}'
     headers:
       cache-control: no-cache
       content-length: '885'
@@ -390,7 +415,7 @@ interactions:
       x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '75'
+      x-ms-server-latency: '65'
     status:
       code: 200
       message: OK
@@ -415,7 +440,7 @@ interactions:
       x-frame-options: SAMEORIGIN
       x-ms-keyvault-network-info: addr=162.211.216.102
       x-ms-keyvault-region: eastus2
-      x-ms-server-latency: '249'
+      x-ms-server-latency: '238'
     status:
       code: 204
       message: ''

--- a/sdk/keyvault/azure-keyvault-administration/tests/recordings/test_backup_client_async.test_selective_key_restore.yaml
+++ b/sdk/keyvault/azure-keyvault-administration/tests/recordings/test_backup_client_async.test_selective_key_restore.yaml
@@ -9,7 +9,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://managedhsm/keys/selective-restore-test-key20e5150d/create?api-version=7.1
   response:
@@ -21,15 +21,15 @@ interactions:
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
       strict-transport-security: max-age=31536000; includeSubDomains
-      www-authenticate: Bearer authorization="https://login.windows-ppe.net/f686d426-8d16-42db-81b7-ab578e110ccd",
-        resource="https://managedhsm-int.azure-int.net"
+      www-authenticate: Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://managedhsm.azure.net"
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-ms-server-latency: '0'
+      x-ms-server-latency: '1'
     status:
       code: 401
       message: Unauthorized
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/keys/selective-restore-test-key20e5150d/create?api-version=7.1
+    url: https://chlowehsm.managedhsm.azure.net/keys/selective-restore-test-key20e5150d/create?api-version=7.1
 - request:
     body: '{"kty": "RSA"}'
     headers:
@@ -40,61 +40,30 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://managedhsm/keys/selective-restore-test-key20e5150d/create?api-version=7.1
   response:
     body:
-      string: '{"attributes":{"created":1599693613,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1599693613},"key":{"e":"AQAB","key_ops":["wrapKey","decrypt","encrypt","unwrapKey","sign","verify"],"kid":"https://managedhsm/keys/selective-restore-test-key20e5150d/7500af2095d145ba1792f41a676385a2","kty":"RSA-HSM","n":"nk0J5UifiL3C-Wb2BzSUMAR8wDVPGIa5eMT0GNHBLjKai-IMj5GF55-yHD-GP2qQgrDWIIPM2wD5j03fcTqdehqSlyOrqBrRTqfBi2dc8hRuZr9bPttLwqrWzQR3mFag5PiDYvSMBj0cRNcp6ZlIONbMcaq68SV8H559sKowLxJIhF4z-5GRfCJboxvcLwtIGSvuv9HnB4qkrJF5tT9OOqeFQUGJgD01XmACGOZedKhJXzUqhUGm8XvwYDHx0aKXebWudw34ClAl7lWIMw5bd2DR-GUQ9T9i-bj4ipkosVZtZl4iyexhWFjKECJZC53kdLJ7K6rW-wlPb2129DvfwQ"}}'
+      string: '{"attributes":{"created":1601510060,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601510060},"key":{"e":"AQAB","key_ops":["wrapKey","decrypt","encrypt","unwrapKey","sign","verify"],"kid":"https://managedhsm/keys/selective-restore-test-key20e5150d/98f443829a3b4a559a01968c159d9a4e","kty":"RSA-HSM","n":"r80gA1lDz1hA5VQY5jY3iwYF8QCBotA_bRmuRIdqO3rYaEXZ4lQM6b0ouIrObPYQp0wpT3nbnNHB4Ho9VTB44Grqt1PFrdrCnR9mJ8VY7HwoDAciQH9qwjlbau-RBUUlN0dfFAZeb1ybrYX6vyuwFmvsJHUx3f1-7Jl1MkIhvhCWD6v6MzOHgHUsmeerJQ3hyX1337J3amiNMQcwYfZnB7IEfOSRWLj_lrjTQz-OQvw1eFkQaERiZnv2_mlUAXtJDgIj3zTVYNnfetoarq52zjYvoGD7CoKkwKeliS1jEL6du_7s7qXgvLLPUeZOQrAiucV06mSqTdUOipkaxg4D3w"}}'
     headers:
       cache-control: no-cache
-      content-length: '753'
+      content-length: '727'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-ms-keyvault-network-info: addr=24.17.201.78
-      x-ms-keyvault-region: EASTUS
-      x-ms-server-latency: '719'
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '228'
     status:
       code: 200
       message: OK
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/keys/selective-restore-test-key20e5150d/create?api-version=7.1
+    url: https://chlowehsm.managedhsm.azure.net/keys/selective-restore-test-key20e5150d/create?api-version=7.1
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - '0'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
-    method: POST
-    uri: https://managedhsm/backup?api-version=7.2-preview
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control: no-cache
-      content-length: '0'
-      content-security-policy: default-src 'self'
-      content-type: application/json; charset=utf-8
-      strict-transport-security: max-age=31536000; includeSubDomains
-      www-authenticate: Bearer authorization="https://login.windows-ppe.net/f686d426-8d16-42db-81b7-ab578e110ccd",
-        resource="https://managedhsm-int.azure-int.net"
-      x-content-type-options: nosniff
-      x-frame-options: SAMEORIGIN
-      x-ms-server-latency: '1'
-    status:
-      code: 401
-      message: Unauthorized
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/backup?api-version=7.2-preview
-- request:
-    body: '{"storageResourceUri": "https://storname.blob.core.windows.net/container46nad73wruezm7t",
-      "token": "redacted"}'
+    body: 'b''b\''b\\\''{"storageResourceUri": "https://storname.blob.core.windows.net/containerjxthg4xsxcvptdc",
+      "token": "redacted"}\\\''\'''''
     headers:
       Accept:
       - application/json
@@ -103,211 +72,334 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://managedhsm/backup?api-version=7.2-preview
   response:
     body:
-      string: '{"status":"InProgress","statusDetails":null,"error":{"code":null,"message":null,"innererror":null},"startTime":1599693615,"endTime":null,"jobId":"6dd3d9ef3c4340d583da7967d366f43c","azureStorageBlobContainerUri":null}'
+      string: '{"status":"InProgress","statusDetails":null,"error":{"code":null,"message":null,"innererror":null},"startTime":1601510062,"endTime":null,"jobId":"ef13bc2e1bd74f51992e2c09d222726c","azureStorageBlobContainerUri":null}'
     headers:
-      azure-asyncoperation: https://managedhsm/backup/6dd3d9ef3c4340d583da7967d366f43c/pending
+      azure-asyncoperation: https://managedhsm/backup/ef13bc2e1bd74f51992e2c09d222726c/pending
       cache-control: no-cache
       content-length: '216'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 09 Sep 2020 23:20:14 GMT
+      date: Wed, 30 Sep 2020 23:54:22 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-ms-keyvault-network-info: addr=24.17.201.78
-      x-ms-keyvault-region: EASTUS
-      x-ms-server-latency: '880'
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '1085'
     status:
       code: 202
-      message: null
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/backup?api-version=7.2-preview
+      message: ''
+    url: https://chlowehsm.managedhsm.azure.net/backup?api-version=7.2-preview
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/backup/ef13bc2e1bd74f51992e2c09d222726c/pending?api-version=7.2-preview
+  response:
+    body:
+      string: '{"azureStorageBlobContainerUri":null,"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"ef13bc2e1bd74f51992e2c09d222726c","startTime":1601510062,"status":"InProgress","statusDetails":null}'
+    headers:
+      cache-control: no-cache
+      content-length: '216'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      date: Wed, 30 Sep 2020 23:54:23 GMT
+      server: Kestrel
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '1233'
+    status:
+      code: 200
+      message: OK
+    url: https://chlowehsm.managedhsm.azure.net/backup/ef13bc2e1bd74f51992e2c09d222726c/pending?api-version=7.2-preview
 - request:
     body: null
     headers:
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/backup/6dd3d9ef3c4340d583da7967d366f43c/pending
+    uri: https://managedhsm/backup/ef13bc2e1bd74f51992e2c09d222726c/pending
   response:
     body:
-      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/container46nad73wruezm7t/mhsm-chriss-eu2-2020090923201530","endTime":1599693626,"error":null,"jobId":"6dd3d9ef3c4340d583da7967d366f43c","startTime":1599693615,"status":"Succeeded","statusDetails":null}'
+      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerjxthg4xsxcvptdc/mhsm-chlowehsm-2020093023542260","endTime":1601510071,"error":null,"jobId":"ef13bc2e1bd74f51992e2c09d222726c","startTime":1601510062,"status":"Succeeded","statusDetails":null}'
     headers:
       cache-control: no-cache
-      content-length: '289'
+      content-length: '288'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 09 Sep 2020 23:20:26 GMT
+      date: Wed, 30 Sep 2020 23:54:34 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-ms-build-version: 1.0.20200909-2-c73be597-develop
-      x-ms-keyvault-network-info: addr=24.17.201.78
-      x-ms-keyvault-region: EASTUS
-      x-ms-server-latency: '636'
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '620'
     status:
       code: 200
       message: OK
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/backup/6dd3d9ef3c4340d583da7967d366f43c/pending
+    url: https://chlowehsm.managedhsm.azure.net/backup/ef13bc2e1bd74f51992e2c09d222726c/pending
 - request:
-    body: '{"sasTokenParameters": {"storageResourceUri": "https://storname.blob.core.windows.net/container46nad73wruezm7t",
-      "token": "redacted"}, "folder": "mhsm-chriss-eu2-2020090923201530"}'
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/backup/ef13bc2e1bd74f51992e2c09d222726c/pending?api-version=7.2-preview
+  response:
+    body:
+      string: '{"azureStorageBlobContainerUri":"https://storname.blob.core.windows.net/containerjxthg4xsxcvptdc/mhsm-chlowehsm-2020093023542260","endTime":1601510071,"error":null,"jobId":"ef13bc2e1bd74f51992e2c09d222726c","startTime":1601510062,"status":"Succeeded","statusDetails":null}'
+    headers:
+      cache-control: no-cache
+      content-length: '288'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      date: Wed, 30 Sep 2020 23:54:35 GMT
+      server: Kestrel
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '776'
+    status:
+      code: 200
+      message: OK
+    url: https://chlowehsm.managedhsm.azure.net/backup/ef13bc2e1bd74f51992e2c09d222726c/pending?api-version=7.2-preview
+- request:
+    body: 'b''b\''b\\\''{"folder": "mhsm-chlowehsm-2020093023542260", "sasTokenParameters":
+      {"storageResourceUri": "https://storname.blob.core.windows.net/containerjxthg4xsxcvptdc",
+      "token": "redacted"}}\\\''\'''''
     headers:
       Accept:
       - application/json
       Content-Length:
-      - '303'
+      - '302'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://managedhsm/keys/selective-restore-test-key20e5150d/restore?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"d8ca0b63bcac42f9b36997f4e163db2f","startTime":1599693627,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"553f617274924a96856434b77330265c","startTime":1601510076,"status":"InProgress","statusDetails":null}'
     headers:
-      azure-asyncoperation: https://managedhsm/restore/d8ca0b63bcac42f9b36997f4e163db2f/pending
+      azure-asyncoperation: https://managedhsm/restore/553f617274924a96856434b77330265c/pending
       cache-control: no-cache
       content-length: '180'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 09 Sep 2020 23:20:27 GMT
+      date: Wed, 30 Sep 2020 23:54:36 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-ms-keyvault-network-info: addr=24.17.201.78
-      x-ms-keyvault-region: EASTUS
-      x-ms-server-latency: '898'
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '1516'
     status:
       code: 202
-      message: null
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/keys/selective-restore-test-key20e5150d/restore?api-version=7.2-preview
+      message: ''
+    url: https://chlowehsm.managedhsm.azure.net/keys/selective-restore-test-key20e5150d/restore?api-version=7.2-preview
 - request:
     body: null
     headers:
+      Accept:
+      - application/json
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/d8ca0b63bcac42f9b36997f4e163db2f/pending
+    uri: https://managedhsm/restore/553f617274924a96856434b77330265c/pending?api-version=7.2-preview
   response:
     body:
-      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"d8ca0b63bcac42f9b36997f4e163db2f","startTime":1599693627,"status":"InProgress","statusDetails":null}'
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"553f617274924a96856434b77330265c","startTime":1601510076,"status":"InProgress","statusDetails":null}'
     headers:
       cache-control: no-cache
       content-length: '180'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 09 Sep 2020 23:20:38 GMT
+      date: Wed, 30 Sep 2020 23:54:37 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-ms-build-version: 1.0.20200909-2-c73be597-develop
-      x-ms-keyvault-network-info: addr=24.17.201.78
-      x-ms-keyvault-region: EASTUS
-      x-ms-server-latency: '656'
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '616'
     status:
       code: 200
       message: OK
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/restore/d8ca0b63bcac42f9b36997f4e163db2f/pending
+    url: https://chlowehsm.managedhsm.azure.net/restore/553f617274924a96856434b77330265c/pending?api-version=7.2-preview
 - request:
     body: null
     headers:
       User-Agent:
-      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://managedhsm/restore/d8ca0b63bcac42f9b36997f4e163db2f/pending
+    uri: https://managedhsm/restore/553f617274924a96856434b77330265c/pending
   response:
     body:
-      string: '{"endTime":1599693639,"error":null,"jobId":"d8ca0b63bcac42f9b36997f4e163db2f","startTime":1599693627,"status":"Succeeded","statusDetails":"Number
+      string: '{"endTime":null,"error":{"code":null,"innererror":null,"message":null},"jobId":"553f617274924a96856434b77330265c","startTime":1601510076,"status":"InProgress","statusDetails":null}'
+    headers:
+      cache-control: no-cache
+      content-length: '180'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      date: Wed, 30 Sep 2020 23:54:47 GMT
+      server: Kestrel
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '447'
+    status:
+      code: 200
+      message: OK
+    url: https://chlowehsm.managedhsm.azure.net/restore/553f617274924a96856434b77330265c/pending
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/restore/553f617274924a96856434b77330265c/pending
+  response:
+    body:
+      string: '{"endTime":1601510088,"error":null,"jobId":"553f617274924a96856434b77330265c","startTime":1601510076,"status":"Succeeded","statusDetails":"Number
         of successful key versions restored: 0, Number of key versions could not overwrite:
-        2"}'
+        3"}'
     headers:
       cache-control: no-cache
       content-length: '233'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
-      date: Wed, 09 Sep 2020 23:20:44 GMT
+      date: Wed, 30 Sep 2020 23:54:53 GMT
       server: Kestrel
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-ms-build-version: 1.0.20200909-2-c73be597-develop
-      x-ms-keyvault-network-info: addr=24.17.201.78
-      x-ms-keyvault-region: EASTUS
-      x-ms-server-latency: '655'
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '492'
     status:
       code: 200
       message: OK
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/restore/d8ca0b63bcac42f9b36997f4e163db2f/pending
+    url: https://chlowehsm.managedhsm.azure.net/restore/553f617274924a96856434b77330265c/pending
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-administration/4.0.0b2 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://managedhsm/restore/553f617274924a96856434b77330265c/pending?api-version=7.2-preview
+  response:
+    body:
+      string: '{"endTime":1601510088,"error":null,"jobId":"553f617274924a96856434b77330265c","startTime":1601510076,"status":"Succeeded","statusDetails":"Number
+        of successful key versions restored: 0, Number of key versions could not overwrite:
+        3"}'
+    headers:
+      cache-control: no-cache
+      content-length: '233'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      date: Wed, 30 Sep 2020 23:54:53 GMT
+      server: Kestrel
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '492'
+    status:
+      code: 200
+      message: OK
+    url: https://chlowehsm.managedhsm.azure.net/restore/553f617274924a96856434b77330265c/pending?api-version=7.2-preview
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://managedhsm/keys/selective-restore-test-key20e5150d?api-version=7.1
   response:
     body:
-      string: '{"attributes":{"created":1599693613,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1599693613},"deletedDate":1599693645,"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","decrypt","encrypt"],"kid":"https://managedhsm/keys/selective-restore-test-key20e5150d/7500af2095d145ba1792f41a676385a2","kty":"RSA-HSM","n":"nk0J5UifiL3C-Wb2BzSUMAR8wDVPGIa5eMT0GNHBLjKai-IMj5GF55-yHD-GP2qQgrDWIIPM2wD5j03fcTqdehqSlyOrqBrRTqfBi2dc8hRuZr9bPttLwqrWzQR3mFag5PiDYvSMBj0cRNcp6ZlIONbMcaq68SV8H559sKowLxJIhF4z-5GRfCJboxvcLwtIGSvuv9HnB4qkrJF5tT9OOqeFQUGJgD01XmACGOZedKhJXzUqhUGm8XvwYDHx0aKXebWudw34ClAl7lWIMw5bd2DR-GUQ9T9i-bj4ipkosVZtZl4iyexhWFjKECJZC53kdLJ7K6rW-wlPb2129DvfwQ"},"recoveryId":"https://managedhsm/deletedkeys/selective-restore-test-key20e5150d","scheduledPurgeDate":1600298445}'
+      string: '{"attributes":{"created":1601510060,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601510060},"deletedDate":1601510095,"key":{"e":"AQAB","key_ops":["wrapKey","verify","sign","unwrapKey","decrypt","encrypt"],"kid":"https://managedhsm/keys/selective-restore-test-key20e5150d/98f443829a3b4a559a01968c159d9a4e","kty":"RSA-HSM","n":"r80gA1lDz1hA5VQY5jY3iwYF8QCBotA_bRmuRIdqO3rYaEXZ4lQM6b0ouIrObPYQp0wpT3nbnNHB4Ho9VTB44Grqt1PFrdrCnR9mJ8VY7HwoDAciQH9qwjlbau-RBUUlN0dfFAZeb1ybrYX6vyuwFmvsJHUx3f1-7Jl1MkIhvhCWD6v6MzOHgHUsmeerJQ3hyX1337J3amiNMQcwYfZnB7IEfOSRWLj_lrjTQz-OQvw1eFkQaERiZnv2_mlUAXtJDgIj3zTVYNnfetoarq52zjYvoGD7CoKkwKeliS1jEL6du_7s7qXgvLLPUeZOQrAiucV06mSqTdUOipkaxg4D3w"},"recoveryId":"https://managedhsm/deletedkeys/selective-restore-test-key20e5150d","scheduledPurgeDate":1609286095}'
     headers:
       cache-control: no-cache
-      content-length: '928'
+      content-length: '885'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-ms-keyvault-network-info: addr=24.17.201.78
-      x-ms-keyvault-region: EASTUS
-      x-ms-server-latency: '483'
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '174'
     status:
       code: 200
       message: OK
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/keys/selective-restore-test-key20e5150d?api-version=7.1
+    url: https://chlowehsm.managedhsm.azure.net/keys/selective-restore-test-key20e5150d?api-version=7.1
 - request:
     body: null
     headers:
       Accept:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://managedhsm/deletedkeys/selective-restore-test-key20e5150d?api-version=7.1
   response:
     body:
-      string: '{"attributes":{"created":1599693613,"enabled":true,"exportable":false,"recoverableDays":7,"recoveryLevel":"CustomizedRecoverable+Purgeable","updated":1599693613},"deletedDate":1599693645,"key":{"e":"AQAB","key_ops":["encrypt","decrypt","unwrapKey","sign","verify","wrapKey"],"kid":"https://managedhsm/keys/selective-restore-test-key20e5150d/7500af2095d145ba1792f41a676385a2","kty":"RSA-HSM","n":"nk0J5UifiL3C-Wb2BzSUMAR8wDVPGIa5eMT0GNHBLjKai-IMj5GF55-yHD-GP2qQgrDWIIPM2wD5j03fcTqdehqSlyOrqBrRTqfBi2dc8hRuZr9bPttLwqrWzQR3mFag5PiDYvSMBj0cRNcp6ZlIONbMcaq68SV8H559sKowLxJIhF4z-5GRfCJboxvcLwtIGSvuv9HnB4qkrJF5tT9OOqeFQUGJgD01XmACGOZedKhJXzUqhUGm8XvwYDHx0aKXebWudw34ClAl7lWIMw5bd2DR-GUQ9T9i-bj4ipkosVZtZl4iyexhWFjKECJZC53kdLJ7K6rW-wlPb2129DvfwQ"},"recoveryId":"https://managedhsm/deletedkeys/selective-restore-test-key20e5150d","scheduledPurgeDate":1600298445}'
+      string: '{"attributes":{"created":1601510060,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1601510060},"deletedDate":1601510095,"key":{"e":"AQAB","key_ops":["encrypt","decrypt","unwrapKey","sign","verify","wrapKey"],"kid":"https://managedhsm/keys/selective-restore-test-key20e5150d/98f443829a3b4a559a01968c159d9a4e","kty":"RSA-HSM","n":"r80gA1lDz1hA5VQY5jY3iwYF8QCBotA_bRmuRIdqO3rYaEXZ4lQM6b0ouIrObPYQp0wpT3nbnNHB4Ho9VTB44Grqt1PFrdrCnR9mJ8VY7HwoDAciQH9qwjlbau-RBUUlN0dfFAZeb1ybrYX6vyuwFmvsJHUx3f1-7Jl1MkIhvhCWD6v6MzOHgHUsmeerJQ3hyX1337J3amiNMQcwYfZnB7IEfOSRWLj_lrjTQz-OQvw1eFkQaERiZnv2_mlUAXtJDgIj3zTVYNnfetoarq52zjYvoGD7CoKkwKeliS1jEL6du_7s7qXgvLLPUeZOQrAiucV06mSqTdUOipkaxg4D3w"},"recoveryId":"https://managedhsm/deletedkeys/selective-restore-test-key20e5150d","scheduledPurgeDate":1609286095}'
     headers:
       cache-control: no-cache
-      content-length: '928'
+      content-length: '885'
       content-security-policy: default-src 'self'
       content-type: application/json; charset=utf-8
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-ms-build-version: 1.0.20200909-2-c73be597-develop
-      x-ms-keyvault-network-info: addr=24.17.201.78
-      x-ms-keyvault-region: EASTUS
-      x-ms-server-latency: '192'
+      x-ms-build-version: 1.0.20200917-2-1617fc9c-develop
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '75'
     status:
       code: 200
       message: OK
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/deletedkeys/selective-restore-test-key20e5150d?api-version=7.1
+    url: https://chlowehsm.managedhsm.azure.net/deletedkeys/selective-restore-test-key20e5150d?api-version=7.1
 - request:
     body: null
     headers:
       User-Agent:
-      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-keyvault-keys/4.2.1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
     method: DELETE
     uri: https://managedhsm/deletedkeys/selective-restore-test-key20e5150d?api-version=7.1
   response:
@@ -321,11 +413,11 @@ interactions:
       strict-transport-security: max-age=31536000; includeSubDomains
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-ms-keyvault-network-info: addr=24.17.201.78
-      x-ms-keyvault-region: EASTUS
-      x-ms-server-latency: '545'
+      x-ms-keyvault-network-info: addr=162.211.216.102
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '249'
     status:
       code: 204
-      message: null
-    url: https://eastus2.chriss-eu2.managedhsm-int.azure-int.net/deletedkeys/selective-restore-test-key20e5150d?api-version=7.1
+      message: ''
+    url: https://chlowehsm.managedhsm.azure.net/deletedkeys/selective-restore-test-key20e5150d?api-version=7.1
 version: 1

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_backup_client.py
@@ -131,6 +131,7 @@ def assert_in_progress_operation(operation):
         assert operation.azure_storage_blob_container_uri is None
     assert operation.status == "InProgress"
     assert operation.end_time is None
+    assert isinstance(operation.start_time, datetime)
 
 
 def assert_successful_operation(operation):


### PR DESCRIPTION
Closes #13718.

Adds methods to `KeyVaultBackupClient` for checking backup and restore operation status. We may want to create a new polling class to make getting job IDs (that are necessary for these methods) easier to obtain.