### PR TITLE
Correct browser credential timeout error message

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_internal/auth_code_redirect_handler.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/auth_code_redirect_handler.py
@@ -56,7 +56,7 @@ class AuthCodeRedirectServer(HTTPServer):
         while not self.query_params:
             try:
                 self.handle_request()
-            except ValueError:
+            except (IOError, ValueError):
                 # socket has been closed, probably by handle_timeout
                 break
 


### PR DESCRIPTION
On Python 2.7, when `InteractiveBrowserCredential.get_token` times out waiting for a user to authenticate it raises `ClientAuthenticationError('Authentication failed: [Errno 9] Bad file descriptor')`. That's the right error but the wrong message. The right message, as seen on Python 3.x, is "Timed out after waiting {...} seconds for the user to authenticate". The difference is due to the behavior of `HTTPServer.handle_request()`. On 2.7 it raises IOError but we were only expecting the ValueError raised on 3.x.

This PR fixes the behavior on 2.7 by handling IOError as well, and updates the test covering this behavior to use an actual instance of the redirect handler rather than a mock.