### PR TITLE
add metrics advisor to package mapping for docs

### DIFF
--- a/doc/sphinx/package_service_mapping.json
+++ b/doc/sphinx/package_service_mapping.json
@@ -916,6 +916,11 @@
     "service_name": "Form Recognizer",
     "manually_generated": true
   },
+  "azure-ai-metricsadvisor": {
+    "category": "Client",
+    "service_name": "Metrics Advisor",
+    "manually_generated": true
+  },
   "azure-storage-blob": {
     "category": "Client",
     "service_name": "Storage",


### PR DESCRIPTION
github.io docs are showing up in other: https://azure.github.io/azure-sdk-for-python/ref/Other.html