### PR TITLE
Add tests.yml file to template sdk directory.

### DIFF
--- a/sdk/template/tests.yml
+++ b/sdk/template/tests.yml
@@ -1,0 +1,14 @@
+trigger: none
+
+jobs:
+  - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+    parameters:
+      AllocateResourceGroup: 'false'
+      BuildTargetingString: $(BuildTargetingString)
+      ServiceDirectory: template
+      EnvVars:
+        TEMPLATE_CONFIG_CONNECTION: $(python-template-connection-string) # Add variables/mappings as appropriate for your service.
+        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
+        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+        TEST_MODE: 'RunLiveNoRecord'


### PR DESCRIPTION
This PR adds a sample ```tests.yml``` file to the ```sdk/template/``` service directory. This is so that we have a consistent baseline for training materials, but also make it easier for folks to cut-and-paste.