### PR TITLE
Communication: Fix mgmt dependency

### DIFF
--- a/sdk/communication/azure-communication-administration/setup.py
+++ b/sdk/communication/azure-communication-administration/setup.py
@@ -64,7 +64,7 @@ setup(
     ]),
     install_requires=[
         "msrest>=0.6.0",
-        "azure-core<2.0.0,>=1.2.2",
+        "azure-core<2.0.0,>=1.8.2",
     ],
     extras_require={
         ":python_version<'3.0'": ['azure-communication-nspkg'],

--- a/sdk/communication/azure-communication-administration/setup.py
+++ b/sdk/communication/azure-communication-administration/setup.py
@@ -64,7 +64,7 @@ setup(
     ]),
     install_requires=[
         "msrest>=0.6.0",
-        "azure-core<2.0.0,>=1.8.2",
+        "azure-core<2.0.0,>=1.6.0",
     ],
     extras_require={
         ":python_version<'3.0'": ['azure-communication-nspkg'],

--- a/sdk/communication/azure-communication-chat/setup.py
+++ b/sdk/communication/azure-communication-chat/setup.py
@@ -59,7 +59,7 @@ setup(
         'azure.communication'
     ]),
     install_requires=[
-        'azure-core<2.0.0,>=1.2.2',
+        'azure-core<2.0.0,>=1.8.2',
         'msrest>=0.6.0',
         'six>=1.6'
     ],

--- a/sdk/communication/azure-communication-chat/setup.py
+++ b/sdk/communication/azure-communication-chat/setup.py
@@ -59,7 +59,7 @@ setup(
         'azure.communication'
     ]),
     install_requires=[
-        'azure-core<2.0.0,>=1.8.2',
+        'azure-core<2.0.0,>=1.6.0',
         'msrest>=0.6.0',
         'six>=1.6'
     ],

--- a/sdk/communication/azure-communication-sms/setup.py
+++ b/sdk/communication/azure-communication-sms/setup.py
@@ -63,7 +63,7 @@ setup(
         'azure.communication'
     ]),
    install_requires=[
-        'azure-core<2.0.0,>=1.2.2',
+        'azure-core<2.0.0,>=1.8.2',
         'msrest>=0.6.0',
         'six>=1.6'
     ],

--- a/sdk/communication/azure-communication-sms/setup.py
+++ b/sdk/communication/azure-communication-sms/setup.py
@@ -63,7 +63,7 @@ setup(
         'azure.communication'
     ]),
    install_requires=[
-        'azure-core<2.0.0,>=1.8.2',
+        'azure-core<2.0.0,>=1.6.0',
         'msrest>=0.6.0',
         'six>=1.6'
     ],

--- a/sdk/communication/azure-mgmt-communication/setup.py
+++ b/sdk/communication/azure-mgmt-communication/setup.py
@@ -83,6 +83,7 @@ setup(
         'msrest>=0.5.0',
         'msrestazure>=0.4.32,<2.0.0',
         'azure-common~=1.1',
+        'azure-mgmt-core>=1.2.0,<2.0.0',
     ],
     extras_require={
         ":python_version<'3.0'": ['azure-mgmt-nspkg'],

--- a/sdk/communication/azure-mgmt-communication/setup.py
+++ b/sdk/communication/azure-mgmt-communication/setup.py
@@ -81,7 +81,6 @@ setup(
     ]),
     install_requires=[
         'msrest>=0.5.0',
-        'msrestazure>=0.4.32,<2.0.0',
         'azure-common~=1.1',
         'azure-mgmt-core>=1.2.0,<2.0.0',
     ],

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -169,5 +169,8 @@ opentelemetry-api==0.13b0
 #override azure-communication-chat msrest>=0.6.0
 #override azure-communication-sms msrest>=0.6.0
 #override azure-communication-administration msrest>=0.6.0
+#override azure-communication-chat azure-core<2.0.0,>=1.6.0
+#override azure-communication-sms azure-core<2.0.0,>=1.6.0
+#override azure-communication-administration azure-core<2.0.0,>=1.6.0
 #override azure-ai-metricsadvisor azure-core<2.0.0,>=1.6.0
 #override azure-ai-metricsadvisor msrest>=0.6.12


### PR DESCRIPTION
* Add `azure.mgmt.core` as a dependency to the `azure.mgmt.communication`. 
* As a result of above change core's version in admin, chat and sms needs to be updated too, to resolve a dependency conflict

This PR is in response to the [failure ](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=588195&view=results)of scheduled run of `python-communication` pipeline