### PR TITLE
Switch testPipeline from variable to parameter

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -1,5 +1,6 @@
 parameters:
   ServiceDirectory: ''
+  TestPipeline: false
   BeforePublishSteps: []
   TestMarkArgument: ''
   BuildTargetingString: 'azure-*'
@@ -119,13 +120,14 @@ jobs:
       vmImage: '$(OSVmImage)'
 
     steps:
-    - task: PowerShell@2
-      displayName: Prep template pipeline for release
-      condition: and(succeeded(),eq(variables['TestPipeline'],'true'))
-      inputs:
-        pwsh: true
-        workingDirectory: $(Build.SourcesDirectory)
-        filePath: eng/scripts/SetTestPipelineVersion.ps1
+    - ${{if eq(parameters.TestPipeline, 'true')}}:
+      - task: PowerShell@2
+        displayName: Prep template pipeline for release
+        condition: succeeded()
+        inputs:
+          pwsh: true
+          workingDirectory: $(Build.SourcesDirectory)
+          filePath: eng/scripts/SetTestPipelineVersion.ps1
 
     - pwsh: |
         $toxenvvar = "whl,sdist"

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -1,5 +1,6 @@
 parameters:
   Artifacts: []
+  TestPipeline: false
   ArtifactName: 'not-specified'
   DependsOn: Build
   DocArtifact: 'documentation'
@@ -28,13 +29,14 @@ stages:
                 deploy:
                   steps:
                     - checkout: self
-                    - task: PowerShell@2
-                      displayName: Prep template pipeline for release
-                      condition: and(succeeded(),eq(variables['TestPipeline'],'true'))
-                      inputs:
-                        pwsh: true
-                        workingDirectory: $(Build.SourcesDirectory)
-                        filePath: eng/scripts/SetTestPipelineVersion.ps1
+                    - ${{if eq(parameters.TestPipeline, 'true')}}:
+                      - task: PowerShell@2
+                        displayName: Prep template pipeline for release
+                        condition: succeeded()
+                        inputs:
+                          pwsh: true
+                          workingDirectory: $(Build.SourcesDirectory)
+                          filePath: eng/scripts/SetTestPipelineVersion.ps1
                     - template: /eng/pipelines/templates/steps/stage-filtered-artifacts.yml
                       parameters:
                         SourceFolder: ${{parameters.ArtifactName}} 
@@ -193,6 +195,7 @@ stages:
                           DocRepoDestinationPath: 'docs-ref-services/' 
                           GHReviewersVariable: 'OwningGHUser'
                           CIConfigs: $(CIConfigs)
+                          CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
 
           - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
             - deployment: UpdatePackageVersion

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -2,6 +2,9 @@ parameters:
 - name: Artifacts
   type: object
   default: []
+- name: TestPipeline
+  type: boolean
+  default: false
 - name: ServiceDirectory
   type: string
   default: not-specified
@@ -35,23 +38,25 @@ stages:
     jobs:
     - template: ../jobs/archetype-sdk-client.yml
       parameters:
-        ServiceDirectory: ${{parameters.ServiceDirectory}}
-        ToxEnvParallel: ${{parameters.ToxEnvParallel}}
-        BuildDocs: ${{parameters.BuildDocs}}
-        InjectedPackages: ${{parameters.InjectedPackages}}
-        SkipPythonVersion: ${{parameters.SkipPythonVersion}}
-        AdditionalTestMatrix: ${{parameters.AdditionalTestMatrix}}
-        DevFeedName: ${{parameters.DevFeedName}}
+        ServiceDirectory: ${{ parameters.ServiceDirectory }}
+        TestPipeline: ${{ parameters.TestPipeline }}
+        ToxEnvParallel: ${{ parameters.ToxEnvParallel }}
+        BuildDocs: ${{ parameters.BuildDocs }}
+        InjectedPackages: ${{ parameters.InjectedPackages }}
+        SkipPythonVersion: ${{ parameters.SkipPythonVersion }}
+        AdditionalTestMatrix: ${{ parameters.AdditionalTestMatrix }}
+        DevFeedName: ${{ parameters.DevFeedName }}
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
     - template: archetype-python-release.yml
       parameters:
         DependsOn: Build
-        ServiceDirectory: ${{parameters.ServiceDirectory}}
-        Artifacts: ${{parameters.Artifacts}}
+        ServiceDirectory: ${{ parameters.ServiceDirectory }}
+        Artifacts: ${{ parameters.Artifacts }}
+        TestPipeline: ${{ parameters.TestPipeline }}
         ArtifactName: packages
         DocArtifact: documentation
-        TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
-        TargetDocRepoName: ${{parameters.TargetDocRepoName}}
-        DevFeedName: ${{parameters.DevFeedName}}
+        TargetDocRepoOwner: ${{ parameters.TargetDocRepoOwner }}
+        TargetDocRepoName: ${{ parameters.TargetDocRepoName }}
+        DevFeedName: ${{ parameters.DevFeedName }}

--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -5,13 +5,14 @@ parameters:
   BuildDocs: true
 
 steps:
-  - task: PowerShell@2
-    displayName: Prep template pipeline for release
-    condition: and(succeeded(),eq(variables['TestPipeline'],'true'))
-    inputs:
-      pwsh: true
-      workingDirectory: $(Build.SourcesDirectory)
-      filePath: eng/scripts/SetTestPipelineVersion.ps1
+  - ${{if eq(parameters.TestPipeline, 'true')}}:
+    - task: PowerShell@2
+      displayName: Prep template pipeline for release
+      condition: succeeded()
+      inputs:
+        pwsh: true
+        workingDirectory: $(Build.SourcesDirectory)
+        filePath: eng/scripts/SetTestPipelineVersion.ps1
 
   - script: |
       echo "##vso[build.addbuildtag]Scheduled"

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -10,7 +10,6 @@ trigger:
   paths:
     include:
     - sdk/template/
-    - eng/common/
 
 pr:
   branches:
@@ -28,6 +27,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: template
+    TestPipeline: true
     Artifacts:
     - name: azure_template
       safeName: azuretemplate


### PR DESCRIPTION
Prevent template pipeline run triggered by eng/common changes.
Auto close update version Pull Requests for template pipelines.
Switch from TestPipeline variable to parameter.

This includes some of the changes from https://github.com/Azure/azure-sdk-for-python/pull/14610 as other changes on that PR will take longer to complete.