### PR TITLE
[Identity] Make pipeline policy configurable via kwargs

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_client.py
@@ -109,10 +109,11 @@ class MsalClient(object):
 def _create_config(**kwargs):
     # type: (Any) -> Configuration
     config = Configuration(**kwargs)
-    config.logging_policy = NetworkTraceLoggingPolicy(**kwargs)
-    config.retry_policy = RetryPolicy(**kwargs)
-    config.proxy_policy = ProxyPolicy(**kwargs)
-    config.user_agent_policy = UserAgentPolicy(base_user_agent=USER_AGENT, **kwargs)
+    config.logging_policy = kwargs.get('logging_policy') or NetworkTraceLoggingPolicy(**kwargs)
+    config.http_logging_policy = kwargs.get('http_logging_policy') or HttpLoggingPolicy(**kwargs)
+    config.retry_policy = kwargs.get('retry_policy') or RetryPolicy(**kwargs)
+    config.proxy_policy = kwargs.get('proxy_policy') or ProxyPolicy(**kwargs)
+    config.user_agent_policy = kwargs.get('user_agent_policy') or UserAgentPolicy(base_user_agent=USER_AGENT, **kwargs)
     return config
 
 
@@ -128,7 +129,7 @@ def _build_pipeline(config=None, policies=None, transport=None, **kwargs):
             config.retry_policy,
             config.logging_policy,
             DistributedTracingPolicy(**kwargs),
-            HttpLoggingPolicy(**kwargs),
+            config.http_logging_policy,
         ]
 
     if not transport:


### PR DESCRIPTION
In track 2 SDKs, `logging_policy` and `http_logging_policy` are configurable via `kwargs` passed to `SubscriptionClientConfiguration.__init__`:

https://github.com/Azure/azure-sdk-for-python/blob/27e4203818e227ba2604ff52dcf55ce2293c4c37/sdk/resources/azure-mgmt-resource/azure/mgmt/resource/subscriptions/v2019_11_01/_configuration.py#L57-L58

Azure Identity hard-codes `HttpLoggingPolicy` while creating `policies`, making it impossible to replace `HttpLoggingPolicy` with `SansIOHTTPPolicy` without overriding the whole `policies`. (I have to override the whole `policies` in order to replace `HttpLoggingPolicy` with `SansIOHTTPPolicy`.) 

https://github.com/Azure/azure-sdk-for-python/blob/fdf11b302b20821e94eae61a2eabd8eb1d776162/sdk/identity/azure-identity/azure/identity/_internal/msal_client.py#L124-L132

Azure Identity should follow the same pattern and make **individual** policies configurable, especially for `http_logging_policy` which is required for Azure CLI to disable logs from `HttpLoggingPolicy`, as it is a redacted/duplicated version of `NetworkTraceLoggingPolicy`.

More detail
- Email: _Need an option to disable http_logging_policy (ARMHttpLoggingPolicy)_
- PR: https://github.com/Azure/azure-cli/pull/15791