### PR TITLE
[formrecognizer] fix receipt test

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt.py
@@ -296,7 +296,7 @@ class TestReceiptFromStream(FormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantName").value, 'Bilbo Baggins')
         self.assertEqual(receipt.fields.get("MerchantPhoneNumber").value, '+15555555555')
         self.assertEqual(receipt.fields.get("Subtotal").value, 300.0)
-        self.assertEqual(receipt.fields.get("Total").value, 100.0)
+        self.assertEqual(receipt.fields.get("Total").value, 430.0)
         self.assertEqual(receipt.page_range.first_page_number, 1)
         self.assertEqual(receipt.page_range.last_page_number, 1)
         self.assertFormPagesHasValues(receipt.pages)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_async.py
@@ -324,7 +324,7 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantName").value, 'Bilbo Baggins')
         self.assertEqual(receipt.fields.get("MerchantPhoneNumber").value, '+15555555555')
         self.assertEqual(receipt.fields.get("Subtotal").value, 300.0)
-        self.assertEqual(receipt.fields.get("Total").value, 100.0)
+        self.assertEqual(receipt.fields.get("Total").value, 430.0)
         self.assertEqual(receipt.page_range.first_page_number, 1)
         self.assertEqual(receipt.page_range.last_page_number, 1)
         self.assertFormPagesHasValues(receipt.pages)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url.py
@@ -234,7 +234,7 @@ class TestReceiptFromUrl(FormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantName").value, 'Bilbo Baggins')
         self.assertEqual(receipt.fields.get("MerchantPhoneNumber").value, '+15555555555')
         self.assertEqual(receipt.fields.get("Subtotal").value, 300.0)
-        self.assertEqual(receipt.fields.get("Total").value, 100.0)
+        self.assertEqual(receipt.fields.get("Total").value, 430.0)
         self.assertEqual(receipt.page_range.first_page_number, 1)
         self.assertEqual(receipt.page_range.last_page_number, 1)
         self.assertFormPagesHasValues(receipt.pages)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url_async.py
@@ -267,7 +267,7 @@ class TestReceiptFromUrlAsync(AsyncFormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantName").value, 'Bilbo Baggins')
         self.assertEqual(receipt.fields.get("MerchantPhoneNumber").value, '+15555555555')
         self.assertEqual(receipt.fields.get("Subtotal").value, 300.0)
-        self.assertEqual(receipt.fields.get("Total").value, 100.0)
+        self.assertEqual(receipt.fields.get("Total").value, 430.0)
         self.assertEqual(receipt.page_range.first_page_number, 1)
         self.assertEqual(receipt.page_range.last_page_number, 1)
         self.assertFormPagesHasValues(receipt.pages)


### PR DESCRIPTION
Total is now returning the correct value:

![image](https://user-images.githubusercontent.com/31998003/98578123-c499e180-2271-11eb-8468-319a316ba8ab.png)
