### PR TITLE
fix retry_interval: set it to 1 second instead of 1000 seconds

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_aiohttp.py
@@ -216,7 +216,7 @@ class AioHttpStreamDownloadGenerator(AsyncIterator):
     async def __anext__(self):
         retry_active = True
         retry_total = 3
-        retry_interval = 1000
+        retry_interval = 1  # 1 second
         while retry_active:
             try:
                 chunk = await self.response.internal_response.content.read(self.block_size)

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_requests_asyncio.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_requests_asyncio.py
@@ -157,7 +157,7 @@ class AsyncioStreamDownloadGenerator(AsyncIterator):
         loop = _get_running_loop()
         retry_active = True
         retry_total = 3
-        retry_interval = 1000
+        retry_interval = 1  # 1 second
         while retry_active:
             try:
                 chunk = await loop.run_in_executor(

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_requests_basic.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_requests_basic.py
@@ -117,7 +117,7 @@ class StreamDownloadGenerator(object):
     def __next__(self):
         retry_active = True
         retry_total = 3
-        retry_interval = 1000
+        retry_interval = 1  # 1 second
         while retry_active:
             try:
                 chunk = next(self.iter_content_func)

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_requests_trio.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_requests_trio.py
@@ -95,7 +95,7 @@ class TrioStreamDownloadGenerator(AsyncIterator):
                 if retry_total <= 0:
                     retry_active = False
                 else:
-                    await trio.sleep(1000)
+                    await trio.sleep(1)
                     headers = {'range': 'bytes=' + str(self.downloaded) + '-'}
                     resp = self.pipeline.run(self.request, stream=True, headers=headers)
                     if resp.status_code == 416:


### PR DESCRIPTION
This looks like it was a typo introduced in https://github.com/Azure/azure-sdk-for-python/pull/5785#pullrequestreview-247892247
The review comment makes me think the author meant 1 second, but maybe thought it was milliseconds.

This `retry_interval` is fed to `time.sleep` and `asyncio.sleep`
Both these methods' arguments are in seconds

in #14067 we are experiencing timeouts after ~15 to 16 min (matching 1000 seconds) that are not solved by configuring timeouts in the client