### PR TITLE
Communication SMS package - nspkg dependency update

### DIFF
--- a/sdk/communication/azure-communication-sms/CHANGELOG.md
+++ b/sdk/communication/azure-communication-sms/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.0.0b3 (2020-10-07)
+- Add dependency to `azure-communication-nspkg` package, to support py2
+
 ## 1.0.0b2 (2020-10-06)
 - Updated `azure-communication-sms` version.
 

--- a/sdk/communication/azure-communication-sms/azure/communication/sms/_version.py
+++ b/sdk/communication/azure-communication-sms/azure/communication/sms/_version.py
@@ -4,6 +4,6 @@
 # license information.
 # --------------------------------------------------------------------------
 
-VERSION = "1.0.0b2"
+VERSION = "1.0.0b3"
 
 SDK_MONIKER = "communication-sms/{}".format(VERSION)  # type: str

--- a/sdk/communication/azure-communication-sms/setup.py
+++ b/sdk/communication/azure-communication-sms/setup.py
@@ -68,7 +68,7 @@ setup(
         'six>=1.6'
     ],
     extras_require={
-        ":python_version<'3.0'": ['azure-nspkg'],
+        ":python_version<'3.0'": ['azure-communication-nspkg'],
         ":python_version<'3.5'": ["typing"]
     }
 )


### PR DESCRIPTION
This PR fixes the CI error: import all in py2 was failing due to the lack of dependency from `azure-communication-nspkg` 
Version is bumped to publish