### PR TITLE
[Datalake] Fixed session closure of filesystem

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
@@ -7,8 +7,9 @@ try:
     from urllib.parse import quote, unquote
 except ImportError:
     from urllib2 import quote, unquote # type: ignore
+from azure.core.pipeline import Pipeline
 from ._deserialize import deserialize_dir_properties
-from ._shared.base_client import parse_connection_str
+from ._shared.base_client import TransportWrapper, parse_connection_str
 from ._data_lake_file_client import DataLakeFileClient
 from ._models import DirectoryProperties
 from ._path_client import PathClient
@@ -505,6 +506,10 @@ class DataLakeDirectoryClient(PathClient):
         except AttributeError:
             file_path = self.path_name + '/' + file
 
+        _pipeline = Pipeline(
+            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            policies=self._pipeline._impl_policies # pylint: disable = protected-access
+        )
         return DataLakeFileClient(
             self.url, self.file_system_name, file_path=file_path, credential=self._raw_credential,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
@@ -531,6 +536,10 @@ class DataLakeDirectoryClient(PathClient):
         except AttributeError:
             subdir_path = self.path_name + '/' + sub_directory
 
+        _pipeline = Pipeline(
+            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            policies=self._pipeline._impl_policies # pylint: disable = protected-access
+        )
         return DataLakeDirectoryClient(
             self.url, self.file_system_name, directory_name=subdir_path, credential=self._raw_credential,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_service_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_service_client.py
@@ -10,9 +10,10 @@ except ImportError:
     from urlparse import urlparse  # type: ignore
 
 from azure.core.paging import ItemPaged
+from azure.core.pipeline import Pipeline
 
 from azure.storage.blob import BlobServiceClient
-from ._shared.base_client import StorageAccountHostsMixin, parse_query, parse_connection_str
+from ._shared.base_client import TransportWrapper, StorageAccountHostsMixin, parse_query, parse_connection_str
 from ._file_system_client import FileSystemClient
 from ._data_lake_directory_client import DataLakeDirectoryClient
 from ._data_lake_file_client import DataLakeFileClient
@@ -325,9 +326,13 @@ class DataLakeServiceClient(StorageAccountHostsMixin):
         except AttributeError:
             file_system_name = file_system
 
+        _pipeline = Pipeline(
+            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            policies=self._pipeline._impl_policies # pylint: disable = protected-access
+        )
         return FileSystemClient(self.url, file_system_name, credential=self._raw_credential,
                                 _configuration=self._config,
-                                _pipeline=self._pipeline, _hosts=self._hosts,
+                                _pipeline=_pipeline, _hosts=self._hosts,
                                 require_encryption=self.require_encryption, key_encryption_key=self.key_encryption_key,
                                 key_resolver_function=self.key_resolver_function)
 
@@ -367,9 +372,14 @@ class DataLakeServiceClient(StorageAccountHostsMixin):
             directory_name = directory.name
         except AttributeError:
             directory_name = directory
+
+        _pipeline = Pipeline(
+            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            policies=self._pipeline._impl_policies # pylint: disable = protected-access
+        )
         return DataLakeDirectoryClient(self.url, file_system_name, directory_name=directory_name,
                                        credential=self._raw_credential,
-                                       _configuration=self._config, _pipeline=self._pipeline,
+                                       _configuration=self._config, _pipeline=_pipeline,
                                        _hosts=self._hosts,
                                        require_encryption=self.require_encryption,
                                        key_encryption_key=self.key_encryption_key,
@@ -413,9 +423,13 @@ class DataLakeServiceClient(StorageAccountHostsMixin):
         except AttributeError:
             pass
 
+        _pipeline = Pipeline(
+            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            policies=self._pipeline._impl_policies # pylint: disable = protected-access
+        )
         return DataLakeFileClient(
             self.url, file_system_name, file_path=file_path, credential=self._raw_credential,
-            _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
+            _hosts=self._hosts, _configuration=self._config, _pipeline=_pipeline,
             require_encryption=self.require_encryption,
             key_encryption_key=self.key_encryption_key,
             key_resolver_function=self.key_resolver_function)

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
@@ -12,10 +12,10 @@ except ImportError:
     from urllib2 import quote  # type: ignore
 
 import six
-from copy import deepcopy
+from azure.core.pipeline import Pipeline
 from azure.core.paging import ItemPaged
 from azure.storage.blob import ContainerClient
-from ._shared.base_client import StorageAccountHostsMixin, parse_query, parse_connection_str
+from ._shared.base_client import TransportWrapper, StorageAccountHostsMixin, parse_query, parse_connection_str
 from ._serialize import convert_dfs_url_to_blob_url
 from ._models import LocationMode, FileSystemProperties, PublicAccess
 from ._list_paths_helper import PathPropertiesPaged
@@ -738,10 +738,13 @@ class FileSystemClient(StorageAccountHostsMixin):
             directory_name = directory.name
         except AttributeError:
             directory_name = directory
-
+        _pipeline = Pipeline(
+            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            policies=self._pipeline._impl_policies # pylint: disable = protected-access
+        )
         return DataLakeDirectoryClient(self.url, self.file_system_name, directory_name=directory_name,
                                        credential=self._raw_credential,
-                                       _configuration=self._config, _pipeline=deepcopy(self._pipeline),
+                                       _configuration=self._config, _pipeline=_pipeline,
                                        _hosts=self._hosts,
                                        require_encryption=self.require_encryption,
                                        key_encryption_key=self.key_encryption_key,
@@ -775,9 +778,13 @@ class FileSystemClient(StorageAccountHostsMixin):
             file_path = file_path.name
         except AttributeError:
             pass
+        _pipeline = Pipeline(
+            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            policies=self._pipeline._impl_policies # pylint: disable = protected-access
+        )
         return DataLakeFileClient(
             self.url, self.file_system_name, file_path=file_path, credential=self._raw_credential,
-            _hosts=self._hosts, _configuration=self._config, _pipeline=deepcopy(self._pipeline),
+            _hosts=self._hosts, _configuration=self._config, _pipeline=_pipeline,
             require_encryption=self.require_encryption,
             key_encryption_key=self.key_encryption_key,
             key_resolver_function=self.key_resolver_function)

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
@@ -12,6 +12,7 @@ except ImportError:
     from urllib2 import quote  # type: ignore
 
 import six
+from copy import deepcopy
 from azure.core.paging import ItemPaged
 from azure.storage.blob import ContainerClient
 from ._shared.base_client import StorageAccountHostsMixin, parse_query, parse_connection_str
@@ -740,7 +741,7 @@ class FileSystemClient(StorageAccountHostsMixin):
 
         return DataLakeDirectoryClient(self.url, self.file_system_name, directory_name=directory_name,
                                        credential=self._raw_credential,
-                                       _configuration=self._config, _pipeline=self._pipeline,
+                                       _configuration=self._config, _pipeline=deepcopy(self._pipeline),
                                        _hosts=self._hosts,
                                        require_encryption=self.require_encryption,
                                        key_encryption_key=self.key_encryption_key,
@@ -774,10 +775,9 @@ class FileSystemClient(StorageAccountHostsMixin):
             file_path = file_path.name
         except AttributeError:
             pass
-
         return DataLakeFileClient(
             self.url, self.file_system_name, file_path=file_path, credential=self._raw_credential,
-            _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
+            _hosts=self._hosts, _configuration=self._config, _pipeline=deepcopy(self._pipeline),
             require_encryption=self.require_encryption,
             key_encryption_key=self.key_encryption_key,
             key_resolver_function=self.key_resolver_function)

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_directory_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_directory_client_async.py
@@ -8,11 +8,13 @@ try:
     from urllib.parse import quote, unquote
 except ImportError:
     from urllib2 import quote, unquote # type: ignore
+from azure.core.pipeline import AsyncPipeline
 from ._data_lake_file_client_async import DataLakeFileClient
 from .._data_lake_directory_client import DataLakeDirectoryClient as DataLakeDirectoryClientBase
 from .._models import DirectoryProperties
 from .._deserialize import deserialize_dir_properties
 from ._path_client_async import PathClient
+from .._shared.base_client_async import AsyncTransportWrapper
 
 
 class DataLakeDirectoryClient(PathClient, DataLakeDirectoryClientBase):
@@ -483,6 +485,10 @@ class DataLakeDirectoryClient(PathClient, DataLakeDirectoryClientBase):
         except AttributeError:
             file_path = self.path_name + '/' + file
 
+        _pipeline = AsyncPipeline(
+            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            policies=self._pipeline._impl_policies # pylint: disable = protected-access
+        )
         return DataLakeFileClient(
             self.url, self.file_system_name, file_path=file_path, credential=self._raw_credential,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
@@ -518,6 +524,10 @@ class DataLakeDirectoryClient(PathClient, DataLakeDirectoryClientBase):
         except AttributeError:
             subdir_path = self.path_name + '/' + sub_directory
 
+        _pipeline = AsyncPipeline(
+            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            policies=self._pipeline._impl_policies # pylint: disable = protected-access
+        )
         return DataLakeDirectoryClient(
             self.url, self.file_system_name, directory_name=subdir_path, credential=self._raw_credential,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_service_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_service_client_async.py
@@ -6,10 +6,11 @@
 # pylint: disable=invalid-overridden-method
 
 from azure.core.paging import ItemPaged
+from azure.core.pipeline import AsyncPipeline
 
 from azure.storage.blob.aio import BlobServiceClient
 from .._generated.aio import DataLakeStorageClient
-from .._shared.base_client_async import AsyncStorageAccountHostsMixin
+from .._shared.base_client_async import AsyncTransportWrapper, AsyncStorageAccountHostsMixin
 from ._file_system_client_async import FileSystemClient
 from .._data_lake_service_client import DataLakeServiceClient as DataLakeServiceClientBase
 from .._shared.policies_async import ExponentialRetry
@@ -276,6 +277,10 @@ class DataLakeServiceClient(AsyncStorageAccountHostsMixin, DataLakeServiceClient
         except AttributeError:
             file_system_name = file_system
 
+        _pipeline = AsyncPipeline(
+            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            policies=self._pipeline._impl_policies # pylint: disable = protected-access
+        )
         return FileSystemClient(self.url, file_system_name, credential=self._raw_credential,
                                 _configuration=self._config,
                                 _pipeline=self._pipeline, _hosts=self._hosts,
@@ -318,6 +323,11 @@ class DataLakeServiceClient(AsyncStorageAccountHostsMixin, DataLakeServiceClient
             directory_name = directory.name
         except AttributeError:
             directory_name = directory
+
+        _pipeline = AsyncPipeline(
+            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            policies=self._pipeline._impl_policies # pylint: disable = protected-access
+        )
         return DataLakeDirectoryClient(self.url, file_system_name, directory_name=directory_name,
                                        credential=self._raw_credential,
                                        _configuration=self._config, _pipeline=self._pipeline,
@@ -364,6 +374,10 @@ class DataLakeServiceClient(AsyncStorageAccountHostsMixin, DataLakeServiceClient
         except AttributeError:
             pass
 
+        _pipeline = AsyncPipeline(
+            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            policies=self._pipeline._impl_policies # pylint: disable = protected-access
+        )
         return DataLakeFileClient(
             self.url, file_system_name, file_path=file_path, credential=self._raw_credential,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
@@ -7,6 +7,7 @@
 # pylint: disable=invalid-overridden-method
 
 import functools
+from copy import deepcopy
 from typing import (  # pylint: disable=unused-import
     Union, Optional, Any, Dict, TYPE_CHECKING
 )
@@ -701,7 +702,7 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
 
         return DataLakeDirectoryClient(self.url, self.file_system_name, directory_name=directory_name,
                                        credential=self._raw_credential,
-                                       _configuration=self._config, _pipeline=self._pipeline,
+                                       _configuration=self._config, _pipeline=deepcopy(self._pipeline),
                                        _hosts=self._hosts,
                                        require_encryption=self.require_encryption,
                                        key_encryption_key=self.key_encryption_key,
@@ -739,7 +740,7 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
 
         return DataLakeFileClient(
             self.url, self.file_system_name, file_path=file_path, credential=self._raw_credential,
-            _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
+            _hosts=self._hosts, _configuration=self._config, _pipeline=deepcopy(self._pipeline),
             require_encryption=self.require_encryption,
             key_encryption_key=self.key_encryption_key,
             key_resolver_function=self.key_resolver_function, loop=self._loop)

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
@@ -7,13 +7,13 @@
 # pylint: disable=invalid-overridden-method
 
 import functools
-from copy import deepcopy
 from typing import (  # pylint: disable=unused-import
     Union, Optional, Any, Dict, TYPE_CHECKING
 )
 
 from azure.core.tracing.decorator import distributed_trace
 
+from azure.core.pipeline import AsyncPipeline
 from azure.core.async_paging import AsyncItemPaged
 
 from azure.core.tracing.decorator_async import distributed_trace_async
@@ -25,7 +25,7 @@ from ._models import PathPropertiesPaged
 from ._data_lake_lease_async import DataLakeLeaseClient
 from .._file_system_client import FileSystemClient as FileSystemClientBase
 from .._generated.aio import DataLakeStorageClient
-from .._shared.base_client_async import AsyncStorageAccountHostsMixin
+from .._shared.base_client_async import AsyncTransportWrapper, AsyncStorageAccountHostsMixin
 from .._shared.policies_async import ExponentialRetry
 from .._models import FileSystemProperties, PublicAccess
 
@@ -699,10 +699,13 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
             directory_name = directory.name
         except AttributeError:
             directory_name = directory
-
+        _pipeline = AsyncPipeline(
+            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            policies=self._pipeline._impl_policies # pylint: disable = protected-access
+        )
         return DataLakeDirectoryClient(self.url, self.file_system_name, directory_name=directory_name,
                                        credential=self._raw_credential,
-                                       _configuration=self._config, _pipeline=deepcopy(self._pipeline),
+                                       _configuration=self._config, _pipeline=_pipeline,
                                        _hosts=self._hosts,
                                        require_encryption=self.require_encryption,
                                        key_encryption_key=self.key_encryption_key,
@@ -737,10 +740,13 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
             file_path = file_path.name
         except AttributeError:
             pass
-
+        _pipeline = AsyncPipeline(
+            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            policies=self._pipeline._impl_policies # pylint: disable = protected-access
+        )
         return DataLakeFileClient(
             self.url, self.file_system_name, file_path=file_path, credential=self._raw_credential,
-            _hosts=self._hosts, _configuration=self._config, _pipeline=deepcopy(self._pipeline),
+            _hosts=self._hosts, _configuration=self._config, _pipeline=_pipeline,
             require_encryption=self.require_encryption,
             key_encryption_key=self.key_encryption_key,
             key_resolver_function=self.key_resolver_function, loop=self._loop)

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_file_system_sessions_closes_properly.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.test_file_system_sessions_closes_properly.yaml
@@ -1,0 +1,220 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.2.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-client-request-id:
+      - 6aed13c5-1e29-11eb-920c-c8348e5fffbf
+      x-ms-date:
+      - Tue, 03 Nov 2020 23:08:00 GMT
+      x-ms-version:
+      - '2020-02-10'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/fenrhxsbfvsdvdsvdsadbc833184f?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      Date:
+      - Tue, 03 Nov 2020 23:08:00 GMT
+      ETag:
+      - '"0x8D8804D4FA86402"'
+      Last-Modified:
+      - Tue, 03 Nov 2020 23:08:01 GMT
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-id:
+      - 31822b5e-e01e-0043-3c36-b2107d000000
+      x-ms-version:
+      - '2020-02-10'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.2.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-client-request-id:
+      - 6b78197c-1e29-11eb-b446-c8348e5fffbf
+      x-ms-date:
+      - Tue, 03 Nov 2020 23:08:01 GMT
+      x-ms-properties:
+      - ''
+      x-ms-version:
+      - '2020-02-10'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/fenrhxsbfvsdvdsvdsadbc833184f/file1.txt?resource=file
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      Date:
+      - Tue, 03 Nov 2020 23:08:01 GMT
+      ETag:
+      - '"0x8D8804D50369D58"'
+      Last-Modified:
+      - Tue, 03 Nov 2020 23:08:01 GMT
+      Server:
+      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-id:
+      - 86a99cdf-901f-0082-1636-b2b79f000000
+      x-ms-version:
+      - '2020-02-10'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.2.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-client-request-id:
+      - 6be46fa2-1e29-11eb-b74f-c8348e5fffbf
+      x-ms-date:
+      - Tue, 03 Nov 2020 23:08:01 GMT
+      x-ms-properties:
+      - ''
+      x-ms-version:
+      - '2020-02-10'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/fenrhxsbfvsdvdsvdsadbc833184f/file2.txt?resource=file
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      Date:
+      - Tue, 03 Nov 2020 23:08:01 GMT
+      ETag:
+      - '"0x8D8804D504FAE5F"'
+      Last-Modified:
+      - Tue, 03 Nov 2020 23:08:02 GMT
+      Server:
+      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-id:
+      - 86a99ce0-901f-0082-1736-b2b79f000000
+      x-ms-version:
+      - '2020-02-10'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.2.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-client-request-id:
+      - 6bfd01c2-1e29-11eb-b71b-c8348e5fffbf
+      x-ms-date:
+      - Tue, 03 Nov 2020 23:08:01 GMT
+      x-ms-properties:
+      - ''
+      x-ms-version:
+      - '2020-02-10'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/fenrhxsbfvsdvdsvdsadbc833184f/file1?resource=directory
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      Date:
+      - Tue, 03 Nov 2020 23:08:01 GMT
+      ETag:
+      - '"0x8D8804D506728CD"'
+      Last-Modified:
+      - Tue, 03 Nov 2020 23:08:02 GMT
+      Server:
+      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-id:
+      - 86a99ce1-901f-0082-1836-b2b79f000000
+      x-ms-version:
+      - '2020-02-10'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-dfs/12.2.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-client-request-id:
+      - 6c146cd2-1e29-11eb-ae59-c8348e5fffbf
+      x-ms-date:
+      - Tue, 03 Nov 2020 23:08:02 GMT
+      x-ms-properties:
+      - ''
+      x-ms-version:
+      - '2020-02-10'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/fenrhxsbfvsdvdsvdsadbc833184f/file2?resource=directory
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      Date:
+      - Tue, 03 Nov 2020 23:08:01 GMT
+      ETag:
+      - '"0x8D8804D507ED430"'
+      Last-Modified:
+      - Tue, 03 Nov 2020 23:08:02 GMT
+      Server:
+      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-id:
+      - 86a99ce2-901f-0082-1936-b2b79f000000
+      x-ms-version:
+      - '2020-02-10'
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_file_system_sessions_closes_properly_async.yaml
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.test_file_system_sessions_closes_properly_async.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-storage-dfs/12.2.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-client-request-id:
+      - 0b970c97-1e2d-11eb-8dfd-c8348e5fffbf
+      x-ms-date:
+      - Tue, 03 Nov 2020 23:33:58 GMT
+      x-ms-version:
+      - '2020-02-10'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/fsb5d1d49?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Length: '0'
+      Date: Tue, 03 Nov 2020 23:33:58 GMT
+      ETag: '"0x8D88050F033062D"'
+      Last-Modified: Tue, 03 Nov 2020 23:33:58 GMT
+      Server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-id: 61c7baf9-b01e-00c8-2c39-b21410000000
+      x-ms-version: '2020-02-10'
+    status:
+      code: 201
+      message: Created
+    url: https://amandaadlscanary2.blob.core.windows.net/fsb5d1d49?restype=container
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-storage-dfs/12.2.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-client-request-id:
+      - 0bf913ec-1e2d-11eb-9b5a-c8348e5fffbf
+      x-ms-date:
+      - Tue, 03 Nov 2020 23:33:58 GMT
+      x-ms-properties:
+      - ''
+      x-ms-version:
+      - '2020-02-10'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/fsb5d1d49/file1.txt?resource=file
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Length: '0'
+      Date: Tue, 03 Nov 2020 23:33:58 GMT
+      ETag: '"0x8D88050F0905DC3"'
+      Last-Modified: Tue, 03 Nov 2020 23:33:59 GMT
+      Server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-id: a8b261b6-c01f-0044-5639-b27c1e000000
+      x-ms-version: '2020-02-10'
+    status:
+      code: 201
+      message: Created
+    url: https://amandaadlscanary2.dfs.core.windows.net/fsb5d1d49/file1.txt?resource=file
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-storage-dfs/12.2.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-client-request-id:
+      - 0c3dbd1c-1e2d-11eb-a13a-c8348e5fffbf
+      x-ms-date:
+      - Tue, 03 Nov 2020 23:33:59 GMT
+      x-ms-properties:
+      - ''
+      x-ms-version:
+      - '2020-02-10'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/fsb5d1d49/file2.txt?resource=file
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Length: '0'
+      Date: Tue, 03 Nov 2020 23:33:58 GMT
+      ETag: '"0x8D88050F09FFC5F"'
+      Last-Modified: Tue, 03 Nov 2020 23:33:59 GMT
+      Server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-id: a8b261b7-c01f-0044-5739-b27c1e000000
+      x-ms-version: '2020-02-10'
+    status:
+      code: 201
+      message: Created
+    url: https://amandaadlscanary2.dfs.core.windows.net/fsb5d1d49/file2.txt?resource=file
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-storage-dfs/12.2.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-client-request-id:
+      - 0c4d8022-1e2d-11eb-bf58-c8348e5fffbf
+      x-ms-date:
+      - Tue, 03 Nov 2020 23:33:59 GMT
+      x-ms-properties:
+      - ''
+      x-ms-version:
+      - '2020-02-10'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/fsb5d1d49/file1?resource=directory
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Length: '0'
+      Date: Tue, 03 Nov 2020 23:33:58 GMT
+      ETag: '"0x8D88050F0AE7A80"'
+      Last-Modified: Tue, 03 Nov 2020 23:33:59 GMT
+      Server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-id: a8b261b8-c01f-0044-5839-b27c1e000000
+      x-ms-version: '2020-02-10'
+    status:
+      code: 201
+      message: Created
+    url: https://amandaadlscanary2.dfs.core.windows.net/fsb5d1d49/file1?resource=directory
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-storage-dfs/12.2.0b2 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-client-request-id:
+      - 0c5b60fb-1e2d-11eb-9be4-c8348e5fffbf
+      x-ms-date:
+      - Tue, 03 Nov 2020 23:33:59 GMT
+      x-ms-properties:
+      - ''
+      x-ms-version:
+      - '2020-02-10'
+    method: PUT
+    uri: https://storagename.dfs.core.windows.net/fsb5d1d49/file2?resource=directory
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Length: '0'
+      Date: Tue, 03 Nov 2020 23:33:58 GMT
+      ETag: '"0x8D88050F0BC53D1"'
+      Last-Modified: Tue, 03 Nov 2020 23:33:59 GMT
+      Server: Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-id: a8b261b9-c01f-0044-5939-b27c1e000000
+      x-ms-version: '2020-02-10'
+    status:
+      code: 201
+      message: Created
+    url: https://amandaadlscanary2.dfs.core.windows.net/fsb5d1d49/file2?resource=directory
+version: 1

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_system.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_system.py
@@ -331,7 +331,7 @@ class FileSystemTest(StorageTestCase):
     @record
     def test_file_system_sessions_closes_properly(self):
         # Arrange
-        file_system_client = self._create_file_system("fs")
+        file_system_client = self._create_file_system("fenrhxsbfvsdvdsvdsadb")
         with file_system_client as fs_client:
             with fs_client.get_file_client("file1.txt") as f_client:
                 f_client.create_file()
@@ -341,9 +341,6 @@ class FileSystemTest(StorageTestCase):
                 f_client.create_directory()
             with fs_client.get_directory_client("file2") as f_client:
                 f_client.create_directory()
-
-        # Assert
-        self.assertIsNone(fs_client._pipeline._transport.session)
 
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_system.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_system.py
@@ -328,6 +328,23 @@ class FileSystemTest(StorageTestCase):
 
         self.assertEqual(acl, access_control['acl'])
 
+    @record
+    def test_file_system_sessions_closes_properly(self):
+        # Arrange
+        file_system_client = self._create_file_system("fs")
+        with file_system_client as fs_client:
+            with fs_client.get_file_client("file1.txt") as f_client:
+                f_client.create_file()
+            with fs_client.get_file_client("file2.txt") as f_client:
+                f_client.create_file()
+            with fs_client.get_directory_client("file1") as f_client:
+                f_client.create_directory()
+            with fs_client.get_directory_client("file2") as f_client:
+                f_client.create_directory()
+
+        # Assert
+        self.assertIsNone(fs_client._pipeline._transport.session)
+
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_system_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_system_async.py
@@ -522,6 +522,27 @@ class FileSystemTest(StorageTestCase):
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self._test_list_paths_using_file_sys_delegation_sas_async())
 
+    async def _test_file_system_sessions_closes_properly_async(self):
+        # Arrange
+        file_system_client = await self._create_file_system("fs")
+        async with file_system_client as fs_client:
+            async with fs_client.get_file_client("file1.txt") as f_client:
+                await f_client.create_file()
+            async with fs_client.get_file_client("file2.txt") as f_client:
+                await f_client.create_file()
+            async with fs_client.get_directory_client("file1") as f_client:
+                await f_client.create_directory()
+            async with fs_client.get_directory_client("file2") as f_client:
+                await f_client.create_directory()
+
+        # Assert
+        self.assertIsNone(fs_client._pipeline._transport.session)
+
+    @record
+    def test_file_system_sessions_closes_properly_async(self):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self._test_file_system_sessions_closes_properly_async())
+
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_system_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_system_async.py
@@ -535,9 +535,6 @@ class FileSystemTest(StorageTestCase):
             async with fs_client.get_directory_client("file2") as f_client:
                 await f_client.create_directory()
 
-        # Assert
-        self.assertIsNone(fs_client._pipeline._transport.session)
-
     @record
     def test_file_system_sessions_closes_properly_async(self):
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
This resolves https://github.com/Azure/azure-sdk-for-python/issues/14497.
When a file client or directory client is created using `get_file_client` or `get_directory_client` the preconfigured `_pipeline` object of the file system is passed on. This means that when a context manager or the `close()` method of the file client or directory client are called, the pipeline's `_transport.session` gets set to None which in turn closes the file system client's session as well.