### PR TITLE
Update Azure.Identity and KeyVault codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,7 +17,7 @@
 # Service team
 ####
 # PRLabel: %Azure.Identity
-/sdk/identity/                                                       @chlowell @schaabs
+/sdk/identity/                                                       @chlowell @mccoyp @schaabs
 
 # PRLabel: %Event Hubs
 /sdk/eventhub/                                                       @annatisch @yunhaoling @KieranBrantnerMagee
@@ -39,7 +39,7 @@
 /sdk/communication/                                                  @RezaJooyandeh @turalf @ankitarorabit @Azure/azure-sdk-communication-code-reviewers
 
 # PRLabel: %KeyVault
-/sdk/keyvault/                                                       @schaabs @chlowell @iscai-msft
+/sdk/keyvault/                                                       @schaabs @chlowell @mccoyp
 
 # PRLabel: %Monitor - LogAnalytics
 /sdk/loganalytics/                                                   @alexeldeib


### PR DESCRIPTION
Adding @mccoyp and removing @iscai-msft so the former gets more spam, the latter less 😸 