### PR TITLE
[ServiceBus] Bring stress-test metrics up to cross-sdk parity. (primarily allow computing of trends)

### DIFF
--- a/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_base.py
+++ b/sdk/servicebus/azure-servicebus/tests/stress_tests/stress_test_base.py
@@ -5,14 +5,24 @@
 #--------------------------------------------------------------------------
 
 import time
+import threading
 from datetime import datetime, timedelta
 import concurrent
 import sys
 import uuid
+import logging
+
+try:
+    import psutil
+except ImportError:
+    pass # If psutil isn't installed, simply does not capture process stats.
 
 from azure.servicebus import ServiceBusClient, Message, BatchMessage
 from azure.servicebus._common.constants import ReceiveMode
 from azure.servicebus.exceptions import MessageAlreadySettled
+
+from utilities import _build_logger
+_logger = _build_logger("stress-test", logging.WARN)
 
 class ReceiveType:
     push="push"
@@ -37,10 +47,21 @@ class StressTestRunnerState(object):
     def __init__(self):
         self.total_sent=0
         self.total_received=0
+        self.cpu_percent = None
+        self.memory_bytes = None
+        self.timestamp = None
+        self.exceptions = []
 
     def __repr__(self):
         return str(vars(self))
 
+    def PopulateProcessStats(self):
+        self.timestamp = datetime.utcnow()
+        try:
+            self.cpu_percent = psutil.cpu_percent()
+            self.memory_bytes = psutil.virtual_memory().total
+        except NameError:
+            return # psutil was not installed, fall back to simply not capturing these stats.
 
 class StressTestRunner:
     '''Framework for running a service bus stress test.
@@ -57,7 +78,8 @@ class StressTestRunner:
                  send_delay = .01,
                  receive_delay = 0,
                  should_complete_messages = True,
-                 max_message_count = 1):
+                 max_message_count = 1,
+                 fail_on_exception = True):
         self.senders = senders
         self.receivers = receivers
         self.duration=duration
@@ -69,6 +91,7 @@ class StressTestRunner:
         self.receive_delay = receive_delay
         self.should_complete_messages = should_complete_messages
         self.max_message_count = max_message_count
+        self.fail_on_exception = fail_on_exception
 
         # Because of pickle we need to create a state object and not just pass around ourselves.
         # If we ever require multiple runs of this one after another, just make Run() reset this.
@@ -110,6 +133,18 @@ class StressTestRunner:
         return payload
 
 
+    def _ScheduleIntervalLogger(self, end_time, description="", interval_seconds=30):
+        def _doIntervalLogging():
+            if end_time > datetime.utcnow():
+                self._state.PopulateProcessStats()
+                _logger.critical("{} RECURRENT STATUS:".format(description))
+                _logger.critical(self._state)
+                self._ScheduleIntervalLogger(end_time, description, interval_seconds)
+
+        t = threading.Timer(interval_seconds, _doIntervalLogging)
+        t.start()
+
+
     def _ConstructMessage(self):
         if self.send_batch_size != None:
             batch = BatchMessage()
@@ -124,48 +159,64 @@ class StressTestRunner:
             self.PreProcessMessage(message)
             return message
 
-
     def _Send(self, sender, end_time):
+        self._ScheduleIntervalLogger(end_time, "Sender " + str(self))
         try:
-            print("STARTING SENDER")
+            _logger.info("STARTING SENDER")
             with sender:
                 while end_time > datetime.utcnow():
-                    print("SENDING")
-                    message = self._ConstructMessage()
-                    sender.send_messages(message)
-                    self.OnSend(self._state, message)
+                    _logger.info("SENDING")
+                    try:
+                        message = self._ConstructMessage()
+                        sender.send_messages(message)
+                        self.OnSend(self._state, message)
+                    except Exception as e:
+                        _logger.exception("Exception during send: {}".format(e))
+                        self._state.exceptions.append(e)
+                        if self.fail_on_exception:
+                            raise
                     self._state.total_sent += 1
                     time.sleep(self.send_delay)
+            self._state.timestamp = datetime.utcnow()
             return self._state
         except Exception as e:
-            print("Exception in sender", e)
-
+            _logger.exception("Exception in sender: {}".format(e))
+            raise
 
     def _Receive(self, receiver, end_time):
+        self._ScheduleIntervalLogger(end_time, "Receiver " + str(self))
         try:
             with receiver:
                 while end_time > datetime.utcnow():
-                    print("RECEIVE LOOP")
-                    if self.receive_type == ReceiveType.pull:
-                        batch = receiver.receive_messages(max_message_count=self.max_message_count, max_wait_time=self.max_wait_time)
-                    elif self.receive_type == ReceiveType.push:
-                        batch = receiver.get_streaming_message_iter(max_wait_time=self.max_wait_time)
+                    _logger.info("RECEIVE LOOP")
+                    try:
+                        if self.receive_type == ReceiveType.pull:
+                            batch = receiver.receive_messages(max_message_count=self.max_message_count, max_wait_time=self.max_wait_time)
+                        elif self.receive_type == ReceiveType.push:
+                            batch = receiver.get_streaming_message_iter(max_wait_time=self.max_wait_time)
 
-                    for message in batch:
-                        self.OnReceive(self._state, message)
-                        try:
-                            if self.should_complete_messages:
-                                message.complete()
-                        except MessageAlreadySettled: # It may have been settled in the plugin callback.
-                            pass
-                        self._state.total_received += 1
-                        #TODO: Get EnqueuedTimeUtc out of broker properties and calculate latency. Should properties/app properties be mostly None?
-                        if end_time <= datetime.utcnow():
-                            break
-                        time.sleep(self.receive_delay)
+                        for message in batch:
+                            self.OnReceive(self._state, message)
+                            try:
+                                if self.should_complete_messages:
+                                    message.complete()
+                            except MessageAlreadySettled: # It may have been settled in the plugin callback.
+                                pass
+                            self._state.total_received += 1
+                            #TODO: Get EnqueuedTimeUtc out of broker properties and calculate latency. Should properties/app properties be mostly None?
+                            if end_time <= datetime.utcnow():
+                                break
+                            time.sleep(self.receive_delay)
+                    except Exception as e:
+                        _logger.exception("Exception during receive: {}".format(e))
+                        self._state.exceptions.append(e)
+                        if self.fail_on_exception:
+                            raise
+            self._state.timestamp = datetime.utcnow()
             return self._state
         except Exception as e:
-            print("Exception in receiver", e)
+            _logger.exception("Exception in receiver {}".format(e))
+            raise
 
 
     def Run(self):
@@ -174,13 +225,13 @@ class StressTestRunner:
         sent_messages = 0
         received_messages = 0
         with concurrent.futures.ThreadPoolExecutor(max_workers=4) as proc_pool:
-            print("STARTING PROC POOL")
+            _logger.info("STARTING PROC POOL")
             senders = [proc_pool.submit(self._Send, sender, end_time) for sender in self.senders]
             receivers = [proc_pool.submit(self._Receive, receiver, end_time) for receiver in self.receivers]
 
             result = StressTestResults()
             for each in concurrent.futures.as_completed(senders + receivers):
-                print("SOMETHING FINISHED")
+                _logger.info("SOMETHING FINISHED")
                 if each in senders:
                     result.state_by_sender[each] = each.result()
                 if each in receivers:
@@ -188,10 +239,10 @@ class StressTestRunner:
             # TODO: do as_completed in one batch to provide a way to short-circuit on failure.
             result.state_by_sender = {s:f.result() for s,f in zip(self.senders, concurrent.futures.as_completed(senders))}
             result.state_by_receiver = {r:f.result() for r,f in zip(self.receivers, concurrent.futures.as_completed(receivers))}
-            print("got receiever results")
+            _logger.info("got receiever results")
             result.total_sent = sum([r.total_sent for r in result.state_by_sender.values()])
             result.total_received = sum([r.total_received for r in result.state_by_receiver.values()])
             result.time_elapsed = end_time - start_time
-            print("Stress test completed.  Results:\n", result)
+            _logger.critical("Stress test completed.  Results:\n{}".format(result))
             return result
 

--- a/sdk/servicebus/azure-servicebus/tests/stress_tests/test_stress_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/stress_tests/test_stress_queues.py
@@ -17,9 +17,8 @@ from devtools_testutils import AzureMgmtTestCase, CachedResourceGroupPreparer
 
 from servicebus_preparer import ServiceBusNamespacePreparer, ServiceBusQueuePreparer
 from stress_tests.stress_test_base import StressTestRunner, ReceiveType
-from utilities import get_logger
 
-_logger = get_logger(logging.DEBUG)
+LOGGING_ENABLE = False
 
 class ServiceBusQueueStressTests(AzureMgmtTestCase):
 
@@ -30,7 +29,7 @@ class ServiceBusQueueStressTests(AzureMgmtTestCase):
     @ServiceBusQueuePreparer(name_prefix='servicebustest')
     def test_stress_queue_send_and_receive(self, servicebus_namespace_connection_string, servicebus_queue):
         sb_client = ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, debug=False)
+            servicebus_namespace_connection_string, logging_enable=LOGGING_ENABLE)
 
         stress_test = StressTestRunner(senders = [sb_client.get_queue_sender(servicebus_queue.name)],
                                        receivers = [sb_client.get_queue_receiver(servicebus_queue.name)],
@@ -48,7 +47,7 @@ class ServiceBusQueueStressTests(AzureMgmtTestCase):
     @ServiceBusQueuePreparer(name_prefix='servicebustest')
     def test_stress_queue_send_and_pull_receive(self, servicebus_namespace_connection_string, servicebus_queue):
         sb_client = ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, debug=False)
+            servicebus_namespace_connection_string, logging_enable=LOGGING_ENABLE)
 
         stress_test = StressTestRunner(senders = [sb_client.get_queue_sender(servicebus_queue.name)],
                                        receivers = [sb_client.get_queue_receiver(servicebus_queue.name)],
@@ -67,7 +66,7 @@ class ServiceBusQueueStressTests(AzureMgmtTestCase):
     @ServiceBusQueuePreparer(name_prefix='servicebustest')
     def test_stress_queue_batch_send_and_receive(self, servicebus_namespace_connection_string, servicebus_queue):
         sb_client = ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, debug=False)
+            servicebus_namespace_connection_string, logging_enable=LOGGING_ENABLE)
 
         stress_test = StressTestRunner(senders = [sb_client.get_queue_sender(servicebus_queue.name)],
                                        receivers = [sb_client.get_queue_receiver(servicebus_queue.name)],
@@ -86,7 +85,7 @@ class ServiceBusQueueStressTests(AzureMgmtTestCase):
     @ServiceBusQueuePreparer(name_prefix='servicebustest')
     def test_stress_queue_slow_send_and_receive(self, servicebus_namespace_connection_string, servicebus_queue):
         sb_client = ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, debug=False)
+            servicebus_namespace_connection_string, logging_enable=LOGGING_ENABLE)
 
         stress_test = StressTestRunner(senders = [sb_client.get_queue_sender(servicebus_queue.name)],
                                        receivers = [sb_client.get_queue_receiver(servicebus_queue.name)],
@@ -105,7 +104,7 @@ class ServiceBusQueueStressTests(AzureMgmtTestCase):
     @ServiceBusQueuePreparer(name_prefix='servicebustest')
     def test_stress_queue_receive_and_delete(self, servicebus_namespace_connection_string, servicebus_queue):
         sb_client = ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, debug=False)
+            servicebus_namespace_connection_string, logging_enable=LOGGING_ENABLE)
 
         stress_test = StressTestRunner(senders = [sb_client.get_queue_sender(servicebus_queue.name)],
                                        receivers = [sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ReceiveMode.ReceiveAndDelete)],
@@ -123,7 +122,7 @@ class ServiceBusQueueStressTests(AzureMgmtTestCase):
     @ServiceBusQueuePreparer(name_prefix='servicebustest')
     def test_stress_queue_unsettled_messages(self, servicebus_namespace_connection_string, servicebus_queue):
         sb_client = ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, debug=False)
+            servicebus_namespace_connection_string, logging_enable=LOGGING_ENABLE)
 
         stress_test = StressTestRunner(senders = [sb_client.get_queue_sender(servicebus_queue.name)],
                                        receivers = [sb_client.get_queue_receiver(servicebus_queue.name)],
@@ -144,7 +143,7 @@ class ServiceBusQueueStressTests(AzureMgmtTestCase):
     @ServiceBusQueuePreparer(name_prefix='servicebustest')
     def test_stress_queue_receive_large_batch_size(self, servicebus_namespace_connection_string, servicebus_queue):
         sb_client = ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, debug=False)
+            servicebus_namespace_connection_string, logging_enable=LOGGING_ENABLE)
 
         stress_test = StressTestRunner(senders = [sb_client.get_queue_sender(servicebus_queue.name)],
                                        receivers = [sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=50)],
@@ -169,7 +168,7 @@ class ServiceBusQueueStressTests(AzureMgmtTestCase):
     @ServiceBusQueuePreparer(name_prefix='servicebustest')
     def test_stress_queue_pull_receive_timeout(self, servicebus_namespace_connection_string, servicebus_queue):
         sb_client = ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=True)
+            servicebus_namespace_connection_string, logging_enable=LOGGING_ENABLE)
         
         stress_test = ServiceBusQueueStressTests.ReceiverTimeoutStressTestRunner(
             senders = [sb_client.get_queue_sender(servicebus_queue.name)],

--- a/sdk/servicebus/azure-servicebus/tests/utilities.py
+++ b/sdk/servicebus/azure-servicebus/tests/utilities.py
@@ -9,19 +9,24 @@ import sys
 import time
 from azure.servicebus._common.utils import utc_now
 
-def get_logger(level):
-    azure_logger = logging.getLogger("azure")
-    if not azure_logger.handlers:
-        azure_logger.setLevel(level)
-        handler = logging.StreamHandler(stream=sys.stdout)
-        handler.setFormatter(logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s'))
-        azure_logger.addHandler(handler)
+def _get_default_handler():
+    handler = logging.StreamHandler(stream=sys.stdout)
+    handler.setFormatter(logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s'))
+    return handler
 
-    uamqp_logger = logging.getLogger("uamqp")
-    if not uamqp_logger.handlers:
-        uamqp_logger.setLevel(logging.INFO)
-        uamqp_logger.addHandler(handler)
-    return azure_logger
+def _build_logger(name, level):
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        logger.setLevel(level)
+        handler = _get_default_handler()
+        logger.addHandler(handler)
+    return logger
+
+# Note: This was the initial generic logger entry point, kept to allow us to
+# move to more fine-grained logging controls incrementally.
+def get_logger(level, uamqp_level=logging.INFO):
+    _build_logger("uamqp", uamqp_level)
+    return _build_logger("azure", level)
 
 
 def print_message(_logger, message):


### PR DESCRIPTION
- Add a scheduled 5 minute logging output to stress tests.
- Converts prints to use logging instead.
- Add optional psutil metrics to stress logging output. (enabled if psutil is installed, chose to not make that enabled by default to bloat the dev_requirements file with VERY specific deps for the time being, feel free to shout if it would be better added)
- Adds timestamps to stress test metrics blob to calculate trends.
- Change legacy debug parameter to logging_enable
- Performs a minor refactoring of the sync get_logger code to allow more fine-grained utilization of the helpers.