### PR TITLE
Allow RC of CPython to install our dev req

### DIFF
--- a/sdk/appconfiguration/azure-appconfiguration/dev_requirements.txt
+++ b/sdk/appconfiguration/azure-appconfiguration/dev_requirements.txt
@@ -1,5 +1,4 @@
 ../../core/azure-core
 -e ../../identity/azure-identity
 aiohttp>=3.0; python_version >= '3.5'
-aiodns>=2.0; python_version >= '3.5'
 msrest>=0.6.10

--- a/sdk/core/azure-mgmt-core/dev_requirements.txt
+++ b/sdk/core/azure-mgmt-core/dev_requirements.txt
@@ -1,7 +1,6 @@
 msrest
 trio; python_version >= '3.5'
 aiohttp>=3.0; python_version >= '3.5'
-aiodns>=2.0; python_version >= '3.5'
 typing_extensions>=3.7.2
 -e ../azure-core
 mock;python_version<="2.7"

--- a/sdk/identity/azure-identity/dev_requirements.txt
+++ b/sdk/identity/azure-identity/dev_requirements.txt
@@ -1,4 +1,4 @@
 ../../core/azure-core
-aiohttp;python_full_version>="3.5.3"
+aiohttp>=3.0; python_version >= '3.5'
 mock;python_version<"3.3"
 typing_extensions>=3.7.2

--- a/sdk/identity/azure-identity/tests/managed-identity-live/requirements.txt
+++ b/sdk/identity/azure-identity/tests/managed-identity-live/requirements.txt
@@ -2,5 +2,5 @@
 ../..
 ../../../../keyvault/azure-keyvault-secrets
 pytest
-pytest-asyncio;python_full_version>="3.5.3"
-aiohttp;python_full_version>="3.5.3"
+pytest-asyncio;python_version>="3.5"
+aiohttp>=3.0; python_version >= '3.5'


### PR DESCRIPTION
`python_full_version>=3.5.3` doesn't allow RC version of Python (like 3.9rc2). We could use `3.5.3.*` or simply keep things simple for a dev_req file and use `python_version` instead (we're trying too hard on the smartness to refuse the bugfix version here)

Side note, aiodns is an optional package, there is no point to have it on the dev_req anyway