### PR TITLE
batching needs azure-core above 1.6.0 when multipart was first introd…

### DIFF
--- a/sdk/tables/azure-data-tables/dev_requirements.txt
+++ b/sdk/tables/azure-data-tables/dev_requirements.txt
@@ -6,3 +6,4 @@ aiohttp>=3.0; python_version >= '3.5'
 -e ../../cosmos/azure-mgmt-cosmosdb
 azure-identity
 ../azure-data-nspkg
+#override azure-data-tables azure-core<2.0.0,>=1.6.0

--- a/sdk/tables/azure-data-tables/dev_requirements.txt
+++ b/sdk/tables/azure-data-tables/dev_requirements.txt
@@ -6,4 +6,3 @@ aiohttp>=3.0; python_version >= '3.5'
 -e ../../cosmos/azure-mgmt-cosmosdb
 azure-identity
 ../azure-data-nspkg
-#override azure-data-tables azure-core<2.0.0,>=1.6.0

--- a/sdk/tables/azure-data-tables/setup.py
+++ b/sdk/tables/azure-data-tables/setup.py
@@ -78,7 +78,7 @@ setup(
         'azure.data',
     ]),
     install_requires=[
-        "azure-core<2.0.0,>=1.2.2",
+        "azure-core<2.0.0,>=1.6.0",
         "msrest>=0.6.10"
         # azure-data-tables
     ],

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -122,6 +122,7 @@ avro<2.0.0,>=1.10.0
 #override azure-core-tracing-opencensus azure-core<2.0.0,>=1.0.0
 #override azure-core-tracing-opentelemetry azure-core<2.0.0,>=1.0.0
 #override azure-cosmos azure-core<2.0.0,>=1.0.0
+#override azure-data-tables azure-core<2.0.0,>=1.6.0
 #override azure-eventhub azure-core<2.0.0,>=1.5.0
 #override azure-identity azure-core<2.0.0,>=1.0.0
 #override azure-keyvault-administration msrest>=0.6.0


### PR DESCRIPTION
…uced

Fixes the failed mindependency in the tox pipeline. Batching uses multipart which was first introduced to the `azure-core` package in 1.6.0, bumps up the requirement.