### PR TITLE
[cosmos] Replace container.id with container.container_link in resource token sample

### DIFF
--- a/sdk/cosmos/azure-cosmos/samples/access_cosmos_with_resource_token.py
+++ b/sdk/cosmos/azure-cosmos/samples/access_cosmos_with_resource_token.py
@@ -141,7 +141,7 @@ def run_sample():
 
         permission = create_permission_if_not_exists(user, permission_definition)
         token = {}
-        token[container.id] = permission.properties["_token"]
+        token[container.container_link] = permission.properties["_token"]
 
         # Use token to connect to database
         token_client = cosmos_client.CosmosClient(HOST, token)
@@ -177,7 +177,7 @@ def run_sample():
         }
         permission = create_permission_if_not_exists(user_2, permission_definition)
         read_token = {}
-        read_token[container.id] = permission.properties["_token"]
+        read_token[container.container_link] = permission.properties["_token"]
 
         # Use token to connect to database
         token_client = cosmos_client.CosmosClient(HOST, read_token)
@@ -209,7 +209,7 @@ def run_sample():
         permission = create_permission_if_not_exists(user_2, permission_definition)
 
         item_token = {}
-        item_token[container.id] = permission.properties["_token"]
+        item_token[container.container_link] = permission.properties["_token"]
 
         # Use token to connect to database
         token_client = cosmos_client.CosmosClient(HOST, item_token)


### PR DESCRIPTION
Closes https://github.com/Azure/azure-sdk-for-python/issues/14829

We updated the resource token dictionary to use the container path instead of the container ID. That attribute is called `container_link`, this PR updates the sample to match.