### PR TITLE
Use Build Number in release Version to fix race condition.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -133,6 +133,7 @@ jobs:
           pwsh: true
           workingDirectory: $(Build.SourcesDirectory)
           filePath: eng/scripts/SetTestPipelineVersion.ps1
+          arguments: '-BuildNumber $(Build.BuildNumber)'
 
     - pwsh: |
         $toxenvvar = "whl,sdist"

--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -14,6 +14,7 @@ steps:
         pwsh: true
         workingDirectory: $(Build.SourcesDirectory)
         filePath: eng/scripts/SetTestPipelineVersion.ps1
+        arguments: '-BuildNumber $(Build.BuildNumber)'
 
   - script: |
       echo "##vso[build.addbuildtag]Scheduled"

--- a/eng/scripts/SetTestPipelineVersion.ps1
+++ b/eng/scripts/SetTestPipelineVersion.ps1
@@ -22,7 +22,7 @@ $semVarsSorted = [AzureEngSemanticVersion]::SortVersionStrings($semVars)
 LogDebug "Last Published Version $($semVarsSorted[0])"
 
 $newVersion = [AzureEngSemanticVersion]::ParsePythonVersionString($semVarsSorted[0])
-$newVersion.PrereleaseLabel = "beta"
+$newVersion.PrereleaseLabel = "b"
 $newVersion.PrereleaseNumber = $BuildNumber
 
 LogDebug "Version to publish [ $($newVersion.ToString()) ]"

--- a/eng/scripts/SetTestPipelineVersion.ps1
+++ b/eng/scripts/SetTestPipelineVersion.ps1
@@ -1,5 +1,11 @@
-# Overides the project file and CHANGELOG.md for the template project using the next publishable version
+# Overides the project file and CHANGELOG.md for the template project.
 # This is to help with testing the release pipeline.
+
+param (
+  [Parameter(mandatory = $true)]
+  $BuildNumber
+)
+
 . "${PSScriptRoot}\..\common\scripts\common.ps1"
 $latestTags = git tag -l "azure-template_*"
 $semVars = @()
@@ -16,7 +22,9 @@ $semVarsSorted = [AzureEngSemanticVersion]::SortVersionStrings($semVars)
 LogDebug "Last Published Version $($semVarsSorted[0])"
 
 $newVersion = [AzureEngSemanticVersion]::ParsePythonVersionString($semVarsSorted[0])
-$newVersion.IncrementAndSetToPrerelease()
+$newVersion.PrereleaseLabel = "beta"
+$newVersion.PrereleaseNumber = $BuildNumber
+
 LogDebug "Version to publish [ $($newVersion.ToString()) ]"
 
 $versionFileContent = Get-Content -Path $versionFile


### PR DESCRIPTION
- Use build Number as prerelease version number to fix race condition.