### PR TITLE
Fix pypi_tools.pypi ImportError

### DIFF
--- a/tools/azure-sdk-tools/pypi_tools/pypi.py
+++ b/tools/azure-sdk-tools/pypi_tools/pypi.py
@@ -1,6 +1,4 @@
-from typing import Optional
-
-from packaging.version import parse as Version, InvalidVersion
+from packaging.version import parse as Version
 
 import requests
 


### PR DESCRIPTION
`pypi_tools.pypi` isn't importable in all 2.7 environments because it attempts to import from `typing`, which isn't part of 2.7's standard library. The module doesn't use this import, so this PR simply removes it.