### PR TITLE
Communication: Fix live-test failures

### DIFF
--- a/sdk/communication/azure-communication-administration/dev_requirements.txt
+++ b/sdk/communication/azure-communication-administration/dev_requirements.txt
@@ -1,5 +1,6 @@
 -e ../../../tools/azure-sdk-tools
 -e ../../../tools/azure-devtools
+-e ../../identity/azure-identity
 ../../core/azure-core
 ../azure-communication-nspkg
 ../azure-mgmt-communication

--- a/sdk/communication/azure-communication-administration/tests/_shared/communication_service_preparer.py
+++ b/sdk/communication/azure-communication-administration/tests/_shared/communication_service_preparer.py
@@ -54,7 +54,7 @@ class CommunicationServicePreparer(AzureMgmtPreparer):
 
         group_name = self._get_resource_group(**kwargs).name
 
-        self.mgmt_client = self.create_mgmt_client(CommunicationServiceManagementClient)
+        self.mgmt_client = self.create_mgmt_client(CommunicationServiceManagementClient, polling_interval=30)
 
         resource = self.mgmt_client.communication_service.begin_create_or_update(
             group_name,

--- a/sdk/communication/azure-communication-administration/tests/_shared/communication_service_preparer.py
+++ b/sdk/communication/azure-communication-administration/tests/_shared/communication_service_preparer.py
@@ -31,6 +31,7 @@ class CommunicationServicePreparer(AzureMgmtPreparer):
             client_kwargs=client_kwargs,
         )
         self.resource_group_parameter_name = resource_group_parameter_name
+        self.random_name_enabled = True
         self.service_name = "TEST-SERVICE-NAME"
         self.mgmt_client = None
 

--- a/sdk/communication/azure-communication-administration/tests/test_phone_number_administration_client.py
+++ b/sdk/communication/azure-communication-administration/tests/test_phone_number_administration_client.py
@@ -16,6 +16,9 @@ from phone_number_helper import PhoneNumberUriReplacer
 from phone_number_testcase import PhoneNumberCommunicationTestCase
 from _shared.testcase import BodyReplacerProcessor
 
+SKIP_PHONE_NUMBER_TESTS = True
+PHONE_NUMBER_TEST_SKIP_REASON= "Phone Number Administration live tests infra not ready yet"
+
 class PhoneNumberAdministrationClientTest(PhoneNumberCommunicationTestCase):
 
     def setUp(self):
@@ -123,11 +126,13 @@ class PhoneNumberAdministrationClientTest(PhoneNumberCommunicationTestCase):
             self.release_id = "release_id"
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_list_all_phone_numbers(self):
         pages = self._phone_number_administration_client.list_all_phone_numbers()
         assert pages.next()
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_get_all_area_codes(self):
         area_codes = self._phone_number_administration_client.get_all_area_codes(
             location_type="NotRequired",
@@ -137,6 +142,7 @@ class PhoneNumberAdministrationClientTest(PhoneNumberCommunicationTestCase):
         assert area_codes.primary_area_codes
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_get_capabilities_update(self):
         capability_response = self._phone_number_administration_client.get_capabilities_update(
             capabilities_update_id=self.capabilities_id
@@ -144,6 +150,7 @@ class PhoneNumberAdministrationClientTest(PhoneNumberCommunicationTestCase):
         assert capability_response.capabilities_update_id
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_update_capabilities(self):
         update = NumberUpdateCapabilities(add=iter(["InboundCalling"]))
 
@@ -157,11 +164,13 @@ class PhoneNumberAdministrationClientTest(PhoneNumberCommunicationTestCase):
         assert capability_response.capabilities_update_id
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_list_all_supported_countries(self):
         countries = self._phone_number_administration_client.list_all_supported_countries()
         assert countries.next().localized_name
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_get_number_configuration(self):
         phone_number_response = self._phone_number_administration_client.get_number_configuration(
             phone_number=self.phonenumber_to_get_config
@@ -169,6 +178,7 @@ class PhoneNumberAdministrationClientTest(PhoneNumberCommunicationTestCase):
         assert phone_number_response.pstn_configuration
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_configure_number(self):
         pstnConfig = PstnConfiguration(
             callback_url="https://callbackurl",
@@ -181,6 +191,7 @@ class PhoneNumberAdministrationClientTest(PhoneNumberCommunicationTestCase):
         assert not configure_number_response
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_list_phone_plan_groups(self):
         phone_plan_group_response = self._phone_number_administration_client.list_phone_plan_groups(
             country_code=self.country_code
@@ -188,6 +199,7 @@ class PhoneNumberAdministrationClientTest(PhoneNumberCommunicationTestCase):
         assert phone_plan_group_response.next().phone_plan_group_id
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_list_phone_plans(self):
         phone_plan_response = self._phone_number_administration_client.list_phone_plans(
             country_code=self.country_code,
@@ -196,6 +208,7 @@ class PhoneNumberAdministrationClientTest(PhoneNumberCommunicationTestCase):
         assert phone_plan_response.next().phone_plan_id
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_get_phone_plan_location_options(self):
         location_options_response = self._phone_number_administration_client.get_phone_plan_location_options(
             country_code=self.country_code,
@@ -205,6 +218,7 @@ class PhoneNumberAdministrationClientTest(PhoneNumberCommunicationTestCase):
         assert location_options_response.location_options.label_id
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_get_release_by_id(self):
         phone_number_release_response = self._phone_number_administration_client.get_release_by_id(
             release_id=self.release_id
@@ -212,11 +226,13 @@ class PhoneNumberAdministrationClientTest(PhoneNumberCommunicationTestCase):
         assert phone_number_release_response.release_id
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_list_all_releases(self):
         releases_response = self._phone_number_administration_client.list_all_releases()
         assert releases_response.next().id
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_release_phone_numbers(self):
         releases_response = self._phone_number_administration_client.release_phone_numbers(
             [self.phonenumber_to_release]
@@ -224,6 +240,7 @@ class PhoneNumberAdministrationClientTest(PhoneNumberCommunicationTestCase):
         assert releases_response.release_id
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_get_search_by_id(self):
         phone_number_search_response = self._phone_number_administration_client.get_search_by_id(
             search_id=self.search_id
@@ -231,6 +248,7 @@ class PhoneNumberAdministrationClientTest(PhoneNumberCommunicationTestCase):
         assert phone_number_search_response.search_id
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_create_search(self):
         searchOptions = CreateSearchOptions(
             area_code=self.area_code_for_search,
@@ -245,6 +263,7 @@ class PhoneNumberAdministrationClientTest(PhoneNumberCommunicationTestCase):
         assert search_response.search_id
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_cancel_search(self):
         cancel_search_response = self._phone_number_administration_client.cancel_search(
             search_id=self.search_id_to_cancel
@@ -252,6 +271,7 @@ class PhoneNumberAdministrationClientTest(PhoneNumberCommunicationTestCase):
         assert not cancel_search_response
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_purchase_search(self):
         purchase_search_response = self._phone_number_administration_client.purchase_search(
             search_id=self.search_id_to_purchase

--- a/sdk/communication/azure-communication-administration/tests/test_phone_number_administration_client_async.py
+++ b/sdk/communication/azure-communication-administration/tests/test_phone_number_administration_client_async.py
@@ -16,6 +16,9 @@ from phone_number_testcase_async import AsyncPhoneNumberCommunicationTestCase
 from _shared.testcase import BodyReplacerProcessor, ResponseReplacerProcessor
 import os
 
+SKIP_PHONE_NUMBER_TESTS = True
+PHONE_NUMBER_TEST_SKIP_REASON= "Phone Number Administration live tests infra not ready yet"
+
 class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTestCase):
 
     def setUp(self):
@@ -125,6 +128,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_list_all_phone_numbers(self):
         async with self._phone_number_administration_client:
             pages = self._phone_number_administration_client.list_all_phone_numbers()
@@ -136,6 +140,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_get_all_area_codes(self):
         async with self._phone_number_administration_client:
             area_codes = await self._phone_number_administration_client.get_all_area_codes(
@@ -147,6 +152,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_get_capabilities_update(self):
         async with self._phone_number_administration_client:
             capability_response = await self._phone_number_administration_client.get_capabilities_update(
@@ -156,6 +162,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_update_capabilities(self):
         update = NumberUpdateCapabilities(add=iter(["InboundCalling"]))
 
@@ -171,6 +178,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_list_all_supported_countries(self):
         async with self._phone_number_administration_client:
             countries = self._phone_number_administration_client.list_all_supported_countries()
@@ -182,6 +190,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_get_number_configuration(self):
         async with self._phone_number_administration_client:
             phone_number_response = await self._phone_number_administration_client.get_number_configuration(
@@ -191,6 +200,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_configure_number(self):
         pstnConfig = PstnConfiguration(
             callback_url="https://callbackurl",
@@ -205,6 +215,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_list_phone_plan_groups(self):
         async with self._phone_number_administration_client:
             phone_plan_group_response = self._phone_number_administration_client.list_phone_plan_groups(
@@ -219,6 +230,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_list_phone_plans(self):
         async with self._phone_number_administration_client:
             phone_plan_response = self._phone_number_administration_client.list_phone_plans(
@@ -234,6 +246,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_get_phone_plan_location_options(self):
         async with self._phone_number_administration_client:
             location_options_response = await self._phone_number_administration_client.get_phone_plan_location_options(
@@ -245,6 +258,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_get_release_by_id(self):
         async with self._phone_number_administration_client:
             phone_number_release_response = await self._phone_number_administration_client.get_release_by_id(
@@ -254,6 +268,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_list_all_releases(self):
         async with self._phone_number_administration_client:
             releases_response = self._phone_number_administration_client.list_all_releases()
@@ -266,6 +281,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_release_phone_numbers(self):
         async with self._phone_number_administration_client:
             releases_response = await self._phone_number_administration_client.release_phone_numbers(
@@ -275,6 +291,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_get_search_by_id(self):
         async with self._phone_number_administration_client:
             phone_number_search_response = await self._phone_number_administration_client.get_search_by_id(
@@ -284,6 +301,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_create_search(self):
         searchOptions = CreateSearchOptions(
             area_code=self.area_code_for_search,
@@ -300,6 +318,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_cancel_search(self):
         async with self._phone_number_administration_client:
             cancel_search_response = await self._phone_number_administration_client.cancel_search(
@@ -309,6 +328,7 @@ class PhoneNumberAdministrationClientTestAsync(AsyncPhoneNumberCommunicationTest
 
     @AsyncPhoneNumberCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_purchase_search(self):
         async with self._phone_number_administration_client:
             purchase_search_response = await self._phone_number_administration_client.purchase_search(

--- a/sdk/communication/azure-communication-sms/tests/test_sms_client_e2e.py
+++ b/sdk/communication/azure-communication-sms/tests/test_sms_client_e2e.py
@@ -15,6 +15,9 @@ from _shared.testcase import (
     ResponseReplacerProcessor
 )
 
+SKIP_PHONE_NUMBER_TESTS = True
+PHONE_NUMBER_TEST_SKIP_REASON= "Phone Number infra for live tests not ready yet"
+
 class SMSClientTest(CommunicationTestCase):
     def __init__(self, method_name):
         super(SMSClientTest, self).__init__(method_name)
@@ -34,6 +37,7 @@ class SMSClientTest(CommunicationTestCase):
         self.sms_client = SmsClient.from_connection_string(self.connection_str)
 
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_send_sms(self):
 
         # calling send() with sms values

--- a/sdk/communication/azure-communication-sms/tests/test_sms_client_e2e_async.py
+++ b/sdk/communication/azure-communication-sms/tests/test_sms_client_e2e_async.py
@@ -28,7 +28,7 @@ class SMSClientTestAsync(AsyncCommunicationTestCase):
         if self.is_playback():
             self.phone_number = "+18000005555"
         else:
-            self.phone_number = os.getenv("PHONE_NUMBER")
+            self.phone_number = os.getenv("AZURE_COMMUNICATION_SERVICE_PHONE_NUMBER")
 
         self.recording_processors.extend([
             BodyReplacerProcessor(keys=["to", "from", "messageId"]),

--- a/sdk/communication/azure-communication-sms/tests/test_sms_client_e2e_async.py
+++ b/sdk/communication/azure-communication-sms/tests/test_sms_client_e2e_async.py
@@ -15,6 +15,9 @@ from _shared.testcase import (
     BodyReplacerProcessor, ResponseReplacerProcessor
 )
 
+SKIP_PHONE_NUMBER_TESTS = True
+PHONE_NUMBER_TEST_SKIP_REASON= "Phone Number infra for live tests not ready yet"
+
 class SMSClientTestAsync(AsyncCommunicationTestCase):
     def __init__(self, method_name):
         super(SMSClientTestAsync, self).__init__(method_name)
@@ -33,6 +36,7 @@ class SMSClientTestAsync(AsyncCommunicationTestCase):
 
     @AsyncCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
+    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_send_sms_async(self):
 
         sms_client = SmsClient.from_connection_string(self.connection_str)

--- a/sdk/communication/tests.yml
+++ b/sdk/communication/tests.yml
@@ -8,4 +8,9 @@ jobs:
       ServiceDirectory: communication
       EnvVars:
         AZURE_TEST_RUN_LIVE: 'true'
+        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+        AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
+        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_COMMUNICATION_SERVICE_CONNECTION_STRING: $(python-communication-connection-string)
+        PHONE_NUMBER: $(python-communication-phone-number)

--- a/sdk/communication/tests.yml
+++ b/sdk/communication/tests.yml
@@ -13,4 +13,4 @@ jobs:
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_COMMUNICATION_SERVICE_CONNECTION_STRING: $(python-communication-connection-string)
-        PHONE_NUMBER: $(python-communication-phone-number)
+        AZURE_COMMUNICATION_SERVICE_PHONE_NUMBER: $(python-communication-phone-number)


### PR DESCRIPTION
This PR adds necessary environment variables into `tests.yml` file.
All phone number related live tests are being skipped for now. It will be unskipped once the infra for e2e live tests is ready