### PR TITLE
[KeyVault] Handle Role Definition UUID Name Internally

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 from azure.core.tracing.decorator import distributed_trace
 
@@ -27,18 +28,18 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace
-    def create_role_assignment(self, role_scope, role_assignment_name, role_definition_id, principal_id, **kwargs):
-        # type: (Union[str, KeyVaultRoleScope], Union[str, UUID], str, str, **Any) -> KeyVaultRoleAssignment
+    def create_role_assignment(self, role_scope, role_definition_id, principal_id, **kwargs):
+        # type: (Union[str, KeyVaultRoleScope], str, str, **Any) -> KeyVaultRoleAssignment
         """Create a role assignment.
 
         :param role_scope: scope the role assignment will apply over. :class:`KeyVaultRoleScope` defines common
             broad scopes. Specify a narrower scope as a string.
         :type role_scope: str or KeyVaultRoleScope
-        :param role_assignment_name: a name for the role assignment. Must be a UUID.
-        :type role_assignment_name: str or uuid.UUID
         :param str role_definition_id: ID of the role's definition
         :param str principal_id: Azure Active Directory object ID of the principal which will be assigned the role. The
             principal can be a user, service principal, or security group.
+        :keyword role_assignment_name: a name for the role assignment. Must be a UUID.
+        :type role_assignment_name: str or uuid.UUID
         :rtype: KeyVaultRoleAssignment
         """
         create_parameters = self._client.role_assignments.models.RoleAssignmentCreateParameters(
@@ -49,7 +50,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         assignment = self._client.role_assignments.create(
             vault_base_url=self._vault_url,
             scope=role_scope,
-            role_assignment_name=role_assignment_name,
+            role_assignment_name=kwargs.pop("role_assignment_name", uuid4()),
             parameters=create_parameters,
             **kwargs
         )

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
@@ -11,6 +11,7 @@ from ._models import KeyVaultRoleAssignment, KeyVaultRoleDefinition
 from ._internal import KeyVaultClientBase
 
 if TYPE_CHECKING:
+    # pylint:disable=ungrouped-imports
     from typing import Any, Union
     from uuid import UUID
     from azure.core.paging import ItemPaged

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
@@ -28,7 +28,9 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace
-    def create_role_assignment(self, role_scope, role_definition_id, principal_id, **kwargs):
+    def create_role_assignment(
+        self, role_scope, role_definition_id, principal_id, **kwargs
+    ):
         # type: (Union[str, KeyVaultRoleScope], str, str, **Any) -> KeyVaultRoleAssignment
         """Create a role assignment.
 
@@ -50,7 +52,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         assignment = self._client.role_assignments.create(
             vault_base_url=self._vault_url,
             scope=role_scope,
-            role_assignment_name=kwargs.pop("role_assignment_name", uuid4()),
+            role_assignment_name=kwargs.pop("role_assignment_name", None) or uuid4(),
             parameters=create_parameters,
             **kwargs
         )
@@ -70,7 +72,10 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         :rtype: KeyVaultRoleAssignment
         """
         assignment = self._client.role_assignments.delete(
-            vault_base_url=self._vault_url, scope=role_scope, role_assignment_name=str(role_assignment_name), **kwargs
+            vault_base_url=self._vault_url,
+            scope=role_scope,
+            role_assignment_name=str(role_assignment_name),
+            **kwargs
         )
         return KeyVaultRoleAssignment._from_generated(assignment)
 
@@ -87,7 +92,10 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         :rtype: KeyVaultRoleAssignment
         """
         assignment = self._client.role_assignments.get(
-            vault_base_url=self._vault_url, scope=role_scope, role_assignment_name=str(role_assignment_name), **kwargs
+            vault_base_url=self._vault_url,
+            scope=role_scope,
+            role_assignment_name=str(role_assignment_name),
+            **kwargs
         )
         return KeyVaultRoleAssignment._from_generated(assignment)
 
@@ -104,7 +112,9 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         return self._client.role_assignments.list_for_scope(
             self._vault_url,
             role_scope,
-            cls=lambda result: [KeyVaultRoleAssignment._from_generated(a) for a in result],
+            cls=lambda result: [
+                KeyVaultRoleAssignment._from_generated(a) for a in result
+            ],
             **kwargs
         )
 
@@ -121,6 +131,8 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         return self._client.role_definitions.list(
             self._vault_url,
             role_scope,
-            cls=lambda result: [KeyVaultRoleDefinition._from_generated(d) for d in result],
+            cls=lambda result: [
+                KeyVaultRoleDefinition._from_generated(d) for d in result
+            ],
             **kwargs
         )

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
@@ -28,9 +28,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace
-    def create_role_assignment(
-        self, role_scope, role_definition_id, principal_id, **kwargs
-    ):
+    def create_role_assignment(self, role_scope, role_definition_id, principal_id, **kwargs):
         # type: (Union[str, KeyVaultRoleScope], str, str, **Any) -> KeyVaultRoleAssignment
         """Create a role assignment.
 
@@ -72,10 +70,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         :rtype: KeyVaultRoleAssignment
         """
         assignment = self._client.role_assignments.delete(
-            vault_base_url=self._vault_url,
-            scope=role_scope,
-            role_assignment_name=str(role_assignment_name),
-            **kwargs
+            vault_base_url=self._vault_url, scope=role_scope, role_assignment_name=str(role_assignment_name), **kwargs
         )
         return KeyVaultRoleAssignment._from_generated(assignment)
 
@@ -92,10 +87,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         :rtype: KeyVaultRoleAssignment
         """
         assignment = self._client.role_assignments.get(
-            vault_base_url=self._vault_url,
-            scope=role_scope,
-            role_assignment_name=str(role_assignment_name),
-            **kwargs
+            vault_base_url=self._vault_url, scope=role_scope, role_assignment_name=str(role_assignment_name), **kwargs
         )
         return KeyVaultRoleAssignment._from_generated(assignment)
 
@@ -112,9 +104,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         return self._client.role_assignments.list_for_scope(
             self._vault_url,
             role_scope,
-            cls=lambda result: [
-                KeyVaultRoleAssignment._from_generated(a) for a in result
-            ],
+            cls=lambda result: [KeyVaultRoleAssignment._from_generated(a) for a in result],
             **kwargs
         )
 
@@ -131,8 +121,6 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         return self._client.role_definitions.list(
             self._vault_url,
             role_scope,
-            cls=lambda result: [
-                KeyVaultRoleDefinition._from_generated(d) for d in result
-            ],
+            cls=lambda result: [KeyVaultRoleDefinition._from_generated(d) for d in result],
             **kwargs
         )

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
@@ -30,11 +30,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def create_role_assignment(
-        self,
-        role_scope: "Union[str, KeyVaultRoleScope]",
-        role_definition_id: str,
-        principal_id: str,
-        **kwargs: "Any"
+        self, role_scope: "Union[str, KeyVaultRoleScope]", role_definition_id: str, principal_id: str, **kwargs: "Any"
     ) -> KeyVaultRoleAssignment:
         """Create a role assignment.
 
@@ -64,10 +60,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def delete_role_assignment(
-        self,
-        role_scope: "Union[str, KeyVaultRoleScope]",
-        role_assignment_name: "Union[str, UUID]",
-        **kwargs: "Any"
+        self, role_scope: "Union[str, KeyVaultRoleScope]", role_assignment_name: "Union[str, UUID]", **kwargs: "Any"
     ) -> KeyVaultRoleAssignment:
         """Delete a role assignment.
 
@@ -80,19 +73,13 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         :rtype: KeyVaultRoleAssignment
         """
         assignment = await self._client.role_assignments.delete(
-            vault_base_url=self._vault_url,
-            scope=role_scope,
-            role_assignment_name=str(role_assignment_name),
-            **kwargs
+            vault_base_url=self._vault_url, scope=role_scope, role_assignment_name=str(role_assignment_name), **kwargs
         )
         return KeyVaultRoleAssignment._from_generated(assignment)
 
     @distributed_trace_async
     async def get_role_assignment(
-        self,
-        role_scope: "Union[str, KeyVaultRoleScope]",
-        role_assignment_name: "Union[str, UUID]",
-        **kwargs: "Any"
+        self, role_scope: "Union[str, KeyVaultRoleScope]", role_assignment_name: "Union[str, UUID]", **kwargs: "Any"
     ) -> KeyVaultRoleAssignment:
         """Get a role assignment.
 
@@ -104,10 +91,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         :rtype: KeyVaultRoleAssignment
         """
         assignment = await self._client.role_assignments.get(
-            vault_base_url=self._vault_url,
-            scope=role_scope,
-            role_assignment_name=str(role_assignment_name),
-            **kwargs
+            vault_base_url=self._vault_url, scope=role_scope, role_assignment_name=str(role_assignment_name), **kwargs
         )
         return KeyVaultRoleAssignment._from_generated(assignment)
 
@@ -125,9 +109,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         return self._client.role_assignments.list_for_scope(
             self._vault_url,
             role_scope,
-            cls=lambda result: [
-                KeyVaultRoleAssignment._from_generated(a) for a in result
-            ],
+            cls=lambda result: [KeyVaultRoleAssignment._from_generated(a) for a in result],
             **kwargs
         )
 
@@ -145,8 +127,6 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         return self._client.role_definitions.list(
             self._vault_url,
             role_scope,
-            cls=lambda result: [
-                KeyVaultRoleDefinition._from_generated(d) for d in result
-            ],
+            cls=lambda result: [KeyVaultRoleDefinition._from_generated(d) for d in result],
             **kwargs
         )

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
@@ -56,7 +56,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         assignment = await self._client.role_assignments.create(
             vault_base_url=self._vault_url,
             scope=role_scope,
-            role_assignment_name=kwargs.pop("role_assignment_name", uuid4),
+            role_assignment_name=kwargs.pop("role_assignment_name", None) or uuid4(),
             parameters=create_parameters,
             **kwargs
         )
@@ -64,7 +64,10 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def delete_role_assignment(
-        self, role_scope: "Union[str, KeyVaultRoleScope]", role_assignment_name: "Union[str, UUID]", **kwargs: "Any"
+        self,
+        role_scope: "Union[str, KeyVaultRoleScope]",
+        role_assignment_name: "Union[str, UUID]",
+        **kwargs: "Any"
     ) -> KeyVaultRoleAssignment:
         """Delete a role assignment.
 
@@ -77,13 +80,19 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         :rtype: KeyVaultRoleAssignment
         """
         assignment = await self._client.role_assignments.delete(
-            vault_base_url=self._vault_url, scope=role_scope, role_assignment_name=str(role_assignment_name), **kwargs
+            vault_base_url=self._vault_url,
+            scope=role_scope,
+            role_assignment_name=str(role_assignment_name),
+            **kwargs
         )
         return KeyVaultRoleAssignment._from_generated(assignment)
 
     @distributed_trace_async
     async def get_role_assignment(
-        self, role_scope: "Union[str, KeyVaultRoleScope]", role_assignment_name: "Union[str, UUID]", **kwargs: "Any"
+        self,
+        role_scope: "Union[str, KeyVaultRoleScope]",
+        role_assignment_name: "Union[str, UUID]",
+        **kwargs: "Any"
     ) -> KeyVaultRoleAssignment:
         """Get a role assignment.
 
@@ -95,7 +104,10 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         :rtype: KeyVaultRoleAssignment
         """
         assignment = await self._client.role_assignments.get(
-            vault_base_url=self._vault_url, scope=role_scope, role_assignment_name=str(role_assignment_name), **kwargs
+            vault_base_url=self._vault_url,
+            scope=role_scope,
+            role_assignment_name=str(role_assignment_name),
+            **kwargs
         )
         return KeyVaultRoleAssignment._from_generated(assignment)
 
@@ -113,7 +125,9 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         return self._client.role_assignments.list_for_scope(
             self._vault_url,
             role_scope,
-            cls=lambda result: [KeyVaultRoleAssignment._from_generated(a) for a in result],
+            cls=lambda result: [
+                KeyVaultRoleAssignment._from_generated(a) for a in result
+            ],
             **kwargs
         )
 
@@ -131,6 +145,8 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         return self._client.role_definitions.list(
             self._vault_url,
             role_scope,
-            cls=lambda result: [KeyVaultRoleDefinition._from_generated(d) for d in result],
+            cls=lambda result: [
+                KeyVaultRoleDefinition._from_generated(d) for d in result
+            ],
             **kwargs
         )

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.decorator_async import distributed_trace_async
@@ -31,7 +32,6 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
     async def create_role_assignment(
         self,
         role_scope: "Union[str, KeyVaultRoleScope]",
-        role_assignment_name: "Union[str, UUID]",
         role_definition_id: str,
         principal_id: str,
         **kwargs: "Any"
@@ -41,11 +41,11 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         :param role_scope: scope the role assignment will apply over. :class:`KeyVaultRoleScope` defines common broad
             scopes. Specify a narrower scope as a string.
         :type role_scope: str or KeyVaultRoleScope
-        :param role_assignment_name: a name for the role assignment. Must be a UUID.
-        :type role_assignment_name: str or uuid.UUID
         :param str role_definition_id: ID of the role's definition
         :param str principal_id: Azure Active Directory object ID of the principal which will be assigned the role. The
             principal can be a user, service principal, or security group.
+        :keyword role_assignment_name: a name for the role assignment. Must be a UUID.
+        :type role_assignment_name: str or uuid.UUID
         :rtype: KeyVaultRoleAssignment
         """
         create_parameters = self._client.role_assignments.models.RoleAssignmentCreateParameters(
@@ -56,7 +56,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         assignment = await self._client.role_assignments.create(
             vault_base_url=self._vault_url,
             scope=role_scope,
-            role_assignment_name=role_assignment_name,
+            role_assignment_name=kwargs.pop("role_assignment_name", uuid4),
             parameters=create_parameters,
             **kwargs
         )

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
@@ -12,6 +12,7 @@ from .._models import KeyVaultRoleAssignment, KeyVaultRoleDefinition
 from .._internal import AsyncKeyVaultClientBase
 
 if TYPE_CHECKING:
+    # pylint:disable=ungrouped-imports
     from typing import Any, Union
     from uuid import UUID
     from azure.core.async_paging import AsyncItemPaged

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_access_control.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_access_control.py
@@ -66,7 +66,7 @@ class AccessControlTests(KeyVaultTestCase):
         principal_id = self.get_service_principal_id()
         name = self.get_replayable_uuid("some-uuid")
 
-        created = client.create_role_assignment(scope, name, definition.id, principal_id)
+        created = client.create_role_assignment(scope, definition.id, principal_id, role_assignment_name=name)
         assert created.name == name
         assert created.principal_id == principal_id
         assert created.role_definition_id == definition.id

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_access_control_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_access_control_async.py
@@ -71,7 +71,7 @@ class AccessControlTests(KeyVaultTestCase):
         principal_id = self.get_service_principal_id()
         name = self.get_replayable_uuid("some-uuid")
 
-        created = await client.create_role_assignment(scope, name, definition.id, principal_id)
+        created = await client.create_role_assignment(scope, definition.id, principal_id, role_assignment_name=name)
         assert created.name == name
         assert created.principal_id == principal_id
         assert created.role_definition_id == definition.id


### PR DESCRIPTION
Closes #13512. 

Makes `role_assignment_name` a keyword-only argument for `create_role_assignment` in `KeyVaultAccessControlClient`, defaulting to a random UUID if not provided by the user.