### PR TITLE
Raise minimum msal version to 1.6.0

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -10,6 +10,7 @@
    provided, the credential will authenticate users to an Azure development
    application.
    ([#14354](https://github.com/Azure/azure-sdk-for-python/issues/14354))
+- Raised minimum msal version to 1.6.0
 
 ### Fixed
 - `ManagedIdentityCredential` uses the API version supported by Azure Functions

--- a/sdk/identity/azure-identity/azure/identity/_credentials/certificate.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/certificate.py
@@ -6,7 +6,7 @@ from binascii import hexlify
 from typing import TYPE_CHECKING
 
 from cryptography import x509
-from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.backends import default_backend
 import six
 
@@ -55,9 +55,10 @@ class CertificateCredential(ClientCredentialBase):
         cert = x509.load_pem_x509_certificate(pem_bytes, default_backend())
         fingerprint = cert.fingerprint(hashes.SHA1())  # nosec
 
-        # TODO: msal doesn't formally support passwords (but soon will); the below depends on an implementation detail
-        private_key = serialization.load_pem_private_key(pem_bytes, password=password, backend=default_backend())
-        client_credential = {"private_key": private_key, "thumbprint": hexlify(fingerprint).decode("utf-8")}
+        client_credential = {"private_key": pem_bytes, "thumbprint": hexlify(fingerprint).decode("utf-8")}
+        if password:
+            client_credential["passphrase"] = password
+
         if kwargs.pop("send_certificate_chain", False):
             try:
                 # the JWT needs the whole chain but load_pem_x509_certificate deserializes only the signing cert

--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -73,7 +73,7 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.0.0",
         "cryptography>=2.1.4",
-        "msal<1.6.0,>=1.3.0",
+        "msal<2.0.0,>=1.6.0",
         "msal-extensions~=0.3.0",
         "six>=1.6",
     ],

--- a/sdk/identity/azure-identity/tests/test_certificate_credential.py
+++ b/sdk/identity/azure-identity/tests/test_certificate_credential.py
@@ -36,7 +36,11 @@ except ImportError:  # python < 3.3
 CERT_PATH = os.path.join(os.path.dirname(__file__), "certificate.pem")
 CERT_WITH_PASSWORD_PATH = os.path.join(os.path.dirname(__file__), "certificate-with-password.pem")
 CERT_PASSWORD = "password"
-BOTH_CERTS = ((CERT_PATH, None), (CERT_WITH_PASSWORD_PATH, CERT_PASSWORD))
+BOTH_CERTS = (
+    (CERT_PATH, None),
+    (CERT_WITH_PASSWORD_PATH, CERT_PASSWORD),  # credential should accept passwords as str or bytes
+    (CERT_WITH_PASSWORD_PATH, CERT_PASSWORD.encode("utf-8")),
+)
 
 
 def test_no_scopes():

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -102,7 +102,7 @@ futures
 mock
 typing
 typing-extensions
-msal<1.6.0,>=1.3.0
+msal<2.0.0,>=1.6.0
 msal-extensions~=0.3.0
 msrest>=0.5.0
 msrestazure<2.0.0,>=0.4.32


### PR DESCRIPTION
msal 1.6.0 added support for certificates with encrypted private keys. This raises the minimum msal version and removes the workaround CertificateCredential was using.