### PR TITLE
[EventGrid] Fix readme refdoc link

### DIFF
--- a/sdk/eventgrid/azure-eventgrid/README.md
+++ b/sdk/eventgrid/azure-eventgrid/README.md
@@ -232,7 +232,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [python-eg-src]: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/eventgrid/azure-eventgrid/
 [python-eg-pypi]: https://pypi.org/project/azure-eventgrid
 [python-eg-product-docs]: https://docs.microsoft.com/azure/event-grid/overview
-[python-eg-ref-docs]: https://aka.ms/azsdk/python/eventgrid/docs
+[python-eg-ref-docs]: https://azuresdkdocs.blob.core.windows.net/$web/python/azure-eventgrid/latest/index.html
 [python-eg-samples]: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/eventgrid/azure-eventgrid/samples
 [python-eg-changelog]: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/eventgrid/azure-eventgrid/CHANGELOG.md
 [pip]: https://pypi.org/project/pip/


### PR DESCRIPTION
refdoc aka.ms link was broken and silently redirecting, have replaced with azuresdkdocs link as is used in other SDKs.