### PR TITLE
[Queue] Added support for receiving one message from queue

### DIFF
--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
@@ -482,6 +482,61 @@ class QueueClient(StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace
+    def receive_one_message(self, **kwargs):
+        # type: (Optional[Any]) -> QueueMessage
+        """Removes one message from the front of the queue.
+
+        When the message is retrieved from the queue, the response includes the message
+        content and a pop_receipt value, which is required to delete the message.
+        The message is not automatically deleted from the queue, but after it has
+        been retrieved, it is not visible to other clients for the time interval
+        specified by the visibility_timeout parameter.
+
+        If the key-encryption-key or resolver field is set on the local service object, the message will be
+        decrypted before being returned.
+
+        :keyword int visibility_timeout:
+            If not specified, the default value is 0. Specifies the
+            new visibility timeout value, in seconds, relative to server time.
+            The value must be larger than or equal to 0, and cannot be
+            larger than 7 days. The visibility timeout of a message cannot be
+            set to a value later than the expiry time. visibility_timeout
+            should be set to a value smaller than the time-to-live value.
+        :keyword int timeout:
+            The server timeout, expressed in seconds.
+        :return:
+            Returns a message from the Queue.
+        :rtype: ~azure.storage.queue.QueueMessage
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/queue_samples_message.py
+                :start-after: [START receive_one_message]
+                :end-before: [END receive_one_message]
+                :language: python
+                :dedent: 12
+                :caption: Receive one message from the queue.
+        """
+        visibility_timeout = kwargs.pop('visibility_timeout', None)
+        timeout = kwargs.pop('timeout', None)
+        self._config.message_decode_policy.configure(
+            require_encryption=self.require_encryption,
+            key_encryption_key=self.key_encryption_key,
+            resolver=self.key_resolver_function)
+        try:
+            message = self._client.messages.dequeue(
+                number_of_messages=1,
+                visibilitytimeout=visibility_timeout,
+                timeout=timeout,
+                cls=self._config.message_decode_policy,
+                **kwargs
+            )
+            wrapped_message = QueueMessage._from_generated(message[0])
+            return wrapped_message
+        except StorageErrorException as error:
+            process_storage_error(error)
+
+    @distributed_trace
     def receive_messages(self, **kwargs):
         # type: (Optional[Any]) -> ItemPaged[QueueMessage]
         """Removes one or more messages from the front of the queue.

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
@@ -482,7 +482,7 @@ class QueueClient(StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace
-    def receive_one_message(self, **kwargs):
+    def receive_message(self, **kwargs):
         # type: (Optional[Any]) -> QueueMessage
         """Removes one message from the front of the queue.
 
@@ -531,7 +531,8 @@ class QueueClient(StorageAccountHostsMixin):
                 cls=self._config.message_decode_policy,
                 **kwargs
             )
-            wrapped_message = QueueMessage._from_generated(message[0]) # pylint: disable=protected-access
+            wrapped_message = QueueMessage._from_generated(  # pylint: disable=protected-access
+                message[0]) if message != [] else None
             return wrapped_message
         except StorageErrorException as error:
             process_storage_error(error)

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
@@ -531,7 +531,7 @@ class QueueClient(StorageAccountHostsMixin):
                 cls=self._config.message_decode_policy,
                 **kwargs
             )
-            wrapped_message = QueueMessage._from_generated(message[0])
+            wrapped_message = QueueMessage._from_generated(message[0]) # pylint: disable=protected-access
             return wrapped_message
         except StorageErrorException as error:
             process_storage_error(error)

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
@@ -401,7 +401,7 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase):
             process_storage_error(error)
 
     @distributed_trace_async
-    async def receive_one_message(self, **kwargs):
+    async def receive_message(self, **kwargs):
         # type: (Optional[Any]) -> QueueMessage
         """Removes one message from the front of the queue.
 
@@ -450,7 +450,8 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase):
                 cls=self._config.message_decode_policy,
                 **kwargs
             )
-            wrapped_message = QueueMessage._from_generated(message[0]) # pylint: disable=protected-access
+            wrapped_message = QueueMessage._from_generated(  # pylint: disable=protected-access
+                message[0]) if message != [] else None
             return wrapped_message
         except StorageErrorException as error:
             process_storage_error(error)

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
@@ -456,7 +456,7 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase):
             process_storage_error(error)
 
     @distributed_trace
-    async def receive_messages(self, **kwargs):
+    def receive_messages(self, **kwargs):
         # type: (Optional[Any]) -> AsyncItemPaged[QueueMessage]
         """Removes one or more messages from the front of the queue.
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
@@ -450,7 +450,7 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase):
                 cls=self._config.message_decode_policy,
                 **kwargs
             )
-            wrapped_message = QueueMessage._from_generated(message[0])
+            wrapped_message = QueueMessage._from_generated(message[0]) # pylint: disable=protected-access
             return wrapped_message
         except StorageErrorException as error:
             process_storage_error(error)

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
@@ -400,8 +400,63 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase):
         except StorageErrorException as error:
             process_storage_error(error)
 
+    @distributed_trace_async
+    async def receive_one_message(self, **kwargs):
+        # type: (Optional[Any]) -> QueueMessage
+        """Removes one message from the front of the queue.
+
+        When the message is retrieved from the queue, the response includes the message
+        content and a pop_receipt value, which is required to delete the message.
+        The message is not automatically deleted from the queue, but after it has
+        been retrieved, it is not visible to other clients for the time interval
+        specified by the visibility_timeout parameter.
+
+        If the key-encryption-key or resolver field is set on the local service object, the message will be
+        decrypted before being returned.
+
+        :keyword int visibility_timeout:
+            If not specified, the default value is 0. Specifies the
+            new visibility timeout value, in seconds, relative to server time.
+            The value must be larger than or equal to 0, and cannot be
+            larger than 7 days. The visibility timeout of a message cannot be
+            set to a value later than the expiry time. visibility_timeout
+            should be set to a value smaller than the time-to-live value.
+        :keyword int timeout:
+            The server timeout, expressed in seconds.
+        :return:
+            Returns a message from the Queue.
+        :rtype: ~azure.storage.queue.QueueMessage
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/queue_samples_message_async.py
+                :start-after: [START receive_one_message]
+                :end-before: [END receive_one_message]
+                :language: python
+                :dedent: 12
+                :caption: Receive one message from the queue.
+        """
+        visibility_timeout = kwargs.pop('visibility_timeout', None)
+        timeout = kwargs.pop('timeout', None)
+        self._config.message_decode_policy.configure(
+            require_encryption=self.require_encryption,
+            key_encryption_key=self.key_encryption_key,
+            resolver=self.key_resolver_function)
+        try:
+            message = await self._client.messages.dequeue(
+                number_of_messages=1,
+                visibilitytimeout=visibility_timeout,
+                timeout=timeout,
+                cls=self._config.message_decode_policy,
+                **kwargs
+            )
+            wrapped_message = QueueMessage._from_generated(message[0])
+            return wrapped_message
+        except StorageErrorException as error:
+            process_storage_error(error)
+
     @distributed_trace
-    def receive_messages(self, **kwargs):
+    async def receive_messages(self, **kwargs):
         # type: (Optional[Any]) -> AsyncItemPaged[QueueMessage]
         """Removes one or more messages from the front of the queue.
 

--- a/sdk/storage/azure-storage-queue/samples/queue_samples_message.py
+++ b/sdk/storage/azure-storage-queue/samples/queue_samples_message.py
@@ -179,10 +179,38 @@ class QueueMessageSamples(object):
         finally:
             queue.delete_queue()
 
-    def delete_and_clear_messages(self):
+    def receive_one_message_from_queue(self):
         # Instantiate a queue client
         from azure.storage.queue import QueueClient
         queue = QueueClient.from_connection_string(self.connection_string, "myqueue5")
+
+        # Create the queue
+        queue.create_queue()
+
+        try:
+            queue.send_message(u"message1")
+            queue.send_message(u"message2")
+            queue.send_message(u"message3")
+
+            # [START receive_one_message]
+            # Pop two messages from the front of the queue
+            message1 = queue.receive_one_message()
+            message2 = queue.receive_one_message()
+            # We should see message 3 if we peek
+            message3 = queue.peek_messages()[0]
+
+            print(message1.content)
+            print(message2.content)
+            print(message3.content)
+            # [END receive_one_message]
+
+        finally:
+            queue.delete_queue()
+
+    def delete_and_clear_messages(self):
+        # Instantiate a queue client
+        from azure.storage.queue import QueueClient
+        queue = QueueClient.from_connection_string(self.connection_string, "myqueue6")
 
         # Create the queue
         queue.create_queue()
@@ -214,7 +242,7 @@ class QueueMessageSamples(object):
     def peek_messages(self):
         # Instantiate a queue client
         from azure.storage.queue import QueueClient
-        queue = QueueClient.from_connection_string(self.connection_string, "myqueue6")
+        queue = QueueClient.from_connection_string(self.connection_string, "myqueue7")
 
         # Create the queue
         queue.create_queue()
@@ -246,7 +274,7 @@ class QueueMessageSamples(object):
     def update_message(self):
         # Instantiate a queue client
         from azure.storage.queue import QueueClient
-        queue = QueueClient.from_connection_string(self.connection_string, "myqueue7")
+        queue = QueueClient.from_connection_string(self.connection_string, "myqueue8")
 
         # Create the queue
         queue.create_queue()
@@ -279,6 +307,7 @@ if __name__ == '__main__':
     sample.queue_metadata()
     sample.send_and_receive_messages()
     sample.list_message_pages()
+    sample.receive_one_message_from_queue()
     sample.delete_and_clear_messages()
     sample.peek_messages()
     sample.update_message()

--- a/sdk/storage/azure-storage-queue/samples/queue_samples_message.py
+++ b/sdk/storage/azure-storage-queue/samples/queue_samples_message.py
@@ -194,8 +194,8 @@ class QueueMessageSamples(object):
 
             # [START receive_one_message]
             # Pop two messages from the front of the queue
-            message1 = queue.receive_one_message()
-            message2 = queue.receive_one_message()
+            message1 = queue.receive_message()
+            message2 = queue.receive_message()
             # We should see message 3 if we peek
             message3 = queue.peek_messages()[0]
 

--- a/sdk/storage/azure-storage-queue/samples/queue_samples_message_async.py
+++ b/sdk/storage/azure-storage-queue/samples/queue_samples_message_async.py
@@ -283,13 +283,13 @@ class QueueMessageSamplesAsync(object):
 
 async def main():
     sample = QueueMessageSamplesAsync()
-    # await sample.set_access_policy_async()
-    # await sample.queue_metadata_async()
-    # await sample.send_and_receive_messages_async()
+    await sample.set_access_policy_async()
+    await sample.queue_metadata_async()
+    await sample.send_and_receive_messages_async()
     await sample.receive_one_message_from_queue()
-    # await sample.delete_and_clear_messages_async()
-    # await sample.peek_messages_async()
-    # await sample.update_message_async()
+    await sample.delete_and_clear_messages_async()
+    await sample.peek_messages_async()
+    await sample.update_message_async()
 
 if __name__ == '__main__':
     loop = asyncio.get_event_loop()

--- a/sdk/storage/azure-storage-queue/samples/queue_samples_message_async.py
+++ b/sdk/storage/azure-storage-queue/samples/queue_samples_message_async.py
@@ -149,6 +149,36 @@ class QueueMessageSamplesAsync(object):
                 # Delete the queue
                 await queue.delete_queue()
 
+    async def receive_one_message_from_queue(self):
+        # Instantiate a queue client
+        from azure.storage.queue.aio import QueueClient
+        queue = QueueClient.from_connection_string(self.connection_string, "myqueue3")
+
+        # Create the queue
+        async with queue:
+            await queue.create_queue()
+
+            try:
+                await asyncio.gather(
+                    queue.send_message(u"message1"),
+                    queue.send_message(u"message2"),
+                    queue.send_message(u"message3"))
+
+                # [START receive_one_message]
+                # Pop two messages from the front of the queue
+                message1 = await queue.receive_one_message()
+                message2 = await queue.receive_one_message()
+                # We should see message 3 if we peek
+                message3 = await queue.peek_messages()
+
+                print(message1.content)
+                print(message2.content)
+                print(message3[0].content)
+                # [END receive_one_message]
+
+            finally:
+                await queue.delete_queue()
+
     async def delete_and_clear_messages_async(self):
         # Instantiate a queue client
         from azure.storage.queue.aio import QueueClient
@@ -253,12 +283,13 @@ class QueueMessageSamplesAsync(object):
 
 async def main():
     sample = QueueMessageSamplesAsync()
-    await sample.set_access_policy_async()
-    await sample.queue_metadata_async()
-    await sample.send_and_receive_messages_async()
-    await sample.delete_and_clear_messages_async()
-    await sample.peek_messages_async()
-    await sample.update_message_async()
+    # await sample.set_access_policy_async()
+    # await sample.queue_metadata_async()
+    # await sample.send_and_receive_messages_async()
+    await sample.receive_one_message_from_queue()
+    # await sample.delete_and_clear_messages_async()
+    # await sample.peek_messages_async()
+    # await sample.update_message_async()
 
 if __name__ == '__main__':
     loop = asyncio.get_event_loop()

--- a/sdk/storage/azure-storage-queue/samples/queue_samples_message_async.py
+++ b/sdk/storage/azure-storage-queue/samples/queue_samples_message_async.py
@@ -166,8 +166,8 @@ class QueueMessageSamplesAsync(object):
 
                 # [START receive_one_message]
                 # Pop two messages from the front of the queue
-                message1 = await queue.receive_one_message()
-                message2 = await queue.receive_one_message()
+                message1 = await queue.receive_message()
+                message2 = await queue.receive_message()
                 # We should see message 3 if we peek
                 message3 = await queue.peek_messages()
 

--- a/sdk/storage/azure-storage-queue/tests/recordings/test_queue.test_receive_one_message.yaml
+++ b/sdk/storage/azure-storage-queue/tests/recordings/test_queue.test_receive_one_message.yaml
@@ -1,0 +1,281 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 28 Oct 2020 21:22:05 GMT
+      x-ms-version:
+      - '2018-03-28'
+    method: PUT
+    uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Wed, 28 Oct 2020 21:22:05 GMT
+      server:
+      - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2018-03-28'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <QueueMessage><MessageText>message1</MessageText></QueueMessage>'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '103'
+      Content-Type:
+      - application/xml; charset=utf-8
+      User-Agent:
+      - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 28 Oct 2020 21:22:05 GMT
+      x-ms-version:
+      - '2018-03-28'
+    method: POST
+    uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>a05e3fee-daca-4f99-b10f-66aa11b0de10</MessageId><InsertionTime>Wed,
+        28 Oct 2020 21:22:05 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:22:05
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAjSXPYnCt1gE=</PopReceipt><TimeNextVisible>Wed,
+        28 Oct 2020 21:22:05 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+    headers:
+      content-type:
+      - application/xml
+      date:
+      - Wed, 28 Oct 2020 21:22:05 GMT
+      server:
+      - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2018-03-28'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <QueueMessage><MessageText>message2</MessageText></QueueMessage>'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '103'
+      Content-Type:
+      - application/xml; charset=utf-8
+      User-Agent:
+      - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 28 Oct 2020 21:22:06 GMT
+      x-ms-version:
+      - '2018-03-28'
+    method: POST
+    uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>49a60678-55e0-4496-ac7c-f615a7d30e5c</MessageId><InsertionTime>Wed,
+        28 Oct 2020 21:22:06 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:22:06
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAIg3mYnCt1gE=</PopReceipt><TimeNextVisible>Wed,
+        28 Oct 2020 21:22:06 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+    headers:
+      content-type:
+      - application/xml
+      date:
+      - Wed, 28 Oct 2020 21:22:05 GMT
+      server:
+      - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2018-03-28'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <QueueMessage><MessageText>message3</MessageText></QueueMessage>'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '103'
+      Content-Type:
+      - application/xml; charset=utf-8
+      User-Agent:
+      - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 28 Oct 2020 21:22:06 GMT
+      x-ms-version:
+      - '2018-03-28'
+    method: POST
+    uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>eb0e2fd2-4cc2-4d0b-98bb-bff0d848441d</MessageId><InsertionTime>Wed,
+        28 Oct 2020 21:22:06 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:22:06
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAXgb+YnCt1gE=</PopReceipt><TimeNextVisible>Wed,
+        28 Oct 2020 21:22:06 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+    headers:
+      content-type:
+      - application/xml
+      date:
+      - Wed, 28 Oct 2020 21:22:05 GMT
+      server:
+      - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2018-03-28'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 28 Oct 2020 21:22:06 GMT
+      x-ms-version:
+      - '2018-03-28'
+    method: GET
+    uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages?numofmessages=1
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>a05e3fee-daca-4f99-b10f-66aa11b0de10</MessageId><InsertionTime>Wed,
+        28 Oct 2020 21:22:05 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:22:05
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAATy33dHCt1gE=</PopReceipt><TimeNextVisible>Wed,
+        28 Oct 2020 21:22:36 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message1</MessageText></QueueMessage></QueueMessagesList>"
+    headers:
+      cache-control:
+      - no-cache
+      content-type:
+      - application/xml
+      date:
+      - Wed, 28 Oct 2020 21:22:05 GMT
+      server:
+      - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2018-03-28'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 28 Oct 2020 21:22:06 GMT
+      x-ms-version:
+      - '2018-03-28'
+    method: GET
+    uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages?numofmessages=1
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>49a60678-55e0-4496-ac7c-f615a7d30e5c</MessageId><InsertionTime>Wed,
+        28 Oct 2020 21:22:06 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:22:06
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAzKUUdXCt1gE=</PopReceipt><TimeNextVisible>Wed,
+        28 Oct 2020 21:22:36 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message2</MessageText></QueueMessage></QueueMessagesList>"
+    headers:
+      cache-control:
+      - no-cache
+      content-type:
+      - application/xml
+      date:
+      - Wed, 28 Oct 2020 21:22:06 GMT
+      server:
+      - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2018-03-28'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 28 Oct 2020 21:22:06 GMT
+      x-ms-version:
+      - '2018-03-28'
+    method: GET
+    uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages?peekonly=true
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>eb0e2fd2-4cc2-4d0b-98bb-bff0d848441d</MessageId><InsertionTime>Wed,
+        28 Oct 2020 21:22:06 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:22:06
+        GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>message3</MessageText></QueueMessage></QueueMessagesList>"
+    headers:
+      cache-control:
+      - no-cache
+      content-type:
+      - application/xml
+      date:
+      - Wed, 28 Oct 2020 21:22:06 GMT
+      server:
+      - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2018-03-28'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/storage/azure-storage-queue/tests/recordings/test_queue.test_receive_one_message.yaml
+++ b/sdk/storage/azure-storage-queue/tests/recordings/test_queue.test_receive_one_message.yaml
@@ -13,7 +13,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 28 Oct 2020 21:22:05 GMT
+      - Thu, 29 Oct 2020 01:22:22 GMT
       x-ms-version:
       - '2018-03-28'
     method: PUT
@@ -25,7 +25,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 28 Oct 2020 21:22:05 GMT
+      - Thu, 29 Oct 2020 01:22:23 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -51,22 +51,22 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 28 Oct 2020 21:22:05 GMT
+      - Thu, 29 Oct 2020 01:22:23 GMT
       x-ms-version:
       - '2018-03-28'
     method: POST
     uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>a05e3fee-daca-4f99-b10f-66aa11b0de10</MessageId><InsertionTime>Wed,
-        28 Oct 2020 21:22:05 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:22:05
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAjSXPYnCt1gE=</PopReceipt><TimeNextVisible>Wed,
-        28 Oct 2020 21:22:05 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>6e344ff6-1d34-4513-8c97-5b49cdc8111a</MessageId><InsertionTime>Thu,
+        29 Oct 2020 01:22:23 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:23
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAxbM09JGt1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 01:22:23 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
     headers:
       content-type:
       - application/xml
       date:
-      - Wed, 28 Oct 2020 21:22:05 GMT
+      - Thu, 29 Oct 2020 01:22:23 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -94,22 +94,22 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 28 Oct 2020 21:22:06 GMT
+      - Thu, 29 Oct 2020 01:22:23 GMT
       x-ms-version:
       - '2018-03-28'
     method: POST
     uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>49a60678-55e0-4496-ac7c-f615a7d30e5c</MessageId><InsertionTime>Wed,
-        28 Oct 2020 21:22:06 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:22:06
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAIg3mYnCt1gE=</PopReceipt><TimeNextVisible>Wed,
-        28 Oct 2020 21:22:06 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>bf8d431c-8732-4a17-a1d2-56b1c7633477</MessageId><InsertionTime>Thu,
+        29 Oct 2020 01:22:23 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:23
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAMyJN9JGt1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 01:22:23 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
     headers:
       content-type:
       - application/xml
       date:
-      - Wed, 28 Oct 2020 21:22:05 GMT
+      - Thu, 29 Oct 2020 01:22:23 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -137,22 +137,22 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 28 Oct 2020 21:22:06 GMT
+      - Thu, 29 Oct 2020 01:22:23 GMT
       x-ms-version:
       - '2018-03-28'
     method: POST
     uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>eb0e2fd2-4cc2-4d0b-98bb-bff0d848441d</MessageId><InsertionTime>Wed,
-        28 Oct 2020 21:22:06 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:22:06
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAXgb+YnCt1gE=</PopReceipt><TimeNextVisible>Wed,
-        28 Oct 2020 21:22:06 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>701932ae-8bdb-476c-a1d7-f17d4a0416c1</MessageId><InsertionTime>Thu,
+        29 Oct 2020 01:22:23 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:23
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAA9tn9JGt1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 01:22:23 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
     headers:
       content-type:
       - application/xml
       date:
-      - Wed, 28 Oct 2020 21:22:05 GMT
+      - Thu, 29 Oct 2020 01:22:23 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -174,24 +174,24 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 28 Oct 2020 21:22:06 GMT
+      - Thu, 29 Oct 2020 01:22:23 GMT
       x-ms-version:
       - '2018-03-28'
     method: GET
     uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages?numofmessages=1
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>a05e3fee-daca-4f99-b10f-66aa11b0de10</MessageId><InsertionTime>Wed,
-        28 Oct 2020 21:22:05 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:22:05
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAATy33dHCt1gE=</PopReceipt><TimeNextVisible>Wed,
-        28 Oct 2020 21:22:36 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message1</MessageText></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>6e344ff6-1d34-4513-8c97-5b49cdc8111a</MessageId><InsertionTime>Thu,
+        29 Oct 2020 01:22:23 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:23
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAFqxkBpKt1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 01:22:53 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message1</MessageText></QueueMessage></QueueMessagesList>"
     headers:
       cache-control:
       - no-cache
       content-type:
       - application/xml
       date:
-      - Wed, 28 Oct 2020 21:22:05 GMT
+      - Thu, 29 Oct 2020 01:22:23 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -213,24 +213,24 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 28 Oct 2020 21:22:06 GMT
+      - Thu, 29 Oct 2020 01:22:23 GMT
       x-ms-version:
       - '2018-03-28'
     method: GET
     uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages?numofmessages=1
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>49a60678-55e0-4496-ac7c-f615a7d30e5c</MessageId><InsertionTime>Wed,
-        28 Oct 2020 21:22:06 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:22:06
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAzKUUdXCt1gE=</PopReceipt><TimeNextVisible>Wed,
-        28 Oct 2020 21:22:36 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message2</MessageText></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>bf8d431c-8732-4a17-a1d2-56b1c7633477</MessageId><InsertionTime>Thu,
+        29 Oct 2020 01:22:23 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:23
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAIFd8BpKt1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 01:22:53 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message2</MessageText></QueueMessage></QueueMessagesList>"
     headers:
       cache-control:
       - no-cache
       content-type:
       - application/xml
       date:
-      - Wed, 28 Oct 2020 21:22:06 GMT
+      - Thu, 29 Oct 2020 01:22:23 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -252,15 +252,15 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 28 Oct 2020 21:22:06 GMT
+      - Thu, 29 Oct 2020 01:22:24 GMT
       x-ms-version:
       - '2018-03-28'
     method: GET
     uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages?peekonly=true
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>eb0e2fd2-4cc2-4d0b-98bb-bff0d848441d</MessageId><InsertionTime>Wed,
-        28 Oct 2020 21:22:06 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:22:06
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>701932ae-8bdb-476c-a1d7-f17d4a0416c1</MessageId><InsertionTime>Thu,
+        29 Oct 2020 01:22:23 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:23
         GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>message3</MessageText></QueueMessage></QueueMessagesList>"
     headers:
       cache-control:
@@ -268,7 +268,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Wed, 28 Oct 2020 21:22:06 GMT
+      - Thu, 29 Oct 2020 01:22:24 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:

--- a/sdk/storage/azure-storage-queue/tests/recordings/test_queue.test_receive_one_message.yaml
+++ b/sdk/storage/azure-storage-queue/tests/recordings/test_queue.test_receive_one_message.yaml
@@ -13,7 +13,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 29 Oct 2020 01:22:22 GMT
+      - Thu, 29 Oct 2020 02:48:17 GMT
       x-ms-version:
       - '2018-03-28'
     method: PUT
@@ -25,7 +25,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 29 Oct 2020 01:22:23 GMT
+      - Thu, 29 Oct 2020 02:48:17 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -33,6 +33,43 @@ interactions:
     status:
       code: 201
       message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 29 Oct 2020 02:48:18 GMT
+      x-ms-version:
+      - '2018-03-28'
+    method: GET
+    uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages?numofmessages=1
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList
+        />"
+    headers:
+      cache-control:
+      - no-cache
+      content-type:
+      - application/xml
+      date:
+      - Thu, 29 Oct 2020 02:48:17 GMT
+      server:
+      - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2018-03-28'
+    status:
+      code: 200
+      message: OK
 - request:
     body: '<?xml version=''1.0'' encoding=''utf-8''?>
 
@@ -51,22 +88,22 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 29 Oct 2020 01:22:23 GMT
+      - Thu, 29 Oct 2020 02:48:18 GMT
       x-ms-version:
       - '2018-03-28'
     method: POST
     uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>6e344ff6-1d34-4513-8c97-5b49cdc8111a</MessageId><InsertionTime>Thu,
-        29 Oct 2020 01:22:23 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:23
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAxbM09JGt1gE=</PopReceipt><TimeNextVisible>Thu,
-        29 Oct 2020 01:22:23 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>78d04178-05f5-4c46-af2e-d184e4dfb298</MessageId><InsertionTime>Thu,
+        29 Oct 2020 02:48:18 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 02:48:18
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAUo399J2t1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 02:48:18 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
     headers:
       content-type:
       - application/xml
       date:
-      - Thu, 29 Oct 2020 01:22:23 GMT
+      - Thu, 29 Oct 2020 02:48:17 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -94,22 +131,22 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 29 Oct 2020 01:22:23 GMT
+      - Thu, 29 Oct 2020 02:48:18 GMT
       x-ms-version:
       - '2018-03-28'
     method: POST
     uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>bf8d431c-8732-4a17-a1d2-56b1c7633477</MessageId><InsertionTime>Thu,
-        29 Oct 2020 01:22:23 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:23
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAMyJN9JGt1gE=</PopReceipt><TimeNextVisible>Thu,
-        29 Oct 2020 01:22:23 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>0902bc9d-169b-4e22-9ba2-b81fac7ada71</MessageId><InsertionTime>Thu,
+        29 Oct 2020 02:48:18 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 02:48:18
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAA4FES9Z2t1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 02:48:18 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
     headers:
       content-type:
       - application/xml
       date:
-      - Thu, 29 Oct 2020 01:22:23 GMT
+      - Thu, 29 Oct 2020 02:48:18 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -137,22 +174,22 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 29 Oct 2020 01:22:23 GMT
+      - Thu, 29 Oct 2020 02:48:18 GMT
       x-ms-version:
       - '2018-03-28'
     method: POST
     uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>701932ae-8bdb-476c-a1d7-f17d4a0416c1</MessageId><InsertionTime>Thu,
-        29 Oct 2020 01:22:23 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:23
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAA9tn9JGt1gE=</PopReceipt><TimeNextVisible>Thu,
-        29 Oct 2020 01:22:23 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>095ce0f7-470d-4c97-8512-69eb14a36ff3</MessageId><InsertionTime>Thu,
+        29 Oct 2020 02:48:18 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 02:48:18
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAJIQr9Z2t1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 02:48:18 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
     headers:
       content-type:
       - application/xml
       date:
-      - Thu, 29 Oct 2020 01:22:23 GMT
+      - Thu, 29 Oct 2020 02:48:18 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -174,24 +211,24 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 29 Oct 2020 01:22:23 GMT
+      - Thu, 29 Oct 2020 02:48:19 GMT
       x-ms-version:
       - '2018-03-28'
     method: GET
     uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages?numofmessages=1
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>6e344ff6-1d34-4513-8c97-5b49cdc8111a</MessageId><InsertionTime>Thu,
-        29 Oct 2020 01:22:23 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:23
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAFqxkBpKt1gE=</PopReceipt><TimeNextVisible>Thu,
-        29 Oct 2020 01:22:53 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message1</MessageText></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>78d04178-05f5-4c46-af2e-d184e4dfb298</MessageId><InsertionTime>Thu,
+        29 Oct 2020 02:48:18 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 02:48:18
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAArXIjB56t1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 02:48:49 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message1</MessageText></QueueMessage></QueueMessagesList>"
     headers:
       cache-control:
       - no-cache
       content-type:
       - application/xml
       date:
-      - Thu, 29 Oct 2020 01:22:23 GMT
+      - Thu, 29 Oct 2020 02:48:18 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -213,24 +250,24 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 29 Oct 2020 01:22:23 GMT
+      - Thu, 29 Oct 2020 02:48:19 GMT
       x-ms-version:
       - '2018-03-28'
     method: GET
     uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages?numofmessages=1
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>bf8d431c-8732-4a17-a1d2-56b1c7633477</MessageId><InsertionTime>Thu,
-        29 Oct 2020 01:22:23 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:23
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAIFd8BpKt1gE=</PopReceipt><TimeNextVisible>Thu,
-        29 Oct 2020 01:22:53 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message2</MessageText></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>0902bc9d-169b-4e22-9ba2-b81fac7ada71</MessageId><InsertionTime>Thu,
+        29 Oct 2020 02:48:18 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 02:48:18
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAPzc4B56t1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 02:48:49 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message2</MessageText></QueueMessage></QueueMessagesList>"
     headers:
       cache-control:
       - no-cache
       content-type:
       - application/xml
       date:
-      - Thu, 29 Oct 2020 01:22:23 GMT
+      - Thu, 29 Oct 2020 02:48:18 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -252,15 +289,15 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 29 Oct 2020 01:22:24 GMT
+      - Thu, 29 Oct 2020 02:48:19 GMT
       x-ms-version:
       - '2018-03-28'
     method: GET
     uri: https://storagename.queue.core.windows.net/pyqueuesync3a60e5a/messages?peekonly=true
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>701932ae-8bdb-476c-a1d7-f17d4a0416c1</MessageId><InsertionTime>Thu,
-        29 Oct 2020 01:22:23 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:23
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>095ce0f7-470d-4c97-8512-69eb14a36ff3</MessageId><InsertionTime>Thu,
+        29 Oct 2020 02:48:18 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 02:48:18
         GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>message3</MessageText></QueueMessage></QueueMessagesList>"
     headers:
       cache-control:
@@ -268,7 +305,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Thu, 29 Oct 2020 01:22:24 GMT
+      - Thu, 29 Oct 2020 02:48:18 GMT
       server:
       - Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:

--- a/sdk/storage/azure-storage-queue/tests/recordings/test_queue_async.test_receive_one_message.yaml
+++ b/sdk/storage/azure-storage-queue/tests/recordings/test_queue_async.test_receive_one_message.yaml
@@ -1,0 +1,219 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 28 Oct 2020 21:41:16 GMT
+      x-ms-version:
+      - '2018-03-28'
+    method: PUT
+    uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Wed, 28 Oct 2020 21:41:16 GMT
+      server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version: '2018-03-28'
+    status:
+      code: 201
+      message: Created
+    url: https://seanmcccanary3.queue.core.windows.net/pyqueueasync640e10d7
+- request:
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <QueueMessage><MessageText>message1</MessageText></QueueMessage>'
+    headers:
+      Accept:
+      - application/xml
+      Content-Length:
+      - '103'
+      Content-Type:
+      - application/xml; charset=utf-8
+      User-Agent:
+      - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 28 Oct 2020 21:41:16 GMT
+      x-ms-version:
+      - '2018-03-28'
+    method: POST
+    uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>e6af54c5-6054-4146-9ac1-e7b29fe4b3f1</MessageId><InsertionTime>Wed,
+        28 Oct 2020 21:41:16 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:41:16
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAACHNEHOt1gE=</PopReceipt><TimeNextVisible>Wed,
+        28 Oct 2020 21:41:16 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+    headers:
+      content-type: application/xml
+      date: Wed, 28 Oct 2020 21:41:16 GMT
+      server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-ms-version: '2018-03-28'
+    status:
+      code: 201
+      message: Created
+    url: https://seanmcccanary3.queue.core.windows.net/pyqueueasync640e10d7/messages
+- request:
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <QueueMessage><MessageText>message2</MessageText></QueueMessage>'
+    headers:
+      Accept:
+      - application/xml
+      Content-Length:
+      - '103'
+      Content-Type:
+      - application/xml; charset=utf-8
+      User-Agent:
+      - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 28 Oct 2020 21:41:16 GMT
+      x-ms-version:
+      - '2018-03-28'
+    method: POST
+    uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>c2f17fee-0526-4832-87ad-3c7a25439a53</MessageId><InsertionTime>Wed,
+        28 Oct 2020 21:41:16 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:41:16
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAD1zXEHOt1gE=</PopReceipt><TimeNextVisible>Wed,
+        28 Oct 2020 21:41:16 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+    headers:
+      content-type: application/xml
+      date: Wed, 28 Oct 2020 21:41:16 GMT
+      server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-ms-version: '2018-03-28'
+    status:
+      code: 201
+      message: Created
+    url: https://seanmcccanary3.queue.core.windows.net/pyqueueasync640e10d7/messages
+- request:
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <QueueMessage><MessageText>message3</MessageText></QueueMessage>'
+    headers:
+      Accept:
+      - application/xml
+      Content-Length:
+      - '103'
+      Content-Type:
+      - application/xml; charset=utf-8
+      User-Agent:
+      - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 28 Oct 2020 21:41:16 GMT
+      x-ms-version:
+      - '2018-03-28'
+    method: POST
+    uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>5dcd17c8-94ac-4d55-922e-308c7974fc3f</MessageId><InsertionTime>Wed,
+        28 Oct 2020 21:41:17 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:41:17
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAApNPgEHOt1gE=</PopReceipt><TimeNextVisible>Wed,
+        28 Oct 2020 21:41:17 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+    headers:
+      content-type: application/xml
+      date: Wed, 28 Oct 2020 21:41:16 GMT
+      server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-ms-version: '2018-03-28'
+    status:
+      code: 201
+      message: Created
+    url: https://seanmcccanary3.queue.core.windows.net/pyqueueasync640e10d7/messages
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 28 Oct 2020 21:41:17 GMT
+      x-ms-version:
+      - '2018-03-28'
+    method: GET
+    uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages?numofmessages=1
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>e6af54c5-6054-4146-9ac1-e7b29fe4b3f1</MessageId><InsertionTime>Wed,
+        28 Oct 2020 21:41:16 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:41:16
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAbDzMInOt1gE=</PopReceipt><TimeNextVisible>Wed,
+        28 Oct 2020 21:41:47 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message1</MessageText></QueueMessage></QueueMessagesList>"
+    headers:
+      cache-control: no-cache
+      content-type: application/xml
+      date: Wed, 28 Oct 2020 21:41:16 GMT
+      server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-ms-version: '2018-03-28'
+    status:
+      code: 200
+      message: OK
+    url: https://seanmcccanary3.queue.core.windows.net/pyqueueasync640e10d7/messages?numofmessages=1
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 28 Oct 2020 21:41:17 GMT
+      x-ms-version:
+      - '2018-03-28'
+    method: GET
+    uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages?numofmessages=1
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>c2f17fee-0526-4832-87ad-3c7a25439a53</MessageId><InsertionTime>Wed,
+        28 Oct 2020 21:41:16 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:41:16
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAYVDWInOt1gE=</PopReceipt><TimeNextVisible>Wed,
+        28 Oct 2020 21:41:47 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message2</MessageText></QueueMessage></QueueMessagesList>"
+    headers:
+      cache-control: no-cache
+      content-type: application/xml
+      date: Wed, 28 Oct 2020 21:41:17 GMT
+      server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-ms-version: '2018-03-28'
+    status:
+      code: 200
+      message: OK
+    url: https://seanmcccanary3.queue.core.windows.net/pyqueueasync640e10d7/messages?numofmessages=1
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 28 Oct 2020 21:41:17 GMT
+      x-ms-version:
+      - '2018-03-28'
+    method: GET
+    uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages?peekonly=true
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>5dcd17c8-94ac-4d55-922e-308c7974fc3f</MessageId><InsertionTime>Wed,
+        28 Oct 2020 21:41:17 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:41:17
+        GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>message3</MessageText></QueueMessage></QueueMessagesList>"
+    headers:
+      cache-control: no-cache
+      content-type: application/xml
+      date: Wed, 28 Oct 2020 21:41:17 GMT
+      server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-ms-version: '2018-03-28'
+    status:
+      code: 200
+      message: OK
+    url: https://seanmcccanary3.queue.core.windows.net/pyqueueasync640e10d7/messages?peekonly=true
+version: 1

--- a/sdk/storage/azure-storage-queue/tests/recordings/test_queue_async.test_receive_one_message.yaml
+++ b/sdk/storage/azure-storage-queue/tests/recordings/test_queue_async.test_receive_one_message.yaml
@@ -5,7 +5,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 28 Oct 2020 21:41:16 GMT
+      - Thu, 29 Oct 2020 01:22:46 GMT
       x-ms-version:
       - '2018-03-28'
     method: PUT
@@ -15,7 +15,7 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 28 Oct 2020 21:41:16 GMT
+      date: Thu, 29 Oct 2020 01:22:45 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2018-03-28'
     status:
@@ -36,20 +36,20 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 28 Oct 2020 21:41:16 GMT
+      - Thu, 29 Oct 2020 01:22:46 GMT
       x-ms-version:
       - '2018-03-28'
     method: POST
     uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>e6af54c5-6054-4146-9ac1-e7b29fe4b3f1</MessageId><InsertionTime>Wed,
-        28 Oct 2020 21:41:16 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:41:16
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAACHNEHOt1gE=</PopReceipt><TimeNextVisible>Wed,
-        28 Oct 2020 21:41:16 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>3d553eb4-d825-4265-a262-7f5690045462</MessageId><InsertionTime>Thu,
+        29 Oct 2020 01:22:46 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:46
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAsU38AZKt1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 01:22:46 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
     headers:
       content-type: application/xml
-      date: Wed, 28 Oct 2020 21:41:16 GMT
+      date: Thu, 29 Oct 2020 01:22:46 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       x-ms-version: '2018-03-28'
@@ -71,20 +71,20 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 28 Oct 2020 21:41:16 GMT
+      - Thu, 29 Oct 2020 01:22:46 GMT
       x-ms-version:
       - '2018-03-28'
     method: POST
     uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>c2f17fee-0526-4832-87ad-3c7a25439a53</MessageId><InsertionTime>Wed,
-        28 Oct 2020 21:41:16 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:41:16
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAD1zXEHOt1gE=</PopReceipt><TimeNextVisible>Wed,
-        28 Oct 2020 21:41:16 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>498a8f7f-d9cc-4d0c-902a-1008f636fee0</MessageId><InsertionTime>Thu,
+        29 Oct 2020 01:22:46 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:46
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAA2q8GApKt1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 01:22:46 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
     headers:
       content-type: application/xml
-      date: Wed, 28 Oct 2020 21:41:16 GMT
+      date: Thu, 29 Oct 2020 01:22:46 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       x-ms-version: '2018-03-28'
@@ -106,20 +106,20 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 28 Oct 2020 21:41:16 GMT
+      - Thu, 29 Oct 2020 01:22:46 GMT
       x-ms-version:
       - '2018-03-28'
     method: POST
     uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>5dcd17c8-94ac-4d55-922e-308c7974fc3f</MessageId><InsertionTime>Wed,
-        28 Oct 2020 21:41:17 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:41:17
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAApNPgEHOt1gE=</PopReceipt><TimeNextVisible>Wed,
-        28 Oct 2020 21:41:17 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>ef2713ef-79ee-4376-ae0b-8f70d08ef7c6</MessageId><InsertionTime>Thu,
+        29 Oct 2020 01:22:46 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:46
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAdycQApKt1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 01:22:46 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
     headers:
       content-type: application/xml
-      date: Wed, 28 Oct 2020 21:41:16 GMT
+      date: Thu, 29 Oct 2020 01:22:46 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       x-ms-version: '2018-03-28'
@@ -135,21 +135,21 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 28 Oct 2020 21:41:17 GMT
+      - Thu, 29 Oct 2020 01:22:46 GMT
       x-ms-version:
       - '2018-03-28'
     method: GET
     uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages?numofmessages=1
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>e6af54c5-6054-4146-9ac1-e7b29fe4b3f1</MessageId><InsertionTime>Wed,
-        28 Oct 2020 21:41:16 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:41:16
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAbDzMInOt1gE=</PopReceipt><TimeNextVisible>Wed,
-        28 Oct 2020 21:41:47 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message1</MessageText></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>3d553eb4-d825-4265-a262-7f5690045462</MessageId><InsertionTime>Thu,
+        29 Oct 2020 01:22:46 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:46
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAA6KH8E5Kt1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 01:23:16 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message1</MessageText></QueueMessage></QueueMessagesList>"
     headers:
       cache-control: no-cache
       content-type: application/xml
-      date: Wed, 28 Oct 2020 21:41:16 GMT
+      date: Thu, 29 Oct 2020 01:22:46 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       x-ms-version: '2018-03-28'
@@ -165,21 +165,21 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 28 Oct 2020 21:41:17 GMT
+      - Thu, 29 Oct 2020 01:22:46 GMT
       x-ms-version:
       - '2018-03-28'
     method: GET
     uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages?numofmessages=1
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>c2f17fee-0526-4832-87ad-3c7a25439a53</MessageId><InsertionTime>Wed,
-        28 Oct 2020 21:41:16 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:41:16
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAYVDWInOt1gE=</PopReceipt><TimeNextVisible>Wed,
-        28 Oct 2020 21:41:47 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message2</MessageText></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>498a8f7f-d9cc-4d0c-902a-1008f636fee0</MessageId><InsertionTime>Thu,
+        29 Oct 2020 01:22:46 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:46
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAr2cGFJKt1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 01:23:16 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message2</MessageText></QueueMessage></QueueMessagesList>"
     headers:
       cache-control: no-cache
       content-type: application/xml
-      date: Wed, 28 Oct 2020 21:41:17 GMT
+      date: Thu, 29 Oct 2020 01:22:46 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       x-ms-version: '2018-03-28'
@@ -195,20 +195,20 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 28 Oct 2020 21:41:17 GMT
+      - Thu, 29 Oct 2020 01:22:46 GMT
       x-ms-version:
       - '2018-03-28'
     method: GET
     uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages?peekonly=true
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>5dcd17c8-94ac-4d55-922e-308c7974fc3f</MessageId><InsertionTime>Wed,
-        28 Oct 2020 21:41:17 GMT</InsertionTime><ExpirationTime>Wed, 04 Nov 2020 21:41:17
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>ef2713ef-79ee-4376-ae0b-8f70d08ef7c6</MessageId><InsertionTime>Thu,
+        29 Oct 2020 01:22:46 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:46
         GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>message3</MessageText></QueueMessage></QueueMessagesList>"
     headers:
       cache-control: no-cache
       content-type: application/xml
-      date: Wed, 28 Oct 2020 21:41:17 GMT
+      date: Thu, 29 Oct 2020 01:22:46 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       x-ms-version: '2018-03-28'

--- a/sdk/storage/azure-storage-queue/tests/recordings/test_queue_async.test_receive_one_message.yaml
+++ b/sdk/storage/azure-storage-queue/tests/recordings/test_queue_async.test_receive_one_message.yaml
@@ -5,7 +5,7 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 29 Oct 2020 01:22:46 GMT
+      - Thu, 29 Oct 2020 02:48:29 GMT
       x-ms-version:
       - '2018-03-28'
     method: PUT
@@ -15,13 +15,41 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Thu, 29 Oct 2020 01:22:45 GMT
+      date: Thu, 29 Oct 2020 02:48:29 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version: '2018-03-28'
     status:
       code: 201
       message: Created
     url: https://seanmcccanary3.queue.core.windows.net/pyqueueasync640e10d7
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      User-Agent:
+      - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 29 Oct 2020 02:48:30 GMT
+      x-ms-version:
+      - '2018-03-28'
+    method: GET
+    uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages?numofmessages=1
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList
+        />"
+    headers:
+      cache-control: no-cache
+      content-type: application/xml
+      date: Thu, 29 Oct 2020 02:48:29 GMT
+      server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-ms-version: '2018-03-28'
+    status:
+      code: 200
+      message: OK
+    url: https://seanmcccanary3.queue.core.windows.net/pyqueueasync640e10d7/messages?numofmessages=1
 - request:
     body: '<?xml version=''1.0'' encoding=''utf-8''?>
 
@@ -36,20 +64,20 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 29 Oct 2020 01:22:46 GMT
+      - Thu, 29 Oct 2020 02:48:30 GMT
       x-ms-version:
       - '2018-03-28'
     method: POST
     uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>3d553eb4-d825-4265-a262-7f5690045462</MessageId><InsertionTime>Thu,
-        29 Oct 2020 01:22:46 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:46
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAsU38AZKt1gE=</PopReceipt><TimeNextVisible>Thu,
-        29 Oct 2020 01:22:46 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>c25fa1f7-cb36-4d2a-bf09-6f75389bbc98</MessageId><InsertionTime>Thu,
+        29 Oct 2020 02:48:30 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 02:48:30
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAv+re+52t1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 02:48:30 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
     headers:
       content-type: application/xml
-      date: Thu, 29 Oct 2020 01:22:46 GMT
+      date: Thu, 29 Oct 2020 02:48:29 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       x-ms-version: '2018-03-28'
@@ -71,20 +99,20 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 29 Oct 2020 01:22:46 GMT
+      - Thu, 29 Oct 2020 02:48:30 GMT
       x-ms-version:
       - '2018-03-28'
     method: POST
     uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>498a8f7f-d9cc-4d0c-902a-1008f636fee0</MessageId><InsertionTime>Thu,
-        29 Oct 2020 01:22:46 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:46
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAA2q8GApKt1gE=</PopReceipt><TimeNextVisible>Thu,
-        29 Oct 2020 01:22:46 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>9159ff30-0b69-4916-8efb-7624a7b1acdb</MessageId><InsertionTime>Thu,
+        29 Oct 2020 02:48:30 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 02:48:30
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAi7Do+52t1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 02:48:30 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
     headers:
       content-type: application/xml
-      date: Thu, 29 Oct 2020 01:22:46 GMT
+      date: Thu, 29 Oct 2020 02:48:29 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       x-ms-version: '2018-03-28'
@@ -106,20 +134,20 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 29 Oct 2020 01:22:46 GMT
+      - Thu, 29 Oct 2020 02:48:30 GMT
       x-ms-version:
       - '2018-03-28'
     method: POST
     uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>ef2713ef-79ee-4376-ae0b-8f70d08ef7c6</MessageId><InsertionTime>Thu,
-        29 Oct 2020 01:22:46 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:46
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAdycQApKt1gE=</PopReceipt><TimeNextVisible>Thu,
-        29 Oct 2020 01:22:46 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>d39f0f34-a85b-4488-924c-d5cf002f4b68</MessageId><InsertionTime>Thu,
+        29 Oct 2020 02:48:30 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 02:48:30
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAFyjy+52t1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 02:48:30 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"
     headers:
       content-type: application/xml
-      date: Thu, 29 Oct 2020 01:22:46 GMT
+      date: Thu, 29 Oct 2020 02:48:29 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       x-ms-version: '2018-03-28'
@@ -135,21 +163,21 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 29 Oct 2020 01:22:46 GMT
+      - Thu, 29 Oct 2020 02:48:30 GMT
       x-ms-version:
       - '2018-03-28'
     method: GET
     uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages?numofmessages=1
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>3d553eb4-d825-4265-a262-7f5690045462</MessageId><InsertionTime>Thu,
-        29 Oct 2020 01:22:46 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:46
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAA6KH8E5Kt1gE=</PopReceipt><TimeNextVisible>Thu,
-        29 Oct 2020 01:23:16 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message1</MessageText></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>c25fa1f7-cb36-4d2a-bf09-6f75389bbc98</MessageId><InsertionTime>Thu,
+        29 Oct 2020 02:48:30 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 02:48:30
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAyWndDZ6t1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 02:49:00 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message1</MessageText></QueueMessage></QueueMessagesList>"
     headers:
       cache-control: no-cache
       content-type: application/xml
-      date: Thu, 29 Oct 2020 01:22:46 GMT
+      date: Thu, 29 Oct 2020 02:48:29 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       x-ms-version: '2018-03-28'
@@ -165,21 +193,21 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 29 Oct 2020 01:22:46 GMT
+      - Thu, 29 Oct 2020 02:48:30 GMT
       x-ms-version:
       - '2018-03-28'
     method: GET
     uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages?numofmessages=1
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>498a8f7f-d9cc-4d0c-902a-1008f636fee0</MessageId><InsertionTime>Thu,
-        29 Oct 2020 01:22:46 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:46
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAr2cGFJKt1gE=</PopReceipt><TimeNextVisible>Thu,
-        29 Oct 2020 01:23:16 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message2</MessageText></QueueMessage></QueueMessagesList>"
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>9159ff30-0b69-4916-8efb-7624a7b1acdb</MessageId><InsertionTime>Thu,
+        29 Oct 2020 02:48:30 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 02:48:30
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAs1bnDZ6t1gE=</PopReceipt><TimeNextVisible>Thu,
+        29 Oct 2020 02:49:00 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>message2</MessageText></QueueMessage></QueueMessagesList>"
     headers:
       cache-control: no-cache
       content-type: application/xml
-      date: Thu, 29 Oct 2020 01:22:46 GMT
+      date: Thu, 29 Oct 2020 02:48:29 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       x-ms-version: '2018-03-28'
@@ -195,20 +223,20 @@ interactions:
       User-Agent:
       - azsdk-python-storage-queue/12.1.4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Thu, 29 Oct 2020 01:22:46 GMT
+      - Thu, 29 Oct 2020 02:48:30 GMT
       x-ms-version:
       - '2018-03-28'
     method: GET
     uri: https://storagename.queue.core.windows.net/pyqueueasync640e10d7/messages?peekonly=true
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>ef2713ef-79ee-4376-ae0b-8f70d08ef7c6</MessageId><InsertionTime>Thu,
-        29 Oct 2020 01:22:46 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 01:22:46
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>d39f0f34-a85b-4488-924c-d5cf002f4b68</MessageId><InsertionTime>Thu,
+        29 Oct 2020 02:48:30 GMT</InsertionTime><ExpirationTime>Thu, 05 Nov 2020 02:48:30
         GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>message3</MessageText></QueueMessage></QueueMessagesList>"
     headers:
       cache-control: no-cache
       content-type: application/xml
-      date: Thu, 29 Oct 2020 01:22:46 GMT
+      date: Thu, 29 Oct 2020 02:48:29 GMT
       server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       x-ms-version: '2018-03-28'

--- a/sdk/storage/azure-storage-queue/tests/test_queue.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue.py
@@ -323,6 +323,37 @@ class StorageQueueTest(StorageTestCase):
         self.assertIsInstance(message.next_visible_on, datetime)
 
     @GlobalStorageAccountPreparer()
+    def test_receive_one_message(self, resource_group, location, storage_account, storage_account_key):
+        # Action
+        qsc = QueueServiceClient(self.account_url(storage_account, "queue"), storage_account_key)
+        queue_client = self._get_queue_reference(qsc)
+        queue_client.create_queue()
+        queue_client.send_message(u'message1')
+        queue_client.send_message(u'message2')
+        queue_client.send_message(u'message3')
+
+        message1 = queue_client.receive_one_message()
+        message2 = queue_client.receive_one_message()
+        peeked_message3 = queue_client.peek_messages()[0]
+
+        # Asserts
+        self.assertIsNotNone(message1)
+        self.assertNotEqual('', message1.id)
+        self.assertEqual(u'message1', message1.content)
+        self.assertNotEqual('', message1.pop_receipt)
+        self.assertEqual(1, message1.dequeue_count)
+
+        self.assertIsNotNone(message2)
+        self.assertNotEqual('', message2.id)
+        self.assertEqual(u'message2', message2.content)
+        self.assertNotEqual('', message2.pop_receipt)
+        self.assertEqual(1, message2.dequeue_count)
+
+        self.assertEqual(u'message3', peeked_message3.content)
+        self.assertEqual(0, peeked_message3.dequeue_count)
+
+
+    @GlobalStorageAccountPreparer()
     def test_get_messages_with_options(self, resource_group, location, storage_account, storage_account_key):
         # Action
         qsc = QueueServiceClient(self.account_url(storage_account, "queue"), storage_account_key)

--- a/sdk/storage/azure-storage-queue/tests/test_queue.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue.py
@@ -332,8 +332,8 @@ class StorageQueueTest(StorageTestCase):
         queue_client.send_message(u'message2')
         queue_client.send_message(u'message3')
 
-        message1 = queue_client.receive_one_message()
-        message2 = queue_client.receive_one_message()
+        message1 = queue_client.receive_message()
+        message2 = queue_client.receive_message()
         peeked_message3 = queue_client.peek_messages()[0]
 
         # Asserts

--- a/sdk/storage/azure-storage-queue/tests/test_queue.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue.py
@@ -50,7 +50,7 @@ class StorageQueueTest(StorageTestCase):
         queue = qsc.get_queue_client(queue_name)
         return queue
 
-    def _create_queue(self, qsc, prefix=TEST_QUEUE_PREFIX, queue_list = None):
+    def _create_queue(self, qsc, prefix=TEST_QUEUE_PREFIX, queue_list=None):
         queue = self._get_queue_reference(qsc, prefix)
         created = queue.create_queue()
         if queue_list is not None:
@@ -328,6 +328,8 @@ class StorageQueueTest(StorageTestCase):
         qsc = QueueServiceClient(self.account_url(storage_account, "queue"), storage_account_key)
         queue_client = self._get_queue_reference(qsc)
         queue_client.create_queue()
+        self.assertIsNone(queue_client.receive_message())
+
         queue_client.send_message(u'message1')
         queue_client.send_message(u'message2')
         queue_client.send_message(u'message3')
@@ -351,7 +353,6 @@ class StorageQueueTest(StorageTestCase):
 
         self.assertEqual(u'message3', peeked_message3.content)
         self.assertEqual(0, peeked_message3.dequeue_count)
-
 
     @GlobalStorageAccountPreparer()
     def test_get_messages_with_options(self, resource_group, location, storage_account, storage_account_key):

--- a/sdk/storage/azure-storage-queue/tests/test_queue_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_async.py
@@ -62,7 +62,7 @@ class StorageQueueTestAsync(AsyncStorageTestCase):
         queue = qsc.get_queue_client(queue_name)
         return queue
 
-    async def _create_queue(self, qsc, prefix=TEST_QUEUE_PREFIX, queue_list = None):
+    async def _create_queue(self, qsc, prefix=TEST_QUEUE_PREFIX, queue_list=None):
         queue = self._get_queue_reference(qsc, prefix)
         created = await queue.create_queue()
         if queue_list:
@@ -353,13 +353,14 @@ class StorageQueueTestAsync(AsyncStorageTestCase):
         self.assertIsInstance(message.expires_on, datetime)
         self.assertIsInstance(message.next_visible_on, datetime)
 
-
     @GlobalStorageAccountPreparer()
     @AsyncStorageTestCase.await_prepared_test
     async def test_receive_one_message(self, resource_group, location, storage_account, storage_account_key):
         # Action
         qsc = QueueServiceClient(self.account_url(storage_account, "queue"), storage_account_key, transport=AiohttpTestTransport())
         queue_client = await self._create_queue(qsc)
+        self.assertIsNone(await queue_client.receive_message())
+
         await queue_client.send_message(u'message1')
         await queue_client.send_message(u'message2')
         await queue_client.send_message(u'message3')

--- a/sdk/storage/azure-storage-queue/tests/test_queue_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_async.py
@@ -364,8 +364,8 @@ class StorageQueueTestAsync(AsyncStorageTestCase):
         await queue_client.send_message(u'message2')
         await queue_client.send_message(u'message3')
 
-        message1 = await queue_client.receive_one_message()
-        message2 = await queue_client.receive_one_message()
+        message1 = await queue_client.receive_message()
+        message2 = await queue_client.receive_message()
         peeked_message3 = await queue_client.peek_messages()
 
         # Asserts


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/14844 and resolves https://github.com/Azure/azure-sdk-for-python/issues/14762. Many customers have reported confusion around using `receive_messages()` to pop one item from the queue.
This PR adds a new API that makes it simpler for the user to pop one element. 
Related issues:
https://github.com/Azure/azure-sdk-for-python/issues/14665
https://github.com/Azure/azure-sdk-for-python/issues/11784
https://github.com/Azure/azure-sdk-for-python/issues/14762
