### PR TITLE
[Communication] Add variable groups necessary for using new azure subscription

### DIFF
--- a/sdk/communication/azure-communication-sms/tests/test_sms_client_e2e.py
+++ b/sdk/communication/azure-communication-sms/tests/test_sms_client_e2e.py
@@ -28,7 +28,7 @@ class SMSClientTest(CommunicationTestCase):
         if self.is_playback():
             self.phone_number = "+18000005555"
         else:
-            self.phone_number = os.getenv("PHONE_NUMBER")
+            self.phone_number = os.getenv("AZURE_COMMUNICATION_SERVICE_PHONE_NUMBER")
 
         self.recording_processors.extend([
             BodyReplacerProcessor(keys=["to", "from", "messageId"]),

--- a/sdk/communication/azure-communication-sms/tests/test_sms_client_e2e.py
+++ b/sdk/communication/azure-communication-sms/tests/test_sms_client_e2e.py
@@ -15,9 +15,6 @@ from _shared.testcase import (
     ResponseReplacerProcessor
 )
 
-SKIP_PHONE_NUMBER_TESTS = False
-PHONE_NUMBER_TEST_SKIP_REASON= "Phone Number infra for live tests not ready yet"
-
 class SMSClientTest(CommunicationTestCase):
     def __init__(self, method_name):
         super(SMSClientTest, self).__init__(method_name)
@@ -37,7 +34,6 @@ class SMSClientTest(CommunicationTestCase):
         self.sms_client = SmsClient.from_connection_string(self.connection_str)
 
     @pytest.mark.live_test_only
-    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     def test_send_sms(self):
 
         # calling send() with sms values

--- a/sdk/communication/azure-communication-sms/tests/test_sms_client_e2e.py
+++ b/sdk/communication/azure-communication-sms/tests/test_sms_client_e2e.py
@@ -15,7 +15,7 @@ from _shared.testcase import (
     ResponseReplacerProcessor
 )
 
-SKIP_PHONE_NUMBER_TESTS = True
+SKIP_PHONE_NUMBER_TESTS = False
 PHONE_NUMBER_TEST_SKIP_REASON= "Phone Number infra for live tests not ready yet"
 
 class SMSClientTest(CommunicationTestCase):

--- a/sdk/communication/azure-communication-sms/tests/test_sms_client_e2e_async.py
+++ b/sdk/communication/azure-communication-sms/tests/test_sms_client_e2e_async.py
@@ -15,9 +15,6 @@ from _shared.testcase import (
     BodyReplacerProcessor, ResponseReplacerProcessor
 )
 
-SKIP_PHONE_NUMBER_TESTS = True
-PHONE_NUMBER_TEST_SKIP_REASON= "Phone Number infra for live tests not ready yet"
-
 class SMSClientTestAsync(AsyncCommunicationTestCase):
     def __init__(self, method_name):
         super(SMSClientTestAsync, self).__init__(method_name)
@@ -36,7 +33,6 @@ class SMSClientTestAsync(AsyncCommunicationTestCase):
 
     @AsyncCommunicationTestCase.await_prepared_test
     @pytest.mark.live_test_only
-    @pytest.mark.skipif(SKIP_PHONE_NUMBER_TESTS, reason=PHONE_NUMBER_TEST_SKIP_REASON)
     async def test_send_sms_async(self):
 
         sms_client = SmsClient.from_connection_string(self.connection_str)

--- a/sdk/communication/tests.yml
+++ b/sdk/communication/tests.yml
@@ -12,5 +12,5 @@ jobs:
         AZURE_SUBSCRIPTION_ID: $(acs-subscription-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-        AZURE_COMMUNICATION_SERVICE_CONNECTION_STRING: $(python-communication-connection-string)
-        AZURE_COMMUNICATION_SERVICE_PHONE_NUMBER: $(python-communication-phone-number)
+        AZURE_COMMUNICATION_SERVICE_CONNECTION_STRING: $(communication-livetest-connection-string)
+        AZURE_COMMUNICATION_SERVICE_PHONE_NUMBER: $(communication-livetest-phone-number)

--- a/sdk/communication/tests.yml
+++ b/sdk/communication/tests.yml
@@ -9,7 +9,7 @@ jobs:
       EnvVars:
         AZURE_TEST_RUN_LIVE: 'true'
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-        AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
+        AZURE_SUBSCRIPTION_ID: $(acs-subscription-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_COMMUNICATION_SERVICE_CONNECTION_STRING: $(python-communication-connection-string)


### PR DESCRIPTION
We are using the new subscription for our testing. 
The new subscription id is added to the keyvault and this PR changes the tests.yml to access that subscriptionId. 
This PR will be updated in case new variables needed to be able to use the new subscription. 