### PR TITLE
[Blob] Throw exception if set service properties isn't provided any positional arguments

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_service_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_service_client.py
@@ -350,6 +350,11 @@ class BlobServiceClient(StorageAccountHostsMixin):
                 :dedent: 8
                 :caption: Setting service properties for the blob service.
         """
+        if all(parameter is None for parameter in [
+                    analytics_logging, hour_metrics, minute_metrics, cors,
+                    target_version, delete_retention_policy, static_website]):
+            raise ValueError("set_service_properties should be called with at least one parameter")
+
         props = StorageServiceProperties(
             logging=analytics_logging,
             hour_metrics=hour_metrics,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_service_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_service_client_async.py
@@ -304,6 +304,11 @@ class BlobServiceClient(AsyncStorageAccountHostsMixin, BlobServiceClientBase):
                 :dedent: 12
                 :caption: Setting service properties for the blob service.
         """
+        if all(parameter is None for parameter in [
+                    analytics_logging, hour_metrics, minute_metrics, cors,
+                    target_version, delete_retention_policy, static_website]):
+            raise ValueError("set_service_properties should be called with at least one parameter")
+
         props = StorageServiceProperties(
             logging=analytics_logging,
             hour_metrics=hour_metrics,

--- a/sdk/storage/azure-storage-blob/tests/test_blob_service_properties.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_service_properties.py
@@ -127,6 +127,12 @@ class ServicePropertiesTest(StorageTestCase):
 
     # --Test cases per feature ---------------------------------------
     @GlobalStorageAccountPreparer()
+    def test_empty_set_service_properties_exception(self, resource_group, location, storage_account, storage_account_key):
+        bsc = BlobServiceClient(self.account_url(storage_account, "blob"), credential=storage_account_key)
+        with self.assertRaises(ValueError):
+            bsc.set_service_properties()
+
+    @GlobalStorageAccountPreparer()
     def test_set_default_service_version(self, resource_group, location, storage_account, storage_account_key):
         # Arrange
         bsc = BlobServiceClient(self.account_url(storage_account, "blob"), credential=storage_account_key)

--- a/sdk/storage/azure-storage-blob/tests/test_blob_service_properties_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_service_properties_async.py
@@ -123,6 +123,13 @@ class ServicePropertiesTestAsync(AsyncStorageTestCase):
     # --Test cases per service ---------------------------------------
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
+    async def test_empty_set_service_properties_exception(self, resource_group, location, storage_account, storage_account_key):
+        bsc = BlobServiceClient(self.account_url(storage_account, "blob"), credential=storage_account_key, transport=AiohttpTestTransport())
+        with self.assertRaises(ValueError):
+            await bsc.set_service_properties()
+
+    @GlobalStorageAccountPreparer()
+    @AsyncStorageTestCase.await_prepared_test
     async def test_blob_service_properties(self, resource_group, location, storage_account, storage_account_key):
         bsc = BlobServiceClient(self.account_url(storage_account, "blob"), credential=storage_account_key, transport=AiohttpTestTransport())
 


### PR DESCRIPTION
`set_service_properties` should raise to users when no input is given to the method.
Track 1 reference: https://github.com/Azure/azure-storage-python/commit/588c11ac2b3889abd2060eebf9219493f4cd7474