### PR TITLE
Add canary region to smoke test matrix

### DIFF
--- a/common/smoketest/smoke-test.yml
+++ b/common/smoketest/smoke-test.yml
@@ -11,36 +11,79 @@ jobs:
           OSVmImage: ubuntu-18.04
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+        Python_27_Linux (AzureCloud Canary):
+          PythonVersion: '2.7'
+          InstallAsyncRequirements: false
+          OSVmImage: ubuntu-18.04
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+          ArmTemplateParameters: $(azureCloudArmParameters)
+          Location: 'eastus2euap'
         Python_37_Linux (AzureCloud):
           PythonVersion: '3.7'
           OSVmImage: ubuntu-18.04
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+        Python_37_Linux (AzureCloud Canary):
+          PythonVersion: '3.7'
+          OSVmImage: ubuntu-18.04
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+          ArmTemplateParameters: $(azureCloudArmParameters)
+          Location: 'eastus2euap'
         Python_38_Linux (AzureCloud):
           PythonVersion: '3.8'
           OSVmImage: ubuntu-18.04
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+        Python_38_Linux (AzureCloud Canary):
+          PythonVersion: '3.8'
+          OSVmImage: ubuntu-18.04
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+          ArmTemplateParameters: $(azureCloudArmParameters)
+          Location: 'eastus2euap'
         Python_37_Windows (AzureCloud):
           PythonVersion: '3.7'
           OSVmImage: windows-2019
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+        Python_37_Windows (AzureCloud Canary):
+          PythonVersion: '3.7'
+          OSVmImage: windows-2019
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+          ArmTemplateParameters: $(azureCloudArmParameters)
+          Location: 'eastus2euap'
         Python_38_Windows (AzureCloud):
           PythonVersion: '3.8'
           OSVmImage: windows-2019
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+        Python_38_Windows (AzureCloud Canary):
+          PythonVersion: '3.8'
+          OSVmImage: windows-2019
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+          ArmTemplateParameters: $(azureCloudArmParameters)
+          Location: 'eastus2euap'
         Python_37_Mac (AzureCloud):
           PythonVersion: '3.7'
           OSVmImage: macOS-10.15
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+        Python_37_Mac (AzureCloud Canary):
+          PythonVersion: '3.7'
+          OSVmImage: macOS-10.15
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+          ArmTemplateParameters: $(azureCloudArmParameters)
+          Location: 'eastus2euap'
         Python_38_Mac (AzureCloud):
           PythonVersion: '3.8'
           OSVmImage: macOS-10.15
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+        Python_38_Mac (AzureCloud Canary):
+          PythonVersion: '3.8'
+          OSVmImage: macOS-10.15
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+          ArmTemplateParameters: $(azureCloudArmParameters)
+          Location: 'eastus2euap'
         Python_38_Linux (AzureUSGovernment):
           PythonVersion: '3.8'
           OSVmImage: ubuntu-18.04

--- a/common/smoketest/smoke-test.yml
+++ b/common/smoketest/smoke-test.yml
@@ -11,24 +11,11 @@ jobs:
           OSVmImage: ubuntu-18.04
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
-        Python_27_Linux (AzureCloud Canary):
-          PythonVersion: '2.7'
-          InstallAsyncRequirements: false
-          OSVmImage: ubuntu-18.04
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ArmTemplateParameters: $(azureCloudArmParameters)
-          Location: 'eastus2euap'
         Python_37_Linux (AzureCloud):
           PythonVersion: '3.7'
           OSVmImage: ubuntu-18.04
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
-        Python_37_Linux (AzureCloud Canary):
-          PythonVersion: '3.7'
-          OSVmImage: ubuntu-18.04
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ArmTemplateParameters: $(azureCloudArmParameters)
-          Location: 'eastus2euap'
         Python_38_Linux (AzureCloud):
           PythonVersion: '3.8'
           OSVmImage: ubuntu-18.04
@@ -45,45 +32,21 @@ jobs:
           OSVmImage: windows-2019
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
-        Python_37_Windows (AzureCloud Canary):
-          PythonVersion: '3.7'
-          OSVmImage: windows-2019
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ArmTemplateParameters: $(azureCloudArmParameters)
-          Location: 'eastus2euap'
         Python_38_Windows (AzureCloud):
           PythonVersion: '3.8'
           OSVmImage: windows-2019
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
-        Python_38_Windows (AzureCloud Canary):
-          PythonVersion: '3.8'
-          OSVmImage: windows-2019
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ArmTemplateParameters: $(azureCloudArmParameters)
-          Location: 'eastus2euap'
         Python_37_Mac (AzureCloud):
           PythonVersion: '3.7'
           OSVmImage: macOS-10.15
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
-        Python_37_Mac (AzureCloud Canary):
-          PythonVersion: '3.7'
-          OSVmImage: macOS-10.15
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ArmTemplateParameters: $(azureCloudArmParameters)
-          Location: 'eastus2euap'
         Python_38_Mac (AzureCloud):
           PythonVersion: '3.8'
           OSVmImage: macOS-10.15
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
-        Python_38_Mac (AzureCloud Canary):
-          PythonVersion: '3.8'
-          OSVmImage: macOS-10.15
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ArmTemplateParameters: $(azureCloudArmParameters)
-          Location: 'eastus2euap'
         Python_38_Linux (AzureUSGovernment):
           PythonVersion: '3.8'
           OSVmImage: ubuntu-18.04


### PR DESCRIPTION
This PR adds a new entry to the smoke test matrix to add a public cloud test against a Canary/EUAP region (specifically eastus2euap).

Azure/azure-sdk#1879