### PR TITLE
Resolve Failing Documentation Build for azure-mgmt-core

### DIFF
--- a/eng/pipelines/templates/steps/test_regression.yml
+++ b/eng/pipelines/templates/steps/test_regression.yml
@@ -15,6 +15,11 @@ steps:
       artifactName: 'artifacts' 
       targetPath: $(Build.ArtifactStagingDirectory)
 
+  - template: ../steps/set-dev-build.yml
+    parameters:
+      ServiceDirectory: ${{ parameters.ServiceDirectory }}
+      BuildTargetingString: ${{ parameters.BuildTargetingString }}
+
   - ${{if eq(variables['System.TeamProject'], 'internal') }}:
     - template: ../steps/auth-dev-feed.yml
       parameters:

--- a/eng/pipelines/templates/steps/test_regression.yml
+++ b/eng/pipelines/templates/steps/test_regression.yml
@@ -2,6 +2,7 @@ parameters:
   BuildTargetingString: 'azure-*'
   ServiceDirectory: ''
   BuildStagingDirectory: $(Build.ArtifactStagingDirectory)
+  DevFeedName: 'public/azure-sdk-for-python'
   
 steps:
   - task: UsePythonVersion@0
@@ -13,6 +14,11 @@ steps:
     inputs:
       artifactName: 'artifacts' 
       targetPath: $(Build.ArtifactStagingDirectory)
+
+  - ${{if eq(variables['System.TeamProject'], 'internal') }}:
+    - template: ../steps/auth-dev-feed.yml
+      parameters:
+        DevFeedName: ${{ parameters.DevFeedName }}
 
   - script: |
       pip install -r eng/ci_tools.txt

--- a/eng/tox/sanitize_setup.py
+++ b/eng/tox/sanitize_setup.py
@@ -16,7 +16,6 @@ from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 from pkg_resources import Requirement
 from pypi_tools.pypi import PyPIClient
-import re
 
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", ".."))
 setup_parser_path = os.path.abspath(os.path.join(root_dir, "eng", "versioning"))
@@ -93,7 +92,7 @@ def process_requires(setup_py_path):
             old_req = str(req)
             version = get_version(pkg_name)
             logging.info("Updating version {0} in requirement {1} to dev build version".format(version, old_req))
-            new_req = re.sub('{}[a]*'.format(version), "{}{}".format(version, DEV_BUILD_IDENTIFIER), old_req)
+            new_req = old_req.replace(version, "{}{}".format(version, DEV_BUILD_IDENTIFIER))
             logging.info("New requirement for package {0}: {1}".format(pkg_name, new_req))
             requirement_to_update[old_req] = new_req
 

--- a/eng/tox/sanitize_setup.py
+++ b/eng/tox/sanitize_setup.py
@@ -13,8 +13,10 @@ import os
 import logging
 import glob
 from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 from pkg_resources import Requirement
 from pypi_tools.pypi import PyPIClient
+import re
 
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", ".."))
 setup_parser_path = os.path.abspath(os.path.join(root_dir, "eng", "versioning"))
@@ -22,7 +24,7 @@ setup_parser_path = os.path.abspath(os.path.join(root_dir, "eng", "versioning"))
 sys.path.append(setup_parser_path)
 from setup_parser import get_install_requires, parse_setup
 
-DEV_BUILD_IDENTIFIER = ".dev"
+DEV_BUILD_IDENTIFIER = "a"
 
 def update_requires(setup_py_path, requires_dict):
     # This method changes package requirement by overriding the specifier
@@ -62,12 +64,16 @@ def get_version(pkg_name):
         # When building package with dev build version, version for packages in same service is updated to dev build 
         # and other packages will not have dev build number
         # strip dev build number so we can check if package exists in PyPI and replace
-        if DEV_BUILD_IDENTIFIER in version:
-            version = version[:version.find(DEV_BUILD_IDENTIFIER)]
+        
+        version_obj = Version(version)
+        if version_obj.pre[0] == DEV_BUILD_IDENTIFIER:
+            version = version_obj.base_version
+
         return version
     else:
         logging.error("setyp.py is not found for package {} to identify current version".format(pkg_name))
         exit(1)
+   
 
 def process_requires(setup_py_path):
     # This method process package requirement to verify if all required packages are available on PyPI
@@ -82,11 +88,12 @@ def process_requires(setup_py_path):
     for req in requires:
         pkg_name = req.key
         spec = SpecifierSet(str(req).replace(pkg_name, ""))
+
         if not is_required_version_on_pypi(pkg_name, spec):
             old_req = str(req)
             version = get_version(pkg_name)
             logging.info("Updating version {0} in requirement {1} to dev build version".format(version, old_req))
-            new_req = old_req.replace(version, "{}.dev".format(version))
+            new_req = re.sub('{}[a]*'.format(version), "{}{}".format(version, DEV_BUILD_IDENTIFIER), old_req)
             logging.info("New requirement for package {0}: {1}".format(pkg_name, new_req))
             requirement_to_update[old_req] = new_req
 

--- a/eng/tox/sanitize_setup.py
+++ b/eng/tox/sanitize_setup.py
@@ -65,8 +65,9 @@ def get_version(pkg_name):
         # strip dev build number so we can check if package exists in PyPI and replace
         
         version_obj = Version(version)
-        if version_obj.pre[0] == DEV_BUILD_IDENTIFIER:
-            version = version_obj.base_version
+        if version_obj.pre:
+            if version_obj.pre[0] == DEV_BUILD_IDENTIFIER:
+                version = version_obj.base_version
 
         return version
     else:

--- a/scripts/devops_tasks/build_packages.py
+++ b/scripts/devops_tasks/build_packages.py
@@ -105,4 +105,4 @@ if __name__ == "__main__":
         target_dir = root_dir
 
     targeted_packages = process_glob_string(args.glob_string, target_dir, args.package_filter_string)
-    build_packages(targeted_packages, args.distribution_directory, args.is_dev_build)
+    build_packages(targeted_packages, args.distribution_directory, bool(args.is_dev_build))

--- a/scripts/devops_tasks/git_helper.py
+++ b/scripts/devops_tasks/git_helper.py
@@ -23,7 +23,8 @@ EXCLUDED_PACKAGE_VERSIONS = {
     'azure-cosmos': '3.2.0',
     'azure-servicebus': '0.50.3',
     'azure-eventgrid': '1.3.0',
-    'azure-schemaregistry-avroserializer': '1.0.0b1'
+    'azure-schemaregistry-avroserializer': '1.0.0b1',
+    'azure-storage-blob-changefeed' : '12.0.0b2'
 }
 
 # This method identifies release tag for latest or oldest released version of a given package


### PR DESCRIPTION
The install_requires wasn't properly replacing to `a<buildid>`. It was looking for `.dev` still.

This means that it's not properly installing the azure-core-1.8.2aXX version that hasn't released yet. This update ensures that `azure-mgmt-core` will require a `1.8.2a` so it'll match the unreleased version of the package.

@praveenkuttappan take a look? This will turn our build green, but isn't repeatable like the `.dev` one was. We should take another look at this and dynamically recreate the `rec`, which will allow us to get away from the string-replacement that is currently happening.

