### PR TITLE
changing BatchErrorException to be an AzureError, then changes in tes…

### DIFF
--- a/sdk/tables/azure-data-tables/azure/data/tables/_models.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_models.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 from enum import Enum
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import HttpResponseError, AzureError
 from azure.core.paging import PageIterator
 from azure.data.tables._generated.models import TableServiceStats as GenTableServiceStats
 
@@ -517,7 +517,7 @@ class PartialBatchErrorException(HttpResponseError):
         super(PartialBatchErrorException, self).__init__(message=message, response=response)
 
 
-class BatchErrorException(HttpResponseError):
+class BatchErrorException(AzureError):
     """There is a failure in batch operations.
 
     :param str message: The message of the exception.

--- a/sdk/tables/azure-data-tables/tests/test_table_batch.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch.py
@@ -397,7 +397,7 @@ class StorageTableBatchTest(TableTestCase):
                 match_condition=MatchConditions.IfNotModified
             )
 
-            with self.assertRaises(HttpResponseError):
+            with pytest.raises(BatchErrorException):
                 self.table.send_batch(batch)
 
             # Assert
@@ -441,7 +441,7 @@ class StorageTableBatchTest(TableTestCase):
                 match_condition=MatchConditions.IfNotModified
             )
 
-            with self.assertRaises(HttpResponseError):
+            with pytest.raises(BatchErrorException):
                 self.table.send_batch(batch)
 
             # Assert
@@ -543,7 +543,7 @@ class StorageTableBatchTest(TableTestCase):
             self._assert_valid_batch_transaction(transaction_result, 1)
             self.assertIsNotNone(transaction_result.get_entity(entity.RowKey))
 
-            with self.assertRaises(ResourceNotFoundError):
+            with pytest.raises(ResourceNotFoundError):
                 entity = self.table.get_entity(partition_key=entity.PartitionKey, row_key=entity.RowKey)
         finally:
             self._tear_down()
@@ -731,7 +731,7 @@ class StorageTableBatchTest(TableTestCase):
             batch.create_entity(entity)
 
             self.table.send_batch(batch)
-            with self.assertRaises(HttpResponseError):
+            with pytest.raises(BatchErrorException):
                 resp = table2.send_batch(batch)
 
             entities = list(self.table.query_entities("PartitionKey eq '003'"))
@@ -759,7 +759,7 @@ class StorageTableBatchTest(TableTestCase):
                 '001', 'batch_negative_1')
             batch.update_entity(entity, mode=UpdateMode.MERGE)
             # Assert
-            with self.assertRaises(HttpResponseError):
+            with pytest.raises(BatchErrorException):
                 self.table.send_batch(batch)
 
         finally:
@@ -784,7 +784,7 @@ class StorageTableBatchTest(TableTestCase):
 
             entity = self._create_random_entity_dict(
                 '002', 'batch_negative_1')
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 batch.create_entity(entity)
         finally:
             self._tear_down()
@@ -800,7 +800,7 @@ class StorageTableBatchTest(TableTestCase):
             self.table.create_entity(entity)
 
             # Act
-            with self.assertRaises(HttpResponseError):
+            with pytest.raises(BatchErrorException):
                 batch = self.table.create_batch()
                 for i in range(0, 101):
                     entity = TableEntity()
@@ -825,7 +825,7 @@ class StorageTableBatchTest(TableTestCase):
 
             batch = self.table.create_batch()
             batch.create_entity(entity)
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 batch.create_entity(entity2)
 
             # Assert

--- a/sdk/tables/azure-data-tables/tests/test_table_batch_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch_async.py
@@ -375,7 +375,7 @@ class StorageTableBatchTest(TableTestCase):
                 match_condition=MatchConditions.IfNotModified
             )
 
-            with self.assertRaises(HttpResponseError):
+            with self.assertRaises(BatchErrorException):
                 await self.table.send_batch(batch)
 
             # Assert

--- a/sdk/tables/azure-data-tables/tests/test_table_client_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_client_async.py
@@ -12,7 +12,8 @@ from azure.data.tables._version import VERSION
 from devtools_testutils import (
     ResourceGroupPreparer,
     CachedResourceGroupPreparer,
-    CachedStorageAccountPreparer
+    CachedStorageAccountPreparer,
+    AzureTestCase
 )
 from _shared.testcase import TableTestCase
 
@@ -497,6 +498,7 @@ class StorageTableClientTest(TableTestCase):
         self.assertEqual(service.table_name, 'bar')
         self.assertEqual(service.account_name, storage_account.name)
 
+    @AzureTestCase.await_prepared_test
     async def test_create_table_client_with_invalid_name_async(self):
         # Arrange
         table_url = "https://{}.table.core.windows.net:443/foo".format("storage_account_name")
@@ -508,6 +510,7 @@ class StorageTableClientTest(TableTestCase):
 
         assert "Table names must be alphanumeric, cannot begin with a number, and must be between 3-63 characters long."in str(excinfo)
 
+    @AzureTestCase.await_prepared_test
     async def test_error_with_malformed_conn_str_async(self):
         # Arrange
 

--- a/sdk/tables/azure-data-tables/tests/test_table_client_cosmos.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_client_cosmos.py
@@ -19,7 +19,7 @@ from _shared.testcase import (
 from azure.core.exceptions import HttpResponseError
 from _shared.cosmos_testcase import CachedCosmosAccountPreparer
 
-from devtools_testutils import CachedResourceGroupPreparer, AzureTestCase
+from devtools_testutils import CachedResourceGroupPreparer
 
 # ------------------------------------------------------------------------------
 SERVICES = {
@@ -557,7 +557,6 @@ class StorageTableClientTest(TableTestCase):
         if self.is_live:
             sleep(SLEEP_DELAY)
 
-    @AzureTestCase.await_prepared_test
     def test_create_table_client_with_invalid_name(self):
         # Arrange
         table_url = "https://{}.table.cosmos.azure.com:443/foo".format("cosmos_account_name")
@@ -572,7 +571,6 @@ class StorageTableClientTest(TableTestCase):
         if self.is_live:
             sleep(SLEEP_DELAY)
 
-    @AzureTestCase.await_prepared_test
     def test_error_with_malformed_conn_str(self):
         # Arrange
 

--- a/sdk/tables/azure-data-tables/tests/test_table_client_cosmos.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_client_cosmos.py
@@ -19,7 +19,7 @@ from _shared.testcase import (
 from azure.core.exceptions import HttpResponseError
 from _shared.cosmos_testcase import CachedCosmosAccountPreparer
 
-from devtools_testutils import CachedResourceGroupPreparer
+from devtools_testutils import CachedResourceGroupPreparer, AzureTestCase
 
 # ------------------------------------------------------------------------------
 SERVICES = {
@@ -557,7 +557,7 @@ class StorageTableClientTest(TableTestCase):
         if self.is_live:
             sleep(SLEEP_DELAY)
 
-    @pytest.mark.skip("kierans theory")
+    @AzureTestCase.await_prepared_test
     def test_create_table_client_with_invalid_name(self):
         # Arrange
         table_url = "https://{}.table.cosmos.azure.com:443/foo".format("cosmos_account_name")
@@ -572,6 +572,7 @@ class StorageTableClientTest(TableTestCase):
         if self.is_live:
             sleep(SLEEP_DELAY)
 
+    @AzureTestCase.await_prepared_test
     def test_error_with_malformed_conn_str(self):
         # Arrange
 


### PR DESCRIPTION
…t to reflect that.

BatchErrorException isn't an HttpResponseError, instead inheriting from AzureError. The tests reflect this change (with a few small tests changes that I made because I noticed them while fixing the others).