### PR TITLE
Remove eng/common sync from template run. Add changelog verification

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -8,6 +8,7 @@ parameters:
   InjectedPackages: ''
   BuildDocs: true
   SkipPythonVersion: ''
+  Artifacts: []
   TestMatrix:
     Linux_Python27:
       OSVmImage: 'ubuntu-18.04'
@@ -88,6 +89,7 @@ jobs:
         BuildTargetingString: ${{ parameters.BuildTargetingString }}
         TestMarkArgument: ${{ parameters.TestMarkArgument }}
         AdditionalTestArgs: '--wheel_dir="$(Build.ArtifactStagingDirectory)"'
+        Artifacts: ${{ parameters.Artifacts }}
 
   - job: 'Test'
     condition: and(succeededOrFailed(), ne(variables['Skip.Test'], 'true'))

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -35,6 +35,11 @@ stages:
                         pwsh: true
                         workingDirectory: $(Build.SourcesDirectory)
                         filePath: eng/scripts/SetTestPipelineVersion.ps1
+                    - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
+                      parameters:
+                        PackageName: ${{artifact.name}}
+                        ServiceName: ${{parameters.ServiceDirectory}}
+                        ForRelease: true
                     - template: /eng/pipelines/templates/steps/stage-filtered-artifacts.yml
                       parameters:
                         SourceFolder: ${{parameters.ArtifactName}} 
@@ -224,6 +229,7 @@ stages:
                           PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
                           CommitMsg: "Increment package version after release of ${{ artifact.name }}"
                           PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
+                          CloseAfterOpenForTesting: $(TestPipeline)
 
   - stage: Integration
     dependsOn: ${{parameters.DependsOn}}

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -42,6 +42,7 @@ stages:
         SkipPythonVersion: ${{parameters.SkipPythonVersion}}
         AdditionalTestMatrix: ${{parameters.AdditionalTestMatrix}}
         DevFeedName: ${{parameters.DevFeedName}}
+        Artifacts: ${{ parameters.Artifacts }}
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
@@ -49,7 +50,7 @@ stages:
       parameters:
         DependsOn: Build
         ServiceDirectory: ${{parameters.ServiceDirectory}}
-        Artifacts: ${{parameters.Artifacts}}
+        Artifacts: ${{ parameters.Artifacts }}
         ArtifactName: packages
         DocArtifact: documentation
         TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -3,15 +3,10 @@ parameters:
   ServiceDirectory: ''
   TestMarkArgument: ''
   AdditionalTestArgs: ''
+  Artifacts: []
 
 steps:
   - template: /eng/pipelines/templates/steps/analyze_dependency.yml
-
-  - task: PythonScript@0
-    displayName: 'Verify Change Log'
-    inputs:
-     scriptPath: 'scripts/devops_tasks/verify_change_log.py'
-     arguments: '"${{ parameters.BuildTargetingString }}" --service=${{parameters.ServiceDirectory}}'
 
     # Using --always-succeed so as not to block the build. Once package
     # target is based on data available per-package the --always-succeed should

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -10,7 +10,6 @@ trigger:
   paths:
     include:
     - sdk/template/
-    - eng/common/
 
 pr:
   branches:


### PR DESCRIPTION
Prevent template pipeline run triggered by eng/common changes.
Add standard ChangeLog Verification.
Use BuildID as preview version.
Update SetTestPipelineVersion.ps1