### PR TITLE
[Fileshare] Disable share leases

### DIFF
--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_lease.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_lease.py
@@ -7,7 +7,7 @@
 import uuid
 
 from typing import (  # pylint: disable=unused-import
-    Union, Optional, Any, TypeVar, TYPE_CHECKING
+    Optional, Any, TypeVar, TYPE_CHECKING
 )
 
 from azure.core.tracing.decorator import distributed_trace
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 class ShareLeaseClient(object):
     """Creates a new ShareLeaseClient.
 
-    This client provides lease operations on a ShareClient or ShareFileClient.
+    This client provides lease operations on a ShareFileClient.
 
     :ivar str id:
         The ID of the lease currently being maintained. This will be `None` if no
@@ -38,9 +38,8 @@ class ShareLeaseClient(object):
         This will be `None` if no lease has yet been acquired or modified.
 
     :param client:
-        The client of the file or share to lease.
-    :type client: ~azure.storage.fileshare.ShareFileClient or
-        ~azure.storage.fileshare.ShareClient
+        The client of the file to lease.
+    :type client: ~azure.storage.fileshare.ShareFileClient
     :param str lease_id:
         A string representing the lease ID of an existing lease. This value does not
         need to be specified in order to acquire a new lease, or break one.
@@ -48,7 +47,7 @@ class ShareLeaseClient(object):
     def __init__(
             self, client, lease_id=None
     ):  # pylint: disable=missing-client-constructor-parameter-credential,missing-client-constructor-parameter-kwargs
-        # type: (Union[ShareFileClient, ShareClient], Optional[str]) -> None
+        # type: (ShareFileClient, Optional[str]) -> None
         self.id = lease_id or str(uuid.uuid4())
         self.last_modified = None
         self.etag = None
@@ -71,19 +70,13 @@ class ShareLeaseClient(object):
     def acquire(self, **kwargs):
         # type: (**Any) -> None
         """Requests a new lease. This operation establishes and manages a lock on a
-        file or share for write and delete operations. If the file or share does not have an active lease,
-        the File or Share service creates a lease on the file or share. If the file has an active lease,
+        file for write and delete operations. If the file does not have an active lease,
+        the File service creates a lease on the file. If the file has an active lease,
         you can only request a new lease using the active lease ID.
 
 
-        If the file or share does not have an active lease, the File or Share service creates a
+        If the file does not have an active lease, the File service creates a
         lease on the file and returns a new lease ID.
-
-        :keyword int lease_duration:
-            Specifies the duration of the lease, in seconds, or negative one
-            (-1) for a lease that never expires. File leases never expire. A non-infinite share lease can be
-            between 15 and 60 seconds. A share lease duration cannot be changed
-            using renew or change. Default is -1 (infinite share lease).
 
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
@@ -106,7 +99,7 @@ class ShareLeaseClient(object):
         self.etag = response.get('etag')  # type: str
 
     @distributed_trace
-    def renew(self, **kwargs):
+    def _renew(self, **kwargs):
         # type: (Any) -> None
         """Renews the share lease.
 
@@ -141,8 +134,8 @@ class ShareLeaseClient(object):
     def release(self, **kwargs):
         # type: (Any) -> None
         """Releases the lease. The lease may be released if the lease ID specified on the request matches
-        that associated with the share or file. Releasing the lease allows another client to immediately acquire
-        the lease for the share or file as soon as the release is complete.
+        that associated with the file. Releasing the lease allows another client to immediately acquire
+        the lease for the or file as soon as the release is complete.
 
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
@@ -169,7 +162,7 @@ class ShareLeaseClient(object):
         a new lease ID in x-ms-proposed-lease-id.
 
         :param str proposed_lease_id:
-            Proposed lease ID, in a GUID string format. The File or Share service will raise an error
+            Proposed lease ID, in a GUID string format. The File service will raise an error
             (Invalid request) if the proposed lease ID is not in the correct format.
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
@@ -193,26 +186,13 @@ class ShareLeaseClient(object):
     @distributed_trace
     def break_lease(self, **kwargs):
         # type: (Any) -> int
-        """Force breaks the lease if the file or share has an active lease. Any authorized request can break the lease;
+        """Force breaks the lease if the file has an active lease. Any authorized request can break the lease;
         the request is not required to specify a matching lease ID. An infinite lease breaks immediately.
 
         Once a lease is broken, it cannot be changed. Any authorized request can break the lease;
         the request is not required to specify a matching lease ID.
         When a lease is successfully broken, the response indicates the interval
         in seconds until a new lease can be acquired.
-
-        :keyword int lease_break_period:
-            This is the proposed duration of seconds that the share lease
-            should continue before it is broken, between 0 and 60 seconds. This
-            break period is only used if it is shorter than the time remaining
-            on the share lease. If longer, the time remaining on the share lease is used.
-            A new share lease will not be available before the break period has
-            expired, but the share lease may be held for longer than the break
-            period. If this header does not appear with a break
-            operation, a fixed-duration share lease breaks after the remaining share lease
-            period elapses, and an infinite share lease breaks immediately.
-
-            .. versionadded:: 12.6.0
 
         :keyword int timeout:
             The timeout parameter is expressed in seconds.

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
@@ -228,7 +228,7 @@ class AccessPolicy(GenAccessPolicy):
 
 
 class LeaseProperties(DictMixin):
-    """File Lease Properties.
+    """File or Share Lease Properties.
 
     :ivar str status:
         The lease status of the file or share. Possible values: locked|unlocked

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
@@ -30,7 +30,7 @@ from ._generated.models import (
     DeleteSnapshotsOptionType,
     SharePermission)
 from ._deserialize import deserialize_share_properties, deserialize_permission_key, deserialize_permission
-from ._serialize import get_api_version, get_access_conditions
+from ._serialize import get_api_version
 from ._directory_client import ShareDirectoryClient
 from ._file_client import ShareFileClient
 from ._lease import ShareLeaseClient

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
@@ -258,7 +258,7 @@ class ShareClient(StorageAccountHostsMixin):
             _pipeline=_pipeline, _location_mode=self._location_mode)
 
     @distributed_trace
-    def acquire_lease(self, lease_duration=-1, lease_id=None, **kwargs):
+    def _acquire_lease(self, lease_duration=-1, lease_id=None, **kwargs):
         # type: (int, Optional[str], **Any) -> ShareLeaseClient
         """Requests a new lease.
 
@@ -401,13 +401,6 @@ class ShareClient(StorageAccountHostsMixin):
 
         :param bool delete_snapshots:
             Indicates if snapshots are to be deleted.
-        :keyword lease:
-            Required if the share has an active lease. Value can be a ShareLeaseClient object
-            or the lease ID as a string.
-
-            .. versionadded:: 12.6.0
-            This keyword argument was introduced in API version '2020-02-02'.
-
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
 
@@ -420,7 +413,6 @@ class ShareClient(StorageAccountHostsMixin):
                 :dedent: 12
                 :caption: Deletes the share and any snapshots.
         """
-        access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         delete_include = None
         if delete_snapshots:
@@ -429,7 +421,6 @@ class ShareClient(StorageAccountHostsMixin):
             self._client.share.delete(
                 timeout=timeout,
                 sharesnapshot=self.snapshot,
-                lease_access_conditions=access_conditions,
                 delete_snapshots=delete_include,
                 **kwargs)
         except StorageErrorException as error:
@@ -444,13 +435,6 @@ class ShareClient(StorageAccountHostsMixin):
 
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :keyword lease:
-            Required if the share has an active lease. Value can be a ShareLeaseClient object
-            or the lease ID as a string.
-
-            .. versionadded:: 12.6.0
-            This keyword argument was introduced in API version '2020-02-02'.
-
         :returns: The share properties.
         :rtype: ~azure.storage.fileshare.ShareProperties
 
@@ -463,14 +447,12 @@ class ShareClient(StorageAccountHostsMixin):
                 :dedent: 12
                 :caption: Gets the share properties.
         """
-        access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         try:
             props = self._client.share.get_properties(
                 timeout=timeout,
                 sharesnapshot=self.snapshot,
                 cls=deserialize_share_properties,
-                lease_access_conditions=access_conditions,
                 **kwargs)
         except StorageErrorException as error:
             process_storage_error(error)
@@ -488,13 +470,6 @@ class ShareClient(StorageAccountHostsMixin):
             Must be greater than 0, and less than or equal to 5TB.
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :keyword lease:
-            Required if the share has an active lease. Value can be a ShareLeaseClient object
-            or the lease ID as a string.
-
-            .. versionadded:: 12.6.0
-            This keyword argument was introduced in API version '2020-02-02'.
-
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: dict(str, Any)
 
@@ -507,14 +482,12 @@ class ShareClient(StorageAccountHostsMixin):
                 :dedent: 12
                 :caption: Sets the share quota.
         """
-        access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         try:
             return self._client.share.set_properties( # type: ignore
                 timeout=timeout,
                 quota=quota,
                 access_tier=None,
-                lease_access_conditions=access_conditions,
                 cls=return_response_headers,
                 **kwargs)
         except StorageErrorException as error:
@@ -536,9 +509,6 @@ class ShareClient(StorageAccountHostsMixin):
             Must be greater than 0, and less than or equal to 5TB.
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :keyword lease:
-            Required if the share has an active lease. Value can be a ShareLeaseClient object
-            or the lease ID as a string.
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: dict(str, Any)
 
@@ -551,7 +521,6 @@ class ShareClient(StorageAccountHostsMixin):
                 :dedent: 12
                 :caption: Sets the share properties.
         """
-        access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         access_tier = kwargs.pop('access_tier', None)
         quota = kwargs.pop('quota', None)
@@ -562,7 +531,6 @@ class ShareClient(StorageAccountHostsMixin):
                 timeout=timeout,
                 quota=quota,
                 access_tier=access_tier,
-                lease_access_conditions=access_conditions,
                 cls=return_response_headers,
                 **kwargs)
         except StorageErrorException as error:
@@ -582,13 +550,6 @@ class ShareClient(StorageAccountHostsMixin):
         :type metadata: dict(str, str)
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :keyword lease:
-            Required if the share has an active lease. Value can be a ShareLeaseClient object
-            or the lease ID as a string.
-
-            .. versionadded:: 12.6.0
-            This keyword argument was introduced in API version '2020-02-02'.
-
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: dict(str, Any)
 
@@ -601,7 +562,6 @@ class ShareClient(StorageAccountHostsMixin):
                 :dedent: 12
                 :caption: Sets the share metadata.
         """
-        access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         headers = kwargs.pop('headers', {})
         headers.update(add_metadata_headers(metadata))
@@ -610,7 +570,6 @@ class ShareClient(StorageAccountHostsMixin):
                 timeout=timeout,
                 cls=return_response_headers,
                 headers=headers,
-                lease_access_conditions=access_conditions,
                 **kwargs)
         except StorageErrorException as error:
             process_storage_error(error)
@@ -623,23 +582,14 @@ class ShareClient(StorageAccountHostsMixin):
 
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :keyword lease:
-            Required if the share has an active lease. Value can be a ShareLeaseClient object
-            or the lease ID as a string.
-
-            .. versionadded:: 12.6.0
-            This keyword argument was introduced in API version '2020-02-02'.
-
         :returns: Access policy information in a dict.
         :rtype: dict[str, Any]
         """
-        access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         try:
             response, identifiers = self._client.share.get_access_policy(
                 timeout=timeout,
                 cls=return_headers_and_deserialized,
-                lease_access_conditions=access_conditions,
                 **kwargs)
         except StorageErrorException as error:
             process_storage_error(error)
@@ -662,17 +612,9 @@ class ShareClient(StorageAccountHostsMixin):
         :type signed_identifiers: dict(str, :class:`~azure.storage.fileshare.AccessPolicy`)
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :keyword lease:
-            Required if the share has an active lease. Value can be a ShareLeaseClient object
-            or the lease ID as a string.
-
-            .. versionadded:: 12.6.0
-            This keyword argument was introduced in API version '2020-02-02'.
-
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: dict(str, Any)
         """
-        access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         if len(signed_identifiers) > 5:
             raise ValueError(
@@ -690,7 +632,6 @@ class ShareClient(StorageAccountHostsMixin):
                 share_acl=signed_identifiers or None,
                 timeout=timeout,
                 cls=return_response_headers,
-                lease_access_conditions=access_conditions,
                 **kwargs)
         except StorageErrorException as error:
             process_storage_error(error)
@@ -705,22 +646,13 @@ class ShareClient(StorageAccountHostsMixin):
 
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :keyword lease:
-            Required if the share has an active lease. Value can be a ShareLeaseClient object
-            or the lease ID as a string.
-
-            .. versionadded:: 12.6.0
-            This keyword argument was introduced in API version '2020-02-02'.
-
         :return: The approximate size of the data (in bytes) stored on the share.
         :rtype: int
         """
-        access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         try:
             stats = self._client.share.get_statistics(
                 timeout=timeout,
-                lease_access_conditions=access_conditions,
                 **kwargs)
             return stats.share_usage_bytes # type: ignore
         except StorageErrorException as error:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
@@ -129,7 +129,7 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
             _pipeline=_pipeline, _location_mode=self._location_mode, loop=self._loop)
 
     @distributed_trace_async()
-    async def acquire_lease(self, lease_duration=-1, lease_id=None, **kwargs):
+    async def _acquire_lease(self, lease_duration=-1, lease_id=None, **kwargs):
         # type: (int, Optional[str], **Any) -> ShareLeaseClient
         """Requests a new lease.
 
@@ -274,13 +274,6 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
             Indicates if snapshots are to be deleted.
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :keyword lease:
-            Required if the share has an active lease. Value can be a ShareLeaseClient object
-            or the lease ID as a string.
-
-            .. versionadded:: 12.6.0
-            This keyword argument was introduced in API version '2020-02-02'.
-
         .. admonition:: Example:
 
             .. literalinclude:: ../samples/file_samples_share_async.py
@@ -290,7 +283,6 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
                 :dedent: 16
                 :caption: Deletes the share and any snapshots.
         """
-        access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         delete_include = None
         if delete_snapshots:
@@ -300,7 +292,6 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
                 timeout=timeout,
                 sharesnapshot=self.snapshot,
                 delete_snapshots=delete_include,
-                lease_access_conditions=access_conditions,
                 **kwargs)
         except StorageErrorException as error:
             process_storage_error(error)
@@ -314,13 +305,6 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
 
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :keyword lease:
-            Required if the share has an active lease. Value can be a ShareLeaseClient object
-            or the lease ID as a string.
-
-            .. versionadded:: 12.6.0
-            This keyword argument was introduced in API version '2020-02-02'.
-
         :returns: The share properties.
         :rtype: ~azure.storage.fileshare.ShareProperties
 
@@ -333,14 +317,12 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
                 :dedent: 16
                 :caption: Gets the share properties.
         """
-        access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         try:
             props = await self._client.share.get_properties(
                 timeout=timeout,
                 sharesnapshot=self.snapshot,
                 cls=deserialize_share_properties,
-                lease_access_conditions=access_conditions,
                 **kwargs)
         except StorageErrorException as error:
             process_storage_error(error)
@@ -358,13 +340,6 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
             Must be greater than 0, and less than or equal to 5TB.
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :keyword lease:
-            Required if the share has an active lease. Value can be a ShareLeaseClient object
-            or the lease ID as a string.
-
-            .. versionadded:: 12.6.0
-            This keyword argument was introduced in API version '2020-02-02'.
-
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: dict(str, Any)
 
@@ -377,7 +352,6 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
                 :dedent: 16
                 :caption: Sets the share quota.
         """
-        access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         try:
             return await self._client.share.set_properties( # type: ignore
@@ -385,7 +359,6 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
                 quota=quota,
                 access_tier=None,
                 cls=return_response_headers,
-                lease_access_conditions=access_conditions,
                 **kwargs)
         except StorageErrorException as error:
             process_storage_error(error)
@@ -405,9 +378,6 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
             Must be greater than 0, and less than or equal to 5TB.
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :keyword lease:
-            Required if the share has an active lease. Value can be a ShareLeaseClient object
-            or the lease ID as a string.
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: dict(str, Any)
 
@@ -420,7 +390,6 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
                 :dedent: 16
                 :caption: Sets the share properties.
         """
-        access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         access_tier = kwargs.pop('access_tier', None)
         quota = kwargs.pop('quota', None)
@@ -431,7 +400,6 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
                 timeout=timeout,
                 quota=quota,
                 access_tier=access_tier,
-                lease_access_conditions=access_conditions,
                 cls=return_response_headers,
                 **kwargs)
         except StorageErrorException as error:
@@ -451,13 +419,6 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
         :type metadata: dict(str, str)
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :keyword lease:
-            Required if the share has an active lease. Value can be a ShareLeaseClient object
-            or the lease ID as a string.
-
-            .. versionadded:: 12.6.0
-            This keyword argument was introduced in API version '2020-02-02'.
-
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: dict(str, Any)
 
@@ -470,7 +431,6 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
                 :dedent: 16
                 :caption: Sets the share metadata.
         """
-        access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         headers = kwargs.pop('headers', {})
         headers.update(add_metadata_headers(metadata))
@@ -479,7 +439,6 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
                 timeout=timeout,
                 cls=return_response_headers,
                 headers=headers,
-                lease_access_conditions=access_conditions,
                 **kwargs)
         except StorageErrorException as error:
             process_storage_error(error)
@@ -492,23 +451,14 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
 
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :keyword lease:
-            Required if the share has an active lease. Value can be a ShareLeaseClient object
-            or the lease ID as a string.
-
-            .. versionadded:: 12.6.0
-            This keyword argument was introduced in API version '2020-02-02'.
-
         :returns: Access policy information in a dict.
         :rtype: dict[str, Any]
         """
-        access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         try:
             response, identifiers = await self._client.share.get_access_policy(
                 timeout=timeout,
                 cls=return_headers_and_deserialized,
-                lease_access_conditions=access_conditions,
                 **kwargs)
         except StorageErrorException as error:
             process_storage_error(error)
@@ -531,17 +481,9 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
         :type signed_identifiers: dict(str, :class:`~azure.storage.fileshare.AccessPolicy`)
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :keyword lease:
-            Required if the share has an active lease. Value can be a ShareLeaseClient object
-            or the lease ID as a string.
-
-            .. versionadded:: 12.6.0
-            This keyword argument was introduced in API version '2020-02-02'.
-
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: dict(str, Any)
         """
-        access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         if len(signed_identifiers) > 5:
             raise ValueError(
@@ -560,7 +502,6 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
                 share_acl=signed_identifiers or None,
                 timeout=timeout,
                 cls=return_response_headers,
-                lease_access_conditions=access_conditions,
                 **kwargs)
         except StorageErrorException as error:
             process_storage_error(error)
@@ -575,22 +516,13 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
 
         :keyword int timeout:
             The timeout parameter is expressed in seconds.
-        :keyword lease:
-            Required if the share has an active lease. Value can be a ShareLeaseClient object
-            or the lease ID as a string.
-
-            .. versionadded:: 12.6.0
-            This keyword argument was introduced in API version '2020-02-02'.
-
         :return: The approximate size of the data (in bytes) stored on the share.
         :rtype: int
         """
-        access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         try:
             stats = await self._client.share.get_statistics(
                 timeout=timeout,
-                lease_access_conditions=access_conditions,
                 **kwargs)
             return stats.share_usage_bytes # type: ignore
         except StorageErrorException as error:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
@@ -25,7 +25,7 @@ from .._generated.models import (
     SignedIdentifier,
     DeleteSnapshotsOptionType)
 from .._deserialize import deserialize_share_properties, deserialize_permission
-from .._serialize import get_api_version, get_access_conditions
+from .._serialize import get_api_version
 from .._share_client import ShareClient as ShareClientBase
 from ._directory_client_async import ShareDirectoryClient
 from ._file_client_async import ShareFileClient

--- a/sdk/storage/azure-storage-file-share/samples/file_samples_share.py
+++ b/sdk/storage/azure-storage-file-share/samples/file_samples_share.py
@@ -143,21 +143,6 @@ class ShareSamples(object):
         # Get the file client to interact with a specific file
         my_file = share.get_file_client("dir1/myfile")
 
-    def acquire_share_lease(self):
-        # Instantiate the ShareClient from a connection string
-        from azure.storage.fileshare import ShareClient
-        share = ShareClient.from_connection_string(self.connection_string, "sharesamples")
-
-        # Create the share
-        share.create_share()
-
-        # [START acquire_and_release_lease_on_share]
-        share.create_directory("mydir")
-        lease = share.acquire_lease()
-        share.get_share_properties(lease=lease)
-        share.delete_share(lease=lease)
-        # [END acquire_and_release_lease_on_share]
-
 
 if __name__ == '__main__':
     sample = ShareSamples()
@@ -166,4 +151,3 @@ if __name__ == '__main__':
     sample.set_share_properties()
     sample.list_directories_and_files()
     sample.get_directory_or_file_client()
-    sample.acquire_share_lease()

--- a/sdk/storage/azure-storage-file-share/tests/test_share.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_share.py
@@ -185,6 +185,7 @@ class StorageShareTest(StorageTestCase):
                 props = restored_share_client.get_share_properties()
                 self.assertIsNotNone(props)
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     def test_lease_share_acquire_and_release(self, resource_group, location, storage_account, storage_account_key):
         self._setup(storage_account, storage_account_key)
@@ -194,6 +195,7 @@ class StorageShareTest(StorageTestCase):
         lease.release()
         # Assert
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     def test_acquire_lease_on_sharesnapshot(self, resource_group, location, storage_account, storage_account_key):
         self._setup(storage_account, storage_account_key)
@@ -231,6 +233,7 @@ class StorageShareTest(StorageTestCase):
         share_lease.release()
         self._delete_shares(share.share_name)
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     def test_lease_share_renew(self, resource_group, location, storage_account, storage_account_key):
         self._setup(storage_account, storage_account_key)
@@ -250,6 +253,7 @@ class StorageShareTest(StorageTestCase):
         self.sleep(10)
         share_client.delete_share()
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     def test_lease_share_with_duration(self, resource_group, location, storage_account, storage_account_key):
         self._setup(storage_account, storage_account_key)
@@ -264,6 +268,7 @@ class StorageShareTest(StorageTestCase):
         self.sleep(15)
         share_client.acquire_lease()
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     def test_lease_share_twice(self, resource_group, location, storage_account, storage_account_key):
         self._setup(storage_account, storage_account_key)
@@ -276,6 +281,7 @@ class StorageShareTest(StorageTestCase):
         lease2 = share_client.acquire_lease(lease_id=lease.id)
         self.assertEqual(lease.id, lease2.id)
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     def test_lease_share_with_proposed_lease_id(self, resource_group, location, storage_account, storage_account_key):
         self._setup(storage_account, storage_account_key)
@@ -288,6 +294,7 @@ class StorageShareTest(StorageTestCase):
         # Assert
         self.assertEqual(proposed_lease_id, lease.id)
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     def test_lease_share_change_lease_id(self, resource_group, location, storage_account, storage_account_key):
         self._setup(storage_account, storage_account_key)
@@ -307,6 +314,7 @@ class StorageShareTest(StorageTestCase):
         self.assertNotEqual(lease_id1, lease_id)
         self.assertEqual(lease_id2, lease_id)
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     def test_set_share_metadata_with_lease_id(self, resource_group, location, storage_account, storage_account_key):
         self._setup(storage_account, storage_account_key)
@@ -321,6 +329,7 @@ class StorageShareTest(StorageTestCase):
         md = share_client.get_share_properties().metadata
         self.assertDictEqual(md, metadata)
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     def test_get_share_metadata_with_lease_id(self, resource_group, location, storage_account, storage_account_key):
         self._setup(storage_account, storage_account_key)
@@ -335,6 +344,7 @@ class StorageShareTest(StorageTestCase):
         # Assert
         self.assertDictEqual(md, metadata)
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     def test_get_share_properties_with_lease_id(self, resource_group, location, storage_account, storage_account_key):
         self._setup(storage_account, storage_account_key)
@@ -354,6 +364,7 @@ class StorageShareTest(StorageTestCase):
         self.assertEqual(props.lease.state, 'leased')
         self.assertEqual(props.lease.status, 'locked')
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     def test_get_share_acl_with_lease_id(self, resource_group, location, storage_account, storage_account_key):
         self._setup(storage_account, storage_account_key)
@@ -367,6 +378,7 @@ class StorageShareTest(StorageTestCase):
         self.assertIsNotNone(acl)
         self.assertIsNone(acl.get('public_access'))
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     def test_set_share_acl_with_lease_id(self, resource_group, location, storage_account, storage_account_key):
         self._setup(storage_account, storage_account_key)
@@ -386,6 +398,7 @@ class StorageShareTest(StorageTestCase):
         self.assertIsNotNone(acl)
         self.assertIsNone(acl.get('public_access'))
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     def test_lease_share_break_period(self, resource_group, location, storage_account, storage_account_key):
         self._setup(storage_account, storage_account_key)
@@ -400,6 +413,7 @@ class StorageShareTest(StorageTestCase):
         with self.assertRaises(HttpResponseError):
             share_client.delete_share(lease=lease)
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     def test_delete_share_with_lease_id(self, resource_group, location, storage_account, storage_account_key):
         self._setup(storage_account, storage_account_key)
@@ -634,6 +648,7 @@ class StorageShareTest(StorageTestCase):
         self.assertIsNotNone(shares[0].next_allowed_quota_downgrade_time)
         self._delete_shares()
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     def test_list_shares_leased_share(self, resource_group, location, storage_account, storage_account_key):
         self._setup(storage_account, storage_account_key)

--- a/sdk/storage/azure-storage-file-share/tests/test_share_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_share_async.py
@@ -202,6 +202,7 @@ class StorageShareTest(AsyncStorageTestCase):
                 self.assertIsNotNone(props)
                 break
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_lease_share_acquire_and_release(self, resource_group, location, storage_account, storage_account_key):
@@ -212,6 +213,7 @@ class StorageShareTest(AsyncStorageTestCase):
         await lease.release()
         # Assert
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_acquire_lease_on_sharesnapshot(self, resource_group, location, storage_account, storage_account_key):
@@ -250,6 +252,7 @@ class StorageShareTest(AsyncStorageTestCase):
         await share_lease.release()
         await self._delete_shares(share.share_name)
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_lease_share_renew(self, resource_group, location, storage_account, storage_account_key):
@@ -270,6 +273,7 @@ class StorageShareTest(AsyncStorageTestCase):
         self.sleep(10)
         await share_client.delete_share()
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_lease_share_with_duration(self, resource_group, location, storage_account, storage_account_key):
@@ -285,6 +289,7 @@ class StorageShareTest(AsyncStorageTestCase):
         self.sleep(15)
         await share_client.acquire_lease()
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_lease_share_twice(self, resource_group, location, storage_account, storage_account_key):
@@ -298,6 +303,7 @@ class StorageShareTest(AsyncStorageTestCase):
         lease2 = await share_client.acquire_lease(lease_id=lease.id)
         self.assertEqual(lease.id, lease2.id)
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_lease_share_with_proposed_lease_id(self, resource_group, location, storage_account, storage_account_key):
@@ -311,6 +317,7 @@ class StorageShareTest(AsyncStorageTestCase):
         # Assert
         self.assertEqual(proposed_lease_id, lease.id)
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_lease_share_change_lease_id(self, resource_group, location, storage_account, storage_account_key):
@@ -331,6 +338,7 @@ class StorageShareTest(AsyncStorageTestCase):
         self.assertNotEqual(lease_id1, lease_id)
         self.assertEqual(lease_id2, lease_id)
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_set_share_metadata_with_lease_id(self, resource_group, location, storage_account, storage_account_key):
@@ -347,6 +355,7 @@ class StorageShareTest(AsyncStorageTestCase):
         md = props.metadata
         self.assertDictEqual(md, metadata)
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_get_share_metadata_with_lease_id(self, resource_group, location, storage_account, storage_account_key):
@@ -363,6 +372,7 @@ class StorageShareTest(AsyncStorageTestCase):
         # Assert
         self.assertDictEqual(md, metadata)
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_get_share_properties_with_lease_id(self, resource_group, location, storage_account, storage_account_key):
@@ -383,6 +393,7 @@ class StorageShareTest(AsyncStorageTestCase):
         self.assertEqual(props.lease.state, 'leased')
         self.assertEqual(props.lease.status, 'locked')
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_get_share_acl_with_lease_id(self, resource_group, location, storage_account, storage_account_key):
@@ -397,6 +408,7 @@ class StorageShareTest(AsyncStorageTestCase):
         self.assertIsNotNone(acl)
         self.assertIsNone(acl.get('public_access'))
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_set_share_acl_with_lease_id(self, resource_group, location, storage_account, storage_account_key):
@@ -417,6 +429,7 @@ class StorageShareTest(AsyncStorageTestCase):
         self.assertIsNotNone(acl)
         self.assertIsNone(acl.get('public_access'))
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_lease_share_break_period(self, resource_group, location, storage_account, storage_account_key):
@@ -432,6 +445,7 @@ class StorageShareTest(AsyncStorageTestCase):
         with self.assertRaises(HttpResponseError):
             await share_client.delete_share(lease=lease)
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_delete_share_with_lease_id(self, resource_group, location, storage_account, storage_account_key):
@@ -690,6 +704,7 @@ class StorageShareTest(AsyncStorageTestCase):
         self.assertIsNotNone(shares[0].next_allowed_quota_downgrade_time)
         await self._delete_shares(share.share_name)
 
+    @pytest.mark.skip("Share leases are currently unavailable.")
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_list_shares_leased_share(self, resource_group, location, storage_account, storage_account_key):


### PR DESCRIPTION
Share leases has been rolled back on server side. This PR disables the feature on the SDK.