### PR TITLE
Update communication pacakges to version b2

### DIFF
--- a/sdk/communication/azure-communication-administration/CHANGELOG.md
+++ b/sdk/communication/azure-communication-administration/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Release History
 
+## 1.0.0b2 (Unreleased)
+
 ## 1.0.0b1 (2020-09-22)
 - Preview release of the package

--- a/sdk/communication/azure-communication-administration/azure/communication/administration/_version.py
+++ b/sdk/communication/azure-communication-administration/azure/communication/administration/_version.py
@@ -4,6 +4,6 @@
 # license information.
 # --------------------------------------------------------------------------
 
-VERSION = "1.0.0b1"
+VERSION = "1.0.0b2"
 
 SDK_MONIKER = "communication-administration/{}".format(VERSION)  # type: str

--- a/sdk/communication/azure-communication-administration/setup.py
+++ b/sdk/communication/azure-communication-administration/setup.py
@@ -43,7 +43,7 @@ setup(
     license='MIT License',
     # ensure that the development status reflects the status of your package
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
 
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',

--- a/sdk/communication/azure-communication-chat/CHANGELOG.md
+++ b/sdk/communication/azure-communication-chat/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Release History
 
+## 1.0.0b2 (Unreleased)
+
 ## 1.0.0b1 (2020-09-22)
   - Add ChatClient and ChatThreadClient

--- a/sdk/communication/azure-communication-chat/azure/communication/chat/_version.py
+++ b/sdk/communication/azure-communication-chat/azure/communication/chat/_version.py
@@ -4,6 +4,6 @@
 # license information.
 # --------------------------------------------------------------------------
 
-VERSION = "1.0.0b1"
+VERSION = "1.0.0b2"
 
 SDK_MONIKER = "communication-chat/{}".format(VERSION)  # type: str

--- a/sdk/communication/azure-communication-sms/CHANGELOG.md
+++ b/sdk/communication/azure-communication-sms/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Release History
 
+## 1.0.0b2 (Unreleased)
+
 ## 1.0.0b1 (2020-09-22)
 - Preview release of the package

--- a/sdk/communication/azure-communication-sms/azure/communication/sms/_version.py
+++ b/sdk/communication/azure-communication-sms/azure/communication/sms/_version.py
@@ -4,6 +4,6 @@
 # license information.
 # --------------------------------------------------------------------------
 
-VERSION = "1.0.0b1"
+VERSION = "1.0.0b2"
 
 SDK_MONIKER = "communication-sms/{}".format(VERSION)  # type: str


### PR DESCRIPTION
Updating package version for communication packages.
Could not reopen [this closed PR](https://github.com/Azure/azure-sdk-for-python/pull/13942)(branch deleted) - that is why created a new one.

mgmt package was not updated as the version had already been updated before to b2