### PR TITLE
Remove App Service identity 2019-08-01 support

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -11,6 +11,11 @@
    application.
    ([#14354](https://github.com/Azure/azure-sdk-for-python/issues/14354))
 
+### Fixed
+- `ManagedIdentityCredential` uses the API version supported by Azure Functions
+  on Linux consumption hosting plans
+  ([#14670](https://github.com/Azure/azure-sdk-for-python/issues/14670))
+
 ## 1.5.0b2 (2020-10-07)
 ### Fixed
 - `AzureCliCredential.get_token` correctly sets token expiration time,

--- a/sdk/identity/azure-identity/azure/identity/_credentials/app_service.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/app_service.py
@@ -50,38 +50,28 @@ def _get_client_args(**kwargs):
     # type: (dict) -> Optional[dict]
     identity_config = kwargs.pop("identity_config", None) or {}
 
-    url = os.environ.get(EnvironmentVariables.IDENTITY_ENDPOINT)
-    secret = os.environ.get(EnvironmentVariables.IDENTITY_HEADER)
-    if url and secret:
-        version = "2019-08-01"
-        base_headers = {"X-IDENTITY-HEADER": secret}
-        content_callback = None
-    else:
-        url = os.environ.get(EnvironmentVariables.MSI_ENDPOINT)
-        secret = os.environ.get(EnvironmentVariables.MSI_SECRET)
-        if not (url and secret):
-            # App Service managed identity isn't available in this environment
-            return None
+    url = os.environ.get(EnvironmentVariables.MSI_ENDPOINT)
+    secret = os.environ.get(EnvironmentVariables.MSI_SECRET)
+    if not (url and secret):
+        # App Service managed identity isn't available in this environment
+        return None
 
-        version = "2017-09-01"
-        base_headers = {"secret": secret}
-        content_callback = _parse_app_service_expires_on
-        if kwargs.get("client_id"):
-            identity_config["clientid"] = kwargs.pop("client_id")
+    if kwargs.get("client_id"):
+        identity_config["clientid"] = kwargs.pop("client_id")
 
     return dict(
         kwargs,
-        _content_callback=content_callback,
+        _content_callback=_parse_app_service_expires_on,
         _identity_config=identity_config,
-        base_headers=base_headers,
-        request_factory=functools.partial(_get_request, url, version),
+        base_headers={"secret": secret},
+        request_factory=functools.partial(_get_request, url),
     )
 
 
-def _get_request(url, version, scope, identity_config):
-    # type: (str, str, str, dict) -> HttpRequest
+def _get_request(url, scope, identity_config):
+    # type: (str, str, dict) -> HttpRequest
     request = HttpRequest("GET", url)
-    request.format_parameters(dict({"api-version": version, "resource": scope}, **identity_config))
+    request.format_parameters(dict({"api-version": "2017-09-01", "resource": scope}, **identity_config))
     return request
 
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -53,20 +53,7 @@ class ManagedIdentityCredential(object):
     def __init__(self, **kwargs):
         # type: (**Any) -> None
         self._credential = None
-        if os.environ.get(EnvironmentVariables.IDENTITY_ENDPOINT) and os.environ.get(
-                EnvironmentVariables.IDENTITY_HEADER
-        ):
-            if os.environ.get(EnvironmentVariables.IDENTITY_SERVER_THUMBPRINT):
-                _LOGGER.info("%s will use Service Fabric managed identity", self.__class__.__name__)
-                from .service_fabric import ServiceFabricCredential
-
-                self._credential = ServiceFabricCredential(**kwargs)
-            else:
-                _LOGGER.info("%s will use App Service managed identity", self.__class__.__name__)
-                from .app_service import AppServiceCredential
-
-                self._credential = AppServiceCredential(**kwargs)
-        elif os.environ.get(EnvironmentVariables.MSI_ENDPOINT):
+        if os.environ.get(EnvironmentVariables.MSI_ENDPOINT):
             if os.environ.get(EnvironmentVariables.MSI_SECRET):
                 _LOGGER.info("%s will use App Service managed identity", self.__class__.__name__)
                 from .app_service import AppServiceCredential
@@ -75,6 +62,15 @@ class ManagedIdentityCredential(object):
             else:
                 _LOGGER.info("%s will use MSI", self.__class__.__name__)
                 self._credential = MsiCredential(**kwargs)
+        elif (
+            os.environ.get(EnvironmentVariables.IDENTITY_ENDPOINT)
+            and os.environ.get(EnvironmentVariables.IDENTITY_HEADER)
+            and os.environ.get(EnvironmentVariables.IDENTITY_SERVER_THUMBPRINT)
+        ):
+            _LOGGER.info("%s will use Service Fabric managed identity", self.__class__.__name__)
+            from .service_fabric import ServiceFabricCredential
+
+            self._credential = ServiceFabricCredential(**kwargs)
         else:
             _LOGGER.info("%s will use IMDS", self.__class__.__name__)
             self._credential = ImdsCredential(**kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -41,20 +41,7 @@ class ManagedIdentityCredential(AsyncContextManager):
     def __init__(self, **kwargs: "Any") -> None:
         self._credential = None
 
-        if os.environ.get(EnvironmentVariables.IDENTITY_ENDPOINT) and os.environ.get(
-            EnvironmentVariables.IDENTITY_HEADER
-        ):
-            if os.environ.get(EnvironmentVariables.IDENTITY_SERVER_THUMBPRINT):
-                _LOGGER.info("%s will use Service Fabric managed identity", self.__class__.__name__)
-                from .service_fabric import ServiceFabricCredential
-
-                self._credential = ServiceFabricCredential(**kwargs)
-            else:
-                _LOGGER.info("%s will use App Service managed identity", self.__class__.__name__)
-                from .app_service import AppServiceCredential
-
-                self._credential = AppServiceCredential(**kwargs)
-        elif os.environ.get(EnvironmentVariables.MSI_ENDPOINT):
+        if os.environ.get(EnvironmentVariables.MSI_ENDPOINT):
             if os.environ.get(EnvironmentVariables.MSI_SECRET):
                 _LOGGER.info("%s will use App Service managed identity", self.__class__.__name__)
                 from .app_service import AppServiceCredential
@@ -63,6 +50,15 @@ class ManagedIdentityCredential(AsyncContextManager):
             else:
                 _LOGGER.info("%s will use MSI", self.__class__.__name__)
                 self._credential = MsiCredential(**kwargs)
+        elif (
+            os.environ.get(EnvironmentVariables.IDENTITY_ENDPOINT)
+            and os.environ.get(EnvironmentVariables.IDENTITY_HEADER)
+            and os.environ.get(EnvironmentVariables.IDENTITY_SERVER_THUMBPRINT)
+        ):
+            _LOGGER.info("%s will use Service Fabric managed identity", self.__class__.__name__)
+            from .service_fabric import ServiceFabricCredential
+
+            self._credential = ServiceFabricCredential(**kwargs)
         else:
             _LOGGER.info("%s will use IMDS", self.__class__.__name__)
             self._credential = ImdsCredential(**kwargs)

--- a/sdk/identity/azure-identity/tests/test_managed_identity.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity.py
@@ -93,6 +93,70 @@ def test_cloud_shell_user_assigned_identity():
         assert token == expected_token
 
 
+def test_prefers_app_service_2017_09_01():
+    """When the environment is configured for both App Service versions, the credential should prefer 2017-09-01
+
+    Support for 2019-08-01 was removed due to https://github.com/Azure/azure-sdk-for-python/issues/14670. This test
+    should be removed when that support is added back.
+    """
+
+    access_token = "****"
+    expires_on = 42
+    expected_token = AccessToken(access_token, expires_on)
+    url = "http://localhost:42/token"
+    secret = "expected-secret"
+    scope = "scope"
+
+    transport = validating_transport(
+        requests=[
+            Request(
+                url,
+                method="GET",
+                required_headers={"secret": secret, "User-Agent": USER_AGENT},
+                required_params={"api-version": "2017-09-01", "resource": scope},
+            )
+        ]
+        * 2,
+        responses=[
+            mock_response(
+                json_payload={
+                    "access_token": access_token,
+                    "expires_on": "01/01/1970 00:00:{} +00:00".format(expires_on),  # linux format
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            ),
+            mock_response(
+                json_payload={
+                    "access_token": access_token,
+                    "expires_on": "1/1/1970 12:00:{} AM +00:00".format(expires_on),  # windows format
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            ),
+        ],
+    )
+
+    with mock.patch.dict(
+        MANAGED_IDENTITY_ENVIRON,
+        {
+            EnvironmentVariables.IDENTITY_ENDPOINT: url,
+            EnvironmentVariables.IDENTITY_HEADER: secret,
+            EnvironmentVariables.MSI_ENDPOINT: url,
+            EnvironmentVariables.MSI_SECRET: secret,
+        },
+        clear=True,
+    ):
+        token = ManagedIdentityCredential(transport=transport).get_token(scope)
+        assert token == expected_token
+        assert token.expires_on == expires_on
+
+        token = ManagedIdentityCredential(transport=transport).get_token(scope)
+        assert token == expected_token
+        assert token.expires_on == expires_on
+
+
+@pytest.mark.skip("2019-08-01 support was removed due to https://github.com/Azure/azure-sdk-for-python/issues/14670. This test should be enabled when that support is added back.")
 def test_prefers_app_service_2019_08_01():
     """When the environment is configured for both App Service versions, the credential should prefer the most recent"""
 
@@ -134,6 +198,7 @@ def test_prefers_app_service_2019_08_01():
     assert token.expires_on == expires_on
 
 
+@pytest.mark.skip("2019-08-01 support was removed due to https://github.com/Azure/azure-sdk-for-python/issues/14670. This test should be enabled when that support is added back.")
 def test_app_service_2019_08_01():
     """App Service 2019-08-01: IDENTITY_ENDPOINT, IDENTITY_HEADER set"""
 

--- a/sdk/identity/azure-identity/tests/test_managed_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity_async.py
@@ -94,6 +94,73 @@ async def test_cloud_shell_user_assigned_identity():
 
 
 @pytest.mark.asyncio
+async def test_prefers_app_service_2017_09_01():
+    """When the environment is configured for both App Service versions, the credential should prefer 2017-09-01
+
+    Support for 2019-08-01 was removed due to https://github.com/Azure/azure-sdk-for-python/issues/14670. This test
+    should be removed when that support is added back.
+    """
+
+    access_token = "****"
+    expires_on = 42
+    expected_token = AccessToken(access_token, expires_on)
+    url = "http://localhost:42/token"
+    secret = "expected-secret"
+    scope = "scope"
+
+    transport = async_validating_transport(
+        requests=[
+            Request(
+                url,
+                method="GET",
+                required_headers={"secret": secret, "User-Agent": USER_AGENT},
+                required_params={"api-version": "2017-09-01", "resource": scope},
+            )
+        ]
+        * 2,
+        responses=[
+            mock_response(
+                json_payload={
+                    "access_token": access_token,
+                    "expires_on": "01/01/1970 00:00:{} +00:00".format(expires_on),  # linux format
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            ),
+            mock_response(
+                json_payload={
+                    "access_token": access_token,
+                    "expires_on": "1/1/1970 12:00:{} AM +00:00".format(expires_on),  # windows format
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            ),
+        ],
+    )
+
+    with mock.patch.dict(
+        MANAGED_IDENTITY_ENVIRON,
+        {
+            EnvironmentVariables.IDENTITY_ENDPOINT: url,
+            EnvironmentVariables.IDENTITY_HEADER: secret,
+            EnvironmentVariables.MSI_ENDPOINT: url,
+            EnvironmentVariables.MSI_SECRET: secret,
+        },
+        clear=True,
+    ):
+        credential = ManagedIdentityCredential(transport=transport)
+        token = await credential.get_token(scope)
+        assert token == expected_token
+        assert token.expires_on == expires_on
+
+        credential = ManagedIdentityCredential(transport=transport)
+        token = await credential.get_token(scope)
+        assert token == expected_token
+        assert token.expires_on == expires_on
+
+
+@pytest.mark.skip("2019-08-01 support was removed due to https://github.com/Azure/azure-sdk-for-python/issues/14670. This test should be enabled when that support is added back.")
+@pytest.mark.asyncio
 async def test_app_service_2019_08_01():
     """App Service 2019-08-01: IDENTITY_ENDPOINT, IDENTITY_HEADER set"""
 


### PR DESCRIPTION
Fixes #14670 by using only App Service managed identity version 2017-09-01, which is available in all App Service environments. We'll revert these changes when 2019-08-01 is consistently available.