### PR TITLE
[EventHubs] Add note to migration guide to clarify incompatibility of V1 and V5 checkpoints

### DIFF
--- a/sdk/eventhub/azure-eventhub/migration_guide.md
+++ b/sdk/eventhub/azure-eventhub/migration_guide.md
@@ -136,7 +136,7 @@ pass a `CheckpointStore` to the constructor.
 If pointed at the same blob, consumption will begin at the first message.
 V1 checkpoint json in the respective blobs can be manually converted (per-partition) if needed.
 In V1 checkpoints (sequence_number and offset) are stored in the format of json along with ownership information
-as the content of the blob, while in V5, checkpoints are kept in the metadata which is composed of name-value pairs of a blob.
+as the content of the blob, while in V5, checkpoints are kept in the metadata of a blob and the metadata is composed of name-value pairs.
 Please check [update_checkpoint](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_blobstoragecs.py#L231-L250) in V5 for implementation detail.
 
 So in V1:

--- a/sdk/eventhub/azure-eventhub/migration_guide.md
+++ b/sdk/eventhub/azure-eventhub/migration_guide.md
@@ -132,7 +132,12 @@ your program when receiving events.
 In V5, `EventHubConsumerClient` allows you to do the same with the `receive()` method if you
 pass a `CheckpointStore` to the constructor.
 
-> **Note:** V1 checkpoints are not compatible with V5 checkpoints.  If pointed at the same blob, consumption will begin at the first message.  Checkpoint json in the respective blobs can be manually converted (per-partition) if needed.
+> **Note:** V1 checkpoints are not compatible with V5 checkpoints.
+If pointed at the same blob, consumption will begin at the first message.
+V1 checkpoint json in the respective blobs can be manually converted (per-partition) if needed.
+In V1 checkpoints (sequence_number and offset) are stored in the format of json along with ownership information
+as the content of the blob, while in V5, checkpoints are kept in the metadata which is composed of name-value pairs of a blob.
+Please check [update_checkpoint](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_blobstoragecs.py#L231-L250) in V5 for implementation detail.
 
 So in V1:
 ```python

--- a/sdk/eventhub/azure-eventhub/migration_guide.md
+++ b/sdk/eventhub/azure-eventhub/migration_guide.md
@@ -132,6 +132,8 @@ your program when receiving events.
 In V5, `EventHubConsumerClient` allows you to do the same with the `receive()` method if you
 pass a `CheckpointStore` to the constructor.
 
+> **Note:** V1 checkpoints are not compatible with V5 checkpoints.  If pointed at the same blob, consumption will begin at the first message.  Checkpoint json in the respective blobs can be manually converted (per-partition) if needed.
+
 So in V1:
 ```python
 import logging


### PR DESCRIPTION
Ideally (for future work) we could give a small snippet of code to demonstrate the transformation needed to accompany this warning.