### PR TITLE
Fix for azure.digitaltwins.core.DigitalTwinsClient.update_components

### DIFF
--- a/sdk/digitaltwins/azure-digitaltwins-core/README.md
+++ b/sdk/digitaltwins/azure-digitaltwins-core/README.md
@@ -218,11 +218,12 @@ To update a component or in other words to replace, remove and/or add a componen
 
 ```Python Snippet:dt_component_lifecycle
 component_path = "Component1"
-options = {
-    "patchDocument": {
-    "ComponentProp1": "value2"
-    }
-}
+options = [
+    {
+        "op": "replace",
+        "path": "/Property1",
+        "value": 42
+    }]
 service_client.update_component(digital_twin_id, component_path, options)
 ```
 

--- a/sdk/digitaltwins/azure-digitaltwins-core/azure/digitaltwins/core/_digitaltwins_client.py
+++ b/sdk/digitaltwins/azure-digitaltwins-core/azure/digitaltwins/core/_digitaltwins_client.py
@@ -172,12 +172,12 @@ class DigitalTwinsClient(object): # type: ignore #pylint: disable=too-many-publi
         json_patch,
         **kwargs
     ):
-        # type: (str, str, Dict[str, object], **Any) -> None
+        # type: (str, str, List[Dict[str, object]], **Any) -> None
         """Update properties of a component on a digital twin using a JSON patch.
 
         :param str digital_twin_id: The Id of the digital twin.
         :param str component_path: The component being updated.
-        :param Dict[str, object] json_patch: An update specification described by JSON Patch.
+        :param List[Dict[str, object]] json_patch: An update specification described by JSON Patch.
         :keyword str etag: Only perform the operation if the entity's etag matches one of
             the etags provided or * is provided.
         :keyword ~azure.core.MatchConditions match_condition: the match condition to use upon the etag
@@ -188,9 +188,6 @@ class DigitalTwinsClient(object): # type: ignore #pylint: disable=too-many-publi
         :raises :class: `~azure.core.exceptions.ResourceNotFoundError`: If there is either no
             digital twin with the provided id or the component path is invalid.
         """
-        etag = kwargs.get("etag", None)
-        match_condition = kwargs.get("match_condition", MatchConditions.Unconditionally)
-
         return self._client.digital_twins.update_component(
             digital_twin_id,
             component_path,

--- a/sdk/digitaltwins/azure-digitaltwins-core/azure/digitaltwins/core/_digitaltwins_client.py
+++ b/sdk/digitaltwins/azure-digitaltwins-core/azure/digitaltwins/core/_digitaltwins_client.py
@@ -195,7 +195,6 @@ class DigitalTwinsClient(object): # type: ignore #pylint: disable=too-many-publi
             digital_twin_id,
             component_path,
             patch_document=json_patch,
-            if_match=prep_if_match(etag, match_condition),
             **kwargs
         )
 


### PR DESCRIPTION
This PR includes changes to address the following problems with the `update_component` method in `azure.digitaltwins.core.DigitalTwinsClient`:

- `adt_client.update_component(dt_id, component_path, patch)` results in a `TypeError` stating that `requests` does not include a param named `if_match`.
- The definition of how the patch should be created, as stated in [`README.md`](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/digitaltwins/azure-digitaltwins-core/README.md#update-digital-twin-components) is not valid.
- Also, the docstring in the method has an incorrect type.

Please note that these issues also affect [the package available in PyPI right now](https://pypi.org/project/azure-digitaltwins-core/1.0.0b1).

The sample code below works as expected for me after applying the changes in this PR:
```Python
import os
from azure.identity import DefaultAzureCredential
from azure.digitaltwins.core import DigitalTwinsClient

# AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_ADT_URL must be env vars
credential = DefaultAzureCredential()
adt_client = DigitalTwinsClient(os.getenv('AZURE_ADT_URL'), credential)

patch = [{"op": "replace",
                    "path": "/mass",
                    "value": -42.42}]
adt_client.update_component('InitialChamber_1', 'Weight', patch)
```

Please let me know if you need any more information.