### PR TITLE
[ServiceBus] CI Test hotfixes

### DIFF
--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/preparers.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/preparers.py
@@ -44,6 +44,9 @@ class AbstractPreparer(object):
         # If the first cached test run does not have any http traffic, a recording will not have been
         # generated, so in_recording will be True even if live_test is false, so a random name would be given.
         # In cached mode we need to avoid this because then for tests with recordings, they would not have a moniker.
+        print("LIVE TEST: " + str(self.live_test))
+        print("IN RECORDING: " + str(test_class_instance.in_recording))
+        print("USE CACHE: " + str(self._use_cache))
         if (self.live_test or test_class_instance.in_recording) \
                 and not (not self.live_test and test_class_instance.in_recording and self._use_cache):
             resource_name = self.random_name

--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/preparers.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/preparers.py
@@ -44,9 +44,6 @@ class AbstractPreparer(object):
         # If the first cached test run does not have any http traffic, a recording will not have been
         # generated, so in_recording will be True even if live_test is false, so a random name would be given.
         # In cached mode we need to avoid this because then for tests with recordings, they would not have a moniker.
-        print("LIVE TEST: " + str(test_class_instance.is_live))
-        print("IN RECORDING: " + str(test_class_instance.in_recording))
-        print("USE CACHE: " + str(self._use_cache))
         if (self.live_test or test_class_instance.in_recording) \
                 and not (not test_class_instance.is_live and test_class_instance.in_recording and self._use_cache):
             resource_name = self.random_name

--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/preparers.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/preparers.py
@@ -44,11 +44,11 @@ class AbstractPreparer(object):
         # If the first cached test run does not have any http traffic, a recording will not have been
         # generated, so in_recording will be True even if live_test is false, so a random name would be given.
         # In cached mode we need to avoid this because then for tests with recordings, they would not have a moniker.
-        print("LIVE TEST: " + str(self.live_test))
+        print("LIVE TEST: " + str(test_class_instance.is_live))
         print("IN RECORDING: " + str(test_class_instance.in_recording))
         print("USE CACHE: " + str(self._use_cache))
         if (self.live_test or test_class_instance.in_recording) \
-                and not (not self.live_test and test_class_instance.in_recording and self._use_cache):
+                and not (not test_class_instance.is_live and test_class_instance.in_recording and self._use_cache):
             resource_name = self.random_name
             if not self.live_test and isinstance(self, RecordingProcessor):
                 test_class_instance.recording_processors.append(self)


### PR DESCRIPTION
Fix preparer fallback conditional.
- the special case was written for cosmos in their preparer adoption, for an edge case that is hit for some tests that did not have recordings.
- However, the live_test flag did not behave as expected on servicebus live tests, and the proper semantic live check (seen here) needed to be substituted.


Edit: (moving this from a comment to head so reviewers note it)
A few notes.
- Spoke with @seankane-msft about the table failure, this has been red for some time and is being triaged actively. Sean reported validating the tests with this branch independently for tables and had confidence that the remaining failures were table-specific.
- The debugging printouts present will be removed once folks have seen the set of green CI and test runs and confirmed that they feel comfortable with this level of coverage.

