### PR TITLE
[ServiceBus] Change name to <entity>_name naming for remaining "name" parameters

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
@@ -176,11 +176,11 @@ class ServiceBusAdministrationClient:  #pylint:disable=too-many-public-methods
             entry.content.queue_description)
         return runtime_properties
 
-    async def create_queue(self, name: str, **kwargs) -> QueueProperties:
+    async def create_queue(self, queue_name: str, **kwargs) -> QueueProperties:
         """Create a queue.
 
-        :param name: Name of the queue.
-        :type name: str
+        :param queue_name: Name of the queue.
+        :type queue_name: str
         :keyword authorization_rules: Authorization rules for resource.
         :type authorization_rules: list[~azure.servicebus.management.AuthorizationRule]
         :keyword auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the queue is
@@ -234,7 +234,7 @@ class ServiceBusAdministrationClient:  #pylint:disable=too-many-public-methods
         :rtype: ~azure.servicebus.management.QueueProperties
         """
         queue = QueueProperties(
-            name,
+            queue_name,
             authorization_rules=kwargs.pop("authorization_rules", None),
             auto_delete_on_idle=kwargs.pop("auto_delete_on_idle", None),
             dead_lettering_on_message_expiration=kwargs.pop("dead_lettering_on_message_expiration", None),
@@ -265,12 +265,12 @@ class ServiceBusAdministrationClient:  #pylint:disable=too-many-public-methods
             entry_ele = cast(
                 ElementTree,
                 await self._impl.entity.put(
-                    name,  # type: ignore
+                    queue_name,  # type: ignore
                     request_body, api_version=constants.API_VERSION, **kwargs)
             )
 
         entry = QueueDescriptionEntry.deserialize(entry_ele)
-        result = QueueProperties._from_internal_entity(name,
+        result = QueueProperties._from_internal_entity(queue_name,
             entry.content.queue_description)
         return result
 
@@ -386,11 +386,11 @@ class ServiceBusAdministrationClient:  #pylint:disable=too-many-public-methods
         topic_description = TopicRuntimeProperties._from_internal_entity(topic_name, entry.content.topic_description)
         return topic_description
 
-    async def create_topic(self, name: str, **kwargs) -> TopicProperties:
+    async def create_topic(self, topic_name: str, **kwargs) -> TopicProperties:
         """Create a topic.
 
-        :param name: Name of the topic.
-        :type name: str
+        :param topic_name: Name of the topic.
+        :type topic_name: str
         :keyword default_message_time_to_live: ISO 8601 default message timespan to live value. This is
          the duration after which the message expires, starting from when the message is sent to Service
          Bus. This is the default value used when TimeToLive is not set on a message itself.
@@ -432,7 +432,7 @@ class ServiceBusAdministrationClient:  #pylint:disable=too-many-public-methods
         """
 
         topic = TopicProperties(
-            name,
+            topic_name,
             default_message_time_to_live=kwargs.pop("default_message_time_to_live", None),
             max_size_in_megabytes=kwargs.pop("max_size_in_megabytes", None),
             requires_duplicate_detection=kwargs.pop("requires_duplicate_detection", None),
@@ -460,11 +460,11 @@ class ServiceBusAdministrationClient:  #pylint:disable=too-many-public-methods
             entry_ele = cast(
                 ElementTree,
                 await self._impl.entity.put(
-                    name,  # type: ignore
+                    topic_name,  # type: ignore
                     request_body, api_version=constants.API_VERSION, **kwargs)
             )
         entry = TopicDescriptionEntry.deserialize(entry_ele)
-        result = TopicProperties._from_internal_entity(name, entry.content.topic_description)
+        result = TopicProperties._from_internal_entity(topic_name, entry.content.topic_description)
         return result
 
     async def update_topic(self, topic: TopicProperties, **kwargs) -> None:
@@ -585,14 +585,14 @@ class ServiceBusAdministrationClient:  #pylint:disable=too-many-public-methods
         return subscription
 
     async def create_subscription(
-            self, topic_name: str, name: str, **kwargs
+            self, topic_name: str, subscription_name: str, **kwargs
     ) -> SubscriptionProperties:
         """Create a topic subscription.
 
         :param str topic_name: The topic that will own the
          to-be-created subscription.
-        :param name: Name of the subscription.
-        :type name: str
+        :param subscription_name: Name of the subscription.
+        :type subscription_name: str
         :keyword lock_duration: ISO 8601 timespan duration of a peek-lock; that is, the amount of time
          that the message is locked for other receivers. The maximum value for LockDuration is 5
          minutes; the default value is 1 minute.
@@ -633,7 +633,7 @@ class ServiceBusAdministrationClient:  #pylint:disable=too-many-public-methods
         _validate_entity_name_type(topic_name, display_name='topic_name')
 
         subscription = SubscriptionProperties(
-            name,
+            subscription_name,
             lock_duration=kwargs.pop("lock_duration", None),
             requires_session=kwargs.pop("requires_session", None),
             default_message_time_to_live=kwargs.pop("default_message_time_to_live", None),
@@ -662,13 +662,13 @@ class ServiceBusAdministrationClient:  #pylint:disable=too-many-public-methods
                 ElementTree,
                 await self._impl.subscription.put(
                     topic_name,
-                    name,  # type: ignore
+                    subscription_name,  # type: ignore
                     request_body, api_version=constants.API_VERSION, **kwargs)
             )
 
         entry = SubscriptionDescriptionEntry.deserialize(entry_ele)
         result = SubscriptionProperties._from_internal_entity(
-            name, entry.content.subscription_description)
+            subscription_name, entry.content.subscription_description)
         return result
 
     async def update_subscription(
@@ -792,15 +792,15 @@ class ServiceBusAdministrationClient:  #pylint:disable=too-many-public-methods
 
     async def create_rule(
             self, topic_name: str, subscription_name: str,
-            name: str, **kwargs) -> RuleProperties:
+            rule_name: str, **kwargs) -> RuleProperties:
         """Create a rule for a topic subscription.
 
         :param str topic_name: The topic that will own the
          to-be-created subscription rule.
         :param str subscription_name: The subscription that
          will own the to-be-created rule.
-        :param name: Name of the rule.
-        :type name: str
+        :param rule_name: Name of the rule.
+        :type rule_name: str
         :keyword filter: The filter of the rule.
         :type filter: Union[~azure.servicebus.management.CorrelationRuleFilter,
          ~azure.servicebus.management.SqlRuleFilter]
@@ -812,7 +812,7 @@ class ServiceBusAdministrationClient:  #pylint:disable=too-many-public-methods
         _validate_topic_and_subscription_types(topic_name, subscription_name)
 
         rule = RuleProperties(
-            name,
+            rule_name,
             filter=kwargs.pop("filter", None),
             action=kwargs.pop("action", None),
             created_at_utc=None
@@ -830,10 +830,10 @@ class ServiceBusAdministrationClient:  #pylint:disable=too-many-public-methods
             entry_ele = await self._impl.rule.put(
                 topic_name,
                 subscription_name,  # type: ignore
-                name,
+                rule_name,
                 request_body, api_version=constants.API_VERSION, **kwargs)
         entry = RuleDescriptionEntry.deserialize(entry_ele)
-        result = RuleProperties._from_internal_entity(name, entry.content.rule_description)
+        result = RuleProperties._from_internal_entity(rule_name, entry.content.rule_description)
         deserialize_rule_key_values(entry_ele, result)  # to remove after #3535 is released.
         return result
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
@@ -170,12 +170,12 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
         runtime_properties = QueueRuntimeProperties._from_internal_entity(queue_name, entry.content.queue_description)
         return runtime_properties
 
-    def create_queue(self, name, **kwargs):
+    def create_queue(self, queue_name, **kwargs):
         # type: (str, Any) -> QueueProperties
         """Create a queue.
 
-        :param name: Name of the queue.
-        :type name: str
+        :param queue_name: Name of the queue.
+        :type queue_name: str
         :keyword authorization_rules: Authorization rules for resource.
         :type authorization_rules: list[~azure.servicebus.management.AuthorizationRule]
         :keyword auto_delete_on_idle: ISO 8601 timeSpan idle interval after which the queue is
@@ -229,7 +229,7 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
         :rtype: ~azure.servicebus.management.QueueProperties
         """
         queue = QueueProperties(
-            name,
+            queue_name,
             authorization_rules=kwargs.pop("authorization_rules", None),
             auto_delete_on_idle=kwargs.pop("auto_delete_on_idle", None),
             dead_lettering_on_message_expiration=kwargs.pop("dead_lettering_on_message_expiration", None),
@@ -260,12 +260,12 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
             entry_ele = cast(
                 ElementTree,
                 self._impl.entity.put(
-                    name,  # type: ignore
+                    queue_name,  # type: ignore
                     request_body, api_version=constants.API_VERSION, **kwargs)
             )
 
         entry = QueueDescriptionEntry.deserialize(entry_ele)
-        result = QueueProperties._from_internal_entity(name, entry.content.queue_description)
+        result = QueueProperties._from_internal_entity(queue_name, entry.content.queue_description)
         return result
 
     def update_queue(self, queue, **kwargs):
@@ -389,12 +389,12 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
         topic_description = TopicRuntimeProperties._from_internal_entity(topic_name, entry.content.topic_description)
         return topic_description
 
-    def create_topic(self, name, **kwargs):
+    def create_topic(self, topic_name, **kwargs):
         # type: (str, Any) -> TopicProperties
         """Create a topic.
 
-        :param name: Name of the topic.
-        :type name: str
+        :param topic_name: Name of the topic.
+        :type topic_name: str
         :keyword default_message_time_to_live: ISO 8601 default message timespan to live value. This is
          the duration after which the message expires, starting from when the message is sent to Service
          Bus. This is the default value used when TimeToLive is not set on a message itself.
@@ -435,7 +435,7 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
         :rtype: ~azure.servicebus.management.TopicProperties
         """
         topic = TopicProperties(
-            name,
+            topic_name,
             default_message_time_to_live=kwargs.pop("default_message_time_to_live", None),
             max_size_in_megabytes=kwargs.pop("max_size_in_megabytes", None),
             requires_duplicate_detection=kwargs.pop("requires_duplicate_detection", None),
@@ -463,11 +463,11 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
             entry_ele = cast(
                 ElementTree,
                 self._impl.entity.put(
-                    name,  # type: ignore
+                    topic_name,  # type: ignore
                     request_body, api_version=constants.API_VERSION, **kwargs)
             )
         entry = TopicDescriptionEntry.deserialize(entry_ele)
-        result = TopicProperties._from_internal_entity(name, entry.content.topic_description)
+        result = TopicProperties._from_internal_entity(topic_name, entry.content.topic_description)
         return result
 
     def update_topic(self, topic, **kwargs):
@@ -594,14 +594,14 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
             entry.title, entry.content.subscription_description)
         return subscription
 
-    def create_subscription(self, topic_name, name, **kwargs):
+    def create_subscription(self, topic_name, subscription_name, **kwargs):
         # type: (str, str, Any) -> SubscriptionProperties
         """Create a topic subscription.
 
         :param str topic_name: The topic that will own the
          to-be-created subscription.
-        :param name: Name of the subscription.
-        :type name: str
+        :param subscription_name: Name of the subscription.
+        :type subscription_name: str
         :keyword lock_duration: ISO 8601 timespan duration of a peek-lock; that is, the amount of time
          that the message is locked for other receivers. The maximum value for LockDuration is 5
          minutes; the default value is 1 minute.
@@ -642,7 +642,7 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
         _validate_entity_name_type(topic_name, display_name='topic_name')
 
         subscription = SubscriptionProperties(
-            name,
+            subscription_name,
             lock_duration=kwargs.pop("lock_duration", None),
             requires_session=kwargs.pop("requires_session", None),
             default_message_time_to_live=kwargs.pop("default_message_time_to_live", None),
@@ -671,13 +671,13 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
                 ElementTree,
                 self._impl.subscription.put(
                     topic_name,
-                    name,  # type: ignore
+                    subscription_name,  # type: ignore
                     request_body, api_version=constants.API_VERSION, **kwargs)
             )
 
         entry = SubscriptionDescriptionEntry.deserialize(entry_ele)
         result = SubscriptionProperties._from_internal_entity(
-            name, entry.content.subscription_description)
+            subscription_name, entry.content.subscription_description)
         return result
 
     def update_subscription(self, topic_name, subscription, **kwargs):
@@ -796,7 +796,7 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
         deserialize_rule_key_values(entry_ele, rule_description)  # to remove after #3535 is released.
         return rule_description
 
-    def create_rule(self, topic_name, subscription_name, name, **kwargs):
+    def create_rule(self, topic_name, subscription_name, rule_name, **kwargs):
         # type: (str, str, str, Any) -> RuleProperties
         """Create a rule for a topic subscription.
 
@@ -804,8 +804,8 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
          to-be-created subscription rule.
         :param str subscription_name: The subscription that
          will own the to-be-created rule.
-        :param name: Name of the rule.
-        :type name: str
+        :param rule_name: Name of the rule.
+        :type rule_name: str
         :keyword filter: The filter of the rule.
         :type filter: Union[~azure.servicebus.management.CorrelationRuleFilter,
          ~azure.servicebus.management.SqlRuleFilter]
@@ -817,7 +817,7 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
         _validate_topic_and_subscription_types(topic_name, subscription_name)
 
         rule = RuleProperties(
-            name,
+            rule_name,
             filter=kwargs.pop("filter", None),
             action=kwargs.pop("action", None),
             created_at_utc=None
@@ -835,10 +835,10 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
             entry_ele = self._impl.rule.put(
                 topic_name,
                 subscription_name,  # type: ignore
-                name,
+                rule_name,
                 request_body, api_version=constants.API_VERSION, **kwargs)
         entry = RuleDescriptionEntry.deserialize(entry_ele)
-        result = RuleProperties._from_internal_entity(name, entry.content.rule_description)
+        result = RuleProperties._from_internal_entity(rule_name, entry.content.rule_description)
         deserialize_rule_key_values(entry_ele, result)  # to remove after #3535 is released.
         return result
 

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_subscriptions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_subscriptions_async.py
@@ -55,7 +55,7 @@ class ServiceBusAdministrationClientSubscriptionAsyncTests(AzureMgmtTestCase):
             await mgmt_service.create_topic(topic_name)
             await mgmt_service.create_subscription(
                 topic_name,
-                name=subscription_name,
+                subscription_name=subscription_name,
                 auto_delete_on_idle=datetime.timedelta(minutes=10),
                 dead_lettering_on_message_expiration=True,
                 default_message_time_to_live=datetime.timedelta(minutes=11),

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_topics_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/mgmt_tests/test_mgmt_topics_async.py
@@ -49,7 +49,7 @@ class ServiceBusAdministrationClientTopicAsyncTests(AzureMgmtTestCase):
         topic_name = "iweidk"
         try:
             await mgmt_service.create_topic(
-                name=topic_name,
+                topic_name=topic_name,
                 auto_delete_on_idle=datetime.timedelta(minutes=10),
                 default_message_time_to_live=datetime.timedelta(minutes=11),
                 duplicate_detection_history_time_window=datetime.timedelta(minutes=12),

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_subscriptions.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_subscriptions.py
@@ -54,7 +54,7 @@ class ServiceBusAdministrationClientSubscriptionTests(AzureMgmtTestCase):
             mgmt_service.create_topic(topic_name)
             mgmt_service.create_subscription(
                 topic_name,
-                name=subscription_name,
+                subscription_name=subscription_name,
                 auto_delete_on_idle=datetime.timedelta(minutes=10),
                 dead_lettering_on_message_expiration=True,
                 default_message_time_to_live=datetime.timedelta(minutes=11),

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_topics.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_topics.py
@@ -48,7 +48,7 @@ class ServiceBusAdministrationClientTopicTests(AzureMgmtTestCase):
         topic_name = "iweidk"
         try:
             mgmt_service.create_topic(
-                name=topic_name,
+                topic_name=topic_name,
                 auto_delete_on_idle=datetime.timedelta(minutes=10),
                 default_message_time_to_live=datetime.timedelta(minutes=11),
                 duplicate_detection_history_time_window=datetime.timedelta(minutes=12),


### PR DESCRIPTION
For AdministrationClient to normalize with existing naming schemes.