### PR TITLE
Add prepare pipelines to v3 branch

### DIFF
--- a/eng/common/pipelines/templates/steps/install-pipeline-generation.yml
+++ b/eng/common/pipelines/templates/steps/install-pipeline-generation.yml
@@ -1,0 +1,15 @@
+parameters:
+  ToolPath: $(Pipeline.Workspace)/pipeline-generator
+
+steps:
+  - script: >
+      mkdir $(Pipeline.Workspace)/pipeline-generator
+    displayName: Setup working directory for pipeline generator.
+  - script: >
+      dotnet tool install
+      Azure.Sdk.Tools.PipelineGenerator
+      --version 1.0.2-dev.20201020.1
+      --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk/nuget/v3/index.json
+      --tool-path ${{parameters.ToolPath}}
+    workingDirectory: $(Pipeline.Workspace)/pipeline-generator
+    displayName: 'Install pipeline generator tool'

--- a/eng/common/pipelines/templates/steps/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/steps/prepare-pipelines.yml
@@ -1,0 +1,135 @@
+parameters:
+  - name: Repository
+    type: string
+    default: $(Build.Repository.Name)
+  - name: Prefix
+    type: string
+  - name: CIConventionOptions
+    type: string
+    default: ''
+  - name: UPConventionOptions
+    type: string
+    default: ''
+  - name: TestsConventionOptions
+    type: string
+    default: ''
+
+steps:
+  - template: install-pipeline-generation.yml
+
+  # This covers our public repos.
+  - ${{ if not(endsWith(parameters.Repository, '-pr'))}}:
+    - script: >
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+        --organization https://dev.azure.com/azure-sdk
+        --project public
+        --prefix ${{parameters.Prefix}}
+        --devopspath "\${{parameters.Prefix}}"
+        --path $(System.DefaultWorkingDirectory)/sdk
+        --endpoint Azure
+        --repository ${{parameters.Repository}}
+        --convention ci
+        --agentpool Hosted
+        --branch refs/heads/master
+        --patvar PATVAR
+        --debug
+        ${{parameters.CIConventionOptions}}
+      displayName: Create CI pipelines for public repository
+      env:
+        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+    - script: >
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+        --organization https://dev.azure.com/azure-sdk
+        --project internal
+        --prefix ${{parameters.Prefix}}
+        --devopspath "\${{parameters.Prefix}}"
+        --path $(System.DefaultWorkingDirectory)/sdk
+        --endpoint Azure
+        --repository ${{parameters.Repository}}
+        --convention up
+        --agentpool Hosted
+        --branch refs/heads/master
+        --patvar PATVAR
+        --debug
+        ${{parameters.UPConventionOptions}}
+      displayName: Create UP pipelines for public repository
+      env:
+        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+    - script: >
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+        --organization https://dev.azure.com/azure-sdk
+        --project internal
+        --prefix ${{parameters.Prefix}}
+        --devopspath "\${{parameters.Prefix}}"
+        --path $(System.DefaultWorkingDirectory)/sdk
+        --endpoint Azure
+        --repository ${{parameters.Repository}}
+        --convention tests
+        --agentpool Hosted
+        --branch refs/heads/master
+        --patvar PATVAR
+        --debug
+        ${{parameters.TestsConventionOptions}}
+      displayName: Create Live Test pipelines for public repository
+      env:
+        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+
+  # This covers our -pr repositories.
+  - ${{ if endsWith(parameters.Repository, '-pr')}}:
+    - script: >
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+        --organization https://dev.azure.com/azure-sdk
+        --project internal
+        --prefix ${{parameters.Prefix}}-pr
+        --devopspath "\${{parameters.Prefix}}\pr"
+        --path $(System.DefaultWorkingDirectory)/sdk
+        --endpoint Azure
+        --repository ${{parameters.Repository}}
+        --convention ci
+        --agentpool Hosted
+        --branch refs/heads/master
+        --patvar PATVAR
+        --debug
+        --no-schedule
+        ${{parameters.CIConventionOptions}}
+      displayName: Create CI pipelines for private repository
+      env:
+        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+    - script: >
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+        --organization https://dev.azure.com/azure-sdk
+        --project internal
+        --prefix ${{parameters.Prefix}}-pr
+        --devopspath "\${{parameters.Prefix}}\pr"
+        --path $(System.DefaultWorkingDirectory)/sdk
+        --endpoint Azure
+        --repository ${{parameters.Repository}}
+        --convention up
+        --agentpool Hosted
+        --branch refs/heads/master
+        --patvar PATVAR
+        --debug
+        --no-schedule
+        ${{parameters.UPConventionOptions}}
+      displayName: Create UP pipelines for private repository
+      env:
+        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+    - script: >
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+        --organization https://dev.azure.com/azure-sdk
+        --project internal
+        --prefix ${{parameters.Prefix}}-pr
+        --devopspath "\${{parameters.Prefix}}\pr"
+        --path $(System.DefaultWorkingDirectory)/sdk
+        --endpoint Azure
+        --repository ${{parameters.Repository}}
+        --convention tests
+        --agentpool Hosted
+        --branch refs/heads/master
+        --patvar PATVAR
+        --debug
+        --no-schedule
+        ${{parameters.TestsConventionOptions}}
+      displayName: Create Live Test pipelines for private repository
+      env:
+        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)

--- a/eng/pipelines/prepare-pipelines.yml
+++ b/eng/pipelines/prepare-pipelines.yml
@@ -1,0 +1,10 @@
+trigger: none
+
+extends:
+  template: /eng/common/pipelines/templates/steps/prepare-pipelines.yml
+  parameters:
+    Repository: $(Build.Repository.Name)
+    Prefix: python
+    CIConventionOptions: ''
+    UPConventionOptions: '--variablegroup 58 --variablegroup 76 --variablegroup 56'
+    TestsConventionOptions: '--variablegroup 64'


### PR DESCRIPTION
This PR pulls across the prepare pipelines code in the long lived release/v3 branch. Because a lot of the requests for pipelines come from this branch we need these files in place.