### PR TITLE
updating error reporting for batching to throw BatchErrorException

### DIFF
--- a/sdk/tables/azure-data-tables/azure/data/tables/_base_client.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_base_client.py
@@ -58,7 +58,6 @@ from ._policies import (
     StorageHosts,
     TablesRetryPolicy,
 )
-from ._error import _process_table_error
 from ._models import BatchErrorException
 from ._sdk_moniker import SDK_MONIKER
 
@@ -255,7 +254,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         ]
         return config, Pipeline(config.transport, policies=policies)
 
-    def _batch_send(
+    def _batch_send( # pylint: disable=inconsistent-return-statements
         self, entities, # type: List[TableEntity]
         *reqs,  # type: List[HttpRequest]
         **kwargs

--- a/sdk/tables/azure-data-tables/azure/data/tables/_base_client.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_base_client.py
@@ -28,7 +28,7 @@ except ImportError:
 
 import six
 from azure.core.configuration import Configuration
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import HttpResponseError, raise_with_traceback
 from azure.core.pipeline import Pipeline
 from azure.core.pipeline.transport import (
     RequestsTransport,
@@ -288,11 +288,13 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
             boundary="batch_{}".format(uuid4())
         )
 
-        pipeline_response = self._pipeline.run(
-            request, **kwargs
-        )
-        response = pipeline_response.http_response
+        error = None
+        parts = None
         try:
+            pipeline_response = self._pipeline.run(
+                request, **kwargs
+            )
+            response = pipeline_response.http_response
             if response.status_code not in [202]:
                 raise HttpResponseError(response=response)
             parts = response.parts()
@@ -303,10 +305,13 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
                         message="There is a failure in the batch operation.",
                         response=response, parts=parts
                     )
-                    raise error
-            return transaction_result
+            if error is None:
+                return transaction_result
         except HttpResponseError as error:
-            _process_table_error(error)
+            raise_with_traceback(BatchErrorException, response=response, parts=parts, error=error)
+        if error:
+            raise error
+
 
 class TransportWrapper(HttpTransport):
     """Wrapper class that ensures that an inner client created

--- a/sdk/tables/azure-data-tables/azure/data/tables/_base_client.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_base_client.py
@@ -29,8 +29,6 @@ except ImportError:
 import six
 from azure.core.configuration import Configuration
 from azure.core.exceptions import (
-    HttpResponseError,
-    raise_with_traceback,
     ClientAuthenticationError,
     ResourceNotFoundError
 )
@@ -302,12 +300,12 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
                 message="There was an error authenticating with the service",
                 response=response
             )
-        elif response.status_code == 404:
+        if response.status_code == 404:
             raise ResourceNotFoundError(
                 message="The resource could not be found",
                 response=response
             )
-        elif response.status_code != 202:
+        if response.status_code != 202:
             raise BatchErrorException(
                 message="There is a failure in the batch operation.",
                 response=response, parts=None

--- a/sdk/tables/azure-data-tables/azure/data/tables/_models.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_models.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 from enum import Enum
-from azure.core.exceptions import HttpResponseError, AzureError
+from azure.core.exceptions import HttpResponseError
 from azure.core.paging import PageIterator
 from azure.data.tables._generated.models import TableServiceStats as GenTableServiceStats
 

--- a/sdk/tables/azure-data-tables/azure/data/tables/_models.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_models.py
@@ -517,7 +517,7 @@ class PartialBatchErrorException(HttpResponseError):
         super(PartialBatchErrorException, self).__init__(message=message, response=response)
 
 
-class BatchErrorException(AzureError):
+class BatchErrorException(HttpResponseError):
     """There is a failure in batch operations.
 
     :param str message: The message of the exception.
@@ -525,9 +525,9 @@ class BatchErrorException(AzureError):
     :param list parts: A list of the parts in multipart response.
     """
 
-    def __init__(self, message, response, parts):
+    def __init__(self, message, response, parts, *args, **kwargs):
         self.parts = parts
-        super(BatchErrorException, self).__init__(message=message, response=response)
+        super(BatchErrorException, self).__init__(message=message, response=response, *args, **kwargs)
 
 
 class BatchTransactionResult(object):

--- a/sdk/tables/azure-data-tables/azure/data/tables/aio/_base_client_async.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/aio/_base_client_async.py
@@ -156,8 +156,10 @@ class AsyncStorageAccountHostsMixin(object):
                 response=response, parts=None
             )
 
-        parts = response.parts()
-        parts = [p async for p in parts]
+        parts_iter = response.parts()
+        parts = []
+        async for p in parts_iter:
+            parts.append(p)
         transaction_result = BatchTransactionResult(reqs, parts, entities)
         if raise_on_any_failure:
             if any(p for p in parts if not 200 <= p.status_code < 300):

--- a/sdk/tables/azure-data-tables/azure/data/tables/aio/_base_client_async.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/aio/_base_client_async.py
@@ -134,7 +134,7 @@ class AsyncStorageAccountHostsMixin(object):
         )
 
         error = None
-        parts = None
+        parts_list = None
         try:
             pipeline_response = await self._pipeline.run(
                 request, **kwargs
@@ -146,17 +146,17 @@ class AsyncStorageAccountHostsMixin(object):
             parts_list = []
             async for part in parts:
                 parts_list.append(part)
-            transaction_result = BatchTransactionResult(reqs, parts, entities)
+            transaction_result = BatchTransactionResult(reqs, parts_list, entities)
             if raise_on_any_failure:
                 if any(p for p in parts_list if not 200 <= p.status_code < 300):
                     error = BatchErrorException(
                         message="There is a failure in the batch operation.",
-                        response=response, parts=parts
+                        response=response, parts=parts_list
                     )
             if error is None:
                 return transaction_result
         except HttpResponseError as error:
-            raise_with_traceback(BatchErrorException, response=response, parts=parts, error=error)
+            raise_with_traceback(BatchErrorException, response=response, parts=parts_list, error=error)
         if error:
             raise error
 

--- a/sdk/tables/azure-data-tables/azure/data/tables/aio/_base_client_async.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/aio/_base_client_async.py
@@ -13,8 +13,6 @@ from uuid import uuid4
 
 from azure.core.pipeline import AsyncPipeline
 from azure.core.exceptions import (
-    HttpResponseError,
-    raise_with_traceback,
     ResourceNotFoundError,
     ClientAuthenticationError
 )
@@ -147,12 +145,12 @@ class AsyncStorageAccountHostsMixin(object):
                 message="There was an error authenticating with the service",
                 response=response
             )
-        elif response.status_code == 404:
+        if response.status_code == 404:
             raise ResourceNotFoundError(
                 message="The resource could not be found",
                 response=response
             )
-        elif response.status_code != 202:
+        if response.status_code != 202:
             raise BatchErrorException(
                 message="There is a failure in the batch operation.",
                 response=response, parts=None
@@ -175,33 +173,6 @@ class AsyncStorageAccountHostsMixin(object):
                     response=response, parts=parts
                 )
         return transaction_result
-
-        # error = None
-        # parts_list = None
-        # try:
-        #     pipeline_response = await self._pipeline.run(
-        #         request, **kwargs
-        #     )
-        #     response = pipeline_response.http_response
-        #     if response.status_code not in [202]:
-        #         raise HttpResponseError(response=response)
-        #     parts = response.parts()
-        #     parts_list = []
-        #     async for part in parts:
-        #         parts_list.append(part)
-        #     transaction_result = BatchTransactionResult(reqs, parts_list, entities)
-        #     if raise_on_any_failure:
-        #         if any(p for p in parts_list if not 200 <= p.status_code < 300):
-        #             error = BatchErrorException(
-        #                 message="There is a failure in the batch operation.",
-        #                 response=response, parts=parts_list
-        #             )
-        #     if error is None:
-        #         return transaction_result
-        # except HttpResponseError as error:
-        #     raise_with_traceback(BatchErrorException, response=response, parts=parts_list, error=error)
-        # if error:
-        #     raise error
 
 
 class AsyncTransportWrapper(AsyncHttpTransport):

--- a/sdk/tables/azure-data-tables/azure/data/tables/aio/_base_client_async.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/aio/_base_client_async.py
@@ -32,7 +32,6 @@ from .._policies import (
     StorageHeadersPolicy
 )
 from ._policies_async import AsyncStorageResponseHook
-from .._error import _process_table_error
 from .._models import BatchErrorException, BatchTransactionResult
 
 if TYPE_CHECKING:

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table_batch.test_new_delete_nonexistent_entity.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table_batch.test_new_delete_nonexistent_entity.yaml
@@ -1,0 +1,155 @@
+interactions:
+- request:
+    body: '{"TableName": "uttable1c74150c"}'
+    headers:
+      Accept:
+      - application/json;odata=minimalmetadata
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json;odata=nometadata
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:12:41 GMT
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:12:41 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablesteststorname.table.core.windows.net/Tables
+  response:
+    body:
+      string: '{"odata.metadata":"https://tablesteststorname.table.core.windows.net/$metadata#Tables/@Element","TableName":"uttable1c74150c"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-type:
+      - application/json;odata=minimalmetadata;streaming=true;charset=utf-8
+      date:
+      - Thu, 05 Nov 2020 21:12:42 GMT
+      location:
+      - https://tablesteststorname.table.core.windows.net/Tables('uttable1c74150c')
+      server:
+      - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-ms-version:
+      - '2019-02-02'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: "--batch_723d728d-713f-4639-823a-43fec6c39058\r\nContent-Type: multipart/mixed;\
+      \ boundary=changeset_45bef08f-42c8-495d-834b-602f6a98ac0c\r\n\r\n--changeset_45bef08f-42c8-495d-834b-602f6a98ac0c\r\
+      \nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID:\
+      \ 0\r\n\r\nDELETE https://tablestestp5vjroapn77olh.table.core.windows.net/uttable1c74150c(PartitionKey='001',RowKey='batch_negative_1')\
+      \ HTTP/1.1\r\nx-ms-version: 2019-02-02\r\nDataServiceVersion: 3.0\r\nIf-Match:\
+      \ *\r\nAccept: application/json;odata=minimalmetadata\r\nx-ms-date: Thu, 05\
+      \ Nov 2020 21:12:42 GMT\r\nDate: Thu, 05 Nov 2020 21:12:42 GMT\r\nx-ms-client-request-id:\
+      \ a4756eb2-1fab-11eb-9a18-58961df361d1\r\n\r\n\r\n--changeset_45bef08f-42c8-495d-834b-602f6a98ac0c--\r\
+      \n\r\n--batch_723d728d-713f-4639-823a-43fec6c39058--\r\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '764'
+      Content-Type:
+      - multipart/mixed; boundary=batch_723d728d-713f-4639-823a-43fec6c39058
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:12:42 GMT
+      MaxDataServiceVersion:
+      - 3.0;NetFx
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:12:42 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablesteststorname.table.core.windows.net/$batch
+  response:
+    body:
+      string: "--batchresponse_96c0dab8-f65f-4d22-8dff-eb50ae8704a7\r\nContent-Type:\
+        \ multipart/mixed; boundary=changesetresponse_0dd8b966-26f3-4ccf-882b-24e7df95f770\r\
+        \n\r\n--changesetresponse_0dd8b966-26f3-4ccf-882b-24e7df95f770\r\nContent-Type:\
+        \ application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 404\
+        \ Not Found\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\
+        \nDataServiceVersion: 3.0;\r\nContent-Type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8\r\
+        \n\r\n{\"odata.error\":{\"code\":\"ResourceNotFound\",\"message\":{\"lang\"\
+        :\"en-US\",\"value\":\"The specified resource does not exist.\\nRequestId:30b6b4f1-2002-000f-46b8-b30f63000000\\\
+        nTime:2020-11-05T21:12:42.9974239Z\"}}}\r\n--changesetresponse_0dd8b966-26f3-4ccf-882b-24e7df95f770--\r\
+        \n--batchresponse_96c0dab8-f65f-4d22-8dff-eb50ae8704a7--\r\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-type:
+      - multipart/mixed; boundary=batchresponse_96c0dab8-f65f-4d22-8dff-eb50ae8704a7
+      date:
+      - Thu, 05 Nov 2020 21:12:42 GMT
+      server:
+      - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-ms-version:
+      - '2019-02-02'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 05 Nov 2020 21:12:42 GMT
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:12:42 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: DELETE
+    uri: https://tablesteststorname.table.core.windows.net/Tables('uttable1c74150c')
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 05 Nov 2020 21:12:42 GMT
+      server:
+      - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      x-content-type-options:
+      - nosniff
+      x-ms-version:
+      - '2019-02-02'
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table_batch.test_new_invalid_key.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table_batch.test_new_invalid_key.yaml
@@ -1,0 +1,70 @@
+interactions:
+- request:
+    body: "--batch_b3de0c4f-674e-4ecf-b4ce-bc10c8a242d5\r\nContent-Type: multipart/mixed;\
+      \ boundary=changeset_6162604d-6df7-463a-9d72-dbf2ffb58293\r\n\r\n--changeset_6162604d-6df7-463a-9d72-dbf2ffb58293\r\
+      \nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID:\
+      \ 0\r\n\r\nPOST https://tablestestp5vjroapn77olh.table.core.windows.net/uttable1d970f0e\
+      \ HTTP/1.1\r\nx-ms-version: 2019-02-02\r\nDataServiceVersion: 3.0\r\nPrefer:\
+      \ return-no-content\r\nContent-Type: application/json;odata=nometadata\r\nAccept:\
+      \ application/json;odata=minimalmetadata\r\nContent-Length: 576\r\nx-ms-date:\
+      \ Thu, 05 Nov 2020 21:12:42 GMT\r\nDate: Thu, 05 Nov 2020 21:12:42 GMT\r\nx-ms-client-request-id:\
+      \ a49ca6ff-1fab-11eb-a1a8-58961df361d1\r\n\r\n{\"PartitionKey\": \"001\", \"\
+      PartitionKey@odata.type\": \"Edm.String\", \"RowKey\": \"batch_negative_1\"\
+      , \"RowKey@odata.type\": \"Edm.String\", \"age\": 39, \"sex\": \"male\", \"\
+      sex@odata.type\": \"Edm.String\", \"married\": true, \"deceased\": false, \"\
+      ratio\": 3.1, \"evenratio\": 3.0, \"large\": 933311100, \"Birthday\": \"1973-10-04T00:00:00Z\"\
+      , \"Birthday@odata.type\": \"Edm.DateTime\", \"birthday\": \"1970-10-04T00:00:00Z\"\
+      , \"birthday@odata.type\": \"Edm.DateTime\", \"binary\": \"YmluYXJ5\", \"binary@odata.type\"\
+      : \"Edm.Binary\", \"other\": 20, \"clsid\": \"c9da6455-213d-42c9-9a79-3e9149a57833\"\
+      , \"clsid@odata.type\": \"Edm.Guid\"}\r\n--changeset_6162604d-6df7-463a-9d72-dbf2ffb58293--\r\
+      \n\r\n--batch_b3de0c4f-674e-4ecf-b4ce-bc10c8a242d5--\r\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1376'
+      Content-Type:
+      - multipart/mixed; boundary=batch_b3de0c4f-674e-4ecf-b4ce-bc10c8a242d5
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:12:42 GMT
+      MaxDataServiceVersion:
+      - 3.0;NetFx
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:12:42 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablesteststorname.table.core.windows.net/$batch
+  response:
+    body:
+      string: '<?xml version="1.0" encoding="utf-8"?><m:error xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"><m:code>AuthenticationFailed</m:code><m:message
+        xml:lang="en-US">Server failed to authenticate the request. Make sure the
+        value of Authorization header is formed correctly including the signature.
+
+        RequestId:1bf4974c-7002-0058-06b8-b3e6ee000000
+
+        Time:2020-11-05T21:12:43.3528159Z</m:message></m:error>'
+    headers:
+      content-length:
+      - '419'
+      content-type:
+      - application/xml
+      date:
+      - Thu, 05 Nov 2020 21:12:42 GMT
+      server:
+      - Microsoft-HTTPAPI/2.0
+      x-ms-error-code:
+      - AuthenticationFailed
+    status:
+      code: 403
+      message: Server failed to authenticate the request. Make sure the value of Authorization
+        header is formed correctly including the signature.
+version: 1

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table_batch.test_new_non_existent_table.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table_batch.test_new_non_existent_table.yaml
@@ -1,0 +1,164 @@
+interactions:
+- request:
+    body: '{"TableName": "uttable93d21204"}'
+    headers:
+      Accept:
+      - application/json;odata=minimalmetadata
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json;odata=nometadata
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:12:42 GMT
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:12:42 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablesteststorname.table.core.windows.net/Tables
+  response:
+    body:
+      string: '{"odata.metadata":"https://tablesteststorname.table.core.windows.net/$metadata#Tables/@Element","TableName":"uttable93d21204"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-type:
+      - application/json;odata=minimalmetadata;streaming=true;charset=utf-8
+      date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      location:
+      - https://tablesteststorname.table.core.windows.net/Tables('uttable93d21204')
+      server:
+      - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-ms-version:
+      - '2019-02-02'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: "--batch_55dca659-df2d-4c82-8c4c-617a581058c7\r\nContent-Type: multipart/mixed;\
+      \ boundary=changeset_75729a3a-4bcf-4b6d-a042-e6d3d023adc3\r\n\r\n--changeset_75729a3a-4bcf-4b6d-a042-e6d3d023adc3\r\
+      \nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID:\
+      \ 0\r\n\r\nPOST https://tablestestp5vjroapn77olh.table.core.windows.net/doesntexist\
+      \ HTTP/1.1\r\nx-ms-version: 2019-02-02\r\nDataServiceVersion: 3.0\r\nPrefer:\
+      \ return-no-content\r\nContent-Type: application/json;odata=nometadata\r\nAccept:\
+      \ application/json;odata=minimalmetadata\r\nContent-Length: 576\r\nx-ms-date:\
+      \ Thu, 05 Nov 2020 21:12:43 GMT\r\nDate: Thu, 05 Nov 2020 21:12:43 GMT\r\nx-ms-client-request-id:\
+      \ a4e512c6-1fab-11eb-8eec-58961df361d1\r\n\r\n{\"PartitionKey\": \"001\", \"\
+      PartitionKey@odata.type\": \"Edm.String\", \"RowKey\": \"batch_negative_1\"\
+      , \"RowKey@odata.type\": \"Edm.String\", \"age\": 39, \"sex\": \"male\", \"\
+      sex@odata.type\": \"Edm.String\", \"married\": true, \"deceased\": false, \"\
+      ratio\": 3.1, \"evenratio\": 3.0, \"large\": 933311100, \"Birthday\": \"1973-10-04T00:00:00Z\"\
+      , \"Birthday@odata.type\": \"Edm.DateTime\", \"birthday\": \"1970-10-04T00:00:00Z\"\
+      , \"birthday@odata.type\": \"Edm.DateTime\", \"binary\": \"YmluYXJ5\", \"binary@odata.type\"\
+      : \"Edm.Binary\", \"other\": 20, \"clsid\": \"c9da6455-213d-42c9-9a79-3e9149a57833\"\
+      , \"clsid@odata.type\": \"Edm.Guid\"}\r\n--changeset_75729a3a-4bcf-4b6d-a042-e6d3d023adc3--\r\
+      \n\r\n--batch_55dca659-df2d-4c82-8c4c-617a581058c7--\r\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1372'
+      Content-Type:
+      - multipart/mixed; boundary=batch_55dca659-df2d-4c82-8c4c-617a581058c7
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      MaxDataServiceVersion:
+      - 3.0;NetFx
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablesteststorname.table.core.windows.net/$batch
+  response:
+    body:
+      string: "--batchresponse_d22a62bc-8ad6-4791-8c04-7e47c72c2e7c\r\nContent-Type:\
+        \ multipart/mixed; boundary=changesetresponse_37d98d47-f4fd-4a20-8171-4be15e3eafd5\r\
+        \n\r\n--changesetresponse_37d98d47-f4fd-4a20-8171-4be15e3eafd5\r\nContent-Type:\
+        \ application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 404\
+        \ Not Found\r\nX-Content-Type-Options: nosniff\r\nDataServiceVersion: 3.0;\r\
+        \nContent-Type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8\r\
+        \n\r\n{\"odata.error\":{\"code\":\"TableNotFound\",\"message\":{\"lang\":\"\
+        en-US\",\"value\":\"0:The table specified does not exist.\\nRequestId:00153365-4002-0014-3eb8-b321f1000000\\\
+        nTime:2020-11-05T21:12:43.6468125Z\"}}}\r\n--changesetresponse_37d98d47-f4fd-4a20-8171-4be15e3eafd5--\r\
+        \n--batchresponse_d22a62bc-8ad6-4791-8c04-7e47c72c2e7c--\r\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-type:
+      - multipart/mixed; boundary=batchresponse_d22a62bc-8ad6-4791-8c04-7e47c72c2e7c
+      date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      server:
+      - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-ms-version:
+      - '2019-02-02'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: DELETE
+    uri: https://tablesteststorname.table.core.windows.net/Tables('uttable93d21204')
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      server:
+      - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      x-content-type-options:
+      - nosniff
+      x-ms-version:
+      - '2019-02-02'
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_async.test_batch_same_row_operations_fail.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_async.test_batch_same_row_operations_fail.yaml
@@ -1,13 +1,9 @@
 interactions:
 - request:
-    body: '{"TableName": "uttable2efa1532"}'
+    body: '{"TableName": "uttableb85917af"}'
     headers:
       Accept:
       - application/json;odata=minimalmetadata
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
       Content-Length:
       - '32'
       Content-Type:
@@ -15,38 +11,31 @@ interactions:
       DataServiceVersion:
       - '3.0'
       Date:
-      - Wed, 04 Nov 2020 22:36:47 GMT
+      - Wed, 04 Nov 2020 22:36:48 GMT
       User-Agent:
       - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 04 Nov 2020 22:36:47 GMT
+      - Wed, 04 Nov 2020 22:36:48 GMT
       x-ms-version:
       - '2019-02-02'
     method: POST
     uri: https://tablesteststorname.table.core.windows.net/Tables
   response:
     body:
-      string: '{"odata.metadata":"https://tablesteststorname.table.core.windows.net/$metadata#Tables/@Element","TableName":"uttable2efa1532"}'
+      string: '{"odata.metadata":"https://tablesteststorname.table.core.windows.net/$metadata#Tables/@Element","TableName":"uttableb85917af"}'
     headers:
-      cache-control:
-      - no-cache
-      content-type:
-      - application/json;odata=minimalmetadata;streaming=true;charset=utf-8
-      date:
-      - Wed, 04 Nov 2020 22:36:47 GMT
-      location:
-      - https://tablesteststorname.table.core.windows.net/Tables('uttable2efa1532')
-      server:
-      - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding:
-      - chunked
-      x-content-type-options:
-      - nosniff
-      x-ms-version:
-      - '2019-02-02'
+      cache-control: no-cache
+      content-type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8
+      date: Wed, 04 Nov 2020 22:36:48 GMT
+      location: https://tablesteststorname.table.core.windows.net/Tables('uttableb85917af')
+      server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-content-type-options: nosniff
+      x-ms-version: '2019-02-02'
     status:
       code: 201
       message: Created
+    url: https://tablestestjcubfezjsaamm2.table.core.windows.net/Tables
 - request:
     body: '{"PartitionKey": "001", "PartitionKey@odata.type": "Edm.String", "RowKey":
       "batch_negative_1", "RowKey@odata.type": "Edm.String", "age": 39, "sex": "male",
@@ -58,10 +47,6 @@ interactions:
     headers:
       Accept:
       - application/json;odata=minimalmetadata
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
       Content-Length:
       - '576'
       Content-Type:
@@ -77,53 +62,45 @@ interactions:
       x-ms-version:
       - '2019-02-02'
     method: POST
-    uri: https://tablesteststorname.table.core.windows.net/uttable2efa1532
+    uri: https://tablesteststorname.table.core.windows.net/uttableb85917af
   response:
     body:
-      string: '{"odata.metadata":"https://tablesteststorname.table.core.windows.net/$metadata#uttable2efa1532/@Element","odata.etag":"W/\"datetime''2020-11-04T22%3A36%3A48.5264123Z''\"","PartitionKey":"001","RowKey":"batch_negative_1","Timestamp":"2020-11-04T22:36:48.5264123Z","age":39,"sex":"male","married":true,"deceased":false,"ratio":3.1,"evenratio":3.0,"large":933311100,"Birthday@odata.type":"Edm.DateTime","Birthday":"1973-10-04T00:00:00Z","birthday@odata.type":"Edm.DateTime","birthday":"1970-10-04T00:00:00Z","binary@odata.type":"Edm.Binary","binary":"YmluYXJ5","other":20,"clsid@odata.type":"Edm.Guid","clsid":"c9da6455-213d-42c9-9a79-3e9149a57833"}'
+      string: '{"odata.metadata":"https://tablesteststorname.table.core.windows.net/$metadata#uttableb85917af/@Element","odata.etag":"W/\"datetime''2020-11-04T22%3A36%3A48.9588088Z''\"","PartitionKey":"001","RowKey":"batch_negative_1","Timestamp":"2020-11-04T22:36:48.9588088Z","age":39,"sex":"male","married":true,"deceased":false,"ratio":3.1,"evenratio":3.0,"large":933311100,"Birthday@odata.type":"Edm.DateTime","Birthday":"1973-10-04T00:00:00Z","birthday@odata.type":"Edm.DateTime","birthday":"1970-10-04T00:00:00Z","binary@odata.type":"Edm.Binary","binary":"YmluYXJ5","other":20,"clsid@odata.type":"Edm.Guid","clsid":"c9da6455-213d-42c9-9a79-3e9149a57833"}'
     headers:
-      cache-control:
-      - no-cache
-      content-type:
-      - application/json;odata=minimalmetadata;streaming=true;charset=utf-8
-      date:
-      - Wed, 04 Nov 2020 22:36:47 GMT
-      etag:
-      - W/"datetime'2020-11-04T22%3A36%3A48.5264123Z'"
-      location:
-      - https://tablesteststorname.table.core.windows.net/uttable2efa1532(PartitionKey='001',RowKey='batch_negative_1')
-      server:
-      - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding:
-      - chunked
-      x-content-type-options:
-      - nosniff
-      x-ms-version:
-      - '2019-02-02'
+      cache-control: no-cache
+      content-type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8
+      date: Wed, 04 Nov 2020 22:36:48 GMT
+      etag: W/"datetime'2020-11-04T22%3A36%3A48.9588088Z'"
+      location: https://tablesteststorname.table.core.windows.net/uttableb85917af(PartitionKey='001',RowKey='batch_negative_1')
+      server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-content-type-options: nosniff
+      x-ms-version: '2019-02-02'
     status:
       code: 201
       message: Created
+    url: https://tablestestjcubfezjsaamm2.table.core.windows.net/uttableb85917af
 - request:
-    body: "--batch_7d6938d9-50c0-441a-b7ab-edb7fa4e7fb9\r\nContent-Type: multipart/mixed;\
-      \ boundary=changeset_d5c39b91-ba5c-4bca-8c04-c9194fe84f63\r\n\r\n--changeset_d5c39b91-ba5c-4bca-8c04-c9194fe84f63\r\
+    body: "--batch_e8c6d6a5-8bf7-4e48-abde-f832c9ffc6cb\r\nContent-Type: multipart/mixed;\
+      \ boundary=changeset_00bde922-dbb9-4cac-9c00-14e6bf5914bd\r\n\r\n--changeset_00bde922-dbb9-4cac-9c00-14e6bf5914bd\r\
       \nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID:\
-      \ 0\r\n\r\nPATCH https://tablestestjcubfezjsaamm2.table.core.windows.net/uttable2efa1532(PartitionKey='001',RowKey='batch_negative_1')\
+      \ 0\r\n\r\nPATCH https://tablestestjcubfezjsaamm2.table.core.windows.net/uttableb85917af(PartitionKey='001',RowKey='batch_negative_1')\
       \ HTTP/1.1\r\nx-ms-version: 2019-02-02\r\nDataServiceVersion: 3.0\r\nIf-Match:\
       \ *\r\nContent-Type: application/json\r\nAccept: application/json\r\nContent-Length:\
       \ 352\r\nx-ms-date: Wed, 04 Nov 2020 22:36:48 GMT\r\nDate: Wed, 04 Nov 2020\
-      \ 22:36:48 GMT\r\nx-ms-client-request-id: 39aa3aa3-1eee-11eb-8e45-58961df361d1\r\
+      \ 22:36:48 GMT\r\nx-ms-client-request-id: 39eb9da0-1eee-11eb-a183-58961df361d1\r\
       \n\r\n{\"PartitionKey\": \"001\", \"PartitionKey@odata.type\": \"Edm.String\"\
       , \"RowKey\": \"batch_negative_1\", \"RowKey@odata.type\": \"Edm.String\", \"\
       age\": \"abc\", \"age@odata.type\": \"Edm.String\", \"sex\": \"female\", \"\
       sex@odata.type\": \"Edm.String\", \"sign\": \"aquarius\", \"sign@odata.type\"\
       : \"Edm.String\", \"birthday\": \"1991-10-04T00:00:00Z\", \"birthday@odata.type\"\
-      : \"Edm.DateTime\"}\r\n--changeset_d5c39b91-ba5c-4bca-8c04-c9194fe84f63\r\n\
+      : \"Edm.DateTime\"}\r\n--changeset_00bde922-dbb9-4cac-9c00-14e6bf5914bd\r\n\
       Content-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID:\
-      \ 1\r\n\r\nPATCH https://tablestestjcubfezjsaamm2.table.core.windows.net/uttable2efa1532(PartitionKey='001',RowKey='batch_negative_1')\
+      \ 1\r\n\r\nPATCH https://tablestestjcubfezjsaamm2.table.core.windows.net/uttableb85917af(PartitionKey='001',RowKey='batch_negative_1')\
       \ HTTP/1.1\r\nx-ms-version: 2019-02-02\r\nDataServiceVersion: 3.0\r\nIf-Match:\
       \ *\r\nContent-Type: application/json\r\nAccept: application/json\r\nContent-Length:\
       \ 576\r\nx-ms-date: Wed, 04 Nov 2020 22:36:48 GMT\r\nDate: Wed, 04 Nov 2020\
-      \ 22:36:48 GMT\r\nx-ms-client-request-id: 39aa3aa4-1eee-11eb-8582-58961df361d1\r\
+      \ 22:36:48 GMT\r\nx-ms-client-request-id: 39eb9da1-1eee-11eb-8cfe-58961df361d1\r\
       \n\r\n{\"PartitionKey\": \"001\", \"PartitionKey@odata.type\": \"Edm.String\"\
       , \"RowKey\": \"batch_negative_1\", \"RowKey@odata.type\": \"Edm.String\", \"\
       age\": 39, \"sex\": \"male\", \"sex@odata.type\": \"Edm.String\", \"married\"\
@@ -132,19 +109,13 @@ interactions:
       : \"Edm.DateTime\", \"birthday\": \"1970-10-04T00:00:00Z\", \"birthday@odata.type\"\
       : \"Edm.DateTime\", \"binary\": \"YmluYXJ5\", \"binary@odata.type\": \"Edm.Binary\"\
       , \"other\": 20, \"clsid\": \"c9da6455-213d-42c9-9a79-3e9149a57833\", \"clsid@odata.type\"\
-      : \"Edm.Guid\"}\r\n--changeset_d5c39b91-ba5c-4bca-8c04-c9194fe84f63--\r\n\r\n\
-      --batch_7d6938d9-50c0-441a-b7ab-edb7fa4e7fb9--\r\n"
+      : \"Edm.Guid\"}\r\n--changeset_00bde922-dbb9-4cac-9c00-14e6bf5914bd--\r\n\r\n\
+      --batch_e8c6d6a5-8bf7-4e48-abde-f832c9ffc6cb--\r\n"
     headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
       Content-Length:
       - '2278'
       Content-Type:
-      - multipart/mixed; boundary=batch_7d6938d9-50c0-441a-b7ab-edb7fa4e7fb9
+      - multipart/mixed; boundary=batch_e8c6d6a5-8bf7-4e48-abde-f832c9ffc6cb
       DataServiceVersion:
       - '3.0'
       Date:
@@ -161,46 +132,34 @@ interactions:
     uri: https://tablesteststorname.table.core.windows.net/$batch
   response:
     body:
-      string: "--batchresponse_af37547e-6430-441a-9871-43a8e64829a5\r\nContent-Type:\
-        \ multipart/mixed; boundary=changesetresponse_adc39adc-2766-4fb6-a29e-156967d647ff\r\
-        \n\r\n--changesetresponse_adc39adc-2766-4fb6-a29e-156967d647ff\r\nContent-Type:\
+      string: "--batchresponse_47272293-b845-4c46-9964-c0fbbfae5410\r\nContent-Type:\
+        \ multipart/mixed; boundary=changesetresponse_a4e95e2e-ebeb-456e-83c3-d1b7bcdf40c4\r\
+        \n\r\n--changesetresponse_a4e95e2e-ebeb-456e-83c3-d1b7bcdf40c4\r\nContent-Type:\
         \ application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 400\
         \ Bad Request\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\
         \nDataServiceVersion: 3.0;\r\nContent-Type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8\r\
         \n\r\n{\"odata.error\":{\"code\":\"InvalidDuplicateRow\",\"message\":{\"lang\"\
         :\"en-US\",\"value\":\"1:The batch request contains multiple changes with\
-        \ same row key. An entity can appear only once in a batch request.\\nRequestId:8f689a71-0002-0014-55fa-b2e00f000000\\\
-        nTime:2020-11-04T22:36:48.5884560Z\"}}}\r\n--changesetresponse_adc39adc-2766-4fb6-a29e-156967d647ff--\r\
-        \n--batchresponse_af37547e-6430-441a-9871-43a8e64829a5--\r\n"
+        \ same row key. An entity can appear only once in a batch request.\\nRequestId:bc029618-d002-0070-6afa-b250af000000\\\
+        nTime:2020-11-04T22:36:49.0028376Z\"}}}\r\n--changesetresponse_a4e95e2e-ebeb-456e-83c3-d1b7bcdf40c4--\r\
+        \n--batchresponse_47272293-b845-4c46-9964-c0fbbfae5410--\r\n"
     headers:
-      cache-control:
-      - no-cache
-      content-type:
-      - multipart/mixed; boundary=batchresponse_af37547e-6430-441a-9871-43a8e64829a5
-      date:
-      - Wed, 04 Nov 2020 22:36:47 GMT
-      server:
-      - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding:
-      - chunked
-      x-content-type-options:
-      - nosniff
-      x-ms-version:
-      - '2019-02-02'
+      cache-control: no-cache
+      content-type: multipart/mixed; boundary=batchresponse_47272293-b845-4c46-9964-c0fbbfae5410
+      date: Wed, 04 Nov 2020 22:36:48 GMT
+      server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-content-type-options: nosniff
+      x-ms-version: '2019-02-02'
     status:
       code: 202
       message: Accepted
+    url: https://tablestestjcubfezjsaamm2.table.core.windows.net/$batch
 - request:
     body: null
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
       Date:
       - Wed, 04 Nov 2020 22:36:48 GMT
       User-Agent:
@@ -210,24 +169,19 @@ interactions:
       x-ms-version:
       - '2019-02-02'
     method: DELETE
-    uri: https://tablesteststorname.table.core.windows.net/Tables('uttable2efa1532')
+    uri: https://tablesteststorname.table.core.windows.net/Tables('uttableb85917af')
   response:
     body:
       string: ''
     headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 04 Nov 2020 22:36:47 GMT
-      server:
-      - Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
-      x-content-type-options:
-      - nosniff
-      x-ms-version:
-      - '2019-02-02'
+      cache-control: no-cache
+      content-length: '0'
+      date: Wed, 04 Nov 2020 22:36:49 GMT
+      server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      x-content-type-options: nosniff
+      x-ms-version: '2019-02-02'
     status:
       code: 204
       message: No Content
+    url: https://tablestestjcubfezjsaamm2.table.core.windows.net/Tables('uttableb85917af')
 version: 1

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_async.test_new_delete_nonexistent_entity.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_async.test_new_delete_nonexistent_entity.yaml
@@ -1,0 +1,121 @@
+interactions:
+- request:
+    body: '{"TableName": "uttablea3561789"}'
+    headers:
+      Accept:
+      - application/json;odata=minimalmetadata
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json;odata=nometadata
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablesteststorname.table.core.windows.net/Tables
+  response:
+    body:
+      string: '{"odata.metadata":"https://tablesteststorname.table.core.windows.net/$metadata#Tables/@Element","TableName":"uttablea3561789"}'
+    headers:
+      cache-control: no-cache
+      content-type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8
+      date: Thu, 05 Nov 2020 21:12:43 GMT
+      location: https://tablesteststorname.table.core.windows.net/Tables('uttablea3561789')
+      server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-content-type-options: nosniff
+      x-ms-version: '2019-02-02'
+    status:
+      code: 201
+      message: Created
+    url: https://tablestestp5vjroapn77olh.table.core.windows.net/Tables
+- request:
+    body: "--batch_072d2c36-cce6-4e61-9da7-3ca8bc80ec6c\r\nContent-Type: multipart/mixed;\
+      \ boundary=changeset_89af84a0-3ad1-43c3-9ffa-89d42483f726\r\n\r\n--changeset_89af84a0-3ad1-43c3-9ffa-89d42483f726\r\
+      \nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID:\
+      \ 0\r\n\r\nDELETE https://tablestestp5vjroapn77olh.table.core.windows.net/uttablea3561789(PartitionKey='001',RowKey='batch_negative_1')\
+      \ HTTP/1.1\r\nx-ms-version: 2019-02-02\r\nDataServiceVersion: 3.0\r\nIf-Match:\
+      \ *\r\nAccept: application/json;odata=minimalmetadata\r\nx-ms-date: Thu, 05\
+      \ Nov 2020 21:12:43 GMT\r\nDate: Thu, 05 Nov 2020 21:12:43 GMT\r\nx-ms-client-request-id:\
+      \ a511ade7-1fab-11eb-bf56-58961df361d1\r\n\r\n\r\n--changeset_89af84a0-3ad1-43c3-9ffa-89d42483f726--\r\
+      \n\r\n--batch_072d2c36-cce6-4e61-9da7-3ca8bc80ec6c--\r\n"
+    headers:
+      Content-Length:
+      - '764'
+      Content-Type:
+      - multipart/mixed; boundary=batch_072d2c36-cce6-4e61-9da7-3ca8bc80ec6c
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      MaxDataServiceVersion:
+      - 3.0;NetFx
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablesteststorname.table.core.windows.net/$batch
+  response:
+    body:
+      string: "--batchresponse_4255292a-d297-43e5-8394-2b1ab1d3bb69\r\nContent-Type:\
+        \ multipart/mixed; boundary=changesetresponse_b9bb9df3-0cc8-4dc9-9d66-c0b0013c03fc\r\
+        \n\r\n--changesetresponse_b9bb9df3-0cc8-4dc9-9d66-c0b0013c03fc\r\nContent-Type:\
+        \ application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 404\
+        \ Not Found\r\nX-Content-Type-Options: nosniff\r\nCache-Control: no-cache\r\
+        \nDataServiceVersion: 3.0;\r\nContent-Type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8\r\
+        \n\r\n{\"odata.error\":{\"code\":\"ResourceNotFound\",\"message\":{\"lang\"\
+        :\"en-US\",\"value\":\"The specified resource does not exist.\\nRequestId:6c4db0c2-c002-0063-3bb8-b3a4b0000000\\\
+        nTime:2020-11-05T21:12:43.9296557Z\"}}}\r\n--changesetresponse_b9bb9df3-0cc8-4dc9-9d66-c0b0013c03fc--\r\
+        \n--batchresponse_4255292a-d297-43e5-8394-2b1ab1d3bb69--\r\n"
+    headers:
+      cache-control: no-cache
+      content-type: multipart/mixed; boundary=batchresponse_4255292a-d297-43e5-8394-2b1ab1d3bb69
+      date: Thu, 05 Nov 2020 21:12:43 GMT
+      server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-content-type-options: nosniff
+      x-ms-version: '2019-02-02'
+    status:
+      code: 202
+      message: Accepted
+    url: https://tablestestp5vjroapn77olh.table.core.windows.net/$batch
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: DELETE
+    uri: https://tablesteststorname.table.core.windows.net/Tables('uttablea3561789')
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control: no-cache
+      content-length: '0'
+      date: Thu, 05 Nov 2020 21:12:43 GMT
+      server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      x-content-type-options: nosniff
+      x-ms-version: '2019-02-02'
+    status:
+      code: 204
+      message: No Content
+    url: https://tablestestp5vjroapn77olh.table.core.windows.net/Tables('uttablea3561789')
+version: 1

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_async.test_new_invalid_key.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_async.test_new_invalid_key.yaml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: "--batch_84c24283-ea82-42d5-b175-4f189fe84b29\r\nContent-Type: multipart/mixed;\
+      \ boundary=changeset_a36040ec-1981-4fa5-9142-aacf0f6c3c1d\r\n\r\n--changeset_a36040ec-1981-4fa5-9142-aacf0f6c3c1d\r\
+      \nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID:\
+      \ 0\r\n\r\nPOST https://tablestestp5vjroapn77olh.table.core.windows.net/uttable81a3118b\
+      \ HTTP/1.1\r\nx-ms-version: 2019-02-02\r\nDataServiceVersion: 3.0\r\nPrefer:\
+      \ return-no-content\r\nContent-Type: application/json;odata=nometadata\r\nAccept:\
+      \ application/json;odata=minimalmetadata\r\nContent-Length: 576\r\nx-ms-date:\
+      \ Thu, 05 Nov 2020 21:12:43 GMT\r\nDate: Thu, 05 Nov 2020 21:12:43 GMT\r\nx-ms-client-request-id:\
+      \ a5275fc7-1fab-11eb-91de-58961df361d1\r\n\r\n{\"PartitionKey\": \"001\", \"\
+      PartitionKey@odata.type\": \"Edm.String\", \"RowKey\": \"batch_negative_1\"\
+      , \"RowKey@odata.type\": \"Edm.String\", \"age\": 39, \"sex\": \"male\", \"\
+      sex@odata.type\": \"Edm.String\", \"married\": true, \"deceased\": false, \"\
+      ratio\": 3.1, \"evenratio\": 3.0, \"large\": 933311100, \"Birthday\": \"1973-10-04T00:00:00Z\"\
+      , \"Birthday@odata.type\": \"Edm.DateTime\", \"birthday\": \"1970-10-04T00:00:00Z\"\
+      , \"birthday@odata.type\": \"Edm.DateTime\", \"binary\": \"YmluYXJ5\", \"binary@odata.type\"\
+      : \"Edm.Binary\", \"other\": 20, \"clsid\": \"c9da6455-213d-42c9-9a79-3e9149a57833\"\
+      , \"clsid@odata.type\": \"Edm.Guid\"}\r\n--changeset_a36040ec-1981-4fa5-9142-aacf0f6c3c1d--\r\
+      \n\r\n--batch_84c24283-ea82-42d5-b175-4f189fe84b29--\r\n"
+    headers:
+      Content-Length:
+      - '1376'
+      Content-Type:
+      - multipart/mixed; boundary=batch_84c24283-ea82-42d5-b175-4f189fe84b29
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      MaxDataServiceVersion:
+      - 3.0;NetFx
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablesteststorname.table.core.windows.net/$batch
+  response:
+    body:
+      string: '<?xml version="1.0" encoding="utf-8"?><m:error xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"><m:code>AuthenticationFailed</m:code><m:message
+        xml:lang="en-US">Server failed to authenticate the request. Make sure the
+        value of Authorization header is formed correctly including the signature.
+
+        RequestId:f457c1fd-2002-004b-21b8-b3d30f000000
+
+        Time:2020-11-05T21:12:44.2242912Z</m:message></m:error>'
+    headers:
+      content-length: '419'
+      content-type: application/xml
+      date: Thu, 05 Nov 2020 21:12:44 GMT
+      server: Microsoft-HTTPAPI/2.0
+      x-ms-error-code: AuthenticationFailed
+    status:
+      code: 403
+      message: Server failed to authenticate the request. Make sure the value of Authorization
+        header is formed correctly including the signature.
+    url: https://tablestestp5vjroapn77olh.table.core.windows.net/$batch
+version: 1

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_async.test_new_non_existent_table.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_async.test_new_non_existent_table.yaml
@@ -1,0 +1,130 @@
+interactions:
+- request:
+    body: '{"TableName": "uttable9581481"}'
+    headers:
+      Accept:
+      - application/json;odata=minimalmetadata
+      Content-Length:
+      - '31'
+      Content-Type:
+      - application/json;odata=nometadata
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablesteststorname.table.core.windows.net/Tables
+  response:
+    body:
+      string: '{"odata.metadata":"https://tablesteststorname.table.core.windows.net/$metadata#Tables/@Element","TableName":"uttable9581481"}'
+    headers:
+      cache-control: no-cache
+      content-type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8
+      date: Thu, 05 Nov 2020 21:12:44 GMT
+      location: https://tablesteststorname.table.core.windows.net/Tables('uttable9581481')
+      server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-content-type-options: nosniff
+      x-ms-version: '2019-02-02'
+    status:
+      code: 201
+      message: Created
+    url: https://tablestestp5vjroapn77olh.table.core.windows.net/Tables
+- request:
+    body: "--batch_5297cc44-47c9-4e51-b576-09993bc8a7df\r\nContent-Type: multipart/mixed;\
+      \ boundary=changeset_7f277740-11f2-40b2-b5ee-7ee0b32d342d\r\n\r\n--changeset_7f277740-11f2-40b2-b5ee-7ee0b32d342d\r\
+      \nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID:\
+      \ 0\r\n\r\nPOST https://tablestestp5vjroapn77olh.table.core.windows.net/doesntexist\
+      \ HTTP/1.1\r\nx-ms-version: 2019-02-02\r\nDataServiceVersion: 3.0\r\nPrefer:\
+      \ return-no-content\r\nContent-Type: application/json;odata=nometadata\r\nAccept:\
+      \ application/json;odata=minimalmetadata\r\nContent-Length: 576\r\nx-ms-date:\
+      \ Thu, 05 Nov 2020 21:12:43 GMT\r\nDate: Thu, 05 Nov 2020 21:12:43 GMT\r\nx-ms-client-request-id:\
+      \ a56912cc-1fab-11eb-84f4-58961df361d1\r\n\r\n{\"PartitionKey\": \"001\", \"\
+      PartitionKey@odata.type\": \"Edm.String\", \"RowKey\": \"batch_negative_1\"\
+      , \"RowKey@odata.type\": \"Edm.String\", \"age\": 39, \"sex\": \"male\", \"\
+      sex@odata.type\": \"Edm.String\", \"married\": true, \"deceased\": false, \"\
+      ratio\": 3.1, \"evenratio\": 3.0, \"large\": 933311100, \"Birthday\": \"1973-10-04T00:00:00Z\"\
+      , \"Birthday@odata.type\": \"Edm.DateTime\", \"birthday\": \"1970-10-04T00:00:00Z\"\
+      , \"birthday@odata.type\": \"Edm.DateTime\", \"binary\": \"YmluYXJ5\", \"binary@odata.type\"\
+      : \"Edm.Binary\", \"other\": 20, \"clsid\": \"c9da6455-213d-42c9-9a79-3e9149a57833\"\
+      , \"clsid@odata.type\": \"Edm.Guid\"}\r\n--changeset_7f277740-11f2-40b2-b5ee-7ee0b32d342d--\r\
+      \n\r\n--batch_5297cc44-47c9-4e51-b576-09993bc8a7df--\r\n"
+    headers:
+      Content-Length:
+      - '1372'
+      Content-Type:
+      - multipart/mixed; boundary=batch_5297cc44-47c9-4e51-b576-09993bc8a7df
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      MaxDataServiceVersion:
+      - 3.0;NetFx
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:12:43 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablesteststorname.table.core.windows.net/$batch
+  response:
+    body:
+      string: "--batchresponse_58b3289d-a9fb-4d18-a652-2c41427c66ef\r\nContent-Type:\
+        \ multipart/mixed; boundary=changesetresponse_51e6490e-7fa3-4cfa-80c0-0808f4df2228\r\
+        \n\r\n--changesetresponse_51e6490e-7fa3-4cfa-80c0-0808f4df2228\r\nContent-Type:\
+        \ application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 404\
+        \ Not Found\r\nX-Content-Type-Options: nosniff\r\nDataServiceVersion: 3.0;\r\
+        \nContent-Type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8\r\
+        \n\r\n{\"odata.error\":{\"code\":\"TableNotFound\",\"message\":{\"lang\":\"\
+        en-US\",\"value\":\"0:The table specified does not exist.\\nRequestId:bc5f7c9b-7002-001c-39b8-b33a82000000\\\
+        nTime:2020-11-05T21:12:44.4994407Z\"}}}\r\n--changesetresponse_51e6490e-7fa3-4cfa-80c0-0808f4df2228--\r\
+        \n--batchresponse_58b3289d-a9fb-4d18-a652-2c41427c66ef--\r\n"
+    headers:
+      cache-control: no-cache
+      content-type: multipart/mixed; boundary=batchresponse_58b3289d-a9fb-4d18-a652-2c41427c66ef
+      date: Thu, 05 Nov 2020 21:12:44 GMT
+      server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+      x-content-type-options: nosniff
+      x-ms-version: '2019-02-02'
+    status:
+      code: 202
+      message: Accepted
+    url: https://tablestestp5vjroapn77olh.table.core.windows.net/$batch
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Date:
+      - Thu, 05 Nov 2020 21:12:44 GMT
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:12:44 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: DELETE
+    uri: https://tablesteststorname.table.core.windows.net/Tables('uttable9581481')
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control: no-cache
+      content-length: '0'
+      date: Thu, 05 Nov 2020 21:12:44 GMT
+      server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0
+      x-content-type-options: nosniff
+      x-ms-version: '2019-02-02'
+    status:
+      code: 204
+      message: No Content
+    url: https://tablestestp5vjroapn77olh.table.core.windows.net/Tables('uttable9581481')
+version: 1

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_cosmos.test_new_delete_nonexistent_entity.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_cosmos.test_new_delete_nonexistent_entity.yaml
@@ -1,0 +1,138 @@
+interactions:
+- request:
+    body: '{"TableName": "uttablebce617ff"}'
+    headers:
+      Accept:
+      - application/json;odata=minimalmetadata
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json;odata=nometadata
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:25:57 GMT
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:25:57 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablestestcosmosname.table.cosmos.azure.com/Tables
+  response:
+    body:
+      string: '{"TableName":"uttablebce617ff","odata.metadata":"https://tablestestcosmosname.table.cosmos.azure.com/$metadata#Tables/@Element"}'
+    headers:
+      content-type:
+      - application/json;odata=minimalmetadata
+      date:
+      - Thu, 05 Nov 2020 21:25:59 GMT
+      etag:
+      - W/"datetime'2020-11-05T21%3A25%3A59.7266951Z'"
+      location:
+      - https://tablestestcosmosname.table.cosmos.azure.com/Tables('uttablebce617ff')
+      server:
+      - Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+    status:
+      code: 201
+      message: Ok
+- request:
+    body: "--batch_64b3d778-695b-4853-ac6b-b487983986c7\r\nContent-Type: multipart/mixed;\
+      \ boundary=changeset_4446305b-0ec0-4ba7-a651-e13da3eb7689\r\n\r\n--changeset_4446305b-0ec0-4ba7-a651-e13da3eb7689\r\
+      \nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID:\
+      \ 0\r\n\r\nDELETE https://tablestestt2hsc5iufdqzwi.table.cosmos.azure.com/uttablebce617ff(PartitionKey='001',RowKey='batch_negative_1')\
+      \ HTTP/1.1\r\nx-ms-version: 2019-02-02\r\nDataServiceVersion: 3.0\r\nIf-Match:\
+      \ *\r\nAccept: application/json;odata=minimalmetadata\r\nx-ms-date: Thu, 05\
+      \ Nov 2020 21:25:59 GMT\r\nDate: Thu, 05 Nov 2020 21:25:59 GMT\r\nx-ms-client-request-id:\
+      \ 7fa74c10-1fad-11eb-9c45-58961df361d1\r\n\r\n\r\n--changeset_4446305b-0ec0-4ba7-a651-e13da3eb7689--\r\
+      \n\r\n--batch_64b3d778-695b-4853-ac6b-b487983986c7--\r\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '764'
+      Content-Type:
+      - multipart/mixed; boundary=batch_64b3d778-695b-4853-ac6b-b487983986c7
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:25:59 GMT
+      MaxDataServiceVersion:
+      - 3.0;NetFx
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:25:59 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablestestcosmosname.table.cosmos.azure.com/$batch
+  response:
+    body:
+      string: "--batchresponse_43c4a36a-3417-4c0d-9ac3-0c2f3bae6e37\nContent-Type:\
+        \ multipart/mixed; boundary=changesetresponse_90ecd268-a4a1-41e9-90e5-21dcbb8fe02e\r\
+        \n\r\n--changesetresponse_90ecd268-a4a1-41e9-90e5-21dcbb8fe02e\nContent-Type:\
+        \ application/http\nContent-Transfer-Encoding: binary\n\nHTTP/1.1 404 Not\
+        \ Found\r\nContent-Type: application/json;odata=fullmetadata\r\n\r\n{\"odata.error\"\
+        :{\"code\":\"ResourceNotFound\",\"message\":{\"lang\":\"en-us\",\"value\"\
+        :\"0:The specified resource does not exist.\\n\\nRequestID:7fa7d21e-1fad-11eb-aeac-58961df361d1\\\
+        n\"}}}\r\n--changesetresponse_90ecd268-a4a1-41e9-90e5-21dcbb8fe02e--\n--batchresponse_43c4a36a-3417-4c0d-9ac3-0c2f3bae6e37--\r\
+        \n"
+    headers:
+      content-type:
+      - multipart/mixed; boundary=batchresponse_43c4a36a-3417-4c0d-9ac3-0c2f3bae6e37
+      date:
+      - Thu, 05 Nov 2020 21:26:00 GMT
+      server:
+      - Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 05 Nov 2020 21:25:59 GMT
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:25:59 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: DELETE
+    uri: https://tablestestcosmosname.table.cosmos.azure.com/Tables('uttablebce617ff')
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Thu, 05 Nov 2020 21:26:00 GMT
+      server:
+      - Microsoft-HTTPAPI/2.0
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_cosmos.test_new_non_existent_table.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_cosmos.test_new_non_existent_table.yaml
@@ -1,0 +1,147 @@
+interactions:
+- request:
+    body: '{"TableName": "uttable1fae14f7"}'
+    headers:
+      Accept:
+      - application/json;odata=minimalmetadata
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json;odata=nometadata
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:26:30 GMT
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:26:30 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablestestcosmosname.table.cosmos.azure.com/Tables
+  response:
+    body:
+      string: '{"TableName":"uttable1fae14f7","odata.metadata":"https://tablestestcosmosname.table.cosmos.azure.com/$metadata#Tables/@Element"}'
+    headers:
+      content-type:
+      - application/json;odata=minimalmetadata
+      date:
+      - Thu, 05 Nov 2020 21:26:31 GMT
+      etag:
+      - W/"datetime'2020-11-05T21%3A26%3A31.7976583Z'"
+      location:
+      - https://tablestestcosmosname.table.cosmos.azure.com/Tables('uttable1fae14f7')
+      server:
+      - Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+    status:
+      code: 201
+      message: Ok
+- request:
+    body: "--batch_4c955218-14c1-4e50-ba80-39cf89709e66\r\nContent-Type: multipart/mixed;\
+      \ boundary=changeset_5f6c60c3-a4f7-457d-8d8c-0dbd533f0521\r\n\r\n--changeset_5f6c60c3-a4f7-457d-8d8c-0dbd533f0521\r\
+      \nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID:\
+      \ 0\r\n\r\nPOST https://tablestestt2hsc5iufdqzwi.table.cosmos.azure.com/doesntexist\
+      \ HTTP/1.1\r\nx-ms-version: 2019-02-02\r\nDataServiceVersion: 3.0\r\nPrefer:\
+      \ return-no-content\r\nContent-Type: application/json;odata=nometadata\r\nAccept:\
+      \ application/json;odata=minimalmetadata\r\nContent-Length: 576\r\nx-ms-date:\
+      \ Thu, 05 Nov 2020 21:26:31 GMT\r\nDate: Thu, 05 Nov 2020 21:26:31 GMT\r\nx-ms-client-request-id:\
+      \ 92d349d4-1fad-11eb-b7b5-58961df361d1\r\n\r\n{\"PartitionKey\": \"001\", \"\
+      PartitionKey@odata.type\": \"Edm.String\", \"RowKey\": \"batch_negative_1\"\
+      , \"RowKey@odata.type\": \"Edm.String\", \"age\": 39, \"sex\": \"male\", \"\
+      sex@odata.type\": \"Edm.String\", \"married\": true, \"deceased\": false, \"\
+      ratio\": 3.1, \"evenratio\": 3.0, \"large\": 933311100, \"Birthday\": \"1973-10-04T00:00:00Z\"\
+      , \"Birthday@odata.type\": \"Edm.DateTime\", \"birthday\": \"1970-10-04T00:00:00Z\"\
+      , \"birthday@odata.type\": \"Edm.DateTime\", \"binary\": \"YmluYXJ5\", \"binary@odata.type\"\
+      : \"Edm.Binary\", \"other\": 20, \"clsid\": \"c9da6455-213d-42c9-9a79-3e9149a57833\"\
+      , \"clsid@odata.type\": \"Edm.Guid\"}\r\n--changeset_5f6c60c3-a4f7-457d-8d8c-0dbd533f0521--\r\
+      \n\r\n--batch_4c955218-14c1-4e50-ba80-39cf89709e66--\r\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1372'
+      Content-Type:
+      - multipart/mixed; boundary=batch_4c955218-14c1-4e50-ba80-39cf89709e66
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:26:31 GMT
+      MaxDataServiceVersion:
+      - 3.0;NetFx
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:26:31 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablestestcosmosname.table.cosmos.azure.com/$batch
+  response:
+    body:
+      string: "--batchresponse_ed1a0ed2-e207-4848-8f86-eda3516c1f99\nContent-Type:\
+        \ multipart/mixed; boundary=changesetresponse_f5bfe96e-8c64-4920-b494-133df85eb940\r\
+        \n\r\n--changesetresponse_f5bfe96e-8c64-4920-b494-133df85eb940\nContent-Type:\
+        \ application/http\nContent-Transfer-Encoding: binary\n\nHTTP/1.1 404 Not\
+        \ Found\r\nContent-Type: application/json;odata=fullmetadata\r\n\r\n{\"odata.error\"\
+        :{\"code\":\"ResourceNotFound\",\"message\":{\"lang\":\"en-us\",\"value\"\
+        :\"The specified resource does not exist.\\nRequestID:92d397ca-1fad-11eb-91cf-58961df361d1\\\
+        n\"}}}\r\n--changesetresponse_f5bfe96e-8c64-4920-b494-133df85eb940--\n--batchresponse_ed1a0ed2-e207-4848-8f86-eda3516c1f99--\r\
+        \n"
+    headers:
+      content-type:
+      - multipart/mixed; boundary=batchresponse_ed1a0ed2-e207-4848-8f86-eda3516c1f99
+      date:
+      - Thu, 05 Nov 2020 21:26:31 GMT
+      server:
+      - Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 05 Nov 2020 21:26:32 GMT
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:26:32 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: DELETE
+    uri: https://tablestestcosmosname.table.cosmos.azure.com/Tables('uttable1fae14f7')
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Thu, 05 Nov 2020 21:26:32 GMT
+      server:
+      - Microsoft-HTTPAPI/2.0
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_cosmos_async.test_batch_same_row_operations_fail.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_cosmos_async.test_batch_same_row_operations_fail.yaml
@@ -1,13 +1,9 @@
 interactions:
 - request:
-    body: '{"TableName": "uttabled25f1825"}'
+    body: '{"TableName": "uttable6d7f1aa2"}'
     headers:
       Accept:
       - application/json;odata=minimalmetadata
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
       Content-Length:
       - '32'
       Content-Type:
@@ -15,34 +11,29 @@ interactions:
       DataServiceVersion:
       - '3.0'
       Date:
-      - Wed, 04 Nov 2020 22:48:03 GMT
+      - Wed, 04 Nov 2020 23:03:16 GMT
       User-Agent:
       - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 04 Nov 2020 22:48:03 GMT
+      - Wed, 04 Nov 2020 23:03:16 GMT
       x-ms-version:
       - '2019-02-02'
     method: POST
     uri: https://tablestestcosmosname.table.cosmos.azure.com/Tables
   response:
     body:
-      string: '{"TableName":"uttabled25f1825","odata.metadata":"https://tablestestcosmosname.table.cosmos.azure.com/$metadata#Tables/@Element"}'
+      string: '{"TableName":"uttable6d7f1aa2","odata.metadata":"https://tablestestcosmosname.table.cosmos.azure.com/$metadata#Tables/@Element"}'
     headers:
-      content-type:
-      - application/json;odata=minimalmetadata
-      date:
-      - Wed, 04 Nov 2020 22:48:05 GMT
-      etag:
-      - W/"datetime'2020-11-04T22%3A48%3A05.2853767Z'"
-      location:
-      - https://tablestestcosmosname.table.cosmos.azure.com/Tables('uttabled25f1825')
-      server:
-      - Microsoft-HTTPAPI/2.0
-      transfer-encoding:
-      - chunked
+      content-type: application/json;odata=minimalmetadata
+      date: Wed, 04 Nov 2020 23:03:17 GMT
+      etag: W/"datetime'2020-11-04T23%3A03%3A18.3070215Z'"
+      location: https://tablestestcosmosname.table.cosmos.azure.com/Tables('uttable6d7f1aa2')
+      server: Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
     status:
       code: 201
       message: Ok
+    url: https://tablestestdjj5popn4sn4h6.table.cosmos.azure.com/Tables
 - request:
     body: '{"PartitionKey": "001", "PartitionKey@odata.type": "Edm.String", "RowKey":
       "batch_negative_1", "RowKey@odata.type": "Edm.String", "age": 39, "sex": "male",
@@ -54,10 +45,6 @@ interactions:
     headers:
       Accept:
       - application/json;odata=minimalmetadata
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
       Content-Length:
       - '576'
       Content-Type:
@@ -65,55 +52,50 @@ interactions:
       DataServiceVersion:
       - '3.0'
       Date:
-      - Wed, 04 Nov 2020 22:48:05 GMT
+      - Wed, 04 Nov 2020 23:03:18 GMT
       User-Agent:
       - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 04 Nov 2020 22:48:05 GMT
+      - Wed, 04 Nov 2020 23:03:18 GMT
       x-ms-version:
       - '2019-02-02'
     method: POST
-    uri: https://tablestestcosmosname.table.cosmos.azure.com/uttabled25f1825
+    uri: https://tablestestcosmosname.table.cosmos.azure.com/uttable6d7f1aa2
   response:
     body:
-      string: '{"odata.metadata":"https://tablestestcosmosname.table.cosmos.azure.com/uttabled25f1825/$metadata#uttabled25f1825/@Element","odata.etag":"W/\"datetime''2020-11-04T22%3A48%3A05.8091527Z''\"","PartitionKey":"001","RowKey":"batch_negative_1","age":39,"sex":"male","married":true,"deceased":false,"ratio":3.1,"evenratio":3.0,"large":933311100,"Birthday@odata.type":"Edm.DateTime","Birthday":"1973-10-04T00:00:00.0000000Z","birthday@odata.type":"Edm.DateTime","birthday":"1970-10-04T00:00:00.0000000Z","binary@odata.type":"Edm.Binary","binary":"YmluYXJ5","other":20,"clsid@odata.type":"Edm.Guid","clsid":"c9da6455-213d-42c9-9a79-3e9149a57833","Timestamp":"2020-11-04T22:48:05.8091527Z"}'
+      string: '{"odata.metadata":"https://tablestestcosmosname.table.cosmos.azure.com/uttable6d7f1aa2/$metadata#uttable6d7f1aa2/@Element","odata.etag":"W/\"datetime''2020-11-04T23%3A03%3A18.8796423Z''\"","PartitionKey":"001","RowKey":"batch_negative_1","age":39,"sex":"male","married":true,"deceased":false,"ratio":3.1,"evenratio":3.0,"large":933311100,"Birthday@odata.type":"Edm.DateTime","Birthday":"1973-10-04T00:00:00.0000000Z","birthday@odata.type":"Edm.DateTime","birthday":"1970-10-04T00:00:00.0000000Z","binary@odata.type":"Edm.Binary","binary":"YmluYXJ5","other":20,"clsid@odata.type":"Edm.Guid","clsid":"c9da6455-213d-42c9-9a79-3e9149a57833","Timestamp":"2020-11-04T23:03:18.8796423Z"}'
     headers:
-      content-type:
-      - application/json;odata=minimalmetadata
-      date:
-      - Wed, 04 Nov 2020 22:48:05 GMT
-      etag:
-      - W/"datetime'2020-11-04T22%3A48%3A05.8091527Z'"
-      location:
-      - https://tablestestcosmosname.table.cosmos.azure.com/uttabled25f1825(PartitionKey='001',RowKey='batch_negative_1')
-      server:
-      - Microsoft-HTTPAPI/2.0
-      transfer-encoding:
-      - chunked
+      content-type: application/json;odata=minimalmetadata
+      date: Wed, 04 Nov 2020 23:03:18 GMT
+      etag: W/"datetime'2020-11-04T23%3A03%3A18.8796423Z'"
+      location: https://tablestestcosmosname.table.cosmos.azure.com/uttable6d7f1aa2(PartitionKey='001',RowKey='batch_negative_1')
+      server: Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
     status:
       code: 201
       message: Created
+    url: https://tablestestdjj5popn4sn4h6.table.cosmos.azure.com/uttable6d7f1aa2
 - request:
-    body: "--batch_89ae5a58-bc92-4bf7-8b8e-193ed27124f4\r\nContent-Type: multipart/mixed;\
-      \ boundary=changeset_f63b54da-d816-4930-ae28-13e390238182\r\n\r\n--changeset_f63b54da-d816-4930-ae28-13e390238182\r\
+    body: "--batch_c1bfeb02-d917-489f-9a74-e0b9a3fe951b\r\nContent-Type: multipart/mixed;\
+      \ boundary=changeset_dab26637-82a3-4433-88ed-0f46c0755602\r\n\r\n--changeset_dab26637-82a3-4433-88ed-0f46c0755602\r\
       \nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID:\
-      \ 0\r\n\r\nPATCH https://tablestestv42zogdboclgsg.table.cosmos.azure.com/uttabled25f1825(PartitionKey='001',RowKey='batch_negative_1')\
+      \ 0\r\n\r\nPATCH https://tablestestdjj5popn4sn4h6.table.cosmos.azure.com/uttable6d7f1aa2(PartitionKey='001',RowKey='batch_negative_1')\
       \ HTTP/1.1\r\nx-ms-version: 2019-02-02\r\nDataServiceVersion: 3.0\r\nIf-Match:\
       \ *\r\nContent-Type: application/json\r\nAccept: application/json\r\nContent-Length:\
-      \ 352\r\nx-ms-date: Wed, 04 Nov 2020 22:48:05 GMT\r\nDate: Wed, 04 Nov 2020\
-      \ 22:48:05 GMT\r\nx-ms-client-request-id: cd5bbacb-1eef-11eb-a876-58961df361d1\r\
+      \ 352\r\nx-ms-date: Wed, 04 Nov 2020 23:03:18 GMT\r\nDate: Wed, 04 Nov 2020\
+      \ 23:03:18 GMT\r\nx-ms-client-request-id: ed953868-1ef1-11eb-9b4c-58961df361d1\r\
       \n\r\n{\"PartitionKey\": \"001\", \"PartitionKey@odata.type\": \"Edm.String\"\
       , \"RowKey\": \"batch_negative_1\", \"RowKey@odata.type\": \"Edm.String\", \"\
       age\": \"abc\", \"age@odata.type\": \"Edm.String\", \"sex\": \"female\", \"\
       sex@odata.type\": \"Edm.String\", \"sign\": \"aquarius\", \"sign@odata.type\"\
       : \"Edm.String\", \"birthday\": \"1991-10-04T00:00:00Z\", \"birthday@odata.type\"\
-      : \"Edm.DateTime\"}\r\n--changeset_f63b54da-d816-4930-ae28-13e390238182\r\n\
+      : \"Edm.DateTime\"}\r\n--changeset_dab26637-82a3-4433-88ed-0f46c0755602\r\n\
       Content-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID:\
-      \ 1\r\n\r\nPATCH https://tablestestv42zogdboclgsg.table.cosmos.azure.com/uttabled25f1825(PartitionKey='001',RowKey='batch_negative_1')\
+      \ 1\r\n\r\nPATCH https://tablestestdjj5popn4sn4h6.table.cosmos.azure.com/uttable6d7f1aa2(PartitionKey='001',RowKey='batch_negative_1')\
       \ HTTP/1.1\r\nx-ms-version: 2019-02-02\r\nDataServiceVersion: 3.0\r\nIf-Match:\
       \ *\r\nContent-Type: application/json\r\nAccept: application/json\r\nContent-Length:\
-      \ 576\r\nx-ms-date: Wed, 04 Nov 2020 22:48:05 GMT\r\nDate: Wed, 04 Nov 2020\
-      \ 22:48:05 GMT\r\nx-ms-client-request-id: cd5bbacc-1eef-11eb-b676-58961df361d1\r\
+      \ 576\r\nx-ms-date: Wed, 04 Nov 2020 23:03:18 GMT\r\nDate: Wed, 04 Nov 2020\
+      \ 23:03:18 GMT\r\nx-ms-client-request-id: ed953869-1ef1-11eb-a944-58961df361d1\r\
       \n\r\n{\"PartitionKey\": \"001\", \"PartitionKey@odata.type\": \"Edm.String\"\
       , \"RowKey\": \"batch_negative_1\", \"RowKey@odata.type\": \"Edm.String\", \"\
       age\": 39, \"sex\": \"male\", \"sex@odata.type\": \"Edm.String\", \"married\"\
@@ -122,29 +104,23 @@ interactions:
       : \"Edm.DateTime\", \"birthday\": \"1970-10-04T00:00:00Z\", \"birthday@odata.type\"\
       : \"Edm.DateTime\", \"binary\": \"YmluYXJ5\", \"binary@odata.type\": \"Edm.Binary\"\
       , \"other\": 20, \"clsid\": \"c9da6455-213d-42c9-9a79-3e9149a57833\", \"clsid@odata.type\"\
-      : \"Edm.Guid\"}\r\n--changeset_f63b54da-d816-4930-ae28-13e390238182--\r\n\r\n\
-      --batch_89ae5a58-bc92-4bf7-8b8e-193ed27124f4--\r\n"
+      : \"Edm.Guid\"}\r\n--changeset_dab26637-82a3-4433-88ed-0f46c0755602--\r\n\r\n\
+      --batch_c1bfeb02-d917-489f-9a74-e0b9a3fe951b--\r\n"
     headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
       Content-Length:
       - '2278'
       Content-Type:
-      - multipart/mixed; boundary=batch_89ae5a58-bc92-4bf7-8b8e-193ed27124f4
+      - multipart/mixed; boundary=batch_c1bfeb02-d917-489f-9a74-e0b9a3fe951b
       DataServiceVersion:
       - '3.0'
       Date:
-      - Wed, 04 Nov 2020 22:48:05 GMT
+      - Wed, 04 Nov 2020 23:03:18 GMT
       MaxDataServiceVersion:
       - 3.0;NetFx
       User-Agent:
       - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 04 Nov 2020 22:48:05 GMT
+      - Wed, 04 Nov 2020 23:03:18 GMT
       x-ms-version:
       - '2019-02-02'
     method: POST
@@ -152,53 +128,42 @@ interactions:
   response:
     body:
       string: "{\"odata.error\":{\"code\":\"InvalidInput\",\"message\":{\"lang\":\"\
-        en-us\",\"value\":\"One of the input values is invalid.\\r\\nActivityId: cd5c08a8-1eef-11eb-a670-58961df361d1,\
+        en-us\",\"value\":\"One of the input values is invalid.\\r\\nActivityId: ed982b91-1ef1-11eb-bc13-58961df361d1,\
         \ documentdb-dotnet-sdk/2.11.0 Host/64-bit MicrosoftWindowsNT/6.2.9200.0\\\
-        nRequestID:cd5c08a8-1eef-11eb-a670-58961df361d1\\n\"}}}\r\n"
+        nRequestID:ed982b91-1ef1-11eb-bc13-58961df361d1\\n\"}}}\r\n"
     headers:
-      content-type:
-      - application/json;odata=fullmetadata
-      date:
-      - Wed, 04 Nov 2020 22:48:05 GMT
-      server:
-      - Microsoft-HTTPAPI/2.0
-      transfer-encoding:
-      - chunked
+      content-type: application/json;odata=fullmetadata
+      date: Wed, 04 Nov 2020 23:03:18 GMT
+      server: Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
     status:
       code: 400
       message: Bad Request
+    url: https://tablestestdjj5popn4sn4h6.table.cosmos.azure.com/$batch
 - request:
     body: null
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
       Date:
-      - Wed, 04 Nov 2020 22:48:05 GMT
+      - Wed, 04 Nov 2020 23:03:18 GMT
       User-Agent:
       - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 04 Nov 2020 22:48:05 GMT
+      - Wed, 04 Nov 2020 23:03:18 GMT
       x-ms-version:
       - '2019-02-02'
     method: DELETE
-    uri: https://tablestestcosmosname.table.cosmos.azure.com/Tables('uttabled25f1825')
+    uri: https://tablestestcosmosname.table.cosmos.azure.com/Tables('uttable6d7f1aa2')
   response:
     body:
       string: ''
     headers:
-      content-length:
-      - '0'
-      date:
-      - Wed, 04 Nov 2020 22:48:05 GMT
-      server:
-      - Microsoft-HTTPAPI/2.0
+      content-length: '0'
+      date: Wed, 04 Nov 2020 23:03:18 GMT
+      server: Microsoft-HTTPAPI/2.0
     status:
       code: 204
       message: No Content
+    url: https://tablestestdjj5popn4sn4h6.table.cosmos.azure.com/Tables('uttable6d7f1aa2')
 version: 1

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_cosmos_async.test_new_delete_nonexistent_entity.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_cosmos_async.test_new_delete_nonexistent_entity.yaml
@@ -1,0 +1,112 @@
+interactions:
+- request:
+    body: '{"TableName": "uttable55891a7c"}'
+    headers:
+      Accept:
+      - application/json;odata=minimalmetadata
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json;odata=nometadata
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:27:02 GMT
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:27:02 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablestestcosmosname.table.cosmos.azure.com/Tables
+  response:
+    body:
+      string: '{"TableName":"uttable55891a7c","odata.metadata":"https://tablestestcosmosname.table.cosmos.azure.com/$metadata#Tables/@Element"}'
+    headers:
+      content-type: application/json;odata=minimalmetadata
+      date: Thu, 05 Nov 2020 21:27:03 GMT
+      etag: W/"datetime'2020-11-05T21%3A27%3A03.8705671Z'"
+      location: https://tablestestcosmosname.table.cosmos.azure.com/Tables('uttable55891a7c')
+      server: Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+    status:
+      code: 201
+      message: Ok
+    url: https://tablestestt2hsc5iufdqzwi.table.cosmos.azure.com/Tables
+- request:
+    body: "--batch_55a7eae8-7eb8-4c4d-bfa4-5127b4fe4ce8\r\nContent-Type: multipart/mixed;\
+      \ boundary=changeset_53193b2f-f6ed-4024-9ae1-c9326a184d62\r\n\r\n--changeset_53193b2f-f6ed-4024-9ae1-c9326a184d62\r\
+      \nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID:\
+      \ 0\r\n\r\nDELETE https://tablestestt2hsc5iufdqzwi.table.cosmos.azure.com/uttable55891a7c(PartitionKey='001',RowKey='batch_negative_1')\
+      \ HTTP/1.1\r\nx-ms-version: 2019-02-02\r\nDataServiceVersion: 3.0\r\nIf-Match:\
+      \ *\r\nAccept: application/json;odata=minimalmetadata\r\nx-ms-date: Thu, 05\
+      \ Nov 2020 21:27:03 GMT\r\nDate: Thu, 05 Nov 2020 21:27:03 GMT\r\nx-ms-client-request-id:\
+      \ a5e7b57c-1fad-11eb-b53a-58961df361d1\r\n\r\n\r\n--changeset_53193b2f-f6ed-4024-9ae1-c9326a184d62--\r\
+      \n\r\n--batch_55a7eae8-7eb8-4c4d-bfa4-5127b4fe4ce8--\r\n"
+    headers:
+      Content-Length:
+      - '764'
+      Content-Type:
+      - multipart/mixed; boundary=batch_55a7eae8-7eb8-4c4d-bfa4-5127b4fe4ce8
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:27:03 GMT
+      MaxDataServiceVersion:
+      - 3.0;NetFx
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:27:03 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablestestcosmosname.table.cosmos.azure.com/$batch
+  response:
+    body:
+      string: "--batchresponse_ee48484b-0d75-4f22-be58-b124ebb2e851\nContent-Type:\
+        \ multipart/mixed; boundary=changesetresponse_e122c444-1c60-4362-8749-09efe7ba226a\r\
+        \n\r\n--changesetresponse_e122c444-1c60-4362-8749-09efe7ba226a\nContent-Type:\
+        \ application/http\nContent-Transfer-Encoding: binary\n\nHTTP/1.1 404 Not\
+        \ Found\r\nContent-Type: application/json;odata=fullmetadata\r\n\r\n{\"odata.error\"\
+        :{\"code\":\"ResourceNotFound\",\"message\":{\"lang\":\"en-us\",\"value\"\
+        :\"0:The specified resource does not exist.\\n\\nRequestID:a5e8c50f-1fad-11eb-a461-58961df361d1\\\
+        n\"}}}\r\n--changesetresponse_e122c444-1c60-4362-8749-09efe7ba226a--\n--batchresponse_ee48484b-0d75-4f22-be58-b124ebb2e851--\r\
+        \n"
+    headers:
+      content-type: multipart/mixed; boundary=batchresponse_ee48484b-0d75-4f22-be58-b124ebb2e851
+      date: Thu, 05 Nov 2020 21:27:03 GMT
+      server: Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+    status:
+      code: 202
+      message: Accepted
+    url: https://tablestestt2hsc5iufdqzwi.table.cosmos.azure.com/$batch
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Date:
+      - Thu, 05 Nov 2020 21:27:03 GMT
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:27:03 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: DELETE
+    uri: https://tablestestcosmosname.table.cosmos.azure.com/Tables('uttable55891a7c')
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Thu, 05 Nov 2020 21:27:03 GMT
+      server: Microsoft-HTTPAPI/2.0
+    status:
+      code: 204
+      message: No Content
+    url: https://tablestestt2hsc5iufdqzwi.table.cosmos.azure.com/Tables('uttable55891a7c')
+version: 1

--- a/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_cosmos_async.test_new_non_existent_table.yaml
+++ b/sdk/tables/azure-data-tables/tests/recordings/test_table_batch_cosmos_async.test_new_non_existent_table.yaml
@@ -1,0 +1,121 @@
+interactions:
+- request:
+    body: '{"TableName": "uttablea6d71774"}'
+    headers:
+      Accept:
+      - application/json;odata=minimalmetadata
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json;odata=nometadata
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:27:34 GMT
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:27:34 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablestestcosmosname.table.cosmos.azure.com/Tables
+  response:
+    body:
+      string: '{"TableName":"uttablea6d71774","odata.metadata":"https://tablestestcosmosname.table.cosmos.azure.com/$metadata#Tables/@Element"}'
+    headers:
+      content-type: application/json;odata=minimalmetadata
+      date: Thu, 05 Nov 2020 21:27:35 GMT
+      etag: W/"datetime'2020-11-05T21%3A27%3A35.7130759Z'"
+      location: https://tablestestcosmosname.table.cosmos.azure.com/Tables('uttablea6d71774')
+      server: Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+    status:
+      code: 201
+      message: Ok
+    url: https://tablestestt2hsc5iufdqzwi.table.cosmos.azure.com/Tables
+- request:
+    body: "--batch_45162934-2811-40b2-87ae-1ab3f6513fc2\r\nContent-Type: multipart/mixed;\
+      \ boundary=changeset_04463ea8-3861-4cea-80b2-11287092f096\r\n\r\n--changeset_04463ea8-3861-4cea-80b2-11287092f096\r\
+      \nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID:\
+      \ 0\r\n\r\nPOST https://tablestestt2hsc5iufdqzwi.table.cosmos.azure.com/doesntexist\
+      \ HTTP/1.1\r\nx-ms-version: 2019-02-02\r\nDataServiceVersion: 3.0\r\nPrefer:\
+      \ return-no-content\r\nContent-Type: application/json;odata=nometadata\r\nAccept:\
+      \ application/json;odata=minimalmetadata\r\nContent-Length: 576\r\nx-ms-date:\
+      \ Thu, 05 Nov 2020 21:27:35 GMT\r\nDate: Thu, 05 Nov 2020 21:27:35 GMT\r\nx-ms-client-request-id:\
+      \ b8e82421-1fad-11eb-a297-58961df361d1\r\n\r\n{\"PartitionKey\": \"001\", \"\
+      PartitionKey@odata.type\": \"Edm.String\", \"RowKey\": \"batch_negative_1\"\
+      , \"RowKey@odata.type\": \"Edm.String\", \"age\": 39, \"sex\": \"male\", \"\
+      sex@odata.type\": \"Edm.String\", \"married\": true, \"deceased\": false, \"\
+      ratio\": 3.1, \"evenratio\": 3.0, \"large\": 933311100, \"Birthday\": \"1973-10-04T00:00:00Z\"\
+      , \"Birthday@odata.type\": \"Edm.DateTime\", \"birthday\": \"1970-10-04T00:00:00Z\"\
+      , \"birthday@odata.type\": \"Edm.DateTime\", \"binary\": \"YmluYXJ5\", \"binary@odata.type\"\
+      : \"Edm.Binary\", \"other\": 20, \"clsid\": \"c9da6455-213d-42c9-9a79-3e9149a57833\"\
+      , \"clsid@odata.type\": \"Edm.Guid\"}\r\n--changeset_04463ea8-3861-4cea-80b2-11287092f096--\r\
+      \n\r\n--batch_45162934-2811-40b2-87ae-1ab3f6513fc2--\r\n"
+    headers:
+      Content-Length:
+      - '1372'
+      Content-Type:
+      - multipart/mixed; boundary=batch_45162934-2811-40b2-87ae-1ab3f6513fc2
+      DataServiceVersion:
+      - '3.0'
+      Date:
+      - Thu, 05 Nov 2020 21:27:35 GMT
+      MaxDataServiceVersion:
+      - 3.0;NetFx
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:27:35 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: POST
+    uri: https://tablestestcosmosname.table.cosmos.azure.com/$batch
+  response:
+    body:
+      string: "--batchresponse_1d81d405-9c9d-40ac-88f2-c17337f0077c\nContent-Type:\
+        \ multipart/mixed; boundary=changesetresponse_d5db6fb9-887a-4b8d-bea5-5a606b10e690\r\
+        \n\r\n--changesetresponse_d5db6fb9-887a-4b8d-bea5-5a606b10e690\nContent-Type:\
+        \ application/http\nContent-Transfer-Encoding: binary\n\nHTTP/1.1 404 Not\
+        \ Found\r\nContent-Type: application/json;odata=fullmetadata\r\n\r\n{\"odata.error\"\
+        :{\"code\":\"ResourceNotFound\",\"message\":{\"lang\":\"en-us\",\"value\"\
+        :\"The specified resource does not exist.\\nRequestID:b8e87259-1fad-11eb-bb93-58961df361d1\\\
+        n\"}}}\r\n--changesetresponse_d5db6fb9-887a-4b8d-bea5-5a606b10e690--\n--batchresponse_1d81d405-9c9d-40ac-88f2-c17337f0077c--\r\
+        \n"
+    headers:
+      content-type: multipart/mixed; boundary=batchresponse_1d81d405-9c9d-40ac-88f2-c17337f0077c
+      date: Thu, 05 Nov 2020 21:27:35 GMT
+      server: Microsoft-HTTPAPI/2.0
+      transfer-encoding: chunked
+    status:
+      code: 202
+      message: Accepted
+    url: https://tablestestt2hsc5iufdqzwi.table.cosmos.azure.com/$batch
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Date:
+      - Thu, 05 Nov 2020 21:27:35 GMT
+      User-Agent:
+      - azsdk-python-data-tables/12.0.0b3 Python/3.9.0rc1 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Thu, 05 Nov 2020 21:27:35 GMT
+      x-ms-version:
+      - '2019-02-02'
+    method: DELETE
+    uri: https://tablestestcosmosname.table.cosmos.azure.com/Tables('uttablea6d71774')
+  response:
+    body:
+      string: ''
+    headers:
+      content-length: '0'
+      date: Thu, 05 Nov 2020 21:27:36 GMT
+      server: Microsoft-HTTPAPI/2.0
+    status:
+      code: 204
+      message: No Content
+    url: https://tablestestt2hsc5iufdqzwi.table.cosmos.azure.com/Tables('uttablea6d71774')
+version: 1

--- a/sdk/tables/azure-data-tables/tests/test_table_batch.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch.py
@@ -764,6 +764,7 @@ class StorageTableBatchTest(TableTestCase):
                 '001', 'batch_negative_1')
             batch.update_entity(entity, mode=UpdateMode.MERGE)
             # Assert
+            
             with pytest.raises(BatchErrorException):
                 self.table.send_batch(batch)
 

--- a/sdk/tables/azure-data-tables/tests/test_table_batch.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch.py
@@ -18,7 +18,8 @@ from azure.core import MatchConditions
 from azure.core.exceptions import (
     ResourceExistsError,
     ResourceNotFoundError,
-    HttpResponseError
+    HttpResponseError,
+    ClientAuthenticationError
 )
 from azure.data.tables import EdmType, TableEntity, EntityProperty, UpdateMode, BatchTransactionResult
 
@@ -764,7 +765,7 @@ class StorageTableBatchTest(TableTestCase):
                 '001', 'batch_negative_1')
             batch.update_entity(entity, mode=UpdateMode.MERGE)
             # Assert
-            
+
             with pytest.raises(BatchErrorException):
                 self.table.send_batch(batch)
 
@@ -835,6 +836,62 @@ class StorageTableBatchTest(TableTestCase):
                 batch.create_entity(entity2)
 
             # Assert
+        finally:
+            self._tear_down()
+
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
+    @CachedResourceGroupPreparer(name_prefix="tablestest")
+    @CachedStorageAccountPreparer(name_prefix="tablestest")
+    def test_new_non_existent_table(self, resource_group, location, storage_account, storage_account_key):
+        # Arrange
+        self._set_up(storage_account, storage_account_key)
+        try:
+            entity = self._create_random_entity_dict('001', 'batch_negative_1')
+
+            tc = self.ts.get_table_client("doesntexist")
+
+            batch = tc.create_batch()
+            batch.create_entity(entity)
+
+            with pytest.raises(ResourceNotFoundError):
+                resp = tc.send_batch(batch)
+            # Assert
+        finally:
+            self._tear_down()
+
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
+    @CachedResourceGroupPreparer(name_prefix="tablestest")
+    @CachedStorageAccountPreparer(name_prefix="tablestest")
+    def test_new_invalid_key(self, resource_group, location, storage_account, storage_account_key):
+        # Arrange
+        invalid_key = storage_account_key[0:-6] + "==" # cut off a bit from the end to invalidate
+        self.ts = TableServiceClient(self.account_url(storage_account, "table"), invalid_key)
+        self.table_name = self.get_resource_name('uttable')
+        self.table = self.ts.get_table_client(self.table_name)
+
+        entity = self._create_random_entity_dict('001', 'batch_negative_1')
+
+        batch = self.table.create_batch()
+        batch.create_entity(entity)
+
+        with pytest.raises(ClientAuthenticationError):
+            resp = self.table.send_batch(batch)
+
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
+    @CachedResourceGroupPreparer(name_prefix="tablestest")
+    @CachedStorageAccountPreparer(name_prefix="tablestest")
+    def test_new_delete_nonexistent_entity(self, resource_group, location, storage_account, storage_account_key):
+        # Arrange
+        self._set_up(storage_account, storage_account_key)
+        try:
+            entity = self._create_random_entity_dict('001', 'batch_negative_1')
+
+            batch = self.table.create_batch()
+            batch.delete_entity(entity['PartitionKey'], entity['RowKey'])
+
+            with pytest.raises(ResourceNotFoundError):
+                resp = self.table.send_batch(batch)
+
         finally:
             self._tear_down()
 

--- a/sdk/tables/azure-data-tables/tests/test_table_batch_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch_async.py
@@ -688,7 +688,7 @@ class StorageTableBatchTest(TableTestCase):
         finally:
             await self._tear_down()
 
-    @pytest.mark.skip("This does not throw an error, but it should")
+    # @pytest.mark.skip("This does not throw an error, but it should")
     @CachedResourceGroupPreparer(name_prefix="tablestest")
     @CachedStorageAccountPreparer(name_prefix="tablestest")
     async def test_batch_same_row_operations_fail(self, resource_group, location, storage_account, storage_account_key):
@@ -706,10 +706,11 @@ class StorageTableBatchTest(TableTestCase):
             batch.update_entity(entity)
             entity = self._create_random_entity_dict(
                 '001', 'batch_negative_1')
+            batch.update_entity(entity)
 
             # Assert
-            with self.assertRaises(HttpResponseError):
-                batch.update_entity(entity, mode=UpdateMode.MERGE)
+            with pytest.raises(BatchErrorException):
+                await self.table.send_batch(batch)
         finally:
             await self._tear_down()
 

--- a/sdk/tables/azure-data-tables/tests/test_table_batch_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch_async.py
@@ -18,7 +18,8 @@ from azure.core import MatchConditions
 from azure.core.exceptions import (
     ResourceExistsError,
     ResourceNotFoundError,
-    HttpResponseError
+    HttpResponseError,
+    ClientAuthenticationError
 )
 from azure.data.tables.aio import TableServiceClient
 from azure.data.tables._models import BatchErrorException
@@ -762,6 +763,69 @@ class StorageTableBatchTest(TableTestCase):
             # Assert
         finally:
             await self._tear_down()
+
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
+    @CachedResourceGroupPreparer(name_prefix="tablestest")
+    @CachedStorageAccountPreparer(name_prefix="tablestest")
+    async def test_new_non_existent_table(self, resource_group, location, storage_account, storage_account_key):
+        # Arrange
+        await self._set_up(storage_account, storage_account_key)
+        try:
+            entity = self._create_random_entity_dict('001', 'batch_negative_1')
+
+            tc = self.ts.get_table_client("doesntexist")
+
+            batch = tc.create_batch()
+            batch.create_entity(entity)
+
+            with pytest.raises(ResourceNotFoundError):
+                resp = await tc.send_batch(batch)
+            # Assert
+        finally:
+            await self._tear_down()
+
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
+    @CachedResourceGroupPreparer(name_prefix="tablestest")
+    @CachedStorageAccountPreparer(name_prefix="tablestest")
+    async def test_new_invalid_key(self, resource_group, location, storage_account, storage_account_key):
+        # Arrange
+        invalid_key = storage_account_key[0:-6] + "==" # cut off a bit from the end to invalidate
+        key_list = list(storage_account_key)
+
+        key_list[-6:] = list("0000==")
+        invalid_key = ''.join(key_list)
+
+        self.ts = TableServiceClient(self.account_url(storage_account, "table"), invalid_key)
+        self.table_name = self.get_resource_name('uttable')
+        self.table = self.ts.get_table_client(self.table_name)
+
+        entity = self._create_random_entity_dict('001', 'batch_negative_1')
+
+        batch = self.table.create_batch()
+        batch.create_entity(entity)
+
+        with pytest.raises(ClientAuthenticationError):
+            resp = await self.table.send_batch(batch)
+
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
+    @CachedResourceGroupPreparer(name_prefix="tablestest")
+    @CachedStorageAccountPreparer(name_prefix="tablestest")
+    async def test_new_delete_nonexistent_entity(self, resource_group, location, storage_account, storage_account_key):
+        # Arrange
+        await self._set_up(storage_account, storage_account_key)
+        try:
+            entity = self._create_random_entity_dict('001', 'batch_negative_1')
+
+            batch = self.table.create_batch()
+            batch.delete_entity(entity['PartitionKey'], entity['RowKey'])
+
+            with pytest.raises(ResourceNotFoundError):
+                resp = await self.table.send_batch(batch)
+
+        finally:
+            await self._tear_down()
+
+
 
 #------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/sdk/tables/azure-data-tables/tests/test_table_batch_cosmos.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch_cosmos.py
@@ -18,7 +18,8 @@ from azure.core import MatchConditions
 from azure.core.exceptions import (
     ResourceExistsError,
     ResourceNotFoundError,
-    HttpResponseError
+    HttpResponseError,
+    ClientAuthenticationError
 )
 from azure.data.tables import EdmType, TableEntity, EntityProperty, UpdateMode, BatchTransactionResult
 
@@ -691,6 +692,69 @@ class StorageTableClientTest(TableTestCase):
             # Assert
         finally:
             self._tear_down()
+
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
+    @CachedResourceGroupPreparer(name_prefix="tablestest")
+    @CachedCosmosAccountPreparer(name_prefix="tablestest")
+    def test_new_non_existent_table(self, resource_group, location, cosmos_account, cosmos_account_key):
+        # Arrange
+        self._set_up(cosmos_account, cosmos_account_key)
+        try:
+            entity = self._create_random_entity_dict('001', 'batch_negative_1')
+
+            tc = self.ts.get_table_client("doesntexist")
+
+            batch = tc.create_batch()
+            batch.create_entity(entity)
+
+            with pytest.raises(ResourceNotFoundError):
+                resp = tc.send_batch(batch)
+            # Assert
+        finally:
+            self._tear_down()
+
+    @pytest.mark.skip("Cannot fake cosmos credential")
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
+    @CachedResourceGroupPreparer(name_prefix="tablestest")
+    @CachedCosmosAccountPreparer(name_prefix="tablestest")
+    def test_new_invalid_key(self, resource_group, location, cosmos_account, cosmos_account_key):
+        # Arrange
+        invalid_key = cosmos_account_key[0:-6] + "==" # cut off a bit from the end to invalidate
+        key_list = list(cosmos_account_key)
+
+        key_list[-6:] = list("0000==")
+        invalid_key = ''.join(key_list)
+
+        self.ts = TableServiceClient(self.account_url(cosmos_account, "table"), invalid_key)
+        self.table_name = self.get_resource_name('uttable')
+        self.table = self.ts.get_table_client(self.table_name)
+
+        entity = self._create_random_entity_dict('001', 'batch_negative_1')
+
+        batch = self.table.create_batch()
+        batch.create_entity(entity)
+
+        with pytest.raises(ClientAuthenticationError):
+            resp = self.table.send_batch(batch)
+
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
+    @CachedResourceGroupPreparer(name_prefix="tablestest")
+    @CachedCosmosAccountPreparer(name_prefix="tablestest")
+    def test_new_delete_nonexistent_entity(self, resource_group, location, cosmos_account, cosmos_account_key):
+        # Arrange
+        self._set_up(cosmos_account, cosmos_account_key)
+        try:
+            entity = self._create_random_entity_dict('001', 'batch_negative_1')
+
+            batch = self.table.create_batch()
+            batch.delete_entity(entity['PartitionKey'], entity['RowKey'])
+
+            with pytest.raises(ResourceNotFoundError):
+                resp = self.table.send_batch(batch)
+
+        finally:
+            self._tear_down()
+
 
 #------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/sdk/tables/azure-data-tables/tests/test_table_batch_cosmos.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch_cosmos.py
@@ -616,7 +616,7 @@ class StorageTableClientTest(TableTestCase):
         finally:
             self._tear_down()
 
-    @pytest.mark.skip("This does not throw an error, but it should")
+    # @pytest.mark.skip("This does not throw an error, but it should")
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @CachedResourceGroupPreparer(name_prefix="tablestest")
     @CachedCosmosAccountPreparer(name_prefix="tablestest")
@@ -635,10 +635,10 @@ class StorageTableClientTest(TableTestCase):
             batch.update_entity(entity)
             entity = self._create_random_entity_dict(
                 '001', 'batch_negative_1')
-
+            batch.update_entity(entity, mode=UpdateMode.MERGE)
             # Assert
-            with self.assertRaises(ValueError):
-                batch.update_entity(entity, mode='MERGE')
+            with pytest.raises(BatchErrorException):
+                self.table.send_batch(batch)
         finally:
             self._tear_down()
 

--- a/sdk/tables/azure-data-tables/tests/test_table_batch_cosmos_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch_cosmos_async.py
@@ -19,7 +19,8 @@ from azure.core import MatchConditions
 from azure.core.exceptions import (
     ResourceExistsError,
     ResourceNotFoundError,
-    HttpResponseError
+    HttpResponseError,
+    ClientAuthenticationError
 )
 from azure.data.tables.aio import TableServiceClient
 from azure.data.tables._models import BatchErrorException
@@ -769,6 +770,68 @@ class StorageTableBatchTest(TableTestCase):
                     batch.create_entity(entity)
 
             # Assert
+        finally:
+            await self._tear_down()
+
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
+    @CachedResourceGroupPreparer(name_prefix="tablestest")
+    @CachedCosmosAccountPreparer(name_prefix="tablestest")
+    async def test_new_non_existent_table(self, resource_group, location, cosmos_account, cosmos_account_key):
+        # Arrange
+        await self._set_up(cosmos_account, cosmos_account_key)
+        try:
+            entity = self._create_random_entity_dict('001', 'batch_negative_1')
+
+            tc = self.ts.get_table_client("doesntexist")
+
+            batch = tc.create_batch()
+            batch.create_entity(entity)
+
+            with pytest.raises(ResourceNotFoundError):
+                resp = await tc.send_batch(batch)
+            # Assert
+        finally:
+            await self._tear_down()
+
+    @pytest.mark.skip("Cannot fake cosmos credential")
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
+    @CachedResourceGroupPreparer(name_prefix="tablestest")
+    @CachedCosmosAccountPreparer(name_prefix="tablestest")
+    async def test_new_invalid_key(self, resource_group, location, cosmos_account, cosmos_account_key):
+        # Arrange
+        invalid_key = cosmos_account_key[0:-6] + "==" # cut off a bit from the end to invalidate
+        key_list = list(cosmos_account_key)
+
+        key_list[-6:] = list("0000==")
+        invalid_key = ''.join(key_list)
+
+        self.ts = TableServiceClient(self.account_url(cosmos_account, "table"), invalid_key)
+        self.table_name = self.get_resource_name('uttable')
+        self.table = self.ts.get_table_client(self.table_name)
+
+        entity = self._create_random_entity_dict('001', 'batch_negative_1')
+
+        batch = self.table.create_batch()
+        batch.create_entity(entity)
+
+        with pytest.raises(ClientAuthenticationError):
+            resp = await self.table.send_batch(batch)
+
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
+    @CachedResourceGroupPreparer(name_prefix="tablestest")
+    @CachedCosmosAccountPreparer(name_prefix="tablestest")
+    async def test_new_delete_nonexistent_entity(self, resource_group, location, cosmos_account, cosmos_account_key):
+        # Arrange
+        await self._set_up(cosmos_account, cosmos_account_key)
+        try:
+            entity = self._create_random_entity_dict('001', 'batch_negative_1')
+
+            batch = self.table.create_batch()
+            batch.delete_entity(entity['PartitionKey'], entity['RowKey'])
+
+            with pytest.raises(ResourceNotFoundError):
+                resp = await self.table.send_batch(batch)
+
         finally:
             await self._tear_down()
 

--- a/sdk/tables/azure-data-tables/tests/test_table_batch_cosmos_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_batch_cosmos_async.py
@@ -696,7 +696,7 @@ class StorageTableBatchTest(TableTestCase):
         finally:
             await self._tear_down()
 
-    @pytest.mark.skip("This does not throw an error, but it should")
+    # @pytest.mark.skip("This does not throw an error, but it should")
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @CachedResourceGroupPreparer(name_prefix="tablestest")
     @CachedCosmosAccountPreparer(name_prefix="tablestest")
@@ -715,10 +715,11 @@ class StorageTableBatchTest(TableTestCase):
             batch.update_entity(entity)
             entity = self._create_random_entity_dict(
                 '001', 'batch_negative_1')
+            batch.update_entity(entity)
 
             # Assert
-            with self.assertRaises(HttpResponseError):
-                batch.update_entity(entity, mode=UpdateMode.MERGE)
+            with pytest.raises(BatchErrorException):
+                await self.table.send_batch(batch)
         finally:
             await self._tear_down()
 


### PR DESCRIPTION
Addresses #14962 

Changes the way batching throws error. `BatchErrorException` now is thrown on batch errors. This change aligns error handling with .NET and Java.