### PR TITLE
[metricsadvisor] enable live tests

### DIFF
--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/samples/README.md
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/samples/README.md
@@ -5,7 +5,6 @@ languages:
 products:
   - azure
   - azure-cognitive-services
-  - azure-metrics-advisor
 urlFragment: metricsadvisor-samples
 ---
 

--- a/sdk/metricsadvisor/tests.yml
+++ b/sdk/metricsadvisor/tests.yml
@@ -5,6 +5,7 @@ jobs:
     parameters:
       BuildTargetingString: azure-ai-metricsadvisor
       ServiceDirectory: metricsadvisor
+      MaxParallel: 1
       EnvVars:
         AZURE_SUBSCRIPTION_ID: $(provisioner-subscription)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)


### PR DESCRIPTION
Even if we have to run sequentially, let's at least enable live tests to run. Still working on parallel execution in another PR.

Also removes the sample metadata header per Kate's request.

Live test pass: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=572827&view=results