### PR TITLE
Fixed a typo in a code sample.

### DIFF
--- a/doc/sphinx/python_mgmt_migration_guide.rst
+++ b/doc/sphinx/python_mgmt_migration_guide.rst
@@ -98,7 +98,7 @@ To the show the code snippets for the change:
 
 .. code:: python
 
-    import azure.mmgt.compute
+    import azure.mgmt.compute
     from azure.identity import ClientSecretCredential
 
     credential = ClientSecretCredential(


### PR DESCRIPTION
The python code sample in the https://azure.github.io/azure-sdk-for-python/python_mgmt_migration_guide.html#authentication had a typo in the 'Equivalent in new version' section that caused errors when a customer followed the guide exactly.

Signed-off-by: kyichii <kyichii@microsoft.com>