### PR TITLE
[formrecognizer] uncomment receipt test assertions - service regression fixed

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_authentication_bad_key.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_authentication_bad_key.yaml
@@ -25,7 +25,7 @@ interactions:
       content-length:
       - '224'
       date:
-      - Wed, 11 Nov 2020 18:03:28 GMT
+      - Mon, 16 Nov 2020 19:08:57 GMT
     status:
       code: 401
       message: PermissionDenied

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_authentication_successful_key.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_authentication_successful_key.yaml
@@ -22,19 +22,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - fd0ce4b0-afb2-47bc-887d-863aa0e76163
+      - 1ff5365d-b8b3-4448-af6d-93b5f1e9a8e4
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:03:31 GMT
+      - Mon, 16 Nov 2020 19:08:58 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/fd0ce4b0-afb2-47bc-887d-863aa0e76163
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/1ff5365d-b8b3-4448-af6d-93b5f1e9a8e4
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '1385'
+      - '677'
     status:
       code: 202
       message: Accepted
@@ -50,65 +50,65 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/fd0ce4b0-afb2-47bc-887d-863aa0e76163
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/1ff5365d-b8b3-4448-af6d-93b5f1e9a8e4
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:03:30Z",
-        "lastUpdatedDateTime": "2020-11-11T18:03:34Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:08:58Z",
+        "lastUpdatedDateTime": "2020-11-16T19:09:02Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [380.9, 282.9,
-        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.716}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [298.3, 676.5, 844.6,
-        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence":
-        0.99}, "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text":
-        "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505, 1331, 255, 1312],
-        "page": 1, "confidence": 0.99}, "TransactionTime": {"type": "time", "valueTime":
-        "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681, 1262, 675, 1341,
-        522, 1332], "page": 1, "confidence": 0.989}, "Items": {"type": "array", "valueArray":
-        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [244, 1581, 288, 1584, 285, 1678, 241, 1675],
-        "page": 1, "confidence": 0.919}, "Name": {"type": "string", "valueString":
-        "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585, 658, 1598,
-        657, 1688, 304, 1679], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1106, 1579,
-        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.959}}}, {"type":
-        "object", "valueObject": {"Quantity": {"type": "number", "valueNumber": 1,
-        "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [294, 1839, 737, 1839,
-        737, 1924, 294, 1924], "page": 1, "confidence": 0.955}, "TotalPrice": {"type":
-        "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox": [1134, 1948,
-        1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence": 0.958}}}]},
-        "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923}, "Tax": {"type": "number", "valueNumber": 1.17, "text": "1.17", "boundingBox":
-        [1186, 2356, 1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence":
-        0.979}, "Tip": {"type": "number", "valueNumber": 463, "text": "$463", "boundingBox":
-        [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "page": 1, "confidence":
-        0.975}, "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50",
-        "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1,
-        "confidence": 0.987}}}]}}'
+        "Itemized", "confidence": 0.692}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [378.2, 292.4,
+        1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8], "page": 1, "confidence": 0.613},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [302,
+        675.8, 848.1, 793.7, 809.9, 970.4, 263.9, 852.5], "page": 1, "confidence":
+        0.99}, "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber":
+        "+19876543210", "text": "987-654-3210", "boundingBox": [278, 1004, 656, 1057,
+        647, 1123, 271, 1075], "page": 1, "confidence": 0.99}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99},
+        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
+        "boundingBox": [541, 1248, 677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence":
+        0.977}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
+        [245, 1583, 299, 1585, 295, 1676, 241, 1671], "page": 1, "confidence": 0.92},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923}, "TotalPrice": {"type": "number", "valueNumber": 2.2, "text": "$2.20",
+        "boundingBox": [1108, 1584, 1263, 1574, 1268, 1656, 1113, 1666], "page": 1,
+        "confidence": 0.918}}}, {"type": "object", "valueObject": {"Quantity": {"type":
+        "number", "valueNumber": 1, "text": "1", "boundingBox": [232, 1834, 286, 1836,
+        285, 1920, 231, 1920], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916},
+        "TotalPrice": {"type": "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox":
+        [1135, 1955, 1257, 1952, 1259, 2036, 1136, 2039], "page": 1, "confidence":
+        0.916}}}]}, "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70",
+        "boundingBox": [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1,
+        "confidence": 0.955}, "Tax": {"type": "number", "valueNumber": 1.17, "text":
+        "1.17", "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "page":
+        1, "confidence": 0.979}, "Tip": {"type": "number", "valueNumber": 1.63, "text":
+        "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591, 1091, 2585], "page":
+        1, "confidence": 0.941}, "Total": {"type": "number", "valueNumber": 14.5,
+        "text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380, 2763, 1030,
+        2739], "page": 1, "confidence": 0.985}}}]}}'
     headers:
       apim-request-id:
-      - 6d4f38cc-a802-4e2f-8e13-b3bd85a0bd69
+      - c2856806-d705-4338-be31-aa24fa0c3489
       content-length:
-      - '2820'
+      - '2835'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:03:35 GMT
+      - Mon, 16 Nov 2020 19:09:03 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '57'
+      - '95'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_blank_page.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_blank_page.yaml
@@ -472,19 +472,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 92427657-528f-468c-8503-24385ba4fb0a
+      - af108532-ae00-46c2-a8b5-b316dd512760
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:03:37 GMT
+      - Mon, 16 Nov 2020 19:09:04 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/92427657-528f-468c-8503-24385ba4fb0a
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/af108532-ae00-46c2-a8b5-b316dd512760
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '203'
+      - '119'
     status:
       code: 202
       message: Accepted
@@ -500,29 +500,29 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/92427657-528f-468c-8503-24385ba4fb0a
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/af108532-ae00-46c2-a8b5-b316dd512760
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:03:37Z",
-        "lastUpdatedDateTime": "2020-11-11T18:03:39Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:09:04Z",
+        "lastUpdatedDateTime": "2020-11-16T19:09:08Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": 0, "width": 8.5, "height": 11,
         "unit": "inch"}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
         [1, 1], "fields": {}}]}}'
     headers:
       apim-request-id:
-      - 082e6567-eb58-4457-af91-24783fd1ff21
+      - 72063e63-d1b4-4f6b-8ac5-2f7ab23a4617
       content-length:
       - '300'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:03:42 GMT
+      - Mon, 16 Nov 2020 19:09:09 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '359'
+      - '16'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_damaged_file_passed_as_bytes.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_damaged_file_passed_as_bytes.yaml
@@ -18,23 +18,23 @@ interactions:
     uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyze?includeTextDetails=false
   response:
     body:
-      string: '{"error": {"code": "BadArgument", "innerError": {"requestId": "bab9230b-4ff3-42aa-81c8-b00582452cb6"},
+      string: '{"error": {"code": "BadArgument", "innerError": {"requestId": "a533931f-55a1-4fd1-ad36-3c11ec5618a2"},
         "message": "Bad or unrecognizable request JSON or binary file."}}'
     headers:
       apim-request-id:
-      - bab9230b-4ff3-42aa-81c8-b00582452cb6
+      - a533931f-55a1-4fd1-ad36-3c11ec5618a2
       content-length:
       - '161'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:03:43 GMT
+      - Mon, 16 Nov 2020 19:09:09 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '10'
+      - '5'
     status:
       code: 400
       message: Bad Request

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_damaged_file_passed_as_bytes_io.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_damaged_file_passed_as_bytes_io.yaml
@@ -23,23 +23,23 @@ interactions:
     uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyze?includeTextDetails=false
   response:
     body:
-      string: '{"error": {"code": "BadArgument", "innerError": {"requestId": "41b84122-4e73-4fdd-9c54-f7bff0ad6907"},
+      string: '{"error": {"code": "BadArgument", "innerError": {"requestId": "f82a52be-58f7-4e3c-a6db-02b08933fb78"},
         "message": "Bad or unrecognizable request JSON or binary file."}}'
     headers:
       apim-request-id:
-      - 41b84122-4e73-4fdd-9c54-f7bff0ad6907
+      - f82a52be-58f7-4e3c-a6db-02b08933fb78
       content-length:
       - '161'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:03:44 GMT
+      - Mon, 16 Nov 2020 19:09:11 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '11'
+      - '5'
     status:
       code: 400
       message: Bad Request

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_passing_enum_content_type.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_passing_enum_content_type.yaml
@@ -22,19 +22,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 15d52c5c-7009-465f-9ccf-bbc77add4f44
+      - 2d4a5d71-b019-48c1-afb0-11a6d7f263ea
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:03:47 GMT
+      - Mon, 16 Nov 2020 19:09:15 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/15d52c5c-7009-465f-9ccf-bbc77add4f44
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/2d4a5d71-b019-48c1-afb0-11a6d7f263ea
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '473'
+      - '745'
     status:
       code: 202
       message: Accepted
@@ -50,60 +50,61 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/15d52c5c-7009-465f-9ccf-bbc77add4f44
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/2d4a5d71-b019-48c1-afb0-11a6d7f263ea
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:03:47Z",
-        "lastUpdatedDateTime": "2020-11-11T18:03:51Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": -0.0752, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:09:15Z",
+        "lastUpdatedDateTime": "2020-11-16T19:09:18Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.2511, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [342.9, 238.1,
-        1061, 278.6, 1038.1, 685.5, 320, 645], "page": 1, "confidence": 0.693}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [308.4, 688, 751.3, 689,
-        750.8, 859.6, 308, 858.5], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "text": "123-456-7890", "boundingBox": [303, 1003,
-        623, 1009, 621, 1071, 303, 1064], "page": 1, "confidence": 0.99}, "TransactionDate":
-        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
-        [299, 1221, 494, 1222, 492, 1292, 299, 1292], "page": 1, "confidence": 0.991},
-        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
-        "boundingBox": [508, 1223, 628, 1224, 625, 1292, 506, 1292], "page": 1, "confidence":
-        0.99}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
-        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [327, 1558, 353, 1559, 352, 1623, 327, 1623], "page": 1, "confidence": 0.745}}},
-        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
-        "8GB RAM (Black)", "text": "8GB RAM (Black)", "boundingBox": [358, 1779, 738,
-        1779, 738, 1860, 358, 1860], "page": 1, "confidence": 0.968}, "TotalPrice":
-        {"type": "number", "valueNumber": 999, "text": "999.00", "boundingBox": [967,
-        1792, 1135, 1796, 1133, 1859, 967, 1855], "page": 1, "confidence": 0.97}}},
-        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [315, 2018, 337, 2017, 338, 2084, 316, 2085],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "SurfacePen", "text": "SurfacePen", "boundingBox": [350, 2017, 624, 2013,
-        624, 2079, 351, 2084], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 99.99, "text": "$99.99", "boundingBox": [963, 2025,
-        1128, 2025, 1128, 2092, 963, 2092], "page": 1, "confidence": 0.775}}}]}, "Subtotal":
-        {"type": "number", "valueNumber": 1098.99, "text": "1098.99", "boundingBox":
-        [954, 2255, 1137, 2251, 1138, 2325, 956, 2329], "page": 1, "confidence": 0.986},
-        "Total": {"type": "number", "valueNumber": 104.4, "text": "104.40", "boundingBox":
-        [976, 2370, 1130, 2368, 1131, 2434, 977, 2438], "page": 1, "confidence": 0.668}}}]}}'
+        "Itemized", "confidence": 0.659}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [349.3, 241.3,
+        1058, 284.4, 1033.5, 687.1, 324.8, 644], "page": 1, "confidence": 0.516},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [319.9,
+        689.9, 750.7, 697.5, 747.8, 865.6, 317, 858], "page": 1, "confidence": 0.986},
+        "MerchantPhoneNumber": {"type": "phoneNumber", "text": "123-456-7890", "boundingBox":
+        [306, 1005, 617, 1012, 615, 1069, 305, 1064], "page": 1, "confidence": 0.99},
+        "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019",
+        "boundingBox": [304, 1224, 506, 1224, 504, 1289, 303, 1288], "page": 1, "confidence":
+        0.985}, "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text":
+        "13:59", "boundingBox": [518, 1225, 628, 1228, 627, 1290, 517, 1289], "page":
+        1, "confidence": 0.968}, "Items": {"type": "array", "valueArray": [{"type":
+        "object", "valueObject": {"Name": {"type": "string", "valueString": "8GB RAM
+        (Black)", "text": "8GB RAM (Black)", "boundingBox": [370.7, 1781.5, 731, 1785,
+        730.3, 1854, 370, 1850.6], "page": 1, "confidence": 0.916}, "TotalPrice":
+        {"type": "number", "valueNumber": 999, "text": "$999.00", "boundingBox": [939,
+        1784.6, 1134.4, 1788.3, 1133, 1863, 937.6, 1859.3], "page": 1, "confidence":
+        0.559}}}, {"type": "object", "valueObject": {"Quantity": {"type": "number",
+        "valueNumber": 1, "text": "1", "boundingBox": [321, 2021, 348, 2020, 349,
+        2084, 322, 2084], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "SurfacePen", "text": "SurfacePen", "boundingBox": [360, 2020,
+        626, 2014, 628, 2077, 362, 2083], "page": 1, "confidence": 0.858}, "TotalPrice":
+        {"type": "number", "valueNumber": 99.99, "text": "99.99", "boundingBox": [1007,
+        2028, 1127, 2028, 1126, 2091, 1007, 2091], "page": 1, "confidence": 0.386}}}]},
+        "Subtotal": {"type": "number", "valueNumber": 1098.99, "text": "1098.99",
+        "boundingBox": [963, 2260, 1136, 2254, 1137, 2320, 966, 2325], "page": 1,
+        "confidence": 0.964}, "Tax": {"type": "number", "valueNumber": 104.4, "text":
+        "$104.40", "boundingBox": [942.6, 2367.5, 1132, 2363.7, 1133.4, 2434.2, 944,
+        2438], "page": 1, "confidence": 0.713}, "Total": {"type": "number", "valueNumber":
+        1203.39, "text": "1203.39", "boundingBox": [955, 2594, 1123, 2611, 1115, 2678,
+        949, 2661], "page": 1, "confidence": 0.774}}}]}}'
     headers:
       apim-request-id:
-      - 2c351c79-d225-44df-a8e9-91b1918f83f8
+      - fe9de0fe-afb6-476b-a5f1-b453b3334a8c
       content-length:
-      - '2548'
+      - '2561'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:03:52 GMT
+      - Mon, 16 Nov 2020 19:09:20 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '28'
+      - '102'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_jpg.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_jpg.yaml
@@ -22,19 +22,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - ca3f01b4-ca86-41c5-acba-bd57188fa5a0
+      - 2e2e531f-889f-4bb8-823c-27a41123ee1c
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:03:59 GMT
+      - Mon, 16 Nov 2020 19:09:28 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/ca3f01b4-ca86-41c5-acba-bd57188fa5a0
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/2e2e531f-889f-4bb8-823c-27a41123ee1c
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '193'
+      - '209'
     status:
       code: 202
       message: Accepted
@@ -50,65 +50,65 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/ca3f01b4-ca86-41c5-acba-bd57188fa5a0
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/2e2e531f-889f-4bb8-823c-27a41123ee1c
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:04:00Z",
-        "lastUpdatedDateTime": "2020-11-11T18:04:02Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:09:28Z",
+        "lastUpdatedDateTime": "2020-11-16T19:09:30Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [380.9, 282.9,
-        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.716}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [298.3, 676.5, 844.6,
-        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence":
-        0.99}, "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text":
-        "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505, 1331, 255, 1312],
-        "page": 1, "confidence": 0.99}, "TransactionTime": {"type": "time", "valueTime":
-        "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681, 1262, 675, 1341,
-        522, 1332], "page": 1, "confidence": 0.989}, "Items": {"type": "array", "valueArray":
-        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [244, 1581, 288, 1584, 285, 1678, 241, 1675],
-        "page": 1, "confidence": 0.919}, "Name": {"type": "string", "valueString":
-        "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585, 658, 1598,
-        657, 1688, 304, 1679], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1106, 1579,
-        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.959}}}, {"type":
-        "object", "valueObject": {"Quantity": {"type": "number", "valueNumber": 1,
-        "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [294, 1839, 737, 1839,
-        737, 1924, 294, 1924], "page": 1, "confidence": 0.955}, "TotalPrice": {"type":
-        "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox": [1134, 1948,
-        1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence": 0.958}}}]},
-        "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923}, "Tax": {"type": "number", "valueNumber": 1.17, "text": "1.17", "boundingBox":
-        [1186, 2356, 1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence":
-        0.979}, "Tip": {"type": "number", "valueNumber": 463, "text": "$463", "boundingBox":
-        [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "page": 1, "confidence":
-        0.975}, "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50",
-        "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1,
-        "confidence": 0.987}}}]}}'
+        "Itemized", "confidence": 0.692}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [378.2, 292.4,
+        1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8], "page": 1, "confidence": 0.613},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [302,
+        675.8, 848.1, 793.7, 809.9, 970.4, 263.9, 852.5], "page": 1, "confidence":
+        0.99}, "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber":
+        "+19876543210", "text": "987-654-3210", "boundingBox": [278, 1004, 656, 1057,
+        647, 1123, 271, 1075], "page": 1, "confidence": 0.99}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99},
+        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
+        "boundingBox": [541, 1248, 677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence":
+        0.977}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
+        [245, 1583, 299, 1585, 295, 1676, 241, 1671], "page": 1, "confidence": 0.92},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923}, "TotalPrice": {"type": "number", "valueNumber": 2.2, "text": "$2.20",
+        "boundingBox": [1108, 1584, 1263, 1574, 1268, 1656, 1113, 1666], "page": 1,
+        "confidence": 0.918}}}, {"type": "object", "valueObject": {"Quantity": {"type":
+        "number", "valueNumber": 1, "text": "1", "boundingBox": [232, 1834, 286, 1836,
+        285, 1920, 231, 1920], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916},
+        "TotalPrice": {"type": "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox":
+        [1135, 1955, 1257, 1952, 1259, 2036, 1136, 2039], "page": 1, "confidence":
+        0.916}}}]}, "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70",
+        "boundingBox": [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1,
+        "confidence": 0.955}, "Tax": {"type": "number", "valueNumber": 1.17, "text":
+        "1.17", "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "page":
+        1, "confidence": 0.979}, "Tip": {"type": "number", "valueNumber": 1.63, "text":
+        "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591, 1091, 2585], "page":
+        1, "confidence": 0.941}, "Total": {"type": "number", "valueNumber": 14.5,
+        "text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380, 2763, 1030,
+        2739], "page": 1, "confidence": 0.985}}}]}}'
     headers:
       apim-request-id:
-      - faf10e14-bd9b-4ffa-8acb-4b902bc1a3f8
+      - ca0b5eb7-5856-4833-8de8-c5929e3d3ab6
       content-length:
-      - '2820'
+      - '2835'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:04:04 GMT
+      - Mon, 16 Nov 2020 19:09:33 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '29'
+      - '18'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_jpg_include_field_elements.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_jpg_include_field_elements.yaml
@@ -22,19 +22,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 1ac37d7a-1cad-4ecd-a4dd-3269bc9e73eb
+      - b5144e95-3762-43c8-9afa-1ee53e1f7a03
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:04:06 GMT
+      - Mon, 16 Nov 2020 19:09:35 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/1ac37d7a-1cad-4ecd-a4dd-3269bc9e73eb
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/b5144e95-3762-43c8-9afa-1ee53e1f7a03
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '277'
+      - '200'
     status:
       code: 202
       message: Accepted
@@ -50,173 +50,146 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/1ac37d7a-1cad-4ecd-a4dd-3269bc9e73eb
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/b5144e95-3762-43c8-9afa-1ee53e1f7a03
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:04:06Z",
-        "lastUpdatedDateTime": "2020-11-11T18:04:09Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
-        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [306,
-        569, 519, 624, 502, 686, 290, 632], "words": [{"text": "Contoso", "boundingBox":
-        [308, 570, 515, 627, 500, 685, 290, 634], "confidence": 0.806}], "appearance":
-        {"style": {"name": "print", "confidence": 0.996}}}, {"text": "Contoso", "boundingBox":
-        [625, 512, 1089, 465, 1096, 561, 631, 607], "words": [{"text": "Contoso",
-        "boundingBox": [625, 512, 1088, 466, 1093, 562, 631, 607], "confidence": 0.984}],
-        "appearance": {"style": {"name": "print", "confidence": 0.999}}}, {"text":
-        "123 Main Street", "boundingBox": [301, 677, 697, 759, 681, 835, 284, 750],
-        "words": [{"text": "123", "boundingBox": [301, 677, 379, 692, 362, 766, 284,
-        751], "confidence": 0.987}, {"text": "Main", "boundingBox": [393, 695, 520,
-        721, 503, 795, 377, 769], "confidence": 0.985}, {"text": "Street", "boundingBox":
-        [534, 724, 694, 763, 676, 835, 517, 798], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.995}}}, {"text": "Redmond, WA
-        98052", "boundingBox": [284, 784, 823, 855, 814, 925, 275, 868], "words":
-        [{"text": "Redmond,", "boundingBox": [287, 784, 544, 829, 535, 905, 275, 853],
-        "confidence": 0.924}, {"text": "WA", "boundingBox": [558, 830, 640, 840, 632,
-        916, 549, 907], "confidence": 0.985}, {"text": "98052", "boundingBox": [654,
-        842, 822, 855, 817, 925, 646, 917], "confidence": 0.985}], "appearance": {"style":
-        {"name": "print", "confidence": 0.999}}}, {"text": "987-654-3210", "boundingBox":
-        [270, 999, 655, 1049, 646, 1125, 264, 1075], "words": [{"text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "confidence":
-        0.978}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "6/10/2019 13:59", "boundingBox": [258, 1224, 683, 1259, 676, 1341, 255, 1309],
-        "words": [{"text": "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505,
-        1331, 255, 1312], "confidence": 0.951}, {"text": "13:59", "boundingBox": [527,
-        1248, 681, 1262, 675, 1341, 522, 1332], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "Sales Associate:
-        Paul", "boundingBox": [252, 1347, 860, 1378, 859, 1449, 249, 1425], "words":
-        [{"text": "Sales", "boundingBox": [255, 1348, 409, 1358, 405, 1432, 249, 1419],
-        "confidence": 0.983}, {"text": "Associate:", "boundingBox": [423, 1359, 704,
-        1373, 703, 1447, 419, 1434], "confidence": 0.933}, {"text": "Paul", "boundingBox":
-        [718, 1373, 858, 1378, 859, 1449, 717, 1448], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "1 Cappuccino", "boundingBox":
-        [244, 1581, 660, 1597, 658, 1688, 241, 1675], "words": [{"text": "1", "boundingBox":
-        [244, 1581, 288, 1584, 285, 1678, 241, 1675], "confidence": 0.977}, {"text":
-        "Cappuccino", "boundingBox": [306, 1585, 658, 1598, 657, 1688, 304, 1679],
-        "confidence": 0.858}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "$2.20", "boundingBox": [1106, 1580, 1264, 1574, 1268, 1656,
-        1108, 1662], "words": [{"text": "$2.20", "boundingBox": [1106, 1579, 1260,
-        1574, 1263, 1656, 1108, 1662], "confidence": 0.981}], "appearance": {"style":
-        {"name": "print", "confidence": 0.849}}}, {"text": "1 BACON & EGGS", "boundingBox":
-        [226, 1838, 740, 1839, 740, 1924, 226, 1923], "words": [{"text": "1", "boundingBox":
-        [227, 1839, 278, 1839, 277, 1924, 226, 1924], "confidence": 0.986}, {"text":
-        "BACON", "boundingBox": [295, 1839, 493, 1840, 493, 1923, 294, 1924], "confidence":
-        0.984}, {"text": "&", "boundingBox": [510, 1840, 555, 1840, 555, 1923, 510,
-        1923], "confidence": 0.983}, {"text": "EGGS", "boundingBox": [572, 1840, 737,
-        1841, 736, 1924, 572, 1923], "confidence": 0.984}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Sunny-side-up", "boundingBox":
-        [343, 1976, 758, 1974, 759, 2061, 343, 2063], "words": [{"text": "Sunny-side-up",
-        "boundingBox": [343, 1977, 757, 1975, 755, 2063, 346, 2064], "confidence":
-        0.973}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "$9.5", "boundingBox": [1134, 1948, 1253, 1948, 1255, 2041, 1137, 2041], "words":
-        [{"text": "$9.5", "boundingBox": [1134, 1948, 1252, 1948, 1252, 2041, 1134,
-        2041], "confidence": 0.983}], "appearance": {"style": {"name": "print", "confidence":
-        0.932}}}, {"text": "- -", "boundingBox": [218, 2143, 291, 2140, 292, 2158,
-        218, 2161], "words": [{"text": "-", "boundingBox": [236, 2143, 255, 2143,
-        255, 2161, 235, 2161], "confidence": 0.559}, {"text": "-", "boundingBox":
-        [271, 2142, 290, 2141, 291, 2158, 272, 2160], "confidence": 0.985}], "appearance":
-        {"style": {"name": "print", "confidence": 0.67}}}, {"text": "-----", "boundingBox":
-        [277, 2142, 461, 2136, 461, 2155, 278, 2161], "words": [{"text": "-----",
-        "boundingBox": [305, 2141, 457, 2136, 458, 2155, 305, 2161], "confidence":
-        0.69}], "appearance": {"style": {"name": "print", "confidence": 0.467}}},
-        {"text": "----", "boundingBox": [471, 2137, 565, 2133, 566, 2150, 472, 2154],
-        "words": [{"text": "----", "boundingBox": [473, 2138, 566, 2134, 566, 2150,
-        473, 2154], "confidence": 0.559}], "appearance": {"style": {"name": "print",
-        "confidence": 0.703}}}, {"text": "--", "boundingBox": [1252, 2129, 1319, 2127,
-        1320, 2143, 1252, 2146], "words": [{"text": "--", "boundingBox": [1277, 2129,
-        1319, 2127, 1319, 2144, 1276, 2145], "confidence": 0.559}], "appearance":
-        {"style": {"name": "print", "confidence": 0.846}}}, {"text": "Sub-Total",
-        "boundingBox": [434, 2232, 768, 2222, 770, 2312, 437, 2322], "words": [{"text":
-        "Sub-Total", "boundingBox": [434, 2234, 769, 2222, 770, 2313, 442, 2322],
-        "confidence": 0.981}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "$ 11.70", "boundingBox": [1082, 2228, 1309, 2228, 1309, 2313,
-        1084, 2312], "words": [{"text": "$", "boundingBox": [1082, 2228, 1122, 2228,
-        1121, 2313, 1082, 2312], "confidence": 0.654}, {"text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "confidence": 0.984}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "Tax", "boundingBox":
-        [433, 2367, 563, 2363, 565, 2458, 435, 2462], "words": [{"text": "Tax", "boundingBox":
-        [433, 2367, 559, 2363, 562, 2458, 435, 2462], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 0.98}}}, {"text": "$ 1.17", "boundingBox":
-        [1125, 2353, 1306, 2362, 1304, 2451, 1121, 2444], "words": [{"text": "$",
-        "boundingBox": [1125, 2353, 1167, 2355, 1163, 2446, 1121, 2444], "confidence":
-        0.966}, {"text": "1.17", "boundingBox": [1186, 2356, 1307, 2361, 1303, 2452,
-        1182, 2447], "confidence": 0.983}], "appearance": {"style": {"name": "print",
-        "confidence": 0.963}}}, {"text": "Tip", "boundingBox": [439, 2502, 545, 2506,
-        541, 2606, 435, 2602], "words": [{"text": "Tip", "boundingBox": [438, 2502,
-        545, 2506, 541, 2606, 435, 2602], "confidence": 0.987}], "appearance": {"style":
-        {"name": "print", "confidence": 0.943}}}, {"text": "$463", "boundingBox":
-        [1038, 2483, 1271, 2489, 1269, 2583, 1032, 2577], "words": [{"text": "$463",
-        "boundingBox": [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "confidence":
-        0.592}], "appearance": {"style": {"name": "handwriting", "confidence": 0.892}}},
-        {"text": "Total", "boundingBox": [431, 2651, 607, 2646, 610, 2739, 435, 2745],
-        "words": [{"text": "Total", "boundingBox": [431, 2651, 605, 2646, 608, 2739,
-        433, 2745], "confidence": 0.983}], "appearance": {"style": {"name": "print",
-        "confidence": 0.991}}}, {"text": "$14.50", "boundingBox": [1034, 2623, 1381,
-        2642, 1374, 2757, 1027, 2740], "words": [{"text": "$14.50", "boundingBox":
-        [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "confidence": 0.845}], "appearance":
-        {"style": {"name": "handwriting", "confidence": 0.991}}}]}], "documentResults":
-        [{"docType": "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType":
-        {"type": "string", "valueString": "Itemized", "confidence": 0.99}, "MerchantName":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:09:35Z",
+        "lastUpdatedDateTime": "2020-11-16T19:09:37Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
+        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [635,
+        510, 1086, 461, 1098, 558, 643, 604], "words": [{"text": "Contoso", "boundingBox":
+        [639, 510, 1087, 461, 1098, 551, 646, 604], "confidence": 0.955}]}, {"text":
+        "Contoso", "boundingBox": [305, 574, 519, 624, 504, 686, 291, 634], "words":
+        [{"text": "Contoso", "boundingBox": [311, 575, 517, 623, 503, 686, 297, 636],
+        "confidence": 0.435}]}, {"text": "123 Main Street", "boundingBox": [300, 675,
+        703, 767, 686, 844, 284, 749], "words": [{"text": "123", "boundingBox": [302,
+        676, 390, 695, 375, 770, 287, 751], "confidence": 0.935}, {"text": "Main",
+        "boundingBox": [405, 698, 528, 726, 512, 802, 390, 774], "confidence": 0.958},
+        {"text": "Street", "boundingBox": [542, 730, 702, 767, 685, 845, 527, 806],
+        "confidence": 0.959}]}, {"text": "Redmond, WA 98052", "boundingBox": [290,
+        784, 828, 850, 820, 933, 279, 868], "words": [{"text": "Redmond,", "boundingBox":
+        [293, 784, 550, 826, 540, 905, 280, 856], "confidence": 0.762}, {"text": "WA",
+        "boundingBox": [565, 828, 645, 837, 637, 917, 555, 907], "confidence": 0.943},
+        {"text": "98052", "boundingBox": [660, 838, 824, 849, 818, 933, 651, 919],
+        "confidence": 0.959}]}, {"text": "987-654-3210", "boundingBox": [275, 1003,
+        656, 1055, 646, 1123, 269, 1073], "words": [{"text": "987-654-3210", "boundingBox":
+        [278, 1004, 656, 1057, 647, 1123, 271, 1075], "confidence": 0.939}]}, {"text":
+        "6/10/2019 13:59", "boundingBox": [265, 1228, 678, 1258, 671, 1344, 258, 1311],
+        "words": [{"text": "6/10/2019", "boundingBox": [267, 1229, 525, 1247, 517,
+        1332, 259, 1313], "confidence": 0.762}, {"text": "13:59", "boundingBox": [541,
+        1248, 677, 1263, 669, 1345, 533, 1333], "confidence": 0.958}]}, {"text": "Sales
+        Associate: Paul", "boundingBox": [253, 1347, 868, 1379, 863, 1457, 249, 1425],
+        "words": [{"text": "Sales", "boundingBox": [259, 1348, 419, 1359, 414, 1435,
+        252, 1422], "confidence": 0.92}, {"text": "Associate:", "boundingBox": [434,
+        1360, 711, 1374, 707, 1452, 428, 1436], "confidence": 0.909}, {"text": "Paul",
+        "boundingBox": [726, 1374, 865, 1379, 862, 1457, 722, 1452], "confidence":
+        0.959}]}, {"text": "1 Cappuccino", "boundingBox": [244, 1583, 658, 1601, 653,
+        1689, 240, 1674], "words": [{"text": "1", "boundingBox": [245, 1583, 299,
+        1585, 295, 1676, 241, 1671], "confidence": 0.824}, {"text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "confidence":
+        0.727}]}, {"text": "$2.20", "boundingBox": [1106, 1584, 1268, 1574, 1270,
+        1656, 1110, 1666], "words": [{"text": "$2.20", "boundingBox": [1108, 1584,
+        1263, 1574, 1268, 1656, 1113, 1666], "confidence": 0.958}]}, {"text": "1 BACON
+        & EGGS", "boundingBox": [232, 1834, 745, 1840, 744, 1924, 231, 1918], "words":
+        [{"text": "1", "boundingBox": [232, 1834, 286, 1836, 285, 1920, 231, 1920],
+        "confidence": 0.845}, {"text": "BACON", "boundingBox": [308, 1836, 506, 1841,
+        504, 1920, 307, 1920], "confidence": 0.885}, {"text": "&", "boundingBox":
+        [523, 1841, 568, 1842, 566, 1921, 521, 1921], "confidence": 0.799}, {"text":
+        "EGGS", "boundingBox": [585, 1842, 746, 1843, 744, 1924, 583, 1921], "confidence":
+        0.949}]}, {"text": "Sunny-side-up", "boundingBox": [347, 1975, 751, 1977,
+        751, 2061, 347, 2060], "words": [{"text": "Sunny-side-up", "boundingBox":
+        [348, 1975, 749, 1979, 747, 2061, 348, 2061], "confidence": 0.946}]}, {"text":
+        "$9.5", "boundingBox": [1135, 1955, 1262, 1952, 1263, 2035, 1136, 2039], "words":
+        [{"text": "$9.5", "boundingBox": [1135, 1955, 1257, 1952, 1259, 2036, 1136,
+        2039], "confidence": 0.95}]}, {"text": "Sub-Total", "boundingBox": [440, 2229,
+        771, 2219, 773, 2318, 442, 2327], "words": [{"text": "Sub-Total", "boundingBox":
+        [441, 2229, 769, 2220, 774, 2319, 443, 2328], "confidence": 0.856}]}, {"text":
+        "$ 11.70", "boundingBox": [1092, 2221, 1301, 2224, 1299, 2319, 1093, 2317],
+        "words": [{"text": "$", "boundingBox": [1092, 2221, 1127, 2221, 1126, 2317,
+        1092, 2316], "confidence": 0.799}, {"text": "11.70", "boundingBox": [1146,
+        2221, 1297, 2223, 1296, 2319, 1145, 2317], "confidence": 0.948}]}, {"text":
+        "Tax", "boundingBox": [442, 2371, 549, 2367, 552, 2454, 445, 2458], "words":
+        [{"text": "Tax", "boundingBox": [445, 2371, 546, 2367, 549, 2454, 448, 2458],
+        "confidence": 0.958}]}, {"text": "$ 1.17", "boundingBox": [1129, 2359, 1310,
+        2359, 1306, 2456, 1129, 2456], "words": [{"text": "$", "boundingBox": [1129,
+        2359, 1171, 2359, 1171, 2456, 1129, 2456], "confidence": 0.89}, {"text": "1.17",
+        "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "confidence":
+        0.942}]}, {"text": "Tip", "boundingBox": [433, 2505, 539, 2506, 540, 2602,
+        434, 2602], "words": [{"text": "Tip", "boundingBox": [436, 2505, 536, 2505,
+        536, 2602, 436, 2602], "confidence": 0.959}]}, {"text": "$ 1.63", "boundingBox":
+        [1030, 2478, 1269, 2486, 1267, 2591, 1024, 2583], "words": [{"text": "$",
+        "boundingBox": [1027, 2478, 1073, 2478, 1069, 2584, 1024, 2583], "confidence":
+        0.788}, {"text": "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591,
+        1091, 2585], "confidence": 0.284}]}, {"text": "Total", "boundingBox": [433,
+        2652, 611, 2644, 615, 2738, 436, 2747], "words": [{"text": "Total", "boundingBox":
+        [435, 2652, 609, 2644, 613, 2739, 439, 2747], "confidence": 0.866}]}, {"text":
+        "$14.50", "boundingBox": [1034, 2620, 1386, 2637, 1380, 2762, 1029, 2739],
+        "words": [{"text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380,
+        2763, 1030, 2739], "confidence": 0.57}]}]}], "documentResults": [{"docType":
+        "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType": {"type":
+        "string", "valueString": "Itemized", "confidence": 0.692}, "MerchantName":
         {"type": "string", "valueString": "Contoso Contoso", "text": "Contoso Contoso",
-        "boundingBox": [380.9, 282.9, 1116, 473.2, 1025, 824.4, 290, 634], "page":
-        1, "confidence": 0.716, "elements": ["#/readResults/0/lines/1/words/0", "#/readResults/0/lines/0/words/0"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
-        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [298.3,
-        676.5, 844.6, 781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989,
-        "elements": ["#/readResults/0/lines/2/words/0", "#/readResults/0/lines/2/words/1",
-        "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1",
-        "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber": {"type": "phoneNumber",
-        "valuePhoneNumber": "+19876543210", "text": "987-654-3210", "boundingBox":
-        [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence": 0.99,
-        "elements": ["#/readResults/0/lines/4/words/0"]}, "TransactionDate": {"type":
-        "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox": [259,
-        1224, 510, 1246, 505, 1331, 255, 1312], "page": 1, "confidence": 0.99, "elements":
-        ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type": "time",
-        "valueTime": "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681,
-        1262, 675, 1341, 522, 1332], "page": 1, "confidence": 0.989, "elements": ["#/readResults/0/lines/5/words/1"]},
-        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        "boundingBox": [378.2, 292.4, 1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8],
+        "page": 1, "confidence": 0.613, "elements": ["#/readResults/0/lines/0/words/0",
+        "#/readResults/0/lines/1/words/0"]}, "MerchantAddress": {"type": "string",
+        "valueString": "123 Main Street Redmond, WA 98052", "text": "123 Main Street
+        Redmond, WA 98052", "boundingBox": [302, 675.8, 848.1, 793.7, 809.9, 970.4,
+        263.9, 852.5], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/2/words/0",
+        "#/readResults/0/lines/2/words/1", "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0",
+        "#/readResults/0/lines/3/words/1", "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber":
+        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
+        "boundingBox": [278, 1004, 656, 1057, 647, 1123, 271, 1075], "page": 1, "confidence":
+        0.99, "elements": ["#/readResults/0/lines/4/words/0"]}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99,
+        "elements": ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type":
+        "time", "valueTime": "13:59:00", "text": "13:59", "boundingBox": [541, 1248,
+        677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence": 0.977, "elements":
+        ["#/readResults/0/lines/5/words/1"]}, "Items": {"type": "array", "valueArray":
+        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
+        1, "text": "1", "boundingBox": [245, 1583, 299, 1585, 295, 1676, 241, 1671],
+        "page": 1, "confidence": 0.92, "elements": ["#/readResults/0/lines/7/words/0"]},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923, "elements": ["#/readResults/0/lines/7/words/1"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1108, 1584,
+        1263, 1574, 1268, 1656, 1113, 1666], "page": 1, "confidence": 0.918, "elements":
+        ["#/readResults/0/lines/8/words/0"]}}}, {"type": "object", "valueObject":
         {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [244, 1581, 288, 1584, 285, 1678, 241, 1675], "page": 1, "confidence": 0.919,
-        "elements": ["#/readResults/0/lines/7/words/0"]}, "Name": {"type": "string",
-        "valueString": "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585,
-        658, 1598, 657, 1688, 304, 1679], "page": 1, "confidence": 0.959, "elements":
-        ["#/readResults/0/lines/7/words/1"]}, "TotalPrice": {"type": "number", "valueNumber":
-        2.2, "text": "$2.20", "boundingBox": [1106, 1579, 1260, 1574, 1263, 1656,
-        1108, 1662], "page": 1, "confidence": 0.959, "elements": ["#/readResults/0/lines/8/words/0"]}}},
-        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91, "elements": ["#/readResults/0/lines/9/words/0"]},
-        "Name": {"type": "string", "valueString": "BACON & EGGS", "text": "BACON &
-        EGGS", "boundingBox": [294, 1839, 737, 1839, 737, 1924, 294, 1924], "page":
-        1, "confidence": 0.955, "elements": ["#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2",
+        [232, 1834, 286, 1836, 285, 1920, 231, 1920], "page": 1, "confidence": 0.858,
+        "elements": ["#/readResults/0/lines/9/words/0"]}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916,
+        "elements": ["#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2",
         "#/readResults/0/lines/9/words/3"]}, "TotalPrice": {"type": "number", "valueNumber":
-        9.5, "text": "$9.5", "boundingBox": [1134, 1948, 1252, 1948, 1252, 2041, 1134,
-        2041], "page": 1, "confidence": 0.958, "elements": ["#/readResults/0/lines/11/words/0"]}}}]},
+        9.5, "text": "$9.5", "boundingBox": [1135, 1955, 1257, 1952, 1259, 2036, 1136,
+        2039], "page": 1, "confidence": 0.916, "elements": ["#/readResults/0/lines/11/words/0"]}}}]},
         "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923, "elements": ["#/readResults/0/lines/17/words/1"]}, "Tax": {"type":
-        "number", "valueNumber": 1.17, "text": "1.17", "boundingBox": [1186, 2356,
-        1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence": 0.979, "elements":
-        ["#/readResults/0/lines/19/words/1"]}, "Tip": {"type": "number", "valueNumber":
-        463, "text": "$463", "boundingBox": [1034, 2483, 1268, 2488, 1266, 2583, 1032,
-        2577], "page": 1, "confidence": 0.975, "elements": ["#/readResults/0/lines/21/words/0"]},
+        [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1, "confidence":
+        0.955, "elements": ["#/readResults/0/lines/13/words/1"]}, "Tax": {"type":
+        "number", "valueNumber": 1.17, "text": "1.17", "boundingBox": [1190, 2359,
+        1304, 2359, 1304, 2456, 1190, 2456], "page": 1, "confidence": 0.979, "elements":
+        ["#/readResults/0/lines/15/words/1"]}, "Tip": {"type": "number", "valueNumber":
+        1.63, "text": "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591,
+        1091, 2585], "page": 1, "confidence": 0.941, "elements": ["#/readResults/0/lines/17/words/1"]},
         "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50", "boundingBox":
-        [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1, "confidence":
-        0.987, "elements": ["#/readResults/0/lines/23/words/0"]}}}]}}'
+        [1034, 2620, 1384, 2638, 1380, 2763, 1030, 2739], "page": 1, "confidence":
+        0.985, "elements": ["#/readResults/0/lines/19/words/0"]}}}]}}'
     headers:
       apim-request-id:
-      - 995315c2-0dcb-44b9-8794-02ec64162162
+      - f5b8f20e-7965-46e4-b7ec-c67b1dc03ac0
       content-length:
-      - '10546'
+      - '8501'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:04:12 GMT
+      - Mon, 16 Nov 2020 19:09:40 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '35'
+      - '18'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_locale_error.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_locale_error.yaml
@@ -20,23 +20,23 @@ interactions:
   response:
     body:
       string: '{"error": {"code": "UnsupportedLocale", "innerError": {"requestId":
-        "a11979c7-545d-42df-8731-ceb5ba76b2db"}, "message": "Locale unsupported. Supported
+        "04fc9a9b-c239-4a3b-80ea-1ab42ef044e4"}, "message": "Locale unsupported. Supported
         locales include en-AU, en-CA, en-GB, en-IN and en-US."}}'
     headers:
       apim-request-id:
-      - a11979c7-545d-42df-8731-ceb5ba76b2db
+      - 04fc9a9b-c239-4a3b-80ea-1ab42ef044e4
       content-length:
       - '200'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:04:12 GMT
+      - Mon, 16 Nov 2020 19:09:41 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '131'
+      - '134'
     status:
       code: 400
       message: Bad Request

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_locale_specified.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_locale_specified.yaml
@@ -22,19 +22,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 339d2f4d-082f-4ea4-842a-5317de8f31f4
+      - 659cb7fd-cbb5-4d0d-be5a-9053e791f441
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:04:14 GMT
+      - Mon, 16 Nov 2020 19:09:42 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/339d2f4d-082f-4ea4-842a-5317de8f31f4
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/659cb7fd-cbb5-4d0d-be5a-9053e791f441
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '341'
+      - '171'
     status:
       code: 202
       message: Accepted
@@ -50,20 +50,20 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/339d2f4d-082f-4ea4-842a-5317de8f31f4
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/659cb7fd-cbb5-4d0d-be5a-9053e791f441
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:04:14Z",
-        "lastUpdatedDateTime": "2020-11-11T18:04:18Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:09:42Z",
+        "lastUpdatedDateTime": "2020-11-16T19:09:45Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
         "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
         "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [380.9, 282.9,
-        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.989}, "MerchantAddress":
+        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.769}, "MerchantAddress":
         {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
         "123 Main Street Redmond, WA 98052", "boundingBox": [298.3, 676.5, 844.6,
-        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.993}, "MerchantPhoneNumber":
+        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.99}, "MerchantPhoneNumber":
         {"type": "phoneNumber", "valuePhoneNumber": "+919876543210", "text": "987-654-3210",
         "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence":
         0.995}, "TransactionDate": {"type": "date", "valueDate": "2019-10-06", "text":
@@ -73,38 +73,40 @@ interactions:
         522, 1332], "page": 1, "confidence": 0.995}, "Items": {"type": "array", "valueArray":
         [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
         1, "text": "1", "boundingBox": [244, 1581, 288, 1584, 285, 1678, 241, 1675],
-        "page": 1, "confidence": 0.919}, "Name": {"type": "string", "valueString":
+        "page": 1, "confidence": 0.936}, "Name": {"type": "string", "valueString":
         "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585, 658, 1598,
-        657, 1688, 304, 1679], "page": 1, "confidence": 0.982}, "TotalPrice": {"type":
+        657, 1688, 304, 1679], "page": 1, "confidence": 0.976}, "TotalPrice": {"type":
         "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1106, 1579,
-        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.971}}}, {"type":
+        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.988}}}, {"type":
         "object", "valueObject": {"Quantity": {"type": "number", "valueNumber": 1,
         "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.918}, "Name": {"type": "string", "valueString":
-        "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [294, 1839, 737, 1839,
-        737, 1924, 294, 1924], "page": 1, "confidence": 0.892}, "TotalPrice": {"type":
-        "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox": [1134, 1948,
-        1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence": 0.969}}}]},
-        "Tax": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.971}, "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50",
-        "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1,
-        "confidence": 0.99}}}]}}'
+        "page": 1, "confidence": 0.882}, "Name": {"type": "string", "valueString":
+        "BACON & EGGS Sunny-side-up", "text": "BACON & EGGS Sunny-side-up", "boundingBox":
+        [294, 1839, 757, 1839, 757, 2064, 294, 2064], "page": 1, "confidence": 0.506},
+        "TotalPrice": {"type": "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox":
+        [1134, 1948, 1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence":
+        0.987}}}]}, "Tax": {"type": "number", "valueNumber": 1.17, "text": "1.17",
+        "boundingBox": [1186, 2356, 1307, 2361, 1303, 2452, 1182, 2447], "page": 1,
+        "confidence": 0.994}, "Total": {"type": "number", "valueNumber": 14.5, "text":
+        "$14.50", "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740],
+        "page": 1, "confidence": 0.988}, "Subtotal": {"type": "number", "valueNumber":
+        11.7, "text": "11.70", "boundingBox": [1139, 2228, 1309, 2228, 1308, 2313,
+        1138, 2313], "page": 1, "confidence": 0.269}}}]}}'
     headers:
       apim-request-id:
-      - 92a3a382-9291-4616-9724-bae57ecbf266
+      - 87385666-9908-4287-9d0f-dd292c3a4326
       content-length:
-      - '2537'
+      - '2711'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:04:18 GMT
+      - Mon, 16 Nov 2020 19:09:47 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '27'
+      - '19'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_multipage.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_multipage.yaml
@@ -1933,19 +1933,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - de20d77e-150f-4287-9d30-61a836485983
+      - cc7063d0-354e-4895-b57c-973685500939
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:04:20 GMT
+      - Mon, 16 Nov 2020 19:09:47 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/de20d77e-150f-4287-9d30-61a836485983
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/cc7063d0-354e-4895-b57c-973685500939
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '158'
+      - '216'
     status:
       code: 202
       message: Accepted
@@ -1961,11 +1961,11 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/de20d77e-150f-4287-9d30-61a836485983
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/cc7063d0-354e-4895-b57c-973685500939
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:04:20Z",
-        "lastUpdatedDateTime": "2020-11-11T18:04:24Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:09:48Z",
+        "lastUpdatedDateTime": "2020-11-16T19:09:52Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": 0, "width": 8.5, "height": 11,
         "unit": "inch", "lines": [{"text": "Company A Invoice", "boundingBox": [0.8861,
         1.1217, 2.3783, 1.1217, 2.3783, 1.2812, 0.8861, 1.2812], "words": [{"text":
@@ -1973,391 +1973,371 @@ interactions:
         0.8861, 1.2812], "confidence": 1}, {"text": "A", "boundingBox": [1.6696, 1.1242,
         1.7749, 1.1242, 1.7749, 1.2473, 1.6696, 1.2473], "confidence": 1}, {"text":
         "Invoice", "boundingBox": [1.8389, 1.1217, 2.3783, 1.1217, 2.3783, 1.2485,
-        1.8389, 1.2485], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "Invoice For:", "boundingBox": [6.0211, 1.0656,
-        7.0357, 1.0656, 7.0357, 1.2121, 6.0211, 1.2121], "words": [{"text": "Invoice",
-        "boundingBox": [6.0211, 1.0656, 6.6362, 1.0656, 6.6362, 1.2121, 6.0211, 1.2121],
-        "confidence": 1}, {"text": "For:", "boundingBox": [6.7147, 1.0691, 7.0357,
-        1.0691, 7.0357, 1.2121, 6.7147, 1.2121], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Address:", "boundingBox":
-        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "words":
-        [{"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825, 1.5657,
-        1.6155, 0.8791, 1.6155], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Bilbo Baggins", "boundingBox": [6.0164,
-        1.4503, 6.8967, 1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "words": [{"text":
-        "Bilbo", "boundingBox": [6.0164, 1.4503, 6.3392, 1.4503, 6.3392, 1.5649, 6.0164,
-        1.5649], "confidence": 1}, {"text": "Baggins", "boundingBox": [6.396, 1.4556,
-        6.8967, 1.4556, 6.8967, 1.5931, 6.396, 1.5931], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "123 Hobbit Lane",
-        "boundingBox": [6.0165, 1.6707, 7.1006, 1.6707, 7.1006, 1.7854, 6.0165, 1.7854],
-        "words": [{"text": "123", "boundingBox": [6.0165, 1.6772, 6.2434, 1.6772,
-        6.2434, 1.7854, 6.0165, 1.7854], "confidence": 1}, {"text": "Hobbit", "boundingBox":
-        [6.3033, 1.6707, 6.7463, 1.6707, 6.7463, 1.7854, 6.3033, 1.7854], "confidence":
-        1}, {"text": "Lane", "boundingBox": [6.803, 1.6782, 7.1006, 1.6782, 7.1006,
-        1.7854, 6.803, 1.7854], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "567 Main St.", "boundingBox": [0.8852,
-        1.846, 1.713, 1.846, 1.713, 1.9554, 0.8852, 1.9554], "words": [{"text": "567",
-        "boundingBox": [0.8852, 1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554],
-        "confidence": 1}, {"text": "Main", "boundingBox": [1.1777, 1.846, 1.5022,
-        1.846, 1.5022, 1.9554, 1.1777, 1.9554], "confidence": 1}, {"text": "St.",
-        "boundingBox": [1.5558, 1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Redmond, WA", "boundingBox": [6.0164, 1.891, 6.9793, 1.891,
-        6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text": "Redmond,", "boundingBox":
-        [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275, 6.0164, 2.0275], "confidence":
-        1}, {"text": "WA", "boundingBox": [6.7408, 1.8982, 6.9793, 1.8982, 6.9793,
-        2.0044, 6.7408, 2.0044], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Redmond, WA", "boundingBox": [0.891,
-        2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,",
-        "boundingBox": [0.891, 2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975],
-        "confidence": 1}, {"text": "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682,
-        1.8537, 2.1744, 1.6152, 2.1744], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "555-555-5555", "boundingBox":
-        [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "words":
-        [{"text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187,
-        6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "555-555-5555", "boundingBox":
+        1.8389, 1.2485], "confidence": 1}]}, {"text": "Invoice For:", "boundingBox":
+        [6.0211, 1.0656, 7.0357, 1.0656, 7.0357, 1.2121, 6.0211, 1.2121], "words":
+        [{"text": "Invoice", "boundingBox": [6.0211, 1.0656, 6.6362, 1.0656, 6.6362,
+        1.2121, 6.0211, 1.2121], "confidence": 1}, {"text": "For:", "boundingBox":
+        [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121, 6.7147, 1.2121], "confidence":
+        1}]}, {"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825,
+        1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text": "Address:", "boundingBox":
+        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "confidence":
+        1}]}, {"text": "Bilbo Baggins", "boundingBox": [6.0164, 1.4503, 6.8967, 1.4503,
+        6.8967, 1.5931, 6.0164, 1.5931], "words": [{"text": "Bilbo", "boundingBox":
+        [6.0164, 1.4503, 6.3392, 1.4503, 6.3392, 1.5649, 6.0164, 1.5649], "confidence":
+        1}, {"text": "Baggins", "boundingBox": [6.396, 1.4556, 6.8967, 1.4556, 6.8967,
+        1.5931, 6.396, 1.5931], "confidence": 1}]}, {"text": "123 Hobbit Lane", "boundingBox":
+        [6.0165, 1.6707, 7.1006, 1.6707, 7.1006, 1.7854, 6.0165, 1.7854], "words":
+        [{"text": "123", "boundingBox": [6.0165, 1.6772, 6.2434, 1.6772, 6.2434, 1.7854,
+        6.0165, 1.7854], "confidence": 1}, {"text": "Hobbit", "boundingBox": [6.3033,
+        1.6707, 6.7463, 1.6707, 6.7463, 1.7854, 6.3033, 1.7854], "confidence": 1},
+        {"text": "Lane", "boundingBox": [6.803, 1.6782, 7.1006, 1.6782, 7.1006, 1.7854,
+        6.803, 1.7854], "confidence": 1}]}, {"text": "567 Main St.", "boundingBox":
+        [0.8852, 1.846, 1.713, 1.846, 1.713, 1.9554, 0.8852, 1.9554], "words": [{"text":
+        "567", "boundingBox": [0.8852, 1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852,
+        1.9554], "confidence": 1}, {"text": "Main", "boundingBox": [1.1777, 1.846,
+        1.5022, 1.846, 1.5022, 1.9554, 1.1777, 1.9554], "confidence": 1}, {"text":
+        "St.", "boundingBox": [1.5558, 1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558,
+        1.9554], "confidence": 1}]}, {"text": "Redmond, WA", "boundingBox": [6.0164,
+        1.891, 6.9793, 1.891, 6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text":
+        "Redmond,", "boundingBox": [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275,
+        6.0164, 2.0275], "confidence": 1}, {"text": "WA", "boundingBox": [6.7408,
+        1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408, 2.0044], "confidence": 1}]},
+        {"text": "Redmond, WA", "boundingBox": [0.891, 2.061, 1.8537, 2.061, 1.8537,
+        2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,", "boundingBox": [0.891,
+        2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975], "confidence": 1}, {"text":
+        "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682, 1.8537, 2.1744, 1.6152,
+        2.1744], "confidence": 1}]}, {"text": "555-555-5555", "boundingBox": [6.0105,
+        2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "words": [{"text":
+        "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254,
+        6.0105, 2.2254], "confidence": 1}]}, {"text": "555-555-5555", "boundingBox":
         [0.8852, 2.2887, 1.8119, 2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "words":
         [{"text": "555-555-5555", "boundingBox": [0.8852, 2.2887, 1.8119, 2.2887,
-        1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Item", "boundingBox": [1.0943,
-        3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
+        1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}]}, {"text": "Item", "boundingBox":
+        [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
         "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943,
-        3.109], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996,
-        3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity", "boundingBox":
-        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Price", "boundingBox": [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423,
-        3.109], "words": [{"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
-        2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "A", "boundingBox": [1.0832,
-        3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A",
-        "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116, 3.3202,
-        3.3176, 3.2589, 3.3176], "words": [{"text": "1", "boundingBox": [3.2589, 3.2116,
-        3.3202, 3.2116, 3.3202, 3.3176, 3.2589, 3.3176], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "10.99", "boundingBox":
+        3.109], "confidence": 1}]}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996,
+        3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity",
+        "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371],
+        "confidence": 1}]}, {"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
+        2.9996, 5.7372, 3.109, 5.423, 3.109], "words": [{"text": "Price", "boundingBox":
+        [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence":
+        1}]}, {"text": "A", "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174,
+        3.318, 1.0832, 3.318], "words": [{"text": "A", "boundingBox": [1.0832, 3.2118,
+        1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "confidence": 1}]}, {"text":
+        "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116, 3.3202, 3.3176, 3.2589,
+        3.3176], "words": [{"text": "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116,
+        3.3202, 3.3176, 3.2589, 3.3176], "confidence": 1}]}, {"text": "10.99", "boundingBox":
         [5.4232, 3.2108, 5.7784, 3.2108, 5.7784, 3.319, 5.4232, 3.319], "words": [{"text":
         "10.99", "boundingBox": [5.4232, 3.2108, 5.7784, 3.2108, 5.7784, 3.319, 5.4232,
-        3.319], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637,
-        3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox": [1.0943, 3.4256,
-        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "2", "boundingBox":
-        [3.2541, 3.4241, 3.3199, 3.4241, 3.3199, 3.531, 3.2541, 3.531], "words": [{"text":
-        "2", "boundingBox": [3.2541, 3.4241, 3.3199, 3.4241, 3.3199, 3.531, 3.2541,
-        3.531], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "14.67", "boundingBox": [5.4232, 3.4241, 5.7789, 3.4241, 5.7789,
-        3.5323, 5.4232, 3.5323], "words": [{"text": "14.67", "boundingBox": [5.4232,
-        3.4241, 5.7789, 3.4241, 5.7789, 3.5323, 5.4232, 3.5323], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "C",
+        3.319], "confidence": 1}]}, {"text": "B", "boundingBox": [1.0943, 3.4256,
+        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox":
+        [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence":
+        1}]}, {"text": "2", "boundingBox": [3.2541, 3.4241, 3.3199, 3.4241, 3.3199,
+        3.531, 3.2541, 3.531], "words": [{"text": "2", "boundingBox": [3.2541, 3.4241,
+        3.3199, 3.4241, 3.3199, 3.531, 3.2541, 3.531], "confidence": 1}]}, {"text":
+        "14.67", "boundingBox": [5.4232, 3.4241, 5.7789, 3.4241, 5.7789, 3.5323, 5.4232,
+        3.5323], "words": [{"text": "14.67", "boundingBox": [5.4232, 3.4241, 5.7789,
+        3.4241, 5.7789, 3.5323, 5.4232, 3.5323], "confidence": 1}]}, {"text": "C",
         "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647, 3.7421, 1.0882, 3.7421],
         "words": [{"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647,
-        3.7421, 1.0882, 3.7421], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "4", "boundingBox": [3.2486, 3.6351,
-        3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "words": [{"text": "4", "boundingBox":
-        [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "15.66", "boundingBox": [5.4232, 3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232,
-        3.7423], "words": [{"text": "15.66", "boundingBox": [5.4232, 3.6341, 5.78,
-        3.6341, 5.78, 3.7423, 5.4232, 3.7423], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "D", "boundingBox": [1.0943,
-        3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text":
-        "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943,
-        3.951], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1", "boundingBox": [3.2589, 3.845, 3.3202, 3.845, 3.3202,
+        3.7421, 1.0882, 3.7421], "confidence": 1}]}, {"text": "4", "boundingBox":
+        [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "words":
+        [{"text": "4", "boundingBox": [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413,
+        3.2486, 3.7413], "confidence": 1}]}, {"text": "15.66", "boundingBox": [5.4232,
+        3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232, 3.7423], "words": [{"text": "15.66",
+        "boundingBox": [5.4232, 3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232, 3.7423],
+        "confidence": 1}]}, {"text": "D", "boundingBox": [1.0943, 3.8456, 1.1753,
+        3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text": "D", "boundingBox":
+        [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "confidence":
+        1}]}, {"text": "1", "boundingBox": [3.2589, 3.845, 3.3202, 3.845, 3.3202,
         3.951, 3.2589, 3.951], "words": [{"text": "1", "boundingBox": [3.2589, 3.845,
-        3.3202, 3.845, 3.3202, 3.951, 3.2589, 3.951], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "12.00", "boundingBox":
-        [5.4232, 3.8441, 5.7809, 3.8441, 5.7809, 3.9523, 5.4232, 3.9523], "words":
-        [{"text": "12.00", "boundingBox": [5.4232, 3.8441, 5.7809, 3.8441, 5.7809,
-        3.9523, 5.4232, 3.9523], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "E", "boundingBox": [1.0943, 4.0561,
-        1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "words": [{"text": "E", "boundingBox":
-        [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617, 3.2486,
-        4.1617], "words": [{"text": "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556,
-        3.3244, 4.1617, 3.2486, 4.1617], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "10.00", "boundingBox": [5.4232,
+        3.3202, 3.845, 3.3202, 3.951, 3.2589, 3.951], "confidence": 1}]}, {"text":
+        "12.00", "boundingBox": [5.4232, 3.8441, 5.7809, 3.8441, 5.7809, 3.9523, 5.4232,
+        3.9523], "words": [{"text": "12.00", "boundingBox": [5.4232, 3.8441, 5.7809,
+        3.8441, 5.7809, 3.9523, 5.4232, 3.9523], "confidence": 1}]}, {"text": "E",
+        "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614],
+        "words": [{"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
+        4.1614, 1.0943, 4.1614], "confidence": 1}]}, {"text": "4", "boundingBox":
+        [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617, 3.2486, 4.1617], "words":
+        [{"text": "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617,
+        3.2486, 4.1617], "confidence": 1}]}, {"text": "10.00", "boundingBox": [5.4232,
         4.0546, 5.781, 4.0546, 5.781, 4.1627, 5.4232, 4.1627], "words": [{"text":
         "10.00", "boundingBox": [5.4232, 4.0546, 5.781, 4.0546, 5.781, 4.1627, 5.4232,
-        4.1627], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497,
-        4.3717, 1.0943, 4.3717], "words": [{"text": "F", "boundingBox": [1.0943, 4.2661,
-        1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "6", "boundingBox":
-        [3.2534, 4.2646, 3.3226, 4.2646, 3.3226, 4.3727, 3.2534, 4.3727], "words":
-        [{"text": "6", "boundingBox": [3.2534, 4.2646, 3.3226, 4.2646, 3.3226, 4.3727,
-        3.2534, 4.3727], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "12.00", "boundingBox": [5.4232, 4.2646, 5.7809,
-        4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "words": [{"text": "12.00", "boundingBox":
-        [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877,
-        4.5827], "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746,
-        1.1735, 4.5827, 1.0877, 4.5827], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "8", "boundingBox": [3.2514,
-        4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514, 4.5827], "words": [{"text":
-        "8", "boundingBox": [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514,
-        4.5827], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781,
-        4.5827, 5.4184, 4.5827], "words": [{"text": "22.00", "boundingBox": [5.4184,
-        4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184, 4.5827], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Subtotal:
-        300.00", "boundingBox": [5.5075, 4.8981, 6.632, 4.8981, 6.632, 5.0131, 5.5075,
-        5.0131], "words": [{"text": "Subtotal:", "boundingBox": [5.5075, 4.8981, 6.1249,
-        4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence": 1}, {"text": "300.00",
-        "boundingBox": [6.1794, 4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Tax: 30.00", "boundingBox": [5.5034, 5.1245, 6.2022, 5.1245,
-        6.2022, 5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:", "boundingBox":
-        [5.5034, 5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333], "confidence":
-        1}, {"text": "30.00", "boundingBox": [5.836, 5.1245, 6.2022, 5.1245, 6.2022,
-        5.2333, 5.836, 5.2333], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Tip: 100.00", "boundingBox": [5.5034,
-        5.3412, 6.2587, 5.3412, 6.2587, 5.481, 5.5034, 5.481], "words": [{"text":
+        4.1627], "confidence": 1}]}, {"text": "F", "boundingBox": [1.0943, 4.2661,
+        1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "words": [{"text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "confidence":
+        1}]}, {"text": "6", "boundingBox": [3.2534, 4.2646, 3.3226, 4.2646, 3.3226,
+        4.3727, 3.2534, 4.3727], "words": [{"text": "6", "boundingBox": [3.2534, 4.2646,
+        3.3226, 4.2646, 3.3226, 4.3727, 3.2534, 4.3727], "confidence": 1}]}, {"text":
+        "12.00", "boundingBox": [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232,
+        4.3727], "words": [{"text": "12.00", "boundingBox": [5.4232, 4.2646, 5.7809,
+        4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "confidence": 1}]}, {"text": "G",
+        "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827],
+        "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
+        4.5827, 1.0877, 4.5827], "confidence": 1}]}, {"text": "8", "boundingBox":
+        [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514, 4.5827], "words":
+        [{"text": "8", "boundingBox": [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827,
+        3.2514, 4.5827], "confidence": 1}]}, {"text": "22.00", "boundingBox": [5.4184,
+        4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184, 4.5827], "words": [{"text":
+        "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184,
+        4.5827], "confidence": 1}]}, {"text": "Subtotal: 300.00", "boundingBox": [5.5075,
+        4.8981, 6.632, 4.8981, 6.632, 5.0131, 5.5075, 5.0131], "words": [{"text":
+        "Subtotal:", "boundingBox": [5.5075, 4.8981, 6.1249, 4.8981, 6.1249, 5.0131,
+        5.5075, 5.0131], "confidence": 1}, {"text": "300.00", "boundingBox": [6.1794,
+        4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131], "confidence": 1}]},
+        {"text": "Tax: 30.00", "boundingBox": [5.5034, 5.1245, 6.2022, 5.1245, 6.2022,
+        5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:", "boundingBox": [5.5034,
+        5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333], "confidence": 1},
+        {"text": "30.00", "boundingBox": [5.836, 5.1245, 6.2022, 5.1245, 6.2022, 5.2333,
+        5.836, 5.2333], "confidence": 1}]}, {"text": "Tip: 100.00", "boundingBox":
+        [5.5034, 5.3412, 6.2587, 5.3412, 6.2587, 5.481, 5.5034, 5.481], "words": [{"text":
         "Tip:", "boundingBox": [5.5034, 5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034,
         5.481], "confidence": 1}, {"text": "100.00", "boundingBox": [5.811, 5.3445,
-        6.2587, 5.3445, 6.2587, 5.4533, 5.811, 5.4533], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Total: 430.00",
-        "boundingBox": [5.5034, 5.5583, 6.3987, 5.5583, 6.3987, 5.6733, 5.5034, 5.6733],
-        "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583,
-        5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "430.00", "boundingBox":
-        [5.942, 5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942, 5.6733], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Signature: ____Bilbo Baggins__________", "boundingBox": [1.0055, 6.6553,
-        3.8342, 6.6553, 3.8342, 6.7981, 1.0055, 6.7981], "words": [{"text": "Signature:",
-        "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981, 1.0055, 6.7981],
-        "confidence": 1}, {"text": "____Bilbo", "boundingBox": [1.747, 6.6553, 2.4278,
-        6.6553, 2.4278, 6.7981, 1.747, 6.7981], "confidence": 1}, {"text": "Baggins__________",
-        "boundingBox": [2.4823, 6.6581, 3.8342, 6.6581, 3.8342, 6.7981, 2.4823, 6.7981],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}]}, {"page": 2, "angle": 0, "width": 8.5, "height": 11, "unit": "inch"},
+        6.2587, 5.3445, 6.2587, 5.4533, 5.811, 5.4533], "confidence": 1}]}, {"text":
+        "Total: 430.00", "boundingBox": [5.5034, 5.5583, 6.3987, 5.5583, 6.3987, 5.6733,
+        5.5034, 5.6733], "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583,
+        5.8915, 5.5583, 5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text":
+        "430.00", "boundingBox": [5.942, 5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942,
+        5.6733], "confidence": 1}]}, {"text": "Signature: ____ Bilbo Baggins__________",
+        "boundingBox": [1.0055, 6.6553, 3.8342, 6.6553, 3.8342, 6.7981, 1.0055, 6.7981],
+        "words": [{"text": "Signature:", "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581,
+        1.6987, 6.7981, 1.0055, 6.7981], "confidence": 1}, {"text": "____", "boundingBox":
+        [1.747, 6.7829, 2.0809, 6.7829, 2.0809, 6.7981, 1.747, 6.7981], "confidence":
+        1}, {"text": "Bilbo", "boundingBox": [2.0925, 6.6553, 2.4278, 6.6553, 2.4278,
+        6.7703, 2.0925, 6.7703], "confidence": 1}, {"text": "Baggins__________", "boundingBox":
+        [2.4823, 6.6581, 3.8342, 6.6581, 3.8342, 6.7981, 2.4823, 6.7981], "confidence":
+        1}]}]}, {"page": 2, "angle": 0, "width": 8.5, "height": 11, "unit": "inch"},
         {"page": 3, "angle": 0, "width": 8.5, "height": 11, "unit": "inch", "lines":
         [{"text": "Company B Invoice", "boundingBox": [0.8861, 1.1217, 2.3734, 1.1217,
         2.3734, 1.2812, 0.8861, 1.2812], "words": [{"text": "Company", "boundingBox":
         [0.8861, 1.1232, 1.6203, 1.1232, 1.6203, 1.2812, 0.8861, 1.2812], "confidence":
         1}, {"text": "B", "boundingBox": [1.6836, 1.1248, 1.764, 1.1248, 1.764, 1.2469,
         1.6836, 1.2469], "confidence": 1}, {"text": "Invoice", "boundingBox": [1.8336,
-        1.1217, 2.3734, 1.1217, 2.3734, 1.2485, 1.8336, 1.2485], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Invoice
-        For:", "boundingBox": [6.0211, 1.0656, 7.0357, 1.0656, 7.0357, 1.2121, 6.0211,
-        1.2121], "words": [{"text": "Invoice", "boundingBox": [6.0211, 1.0656, 6.6362,
-        1.0656, 6.6362, 1.2121, 6.0211, 1.2121], "confidence": 1}, {"text": "For:",
-        "boundingBox": [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121, 6.7147, 1.2121],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825,
-        1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text": "Address:", "boundingBox":
-        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Frodo Baggins", "boundingBox": [6.0164, 1.4506, 6.9506, 1.4506, 6.9506, 1.5931,
-        6.0164, 1.5931], "words": [{"text": "Frodo", "boundingBox": [6.0164, 1.4506,
-        6.3895, 1.4506, 6.3895, 1.5649, 6.0164, 1.5649], "confidence": 1}, {"text":
-        "Baggins", "boundingBox": [6.45, 1.4556, 6.9506, 1.4556, 6.9506, 1.5931, 6.45,
-        1.5931], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "123 Hobbit Lane", "boundingBox": [6.0165, 1.6707, 7.1006,
+        1.1217, 2.3734, 1.1217, 2.3734, 1.2485, 1.8336, 1.2485], "confidence": 1}]},
+        {"text": "Invoice For:", "boundingBox": [6.0211, 1.0656, 7.0357, 1.0656, 7.0357,
+        1.2121, 6.0211, 1.2121], "words": [{"text": "Invoice", "boundingBox": [6.0211,
+        1.0656, 6.6362, 1.0656, 6.6362, 1.2121, 6.0211, 1.2121], "confidence": 1},
+        {"text": "For:", "boundingBox": [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121,
+        6.7147, 1.2121], "confidence": 1}]}, {"text": "Address:", "boundingBox": [0.8791,
+        1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text":
+        "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155,
+        0.8791, 1.6155], "confidence": 1}]}, {"text": "Frodo Baggins", "boundingBox":
+        [6.0164, 1.4506, 6.9506, 1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "words":
+        [{"text": "Frodo", "boundingBox": [6.0164, 1.4506, 6.3895, 1.4506, 6.3895,
+        1.5649, 6.0164, 1.5649], "confidence": 1}, {"text": "Baggins", "boundingBox":
+        [6.45, 1.4556, 6.9506, 1.4556, 6.9506, 1.5931, 6.45, 1.5931], "confidence":
+        1}]}, {"text": "123 Hobbit Lane", "boundingBox": [6.0165, 1.6707, 7.1006,
         1.6707, 7.1006, 1.7854, 6.0165, 1.7854], "words": [{"text": "123", "boundingBox":
         [6.0165, 1.6772, 6.2434, 1.6772, 6.2434, 1.7854, 6.0165, 1.7854], "confidence":
         1}, {"text": "Hobbit", "boundingBox": [6.3033, 1.6707, 6.7463, 1.6707, 6.7463,
         1.7854, 6.3033, 1.7854], "confidence": 1}, {"text": "Lane", "boundingBox":
         [6.803, 1.6782, 7.1006, 1.6782, 7.1006, 1.7854, 6.803, 1.7854], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "567 Main St.", "boundingBox": [0.8852, 1.846, 1.713, 1.846, 1.713, 1.9554,
-        0.8852, 1.9554], "words": [{"text": "567", "boundingBox": [0.8852, 1.8472,
-        1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554], "confidence": 1}, {"text":
-        "Main", "boundingBox": [1.1777, 1.846, 1.5022, 1.846, 1.5022, 1.9554, 1.1777,
-        1.9554], "confidence": 1}, {"text": "St.", "boundingBox": [1.5558, 1.8472,
-        1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Redmond, WA", "boundingBox":
-        [6.0164, 1.891, 6.9793, 1.891, 6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text":
-        "Redmond,", "boundingBox": [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275,
-        6.0164, 2.0275], "confidence": 1}, {"text": "WA", "boundingBox": [6.7408,
-        1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408, 2.0044], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Redmond,
-        WA", "boundingBox": [0.891, 2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975],
-        "words": [{"text": "Redmond,", "boundingBox": [0.891, 2.061, 1.5605, 2.061,
-        1.5605, 2.1975, 0.891, 2.1975], "confidence": 1}, {"text": "WA", "boundingBox":
-        [1.6152, 2.0682, 1.8537, 2.0682, 1.8537, 2.1744, 1.6152, 2.1744], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254,
-        6.0105, 2.2254], "words": [{"text": "555-555-5555", "boundingBox": [6.0105,
-        2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "555-555-5555",
+        1}]}, {"text": "567 Main St.", "boundingBox": [0.8852, 1.846, 1.713, 1.846,
+        1.713, 1.9554, 0.8852, 1.9554], "words": [{"text": "567", "boundingBox": [0.8852,
+        1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554], "confidence": 1},
+        {"text": "Main", "boundingBox": [1.1777, 1.846, 1.5022, 1.846, 1.5022, 1.9554,
+        1.1777, 1.9554], "confidence": 1}, {"text": "St.", "boundingBox": [1.5558,
+        1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554], "confidence": 1}]},
+        {"text": "Redmond, WA", "boundingBox": [6.0164, 1.891, 6.9793, 1.891, 6.9793,
+        2.0275, 6.0164, 2.0275], "words": [{"text": "Redmond,", "boundingBox": [6.0164,
+        1.891, 6.6861, 1.891, 6.6861, 2.0275, 6.0164, 2.0275], "confidence": 1}, {"text":
+        "WA", "boundingBox": [6.7408, 1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408,
+        2.0044], "confidence": 1}]}, {"text": "Redmond, WA", "boundingBox": [0.891,
+        2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,",
+        "boundingBox": [0.891, 2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975],
+        "confidence": 1}, {"text": "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682,
+        1.8537, 2.1744, 1.6152, 2.1744], "confidence": 1}]}, {"text": "555-555-5555",
+        "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254],
+        "words": [{"text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371,
+        2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}]}, {"text": "555-555-5555",
         "boundingBox": [0.8852, 2.2887, 1.8119, 2.2887, 1.8119, 2.3954, 0.8852, 2.3954],
         "words": [{"text": "555-555-5555", "boundingBox": [0.8852, 2.2887, 1.8119,
-        2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Item", "boundingBox":
-        [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
-        "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943,
-        3.109], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996,
-        3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity", "boundingBox":
-        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
+        2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}]}, {"text": "Item",
+        "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109],
+        "words": [{"text": "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018,
+        1.3842, 3.109, 1.0943, 3.109], "confidence": 1}]}, {"text": "Quantity", "boundingBox":
+        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "words":
+        [{"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996, 3.8367,
+        3.1371, 3.2527, 3.1371], "confidence": 1}]}, {"text": "Price", "boundingBox":
+        [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423, 3.109], "words": [{"text":
         "Price", "boundingBox": [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423,
-        3.109], "words": [{"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
-        2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "A", "boundingBox": [1.0832,
-        3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A",
-        "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "10", "boundingBox": [3.2589, 3.2108, 3.4067, 3.2108, 3.4067,
+        3.109], "confidence": 1}]}, {"text": "A", "boundingBox": [1.0832, 3.2118,
+        1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A", "boundingBox":
+        [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "confidence":
+        1}]}, {"text": "10", "boundingBox": [3.2589, 3.2108, 3.4067, 3.2108, 3.4067,
         3.319, 3.2589, 3.319], "words": [{"text": "10", "boundingBox": [3.2589, 3.2108,
-        3.4067, 3.2108, 3.4067, 3.319, 3.2589, 3.319], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "100.99", "boundingBox":
-        [5.4232, 3.2108, 5.8617, 3.2108, 5.8617, 3.319, 5.4232, 3.319], "words": [{"text":
+        3.4067, 3.2108, 3.4067, 3.319, 3.2589, 3.319], "confidence": 1}]}, {"text":
         "100.99", "boundingBox": [5.4232, 3.2108, 5.8617, 3.2108, 5.8617, 3.319, 5.4232,
-        3.319], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637,
-        3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox": [1.0943, 3.4256,
-        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "20", "boundingBox":
-        [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323], "words":
-        [{"text": "20", "boundingBox": [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323,
-        3.2541, 3.5323], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "140.67", "boundingBox": [5.4232, 3.4241, 5.8622,
+        3.319], "words": [{"text": "100.99", "boundingBox": [5.4232, 3.2108, 5.8617,
+        3.2108, 5.8617, 3.319, 5.4232, 3.319], "confidence": 1}]}, {"text": "B", "boundingBox":
+        [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "words": [{"text":
+        "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943,
+        3.531], "confidence": 1}]}, {"text": "20", "boundingBox": [3.2541, 3.4241,
+        3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323], "words": [{"text": "20",
+        "boundingBox": [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323],
+        "confidence": 1}]}, {"text": "140.67", "boundingBox": [5.4232, 3.4241, 5.8622,
         3.4241, 5.8622, 3.5323, 5.4232, 3.5323], "words": [{"text": "140.67", "boundingBox":
         [5.4232, 3.4241, 5.8622, 3.4241, 5.8622, 3.5323, 5.4232, 3.5323], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647, 3.7421, 1.0882,
-        3.7421], "words": [{"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343,
-        1.1647, 3.7421, 1.0882, 3.7421], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "40", "boundingBox": [3.2486,
-        3.6341, 3.4067, 3.6341, 3.4067, 3.7423, 3.2486, 3.7423], "words": [{"text":
+        1}]}, {"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647,
+        3.7421, 1.0882, 3.7421], "words": [{"text": "C", "boundingBox": [1.0882, 3.6343,
+        1.1647, 3.6343, 1.1647, 3.7421, 1.0882, 3.7421], "confidence": 1}]}, {"text":
         "40", "boundingBox": [3.2486, 3.6341, 3.4067, 3.6341, 3.4067, 3.7423, 3.2486,
-        3.7423], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "150.66", "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341, 5.8634,
-        3.7423, 5.4232, 3.7423], "words": [{"text": "150.66", "boundingBox": [5.4232,
-        3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "D",
-        "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951],
-        "words": [{"text": "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753,
-        3.951, 1.0943, 3.951], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "10", "boundingBox": [3.2589, 3.8441,
+        3.7423], "words": [{"text": "40", "boundingBox": [3.2486, 3.6341, 3.4067,
+        3.6341, 3.4067, 3.7423, 3.2486, 3.7423], "confidence": 1}]}, {"text": "150.66",
+        "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423],
+        "words": [{"text": "150.66", "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341,
+        5.8634, 3.7423, 5.4232, 3.7423], "confidence": 1}]}, {"text": "D", "boundingBox":
+        [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text":
+        "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943,
+        3.951], "confidence": 1}]}, {"text": "10", "boundingBox": [3.2589, 3.8441,
         3.4067, 3.8441, 3.4067, 3.9523, 3.2589, 3.9523], "words": [{"text": "10",
         "boundingBox": [3.2589, 3.8441, 3.4067, 3.8441, 3.4067, 3.9523, 3.2589, 3.9523],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "120.00", "boundingBox": [5.4232, 3.8441, 5.8642, 3.8441, 5.8642,
-        3.9523, 5.4232, 3.9523], "words": [{"text": "120.00", "boundingBox": [5.4232,
-        3.8441, 5.8642, 3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "E",
-        "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614],
-        "words": [{"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
-        4.1614, 1.0943, 4.1614], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "40", "boundingBox": [3.2486, 4.0546,
-        3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "words": [{"text": "40",
-        "boundingBox": [3.2486, 4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "100.00", "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546, 5.8644,
-        4.1627, 5.4232, 4.1627], "words": [{"text": "100.00", "boundingBox": [5.4232,
-        4.0546, 5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "F",
-        "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717],
-        "words": [{"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497,
-        4.3717, 1.0943, 4.3717], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "60", "boundingBox": [3.2534, 4.2646,
-        3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727], "words": [{"text": "60",
-        "boundingBox": [3.2534, 4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "120.00", "boundingBox": [5.4232, 4.2646, 5.8642, 4.2646, 5.8642,
-        4.3727, 5.4232, 4.3727], "words": [{"text": "120.00", "boundingBox": [5.4232,
-        4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "G",
-        "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827],
-        "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
-        4.5827, 1.0877, 4.5827], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "80", "boundingBox": [3.2514, 4.4746,
-        3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827], "words": [{"text": "80",
-        "boundingBox": [3.2514, 4.4746, 3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "220.00", "boundingBox": [5.4184, 4.4746, 5.8644, 4.4746, 5.8644,
+        "confidence": 1}]}, {"text": "120.00", "boundingBox": [5.4232, 3.8441, 5.8642,
+        3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "words": [{"text": "120.00", "boundingBox":
+        [5.4232, 3.8441, 5.8642, 3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "confidence":
+        1}]}, {"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
+        4.1614, 1.0943, 4.1614], "words": [{"text": "E", "boundingBox": [1.0943, 4.0561,
+        1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "confidence": 1}]}, {"text":
+        "40", "boundingBox": [3.2486, 4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486,
+        4.1627], "words": [{"text": "40", "boundingBox": [3.2486, 4.0546, 3.4067,
+        4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "confidence": 1}]}, {"text": "100.00",
+        "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627],
+        "words": [{"text": "100.00", "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546,
+        5.8644, 4.1627, 5.4232, 4.1627], "confidence": 1}]}, {"text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "words":
+        [{"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717,
+        1.0943, 4.3717], "confidence": 1}]}, {"text": "60", "boundingBox": [3.2534,
+        4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727], "words": [{"text":
+        "60", "boundingBox": [3.2534, 4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534,
+        4.3727], "confidence": 1}]}, {"text": "120.00", "boundingBox": [5.4232, 4.2646,
+        5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "words": [{"text": "120.00",
+        "boundingBox": [5.4232, 4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727],
+        "confidence": 1}]}, {"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735,
+        4.4746, 1.1735, 4.5827, 1.0877, 4.5827], "words": [{"text": "G", "boundingBox":
+        [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827], "confidence":
+        1}]}, {"text": "80", "boundingBox": [3.2514, 4.4746, 3.4067, 4.4746, 3.4067,
+        4.5827, 3.2514, 4.5827], "words": [{"text": "80", "boundingBox": [3.2514,
+        4.4746, 3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827], "confidence": 1}]},
+        {"text": "220.00", "boundingBox": [5.4184, 4.4746, 5.8644, 4.4746, 5.8644,
         4.5827, 5.4184, 4.5827], "words": [{"text": "220.00", "boundingBox": [5.4184,
-        4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Subtotal:
-        3000.00", "boundingBox": [5.5075, 4.8981, 6.7158, 4.8981, 6.7158, 5.0131,
-        5.5075, 5.0131], "words": [{"text": "Subtotal:", "boundingBox": [5.5075, 4.8981,
-        6.1249, 4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence": 1}, {"text":
-        "3000.00", "boundingBox": [6.1794, 4.9042, 6.7158, 4.9042, 6.7158, 5.0131,
-        6.1794, 5.0131], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "Tax: 300.00", "boundingBox": [5.5034, 5.1245,
-        6.2887, 5.1245, 6.2887, 5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:",
-        "boundingBox": [5.5034, 5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333],
-        "confidence": 1}, {"text": "300.00", "boundingBox": [5.836, 5.1245, 6.2887,
-        5.1245, 6.2887, 5.2333, 5.836, 5.2333], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Tip: 1000.00", "boundingBox":
-        [5.5034, 5.3412, 6.3422, 5.3412, 6.3422, 5.481, 5.5034, 5.481], "words": [{"text":
-        "Tip:", "boundingBox": [5.5034, 5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034,
-        5.481], "confidence": 1}, {"text": "1000.00", "boundingBox": [5.811, 5.3445,
-        6.3422, 5.3445, 6.3422, 5.4533, 5.811, 5.4533], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Total: 4300.00",
-        "boundingBox": [5.5034, 5.5583, 6.4825, 5.5583, 6.4825, 5.6733, 5.5034, 5.6733],
-        "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583,
-        5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "4300.00", "boundingBox":
+        4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "confidence": 1}]},
+        {"text": "Subtotal: 3000.00", "boundingBox": [5.5075, 4.8981, 6.7158, 4.8981,
+        6.7158, 5.0131, 5.5075, 5.0131], "words": [{"text": "Subtotal:", "boundingBox":
+        [5.5075, 4.8981, 6.1249, 4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence":
+        1}, {"text": "3000.00", "boundingBox": [6.1794, 4.9042, 6.7158, 4.9042, 6.7158,
+        5.0131, 6.1794, 5.0131], "confidence": 1}]}, {"text": "Tax: 300.00", "boundingBox":
+        [5.5034, 5.1245, 6.2887, 5.1245, 6.2887, 5.2333, 5.5034, 5.2333], "words":
+        [{"text": "Tax:", "boundingBox": [5.5034, 5.1263, 5.7812, 5.1263, 5.7812,
+        5.2333, 5.5034, 5.2333], "confidence": 1}, {"text": "300.00", "boundingBox":
+        [5.836, 5.1245, 6.2887, 5.1245, 6.2887, 5.2333, 5.836, 5.2333], "confidence":
+        1}]}, {"text": "Tip: 1000.00", "boundingBox": [5.5034, 5.3412, 6.3422, 5.3412,
+        6.3422, 5.481, 5.5034, 5.481], "words": [{"text": "Tip:", "boundingBox": [5.5034,
+        5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034, 5.481], "confidence": 1}, {"text":
+        "1000.00", "boundingBox": [5.811, 5.3445, 6.3422, 5.3445, 6.3422, 5.4533,
+        5.811, 5.4533], "confidence": 1}]}, {"text": "Total: 4300.00", "boundingBox":
+        [5.5034, 5.5583, 6.4825, 5.5583, 6.4825, 5.6733, 5.5034, 5.6733], "words":
+        [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583, 5.8915,
+        5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "4300.00", "boundingBox":
         [5.942, 5.5645, 6.4825, 5.5645, 6.4825, 5.6733, 5.942, 5.6733], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Signature: ____Frodo Baggins__________", "boundingBox": [1.0055, 6.6556,
-        3.8842, 6.6556, 3.8842, 6.7981, 1.0055, 6.7981], "words": [{"text": "Signature:",
-        "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981, 1.0055, 6.7981],
-        "confidence": 1}, {"text": "____Frodo", "boundingBox": [1.747, 6.6556, 2.4778,
-        6.6556, 2.4778, 6.7981, 1.747, 6.7981], "confidence": 1}, {"text": "Baggins__________",
-        "boundingBox": [2.5325, 6.6581, 3.8842, 6.6581, 3.8842, 6.7981, 2.5325, 6.7981],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}]}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
+        1}]}, {"text": "Signature: ____ Frodo Baggins__________", "boundingBox": [1.0055,
+        6.6556, 3.8842, 6.6556, 3.8842, 6.7981, 1.0055, 6.7981], "words": [{"text":
+        "Signature:", "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981,
+        1.0055, 6.7981], "confidence": 1}, {"text": "____", "boundingBox": [1.747,
+        6.7829, 2.0809, 6.7829, 2.0809, 6.7981, 1.747, 6.7981], "confidence": 1},
+        {"text": "Frodo", "boundingBox": [2.0925, 6.6556, 2.4778, 6.6556, 2.4778,
+        6.7703, 2.0925, 6.7703], "confidence": 1}, {"text": "Baggins__________", "boundingBox":
+        [2.5325, 6.6581, 3.8842, 6.6581, 3.8842, 6.7981, 2.5325, 6.7981], "confidence":
+        1}]}]}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
         [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString": "Itemized",
-        "confidence": 0.991}, "MerchantName": {"type": "string", "valueString": "Bilbo
+        "confidence": 0.99}, "MerchantName": {"type": "string", "valueString": "Bilbo
         Baggins", "text": "Bilbo Baggins", "boundingBox": [6.0164, 1.4503, 6.8967,
-        1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "page": 1, "confidence": 0.669, "elements":
+        1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "page": 1, "confidence": 0.987, "elements":
         ["#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1"]}, "MerchantAddress":
         {"type": "string", "valueString": "123 Hobbit Lane 567 Main St. Redmond, WA
         Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA",
         "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975, 0.8852, 2.1975],
-        "page": 1, "confidence": 0.345, "elements": ["#/readResults/0/lines/4/words/0",
+        "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/4/words/0",
         "#/readResults/0/lines/4/words/1", "#/readResults/0/lines/4/words/2", "#/readResults/0/lines/5/words/0",
         "#/readResults/0/lines/5/words/1", "#/readResults/0/lines/5/words/2", "#/readResults/0/lines/6/words/0",
         "#/readResults/0/lines/6/words/1", "#/readResults/0/lines/7/words/0", "#/readResults/0/lines/7/words/1"]},
         "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber": "+15555555555",
         "text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371,
-        2.2254, 6.0105, 2.2254], "page": 1, "confidence": 0.932, "elements": ["#/readResults/0/lines/8/words/0"]},
+        2.2254, 6.0105, 2.2254], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/8/words/0"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "F", "text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "page":
+        1, "confidence": 0.964, "elements": ["#/readResults/0/lines/28/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 12, "text": "12.00", "boundingBox":
+        [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "page":
+        1, "confidence": 0.947, "elements": ["#/readResults/0/lines/30/words/0"]}}},
+        {"type": "object", "valueObject": {"TotalPrice": {"type": "number", "valueNumber":
+        22, "text": "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781,
+        4.5827, 5.4184, 4.5827], "page": 1, "confidence": 0.935, "elements": ["#/readResults/0/lines/33/words/0"]}}}]},
         "Subtotal": {"type": "number", "valueNumber": 300, "text": "300.00", "boundingBox":
         [6.1794, 4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131], "page": 1,
-        "confidence": 0.96, "elements": ["#/readResults/0/lines/34/words/1"]}}}, {"docType":
-        "prebuilt:receipt", "pageRange": [2, 2], "fields": {}}, {"docType": "prebuilt:receipt",
-        "pageRange": [3, 3], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Frodo Baggins", "text": "Frodo Baggins", "boundingBox": [6.0164, 1.4506,
-        6.9506, 1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "page": 3, "confidence":
-        0.529, "elements": ["#/readResults/2/lines/3/words/0", "#/readResults/2/lines/3/words/1"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Hobbit Lane 567
-        Main St. Redmond, WA Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond,
-        WA Redmond, WA", "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975,
-        0.8852, 2.1975], "page": 3, "confidence": 0.523, "elements": ["#/readResults/2/lines/4/words/0",
+        "confidence": 0.99, "elements": ["#/readResults/0/lines/34/words/1"]}, "Total":
+        {"type": "number", "valueNumber": 430, "text": "430.00", "boundingBox": [5.942,
+        5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942, 5.6733], "page": 1, "confidence":
+        0.985, "elements": ["#/readResults/0/lines/37/words/1"]}}}, {"docType": "prebuilt:receipt",
+        "pageRange": [2, 2], "fields": {}}, {"docType": "prebuilt:receipt", "pageRange":
+        [3, 3], "fields": {"ReceiptType": {"type": "string", "valueString": "Itemized",
+        "confidence": 0.99}, "MerchantName": {"type": "string", "valueString": "Frodo
+        Baggins", "text": "Frodo Baggins", "boundingBox": [6.0164, 1.4506, 6.9506,
+        1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "page": 3, "confidence": 0.984, "elements":
+        ["#/readResults/2/lines/3/words/0", "#/readResults/2/lines/3/words/1"]}, "MerchantAddress":
+        {"type": "string", "valueString": "123 Hobbit Lane 567 Main St. Redmond, WA
+        Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA",
+        "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975, 0.8852, 2.1975],
+        "page": 3, "confidence": 0.99, "elements": ["#/readResults/2/lines/4/words/0",
         "#/readResults/2/lines/4/words/1", "#/readResults/2/lines/4/words/2", "#/readResults/2/lines/5/words/0",
         "#/readResults/2/lines/5/words/1", "#/readResults/2/lines/5/words/2", "#/readResults/2/lines/6/words/0",
         "#/readResults/2/lines/6/words/1", "#/readResults/2/lines/7/words/0", "#/readResults/2/lines/7/words/1"]},
         "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber": "+15555555555",
         "text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371,
-        2.2254, 6.0105, 2.2254], "page": 3, "confidence": 0.926, "elements": ["#/readResults/2/lines/8/words/0"]},
-        "Subtotal": {"type": "number", "valueNumber": 150.66, "text": "150.66", "boundingBox":
-        [5.4232, 3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423], "page":
-        3, "confidence": 0.664, "elements": ["#/readResults/2/lines/21/words/0"]}}}]}}'
+        2.2254, 6.0105, 2.2254], "page": 3, "confidence": 0.99, "elements": ["#/readResults/2/lines/8/words/0"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "E", "text": "E", "boundingBox":
+        [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "page": 3,
+        "confidence": 0.935, "elements": ["#/readResults/2/lines/25/words/0"]}, "Quantity":
+        {"type": "number", "valueNumber": 40, "text": "40", "boundingBox": [3.2486,
+        4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "page": 3, "confidence":
+        0, "elements": ["#/readResults/2/lines/26/words/0"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 100, "text": "100.00", "boundingBox": [5.4232, 4.0546,
+        5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627], "page": 3, "confidence":
+        0.723, "elements": ["#/readResults/2/lines/27/words/0"]}}}, {"type": "object",
+        "valueObject": {"Name": {"type": "string", "valueString": "F", "text": "F",
+        "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717],
+        "page": 3, "confidence": 0.905, "elements": ["#/readResults/2/lines/28/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 120, "text": "120.00", "boundingBox":
+        [5.4232, 4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "page":
+        3, "confidence": 0.967, "elements": ["#/readResults/2/lines/30/words/0"]}}},
+        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
+        "G", "text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
+        4.5827, 1.0877, 4.5827], "page": 3, "confidence": 0.896, "elements": ["#/readResults/2/lines/31/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 220, "text": "220.00", "boundingBox":
+        [5.4184, 4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "page":
+        3, "confidence": 0.958, "elements": ["#/readResults/2/lines/33/words/0"]}}}]},
+        "Subtotal": {"type": "number", "valueNumber": 3000, "text": "3000.00", "boundingBox":
+        [6.1794, 4.9042, 6.7158, 4.9042, 6.7158, 5.0131, 6.1794, 5.0131], "page":
+        3, "confidence": 0.99, "elements": ["#/readResults/2/lines/34/words/1"]},
+        "Total": {"type": "number", "valueNumber": 1000, "text": "1000.00", "boundingBox":
+        [5.811, 5.3445, 6.3422, 5.3445, 6.3422, 5.4533, 5.811, 5.4533], "page": 3,
+        "confidence": 0.985, "elements": ["#/readResults/2/lines/36/words/1"]}}}]}}'
     headers:
       apim-request-id:
-      - 9aee24c6-ee34-4964-b29d-5e14c94d22a6
+      - 445d0a1f-8858-4bb5-92c3-902f3123eda4
       content-length:
-      - '26841'
+      - '25475'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:04:24 GMT
+      - Mon, 16 Nov 2020 19:09:53 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '34'
+      - '23'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_multipage_transform.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_multipage_transform.yaml
@@ -1933,19 +1933,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 4a5b5d7a-80b7-40b8-ac26-1761057d4325
+      - 555d007b-edf8-4b46-93f6-86383933f4bb
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:04:26 GMT
+      - Mon, 16 Nov 2020 19:09:54 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/4a5b5d7a-80b7-40b8-ac26-1761057d4325
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/555d007b-edf8-4b46-93f6-86383933f4bb
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '443'
+      - '148'
     status:
       code: 202
       message: Accepted
@@ -1961,11 +1961,11 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/4a5b5d7a-80b7-40b8-ac26-1761057d4325
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/555d007b-edf8-4b46-93f6-86383933f4bb
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:04:26Z",
-        "lastUpdatedDateTime": "2020-11-11T18:04:30Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:09:55Z",
+        "lastUpdatedDateTime": "2020-11-16T19:09:59Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": 0, "width": 8.5, "height": 11,
         "unit": "inch", "lines": [{"text": "Company A Invoice", "boundingBox": [0.8861,
         1.1217, 2.3783, 1.1217, 2.3783, 1.2812, 0.8861, 1.2812], "words": [{"text":
@@ -1973,391 +1973,371 @@ interactions:
         0.8861, 1.2812], "confidence": 1}, {"text": "A", "boundingBox": [1.6696, 1.1242,
         1.7749, 1.1242, 1.7749, 1.2473, 1.6696, 1.2473], "confidence": 1}, {"text":
         "Invoice", "boundingBox": [1.8389, 1.1217, 2.3783, 1.1217, 2.3783, 1.2485,
-        1.8389, 1.2485], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "Invoice For:", "boundingBox": [6.0211, 1.0656,
-        7.0357, 1.0656, 7.0357, 1.2121, 6.0211, 1.2121], "words": [{"text": "Invoice",
-        "boundingBox": [6.0211, 1.0656, 6.6362, 1.0656, 6.6362, 1.2121, 6.0211, 1.2121],
-        "confidence": 1}, {"text": "For:", "boundingBox": [6.7147, 1.0691, 7.0357,
-        1.0691, 7.0357, 1.2121, 6.7147, 1.2121], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Address:", "boundingBox":
-        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "words":
-        [{"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825, 1.5657,
-        1.6155, 0.8791, 1.6155], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Bilbo Baggins", "boundingBox": [6.0164,
-        1.4503, 6.8967, 1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "words": [{"text":
-        "Bilbo", "boundingBox": [6.0164, 1.4503, 6.3392, 1.4503, 6.3392, 1.5649, 6.0164,
-        1.5649], "confidence": 1}, {"text": "Baggins", "boundingBox": [6.396, 1.4556,
-        6.8967, 1.4556, 6.8967, 1.5931, 6.396, 1.5931], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "123 Hobbit Lane",
-        "boundingBox": [6.0165, 1.6707, 7.1006, 1.6707, 7.1006, 1.7854, 6.0165, 1.7854],
-        "words": [{"text": "123", "boundingBox": [6.0165, 1.6772, 6.2434, 1.6772,
-        6.2434, 1.7854, 6.0165, 1.7854], "confidence": 1}, {"text": "Hobbit", "boundingBox":
-        [6.3033, 1.6707, 6.7463, 1.6707, 6.7463, 1.7854, 6.3033, 1.7854], "confidence":
-        1}, {"text": "Lane", "boundingBox": [6.803, 1.6782, 7.1006, 1.6782, 7.1006,
-        1.7854, 6.803, 1.7854], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "567 Main St.", "boundingBox": [0.8852,
-        1.846, 1.713, 1.846, 1.713, 1.9554, 0.8852, 1.9554], "words": [{"text": "567",
-        "boundingBox": [0.8852, 1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554],
-        "confidence": 1}, {"text": "Main", "boundingBox": [1.1777, 1.846, 1.5022,
-        1.846, 1.5022, 1.9554, 1.1777, 1.9554], "confidence": 1}, {"text": "St.",
-        "boundingBox": [1.5558, 1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Redmond, WA", "boundingBox": [6.0164, 1.891, 6.9793, 1.891,
-        6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text": "Redmond,", "boundingBox":
-        [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275, 6.0164, 2.0275], "confidence":
-        1}, {"text": "WA", "boundingBox": [6.7408, 1.8982, 6.9793, 1.8982, 6.9793,
-        2.0044, 6.7408, 2.0044], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Redmond, WA", "boundingBox": [0.891,
-        2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,",
-        "boundingBox": [0.891, 2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975],
-        "confidence": 1}, {"text": "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682,
-        1.8537, 2.1744, 1.6152, 2.1744], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "555-555-5555", "boundingBox":
-        [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "words":
-        [{"text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187,
-        6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "555-555-5555", "boundingBox":
+        1.8389, 1.2485], "confidence": 1}]}, {"text": "Invoice For:", "boundingBox":
+        [6.0211, 1.0656, 7.0357, 1.0656, 7.0357, 1.2121, 6.0211, 1.2121], "words":
+        [{"text": "Invoice", "boundingBox": [6.0211, 1.0656, 6.6362, 1.0656, 6.6362,
+        1.2121, 6.0211, 1.2121], "confidence": 1}, {"text": "For:", "boundingBox":
+        [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121, 6.7147, 1.2121], "confidence":
+        1}]}, {"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825,
+        1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text": "Address:", "boundingBox":
+        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "confidence":
+        1}]}, {"text": "Bilbo Baggins", "boundingBox": [6.0164, 1.4503, 6.8967, 1.4503,
+        6.8967, 1.5931, 6.0164, 1.5931], "words": [{"text": "Bilbo", "boundingBox":
+        [6.0164, 1.4503, 6.3392, 1.4503, 6.3392, 1.5649, 6.0164, 1.5649], "confidence":
+        1}, {"text": "Baggins", "boundingBox": [6.396, 1.4556, 6.8967, 1.4556, 6.8967,
+        1.5931, 6.396, 1.5931], "confidence": 1}]}, {"text": "123 Hobbit Lane", "boundingBox":
+        [6.0165, 1.6707, 7.1006, 1.6707, 7.1006, 1.7854, 6.0165, 1.7854], "words":
+        [{"text": "123", "boundingBox": [6.0165, 1.6772, 6.2434, 1.6772, 6.2434, 1.7854,
+        6.0165, 1.7854], "confidence": 1}, {"text": "Hobbit", "boundingBox": [6.3033,
+        1.6707, 6.7463, 1.6707, 6.7463, 1.7854, 6.3033, 1.7854], "confidence": 1},
+        {"text": "Lane", "boundingBox": [6.803, 1.6782, 7.1006, 1.6782, 7.1006, 1.7854,
+        6.803, 1.7854], "confidence": 1}]}, {"text": "567 Main St.", "boundingBox":
+        [0.8852, 1.846, 1.713, 1.846, 1.713, 1.9554, 0.8852, 1.9554], "words": [{"text":
+        "567", "boundingBox": [0.8852, 1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852,
+        1.9554], "confidence": 1}, {"text": "Main", "boundingBox": [1.1777, 1.846,
+        1.5022, 1.846, 1.5022, 1.9554, 1.1777, 1.9554], "confidence": 1}, {"text":
+        "St.", "boundingBox": [1.5558, 1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558,
+        1.9554], "confidence": 1}]}, {"text": "Redmond, WA", "boundingBox": [6.0164,
+        1.891, 6.9793, 1.891, 6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text":
+        "Redmond,", "boundingBox": [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275,
+        6.0164, 2.0275], "confidence": 1}, {"text": "WA", "boundingBox": [6.7408,
+        1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408, 2.0044], "confidence": 1}]},
+        {"text": "Redmond, WA", "boundingBox": [0.891, 2.061, 1.8537, 2.061, 1.8537,
+        2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,", "boundingBox": [0.891,
+        2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975], "confidence": 1}, {"text":
+        "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682, 1.8537, 2.1744, 1.6152,
+        2.1744], "confidence": 1}]}, {"text": "555-555-5555", "boundingBox": [6.0105,
+        2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "words": [{"text":
+        "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254,
+        6.0105, 2.2254], "confidence": 1}]}, {"text": "555-555-5555", "boundingBox":
         [0.8852, 2.2887, 1.8119, 2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "words":
         [{"text": "555-555-5555", "boundingBox": [0.8852, 2.2887, 1.8119, 2.2887,
-        1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Item", "boundingBox": [1.0943,
-        3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
+        1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}]}, {"text": "Item", "boundingBox":
+        [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
         "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943,
-        3.109], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996,
-        3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity", "boundingBox":
-        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Price", "boundingBox": [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423,
-        3.109], "words": [{"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
-        2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "A", "boundingBox": [1.0832,
-        3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A",
-        "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116, 3.3202,
-        3.3176, 3.2589, 3.3176], "words": [{"text": "1", "boundingBox": [3.2589, 3.2116,
-        3.3202, 3.2116, 3.3202, 3.3176, 3.2589, 3.3176], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "10.99", "boundingBox":
+        3.109], "confidence": 1}]}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996,
+        3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity",
+        "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371],
+        "confidence": 1}]}, {"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
+        2.9996, 5.7372, 3.109, 5.423, 3.109], "words": [{"text": "Price", "boundingBox":
+        [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence":
+        1}]}, {"text": "A", "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174,
+        3.318, 1.0832, 3.318], "words": [{"text": "A", "boundingBox": [1.0832, 3.2118,
+        1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "confidence": 1}]}, {"text":
+        "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116, 3.3202, 3.3176, 3.2589,
+        3.3176], "words": [{"text": "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116,
+        3.3202, 3.3176, 3.2589, 3.3176], "confidence": 1}]}, {"text": "10.99", "boundingBox":
         [5.4232, 3.2108, 5.7784, 3.2108, 5.7784, 3.319, 5.4232, 3.319], "words": [{"text":
         "10.99", "boundingBox": [5.4232, 3.2108, 5.7784, 3.2108, 5.7784, 3.319, 5.4232,
-        3.319], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637,
-        3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox": [1.0943, 3.4256,
-        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "2", "boundingBox":
-        [3.2541, 3.4241, 3.3199, 3.4241, 3.3199, 3.531, 3.2541, 3.531], "words": [{"text":
-        "2", "boundingBox": [3.2541, 3.4241, 3.3199, 3.4241, 3.3199, 3.531, 3.2541,
-        3.531], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "14.67", "boundingBox": [5.4232, 3.4241, 5.7789, 3.4241, 5.7789,
-        3.5323, 5.4232, 3.5323], "words": [{"text": "14.67", "boundingBox": [5.4232,
-        3.4241, 5.7789, 3.4241, 5.7789, 3.5323, 5.4232, 3.5323], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "C",
+        3.319], "confidence": 1}]}, {"text": "B", "boundingBox": [1.0943, 3.4256,
+        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox":
+        [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence":
+        1}]}, {"text": "2", "boundingBox": [3.2541, 3.4241, 3.3199, 3.4241, 3.3199,
+        3.531, 3.2541, 3.531], "words": [{"text": "2", "boundingBox": [3.2541, 3.4241,
+        3.3199, 3.4241, 3.3199, 3.531, 3.2541, 3.531], "confidence": 1}]}, {"text":
+        "14.67", "boundingBox": [5.4232, 3.4241, 5.7789, 3.4241, 5.7789, 3.5323, 5.4232,
+        3.5323], "words": [{"text": "14.67", "boundingBox": [5.4232, 3.4241, 5.7789,
+        3.4241, 5.7789, 3.5323, 5.4232, 3.5323], "confidence": 1}]}, {"text": "C",
         "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647, 3.7421, 1.0882, 3.7421],
         "words": [{"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647,
-        3.7421, 1.0882, 3.7421], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "4", "boundingBox": [3.2486, 3.6351,
-        3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "words": [{"text": "4", "boundingBox":
-        [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "15.66", "boundingBox": [5.4232, 3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232,
-        3.7423], "words": [{"text": "15.66", "boundingBox": [5.4232, 3.6341, 5.78,
-        3.6341, 5.78, 3.7423, 5.4232, 3.7423], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "D", "boundingBox": [1.0943,
-        3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text":
-        "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943,
-        3.951], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1", "boundingBox": [3.2589, 3.845, 3.3202, 3.845, 3.3202,
+        3.7421, 1.0882, 3.7421], "confidence": 1}]}, {"text": "4", "boundingBox":
+        [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "words":
+        [{"text": "4", "boundingBox": [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413,
+        3.2486, 3.7413], "confidence": 1}]}, {"text": "15.66", "boundingBox": [5.4232,
+        3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232, 3.7423], "words": [{"text": "15.66",
+        "boundingBox": [5.4232, 3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232, 3.7423],
+        "confidence": 1}]}, {"text": "D", "boundingBox": [1.0943, 3.8456, 1.1753,
+        3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text": "D", "boundingBox":
+        [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "confidence":
+        1}]}, {"text": "1", "boundingBox": [3.2589, 3.845, 3.3202, 3.845, 3.3202,
         3.951, 3.2589, 3.951], "words": [{"text": "1", "boundingBox": [3.2589, 3.845,
-        3.3202, 3.845, 3.3202, 3.951, 3.2589, 3.951], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "12.00", "boundingBox":
-        [5.4232, 3.8441, 5.7809, 3.8441, 5.7809, 3.9523, 5.4232, 3.9523], "words":
-        [{"text": "12.00", "boundingBox": [5.4232, 3.8441, 5.7809, 3.8441, 5.7809,
-        3.9523, 5.4232, 3.9523], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "E", "boundingBox": [1.0943, 4.0561,
-        1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "words": [{"text": "E", "boundingBox":
-        [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617, 3.2486,
-        4.1617], "words": [{"text": "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556,
-        3.3244, 4.1617, 3.2486, 4.1617], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "10.00", "boundingBox": [5.4232,
+        3.3202, 3.845, 3.3202, 3.951, 3.2589, 3.951], "confidence": 1}]}, {"text":
+        "12.00", "boundingBox": [5.4232, 3.8441, 5.7809, 3.8441, 5.7809, 3.9523, 5.4232,
+        3.9523], "words": [{"text": "12.00", "boundingBox": [5.4232, 3.8441, 5.7809,
+        3.8441, 5.7809, 3.9523, 5.4232, 3.9523], "confidence": 1}]}, {"text": "E",
+        "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614],
+        "words": [{"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
+        4.1614, 1.0943, 4.1614], "confidence": 1}]}, {"text": "4", "boundingBox":
+        [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617, 3.2486, 4.1617], "words":
+        [{"text": "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617,
+        3.2486, 4.1617], "confidence": 1}]}, {"text": "10.00", "boundingBox": [5.4232,
         4.0546, 5.781, 4.0546, 5.781, 4.1627, 5.4232, 4.1627], "words": [{"text":
         "10.00", "boundingBox": [5.4232, 4.0546, 5.781, 4.0546, 5.781, 4.1627, 5.4232,
-        4.1627], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497,
-        4.3717, 1.0943, 4.3717], "words": [{"text": "F", "boundingBox": [1.0943, 4.2661,
-        1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "6", "boundingBox":
-        [3.2534, 4.2646, 3.3226, 4.2646, 3.3226, 4.3727, 3.2534, 4.3727], "words":
-        [{"text": "6", "boundingBox": [3.2534, 4.2646, 3.3226, 4.2646, 3.3226, 4.3727,
-        3.2534, 4.3727], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "12.00", "boundingBox": [5.4232, 4.2646, 5.7809,
-        4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "words": [{"text": "12.00", "boundingBox":
-        [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877,
-        4.5827], "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746,
-        1.1735, 4.5827, 1.0877, 4.5827], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "8", "boundingBox": [3.2514,
-        4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514, 4.5827], "words": [{"text":
-        "8", "boundingBox": [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514,
-        4.5827], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781,
-        4.5827, 5.4184, 4.5827], "words": [{"text": "22.00", "boundingBox": [5.4184,
-        4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184, 4.5827], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Subtotal:
-        300.00", "boundingBox": [5.5075, 4.8981, 6.632, 4.8981, 6.632, 5.0131, 5.5075,
-        5.0131], "words": [{"text": "Subtotal:", "boundingBox": [5.5075, 4.8981, 6.1249,
-        4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence": 1}, {"text": "300.00",
-        "boundingBox": [6.1794, 4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Tax: 30.00", "boundingBox": [5.5034, 5.1245, 6.2022, 5.1245,
-        6.2022, 5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:", "boundingBox":
-        [5.5034, 5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333], "confidence":
-        1}, {"text": "30.00", "boundingBox": [5.836, 5.1245, 6.2022, 5.1245, 6.2022,
-        5.2333, 5.836, 5.2333], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Tip: 100.00", "boundingBox": [5.5034,
-        5.3412, 6.2587, 5.3412, 6.2587, 5.481, 5.5034, 5.481], "words": [{"text":
+        4.1627], "confidence": 1}]}, {"text": "F", "boundingBox": [1.0943, 4.2661,
+        1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "words": [{"text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "confidence":
+        1}]}, {"text": "6", "boundingBox": [3.2534, 4.2646, 3.3226, 4.2646, 3.3226,
+        4.3727, 3.2534, 4.3727], "words": [{"text": "6", "boundingBox": [3.2534, 4.2646,
+        3.3226, 4.2646, 3.3226, 4.3727, 3.2534, 4.3727], "confidence": 1}]}, {"text":
+        "12.00", "boundingBox": [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232,
+        4.3727], "words": [{"text": "12.00", "boundingBox": [5.4232, 4.2646, 5.7809,
+        4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "confidence": 1}]}, {"text": "G",
+        "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827],
+        "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
+        4.5827, 1.0877, 4.5827], "confidence": 1}]}, {"text": "8", "boundingBox":
+        [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514, 4.5827], "words":
+        [{"text": "8", "boundingBox": [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827,
+        3.2514, 4.5827], "confidence": 1}]}, {"text": "22.00", "boundingBox": [5.4184,
+        4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184, 4.5827], "words": [{"text":
+        "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184,
+        4.5827], "confidence": 1}]}, {"text": "Subtotal: 300.00", "boundingBox": [5.5075,
+        4.8981, 6.632, 4.8981, 6.632, 5.0131, 5.5075, 5.0131], "words": [{"text":
+        "Subtotal:", "boundingBox": [5.5075, 4.8981, 6.1249, 4.8981, 6.1249, 5.0131,
+        5.5075, 5.0131], "confidence": 1}, {"text": "300.00", "boundingBox": [6.1794,
+        4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131], "confidence": 1}]},
+        {"text": "Tax: 30.00", "boundingBox": [5.5034, 5.1245, 6.2022, 5.1245, 6.2022,
+        5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:", "boundingBox": [5.5034,
+        5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333], "confidence": 1},
+        {"text": "30.00", "boundingBox": [5.836, 5.1245, 6.2022, 5.1245, 6.2022, 5.2333,
+        5.836, 5.2333], "confidence": 1}]}, {"text": "Tip: 100.00", "boundingBox":
+        [5.5034, 5.3412, 6.2587, 5.3412, 6.2587, 5.481, 5.5034, 5.481], "words": [{"text":
         "Tip:", "boundingBox": [5.5034, 5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034,
         5.481], "confidence": 1}, {"text": "100.00", "boundingBox": [5.811, 5.3445,
-        6.2587, 5.3445, 6.2587, 5.4533, 5.811, 5.4533], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Total: 430.00",
-        "boundingBox": [5.5034, 5.5583, 6.3987, 5.5583, 6.3987, 5.6733, 5.5034, 5.6733],
-        "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583,
-        5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "430.00", "boundingBox":
-        [5.942, 5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942, 5.6733], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Signature: ____Bilbo Baggins__________", "boundingBox": [1.0055, 6.6553,
-        3.8342, 6.6553, 3.8342, 6.7981, 1.0055, 6.7981], "words": [{"text": "Signature:",
-        "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981, 1.0055, 6.7981],
-        "confidence": 1}, {"text": "____Bilbo", "boundingBox": [1.747, 6.6553, 2.4278,
-        6.6553, 2.4278, 6.7981, 1.747, 6.7981], "confidence": 1}, {"text": "Baggins__________",
-        "boundingBox": [2.4823, 6.6581, 3.8342, 6.6581, 3.8342, 6.7981, 2.4823, 6.7981],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}]}, {"page": 2, "angle": 0, "width": 8.5, "height": 11, "unit": "inch"},
+        6.2587, 5.3445, 6.2587, 5.4533, 5.811, 5.4533], "confidence": 1}]}, {"text":
+        "Total: 430.00", "boundingBox": [5.5034, 5.5583, 6.3987, 5.5583, 6.3987, 5.6733,
+        5.5034, 5.6733], "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583,
+        5.8915, 5.5583, 5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text":
+        "430.00", "boundingBox": [5.942, 5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942,
+        5.6733], "confidence": 1}]}, {"text": "Signature: ____ Bilbo Baggins__________",
+        "boundingBox": [1.0055, 6.6553, 3.8342, 6.6553, 3.8342, 6.7981, 1.0055, 6.7981],
+        "words": [{"text": "Signature:", "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581,
+        1.6987, 6.7981, 1.0055, 6.7981], "confidence": 1}, {"text": "____", "boundingBox":
+        [1.747, 6.7829, 2.0809, 6.7829, 2.0809, 6.7981, 1.747, 6.7981], "confidence":
+        1}, {"text": "Bilbo", "boundingBox": [2.0925, 6.6553, 2.4278, 6.6553, 2.4278,
+        6.7703, 2.0925, 6.7703], "confidence": 1}, {"text": "Baggins__________", "boundingBox":
+        [2.4823, 6.6581, 3.8342, 6.6581, 3.8342, 6.7981, 2.4823, 6.7981], "confidence":
+        1}]}]}, {"page": 2, "angle": 0, "width": 8.5, "height": 11, "unit": "inch"},
         {"page": 3, "angle": 0, "width": 8.5, "height": 11, "unit": "inch", "lines":
         [{"text": "Company B Invoice", "boundingBox": [0.8861, 1.1217, 2.3734, 1.1217,
         2.3734, 1.2812, 0.8861, 1.2812], "words": [{"text": "Company", "boundingBox":
         [0.8861, 1.1232, 1.6203, 1.1232, 1.6203, 1.2812, 0.8861, 1.2812], "confidence":
         1}, {"text": "B", "boundingBox": [1.6836, 1.1248, 1.764, 1.1248, 1.764, 1.2469,
         1.6836, 1.2469], "confidence": 1}, {"text": "Invoice", "boundingBox": [1.8336,
-        1.1217, 2.3734, 1.1217, 2.3734, 1.2485, 1.8336, 1.2485], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Invoice
-        For:", "boundingBox": [6.0211, 1.0656, 7.0357, 1.0656, 7.0357, 1.2121, 6.0211,
-        1.2121], "words": [{"text": "Invoice", "boundingBox": [6.0211, 1.0656, 6.6362,
-        1.0656, 6.6362, 1.2121, 6.0211, 1.2121], "confidence": 1}, {"text": "For:",
-        "boundingBox": [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121, 6.7147, 1.2121],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825,
-        1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text": "Address:", "boundingBox":
-        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Frodo Baggins", "boundingBox": [6.0164, 1.4506, 6.9506, 1.4506, 6.9506, 1.5931,
-        6.0164, 1.5931], "words": [{"text": "Frodo", "boundingBox": [6.0164, 1.4506,
-        6.3895, 1.4506, 6.3895, 1.5649, 6.0164, 1.5649], "confidence": 1}, {"text":
-        "Baggins", "boundingBox": [6.45, 1.4556, 6.9506, 1.4556, 6.9506, 1.5931, 6.45,
-        1.5931], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "123 Hobbit Lane", "boundingBox": [6.0165, 1.6707, 7.1006,
+        1.1217, 2.3734, 1.1217, 2.3734, 1.2485, 1.8336, 1.2485], "confidence": 1}]},
+        {"text": "Invoice For:", "boundingBox": [6.0211, 1.0656, 7.0357, 1.0656, 7.0357,
+        1.2121, 6.0211, 1.2121], "words": [{"text": "Invoice", "boundingBox": [6.0211,
+        1.0656, 6.6362, 1.0656, 6.6362, 1.2121, 6.0211, 1.2121], "confidence": 1},
+        {"text": "For:", "boundingBox": [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121,
+        6.7147, 1.2121], "confidence": 1}]}, {"text": "Address:", "boundingBox": [0.8791,
+        1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text":
+        "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155,
+        0.8791, 1.6155], "confidence": 1}]}, {"text": "Frodo Baggins", "boundingBox":
+        [6.0164, 1.4506, 6.9506, 1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "words":
+        [{"text": "Frodo", "boundingBox": [6.0164, 1.4506, 6.3895, 1.4506, 6.3895,
+        1.5649, 6.0164, 1.5649], "confidence": 1}, {"text": "Baggins", "boundingBox":
+        [6.45, 1.4556, 6.9506, 1.4556, 6.9506, 1.5931, 6.45, 1.5931], "confidence":
+        1}]}, {"text": "123 Hobbit Lane", "boundingBox": [6.0165, 1.6707, 7.1006,
         1.6707, 7.1006, 1.7854, 6.0165, 1.7854], "words": [{"text": "123", "boundingBox":
         [6.0165, 1.6772, 6.2434, 1.6772, 6.2434, 1.7854, 6.0165, 1.7854], "confidence":
         1}, {"text": "Hobbit", "boundingBox": [6.3033, 1.6707, 6.7463, 1.6707, 6.7463,
         1.7854, 6.3033, 1.7854], "confidence": 1}, {"text": "Lane", "boundingBox":
         [6.803, 1.6782, 7.1006, 1.6782, 7.1006, 1.7854, 6.803, 1.7854], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "567 Main St.", "boundingBox": [0.8852, 1.846, 1.713, 1.846, 1.713, 1.9554,
-        0.8852, 1.9554], "words": [{"text": "567", "boundingBox": [0.8852, 1.8472,
-        1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554], "confidence": 1}, {"text":
-        "Main", "boundingBox": [1.1777, 1.846, 1.5022, 1.846, 1.5022, 1.9554, 1.1777,
-        1.9554], "confidence": 1}, {"text": "St.", "boundingBox": [1.5558, 1.8472,
-        1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Redmond, WA", "boundingBox":
-        [6.0164, 1.891, 6.9793, 1.891, 6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text":
-        "Redmond,", "boundingBox": [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275,
-        6.0164, 2.0275], "confidence": 1}, {"text": "WA", "boundingBox": [6.7408,
-        1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408, 2.0044], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Redmond,
-        WA", "boundingBox": [0.891, 2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975],
-        "words": [{"text": "Redmond,", "boundingBox": [0.891, 2.061, 1.5605, 2.061,
-        1.5605, 2.1975, 0.891, 2.1975], "confidence": 1}, {"text": "WA", "boundingBox":
-        [1.6152, 2.0682, 1.8537, 2.0682, 1.8537, 2.1744, 1.6152, 2.1744], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254,
-        6.0105, 2.2254], "words": [{"text": "555-555-5555", "boundingBox": [6.0105,
-        2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "555-555-5555",
+        1}]}, {"text": "567 Main St.", "boundingBox": [0.8852, 1.846, 1.713, 1.846,
+        1.713, 1.9554, 0.8852, 1.9554], "words": [{"text": "567", "boundingBox": [0.8852,
+        1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554], "confidence": 1},
+        {"text": "Main", "boundingBox": [1.1777, 1.846, 1.5022, 1.846, 1.5022, 1.9554,
+        1.1777, 1.9554], "confidence": 1}, {"text": "St.", "boundingBox": [1.5558,
+        1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554], "confidence": 1}]},
+        {"text": "Redmond, WA", "boundingBox": [6.0164, 1.891, 6.9793, 1.891, 6.9793,
+        2.0275, 6.0164, 2.0275], "words": [{"text": "Redmond,", "boundingBox": [6.0164,
+        1.891, 6.6861, 1.891, 6.6861, 2.0275, 6.0164, 2.0275], "confidence": 1}, {"text":
+        "WA", "boundingBox": [6.7408, 1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408,
+        2.0044], "confidence": 1}]}, {"text": "Redmond, WA", "boundingBox": [0.891,
+        2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,",
+        "boundingBox": [0.891, 2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975],
+        "confidence": 1}, {"text": "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682,
+        1.8537, 2.1744, 1.6152, 2.1744], "confidence": 1}]}, {"text": "555-555-5555",
+        "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254],
+        "words": [{"text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371,
+        2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}]}, {"text": "555-555-5555",
         "boundingBox": [0.8852, 2.2887, 1.8119, 2.2887, 1.8119, 2.3954, 0.8852, 2.3954],
         "words": [{"text": "555-555-5555", "boundingBox": [0.8852, 2.2887, 1.8119,
-        2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Item", "boundingBox":
-        [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
-        "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943,
-        3.109], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996,
-        3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity", "boundingBox":
-        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
+        2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}]}, {"text": "Item",
+        "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109],
+        "words": [{"text": "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018,
+        1.3842, 3.109, 1.0943, 3.109], "confidence": 1}]}, {"text": "Quantity", "boundingBox":
+        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "words":
+        [{"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996, 3.8367,
+        3.1371, 3.2527, 3.1371], "confidence": 1}]}, {"text": "Price", "boundingBox":
+        [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423, 3.109], "words": [{"text":
         "Price", "boundingBox": [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423,
-        3.109], "words": [{"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
-        2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "A", "boundingBox": [1.0832,
-        3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A",
-        "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "10", "boundingBox": [3.2589, 3.2108, 3.4067, 3.2108, 3.4067,
+        3.109], "confidence": 1}]}, {"text": "A", "boundingBox": [1.0832, 3.2118,
+        1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A", "boundingBox":
+        [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "confidence":
+        1}]}, {"text": "10", "boundingBox": [3.2589, 3.2108, 3.4067, 3.2108, 3.4067,
         3.319, 3.2589, 3.319], "words": [{"text": "10", "boundingBox": [3.2589, 3.2108,
-        3.4067, 3.2108, 3.4067, 3.319, 3.2589, 3.319], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "100.99", "boundingBox":
-        [5.4232, 3.2108, 5.8617, 3.2108, 5.8617, 3.319, 5.4232, 3.319], "words": [{"text":
+        3.4067, 3.2108, 3.4067, 3.319, 3.2589, 3.319], "confidence": 1}]}, {"text":
         "100.99", "boundingBox": [5.4232, 3.2108, 5.8617, 3.2108, 5.8617, 3.319, 5.4232,
-        3.319], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637,
-        3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox": [1.0943, 3.4256,
-        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "20", "boundingBox":
-        [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323], "words":
-        [{"text": "20", "boundingBox": [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323,
-        3.2541, 3.5323], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "140.67", "boundingBox": [5.4232, 3.4241, 5.8622,
+        3.319], "words": [{"text": "100.99", "boundingBox": [5.4232, 3.2108, 5.8617,
+        3.2108, 5.8617, 3.319, 5.4232, 3.319], "confidence": 1}]}, {"text": "B", "boundingBox":
+        [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "words": [{"text":
+        "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943,
+        3.531], "confidence": 1}]}, {"text": "20", "boundingBox": [3.2541, 3.4241,
+        3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323], "words": [{"text": "20",
+        "boundingBox": [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323],
+        "confidence": 1}]}, {"text": "140.67", "boundingBox": [5.4232, 3.4241, 5.8622,
         3.4241, 5.8622, 3.5323, 5.4232, 3.5323], "words": [{"text": "140.67", "boundingBox":
         [5.4232, 3.4241, 5.8622, 3.4241, 5.8622, 3.5323, 5.4232, 3.5323], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647, 3.7421, 1.0882,
-        3.7421], "words": [{"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343,
-        1.1647, 3.7421, 1.0882, 3.7421], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "40", "boundingBox": [3.2486,
-        3.6341, 3.4067, 3.6341, 3.4067, 3.7423, 3.2486, 3.7423], "words": [{"text":
+        1}]}, {"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647,
+        3.7421, 1.0882, 3.7421], "words": [{"text": "C", "boundingBox": [1.0882, 3.6343,
+        1.1647, 3.6343, 1.1647, 3.7421, 1.0882, 3.7421], "confidence": 1}]}, {"text":
         "40", "boundingBox": [3.2486, 3.6341, 3.4067, 3.6341, 3.4067, 3.7423, 3.2486,
-        3.7423], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "150.66", "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341, 5.8634,
-        3.7423, 5.4232, 3.7423], "words": [{"text": "150.66", "boundingBox": [5.4232,
-        3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "D",
-        "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951],
-        "words": [{"text": "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753,
-        3.951, 1.0943, 3.951], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "10", "boundingBox": [3.2589, 3.8441,
+        3.7423], "words": [{"text": "40", "boundingBox": [3.2486, 3.6341, 3.4067,
+        3.6341, 3.4067, 3.7423, 3.2486, 3.7423], "confidence": 1}]}, {"text": "150.66",
+        "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423],
+        "words": [{"text": "150.66", "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341,
+        5.8634, 3.7423, 5.4232, 3.7423], "confidence": 1}]}, {"text": "D", "boundingBox":
+        [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text":
+        "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943,
+        3.951], "confidence": 1}]}, {"text": "10", "boundingBox": [3.2589, 3.8441,
         3.4067, 3.8441, 3.4067, 3.9523, 3.2589, 3.9523], "words": [{"text": "10",
         "boundingBox": [3.2589, 3.8441, 3.4067, 3.8441, 3.4067, 3.9523, 3.2589, 3.9523],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "120.00", "boundingBox": [5.4232, 3.8441, 5.8642, 3.8441, 5.8642,
-        3.9523, 5.4232, 3.9523], "words": [{"text": "120.00", "boundingBox": [5.4232,
-        3.8441, 5.8642, 3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "E",
-        "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614],
-        "words": [{"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
-        4.1614, 1.0943, 4.1614], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "40", "boundingBox": [3.2486, 4.0546,
-        3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "words": [{"text": "40",
-        "boundingBox": [3.2486, 4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "100.00", "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546, 5.8644,
-        4.1627, 5.4232, 4.1627], "words": [{"text": "100.00", "boundingBox": [5.4232,
-        4.0546, 5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "F",
-        "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717],
-        "words": [{"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497,
-        4.3717, 1.0943, 4.3717], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "60", "boundingBox": [3.2534, 4.2646,
-        3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727], "words": [{"text": "60",
-        "boundingBox": [3.2534, 4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "120.00", "boundingBox": [5.4232, 4.2646, 5.8642, 4.2646, 5.8642,
-        4.3727, 5.4232, 4.3727], "words": [{"text": "120.00", "boundingBox": [5.4232,
-        4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "G",
-        "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827],
-        "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
-        4.5827, 1.0877, 4.5827], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "80", "boundingBox": [3.2514, 4.4746,
-        3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827], "words": [{"text": "80",
-        "boundingBox": [3.2514, 4.4746, 3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "220.00", "boundingBox": [5.4184, 4.4746, 5.8644, 4.4746, 5.8644,
+        "confidence": 1}]}, {"text": "120.00", "boundingBox": [5.4232, 3.8441, 5.8642,
+        3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "words": [{"text": "120.00", "boundingBox":
+        [5.4232, 3.8441, 5.8642, 3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "confidence":
+        1}]}, {"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
+        4.1614, 1.0943, 4.1614], "words": [{"text": "E", "boundingBox": [1.0943, 4.0561,
+        1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "confidence": 1}]}, {"text":
+        "40", "boundingBox": [3.2486, 4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486,
+        4.1627], "words": [{"text": "40", "boundingBox": [3.2486, 4.0546, 3.4067,
+        4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "confidence": 1}]}, {"text": "100.00",
+        "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627],
+        "words": [{"text": "100.00", "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546,
+        5.8644, 4.1627, 5.4232, 4.1627], "confidence": 1}]}, {"text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "words":
+        [{"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717,
+        1.0943, 4.3717], "confidence": 1}]}, {"text": "60", "boundingBox": [3.2534,
+        4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727], "words": [{"text":
+        "60", "boundingBox": [3.2534, 4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534,
+        4.3727], "confidence": 1}]}, {"text": "120.00", "boundingBox": [5.4232, 4.2646,
+        5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "words": [{"text": "120.00",
+        "boundingBox": [5.4232, 4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727],
+        "confidence": 1}]}, {"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735,
+        4.4746, 1.1735, 4.5827, 1.0877, 4.5827], "words": [{"text": "G", "boundingBox":
+        [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827], "confidence":
+        1}]}, {"text": "80", "boundingBox": [3.2514, 4.4746, 3.4067, 4.4746, 3.4067,
+        4.5827, 3.2514, 4.5827], "words": [{"text": "80", "boundingBox": [3.2514,
+        4.4746, 3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827], "confidence": 1}]},
+        {"text": "220.00", "boundingBox": [5.4184, 4.4746, 5.8644, 4.4746, 5.8644,
         4.5827, 5.4184, 4.5827], "words": [{"text": "220.00", "boundingBox": [5.4184,
-        4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Subtotal:
-        3000.00", "boundingBox": [5.5075, 4.8981, 6.7158, 4.8981, 6.7158, 5.0131,
-        5.5075, 5.0131], "words": [{"text": "Subtotal:", "boundingBox": [5.5075, 4.8981,
-        6.1249, 4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence": 1}, {"text":
-        "3000.00", "boundingBox": [6.1794, 4.9042, 6.7158, 4.9042, 6.7158, 5.0131,
-        6.1794, 5.0131], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "Tax: 300.00", "boundingBox": [5.5034, 5.1245,
-        6.2887, 5.1245, 6.2887, 5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:",
-        "boundingBox": [5.5034, 5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333],
-        "confidence": 1}, {"text": "300.00", "boundingBox": [5.836, 5.1245, 6.2887,
-        5.1245, 6.2887, 5.2333, 5.836, 5.2333], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Tip: 1000.00", "boundingBox":
-        [5.5034, 5.3412, 6.3422, 5.3412, 6.3422, 5.481, 5.5034, 5.481], "words": [{"text":
-        "Tip:", "boundingBox": [5.5034, 5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034,
-        5.481], "confidence": 1}, {"text": "1000.00", "boundingBox": [5.811, 5.3445,
-        6.3422, 5.3445, 6.3422, 5.4533, 5.811, 5.4533], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Total: 4300.00",
-        "boundingBox": [5.5034, 5.5583, 6.4825, 5.5583, 6.4825, 5.6733, 5.5034, 5.6733],
-        "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583,
-        5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "4300.00", "boundingBox":
+        4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "confidence": 1}]},
+        {"text": "Subtotal: 3000.00", "boundingBox": [5.5075, 4.8981, 6.7158, 4.8981,
+        6.7158, 5.0131, 5.5075, 5.0131], "words": [{"text": "Subtotal:", "boundingBox":
+        [5.5075, 4.8981, 6.1249, 4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence":
+        1}, {"text": "3000.00", "boundingBox": [6.1794, 4.9042, 6.7158, 4.9042, 6.7158,
+        5.0131, 6.1794, 5.0131], "confidence": 1}]}, {"text": "Tax: 300.00", "boundingBox":
+        [5.5034, 5.1245, 6.2887, 5.1245, 6.2887, 5.2333, 5.5034, 5.2333], "words":
+        [{"text": "Tax:", "boundingBox": [5.5034, 5.1263, 5.7812, 5.1263, 5.7812,
+        5.2333, 5.5034, 5.2333], "confidence": 1}, {"text": "300.00", "boundingBox":
+        [5.836, 5.1245, 6.2887, 5.1245, 6.2887, 5.2333, 5.836, 5.2333], "confidence":
+        1}]}, {"text": "Tip: 1000.00", "boundingBox": [5.5034, 5.3412, 6.3422, 5.3412,
+        6.3422, 5.481, 5.5034, 5.481], "words": [{"text": "Tip:", "boundingBox": [5.5034,
+        5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034, 5.481], "confidence": 1}, {"text":
+        "1000.00", "boundingBox": [5.811, 5.3445, 6.3422, 5.3445, 6.3422, 5.4533,
+        5.811, 5.4533], "confidence": 1}]}, {"text": "Total: 4300.00", "boundingBox":
+        [5.5034, 5.5583, 6.4825, 5.5583, 6.4825, 5.6733, 5.5034, 5.6733], "words":
+        [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583, 5.8915,
+        5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "4300.00", "boundingBox":
         [5.942, 5.5645, 6.4825, 5.5645, 6.4825, 5.6733, 5.942, 5.6733], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Signature: ____Frodo Baggins__________", "boundingBox": [1.0055, 6.6556,
-        3.8842, 6.6556, 3.8842, 6.7981, 1.0055, 6.7981], "words": [{"text": "Signature:",
-        "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981, 1.0055, 6.7981],
-        "confidence": 1}, {"text": "____Frodo", "boundingBox": [1.747, 6.6556, 2.4778,
-        6.6556, 2.4778, 6.7981, 1.747, 6.7981], "confidence": 1}, {"text": "Baggins__________",
-        "boundingBox": [2.5325, 6.6581, 3.8842, 6.6581, 3.8842, 6.7981, 2.5325, 6.7981],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}]}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
+        1}]}, {"text": "Signature: ____ Frodo Baggins__________", "boundingBox": [1.0055,
+        6.6556, 3.8842, 6.6556, 3.8842, 6.7981, 1.0055, 6.7981], "words": [{"text":
+        "Signature:", "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981,
+        1.0055, 6.7981], "confidence": 1}, {"text": "____", "boundingBox": [1.747,
+        6.7829, 2.0809, 6.7829, 2.0809, 6.7981, 1.747, 6.7981], "confidence": 1},
+        {"text": "Frodo", "boundingBox": [2.0925, 6.6556, 2.4778, 6.6556, 2.4778,
+        6.7703, 2.0925, 6.7703], "confidence": 1}, {"text": "Baggins__________", "boundingBox":
+        [2.5325, 6.6581, 3.8842, 6.6581, 3.8842, 6.7981, 2.5325, 6.7981], "confidence":
+        1}]}]}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
         [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString": "Itemized",
-        "confidence": 0.991}, "MerchantName": {"type": "string", "valueString": "Bilbo
+        "confidence": 0.99}, "MerchantName": {"type": "string", "valueString": "Bilbo
         Baggins", "text": "Bilbo Baggins", "boundingBox": [6.0164, 1.4503, 6.8967,
-        1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "page": 1, "confidence": 0.669, "elements":
+        1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "page": 1, "confidence": 0.987, "elements":
         ["#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1"]}, "MerchantAddress":
         {"type": "string", "valueString": "123 Hobbit Lane 567 Main St. Redmond, WA
         Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA",
         "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975, 0.8852, 2.1975],
-        "page": 1, "confidence": 0.345, "elements": ["#/readResults/0/lines/4/words/0",
+        "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/4/words/0",
         "#/readResults/0/lines/4/words/1", "#/readResults/0/lines/4/words/2", "#/readResults/0/lines/5/words/0",
         "#/readResults/0/lines/5/words/1", "#/readResults/0/lines/5/words/2", "#/readResults/0/lines/6/words/0",
         "#/readResults/0/lines/6/words/1", "#/readResults/0/lines/7/words/0", "#/readResults/0/lines/7/words/1"]},
         "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber": "+15555555555",
         "text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371,
-        2.2254, 6.0105, 2.2254], "page": 1, "confidence": 0.932, "elements": ["#/readResults/0/lines/8/words/0"]},
+        2.2254, 6.0105, 2.2254], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/8/words/0"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "F", "text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "page":
+        1, "confidence": 0.964, "elements": ["#/readResults/0/lines/28/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 12, "text": "12.00", "boundingBox":
+        [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "page":
+        1, "confidence": 0.947, "elements": ["#/readResults/0/lines/30/words/0"]}}},
+        {"type": "object", "valueObject": {"TotalPrice": {"type": "number", "valueNumber":
+        22, "text": "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781,
+        4.5827, 5.4184, 4.5827], "page": 1, "confidence": 0.935, "elements": ["#/readResults/0/lines/33/words/0"]}}}]},
         "Subtotal": {"type": "number", "valueNumber": 300, "text": "300.00", "boundingBox":
         [6.1794, 4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131], "page": 1,
-        "confidence": 0.96, "elements": ["#/readResults/0/lines/34/words/1"]}}}, {"docType":
-        "prebuilt:receipt", "pageRange": [2, 2], "fields": {}}, {"docType": "prebuilt:receipt",
-        "pageRange": [3, 3], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Frodo Baggins", "text": "Frodo Baggins", "boundingBox": [6.0164, 1.4506,
-        6.9506, 1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "page": 3, "confidence":
-        0.529, "elements": ["#/readResults/2/lines/3/words/0", "#/readResults/2/lines/3/words/1"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Hobbit Lane 567
-        Main St. Redmond, WA Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond,
-        WA Redmond, WA", "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975,
-        0.8852, 2.1975], "page": 3, "confidence": 0.523, "elements": ["#/readResults/2/lines/4/words/0",
+        "confidence": 0.99, "elements": ["#/readResults/0/lines/34/words/1"]}, "Total":
+        {"type": "number", "valueNumber": 430, "text": "430.00", "boundingBox": [5.942,
+        5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942, 5.6733], "page": 1, "confidence":
+        0.985, "elements": ["#/readResults/0/lines/37/words/1"]}}}, {"docType": "prebuilt:receipt",
+        "pageRange": [2, 2], "fields": {}}, {"docType": "prebuilt:receipt", "pageRange":
+        [3, 3], "fields": {"ReceiptType": {"type": "string", "valueString": "Itemized",
+        "confidence": 0.99}, "MerchantName": {"type": "string", "valueString": "Frodo
+        Baggins", "text": "Frodo Baggins", "boundingBox": [6.0164, 1.4506, 6.9506,
+        1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "page": 3, "confidence": 0.984, "elements":
+        ["#/readResults/2/lines/3/words/0", "#/readResults/2/lines/3/words/1"]}, "MerchantAddress":
+        {"type": "string", "valueString": "123 Hobbit Lane 567 Main St. Redmond, WA
+        Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA",
+        "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975, 0.8852, 2.1975],
+        "page": 3, "confidence": 0.99, "elements": ["#/readResults/2/lines/4/words/0",
         "#/readResults/2/lines/4/words/1", "#/readResults/2/lines/4/words/2", "#/readResults/2/lines/5/words/0",
         "#/readResults/2/lines/5/words/1", "#/readResults/2/lines/5/words/2", "#/readResults/2/lines/6/words/0",
         "#/readResults/2/lines/6/words/1", "#/readResults/2/lines/7/words/0", "#/readResults/2/lines/7/words/1"]},
         "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber": "+15555555555",
         "text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371,
-        2.2254, 6.0105, 2.2254], "page": 3, "confidence": 0.926, "elements": ["#/readResults/2/lines/8/words/0"]},
-        "Subtotal": {"type": "number", "valueNumber": 150.66, "text": "150.66", "boundingBox":
-        [5.4232, 3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423], "page":
-        3, "confidence": 0.664, "elements": ["#/readResults/2/lines/21/words/0"]}}}]}}'
+        2.2254, 6.0105, 2.2254], "page": 3, "confidence": 0.99, "elements": ["#/readResults/2/lines/8/words/0"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "E", "text": "E", "boundingBox":
+        [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "page": 3,
+        "confidence": 0.935, "elements": ["#/readResults/2/lines/25/words/0"]}, "Quantity":
+        {"type": "number", "valueNumber": 40, "text": "40", "boundingBox": [3.2486,
+        4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "page": 3, "confidence":
+        0, "elements": ["#/readResults/2/lines/26/words/0"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 100, "text": "100.00", "boundingBox": [5.4232, 4.0546,
+        5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627], "page": 3, "confidence":
+        0.723, "elements": ["#/readResults/2/lines/27/words/0"]}}}, {"type": "object",
+        "valueObject": {"Name": {"type": "string", "valueString": "F", "text": "F",
+        "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717],
+        "page": 3, "confidence": 0.905, "elements": ["#/readResults/2/lines/28/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 120, "text": "120.00", "boundingBox":
+        [5.4232, 4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "page":
+        3, "confidence": 0.967, "elements": ["#/readResults/2/lines/30/words/0"]}}},
+        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
+        "G", "text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
+        4.5827, 1.0877, 4.5827], "page": 3, "confidence": 0.896, "elements": ["#/readResults/2/lines/31/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 220, "text": "220.00", "boundingBox":
+        [5.4184, 4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "page":
+        3, "confidence": 0.958, "elements": ["#/readResults/2/lines/33/words/0"]}}}]},
+        "Subtotal": {"type": "number", "valueNumber": 3000, "text": "3000.00", "boundingBox":
+        [6.1794, 4.9042, 6.7158, 4.9042, 6.7158, 5.0131, 6.1794, 5.0131], "page":
+        3, "confidence": 0.99, "elements": ["#/readResults/2/lines/34/words/1"]},
+        "Total": {"type": "number", "valueNumber": 1000, "text": "1000.00", "boundingBox":
+        [5.811, 5.3445, 6.3422, 5.3445, 6.3422, 5.4533, 5.811, 5.4533], "page": 3,
+        "confidence": 0.985, "elements": ["#/readResults/2/lines/36/words/1"]}}}]}}'
     headers:
       apim-request-id:
-      - 385855f2-59c8-4f40-a9b9-c83dfcfe72bd
+      - ae44ff0e-4785-4515-9aa3-ce10c90525a1
       content-length:
-      - '26841'
+      - '25475'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:04:32 GMT
+      - Mon, 16 Nov 2020 19:10:00 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '28'
+      - '26'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_png.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_png.yaml
@@ -31810,19 +31810,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 2ade69c7-b339-44be-8ddc-e84ee8e4324b
+      - 35a8718c-5ec7-481d-85ea-90f7c40946a3
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:04:35 GMT
+      - Mon, 16 Nov 2020 19:10:03 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/2ade69c7-b339-44be-8ddc-e84ee8e4324b
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/35a8718c-5ec7-481d-85ea-90f7c40946a3
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '498'
+      - '461'
     status:
       code: 202
       message: Accepted
@@ -31838,60 +31838,61 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/2ade69c7-b339-44be-8ddc-e84ee8e4324b
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/35a8718c-5ec7-481d-85ea-90f7c40946a3
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:04:35Z",
-        "lastUpdatedDateTime": "2020-11-11T18:04:38Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": -0.0752, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:10:04Z",
+        "lastUpdatedDateTime": "2020-11-16T19:10:07Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.2511, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [342.9, 238.1,
-        1061, 278.6, 1038.1, 685.5, 320, 645], "page": 1, "confidence": 0.693}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [308.4, 688, 751.3, 689,
-        750.8, 859.6, 308, 858.5], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "text": "123-456-7890", "boundingBox": [303, 1003,
-        623, 1009, 621, 1071, 303, 1064], "page": 1, "confidence": 0.99}, "TransactionDate":
-        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
-        [299, 1221, 494, 1222, 492, 1292, 299, 1292], "page": 1, "confidence": 0.991},
-        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
-        "boundingBox": [508, 1223, 628, 1224, 625, 1292, 506, 1292], "page": 1, "confidence":
-        0.99}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
-        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [327, 1558, 353, 1559, 352, 1623, 327, 1623], "page": 1, "confidence": 0.745}}},
-        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
-        "8GB RAM (Black)", "text": "8GB RAM (Black)", "boundingBox": [358, 1779, 738,
-        1779, 738, 1860, 358, 1860], "page": 1, "confidence": 0.968}, "TotalPrice":
-        {"type": "number", "valueNumber": 999, "text": "999.00", "boundingBox": [967,
-        1792, 1135, 1796, 1133, 1859, 967, 1855], "page": 1, "confidence": 0.97}}},
-        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [315, 2018, 337, 2017, 338, 2084, 316, 2085],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "SurfacePen", "text": "SurfacePen", "boundingBox": [350, 2017, 624, 2013,
-        624, 2079, 351, 2084], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 99.99, "text": "$99.99", "boundingBox": [963, 2025,
-        1128, 2025, 1128, 2092, 963, 2092], "page": 1, "confidence": 0.775}}}]}, "Subtotal":
-        {"type": "number", "valueNumber": 1098.99, "text": "1098.99", "boundingBox":
-        [954, 2255, 1137, 2251, 1138, 2325, 956, 2329], "page": 1, "confidence": 0.986},
-        "Total": {"type": "number", "valueNumber": 104.4, "text": "104.40", "boundingBox":
-        [976, 2370, 1130, 2368, 1131, 2434, 977, 2438], "page": 1, "confidence": 0.668}}}]}}'
+        "Itemized", "confidence": 0.659}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [349.3, 241.3,
+        1058, 284.4, 1033.5, 687.1, 324.8, 644], "page": 1, "confidence": 0.516},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [319.9,
+        689.9, 750.7, 697.5, 747.8, 865.6, 317, 858], "page": 1, "confidence": 0.986},
+        "MerchantPhoneNumber": {"type": "phoneNumber", "text": "123-456-7890", "boundingBox":
+        [306, 1005, 617, 1012, 615, 1069, 305, 1064], "page": 1, "confidence": 0.99},
+        "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019",
+        "boundingBox": [304, 1224, 506, 1224, 504, 1289, 303, 1288], "page": 1, "confidence":
+        0.985}, "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text":
+        "13:59", "boundingBox": [518, 1225, 628, 1228, 627, 1290, 517, 1289], "page":
+        1, "confidence": 0.968}, "Items": {"type": "array", "valueArray": [{"type":
+        "object", "valueObject": {"Name": {"type": "string", "valueString": "8GB RAM
+        (Black)", "text": "8GB RAM (Black)", "boundingBox": [370.7, 1781.5, 731, 1785,
+        730.3, 1854, 370, 1850.6], "page": 1, "confidence": 0.916}, "TotalPrice":
+        {"type": "number", "valueNumber": 999, "text": "$999.00", "boundingBox": [939,
+        1784.6, 1134.4, 1788.3, 1133, 1863, 937.6, 1859.3], "page": 1, "confidence":
+        0.559}}}, {"type": "object", "valueObject": {"Quantity": {"type": "number",
+        "valueNumber": 1, "text": "1", "boundingBox": [321, 2021, 348, 2020, 349,
+        2084, 322, 2084], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "SurfacePen", "text": "SurfacePen", "boundingBox": [360, 2020,
+        626, 2014, 628, 2077, 362, 2083], "page": 1, "confidence": 0.858}, "TotalPrice":
+        {"type": "number", "valueNumber": 99.99, "text": "99.99", "boundingBox": [1007,
+        2028, 1127, 2028, 1126, 2091, 1007, 2091], "page": 1, "confidence": 0.386}}}]},
+        "Subtotal": {"type": "number", "valueNumber": 1098.99, "text": "1098.99",
+        "boundingBox": [963, 2260, 1136, 2254, 1137, 2320, 966, 2325], "page": 1,
+        "confidence": 0.964}, "Tax": {"type": "number", "valueNumber": 104.4, "text":
+        "$104.40", "boundingBox": [942.6, 2367.5, 1132, 2363.7, 1133.4, 2434.2, 944,
+        2438], "page": 1, "confidence": 0.713}, "Total": {"type": "number", "valueNumber":
+        1203.39, "text": "1203.39", "boundingBox": [955, 2594, 1123, 2611, 1115, 2678,
+        949, 2661], "page": 1, "confidence": 0.774}}}]}}'
     headers:
       apim-request-id:
-      - 65e8e4d0-1706-4bcd-b7c8-c607f2728afe
+      - 945265e9-f87d-4c53-b3ec-0d4d6b1fb868
       content-length:
-      - '2548'
+      - '2561'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:04:40 GMT
+      - Mon, 16 Nov 2020 19:10:08 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '25'
+      - '18'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_stream_transform_jpg.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_stream_transform_jpg.yaml
@@ -22,19 +22,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - b8549a8c-2621-46cd-9a50-c6cdb01fa640
+      - 6f8146b3-4d05-4d6e-9347-43368510b9a2
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:04:46 GMT
+      - Mon, 16 Nov 2020 19:10:12 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/b8549a8c-2621-46cd-9a50-c6cdb01fa640
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/6f8146b3-4d05-4d6e-9347-43368510b9a2
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '241'
+      - '193'
     status:
       code: 202
       message: Accepted
@@ -50,173 +50,146 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/b8549a8c-2621-46cd-9a50-c6cdb01fa640
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/6f8146b3-4d05-4d6e-9347-43368510b9a2
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:04:46Z",
-        "lastUpdatedDateTime": "2020-11-11T18:04:48Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
-        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [306,
-        569, 519, 624, 502, 686, 290, 632], "words": [{"text": "Contoso", "boundingBox":
-        [308, 570, 515, 627, 500, 685, 290, 634], "confidence": 0.806}], "appearance":
-        {"style": {"name": "print", "confidence": 0.996}}}, {"text": "Contoso", "boundingBox":
-        [625, 512, 1089, 465, 1096, 561, 631, 607], "words": [{"text": "Contoso",
-        "boundingBox": [625, 512, 1088, 466, 1093, 562, 631, 607], "confidence": 0.984}],
-        "appearance": {"style": {"name": "print", "confidence": 0.999}}}, {"text":
-        "123 Main Street", "boundingBox": [301, 677, 697, 759, 681, 835, 284, 750],
-        "words": [{"text": "123", "boundingBox": [301, 677, 379, 692, 362, 766, 284,
-        751], "confidence": 0.987}, {"text": "Main", "boundingBox": [393, 695, 520,
-        721, 503, 795, 377, 769], "confidence": 0.985}, {"text": "Street", "boundingBox":
-        [534, 724, 694, 763, 676, 835, 517, 798], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.995}}}, {"text": "Redmond, WA
-        98052", "boundingBox": [284, 784, 823, 855, 814, 925, 275, 868], "words":
-        [{"text": "Redmond,", "boundingBox": [287, 784, 544, 829, 535, 905, 275, 853],
-        "confidence": 0.924}, {"text": "WA", "boundingBox": [558, 830, 640, 840, 632,
-        916, 549, 907], "confidence": 0.985}, {"text": "98052", "boundingBox": [654,
-        842, 822, 855, 817, 925, 646, 917], "confidence": 0.985}], "appearance": {"style":
-        {"name": "print", "confidence": 0.999}}}, {"text": "987-654-3210", "boundingBox":
-        [270, 999, 655, 1049, 646, 1125, 264, 1075], "words": [{"text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "confidence":
-        0.978}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "6/10/2019 13:59", "boundingBox": [258, 1224, 683, 1259, 676, 1341, 255, 1309],
-        "words": [{"text": "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505,
-        1331, 255, 1312], "confidence": 0.951}, {"text": "13:59", "boundingBox": [527,
-        1248, 681, 1262, 675, 1341, 522, 1332], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "Sales Associate:
-        Paul", "boundingBox": [252, 1347, 860, 1378, 859, 1449, 249, 1425], "words":
-        [{"text": "Sales", "boundingBox": [255, 1348, 409, 1358, 405, 1432, 249, 1419],
-        "confidence": 0.983}, {"text": "Associate:", "boundingBox": [423, 1359, 704,
-        1373, 703, 1447, 419, 1434], "confidence": 0.933}, {"text": "Paul", "boundingBox":
-        [718, 1373, 858, 1378, 859, 1449, 717, 1448], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "1 Cappuccino", "boundingBox":
-        [244, 1581, 660, 1597, 658, 1688, 241, 1675], "words": [{"text": "1", "boundingBox":
-        [244, 1581, 288, 1584, 285, 1678, 241, 1675], "confidence": 0.977}, {"text":
-        "Cappuccino", "boundingBox": [306, 1585, 658, 1598, 657, 1688, 304, 1679],
-        "confidence": 0.858}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "$2.20", "boundingBox": [1106, 1580, 1264, 1574, 1268, 1656,
-        1108, 1662], "words": [{"text": "$2.20", "boundingBox": [1106, 1579, 1260,
-        1574, 1263, 1656, 1108, 1662], "confidence": 0.981}], "appearance": {"style":
-        {"name": "print", "confidence": 0.849}}}, {"text": "1 BACON & EGGS", "boundingBox":
-        [226, 1838, 740, 1839, 740, 1924, 226, 1923], "words": [{"text": "1", "boundingBox":
-        [227, 1839, 278, 1839, 277, 1924, 226, 1924], "confidence": 0.986}, {"text":
-        "BACON", "boundingBox": [295, 1839, 493, 1840, 493, 1923, 294, 1924], "confidence":
-        0.984}, {"text": "&", "boundingBox": [510, 1840, 555, 1840, 555, 1923, 510,
-        1923], "confidence": 0.983}, {"text": "EGGS", "boundingBox": [572, 1840, 737,
-        1841, 736, 1924, 572, 1923], "confidence": 0.984}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Sunny-side-up", "boundingBox":
-        [343, 1976, 758, 1974, 759, 2061, 343, 2063], "words": [{"text": "Sunny-side-up",
-        "boundingBox": [343, 1977, 757, 1975, 755, 2063, 346, 2064], "confidence":
-        0.973}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "$9.5", "boundingBox": [1134, 1948, 1253, 1948, 1255, 2041, 1137, 2041], "words":
-        [{"text": "$9.5", "boundingBox": [1134, 1948, 1252, 1948, 1252, 2041, 1134,
-        2041], "confidence": 0.983}], "appearance": {"style": {"name": "print", "confidence":
-        0.932}}}, {"text": "- -", "boundingBox": [218, 2143, 291, 2140, 292, 2158,
-        218, 2161], "words": [{"text": "-", "boundingBox": [236, 2143, 255, 2143,
-        255, 2161, 235, 2161], "confidence": 0.559}, {"text": "-", "boundingBox":
-        [271, 2142, 290, 2141, 291, 2158, 272, 2160], "confidence": 0.985}], "appearance":
-        {"style": {"name": "print", "confidence": 0.67}}}, {"text": "-----", "boundingBox":
-        [277, 2142, 461, 2136, 461, 2155, 278, 2161], "words": [{"text": "-----",
-        "boundingBox": [305, 2141, 457, 2136, 458, 2155, 305, 2161], "confidence":
-        0.69}], "appearance": {"style": {"name": "print", "confidence": 0.467}}},
-        {"text": "----", "boundingBox": [471, 2137, 565, 2133, 566, 2150, 472, 2154],
-        "words": [{"text": "----", "boundingBox": [473, 2138, 566, 2134, 566, 2150,
-        473, 2154], "confidence": 0.559}], "appearance": {"style": {"name": "print",
-        "confidence": 0.703}}}, {"text": "--", "boundingBox": [1252, 2129, 1319, 2127,
-        1320, 2143, 1252, 2146], "words": [{"text": "--", "boundingBox": [1277, 2129,
-        1319, 2127, 1319, 2144, 1276, 2145], "confidence": 0.559}], "appearance":
-        {"style": {"name": "print", "confidence": 0.846}}}, {"text": "Sub-Total",
-        "boundingBox": [434, 2232, 768, 2222, 770, 2312, 437, 2322], "words": [{"text":
-        "Sub-Total", "boundingBox": [434, 2234, 769, 2222, 770, 2313, 442, 2322],
-        "confidence": 0.981}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "$ 11.70", "boundingBox": [1082, 2228, 1309, 2228, 1309, 2313,
-        1084, 2312], "words": [{"text": "$", "boundingBox": [1082, 2228, 1122, 2228,
-        1121, 2313, 1082, 2312], "confidence": 0.654}, {"text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "confidence": 0.984}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "Tax", "boundingBox":
-        [433, 2367, 563, 2363, 565, 2458, 435, 2462], "words": [{"text": "Tax", "boundingBox":
-        [433, 2367, 559, 2363, 562, 2458, 435, 2462], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 0.98}}}, {"text": "$ 1.17", "boundingBox":
-        [1125, 2353, 1306, 2362, 1304, 2451, 1121, 2444], "words": [{"text": "$",
-        "boundingBox": [1125, 2353, 1167, 2355, 1163, 2446, 1121, 2444], "confidence":
-        0.966}, {"text": "1.17", "boundingBox": [1186, 2356, 1307, 2361, 1303, 2452,
-        1182, 2447], "confidence": 0.983}], "appearance": {"style": {"name": "print",
-        "confidence": 0.963}}}, {"text": "Tip", "boundingBox": [439, 2502, 545, 2506,
-        541, 2606, 435, 2602], "words": [{"text": "Tip", "boundingBox": [438, 2502,
-        545, 2506, 541, 2606, 435, 2602], "confidence": 0.987}], "appearance": {"style":
-        {"name": "print", "confidence": 0.943}}}, {"text": "$463", "boundingBox":
-        [1038, 2483, 1271, 2489, 1269, 2583, 1032, 2577], "words": [{"text": "$463",
-        "boundingBox": [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "confidence":
-        0.592}], "appearance": {"style": {"name": "handwriting", "confidence": 0.892}}},
-        {"text": "Total", "boundingBox": [431, 2651, 607, 2646, 610, 2739, 435, 2745],
-        "words": [{"text": "Total", "boundingBox": [431, 2651, 605, 2646, 608, 2739,
-        433, 2745], "confidence": 0.983}], "appearance": {"style": {"name": "print",
-        "confidence": 0.991}}}, {"text": "$14.50", "boundingBox": [1034, 2623, 1381,
-        2642, 1374, 2757, 1027, 2740], "words": [{"text": "$14.50", "boundingBox":
-        [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "confidence": 0.845}], "appearance":
-        {"style": {"name": "handwriting", "confidence": 0.991}}}]}], "documentResults":
-        [{"docType": "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType":
-        {"type": "string", "valueString": "Itemized", "confidence": 0.99}, "MerchantName":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:10:13Z",
+        "lastUpdatedDateTime": "2020-11-16T19:10:14Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
+        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [635,
+        510, 1086, 461, 1098, 558, 643, 604], "words": [{"text": "Contoso", "boundingBox":
+        [639, 510, 1087, 461, 1098, 551, 646, 604], "confidence": 0.955}]}, {"text":
+        "Contoso", "boundingBox": [305, 574, 519, 624, 504, 686, 291, 634], "words":
+        [{"text": "Contoso", "boundingBox": [311, 575, 517, 623, 503, 686, 297, 636],
+        "confidence": 0.435}]}, {"text": "123 Main Street", "boundingBox": [300, 675,
+        703, 767, 686, 844, 284, 749], "words": [{"text": "123", "boundingBox": [302,
+        676, 390, 695, 375, 770, 287, 751], "confidence": 0.935}, {"text": "Main",
+        "boundingBox": [405, 698, 528, 726, 512, 802, 390, 774], "confidence": 0.958},
+        {"text": "Street", "boundingBox": [542, 730, 702, 767, 685, 845, 527, 806],
+        "confidence": 0.959}]}, {"text": "Redmond, WA 98052", "boundingBox": [290,
+        784, 828, 850, 820, 933, 279, 868], "words": [{"text": "Redmond,", "boundingBox":
+        [293, 784, 550, 826, 540, 905, 280, 856], "confidence": 0.762}, {"text": "WA",
+        "boundingBox": [565, 828, 645, 837, 637, 917, 555, 907], "confidence": 0.943},
+        {"text": "98052", "boundingBox": [660, 838, 824, 849, 818, 933, 651, 919],
+        "confidence": 0.959}]}, {"text": "987-654-3210", "boundingBox": [275, 1003,
+        656, 1055, 646, 1123, 269, 1073], "words": [{"text": "987-654-3210", "boundingBox":
+        [278, 1004, 656, 1057, 647, 1123, 271, 1075], "confidence": 0.939}]}, {"text":
+        "6/10/2019 13:59", "boundingBox": [265, 1228, 678, 1258, 671, 1344, 258, 1311],
+        "words": [{"text": "6/10/2019", "boundingBox": [267, 1229, 525, 1247, 517,
+        1332, 259, 1313], "confidence": 0.762}, {"text": "13:59", "boundingBox": [541,
+        1248, 677, 1263, 669, 1345, 533, 1333], "confidence": 0.958}]}, {"text": "Sales
+        Associate: Paul", "boundingBox": [253, 1347, 868, 1379, 863, 1457, 249, 1425],
+        "words": [{"text": "Sales", "boundingBox": [259, 1348, 419, 1359, 414, 1435,
+        252, 1422], "confidence": 0.92}, {"text": "Associate:", "boundingBox": [434,
+        1360, 711, 1374, 707, 1452, 428, 1436], "confidence": 0.909}, {"text": "Paul",
+        "boundingBox": [726, 1374, 865, 1379, 862, 1457, 722, 1452], "confidence":
+        0.959}]}, {"text": "1 Cappuccino", "boundingBox": [244, 1583, 658, 1601, 653,
+        1689, 240, 1674], "words": [{"text": "1", "boundingBox": [245, 1583, 299,
+        1585, 295, 1676, 241, 1671], "confidence": 0.824}, {"text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "confidence":
+        0.727}]}, {"text": "$2.20", "boundingBox": [1106, 1584, 1268, 1574, 1270,
+        1656, 1110, 1666], "words": [{"text": "$2.20", "boundingBox": [1108, 1584,
+        1263, 1574, 1268, 1656, 1113, 1666], "confidence": 0.958}]}, {"text": "1 BACON
+        & EGGS", "boundingBox": [232, 1834, 745, 1840, 744, 1924, 231, 1918], "words":
+        [{"text": "1", "boundingBox": [232, 1834, 286, 1836, 285, 1920, 231, 1920],
+        "confidence": 0.845}, {"text": "BACON", "boundingBox": [308, 1836, 506, 1841,
+        504, 1920, 307, 1920], "confidence": 0.885}, {"text": "&", "boundingBox":
+        [523, 1841, 568, 1842, 566, 1921, 521, 1921], "confidence": 0.799}, {"text":
+        "EGGS", "boundingBox": [585, 1842, 746, 1843, 744, 1924, 583, 1921], "confidence":
+        0.949}]}, {"text": "Sunny-side-up", "boundingBox": [347, 1975, 751, 1977,
+        751, 2061, 347, 2060], "words": [{"text": "Sunny-side-up", "boundingBox":
+        [348, 1975, 749, 1979, 747, 2061, 348, 2061], "confidence": 0.946}]}, {"text":
+        "$9.5", "boundingBox": [1135, 1955, 1262, 1952, 1263, 2035, 1136, 2039], "words":
+        [{"text": "$9.5", "boundingBox": [1135, 1955, 1257, 1952, 1259, 2036, 1136,
+        2039], "confidence": 0.95}]}, {"text": "Sub-Total", "boundingBox": [440, 2229,
+        771, 2219, 773, 2318, 442, 2327], "words": [{"text": "Sub-Total", "boundingBox":
+        [441, 2229, 769, 2220, 774, 2319, 443, 2328], "confidence": 0.856}]}, {"text":
+        "$ 11.70", "boundingBox": [1092, 2221, 1301, 2224, 1299, 2319, 1093, 2317],
+        "words": [{"text": "$", "boundingBox": [1092, 2221, 1127, 2221, 1126, 2317,
+        1092, 2316], "confidence": 0.799}, {"text": "11.70", "boundingBox": [1146,
+        2221, 1297, 2223, 1296, 2319, 1145, 2317], "confidence": 0.948}]}, {"text":
+        "Tax", "boundingBox": [442, 2371, 549, 2367, 552, 2454, 445, 2458], "words":
+        [{"text": "Tax", "boundingBox": [445, 2371, 546, 2367, 549, 2454, 448, 2458],
+        "confidence": 0.958}]}, {"text": "$ 1.17", "boundingBox": [1129, 2359, 1310,
+        2359, 1306, 2456, 1129, 2456], "words": [{"text": "$", "boundingBox": [1129,
+        2359, 1171, 2359, 1171, 2456, 1129, 2456], "confidence": 0.89}, {"text": "1.17",
+        "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "confidence":
+        0.942}]}, {"text": "Tip", "boundingBox": [433, 2505, 539, 2506, 540, 2602,
+        434, 2602], "words": [{"text": "Tip", "boundingBox": [436, 2505, 536, 2505,
+        536, 2602, 436, 2602], "confidence": 0.959}]}, {"text": "$ 1.63", "boundingBox":
+        [1030, 2478, 1269, 2486, 1267, 2591, 1024, 2583], "words": [{"text": "$",
+        "boundingBox": [1027, 2478, 1073, 2478, 1069, 2584, 1024, 2583], "confidence":
+        0.788}, {"text": "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591,
+        1091, 2585], "confidence": 0.284}]}, {"text": "Total", "boundingBox": [433,
+        2652, 611, 2644, 615, 2738, 436, 2747], "words": [{"text": "Total", "boundingBox":
+        [435, 2652, 609, 2644, 613, 2739, 439, 2747], "confidence": 0.866}]}, {"text":
+        "$14.50", "boundingBox": [1034, 2620, 1386, 2637, 1380, 2762, 1029, 2739],
+        "words": [{"text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380,
+        2763, 1030, 2739], "confidence": 0.57}]}]}], "documentResults": [{"docType":
+        "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType": {"type":
+        "string", "valueString": "Itemized", "confidence": 0.692}, "MerchantName":
         {"type": "string", "valueString": "Contoso Contoso", "text": "Contoso Contoso",
-        "boundingBox": [380.9, 282.9, 1116, 473.2, 1025, 824.4, 290, 634], "page":
-        1, "confidence": 0.716, "elements": ["#/readResults/0/lines/1/words/0", "#/readResults/0/lines/0/words/0"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
-        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [298.3,
-        676.5, 844.6, 781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989,
-        "elements": ["#/readResults/0/lines/2/words/0", "#/readResults/0/lines/2/words/1",
-        "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1",
-        "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber": {"type": "phoneNumber",
-        "valuePhoneNumber": "+19876543210", "text": "987-654-3210", "boundingBox":
-        [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence": 0.99,
-        "elements": ["#/readResults/0/lines/4/words/0"]}, "TransactionDate": {"type":
-        "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox": [259,
-        1224, 510, 1246, 505, 1331, 255, 1312], "page": 1, "confidence": 0.99, "elements":
-        ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type": "time",
-        "valueTime": "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681,
-        1262, 675, 1341, 522, 1332], "page": 1, "confidence": 0.989, "elements": ["#/readResults/0/lines/5/words/1"]},
-        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        "boundingBox": [378.2, 292.4, 1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8],
+        "page": 1, "confidence": 0.613, "elements": ["#/readResults/0/lines/0/words/0",
+        "#/readResults/0/lines/1/words/0"]}, "MerchantAddress": {"type": "string",
+        "valueString": "123 Main Street Redmond, WA 98052", "text": "123 Main Street
+        Redmond, WA 98052", "boundingBox": [302, 675.8, 848.1, 793.7, 809.9, 970.4,
+        263.9, 852.5], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/2/words/0",
+        "#/readResults/0/lines/2/words/1", "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0",
+        "#/readResults/0/lines/3/words/1", "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber":
+        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
+        "boundingBox": [278, 1004, 656, 1057, 647, 1123, 271, 1075], "page": 1, "confidence":
+        0.99, "elements": ["#/readResults/0/lines/4/words/0"]}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99,
+        "elements": ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type":
+        "time", "valueTime": "13:59:00", "text": "13:59", "boundingBox": [541, 1248,
+        677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence": 0.977, "elements":
+        ["#/readResults/0/lines/5/words/1"]}, "Items": {"type": "array", "valueArray":
+        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
+        1, "text": "1", "boundingBox": [245, 1583, 299, 1585, 295, 1676, 241, 1671],
+        "page": 1, "confidence": 0.92, "elements": ["#/readResults/0/lines/7/words/0"]},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923, "elements": ["#/readResults/0/lines/7/words/1"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1108, 1584,
+        1263, 1574, 1268, 1656, 1113, 1666], "page": 1, "confidence": 0.918, "elements":
+        ["#/readResults/0/lines/8/words/0"]}}}, {"type": "object", "valueObject":
         {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [244, 1581, 288, 1584, 285, 1678, 241, 1675], "page": 1, "confidence": 0.919,
-        "elements": ["#/readResults/0/lines/7/words/0"]}, "Name": {"type": "string",
-        "valueString": "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585,
-        658, 1598, 657, 1688, 304, 1679], "page": 1, "confidence": 0.959, "elements":
-        ["#/readResults/0/lines/7/words/1"]}, "TotalPrice": {"type": "number", "valueNumber":
-        2.2, "text": "$2.20", "boundingBox": [1106, 1579, 1260, 1574, 1263, 1656,
-        1108, 1662], "page": 1, "confidence": 0.959, "elements": ["#/readResults/0/lines/8/words/0"]}}},
-        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91, "elements": ["#/readResults/0/lines/9/words/0"]},
-        "Name": {"type": "string", "valueString": "BACON & EGGS", "text": "BACON &
-        EGGS", "boundingBox": [294, 1839, 737, 1839, 737, 1924, 294, 1924], "page":
-        1, "confidence": 0.955, "elements": ["#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2",
+        [232, 1834, 286, 1836, 285, 1920, 231, 1920], "page": 1, "confidence": 0.858,
+        "elements": ["#/readResults/0/lines/9/words/0"]}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916,
+        "elements": ["#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2",
         "#/readResults/0/lines/9/words/3"]}, "TotalPrice": {"type": "number", "valueNumber":
-        9.5, "text": "$9.5", "boundingBox": [1134, 1948, 1252, 1948, 1252, 2041, 1134,
-        2041], "page": 1, "confidence": 0.958, "elements": ["#/readResults/0/lines/11/words/0"]}}}]},
+        9.5, "text": "$9.5", "boundingBox": [1135, 1955, 1257, 1952, 1259, 2036, 1136,
+        2039], "page": 1, "confidence": 0.916, "elements": ["#/readResults/0/lines/11/words/0"]}}}]},
         "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923, "elements": ["#/readResults/0/lines/17/words/1"]}, "Tax": {"type":
-        "number", "valueNumber": 1.17, "text": "1.17", "boundingBox": [1186, 2356,
-        1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence": 0.979, "elements":
-        ["#/readResults/0/lines/19/words/1"]}, "Tip": {"type": "number", "valueNumber":
-        463, "text": "$463", "boundingBox": [1034, 2483, 1268, 2488, 1266, 2583, 1032,
-        2577], "page": 1, "confidence": 0.975, "elements": ["#/readResults/0/lines/21/words/0"]},
+        [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1, "confidence":
+        0.955, "elements": ["#/readResults/0/lines/13/words/1"]}, "Tax": {"type":
+        "number", "valueNumber": 1.17, "text": "1.17", "boundingBox": [1190, 2359,
+        1304, 2359, 1304, 2456, 1190, 2456], "page": 1, "confidence": 0.979, "elements":
+        ["#/readResults/0/lines/15/words/1"]}, "Tip": {"type": "number", "valueNumber":
+        1.63, "text": "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591,
+        1091, 2585], "page": 1, "confidence": 0.941, "elements": ["#/readResults/0/lines/17/words/1"]},
         "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50", "boundingBox":
-        [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1, "confidence":
-        0.987, "elements": ["#/readResults/0/lines/23/words/0"]}}}]}}'
+        [1034, 2620, 1384, 2638, 1380, 2763, 1030, 2739], "page": 1, "confidence":
+        0.985, "elements": ["#/readResults/0/lines/19/words/0"]}}}]}}'
     headers:
       apim-request-id:
-      - 9be0794a-5085-4a50-a8e0-a9b9c26b69a3
+      - e2d74093-741c-4216-81d7-7364c512a7e8
       content-length:
-      - '10546'
+      - '8501'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:04:51 GMT
+      - Mon, 16 Nov 2020 19:10:18 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '27'
+      - '22'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_stream_transform_png.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt.test_receipt_stream_transform_png.yaml
@@ -22,19 +22,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 59eabde0-daca-42c0-9cc6-7e81a9a79e92
+      - b321a831-1725-4c16-b3df-7c099b3767fc
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:04:54 GMT
+      - Mon, 16 Nov 2020 19:10:21 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/59eabde0-daca-42c0-9cc6-7e81a9a79e92
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/b321a831-1725-4c16-b3df-7c099b3767fc
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '485'
+      - '431'
     status:
       code: 202
       message: Accepted
@@ -50,174 +50,149 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/59eabde0-daca-42c0-9cc6-7e81a9a79e92
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/b321a831-1725-4c16-b3df-7c099b3767fc
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:04:55Z",
-        "lastUpdatedDateTime": "2020-11-11T18:04:58Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": -0.0752, "width": 1688, "height":
-        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [612,
-        287, 1052, 277, 1055, 384, 614, 397], "words": [{"text": "Contoso", "boundingBox":
-        [613, 288, 1051, 278, 1055, 385, 614, 398], "confidence": 0.985}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Contoso", "boundingBox":
-        [322, 590, 503, 599, 500, 654, 319, 644], "words": [{"text": "Contoso", "boundingBox":
-        [324, 590, 501, 601, 498, 654, 320, 645], "confidence": 0.932}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "123 Main Street",
-        "boundingBox": [317, 688, 647, 691, 646, 756, 317, 753], "words": [{"text":
-        "123", "boundingBox": [319, 688, 375, 690, 373, 755, 317, 753], "confidence":
-        0.987}, {"text": "Main", "boundingBox": [388, 691, 490, 694, 489, 756, 386,
-        755], "confidence": 0.986}, {"text": "Street", "boundingBox": [503, 694, 644,
-        695, 644, 754, 502, 756], "confidence": 0.985}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Redmond, WA 98052", "boundingBox":
-        [307, 795, 752, 793, 752, 857, 307, 859], "words": [{"text": "Redmond,", "boundingBox":
-        [310, 796, 516, 796, 514, 859, 308, 858], "confidence": 0.924}, {"text": "WA",
-        "boundingBox": [528, 796, 593, 796, 591, 859, 526, 859], "confidence": 0.987},
-        {"text": "98052", "boundingBox": [605, 795, 751, 793, 749, 854, 603, 859],
-        "confidence": 0.985}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "123-456-7890", "boundingBox": [303, 1003, 623, 1008, 622,
-        1070, 303, 1063], "words": [{"text": "123-456-7890", "boundingBox": [303,
-        1003, 623, 1009, 621, 1071, 303, 1064], "confidence": 0.978}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "6/10/2019 13:59",
-        "boundingBox": [299, 1221, 631, 1222, 631, 1291, 299, 1290], "words": [{"text":
-        "6/10/2019", "boundingBox": [299, 1221, 494, 1222, 492, 1292, 299, 1292],
-        "confidence": 0.955}, {"text": "13:59", "boundingBox": [508, 1223, 628, 1224,
-        625, 1292, 506, 1292], "confidence": 0.985}], "appearance": {"style": {"name":
-        "print", "confidence": 0.998}}}, {"text": "Sales Associate: Paul", "boundingBox":
-        [299, 1335, 772, 1335, 772, 1398, 299, 1396], "words": [{"text": "Sales",
-        "boundingBox": [299, 1335, 406, 1337, 408, 1397, 301, 1396], "confidence":
-        0.986}, {"text": "Associate:", "boundingBox": [418, 1337, 644, 1337, 645,
-        1399, 419, 1397], "confidence": 0.979}, {"text": "Paul", "boundingBox": [656,
-        1337, 771, 1335, 771, 1399, 656, 1399], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "---", "boundingBox":
-        [306, 1470, 370, 1469, 370, 1488, 306, 1489], "words": [{"text": "---", "boundingBox":
-        [307, 1471, 370, 1470, 371, 1489, 307, 1490], "confidence": 0.825}], "appearance":
-        {"style": {"name": "print", "confidence": 0.876}}}, {"text": "--- - -", "boundingBox":
-        [1021, 1474, 1112, 1473, 1112, 1490, 1021, 1491], "words": [{"text": "---",
-        "boundingBox": [1021, 1475, 1061, 1475, 1061, 1491, 1021, 1491], "confidence":
-        0.669}, {"text": "-", "boundingBox": [1068, 1475, 1084, 1474, 1084, 1491,
-        1067, 1491], "confidence": 0.966}, {"text": "-", "boundingBox": [1092, 1474,
-        1109, 1474, 1108, 1491, 1092, 1491], "confidence": 0.968}], "appearance":
-        {"style": {"name": "print", "confidence": 0.996}}}, {"text": "1 Surface Pro
-        6", "boundingBox": [327, 1558, 679, 1560, 678, 1624, 326, 1622], "words":
-        [{"text": "1", "boundingBox": [327, 1558, 353, 1559, 352, 1623, 327, 1623],
-        "confidence": 0.983}, {"text": "Surface", "boundingBox": [366, 1559, 536,
-        1561, 535, 1624, 365, 1623], "confidence": 0.983}, {"text": "Pro", "boundingBox":
-        [549, 1561, 622, 1562, 621, 1624, 548, 1624], "confidence": 0.952}, {"text":
-        "6", "boundingBox": [635, 1562, 677, 1563, 676, 1624, 633, 1624], "confidence":
-        0.986}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "256GB / Intel Core i5 /", "boundingBox": [366, 1666, 850, 1668, 849, 1746,
-        366, 1744], "words": [{"text": "256GB", "boundingBox": [367, 1667, 493, 1668,
-        492, 1745, 366, 1744], "confidence": 0.984}, {"text": "/", "boundingBox":
-        [508, 1668, 518, 1669, 517, 1745, 507, 1745], "confidence": 0.985}, {"text":
-        "Intel", "boundingBox": [533, 1669, 634, 1669, 632, 1746, 532, 1745], "confidence":
-        0.906}, {"text": "Core", "boundingBox": [649, 1669, 745, 1669, 743, 1747,
-        647, 1746], "confidence": 0.986}, {"text": "i5", "boundingBox": [760, 1669,
-        795, 1669, 793, 1747, 758, 1747], "confidence": 0.886}, {"text": "/", "boundingBox":
-        [811, 1669, 851, 1669, 848, 1747, 808, 1747], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "8GB RAM (Black)",
-        "boundingBox": [357, 1779, 738, 1779, 738, 1858, 357, 1859], "words": [{"text":
-        "8GB", "boundingBox": [359, 1779, 434, 1779, 433, 1860, 358, 1860], "confidence":
-        0.942}, {"text": "RAM", "boundingBox": [450, 1779, 546, 1779, 545, 1859, 449,
-        1860], "confidence": 0.986}, {"text": "(Black)", "boundingBox": [562, 1779,
-        738, 1780, 737, 1860, 561, 1859], "confidence": 0.982}], "appearance": {"style":
-        {"name": "print", "confidence": 0.999}}}, {"text": "999.00", "boundingBox":
-        [967, 1792, 1136, 1797, 1134, 1858, 967, 1855], "words": [{"text": "999.00",
-        "boundingBox": [967, 1792, 1135, 1796, 1133, 1859, 967, 1855], "confidence":
-        0.984}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "1 SurfacePen", "boundingBox": [314, 2017, 626, 2013, 627, 2078, 316, 2084],
-        "words": [{"text": "1", "boundingBox": [315, 2018, 337, 2017, 338, 2084, 316,
-        2085], "confidence": 0.986}, {"text": "SurfacePen", "boundingBox": [350, 2017,
-        624, 2013, 624, 2079, 351, 2084], "confidence": 0.979}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "$ 99.99", "boundingBox": [963,
-        2026, 1129, 2025, 1128, 2092, 963, 2092], "words": [{"text": "$", "boundingBox":
-        [963, 2025, 985, 2025, 985, 2092, 963, 2092], "confidence": 0.986}, {"text":
-        "99.99", "boundingBox": [999, 2025, 1128, 2025, 1128, 2092, 999, 2092], "confidence":
-        0.982}], "appearance": {"style": {"name": "print", "confidence": 0.994}}},
-        {"text": "------ ---", "boundingBox": [279, 2166, 491, 2157, 492, 2176, 279,
-        2186], "words": [{"text": "------", "boundingBox": [280, 2167, 421, 2161,
-        421, 2178, 280, 2186], "confidence": 0.638}, {"text": "---", "boundingBox":
-        [428, 2161, 490, 2157, 490, 2177, 427, 2178], "confidence": 0.721}], "appearance":
-        {"style": {"name": "print", "confidence": 0.903}}}, {"text": "Sub-Total",
-        "boundingBox": [464, 2243, 697, 2244, 696, 2310, 464, 2307], "words": [{"text":
-        "Sub-Total", "boundingBox": [465, 2243, 697, 2244, 694, 2311, 465, 2306],
-        "confidence": 0.935}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1098.99", "boundingBox": [952, 2255, 1141, 2251, 1140, 2325,
-        951, 2330], "words": [{"text": "1098.99", "boundingBox": [954, 2255, 1137,
-        2251, 1138, 2325, 956, 2329], "confidence": 0.982}], "appearance": {"style":
-        {"name": "print", "confidence": 0.995}}}, {"text": "Tax", "boundingBox": [564,
-        2349, 662, 2347, 662, 2423, 564, 2425], "words": [{"text": "Tax", "boundingBox":
-        [564, 2349, 657, 2347, 659, 2422, 564, 2424], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 0.993}}}, {"text": "$ 104.40", "boundingBox":
-        [940, 2371, 1131, 2368, 1129, 2433, 942, 2439], "words": [{"text": "$", "boundingBox":
-        [940, 2371, 962, 2370, 964, 2438, 941, 2439], "confidence": 0.987}, {"text":
-        "104.40", "boundingBox": [976, 2370, 1130, 2368, 1131, 2434, 977, 2438], "confidence":
-        0.984}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Total", "boundingBox": [538, 2592, 669, 2590, 669, 2650, 541, 2654], "words":
-        [{"text": "Total", "boundingBox": [538, 2592, 666, 2590, 667, 2651, 539, 2654],
-        "confidence": 0.952}], "appearance": {"style": {"name": "print", "confidence":
-        0.997}}}, {"text": "$ 1203.39", "boundingBox": [914, 2591, 1124, 2610, 1117,
-        2676, 910, 2653], "words": [{"text": "$", "boundingBox": [914, 2591, 935,
-        2593, 931, 2657, 911, 2655], "confidence": 0.987}, {"text": "1203.39", "boundingBox":
-        [947, 2593, 1123, 2612, 1116, 2676, 943, 2659], "confidence": 0.982}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}]}], "documentResults": [{"docType":
-        "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType": {"type":
-        "string", "valueString": "Itemized", "confidence": 0.99}, "MerchantName":
-        {"type": "string", "valueString": "Contoso Contoso", "text": "Contoso Contoso",
-        "boundingBox": [342.9, 238.1, 1061, 278.6, 1038.1, 685.5, 320, 645], "page":
-        1, "confidence": 0.693, "elements": ["#/readResults/0/lines/0/words/0", "#/readResults/0/lines/1/words/0"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
-        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [308.4,
-        688, 751.3, 689, 750.8, 859.6, 308, 858.5], "page": 1, "confidence": 0.989,
-        "elements": ["#/readResults/0/lines/2/words/0", "#/readResults/0/lines/2/words/1",
-        "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1",
-        "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber": {"type": "phoneNumber",
-        "text": "123-456-7890", "boundingBox": [303, 1003, 623, 1009, 621, 1071, 303,
-        1064], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/4/words/0"]},
-        "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019",
-        "boundingBox": [299, 1221, 494, 1222, 492, 1292, 299, 1292], "page": 1, "confidence":
-        0.991, "elements": ["#/readResults/0/lines/5/words/0"]}, "TransactionTime":
-        {"type": "time", "valueTime": "13:59:00", "text": "13:59", "boundingBox":
-        [508, 1223, 628, 1224, 625, 1292, 506, 1292], "page": 1, "confidence": 0.99,
-        "elements": ["#/readResults/0/lines/5/words/1"]}, "Items": {"type": "array",
-        "valueArray": [{"type": "object", "valueObject": {"Quantity": {"type": "number",
-        "valueNumber": 1, "text": "1", "boundingBox": [327, 1558, 353, 1559, 352,
-        1623, 327, 1623], "page": 1, "confidence": 0.745, "elements": ["#/readResults/0/lines/9/words/0"]}}},
-        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
-        "8GB RAM (Black)", "text": "8GB RAM (Black)", "boundingBox": [358, 1779, 738,
-        1779, 738, 1860, 358, 1860], "page": 1, "confidence": 0.968, "elements": ["#/readResults/0/lines/11/words/0",
-        "#/readResults/0/lines/11/words/1", "#/readResults/0/lines/11/words/2"]},
-        "TotalPrice": {"type": "number", "valueNumber": 999, "text": "999.00", "boundingBox":
-        [967, 1792, 1135, 1796, 1133, 1859, 967, 1855], "page": 1, "confidence": 0.97,
-        "elements": ["#/readResults/0/lines/12/words/0"]}}}, {"type": "object", "valueObject":
-        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [315, 2018, 337, 2017, 338, 2084, 316, 2085], "page": 1, "confidence": 0.91,
-        "elements": ["#/readResults/0/lines/13/words/0"]}, "Name": {"type": "string",
-        "valueString": "SurfacePen", "text": "SurfacePen", "boundingBox": [350, 2017,
-        624, 2013, 624, 2079, 351, 2084], "page": 1, "confidence": 0.959, "elements":
-        ["#/readResults/0/lines/13/words/1"]}, "TotalPrice": {"type": "number", "valueNumber":
-        99.99, "text": "$99.99", "boundingBox": [963, 2025, 1128, 2025, 1128, 2092,
-        963, 2092], "page": 1, "confidence": 0.775, "elements": ["#/readResults/0/lines/14/words/0",
-        "#/readResults/0/lines/14/words/1"]}}}]}, "Subtotal": {"type": "number", "valueNumber":
-        1098.99, "text": "1098.99", "boundingBox": [954, 2255, 1137, 2251, 1138, 2325,
-        956, 2329], "page": 1, "confidence": 0.986, "elements": ["#/readResults/0/lines/17/words/0"]},
-        "Total": {"type": "number", "valueNumber": 104.4, "text": "104.40", "boundingBox":
-        [976, 2370, 1130, 2368, 1131, 2434, 977, 2438], "page": 1, "confidence": 0.668,
-        "elements": ["#/readResults/0/lines/19/words/1"]}}}]}}'
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:10:22Z",
+        "lastUpdatedDateTime": "2020-11-16T19:10:24Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.2511, "width": 1688, "height":
+        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [619,
+        291, 1051, 284, 1053, 384, 620, 396], "words": [{"text": "Contoso", "boundingBox":
+        [623, 292, 1051, 284, 1052, 383, 624, 397], "confidence": 0.959}]}, {"text":
+        "Contoso", "boundingBox": [322, 591, 501, 601, 498, 654, 319, 644], "words":
+        [{"text": "Contoso", "boundingBox": [328, 591, 500, 602, 498, 654, 325, 644],
+        "confidence": 0.727}]}, {"text": "123 Main Street", "boundingBox": [319, 690,
+        655, 695, 654, 757, 318, 752], "words": [{"text": "123", "boundingBox": [323,
+        690, 387, 692, 383, 754, 319, 753], "confidence": 0.958}, {"text": "Main",
+        "boundingBox": [399, 692, 502, 694, 498, 756, 395, 754], "confidence": 0.958},
+        {"text": "Street", "boundingBox": [514, 695, 656, 698, 653, 758, 510, 756],
+        "confidence": 0.958}]}, {"text": "Redmond, WA 98052", "boundingBox": [317,
+        795, 751, 795, 752, 859, 317, 860], "words": [{"text": "Redmond,", "boundingBox":
+        [321, 795, 523, 795, 520, 861, 317, 858], "confidence": 0.57}, {"text": "WA",
+        "boundingBox": [535, 795, 597, 795, 595, 861, 532, 861], "confidence": 0.958},
+        {"text": "98052", "boundingBox": [610, 795, 749, 796, 747, 858, 607, 861],
+        "confidence": 0.958}]}, {"text": "123-456-7890", "boundingBox": [306, 1005,
+        618, 1011, 616, 1068, 305, 1062], "words": [{"text": "123-456-7890", "boundingBox":
+        [306, 1005, 617, 1012, 615, 1069, 305, 1064], "confidence": 0.937}]}, {"text":
+        "6/10/2019 13:59", "boundingBox": [303, 1223, 630, 1225, 629, 1289, 302, 1286],
+        "words": [{"text": "6/10/2019", "boundingBox": [304, 1224, 506, 1224, 504,
+        1289, 303, 1288], "confidence": 0.762}, {"text": "13:59", "boundingBox": [518,
+        1225, 628, 1228, 627, 1290, 517, 1289], "confidence": 0.949}]}, {"text": "Sales
+        Associate: Paul", "boundingBox": [294, 1335, 768, 1335, 768, 1401, 294, 1399],
+        "words": [{"text": "Sales", "boundingBox": [302, 1336, 418, 1335, 416, 1399,
+        301, 1399], "confidence": 0.959}, {"text": "Associate:", "boundingBox": [430,
+        1335, 649, 1336, 646, 1401, 428, 1399], "confidence": 0.95}, {"text": "Paul",
+        "boundingBox": [661, 1336, 767, 1336, 764, 1402, 659, 1401], "confidence":
+        0.959}]}, {"text": "1 Surface Pro 6", "boundingBox": [336, 1560, 679, 1561,
+        678, 1625, 336, 1623], "words": [{"text": "1", "boundingBox": [337, 1560,
+        360, 1561, 360, 1625, 337, 1625], "confidence": 0.799}, {"text": "Surface",
+        "boundingBox": [373, 1561, 543, 1562, 542, 1624, 373, 1625], "confidence":
+        0.958}, {"text": "Pro", "boundingBox": [555, 1562, 632, 1563, 631, 1625, 555,
+        1624], "confidence": 0.91}, {"text": "6", "boundingBox": [644, 1563, 676,
+        1563, 675, 1625, 644, 1625], "confidence": 0.762}]}, {"text": "256GB / Intel
+        Core i5 /", "boundingBox": [372, 1669, 846, 1669, 846, 1743, 372, 1742], "words":
+        [{"text": "256GB", "boundingBox": [375, 1670, 506, 1671, 504, 1740, 373, 1740],
+        "confidence": 0.952}, {"text": "/", "boundingBox": [520, 1671, 533, 1671,
+        531, 1740, 517, 1740], "confidence": 0.879}, {"text": "Intel", "boundingBox":
+        [547, 1671, 648, 1671, 646, 1741, 545, 1740], "confidence": 0.879}, {"text":
+        "Core", "boundingBox": [662, 1671, 758, 1670, 756, 1743, 660, 1741], "confidence":
+        0.95}, {"text": "i5", "boundingBox": [772, 1670, 809, 1670, 807, 1744, 770,
+        1743], "confidence": 0.817}, {"text": "/", "boundingBox": [823, 1670, 847,
+        1670, 846, 1744, 821, 1744], "confidence": 0.841}]}, {"text": "8GB RAM (Black)",
+        "boundingBox": [370, 1782, 732, 1785, 731, 1853, 370, 1850], "words": [{"text":
+        "8GB", "boundingBox": [374, 1783, 451, 1783, 448, 1850, 370, 1850], "confidence":
+        0.798}, {"text": "RAM", "boundingBox": [465, 1783, 561, 1784, 559, 1851, 461,
+        1850], "confidence": 0.958}, {"text": "(Black)", "boundingBox": [575, 1784,
+        731, 1785, 729, 1854, 572, 1852], "confidence": 0.959}]}, {"text": "$ 999.00",
+        "boundingBox": [937, 1785, 1139, 1790, 1137, 1862, 936, 1859], "words": [{"text":
+        "$", "boundingBox": [939, 1785, 959, 1785, 958, 1859, 938, 1859], "confidence":
+        0.895}, {"text": "999.00", "boundingBox": [974, 1786, 1134, 1789, 1133, 1863,
+        973, 1860], "confidence": 0.877}]}, {"text": "1 SurfacePen", "boundingBox":
+        [320, 2019, 627, 2013, 629, 2076, 321, 2083], "words": [{"text": "1", "boundingBox":
+        [321, 2021, 348, 2020, 349, 2084, 322, 2084], "confidence": 0.82}, {"text":
+        "SurfacePen", "boundingBox": [360, 2020, 626, 2014, 628, 2077, 362, 2083],
+        "confidence": 0.928}]}, {"text": "$ 99.99", "boundingBox": [967, 2028, 1128,
+        2029, 1127, 2091, 967, 2091], "words": [{"text": "$", "boundingBox": [969,
+        2028, 994, 2028, 994, 2091, 969, 2091], "confidence": 0.888}, {"text": "99.99",
+        "boundingBox": [1007, 2028, 1127, 2028, 1126, 2091, 1007, 2091], "confidence":
+        0.911}]}, {"text": "Sub-Total", "boundingBox": [474, 2242, 697, 2244, 697,
+        2310, 473, 2308], "words": [{"text": "Sub-Total", "boundingBox": [477, 2242,
+        695, 2245, 694, 2310, 474, 2308], "confidence": 0.915}]}, {"text": "$ 1098.99",
+        "boundingBox": [922, 2259, 1136, 2253, 1138, 2318, 924, 2325], "words": [{"text":
+        "$", "boundingBox": [924, 2261, 950, 2260, 954, 2326, 928, 2326], "confidence":
+        0.881}, {"text": "1098.99", "boundingBox": [963, 2260, 1136, 2254, 1137, 2320,
+        966, 2325], "confidence": 0.942}]}, {"text": "Tax", "boundingBox": [570, 2355,
+        655, 2357, 654, 2415, 568, 2413], "words": [{"text": "Tax", "boundingBox":
+        [571, 2355, 654, 2357, 653, 2415, 570, 2413], "confidence": 0.958}]}, {"text":
+        "$ 104.40", "boundingBox": [941, 2368, 1134, 2364, 1137, 2433, 942, 2438],
+        "words": [{"text": "$", "boundingBox": [943, 2368, 966, 2367, 968, 2437, 944,
+        2438], "confidence": 0.892}, {"text": "104.40", "boundingBox": [980, 2367,
+        1132, 2364, 1133, 2434, 982, 2437], "confidence": 0.952}]}, {"text": "Total",
+        "boundingBox": [551, 2591, 672, 2584, 675, 2652, 554, 2659], "words": [{"text":
+        "Total", "boundingBox": [551, 2591, 668, 2584, 672, 2652, 554, 2659], "confidence":
+        0.727}]}, {"text": "$ 1203.39", "boundingBox": [918, 2589, 1123, 2611, 1116,
+        2677, 912, 2656], "words": [{"text": "$", "boundingBox": [918, 2590, 942,
+        2592, 936, 2659, 913, 2656], "confidence": 0.886}, {"text": "1203.39", "boundingBox":
+        [955, 2594, 1123, 2611, 1115, 2678, 949, 2661], "confidence": 0.951}]}]}],
+        "documentResults": [{"docType": "prebuilt:receipt", "pageRange": [1, 1], "fields":
+        {"ReceiptType": {"type": "string", "valueString": "Itemized", "confidence":
+        0.659}, "MerchantName": {"type": "string", "valueString": "Contoso Contoso",
+        "text": "Contoso Contoso", "boundingBox": [349.3, 241.3, 1058, 284.4, 1033.5,
+        687.1, 324.8, 644], "page": 1, "confidence": 0.516, "elements": ["#/readResults/0/lines/0/words/0",
+        "#/readResults/0/lines/1/words/0"]}, "MerchantAddress": {"type": "string",
+        "valueString": "123 Main Street Redmond, WA 98052", "text": "123 Main Street
+        Redmond, WA 98052", "boundingBox": [319.9, 689.9, 750.7, 697.5, 747.8, 865.6,
+        317, 858], "page": 1, "confidence": 0.986, "elements": ["#/readResults/0/lines/2/words/0",
+        "#/readResults/0/lines/2/words/1", "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0",
+        "#/readResults/0/lines/3/words/1", "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber":
+        {"type": "phoneNumber", "text": "123-456-7890", "boundingBox": [306, 1005,
+        617, 1012, 615, 1069, 305, 1064], "page": 1, "confidence": 0.99, "elements":
+        ["#/readResults/0/lines/4/words/0"]}, "TransactionDate": {"type": "date",
+        "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox": [304, 1224,
+        506, 1224, 504, 1289, 303, 1288], "page": 1, "confidence": 0.985, "elements":
+        ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type": "time",
+        "valueTime": "13:59:00", "text": "13:59", "boundingBox": [518, 1225, 628,
+        1228, 627, 1290, 517, 1289], "page": 1, "confidence": 0.968, "elements": ["#/readResults/0/lines/5/words/1"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "8GB RAM (Black)", "text": "8GB
+        RAM (Black)", "boundingBox": [370.7, 1781.5, 731, 1785, 730.3, 1854, 370,
+        1850.6], "page": 1, "confidence": 0.916, "elements": ["#/readResults/0/lines/9/words/0",
+        "#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2"]}, "TotalPrice":
+        {"type": "number", "valueNumber": 999, "text": "$999.00", "boundingBox": [939,
+        1784.6, 1134.4, 1788.3, 1133, 1863, 937.6, 1859.3], "page": 1, "confidence":
+        0.559, "elements": ["#/readResults/0/lines/10/words/0", "#/readResults/0/lines/10/words/1"]}}},
+        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
+        1, "text": "1", "boundingBox": [321, 2021, 348, 2020, 349, 2084, 322, 2084],
+        "page": 1, "confidence": 0.858, "elements": ["#/readResults/0/lines/11/words/0"]},
+        "Name": {"type": "string", "valueString": "SurfacePen", "text": "SurfacePen",
+        "boundingBox": [360, 2020, 626, 2014, 628, 2077, 362, 2083], "page": 1, "confidence":
+        0.858, "elements": ["#/readResults/0/lines/11/words/1"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 99.99, "text": "99.99", "boundingBox": [1007, 2028,
+        1127, 2028, 1126, 2091, 1007, 2091], "page": 1, "confidence": 0.386, "elements":
+        ["#/readResults/0/lines/12/words/1"]}}}]}, "Subtotal": {"type": "number",
+        "valueNumber": 1098.99, "text": "1098.99", "boundingBox": [963, 2260, 1136,
+        2254, 1137, 2320, 966, 2325], "page": 1, "confidence": 0.964, "elements":
+        ["#/readResults/0/lines/14/words/1"]}, "Tax": {"type": "number", "valueNumber":
+        104.4, "text": "$104.40", "boundingBox": [942.6, 2367.5, 1132, 2363.7, 1133.4,
+        2434.2, 944, 2438], "page": 1, "confidence": 0.713, "elements": ["#/readResults/0/lines/16/words/0",
+        "#/readResults/0/lines/16/words/1"]}, "Total": {"type": "number", "valueNumber":
+        1203.39, "text": "1203.39", "boundingBox": [955, 2594, 1123, 2611, 1115, 2678,
+        949, 2661], "page": 1, "confidence": 0.774, "elements": ["#/readResults/0/lines/18/words/1"]}}}]}}'
     headers:
       apim-request-id:
-      - 596b2fe6-484c-4f38-88e4-e5ae57cd6718
+      - ec590885-7ba2-4133-b745-62274c475dc5
       content-length:
-      - '10615'
+      - '8807'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:04:59 GMT
+      - Mon, 16 Nov 2020 19:10:26 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '27'
+      - '22'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_authentication_bad_key.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_authentication_bad_key.yaml
@@ -17,7 +17,7 @@ interactions:
         an active subscription and use a correct regional API endpoint for your resource."}}'
     headers:
       content-length: '224'
-      date: Wed, 11 Nov 2020 18:05:00 GMT
+      date: Mon, 16 Nov 2020 19:10:27 GMT
     status:
       code: 401
       message: PermissionDenied

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_authentication_successful_key.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_authentication_successful_key.yaml
@@ -15,13 +15,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 9a635590-bac3-4a54-9154-296a15d8bd8e
+      apim-request-id: 4dcc100a-b8bf-461c-9bb5-e1692dbbea4d
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:05:01 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/9a635590-bac3-4a54-9154-296a15d8bd8e
+      date: Mon, 16 Nov 2020 19:10:28 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/4dcc100a-b8bf-461c-9bb5-e1692dbbea4d
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '243'
+      x-envoy-upstream-service-time: '196'
     status:
       code: 202
       message: Accepted
@@ -32,60 +32,60 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/9a635590-bac3-4a54-9154-296a15d8bd8e
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/4dcc100a-b8bf-461c-9bb5-e1692dbbea4d
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:05:01Z",
-        "lastUpdatedDateTime": "2020-11-11T18:05:04Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:10:28Z",
+        "lastUpdatedDateTime": "2020-11-16T19:10:31Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [380.9, 282.9,
-        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.716}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [298.3, 676.5, 844.6,
-        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence":
-        0.99}, "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text":
-        "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505, 1331, 255, 1312],
-        "page": 1, "confidence": 0.99}, "TransactionTime": {"type": "time", "valueTime":
-        "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681, 1262, 675, 1341,
-        522, 1332], "page": 1, "confidence": 0.989}, "Items": {"type": "array", "valueArray":
-        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [244, 1581, 288, 1584, 285, 1678, 241, 1675],
-        "page": 1, "confidence": 0.919}, "Name": {"type": "string", "valueString":
-        "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585, 658, 1598,
-        657, 1688, 304, 1679], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1106, 1579,
-        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.959}}}, {"type":
-        "object", "valueObject": {"Quantity": {"type": "number", "valueNumber": 1,
-        "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [294, 1839, 737, 1839,
-        737, 1924, 294, 1924], "page": 1, "confidence": 0.955}, "TotalPrice": {"type":
-        "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox": [1134, 1948,
-        1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence": 0.958}}}]},
-        "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923}, "Tax": {"type": "number", "valueNumber": 1.17, "text": "1.17", "boundingBox":
-        [1186, 2356, 1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence":
-        0.979}, "Tip": {"type": "number", "valueNumber": 463, "text": "$463", "boundingBox":
-        [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "page": 1, "confidence":
-        0.975}, "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50",
-        "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1,
-        "confidence": 0.987}}}]}}'
+        "Itemized", "confidence": 0.692}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [378.2, 292.4,
+        1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8], "page": 1, "confidence": 0.613},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [302,
+        675.8, 848.1, 793.7, 809.9, 970.4, 263.9, 852.5], "page": 1, "confidence":
+        0.99}, "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber":
+        "+19876543210", "text": "987-654-3210", "boundingBox": [278, 1004, 656, 1057,
+        647, 1123, 271, 1075], "page": 1, "confidence": 0.99}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99},
+        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
+        "boundingBox": [541, 1248, 677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence":
+        0.977}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
+        [245, 1583, 299, 1585, 295, 1676, 241, 1671], "page": 1, "confidence": 0.92},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923}, "TotalPrice": {"type": "number", "valueNumber": 2.2, "text": "$2.20",
+        "boundingBox": [1108, 1584, 1263, 1574, 1268, 1656, 1113, 1666], "page": 1,
+        "confidence": 0.918}}}, {"type": "object", "valueObject": {"Quantity": {"type":
+        "number", "valueNumber": 1, "text": "1", "boundingBox": [232, 1834, 286, 1836,
+        285, 1920, 231, 1920], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916},
+        "TotalPrice": {"type": "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox":
+        [1135, 1955, 1257, 1952, 1259, 2036, 1136, 2039], "page": 1, "confidence":
+        0.916}}}]}, "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70",
+        "boundingBox": [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1,
+        "confidence": 0.955}, "Tax": {"type": "number", "valueNumber": 1.17, "text":
+        "1.17", "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "page":
+        1, "confidence": 0.979}, "Tip": {"type": "number", "valueNumber": 1.63, "text":
+        "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591, 1091, 2585], "page":
+        1, "confidence": 0.941}, "Total": {"type": "number", "valueNumber": 14.5,
+        "text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380, 2763, 1030,
+        2739], "page": 1, "confidence": 0.985}}}]}}'
     headers:
-      apim-request-id: feb0f07d-1ec4-4ada-856a-f46447e1b02a
-      content-length: '2820'
+      apim-request-id: a0fd00ee-d32c-4126-b0fc-193c74165eea
+      content-length: '2835'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:05:06 GMT
+      date: Mon, 16 Nov 2020 19:10:33 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '25'
+      x-envoy-upstream-service-time: '22'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/9a635590-bac3-4a54-9154-296a15d8bd8e
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/4dcc100a-b8bf-461c-9bb5-e1692dbbea4d
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_blank_page.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_blank_page.yaml
@@ -465,13 +465,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 26e0c2fc-0a22-441a-9f0b-fb131a111aa4
+      apim-request-id: 2fbfd355-3a68-4f86-b2e7-ec244d483198
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:05:06 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/26e0c2fc-0a22-441a-9f0b-fb131a111aa4
+      date: Mon, 16 Nov 2020 19:10:34 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/2fbfd355-3a68-4f86-b2e7-ec244d483198
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '55'
+      x-envoy-upstream-service-time: '153'
     status:
       code: 202
       message: Accepted
@@ -482,24 +482,24 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/26e0c2fc-0a22-441a-9f0b-fb131a111aa4
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/2fbfd355-3a68-4f86-b2e7-ec244d483198
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:05:07Z",
-        "lastUpdatedDateTime": "2020-11-11T18:05:08Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:10:34Z",
+        "lastUpdatedDateTime": "2020-11-16T19:10:37Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": 0, "width": 8.5, "height": 11,
         "unit": "inch"}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
         [1, 1], "fields": {}}]}}'
     headers:
-      apim-request-id: 73684419-d081-4601-873f-b1ddc8c500fe
+      apim-request-id: 4a803893-e016-4911-b9c3-9bdb652be2b8
       content-length: '300'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:05:12 GMT
+      date: Mon, 16 Nov 2020 19:10:38 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '20'
+      x-envoy-upstream-service-time: '22'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/26e0c2fc-0a22-441a-9f0b-fb131a111aa4
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/2fbfd355-3a68-4f86-b2e7-ec244d483198
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_damaged_file_passed_as_bytes.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_damaged_file_passed_as_bytes.yaml
@@ -12,16 +12,16 @@ interactions:
     uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyze?includeTextDetails=false
   response:
     body:
-      string: '{"error": {"code": "BadArgument", "innerError": {"requestId": "11c9dbe9-8d49-4eff-90f3-c5a0eb48c260"},
+      string: '{"error": {"code": "BadArgument", "innerError": {"requestId": "0382c6a9-63ef-45df-a1b2-0ffb32e86127"},
         "message": "Bad or unrecognizable request JSON or binary file."}}'
     headers:
-      apim-request-id: 11c9dbe9-8d49-4eff-90f3-c5a0eb48c260
+      apim-request-id: 0382c6a9-63ef-45df-a1b2-0ffb32e86127
       content-length: '161'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:05:12 GMT
+      date: Mon, 16 Nov 2020 19:10:39 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '5'
+      x-envoy-upstream-service-time: '3'
     status:
       code: 400
       message: Bad Request

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_damaged_file_passed_as_bytes_io.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_damaged_file_passed_as_bytes_io.yaml
@@ -17,16 +17,16 @@ interactions:
     uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyze?includeTextDetails=false
   response:
     body:
-      string: '{"error": {"code": "InvalidImage", "innerError": {"requestId": "ce700c89-3243-4491-aba3-8d71b5bc6381"},
+      string: '{"error": {"code": "InvalidImage", "innerError": {"requestId": "b0b0ee76-9bb2-4e7f-84f4-fe69002a85fc"},
         "message": "The input data is not a valid image or password protected."}}'
     headers:
-      apim-request-id: ce700c89-3243-4491-aba3-8d71b5bc6381
+      apim-request-id: b0b0ee76-9bb2-4e7f-84f4-fe69002a85fc
       content-length: '170'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:05:12 GMT
+      date: Mon, 16 Nov 2020 19:10:39 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '4'
+      x-envoy-upstream-service-time: '3'
     status:
       code: 400
       message: Bad Request

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_passing_enum_content_type.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_passing_enum_content_type.yaml
@@ -15,13 +15,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: aea2855b-0cfe-4e4b-9661-3f8d89d4e7bf
+      apim-request-id: 71323505-bb82-4c88-a1d9-d0dd4aafa439
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:05:17 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/aea2855b-0cfe-4e4b-9661-3f8d89d4e7bf
+      date: Mon, 16 Nov 2020 19:10:43 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/71323505-bb82-4c88-a1d9-d0dd4aafa439
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '477'
+      x-envoy-upstream-service-time: '460'
     status:
       code: 202
       message: Accepted
@@ -32,55 +32,56 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/aea2855b-0cfe-4e4b-9661-3f8d89d4e7bf
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/71323505-bb82-4c88-a1d9-d0dd4aafa439
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:05:17Z",
-        "lastUpdatedDateTime": "2020-11-11T18:05:19Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": -0.0752, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:10:44Z",
+        "lastUpdatedDateTime": "2020-11-16T19:10:47Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.2511, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [342.9, 238.1,
-        1061, 278.6, 1038.1, 685.5, 320, 645], "page": 1, "confidence": 0.693}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [308.4, 688, 751.3, 689,
-        750.8, 859.6, 308, 858.5], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "text": "123-456-7890", "boundingBox": [303, 1003,
-        623, 1009, 621, 1071, 303, 1064], "page": 1, "confidence": 0.99}, "TransactionDate":
-        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
-        [299, 1221, 494, 1222, 492, 1292, 299, 1292], "page": 1, "confidence": 0.991},
-        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
-        "boundingBox": [508, 1223, 628, 1224, 625, 1292, 506, 1292], "page": 1, "confidence":
-        0.99}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
-        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [327, 1558, 353, 1559, 352, 1623, 327, 1623], "page": 1, "confidence": 0.745}}},
-        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
-        "8GB RAM (Black)", "text": "8GB RAM (Black)", "boundingBox": [358, 1779, 738,
-        1779, 738, 1860, 358, 1860], "page": 1, "confidence": 0.968}, "TotalPrice":
-        {"type": "number", "valueNumber": 999, "text": "999.00", "boundingBox": [967,
-        1792, 1135, 1796, 1133, 1859, 967, 1855], "page": 1, "confidence": 0.97}}},
-        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [315, 2018, 337, 2017, 338, 2084, 316, 2085],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "SurfacePen", "text": "SurfacePen", "boundingBox": [350, 2017, 624, 2013,
-        624, 2079, 351, 2084], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 99.99, "text": "$99.99", "boundingBox": [963, 2025,
-        1128, 2025, 1128, 2092, 963, 2092], "page": 1, "confidence": 0.775}}}]}, "Subtotal":
-        {"type": "number", "valueNumber": 1098.99, "text": "1098.99", "boundingBox":
-        [954, 2255, 1137, 2251, 1138, 2325, 956, 2329], "page": 1, "confidence": 0.986},
-        "Total": {"type": "number", "valueNumber": 104.4, "text": "104.40", "boundingBox":
-        [976, 2370, 1130, 2368, 1131, 2434, 977, 2438], "page": 1, "confidence": 0.668}}}]}}'
+        "Itemized", "confidence": 0.659}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [349.3, 241.3,
+        1058, 284.4, 1033.5, 687.1, 324.8, 644], "page": 1, "confidence": 0.516},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [319.9,
+        689.9, 750.7, 697.5, 747.8, 865.6, 317, 858], "page": 1, "confidence": 0.986},
+        "MerchantPhoneNumber": {"type": "phoneNumber", "text": "123-456-7890", "boundingBox":
+        [306, 1005, 617, 1012, 615, 1069, 305, 1064], "page": 1, "confidence": 0.99},
+        "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019",
+        "boundingBox": [304, 1224, 506, 1224, 504, 1289, 303, 1288], "page": 1, "confidence":
+        0.985}, "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text":
+        "13:59", "boundingBox": [518, 1225, 628, 1228, 627, 1290, 517, 1289], "page":
+        1, "confidence": 0.968}, "Items": {"type": "array", "valueArray": [{"type":
+        "object", "valueObject": {"Name": {"type": "string", "valueString": "8GB RAM
+        (Black)", "text": "8GB RAM (Black)", "boundingBox": [370.7, 1781.5, 731, 1785,
+        730.3, 1854, 370, 1850.6], "page": 1, "confidence": 0.916}, "TotalPrice":
+        {"type": "number", "valueNumber": 999, "text": "$999.00", "boundingBox": [939,
+        1784.6, 1134.4, 1788.3, 1133, 1863, 937.6, 1859.3], "page": 1, "confidence":
+        0.559}}}, {"type": "object", "valueObject": {"Quantity": {"type": "number",
+        "valueNumber": 1, "text": "1", "boundingBox": [321, 2021, 348, 2020, 349,
+        2084, 322, 2084], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "SurfacePen", "text": "SurfacePen", "boundingBox": [360, 2020,
+        626, 2014, 628, 2077, 362, 2083], "page": 1, "confidence": 0.858}, "TotalPrice":
+        {"type": "number", "valueNumber": 99.99, "text": "99.99", "boundingBox": [1007,
+        2028, 1127, 2028, 1126, 2091, 1007, 2091], "page": 1, "confidence": 0.386}}}]},
+        "Subtotal": {"type": "number", "valueNumber": 1098.99, "text": "1098.99",
+        "boundingBox": [963, 2260, 1136, 2254, 1137, 2320, 966, 2325], "page": 1,
+        "confidence": 0.964}, "Tax": {"type": "number", "valueNumber": 104.4, "text":
+        "$104.40", "boundingBox": [942.6, 2367.5, 1132, 2363.7, 1133.4, 2434.2, 944,
+        2438], "page": 1, "confidence": 0.713}, "Total": {"type": "number", "valueNumber":
+        1203.39, "text": "1203.39", "boundingBox": [955, 2594, 1123, 2611, 1115, 2678,
+        949, 2661], "page": 1, "confidence": 0.772}}}]}}'
     headers:
-      apim-request-id: a09021a6-6a77-4e2f-9837-74f23b06a8c1
-      content-length: '2548'
+      apim-request-id: a2a1533c-530e-4a84-8d5d-17fdf3b74209
+      content-length: '2561'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:05:21 GMT
+      date: Mon, 16 Nov 2020 19:10:49 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '22'
+      x-envoy-upstream-service-time: '21'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/aea2855b-0cfe-4e4b-9661-3f8d89d4e7bf
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/71323505-bb82-4c88-a1d9-d0dd4aafa439
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_jpg.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_jpg.yaml
@@ -15,13 +15,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 06dac513-0a47-4af6-8156-51e5066d09a2
+      apim-request-id: 6f7ec35a-461b-4acc-851b-cee042773b97
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:05:33 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/06dac513-0a47-4af6-8156-51e5066d09a2
+      date: Mon, 16 Nov 2020 19:11:00 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/6f7ec35a-461b-4acc-851b-cee042773b97
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '174'
+      x-envoy-upstream-service-time: '215'
     status:
       code: 202
       message: Accepted
@@ -32,60 +32,60 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/06dac513-0a47-4af6-8156-51e5066d09a2
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/6f7ec35a-461b-4acc-851b-cee042773b97
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:05:34Z",
-        "lastUpdatedDateTime": "2020-11-11T18:05:36Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:11:01Z",
+        "lastUpdatedDateTime": "2020-11-16T19:11:02Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [380.9, 282.9,
-        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.716}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [298.3, 676.5, 844.6,
-        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence":
-        0.99}, "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text":
-        "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505, 1331, 255, 1312],
-        "page": 1, "confidence": 0.99}, "TransactionTime": {"type": "time", "valueTime":
-        "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681, 1262, 675, 1341,
-        522, 1332], "page": 1, "confidence": 0.989}, "Items": {"type": "array", "valueArray":
-        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [244, 1581, 288, 1584, 285, 1678, 241, 1675],
-        "page": 1, "confidence": 0.919}, "Name": {"type": "string", "valueString":
-        "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585, 658, 1598,
-        657, 1688, 304, 1679], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1106, 1579,
-        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.959}}}, {"type":
-        "object", "valueObject": {"Quantity": {"type": "number", "valueNumber": 1,
-        "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [294, 1839, 737, 1839,
-        737, 1924, 294, 1924], "page": 1, "confidence": 0.955}, "TotalPrice": {"type":
-        "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox": [1134, 1948,
-        1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence": 0.958}}}]},
-        "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923}, "Tax": {"type": "number", "valueNumber": 1.17, "text": "1.17", "boundingBox":
-        [1186, 2356, 1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence":
-        0.979}, "Tip": {"type": "number", "valueNumber": 463, "text": "$463", "boundingBox":
-        [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "page": 1, "confidence":
-        0.975}, "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50",
-        "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1,
-        "confidence": 0.987}}}]}}'
+        "Itemized", "confidence": 0.692}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [378.2, 292.4,
+        1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8], "page": 1, "confidence": 0.613},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [302,
+        675.8, 848.1, 793.7, 809.9, 970.4, 263.9, 852.5], "page": 1, "confidence":
+        0.99}, "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber":
+        "+19876543210", "text": "987-654-3210", "boundingBox": [278, 1004, 656, 1057,
+        647, 1123, 271, 1075], "page": 1, "confidence": 0.99}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99},
+        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
+        "boundingBox": [541, 1248, 677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence":
+        0.977}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
+        [245, 1583, 299, 1585, 295, 1676, 241, 1671], "page": 1, "confidence": 0.92},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923}, "TotalPrice": {"type": "number", "valueNumber": 2.2, "text": "$2.20",
+        "boundingBox": [1108, 1584, 1263, 1574, 1268, 1656, 1113, 1666], "page": 1,
+        "confidence": 0.918}}}, {"type": "object", "valueObject": {"Quantity": {"type":
+        "number", "valueNumber": 1, "text": "1", "boundingBox": [232, 1834, 286, 1836,
+        285, 1920, 231, 1920], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916},
+        "TotalPrice": {"type": "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox":
+        [1135, 1955, 1257, 1952, 1259, 2036, 1136, 2039], "page": 1, "confidence":
+        0.916}}}]}, "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70",
+        "boundingBox": [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1,
+        "confidence": 0.955}, "Tax": {"type": "number", "valueNumber": 1.17, "text":
+        "1.17", "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "page":
+        1, "confidence": 0.979}, "Tip": {"type": "number", "valueNumber": 1.63, "text":
+        "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591, 1091, 2585], "page":
+        1, "confidence": 0.941}, "Total": {"type": "number", "valueNumber": 14.5,
+        "text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380, 2763, 1030,
+        2739], "page": 1, "confidence": 0.985}}}]}}'
     headers:
-      apim-request-id: b161b7aa-0745-4d65-8fd5-648446dd8cac
-      content-length: '2820'
+      apim-request-id: 7721abd9-11a6-4687-8533-c6daff2c5199
+      content-length: '2835'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:05:38 GMT
+      date: Mon, 16 Nov 2020 19:11:05 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '21'
+      x-envoy-upstream-service-time: '20'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/06dac513-0a47-4af6-8156-51e5066d09a2
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/6f7ec35a-461b-4acc-851b-cee042773b97
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_jpg_include_field_elements.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_jpg_include_field_elements.yaml
@@ -15,13 +15,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 79bcd661-35d0-4698-9f69-c17e9076a852
+      apim-request-id: 17517e5c-1610-4724-8a15-70dce74c6f8e
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:05:39 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/79bcd661-35d0-4698-9f69-c17e9076a852
+      date: Mon, 16 Nov 2020 19:11:06 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/17517e5c-1610-4724-8a15-70dce74c6f8e
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '238'
+      x-envoy-upstream-service-time: '207'
     status:
       code: 202
       message: Accepted
@@ -32,168 +32,141 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/79bcd661-35d0-4698-9f69-c17e9076a852
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/17517e5c-1610-4724-8a15-70dce74c6f8e
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:05:40Z",
-        "lastUpdatedDateTime": "2020-11-11T18:05:42Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
-        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [306,
-        569, 519, 624, 502, 686, 290, 632], "words": [{"text": "Contoso", "boundingBox":
-        [308, 570, 515, 627, 500, 685, 290, 634], "confidence": 0.806}], "appearance":
-        {"style": {"name": "print", "confidence": 0.996}}}, {"text": "Contoso", "boundingBox":
-        [625, 512, 1089, 465, 1096, 561, 631, 607], "words": [{"text": "Contoso",
-        "boundingBox": [625, 512, 1088, 466, 1093, 562, 631, 607], "confidence": 0.984}],
-        "appearance": {"style": {"name": "print", "confidence": 0.999}}}, {"text":
-        "123 Main Street", "boundingBox": [301, 677, 697, 759, 681, 835, 284, 750],
-        "words": [{"text": "123", "boundingBox": [301, 677, 379, 692, 362, 766, 284,
-        751], "confidence": 0.987}, {"text": "Main", "boundingBox": [393, 695, 520,
-        721, 503, 795, 377, 769], "confidence": 0.985}, {"text": "Street", "boundingBox":
-        [534, 724, 694, 763, 676, 835, 517, 798], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.995}}}, {"text": "Redmond, WA
-        98052", "boundingBox": [284, 784, 823, 855, 814, 925, 275, 868], "words":
-        [{"text": "Redmond,", "boundingBox": [287, 784, 544, 829, 535, 905, 275, 853],
-        "confidence": 0.924}, {"text": "WA", "boundingBox": [558, 830, 640, 840, 632,
-        916, 549, 907], "confidence": 0.985}, {"text": "98052", "boundingBox": [654,
-        842, 822, 855, 817, 925, 646, 917], "confidence": 0.985}], "appearance": {"style":
-        {"name": "print", "confidence": 0.999}}}, {"text": "987-654-3210", "boundingBox":
-        [270, 999, 655, 1049, 646, 1125, 264, 1075], "words": [{"text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "confidence":
-        0.978}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "6/10/2019 13:59", "boundingBox": [258, 1224, 683, 1259, 676, 1341, 255, 1309],
-        "words": [{"text": "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505,
-        1331, 255, 1312], "confidence": 0.951}, {"text": "13:59", "boundingBox": [527,
-        1248, 681, 1262, 675, 1341, 522, 1332], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "Sales Associate:
-        Paul", "boundingBox": [252, 1347, 860, 1378, 859, 1449, 249, 1425], "words":
-        [{"text": "Sales", "boundingBox": [255, 1348, 409, 1358, 405, 1432, 249, 1419],
-        "confidence": 0.983}, {"text": "Associate:", "boundingBox": [423, 1359, 704,
-        1373, 703, 1447, 419, 1434], "confidence": 0.933}, {"text": "Paul", "boundingBox":
-        [718, 1373, 858, 1378, 859, 1449, 717, 1448], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "1 Cappuccino", "boundingBox":
-        [244, 1581, 660, 1597, 658, 1688, 241, 1675], "words": [{"text": "1", "boundingBox":
-        [244, 1581, 288, 1584, 285, 1678, 241, 1675], "confidence": 0.977}, {"text":
-        "Cappuccino", "boundingBox": [306, 1585, 658, 1598, 657, 1688, 304, 1679],
-        "confidence": 0.858}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "$2.20", "boundingBox": [1106, 1580, 1264, 1574, 1268, 1656,
-        1108, 1662], "words": [{"text": "$2.20", "boundingBox": [1106, 1579, 1260,
-        1574, 1263, 1656, 1108, 1662], "confidence": 0.981}], "appearance": {"style":
-        {"name": "print", "confidence": 0.849}}}, {"text": "1 BACON & EGGS", "boundingBox":
-        [226, 1838, 740, 1839, 740, 1924, 226, 1923], "words": [{"text": "1", "boundingBox":
-        [227, 1839, 278, 1839, 277, 1924, 226, 1924], "confidence": 0.986}, {"text":
-        "BACON", "boundingBox": [295, 1839, 493, 1840, 493, 1923, 294, 1924], "confidence":
-        0.984}, {"text": "&", "boundingBox": [510, 1840, 555, 1840, 555, 1923, 510,
-        1923], "confidence": 0.983}, {"text": "EGGS", "boundingBox": [572, 1840, 737,
-        1841, 736, 1924, 572, 1923], "confidence": 0.984}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Sunny-side-up", "boundingBox":
-        [343, 1976, 758, 1974, 759, 2061, 343, 2063], "words": [{"text": "Sunny-side-up",
-        "boundingBox": [343, 1977, 757, 1975, 755, 2063, 346, 2064], "confidence":
-        0.973}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "$9.5", "boundingBox": [1134, 1948, 1253, 1948, 1255, 2041, 1137, 2041], "words":
-        [{"text": "$9.5", "boundingBox": [1134, 1948, 1252, 1948, 1252, 2041, 1134,
-        2041], "confidence": 0.983}], "appearance": {"style": {"name": "print", "confidence":
-        0.932}}}, {"text": "- -", "boundingBox": [218, 2143, 291, 2140, 292, 2158,
-        218, 2161], "words": [{"text": "-", "boundingBox": [236, 2143, 255, 2143,
-        255, 2161, 235, 2161], "confidence": 0.559}, {"text": "-", "boundingBox":
-        [271, 2142, 290, 2141, 291, 2158, 272, 2160], "confidence": 0.985}], "appearance":
-        {"style": {"name": "print", "confidence": 0.67}}}, {"text": "-----", "boundingBox":
-        [277, 2142, 461, 2136, 461, 2155, 278, 2161], "words": [{"text": "-----",
-        "boundingBox": [305, 2141, 457, 2136, 458, 2155, 305, 2161], "confidence":
-        0.69}], "appearance": {"style": {"name": "print", "confidence": 0.467}}},
-        {"text": "----", "boundingBox": [471, 2137, 565, 2133, 566, 2150, 472, 2154],
-        "words": [{"text": "----", "boundingBox": [473, 2138, 566, 2134, 566, 2150,
-        473, 2154], "confidence": 0.559}], "appearance": {"style": {"name": "print",
-        "confidence": 0.703}}}, {"text": "--", "boundingBox": [1252, 2129, 1319, 2127,
-        1320, 2143, 1252, 2146], "words": [{"text": "--", "boundingBox": [1277, 2129,
-        1319, 2127, 1319, 2144, 1276, 2145], "confidence": 0.559}], "appearance":
-        {"style": {"name": "print", "confidence": 0.846}}}, {"text": "Sub-Total",
-        "boundingBox": [434, 2232, 768, 2222, 770, 2312, 437, 2322], "words": [{"text":
-        "Sub-Total", "boundingBox": [434, 2234, 769, 2222, 770, 2313, 442, 2322],
-        "confidence": 0.981}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "$ 11.70", "boundingBox": [1082, 2228, 1309, 2228, 1309, 2313,
-        1084, 2312], "words": [{"text": "$", "boundingBox": [1082, 2228, 1122, 2228,
-        1121, 2313, 1082, 2312], "confidence": 0.654}, {"text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "confidence": 0.984}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "Tax", "boundingBox":
-        [433, 2367, 563, 2363, 565, 2458, 435, 2462], "words": [{"text": "Tax", "boundingBox":
-        [433, 2367, 559, 2363, 562, 2458, 435, 2462], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 0.98}}}, {"text": "$ 1.17", "boundingBox":
-        [1125, 2353, 1306, 2362, 1304, 2451, 1121, 2444], "words": [{"text": "$",
-        "boundingBox": [1125, 2353, 1167, 2355, 1163, 2446, 1121, 2444], "confidence":
-        0.966}, {"text": "1.17", "boundingBox": [1186, 2356, 1307, 2361, 1303, 2452,
-        1182, 2447], "confidence": 0.983}], "appearance": {"style": {"name": "print",
-        "confidence": 0.963}}}, {"text": "Tip", "boundingBox": [439, 2502, 545, 2506,
-        541, 2606, 435, 2602], "words": [{"text": "Tip", "boundingBox": [438, 2502,
-        545, 2506, 541, 2606, 435, 2602], "confidence": 0.987}], "appearance": {"style":
-        {"name": "print", "confidence": 0.943}}}, {"text": "$463", "boundingBox":
-        [1038, 2483, 1271, 2489, 1269, 2583, 1032, 2577], "words": [{"text": "$463",
-        "boundingBox": [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "confidence":
-        0.592}], "appearance": {"style": {"name": "handwriting", "confidence": 0.892}}},
-        {"text": "Total", "boundingBox": [431, 2651, 607, 2646, 610, 2739, 435, 2745],
-        "words": [{"text": "Total", "boundingBox": [431, 2651, 605, 2646, 608, 2739,
-        433, 2745], "confidence": 0.983}], "appearance": {"style": {"name": "print",
-        "confidence": 0.991}}}, {"text": "$14.50", "boundingBox": [1034, 2623, 1381,
-        2642, 1374, 2757, 1027, 2740], "words": [{"text": "$14.50", "boundingBox":
-        [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "confidence": 0.845}], "appearance":
-        {"style": {"name": "handwriting", "confidence": 0.991}}}]}], "documentResults":
-        [{"docType": "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType":
-        {"type": "string", "valueString": "Itemized", "confidence": 0.99}, "MerchantName":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:11:07Z",
+        "lastUpdatedDateTime": "2020-11-16T19:11:08Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
+        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [635,
+        510, 1086, 461, 1098, 558, 643, 604], "words": [{"text": "Contoso", "boundingBox":
+        [639, 510, 1087, 461, 1098, 551, 646, 604], "confidence": 0.955}]}, {"text":
+        "Contoso", "boundingBox": [305, 574, 519, 624, 504, 686, 291, 634], "words":
+        [{"text": "Contoso", "boundingBox": [311, 575, 517, 623, 503, 686, 297, 636],
+        "confidence": 0.435}]}, {"text": "123 Main Street", "boundingBox": [300, 675,
+        703, 767, 686, 844, 284, 749], "words": [{"text": "123", "boundingBox": [302,
+        676, 390, 695, 375, 770, 287, 751], "confidence": 0.935}, {"text": "Main",
+        "boundingBox": [405, 698, 528, 726, 512, 802, 390, 774], "confidence": 0.958},
+        {"text": "Street", "boundingBox": [542, 730, 702, 767, 685, 845, 527, 806],
+        "confidence": 0.959}]}, {"text": "Redmond, WA 98052", "boundingBox": [290,
+        784, 828, 850, 820, 933, 279, 868], "words": [{"text": "Redmond,", "boundingBox":
+        [293, 784, 550, 826, 540, 905, 280, 856], "confidence": 0.762}, {"text": "WA",
+        "boundingBox": [565, 828, 645, 837, 637, 917, 555, 907], "confidence": 0.943},
+        {"text": "98052", "boundingBox": [660, 838, 824, 849, 818, 933, 651, 919],
+        "confidence": 0.959}]}, {"text": "987-654-3210", "boundingBox": [275, 1003,
+        656, 1055, 646, 1123, 269, 1073], "words": [{"text": "987-654-3210", "boundingBox":
+        [278, 1004, 656, 1057, 647, 1123, 271, 1075], "confidence": 0.939}]}, {"text":
+        "6/10/2019 13:59", "boundingBox": [265, 1228, 678, 1258, 671, 1344, 258, 1311],
+        "words": [{"text": "6/10/2019", "boundingBox": [267, 1229, 525, 1247, 517,
+        1332, 259, 1313], "confidence": 0.762}, {"text": "13:59", "boundingBox": [541,
+        1248, 677, 1263, 669, 1345, 533, 1333], "confidence": 0.958}]}, {"text": "Sales
+        Associate: Paul", "boundingBox": [253, 1347, 868, 1379, 863, 1457, 249, 1425],
+        "words": [{"text": "Sales", "boundingBox": [259, 1348, 419, 1359, 414, 1435,
+        252, 1422], "confidence": 0.92}, {"text": "Associate:", "boundingBox": [434,
+        1360, 711, 1374, 707, 1452, 428, 1436], "confidence": 0.909}, {"text": "Paul",
+        "boundingBox": [726, 1374, 865, 1379, 862, 1457, 722, 1452], "confidence":
+        0.959}]}, {"text": "1 Cappuccino", "boundingBox": [244, 1583, 658, 1601, 653,
+        1689, 240, 1674], "words": [{"text": "1", "boundingBox": [245, 1583, 299,
+        1585, 295, 1676, 241, 1671], "confidence": 0.824}, {"text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "confidence":
+        0.727}]}, {"text": "$2.20", "boundingBox": [1106, 1584, 1268, 1574, 1270,
+        1656, 1110, 1666], "words": [{"text": "$2.20", "boundingBox": [1108, 1584,
+        1263, 1574, 1268, 1656, 1113, 1666], "confidence": 0.958}]}, {"text": "1 BACON
+        & EGGS", "boundingBox": [232, 1834, 745, 1840, 744, 1924, 231, 1918], "words":
+        [{"text": "1", "boundingBox": [232, 1834, 286, 1836, 285, 1920, 231, 1920],
+        "confidence": 0.845}, {"text": "BACON", "boundingBox": [308, 1836, 506, 1841,
+        504, 1920, 307, 1920], "confidence": 0.885}, {"text": "&", "boundingBox":
+        [523, 1841, 568, 1842, 566, 1921, 521, 1921], "confidence": 0.799}, {"text":
+        "EGGS", "boundingBox": [585, 1842, 746, 1843, 744, 1924, 583, 1921], "confidence":
+        0.949}]}, {"text": "Sunny-side-up", "boundingBox": [347, 1975, 751, 1977,
+        751, 2061, 347, 2060], "words": [{"text": "Sunny-side-up", "boundingBox":
+        [348, 1975, 749, 1979, 747, 2061, 348, 2061], "confidence": 0.946}]}, {"text":
+        "$9.5", "boundingBox": [1135, 1955, 1262, 1952, 1263, 2035, 1136, 2039], "words":
+        [{"text": "$9.5", "boundingBox": [1135, 1955, 1257, 1952, 1259, 2036, 1136,
+        2039], "confidence": 0.95}]}, {"text": "Sub-Total", "boundingBox": [440, 2229,
+        771, 2219, 773, 2318, 442, 2327], "words": [{"text": "Sub-Total", "boundingBox":
+        [441, 2229, 769, 2220, 774, 2319, 443, 2328], "confidence": 0.856}]}, {"text":
+        "$ 11.70", "boundingBox": [1092, 2221, 1301, 2224, 1299, 2319, 1093, 2317],
+        "words": [{"text": "$", "boundingBox": [1092, 2221, 1127, 2221, 1126, 2317,
+        1092, 2316], "confidence": 0.799}, {"text": "11.70", "boundingBox": [1146,
+        2221, 1297, 2223, 1296, 2319, 1145, 2317], "confidence": 0.948}]}, {"text":
+        "Tax", "boundingBox": [442, 2371, 549, 2367, 552, 2454, 445, 2458], "words":
+        [{"text": "Tax", "boundingBox": [445, 2371, 546, 2367, 549, 2454, 448, 2458],
+        "confidence": 0.958}]}, {"text": "$ 1.17", "boundingBox": [1129, 2359, 1310,
+        2359, 1306, 2456, 1129, 2456], "words": [{"text": "$", "boundingBox": [1129,
+        2359, 1171, 2359, 1171, 2456, 1129, 2456], "confidence": 0.89}, {"text": "1.17",
+        "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "confidence":
+        0.942}]}, {"text": "Tip", "boundingBox": [433, 2505, 539, 2506, 540, 2602,
+        434, 2602], "words": [{"text": "Tip", "boundingBox": [436, 2505, 536, 2505,
+        536, 2602, 436, 2602], "confidence": 0.959}]}, {"text": "$ 1.63", "boundingBox":
+        [1030, 2478, 1269, 2486, 1267, 2591, 1024, 2583], "words": [{"text": "$",
+        "boundingBox": [1027, 2478, 1073, 2478, 1069, 2584, 1024, 2583], "confidence":
+        0.788}, {"text": "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591,
+        1091, 2585], "confidence": 0.284}]}, {"text": "Total", "boundingBox": [433,
+        2652, 611, 2644, 615, 2738, 436, 2747], "words": [{"text": "Total", "boundingBox":
+        [435, 2652, 609, 2644, 613, 2739, 439, 2747], "confidence": 0.866}]}, {"text":
+        "$14.50", "boundingBox": [1034, 2620, 1386, 2637, 1380, 2762, 1029, 2739],
+        "words": [{"text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380,
+        2763, 1030, 2739], "confidence": 0.57}]}]}], "documentResults": [{"docType":
+        "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType": {"type":
+        "string", "valueString": "Itemized", "confidence": 0.692}, "MerchantName":
         {"type": "string", "valueString": "Contoso Contoso", "text": "Contoso Contoso",
-        "boundingBox": [380.9, 282.9, 1116, 473.2, 1025, 824.4, 290, 634], "page":
-        1, "confidence": 0.716, "elements": ["#/readResults/0/lines/1/words/0", "#/readResults/0/lines/0/words/0"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
-        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [298.3,
-        676.5, 844.6, 781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989,
-        "elements": ["#/readResults/0/lines/2/words/0", "#/readResults/0/lines/2/words/1",
-        "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1",
-        "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber": {"type": "phoneNumber",
-        "valuePhoneNumber": "+19876543210", "text": "987-654-3210", "boundingBox":
-        [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence": 0.99,
-        "elements": ["#/readResults/0/lines/4/words/0"]}, "TransactionDate": {"type":
-        "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox": [259,
-        1224, 510, 1246, 505, 1331, 255, 1312], "page": 1, "confidence": 0.99, "elements":
-        ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type": "time",
-        "valueTime": "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681,
-        1262, 675, 1341, 522, 1332], "page": 1, "confidence": 0.989, "elements": ["#/readResults/0/lines/5/words/1"]},
-        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        "boundingBox": [378.2, 292.4, 1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8],
+        "page": 1, "confidence": 0.613, "elements": ["#/readResults/0/lines/0/words/0",
+        "#/readResults/0/lines/1/words/0"]}, "MerchantAddress": {"type": "string",
+        "valueString": "123 Main Street Redmond, WA 98052", "text": "123 Main Street
+        Redmond, WA 98052", "boundingBox": [302, 675.8, 848.1, 793.7, 809.9, 970.4,
+        263.9, 852.5], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/2/words/0",
+        "#/readResults/0/lines/2/words/1", "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0",
+        "#/readResults/0/lines/3/words/1", "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber":
+        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
+        "boundingBox": [278, 1004, 656, 1057, 647, 1123, 271, 1075], "page": 1, "confidence":
+        0.99, "elements": ["#/readResults/0/lines/4/words/0"]}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99,
+        "elements": ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type":
+        "time", "valueTime": "13:59:00", "text": "13:59", "boundingBox": [541, 1248,
+        677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence": 0.977, "elements":
+        ["#/readResults/0/lines/5/words/1"]}, "Items": {"type": "array", "valueArray":
+        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
+        1, "text": "1", "boundingBox": [245, 1583, 299, 1585, 295, 1676, 241, 1671],
+        "page": 1, "confidence": 0.92, "elements": ["#/readResults/0/lines/7/words/0"]},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923, "elements": ["#/readResults/0/lines/7/words/1"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1108, 1584,
+        1263, 1574, 1268, 1656, 1113, 1666], "page": 1, "confidence": 0.918, "elements":
+        ["#/readResults/0/lines/8/words/0"]}}}, {"type": "object", "valueObject":
         {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [244, 1581, 288, 1584, 285, 1678, 241, 1675], "page": 1, "confidence": 0.919,
-        "elements": ["#/readResults/0/lines/7/words/0"]}, "Name": {"type": "string",
-        "valueString": "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585,
-        658, 1598, 657, 1688, 304, 1679], "page": 1, "confidence": 0.959, "elements":
-        ["#/readResults/0/lines/7/words/1"]}, "TotalPrice": {"type": "number", "valueNumber":
-        2.2, "text": "$2.20", "boundingBox": [1106, 1579, 1260, 1574, 1263, 1656,
-        1108, 1662], "page": 1, "confidence": 0.959, "elements": ["#/readResults/0/lines/8/words/0"]}}},
-        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91, "elements": ["#/readResults/0/lines/9/words/0"]},
-        "Name": {"type": "string", "valueString": "BACON & EGGS", "text": "BACON &
-        EGGS", "boundingBox": [294, 1839, 737, 1839, 737, 1924, 294, 1924], "page":
-        1, "confidence": 0.955, "elements": ["#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2",
+        [232, 1834, 286, 1836, 285, 1920, 231, 1920], "page": 1, "confidence": 0.858,
+        "elements": ["#/readResults/0/lines/9/words/0"]}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916,
+        "elements": ["#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2",
         "#/readResults/0/lines/9/words/3"]}, "TotalPrice": {"type": "number", "valueNumber":
-        9.5, "text": "$9.5", "boundingBox": [1134, 1948, 1252, 1948, 1252, 2041, 1134,
-        2041], "page": 1, "confidence": 0.958, "elements": ["#/readResults/0/lines/11/words/0"]}}}]},
+        9.5, "text": "$9.5", "boundingBox": [1135, 1955, 1257, 1952, 1259, 2036, 1136,
+        2039], "page": 1, "confidence": 0.916, "elements": ["#/readResults/0/lines/11/words/0"]}}}]},
         "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923, "elements": ["#/readResults/0/lines/17/words/1"]}, "Tax": {"type":
-        "number", "valueNumber": 1.17, "text": "1.17", "boundingBox": [1186, 2356,
-        1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence": 0.979, "elements":
-        ["#/readResults/0/lines/19/words/1"]}, "Tip": {"type": "number", "valueNumber":
-        463, "text": "$463", "boundingBox": [1034, 2483, 1268, 2488, 1266, 2583, 1032,
-        2577], "page": 1, "confidence": 0.975, "elements": ["#/readResults/0/lines/21/words/0"]},
+        [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1, "confidence":
+        0.955, "elements": ["#/readResults/0/lines/13/words/1"]}, "Tax": {"type":
+        "number", "valueNumber": 1.17, "text": "1.17", "boundingBox": [1190, 2359,
+        1304, 2359, 1304, 2456, 1190, 2456], "page": 1, "confidence": 0.979, "elements":
+        ["#/readResults/0/lines/15/words/1"]}, "Tip": {"type": "number", "valueNumber":
+        1.63, "text": "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591,
+        1091, 2585], "page": 1, "confidence": 0.941, "elements": ["#/readResults/0/lines/17/words/1"]},
         "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50", "boundingBox":
-        [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1, "confidence":
-        0.987, "elements": ["#/readResults/0/lines/23/words/0"]}}}]}}'
+        [1034, 2620, 1384, 2638, 1380, 2763, 1030, 2739], "page": 1, "confidence":
+        0.985, "elements": ["#/readResults/0/lines/19/words/0"]}}}]}}'
     headers:
-      apim-request-id: 957e0f89-611e-4d8c-a452-2aaf3c701575
-      content-length: '10546'
+      apim-request-id: fd595ee2-e5c5-4bb3-8074-8339e780953f
+      content-length: '8501'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:05:45 GMT
+      date: Mon, 16 Nov 2020 19:11:11 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '18'
+      x-envoy-upstream-service-time: '20'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/79bcd661-35d0-4698-9f69-c17e9076a852
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/17517e5c-1610-4724-8a15-70dce74c6f8e
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_locale_error.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_locale_error.yaml
@@ -14,16 +14,16 @@ interactions:
   response:
     body:
       string: '{"error": {"code": "UnsupportedLocale", "innerError": {"requestId":
-        "50ed00fe-b15e-486e-9ce2-7fcebe60a975"}, "message": "Locale unsupported. Supported
+        "347827d1-e8dd-4485-ac9e-9b1af858a2d7"}, "message": "Locale unsupported. Supported
         locales include en-AU, en-CA, en-GB, en-IN and en-US."}}'
     headers:
-      apim-request-id: 50ed00fe-b15e-486e-9ce2-7fcebe60a975
+      apim-request-id: 347827d1-e8dd-4485-ac9e-9b1af858a2d7
       content-length: '200'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:05:45 GMT
+      date: Mon, 16 Nov 2020 19:11:12 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '159'
+      x-envoy-upstream-service-time: '138'
     status:
       code: 400
       message: Bad Request

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_locale_specified.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_locale_specified.yaml
@@ -15,13 +15,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 1915f32d-ee3f-4f9b-a3d7-9203b87112aa
+      apim-request-id: e16129ba-e34f-45fd-97b2-f838a12d7636
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:05:46 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/1915f32d-ee3f-4f9b-a3d7-9203b87112aa
+      date: Mon, 16 Nov 2020 19:11:13 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/e16129ba-e34f-45fd-97b2-f838a12d7636
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '197'
+      x-envoy-upstream-service-time: '214'
     status:
       code: 202
       message: Accepted
@@ -32,20 +32,20 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/1915f32d-ee3f-4f9b-a3d7-9203b87112aa
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/e16129ba-e34f-45fd-97b2-f838a12d7636
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:05:47Z",
-        "lastUpdatedDateTime": "2020-11-11T18:05:50Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:11:13Z",
+        "lastUpdatedDateTime": "2020-11-16T19:11:16Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
         "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
         "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [380.9, 282.9,
-        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.989}, "MerchantAddress":
+        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.769}, "MerchantAddress":
         {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
         "123 Main Street Redmond, WA 98052", "boundingBox": [298.3, 676.5, 844.6,
-        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.993}, "MerchantPhoneNumber":
+        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.99}, "MerchantPhoneNumber":
         {"type": "phoneNumber", "valuePhoneNumber": "+919876543210", "text": "987-654-3210",
         "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence":
         0.995}, "TransactionDate": {"type": "date", "valueDate": "2019-10-06", "text":
@@ -55,33 +55,35 @@ interactions:
         522, 1332], "page": 1, "confidence": 0.995}, "Items": {"type": "array", "valueArray":
         [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
         1, "text": "1", "boundingBox": [244, 1581, 288, 1584, 285, 1678, 241, 1675],
-        "page": 1, "confidence": 0.919}, "Name": {"type": "string", "valueString":
+        "page": 1, "confidence": 0.936}, "Name": {"type": "string", "valueString":
         "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585, 658, 1598,
-        657, 1688, 304, 1679], "page": 1, "confidence": 0.982}, "TotalPrice": {"type":
+        657, 1688, 304, 1679], "page": 1, "confidence": 0.976}, "TotalPrice": {"type":
         "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1106, 1579,
-        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.971}}}, {"type":
+        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.988}}}, {"type":
         "object", "valueObject": {"Quantity": {"type": "number", "valueNumber": 1,
         "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.918}, "Name": {"type": "string", "valueString":
-        "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [294, 1839, 737, 1839,
-        737, 1924, 294, 1924], "page": 1, "confidence": 0.892}, "TotalPrice": {"type":
-        "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox": [1134, 1948,
-        1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence": 0.969}}}]},
-        "Tax": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.971}, "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50",
-        "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1,
-        "confidence": 0.99}}}]}}'
+        "page": 1, "confidence": 0.882}, "Name": {"type": "string", "valueString":
+        "BACON & EGGS Sunny-side-up", "text": "BACON & EGGS Sunny-side-up", "boundingBox":
+        [294, 1839, 757, 1839, 757, 2064, 294, 2064], "page": 1, "confidence": 0.506},
+        "TotalPrice": {"type": "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox":
+        [1134, 1948, 1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence":
+        0.987}}}]}, "Tax": {"type": "number", "valueNumber": 1.17, "text": "1.17",
+        "boundingBox": [1186, 2356, 1307, 2361, 1303, 2452, 1182, 2447], "page": 1,
+        "confidence": 0.994}, "Total": {"type": "number", "valueNumber": 14.5, "text":
+        "$14.50", "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740],
+        "page": 1, "confidence": 0.988}, "Subtotal": {"type": "number", "valueNumber":
+        11.7, "text": "11.70", "boundingBox": [1139, 2228, 1309, 2228, 1308, 2313,
+        1138, 2313], "page": 1, "confidence": 0.269}}}]}}'
     headers:
-      apim-request-id: 24d7bb1f-fa6d-40e4-b812-2604dc1a6082
-      content-length: '2537'
+      apim-request-id: 95282ba1-68b2-4bab-9959-0f181e934f6b
+      content-length: '2711'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:05:52 GMT
+      date: Mon, 16 Nov 2020 19:11:18 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '23'
+      x-envoy-upstream-service-time: '18'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/1915f32d-ee3f-4f9b-a3d7-9203b87112aa
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/e16129ba-e34f-45fd-97b2-f838a12d7636
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_multipage.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_multipage.yaml
@@ -1926,13 +1926,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: a532c0d6-c245-4283-9a1d-889b1b8409f7
+      apim-request-id: 27c0de9d-de42-47c0-a279-72087a4b18f2
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:05:52 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/a532c0d6-c245-4283-9a1d-889b1b8409f7
+      date: Mon, 16 Nov 2020 19:11:19 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/27c0de9d-de42-47c0-a279-72087a4b18f2
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '87'
+      x-envoy-upstream-service-time: '99'
     status:
       code: 202
       message: Accepted
@@ -1943,11 +1943,11 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/a532c0d6-c245-4283-9a1d-889b1b8409f7
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/27c0de9d-de42-47c0-a279-72087a4b18f2
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:05:52Z",
-        "lastUpdatedDateTime": "2020-11-11T18:05:56Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:11:19Z",
+        "lastUpdatedDateTime": "2020-11-16T19:11:23Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": 0, "width": 8.5, "height": 11,
         "unit": "inch", "lines": [{"text": "Company A Invoice", "boundingBox": [0.8861,
         1.1217, 2.3783, 1.1217, 2.3783, 1.2812, 0.8861, 1.2812], "words": [{"text":
@@ -1955,386 +1955,366 @@ interactions:
         0.8861, 1.2812], "confidence": 1}, {"text": "A", "boundingBox": [1.6696, 1.1242,
         1.7749, 1.1242, 1.7749, 1.2473, 1.6696, 1.2473], "confidence": 1}, {"text":
         "Invoice", "boundingBox": [1.8389, 1.1217, 2.3783, 1.1217, 2.3783, 1.2485,
-        1.8389, 1.2485], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "Invoice For:", "boundingBox": [6.0211, 1.0656,
-        7.0357, 1.0656, 7.0357, 1.2121, 6.0211, 1.2121], "words": [{"text": "Invoice",
-        "boundingBox": [6.0211, 1.0656, 6.6362, 1.0656, 6.6362, 1.2121, 6.0211, 1.2121],
-        "confidence": 1}, {"text": "For:", "boundingBox": [6.7147, 1.0691, 7.0357,
-        1.0691, 7.0357, 1.2121, 6.7147, 1.2121], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Address:", "boundingBox":
-        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "words":
-        [{"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825, 1.5657,
-        1.6155, 0.8791, 1.6155], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Bilbo Baggins", "boundingBox": [6.0164,
-        1.4503, 6.8967, 1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "words": [{"text":
-        "Bilbo", "boundingBox": [6.0164, 1.4503, 6.3392, 1.4503, 6.3392, 1.5649, 6.0164,
-        1.5649], "confidence": 1}, {"text": "Baggins", "boundingBox": [6.396, 1.4556,
-        6.8967, 1.4556, 6.8967, 1.5931, 6.396, 1.5931], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "123 Hobbit Lane",
-        "boundingBox": [6.0165, 1.6707, 7.1006, 1.6707, 7.1006, 1.7854, 6.0165, 1.7854],
-        "words": [{"text": "123", "boundingBox": [6.0165, 1.6772, 6.2434, 1.6772,
-        6.2434, 1.7854, 6.0165, 1.7854], "confidence": 1}, {"text": "Hobbit", "boundingBox":
-        [6.3033, 1.6707, 6.7463, 1.6707, 6.7463, 1.7854, 6.3033, 1.7854], "confidence":
-        1}, {"text": "Lane", "boundingBox": [6.803, 1.6782, 7.1006, 1.6782, 7.1006,
-        1.7854, 6.803, 1.7854], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "567 Main St.", "boundingBox": [0.8852,
-        1.846, 1.713, 1.846, 1.713, 1.9554, 0.8852, 1.9554], "words": [{"text": "567",
-        "boundingBox": [0.8852, 1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554],
-        "confidence": 1}, {"text": "Main", "boundingBox": [1.1777, 1.846, 1.5022,
-        1.846, 1.5022, 1.9554, 1.1777, 1.9554], "confidence": 1}, {"text": "St.",
-        "boundingBox": [1.5558, 1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Redmond, WA", "boundingBox": [6.0164, 1.891, 6.9793, 1.891,
-        6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text": "Redmond,", "boundingBox":
-        [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275, 6.0164, 2.0275], "confidence":
-        1}, {"text": "WA", "boundingBox": [6.7408, 1.8982, 6.9793, 1.8982, 6.9793,
-        2.0044, 6.7408, 2.0044], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Redmond, WA", "boundingBox": [0.891,
-        2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,",
-        "boundingBox": [0.891, 2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975],
-        "confidence": 1}, {"text": "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682,
-        1.8537, 2.1744, 1.6152, 2.1744], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "555-555-5555", "boundingBox":
-        [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "words":
-        [{"text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187,
-        6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "555-555-5555", "boundingBox":
+        1.8389, 1.2485], "confidence": 1}]}, {"text": "Invoice For:", "boundingBox":
+        [6.0211, 1.0656, 7.0357, 1.0656, 7.0357, 1.2121, 6.0211, 1.2121], "words":
+        [{"text": "Invoice", "boundingBox": [6.0211, 1.0656, 6.6362, 1.0656, 6.6362,
+        1.2121, 6.0211, 1.2121], "confidence": 1}, {"text": "For:", "boundingBox":
+        [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121, 6.7147, 1.2121], "confidence":
+        1}]}, {"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825,
+        1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text": "Address:", "boundingBox":
+        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "confidence":
+        1}]}, {"text": "Bilbo Baggins", "boundingBox": [6.0164, 1.4503, 6.8967, 1.4503,
+        6.8967, 1.5931, 6.0164, 1.5931], "words": [{"text": "Bilbo", "boundingBox":
+        [6.0164, 1.4503, 6.3392, 1.4503, 6.3392, 1.5649, 6.0164, 1.5649], "confidence":
+        1}, {"text": "Baggins", "boundingBox": [6.396, 1.4556, 6.8967, 1.4556, 6.8967,
+        1.5931, 6.396, 1.5931], "confidence": 1}]}, {"text": "123 Hobbit Lane", "boundingBox":
+        [6.0165, 1.6707, 7.1006, 1.6707, 7.1006, 1.7854, 6.0165, 1.7854], "words":
+        [{"text": "123", "boundingBox": [6.0165, 1.6772, 6.2434, 1.6772, 6.2434, 1.7854,
+        6.0165, 1.7854], "confidence": 1}, {"text": "Hobbit", "boundingBox": [6.3033,
+        1.6707, 6.7463, 1.6707, 6.7463, 1.7854, 6.3033, 1.7854], "confidence": 1},
+        {"text": "Lane", "boundingBox": [6.803, 1.6782, 7.1006, 1.6782, 7.1006, 1.7854,
+        6.803, 1.7854], "confidence": 1}]}, {"text": "567 Main St.", "boundingBox":
+        [0.8852, 1.846, 1.713, 1.846, 1.713, 1.9554, 0.8852, 1.9554], "words": [{"text":
+        "567", "boundingBox": [0.8852, 1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852,
+        1.9554], "confidence": 1}, {"text": "Main", "boundingBox": [1.1777, 1.846,
+        1.5022, 1.846, 1.5022, 1.9554, 1.1777, 1.9554], "confidence": 1}, {"text":
+        "St.", "boundingBox": [1.5558, 1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558,
+        1.9554], "confidence": 1}]}, {"text": "Redmond, WA", "boundingBox": [6.0164,
+        1.891, 6.9793, 1.891, 6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text":
+        "Redmond,", "boundingBox": [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275,
+        6.0164, 2.0275], "confidence": 1}, {"text": "WA", "boundingBox": [6.7408,
+        1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408, 2.0044], "confidence": 1}]},
+        {"text": "Redmond, WA", "boundingBox": [0.891, 2.061, 1.8537, 2.061, 1.8537,
+        2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,", "boundingBox": [0.891,
+        2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975], "confidence": 1}, {"text":
+        "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682, 1.8537, 2.1744, 1.6152,
+        2.1744], "confidence": 1}]}, {"text": "555-555-5555", "boundingBox": [6.0105,
+        2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "words": [{"text":
+        "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254,
+        6.0105, 2.2254], "confidence": 1}]}, {"text": "555-555-5555", "boundingBox":
         [0.8852, 2.2887, 1.8119, 2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "words":
         [{"text": "555-555-5555", "boundingBox": [0.8852, 2.2887, 1.8119, 2.2887,
-        1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Item", "boundingBox": [1.0943,
-        3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
+        1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}]}, {"text": "Item", "boundingBox":
+        [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
         "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943,
-        3.109], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996,
-        3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity", "boundingBox":
-        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Price", "boundingBox": [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423,
-        3.109], "words": [{"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
-        2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "A", "boundingBox": [1.0832,
-        3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A",
-        "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116, 3.3202,
-        3.3176, 3.2589, 3.3176], "words": [{"text": "1", "boundingBox": [3.2589, 3.2116,
-        3.3202, 3.2116, 3.3202, 3.3176, 3.2589, 3.3176], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "10.99", "boundingBox":
+        3.109], "confidence": 1}]}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996,
+        3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity",
+        "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371],
+        "confidence": 1}]}, {"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
+        2.9996, 5.7372, 3.109, 5.423, 3.109], "words": [{"text": "Price", "boundingBox":
+        [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence":
+        1}]}, {"text": "A", "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174,
+        3.318, 1.0832, 3.318], "words": [{"text": "A", "boundingBox": [1.0832, 3.2118,
+        1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "confidence": 1}]}, {"text":
+        "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116, 3.3202, 3.3176, 3.2589,
+        3.3176], "words": [{"text": "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116,
+        3.3202, 3.3176, 3.2589, 3.3176], "confidence": 1}]}, {"text": "10.99", "boundingBox":
         [5.4232, 3.2108, 5.7784, 3.2108, 5.7784, 3.319, 5.4232, 3.319], "words": [{"text":
         "10.99", "boundingBox": [5.4232, 3.2108, 5.7784, 3.2108, 5.7784, 3.319, 5.4232,
-        3.319], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637,
-        3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox": [1.0943, 3.4256,
-        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "2", "boundingBox":
-        [3.2541, 3.4241, 3.3199, 3.4241, 3.3199, 3.531, 3.2541, 3.531], "words": [{"text":
-        "2", "boundingBox": [3.2541, 3.4241, 3.3199, 3.4241, 3.3199, 3.531, 3.2541,
-        3.531], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "14.67", "boundingBox": [5.4232, 3.4241, 5.7789, 3.4241, 5.7789,
-        3.5323, 5.4232, 3.5323], "words": [{"text": "14.67", "boundingBox": [5.4232,
-        3.4241, 5.7789, 3.4241, 5.7789, 3.5323, 5.4232, 3.5323], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "C",
+        3.319], "confidence": 1}]}, {"text": "B", "boundingBox": [1.0943, 3.4256,
+        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox":
+        [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence":
+        1}]}, {"text": "2", "boundingBox": [3.2541, 3.4241, 3.3199, 3.4241, 3.3199,
+        3.531, 3.2541, 3.531], "words": [{"text": "2", "boundingBox": [3.2541, 3.4241,
+        3.3199, 3.4241, 3.3199, 3.531, 3.2541, 3.531], "confidence": 1}]}, {"text":
+        "14.67", "boundingBox": [5.4232, 3.4241, 5.7789, 3.4241, 5.7789, 3.5323, 5.4232,
+        3.5323], "words": [{"text": "14.67", "boundingBox": [5.4232, 3.4241, 5.7789,
+        3.4241, 5.7789, 3.5323, 5.4232, 3.5323], "confidence": 1}]}, {"text": "C",
         "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647, 3.7421, 1.0882, 3.7421],
         "words": [{"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647,
-        3.7421, 1.0882, 3.7421], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "4", "boundingBox": [3.2486, 3.6351,
-        3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "words": [{"text": "4", "boundingBox":
-        [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "15.66", "boundingBox": [5.4232, 3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232,
-        3.7423], "words": [{"text": "15.66", "boundingBox": [5.4232, 3.6341, 5.78,
-        3.6341, 5.78, 3.7423, 5.4232, 3.7423], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "D", "boundingBox": [1.0943,
-        3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text":
-        "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943,
-        3.951], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1", "boundingBox": [3.2589, 3.845, 3.3202, 3.845, 3.3202,
+        3.7421, 1.0882, 3.7421], "confidence": 1}]}, {"text": "4", "boundingBox":
+        [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "words":
+        [{"text": "4", "boundingBox": [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413,
+        3.2486, 3.7413], "confidence": 1}]}, {"text": "15.66", "boundingBox": [5.4232,
+        3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232, 3.7423], "words": [{"text": "15.66",
+        "boundingBox": [5.4232, 3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232, 3.7423],
+        "confidence": 1}]}, {"text": "D", "boundingBox": [1.0943, 3.8456, 1.1753,
+        3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text": "D", "boundingBox":
+        [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "confidence":
+        1}]}, {"text": "1", "boundingBox": [3.2589, 3.845, 3.3202, 3.845, 3.3202,
         3.951, 3.2589, 3.951], "words": [{"text": "1", "boundingBox": [3.2589, 3.845,
-        3.3202, 3.845, 3.3202, 3.951, 3.2589, 3.951], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "12.00", "boundingBox":
-        [5.4232, 3.8441, 5.7809, 3.8441, 5.7809, 3.9523, 5.4232, 3.9523], "words":
-        [{"text": "12.00", "boundingBox": [5.4232, 3.8441, 5.7809, 3.8441, 5.7809,
-        3.9523, 5.4232, 3.9523], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "E", "boundingBox": [1.0943, 4.0561,
-        1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "words": [{"text": "E", "boundingBox":
-        [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617, 3.2486,
-        4.1617], "words": [{"text": "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556,
-        3.3244, 4.1617, 3.2486, 4.1617], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "10.00", "boundingBox": [5.4232,
+        3.3202, 3.845, 3.3202, 3.951, 3.2589, 3.951], "confidence": 1}]}, {"text":
+        "12.00", "boundingBox": [5.4232, 3.8441, 5.7809, 3.8441, 5.7809, 3.9523, 5.4232,
+        3.9523], "words": [{"text": "12.00", "boundingBox": [5.4232, 3.8441, 5.7809,
+        3.8441, 5.7809, 3.9523, 5.4232, 3.9523], "confidence": 1}]}, {"text": "E",
+        "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614],
+        "words": [{"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
+        4.1614, 1.0943, 4.1614], "confidence": 1}]}, {"text": "4", "boundingBox":
+        [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617, 3.2486, 4.1617], "words":
+        [{"text": "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617,
+        3.2486, 4.1617], "confidence": 1}]}, {"text": "10.00", "boundingBox": [5.4232,
         4.0546, 5.781, 4.0546, 5.781, 4.1627, 5.4232, 4.1627], "words": [{"text":
         "10.00", "boundingBox": [5.4232, 4.0546, 5.781, 4.0546, 5.781, 4.1627, 5.4232,
-        4.1627], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497,
-        4.3717, 1.0943, 4.3717], "words": [{"text": "F", "boundingBox": [1.0943, 4.2661,
-        1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "6", "boundingBox":
-        [3.2534, 4.2646, 3.3226, 4.2646, 3.3226, 4.3727, 3.2534, 4.3727], "words":
-        [{"text": "6", "boundingBox": [3.2534, 4.2646, 3.3226, 4.2646, 3.3226, 4.3727,
-        3.2534, 4.3727], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "12.00", "boundingBox": [5.4232, 4.2646, 5.7809,
-        4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "words": [{"text": "12.00", "boundingBox":
-        [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877,
-        4.5827], "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746,
-        1.1735, 4.5827, 1.0877, 4.5827], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "8", "boundingBox": [3.2514,
-        4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514, 4.5827], "words": [{"text":
-        "8", "boundingBox": [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514,
-        4.5827], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781,
-        4.5827, 5.4184, 4.5827], "words": [{"text": "22.00", "boundingBox": [5.4184,
-        4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184, 4.5827], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Subtotal:
-        300.00", "boundingBox": [5.5075, 4.8981, 6.632, 4.8981, 6.632, 5.0131, 5.5075,
-        5.0131], "words": [{"text": "Subtotal:", "boundingBox": [5.5075, 4.8981, 6.1249,
-        4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence": 1}, {"text": "300.00",
-        "boundingBox": [6.1794, 4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Tax: 30.00", "boundingBox": [5.5034, 5.1245, 6.2022, 5.1245,
-        6.2022, 5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:", "boundingBox":
-        [5.5034, 5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333], "confidence":
-        1}, {"text": "30.00", "boundingBox": [5.836, 5.1245, 6.2022, 5.1245, 6.2022,
-        5.2333, 5.836, 5.2333], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Tip: 100.00", "boundingBox": [5.5034,
-        5.3412, 6.2587, 5.3412, 6.2587, 5.481, 5.5034, 5.481], "words": [{"text":
+        4.1627], "confidence": 1}]}, {"text": "F", "boundingBox": [1.0943, 4.2661,
+        1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "words": [{"text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "confidence":
+        1}]}, {"text": "6", "boundingBox": [3.2534, 4.2646, 3.3226, 4.2646, 3.3226,
+        4.3727, 3.2534, 4.3727], "words": [{"text": "6", "boundingBox": [3.2534, 4.2646,
+        3.3226, 4.2646, 3.3226, 4.3727, 3.2534, 4.3727], "confidence": 1}]}, {"text":
+        "12.00", "boundingBox": [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232,
+        4.3727], "words": [{"text": "12.00", "boundingBox": [5.4232, 4.2646, 5.7809,
+        4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "confidence": 1}]}, {"text": "G",
+        "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827],
+        "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
+        4.5827, 1.0877, 4.5827], "confidence": 1}]}, {"text": "8", "boundingBox":
+        [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514, 4.5827], "words":
+        [{"text": "8", "boundingBox": [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827,
+        3.2514, 4.5827], "confidence": 1}]}, {"text": "22.00", "boundingBox": [5.4184,
+        4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184, 4.5827], "words": [{"text":
+        "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184,
+        4.5827], "confidence": 1}]}, {"text": "Subtotal: 300.00", "boundingBox": [5.5075,
+        4.8981, 6.632, 4.8981, 6.632, 5.0131, 5.5075, 5.0131], "words": [{"text":
+        "Subtotal:", "boundingBox": [5.5075, 4.8981, 6.1249, 4.8981, 6.1249, 5.0131,
+        5.5075, 5.0131], "confidence": 1}, {"text": "300.00", "boundingBox": [6.1794,
+        4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131], "confidence": 1}]},
+        {"text": "Tax: 30.00", "boundingBox": [5.5034, 5.1245, 6.2022, 5.1245, 6.2022,
+        5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:", "boundingBox": [5.5034,
+        5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333], "confidence": 1},
+        {"text": "30.00", "boundingBox": [5.836, 5.1245, 6.2022, 5.1245, 6.2022, 5.2333,
+        5.836, 5.2333], "confidence": 1}]}, {"text": "Tip: 100.00", "boundingBox":
+        [5.5034, 5.3412, 6.2587, 5.3412, 6.2587, 5.481, 5.5034, 5.481], "words": [{"text":
         "Tip:", "boundingBox": [5.5034, 5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034,
         5.481], "confidence": 1}, {"text": "100.00", "boundingBox": [5.811, 5.3445,
-        6.2587, 5.3445, 6.2587, 5.4533, 5.811, 5.4533], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Total: 430.00",
-        "boundingBox": [5.5034, 5.5583, 6.3987, 5.5583, 6.3987, 5.6733, 5.5034, 5.6733],
-        "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583,
-        5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "430.00", "boundingBox":
-        [5.942, 5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942, 5.6733], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Signature: ____Bilbo Baggins__________", "boundingBox": [1.0055, 6.6553,
-        3.8342, 6.6553, 3.8342, 6.7981, 1.0055, 6.7981], "words": [{"text": "Signature:",
-        "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981, 1.0055, 6.7981],
-        "confidence": 1}, {"text": "____Bilbo", "boundingBox": [1.747, 6.6553, 2.4278,
-        6.6553, 2.4278, 6.7981, 1.747, 6.7981], "confidence": 1}, {"text": "Baggins__________",
-        "boundingBox": [2.4823, 6.6581, 3.8342, 6.6581, 3.8342, 6.7981, 2.4823, 6.7981],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}]}, {"page": 2, "angle": 0, "width": 8.5, "height": 11, "unit": "inch"},
+        6.2587, 5.3445, 6.2587, 5.4533, 5.811, 5.4533], "confidence": 1}]}, {"text":
+        "Total: 430.00", "boundingBox": [5.5034, 5.5583, 6.3987, 5.5583, 6.3987, 5.6733,
+        5.5034, 5.6733], "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583,
+        5.8915, 5.5583, 5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text":
+        "430.00", "boundingBox": [5.942, 5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942,
+        5.6733], "confidence": 1}]}, {"text": "Signature: ____ Bilbo Baggins__________",
+        "boundingBox": [1.0055, 6.6553, 3.8342, 6.6553, 3.8342, 6.7981, 1.0055, 6.7981],
+        "words": [{"text": "Signature:", "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581,
+        1.6987, 6.7981, 1.0055, 6.7981], "confidence": 1}, {"text": "____", "boundingBox":
+        [1.747, 6.7829, 2.0809, 6.7829, 2.0809, 6.7981, 1.747, 6.7981], "confidence":
+        1}, {"text": "Bilbo", "boundingBox": [2.0925, 6.6553, 2.4278, 6.6553, 2.4278,
+        6.7703, 2.0925, 6.7703], "confidence": 1}, {"text": "Baggins__________", "boundingBox":
+        [2.4823, 6.6581, 3.8342, 6.6581, 3.8342, 6.7981, 2.4823, 6.7981], "confidence":
+        1}]}]}, {"page": 2, "angle": 0, "width": 8.5, "height": 11, "unit": "inch"},
         {"page": 3, "angle": 0, "width": 8.5, "height": 11, "unit": "inch", "lines":
         [{"text": "Company B Invoice", "boundingBox": [0.8861, 1.1217, 2.3734, 1.1217,
         2.3734, 1.2812, 0.8861, 1.2812], "words": [{"text": "Company", "boundingBox":
         [0.8861, 1.1232, 1.6203, 1.1232, 1.6203, 1.2812, 0.8861, 1.2812], "confidence":
         1}, {"text": "B", "boundingBox": [1.6836, 1.1248, 1.764, 1.1248, 1.764, 1.2469,
         1.6836, 1.2469], "confidence": 1}, {"text": "Invoice", "boundingBox": [1.8336,
-        1.1217, 2.3734, 1.1217, 2.3734, 1.2485, 1.8336, 1.2485], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Invoice
-        For:", "boundingBox": [6.0211, 1.0656, 7.0357, 1.0656, 7.0357, 1.2121, 6.0211,
-        1.2121], "words": [{"text": "Invoice", "boundingBox": [6.0211, 1.0656, 6.6362,
-        1.0656, 6.6362, 1.2121, 6.0211, 1.2121], "confidence": 1}, {"text": "For:",
-        "boundingBox": [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121, 6.7147, 1.2121],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825,
-        1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text": "Address:", "boundingBox":
-        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Frodo Baggins", "boundingBox": [6.0164, 1.4506, 6.9506, 1.4506, 6.9506, 1.5931,
-        6.0164, 1.5931], "words": [{"text": "Frodo", "boundingBox": [6.0164, 1.4506,
-        6.3895, 1.4506, 6.3895, 1.5649, 6.0164, 1.5649], "confidence": 1}, {"text":
-        "Baggins", "boundingBox": [6.45, 1.4556, 6.9506, 1.4556, 6.9506, 1.5931, 6.45,
-        1.5931], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "123 Hobbit Lane", "boundingBox": [6.0165, 1.6707, 7.1006,
+        1.1217, 2.3734, 1.1217, 2.3734, 1.2485, 1.8336, 1.2485], "confidence": 1}]},
+        {"text": "Invoice For:", "boundingBox": [6.0211, 1.0656, 7.0357, 1.0656, 7.0357,
+        1.2121, 6.0211, 1.2121], "words": [{"text": "Invoice", "boundingBox": [6.0211,
+        1.0656, 6.6362, 1.0656, 6.6362, 1.2121, 6.0211, 1.2121], "confidence": 1},
+        {"text": "For:", "boundingBox": [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121,
+        6.7147, 1.2121], "confidence": 1}]}, {"text": "Address:", "boundingBox": [0.8791,
+        1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text":
+        "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155,
+        0.8791, 1.6155], "confidence": 1}]}, {"text": "Frodo Baggins", "boundingBox":
+        [6.0164, 1.4506, 6.9506, 1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "words":
+        [{"text": "Frodo", "boundingBox": [6.0164, 1.4506, 6.3895, 1.4506, 6.3895,
+        1.5649, 6.0164, 1.5649], "confidence": 1}, {"text": "Baggins", "boundingBox":
+        [6.45, 1.4556, 6.9506, 1.4556, 6.9506, 1.5931, 6.45, 1.5931], "confidence":
+        1}]}, {"text": "123 Hobbit Lane", "boundingBox": [6.0165, 1.6707, 7.1006,
         1.6707, 7.1006, 1.7854, 6.0165, 1.7854], "words": [{"text": "123", "boundingBox":
         [6.0165, 1.6772, 6.2434, 1.6772, 6.2434, 1.7854, 6.0165, 1.7854], "confidence":
         1}, {"text": "Hobbit", "boundingBox": [6.3033, 1.6707, 6.7463, 1.6707, 6.7463,
         1.7854, 6.3033, 1.7854], "confidence": 1}, {"text": "Lane", "boundingBox":
         [6.803, 1.6782, 7.1006, 1.6782, 7.1006, 1.7854, 6.803, 1.7854], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "567 Main St.", "boundingBox": [0.8852, 1.846, 1.713, 1.846, 1.713, 1.9554,
-        0.8852, 1.9554], "words": [{"text": "567", "boundingBox": [0.8852, 1.8472,
-        1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554], "confidence": 1}, {"text":
-        "Main", "boundingBox": [1.1777, 1.846, 1.5022, 1.846, 1.5022, 1.9554, 1.1777,
-        1.9554], "confidence": 1}, {"text": "St.", "boundingBox": [1.5558, 1.8472,
-        1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Redmond, WA", "boundingBox":
-        [6.0164, 1.891, 6.9793, 1.891, 6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text":
-        "Redmond,", "boundingBox": [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275,
-        6.0164, 2.0275], "confidence": 1}, {"text": "WA", "boundingBox": [6.7408,
-        1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408, 2.0044], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Redmond,
-        WA", "boundingBox": [0.891, 2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975],
-        "words": [{"text": "Redmond,", "boundingBox": [0.891, 2.061, 1.5605, 2.061,
-        1.5605, 2.1975, 0.891, 2.1975], "confidence": 1}, {"text": "WA", "boundingBox":
-        [1.6152, 2.0682, 1.8537, 2.0682, 1.8537, 2.1744, 1.6152, 2.1744], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254,
-        6.0105, 2.2254], "words": [{"text": "555-555-5555", "boundingBox": [6.0105,
-        2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "555-555-5555",
+        1}]}, {"text": "567 Main St.", "boundingBox": [0.8852, 1.846, 1.713, 1.846,
+        1.713, 1.9554, 0.8852, 1.9554], "words": [{"text": "567", "boundingBox": [0.8852,
+        1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554], "confidence": 1},
+        {"text": "Main", "boundingBox": [1.1777, 1.846, 1.5022, 1.846, 1.5022, 1.9554,
+        1.1777, 1.9554], "confidence": 1}, {"text": "St.", "boundingBox": [1.5558,
+        1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554], "confidence": 1}]},
+        {"text": "Redmond, WA", "boundingBox": [6.0164, 1.891, 6.9793, 1.891, 6.9793,
+        2.0275, 6.0164, 2.0275], "words": [{"text": "Redmond,", "boundingBox": [6.0164,
+        1.891, 6.6861, 1.891, 6.6861, 2.0275, 6.0164, 2.0275], "confidence": 1}, {"text":
+        "WA", "boundingBox": [6.7408, 1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408,
+        2.0044], "confidence": 1}]}, {"text": "Redmond, WA", "boundingBox": [0.891,
+        2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,",
+        "boundingBox": [0.891, 2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975],
+        "confidence": 1}, {"text": "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682,
+        1.8537, 2.1744, 1.6152, 2.1744], "confidence": 1}]}, {"text": "555-555-5555",
+        "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254],
+        "words": [{"text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371,
+        2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}]}, {"text": "555-555-5555",
         "boundingBox": [0.8852, 2.2887, 1.8119, 2.2887, 1.8119, 2.3954, 0.8852, 2.3954],
         "words": [{"text": "555-555-5555", "boundingBox": [0.8852, 2.2887, 1.8119,
-        2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Item", "boundingBox":
-        [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
-        "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943,
-        3.109], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996,
-        3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity", "boundingBox":
-        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
+        2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}]}, {"text": "Item",
+        "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109],
+        "words": [{"text": "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018,
+        1.3842, 3.109, 1.0943, 3.109], "confidence": 1}]}, {"text": "Quantity", "boundingBox":
+        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "words":
+        [{"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996, 3.8367,
+        3.1371, 3.2527, 3.1371], "confidence": 1}]}, {"text": "Price", "boundingBox":
+        [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423, 3.109], "words": [{"text":
         "Price", "boundingBox": [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423,
-        3.109], "words": [{"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
-        2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "A", "boundingBox": [1.0832,
-        3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A",
-        "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "10", "boundingBox": [3.2589, 3.2108, 3.4067, 3.2108, 3.4067,
+        3.109], "confidence": 1}]}, {"text": "A", "boundingBox": [1.0832, 3.2118,
+        1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A", "boundingBox":
+        [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "confidence":
+        1}]}, {"text": "10", "boundingBox": [3.2589, 3.2108, 3.4067, 3.2108, 3.4067,
         3.319, 3.2589, 3.319], "words": [{"text": "10", "boundingBox": [3.2589, 3.2108,
-        3.4067, 3.2108, 3.4067, 3.319, 3.2589, 3.319], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "100.99", "boundingBox":
-        [5.4232, 3.2108, 5.8617, 3.2108, 5.8617, 3.319, 5.4232, 3.319], "words": [{"text":
+        3.4067, 3.2108, 3.4067, 3.319, 3.2589, 3.319], "confidence": 1}]}, {"text":
         "100.99", "boundingBox": [5.4232, 3.2108, 5.8617, 3.2108, 5.8617, 3.319, 5.4232,
-        3.319], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637,
-        3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox": [1.0943, 3.4256,
-        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "20", "boundingBox":
-        [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323], "words":
-        [{"text": "20", "boundingBox": [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323,
-        3.2541, 3.5323], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "140.67", "boundingBox": [5.4232, 3.4241, 5.8622,
+        3.319], "words": [{"text": "100.99", "boundingBox": [5.4232, 3.2108, 5.8617,
+        3.2108, 5.8617, 3.319, 5.4232, 3.319], "confidence": 1}]}, {"text": "B", "boundingBox":
+        [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "words": [{"text":
+        "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943,
+        3.531], "confidence": 1}]}, {"text": "20", "boundingBox": [3.2541, 3.4241,
+        3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323], "words": [{"text": "20",
+        "boundingBox": [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323],
+        "confidence": 1}]}, {"text": "140.67", "boundingBox": [5.4232, 3.4241, 5.8622,
         3.4241, 5.8622, 3.5323, 5.4232, 3.5323], "words": [{"text": "140.67", "boundingBox":
         [5.4232, 3.4241, 5.8622, 3.4241, 5.8622, 3.5323, 5.4232, 3.5323], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647, 3.7421, 1.0882,
-        3.7421], "words": [{"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343,
-        1.1647, 3.7421, 1.0882, 3.7421], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "40", "boundingBox": [3.2486,
-        3.6341, 3.4067, 3.6341, 3.4067, 3.7423, 3.2486, 3.7423], "words": [{"text":
+        1}]}, {"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647,
+        3.7421, 1.0882, 3.7421], "words": [{"text": "C", "boundingBox": [1.0882, 3.6343,
+        1.1647, 3.6343, 1.1647, 3.7421, 1.0882, 3.7421], "confidence": 1}]}, {"text":
         "40", "boundingBox": [3.2486, 3.6341, 3.4067, 3.6341, 3.4067, 3.7423, 3.2486,
-        3.7423], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "150.66", "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341, 5.8634,
-        3.7423, 5.4232, 3.7423], "words": [{"text": "150.66", "boundingBox": [5.4232,
-        3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "D",
-        "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951],
-        "words": [{"text": "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753,
-        3.951, 1.0943, 3.951], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "10", "boundingBox": [3.2589, 3.8441,
+        3.7423], "words": [{"text": "40", "boundingBox": [3.2486, 3.6341, 3.4067,
+        3.6341, 3.4067, 3.7423, 3.2486, 3.7423], "confidence": 1}]}, {"text": "150.66",
+        "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423],
+        "words": [{"text": "150.66", "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341,
+        5.8634, 3.7423, 5.4232, 3.7423], "confidence": 1}]}, {"text": "D", "boundingBox":
+        [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text":
+        "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943,
+        3.951], "confidence": 1}]}, {"text": "10", "boundingBox": [3.2589, 3.8441,
         3.4067, 3.8441, 3.4067, 3.9523, 3.2589, 3.9523], "words": [{"text": "10",
         "boundingBox": [3.2589, 3.8441, 3.4067, 3.8441, 3.4067, 3.9523, 3.2589, 3.9523],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "120.00", "boundingBox": [5.4232, 3.8441, 5.8642, 3.8441, 5.8642,
-        3.9523, 5.4232, 3.9523], "words": [{"text": "120.00", "boundingBox": [5.4232,
-        3.8441, 5.8642, 3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "E",
-        "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614],
-        "words": [{"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
-        4.1614, 1.0943, 4.1614], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "40", "boundingBox": [3.2486, 4.0546,
-        3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "words": [{"text": "40",
-        "boundingBox": [3.2486, 4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "100.00", "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546, 5.8644,
-        4.1627, 5.4232, 4.1627], "words": [{"text": "100.00", "boundingBox": [5.4232,
-        4.0546, 5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "F",
-        "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717],
-        "words": [{"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497,
-        4.3717, 1.0943, 4.3717], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "60", "boundingBox": [3.2534, 4.2646,
-        3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727], "words": [{"text": "60",
-        "boundingBox": [3.2534, 4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "120.00", "boundingBox": [5.4232, 4.2646, 5.8642, 4.2646, 5.8642,
-        4.3727, 5.4232, 4.3727], "words": [{"text": "120.00", "boundingBox": [5.4232,
-        4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "G",
-        "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827],
-        "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
-        4.5827, 1.0877, 4.5827], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "80", "boundingBox": [3.2514, 4.4746,
-        3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827], "words": [{"text": "80",
-        "boundingBox": [3.2514, 4.4746, 3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "220.00", "boundingBox": [5.4184, 4.4746, 5.8644, 4.4746, 5.8644,
+        "confidence": 1}]}, {"text": "120.00", "boundingBox": [5.4232, 3.8441, 5.8642,
+        3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "words": [{"text": "120.00", "boundingBox":
+        [5.4232, 3.8441, 5.8642, 3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "confidence":
+        1}]}, {"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
+        4.1614, 1.0943, 4.1614], "words": [{"text": "E", "boundingBox": [1.0943, 4.0561,
+        1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "confidence": 1}]}, {"text":
+        "40", "boundingBox": [3.2486, 4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486,
+        4.1627], "words": [{"text": "40", "boundingBox": [3.2486, 4.0546, 3.4067,
+        4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "confidence": 1}]}, {"text": "100.00",
+        "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627],
+        "words": [{"text": "100.00", "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546,
+        5.8644, 4.1627, 5.4232, 4.1627], "confidence": 1}]}, {"text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "words":
+        [{"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717,
+        1.0943, 4.3717], "confidence": 1}]}, {"text": "60", "boundingBox": [3.2534,
+        4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727], "words": [{"text":
+        "60", "boundingBox": [3.2534, 4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534,
+        4.3727], "confidence": 1}]}, {"text": "120.00", "boundingBox": [5.4232, 4.2646,
+        5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "words": [{"text": "120.00",
+        "boundingBox": [5.4232, 4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727],
+        "confidence": 1}]}, {"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735,
+        4.4746, 1.1735, 4.5827, 1.0877, 4.5827], "words": [{"text": "G", "boundingBox":
+        [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827], "confidence":
+        1}]}, {"text": "80", "boundingBox": [3.2514, 4.4746, 3.4067, 4.4746, 3.4067,
+        4.5827, 3.2514, 4.5827], "words": [{"text": "80", "boundingBox": [3.2514,
+        4.4746, 3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827], "confidence": 1}]},
+        {"text": "220.00", "boundingBox": [5.4184, 4.4746, 5.8644, 4.4746, 5.8644,
         4.5827, 5.4184, 4.5827], "words": [{"text": "220.00", "boundingBox": [5.4184,
-        4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Subtotal:
-        3000.00", "boundingBox": [5.5075, 4.8981, 6.7158, 4.8981, 6.7158, 5.0131,
-        5.5075, 5.0131], "words": [{"text": "Subtotal:", "boundingBox": [5.5075, 4.8981,
-        6.1249, 4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence": 1}, {"text":
-        "3000.00", "boundingBox": [6.1794, 4.9042, 6.7158, 4.9042, 6.7158, 5.0131,
-        6.1794, 5.0131], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "Tax: 300.00", "boundingBox": [5.5034, 5.1245,
-        6.2887, 5.1245, 6.2887, 5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:",
-        "boundingBox": [5.5034, 5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333],
-        "confidence": 1}, {"text": "300.00", "boundingBox": [5.836, 5.1245, 6.2887,
-        5.1245, 6.2887, 5.2333, 5.836, 5.2333], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Tip: 1000.00", "boundingBox":
-        [5.5034, 5.3412, 6.3422, 5.3412, 6.3422, 5.481, 5.5034, 5.481], "words": [{"text":
-        "Tip:", "boundingBox": [5.5034, 5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034,
-        5.481], "confidence": 1}, {"text": "1000.00", "boundingBox": [5.811, 5.3445,
-        6.3422, 5.3445, 6.3422, 5.4533, 5.811, 5.4533], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Total: 4300.00",
-        "boundingBox": [5.5034, 5.5583, 6.4825, 5.5583, 6.4825, 5.6733, 5.5034, 5.6733],
-        "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583,
-        5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "4300.00", "boundingBox":
+        4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "confidence": 1}]},
+        {"text": "Subtotal: 3000.00", "boundingBox": [5.5075, 4.8981, 6.7158, 4.8981,
+        6.7158, 5.0131, 5.5075, 5.0131], "words": [{"text": "Subtotal:", "boundingBox":
+        [5.5075, 4.8981, 6.1249, 4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence":
+        1}, {"text": "3000.00", "boundingBox": [6.1794, 4.9042, 6.7158, 4.9042, 6.7158,
+        5.0131, 6.1794, 5.0131], "confidence": 1}]}, {"text": "Tax: 300.00", "boundingBox":
+        [5.5034, 5.1245, 6.2887, 5.1245, 6.2887, 5.2333, 5.5034, 5.2333], "words":
+        [{"text": "Tax:", "boundingBox": [5.5034, 5.1263, 5.7812, 5.1263, 5.7812,
+        5.2333, 5.5034, 5.2333], "confidence": 1}, {"text": "300.00", "boundingBox":
+        [5.836, 5.1245, 6.2887, 5.1245, 6.2887, 5.2333, 5.836, 5.2333], "confidence":
+        1}]}, {"text": "Tip: 1000.00", "boundingBox": [5.5034, 5.3412, 6.3422, 5.3412,
+        6.3422, 5.481, 5.5034, 5.481], "words": [{"text": "Tip:", "boundingBox": [5.5034,
+        5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034, 5.481], "confidence": 1}, {"text":
+        "1000.00", "boundingBox": [5.811, 5.3445, 6.3422, 5.3445, 6.3422, 5.4533,
+        5.811, 5.4533], "confidence": 1}]}, {"text": "Total: 4300.00", "boundingBox":
+        [5.5034, 5.5583, 6.4825, 5.5583, 6.4825, 5.6733, 5.5034, 5.6733], "words":
+        [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583, 5.8915,
+        5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "4300.00", "boundingBox":
         [5.942, 5.5645, 6.4825, 5.5645, 6.4825, 5.6733, 5.942, 5.6733], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Signature: ____Frodo Baggins__________", "boundingBox": [1.0055, 6.6556,
-        3.8842, 6.6556, 3.8842, 6.7981, 1.0055, 6.7981], "words": [{"text": "Signature:",
-        "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981, 1.0055, 6.7981],
-        "confidence": 1}, {"text": "____Frodo", "boundingBox": [1.747, 6.6556, 2.4778,
-        6.6556, 2.4778, 6.7981, 1.747, 6.7981], "confidence": 1}, {"text": "Baggins__________",
-        "boundingBox": [2.5325, 6.6581, 3.8842, 6.6581, 3.8842, 6.7981, 2.5325, 6.7981],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}]}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
+        1}]}, {"text": "Signature: ____ Frodo Baggins__________", "boundingBox": [1.0055,
+        6.6556, 3.8842, 6.6556, 3.8842, 6.7981, 1.0055, 6.7981], "words": [{"text":
+        "Signature:", "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981,
+        1.0055, 6.7981], "confidence": 1}, {"text": "____", "boundingBox": [1.747,
+        6.7829, 2.0809, 6.7829, 2.0809, 6.7981, 1.747, 6.7981], "confidence": 1},
+        {"text": "Frodo", "boundingBox": [2.0925, 6.6556, 2.4778, 6.6556, 2.4778,
+        6.7703, 2.0925, 6.7703], "confidence": 1}, {"text": "Baggins__________", "boundingBox":
+        [2.5325, 6.6581, 3.8842, 6.6581, 3.8842, 6.7981, 2.5325, 6.7981], "confidence":
+        1}]}]}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
         [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString": "Itemized",
-        "confidence": 0.991}, "MerchantName": {"type": "string", "valueString": "Bilbo
+        "confidence": 0.99}, "MerchantName": {"type": "string", "valueString": "Bilbo
         Baggins", "text": "Bilbo Baggins", "boundingBox": [6.0164, 1.4503, 6.8967,
-        1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "page": 1, "confidence": 0.669, "elements":
+        1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "page": 1, "confidence": 0.987, "elements":
         ["#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1"]}, "MerchantAddress":
         {"type": "string", "valueString": "123 Hobbit Lane 567 Main St. Redmond, WA
         Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA",
         "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975, 0.8852, 2.1975],
-        "page": 1, "confidence": 0.345, "elements": ["#/readResults/0/lines/4/words/0",
+        "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/4/words/0",
         "#/readResults/0/lines/4/words/1", "#/readResults/0/lines/4/words/2", "#/readResults/0/lines/5/words/0",
         "#/readResults/0/lines/5/words/1", "#/readResults/0/lines/5/words/2", "#/readResults/0/lines/6/words/0",
         "#/readResults/0/lines/6/words/1", "#/readResults/0/lines/7/words/0", "#/readResults/0/lines/7/words/1"]},
         "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber": "+15555555555",
         "text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371,
-        2.2254, 6.0105, 2.2254], "page": 1, "confidence": 0.932, "elements": ["#/readResults/0/lines/8/words/0"]},
+        2.2254, 6.0105, 2.2254], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/8/words/0"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "F", "text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "page":
+        1, "confidence": 0.964, "elements": ["#/readResults/0/lines/28/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 12, "text": "12.00", "boundingBox":
+        [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "page":
+        1, "confidence": 0.947, "elements": ["#/readResults/0/lines/30/words/0"]}}},
+        {"type": "object", "valueObject": {"TotalPrice": {"type": "number", "valueNumber":
+        22, "text": "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781,
+        4.5827, 5.4184, 4.5827], "page": 1, "confidence": 0.935, "elements": ["#/readResults/0/lines/33/words/0"]}}}]},
         "Subtotal": {"type": "number", "valueNumber": 300, "text": "300.00", "boundingBox":
         [6.1794, 4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131], "page": 1,
-        "confidence": 0.96, "elements": ["#/readResults/0/lines/34/words/1"]}}}, {"docType":
-        "prebuilt:receipt", "pageRange": [2, 2], "fields": {}}, {"docType": "prebuilt:receipt",
-        "pageRange": [3, 3], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Frodo Baggins", "text": "Frodo Baggins", "boundingBox": [6.0164, 1.4506,
-        6.9506, 1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "page": 3, "confidence":
-        0.529, "elements": ["#/readResults/2/lines/3/words/0", "#/readResults/2/lines/3/words/1"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Hobbit Lane 567
-        Main St. Redmond, WA Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond,
-        WA Redmond, WA", "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975,
-        0.8852, 2.1975], "page": 3, "confidence": 0.523, "elements": ["#/readResults/2/lines/4/words/0",
+        "confidence": 0.99, "elements": ["#/readResults/0/lines/34/words/1"]}, "Total":
+        {"type": "number", "valueNumber": 430, "text": "430.00", "boundingBox": [5.942,
+        5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942, 5.6733], "page": 1, "confidence":
+        0.985, "elements": ["#/readResults/0/lines/37/words/1"]}}}, {"docType": "prebuilt:receipt",
+        "pageRange": [2, 2], "fields": {}}, {"docType": "prebuilt:receipt", "pageRange":
+        [3, 3], "fields": {"ReceiptType": {"type": "string", "valueString": "Itemized",
+        "confidence": 0.99}, "MerchantName": {"type": "string", "valueString": "Frodo
+        Baggins", "text": "Frodo Baggins", "boundingBox": [6.0164, 1.4506, 6.9506,
+        1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "page": 3, "confidence": 0.984, "elements":
+        ["#/readResults/2/lines/3/words/0", "#/readResults/2/lines/3/words/1"]}, "MerchantAddress":
+        {"type": "string", "valueString": "123 Hobbit Lane 567 Main St. Redmond, WA
+        Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA",
+        "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975, 0.8852, 2.1975],
+        "page": 3, "confidence": 0.99, "elements": ["#/readResults/2/lines/4/words/0",
         "#/readResults/2/lines/4/words/1", "#/readResults/2/lines/4/words/2", "#/readResults/2/lines/5/words/0",
         "#/readResults/2/lines/5/words/1", "#/readResults/2/lines/5/words/2", "#/readResults/2/lines/6/words/0",
         "#/readResults/2/lines/6/words/1", "#/readResults/2/lines/7/words/0", "#/readResults/2/lines/7/words/1"]},
         "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber": "+15555555555",
         "text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371,
-        2.2254, 6.0105, 2.2254], "page": 3, "confidence": 0.926, "elements": ["#/readResults/2/lines/8/words/0"]},
-        "Subtotal": {"type": "number", "valueNumber": 150.66, "text": "150.66", "boundingBox":
-        [5.4232, 3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423], "page":
-        3, "confidence": 0.664, "elements": ["#/readResults/2/lines/21/words/0"]}}}]}}'
+        2.2254, 6.0105, 2.2254], "page": 3, "confidence": 0.99, "elements": ["#/readResults/2/lines/8/words/0"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "E", "text": "E", "boundingBox":
+        [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "page": 3,
+        "confidence": 0.935, "elements": ["#/readResults/2/lines/25/words/0"]}, "Quantity":
+        {"type": "number", "valueNumber": 40, "text": "40", "boundingBox": [3.2486,
+        4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "page": 3, "confidence":
+        0, "elements": ["#/readResults/2/lines/26/words/0"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 100, "text": "100.00", "boundingBox": [5.4232, 4.0546,
+        5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627], "page": 3, "confidence":
+        0.723, "elements": ["#/readResults/2/lines/27/words/0"]}}}, {"type": "object",
+        "valueObject": {"Name": {"type": "string", "valueString": "F", "text": "F",
+        "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717],
+        "page": 3, "confidence": 0.905, "elements": ["#/readResults/2/lines/28/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 120, "text": "120.00", "boundingBox":
+        [5.4232, 4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "page":
+        3, "confidence": 0.967, "elements": ["#/readResults/2/lines/30/words/0"]}}},
+        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
+        "G", "text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
+        4.5827, 1.0877, 4.5827], "page": 3, "confidence": 0.896, "elements": ["#/readResults/2/lines/31/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 220, "text": "220.00", "boundingBox":
+        [5.4184, 4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "page":
+        3, "confidence": 0.958, "elements": ["#/readResults/2/lines/33/words/0"]}}}]},
+        "Subtotal": {"type": "number", "valueNumber": 3000, "text": "3000.00", "boundingBox":
+        [6.1794, 4.9042, 6.7158, 4.9042, 6.7158, 5.0131, 6.1794, 5.0131], "page":
+        3, "confidence": 0.99, "elements": ["#/readResults/2/lines/34/words/1"]},
+        "Total": {"type": "number", "valueNumber": 1000, "text": "1000.00", "boundingBox":
+        [5.811, 5.3445, 6.3422, 5.3445, 6.3422, 5.4533, 5.811, 5.4533], "page": 3,
+        "confidence": 0.985, "elements": ["#/readResults/2/lines/36/words/1"]}}}]}}'
     headers:
-      apim-request-id: 52d5e230-fb1c-40d5-8d43-21237ec179da
-      content-length: '26841'
+      apim-request-id: 21cd94ae-5d53-48eb-a5ef-e0beaca75f62
+      content-length: '25475'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:05:58 GMT
+      date: Mon, 16 Nov 2020 19:11:24 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '33'
+      x-envoy-upstream-service-time: '25'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/a532c0d6-c245-4283-9a1d-889b1b8409f7
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/27c0de9d-de42-47c0-a279-72087a4b18f2
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_multipage_transform.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_multipage_transform.yaml
@@ -1926,13 +1926,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 08399a8d-b126-4959-9438-25ae7ffad6a0
+      apim-request-id: ea6e6c9b-8459-47b6-ba7d-8a6c3c022f10
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:05:58 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/08399a8d-b126-4959-9438-25ae7ffad6a0
+      date: Mon, 16 Nov 2020 19:11:25 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/ea6e6c9b-8459-47b6-ba7d-8a6c3c022f10
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '74'
+      x-envoy-upstream-service-time: '107'
     status:
       code: 202
       message: Accepted
@@ -1943,11 +1943,11 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/08399a8d-b126-4959-9438-25ae7ffad6a0
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/ea6e6c9b-8459-47b6-ba7d-8a6c3c022f10
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:05:59Z",
-        "lastUpdatedDateTime": "2020-11-11T18:06:01Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:11:25Z",
+        "lastUpdatedDateTime": "2020-11-16T19:11:30Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": 0, "width": 8.5, "height": 11,
         "unit": "inch", "lines": [{"text": "Company A Invoice", "boundingBox": [0.8861,
         1.1217, 2.3783, 1.1217, 2.3783, 1.2812, 0.8861, 1.2812], "words": [{"text":
@@ -1955,386 +1955,366 @@ interactions:
         0.8861, 1.2812], "confidence": 1}, {"text": "A", "boundingBox": [1.6696, 1.1242,
         1.7749, 1.1242, 1.7749, 1.2473, 1.6696, 1.2473], "confidence": 1}, {"text":
         "Invoice", "boundingBox": [1.8389, 1.1217, 2.3783, 1.1217, 2.3783, 1.2485,
-        1.8389, 1.2485], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "Invoice For:", "boundingBox": [6.0211, 1.0656,
-        7.0357, 1.0656, 7.0357, 1.2121, 6.0211, 1.2121], "words": [{"text": "Invoice",
-        "boundingBox": [6.0211, 1.0656, 6.6362, 1.0656, 6.6362, 1.2121, 6.0211, 1.2121],
-        "confidence": 1}, {"text": "For:", "boundingBox": [6.7147, 1.0691, 7.0357,
-        1.0691, 7.0357, 1.2121, 6.7147, 1.2121], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Address:", "boundingBox":
-        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "words":
-        [{"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825, 1.5657,
-        1.6155, 0.8791, 1.6155], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Bilbo Baggins", "boundingBox": [6.0164,
-        1.4503, 6.8967, 1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "words": [{"text":
-        "Bilbo", "boundingBox": [6.0164, 1.4503, 6.3392, 1.4503, 6.3392, 1.5649, 6.0164,
-        1.5649], "confidence": 1}, {"text": "Baggins", "boundingBox": [6.396, 1.4556,
-        6.8967, 1.4556, 6.8967, 1.5931, 6.396, 1.5931], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "123 Hobbit Lane",
-        "boundingBox": [6.0165, 1.6707, 7.1006, 1.6707, 7.1006, 1.7854, 6.0165, 1.7854],
-        "words": [{"text": "123", "boundingBox": [6.0165, 1.6772, 6.2434, 1.6772,
-        6.2434, 1.7854, 6.0165, 1.7854], "confidence": 1}, {"text": "Hobbit", "boundingBox":
-        [6.3033, 1.6707, 6.7463, 1.6707, 6.7463, 1.7854, 6.3033, 1.7854], "confidence":
-        1}, {"text": "Lane", "boundingBox": [6.803, 1.6782, 7.1006, 1.6782, 7.1006,
-        1.7854, 6.803, 1.7854], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "567 Main St.", "boundingBox": [0.8852,
-        1.846, 1.713, 1.846, 1.713, 1.9554, 0.8852, 1.9554], "words": [{"text": "567",
-        "boundingBox": [0.8852, 1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554],
-        "confidence": 1}, {"text": "Main", "boundingBox": [1.1777, 1.846, 1.5022,
-        1.846, 1.5022, 1.9554, 1.1777, 1.9554], "confidence": 1}, {"text": "St.",
-        "boundingBox": [1.5558, 1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Redmond, WA", "boundingBox": [6.0164, 1.891, 6.9793, 1.891,
-        6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text": "Redmond,", "boundingBox":
-        [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275, 6.0164, 2.0275], "confidence":
-        1}, {"text": "WA", "boundingBox": [6.7408, 1.8982, 6.9793, 1.8982, 6.9793,
-        2.0044, 6.7408, 2.0044], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Redmond, WA", "boundingBox": [0.891,
-        2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,",
-        "boundingBox": [0.891, 2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975],
-        "confidence": 1}, {"text": "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682,
-        1.8537, 2.1744, 1.6152, 2.1744], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "555-555-5555", "boundingBox":
-        [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "words":
-        [{"text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187,
-        6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "555-555-5555", "boundingBox":
+        1.8389, 1.2485], "confidence": 1}]}, {"text": "Invoice For:", "boundingBox":
+        [6.0211, 1.0656, 7.0357, 1.0656, 7.0357, 1.2121, 6.0211, 1.2121], "words":
+        [{"text": "Invoice", "boundingBox": [6.0211, 1.0656, 6.6362, 1.0656, 6.6362,
+        1.2121, 6.0211, 1.2121], "confidence": 1}, {"text": "For:", "boundingBox":
+        [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121, 6.7147, 1.2121], "confidence":
+        1}]}, {"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825,
+        1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text": "Address:", "boundingBox":
+        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "confidence":
+        1}]}, {"text": "Bilbo Baggins", "boundingBox": [6.0164, 1.4503, 6.8967, 1.4503,
+        6.8967, 1.5931, 6.0164, 1.5931], "words": [{"text": "Bilbo", "boundingBox":
+        [6.0164, 1.4503, 6.3392, 1.4503, 6.3392, 1.5649, 6.0164, 1.5649], "confidence":
+        1}, {"text": "Baggins", "boundingBox": [6.396, 1.4556, 6.8967, 1.4556, 6.8967,
+        1.5931, 6.396, 1.5931], "confidence": 1}]}, {"text": "123 Hobbit Lane", "boundingBox":
+        [6.0165, 1.6707, 7.1006, 1.6707, 7.1006, 1.7854, 6.0165, 1.7854], "words":
+        [{"text": "123", "boundingBox": [6.0165, 1.6772, 6.2434, 1.6772, 6.2434, 1.7854,
+        6.0165, 1.7854], "confidence": 1}, {"text": "Hobbit", "boundingBox": [6.3033,
+        1.6707, 6.7463, 1.6707, 6.7463, 1.7854, 6.3033, 1.7854], "confidence": 1},
+        {"text": "Lane", "boundingBox": [6.803, 1.6782, 7.1006, 1.6782, 7.1006, 1.7854,
+        6.803, 1.7854], "confidence": 1}]}, {"text": "567 Main St.", "boundingBox":
+        [0.8852, 1.846, 1.713, 1.846, 1.713, 1.9554, 0.8852, 1.9554], "words": [{"text":
+        "567", "boundingBox": [0.8852, 1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852,
+        1.9554], "confidence": 1}, {"text": "Main", "boundingBox": [1.1777, 1.846,
+        1.5022, 1.846, 1.5022, 1.9554, 1.1777, 1.9554], "confidence": 1}, {"text":
+        "St.", "boundingBox": [1.5558, 1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558,
+        1.9554], "confidence": 1}]}, {"text": "Redmond, WA", "boundingBox": [6.0164,
+        1.891, 6.9793, 1.891, 6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text":
+        "Redmond,", "boundingBox": [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275,
+        6.0164, 2.0275], "confidence": 1}, {"text": "WA", "boundingBox": [6.7408,
+        1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408, 2.0044], "confidence": 1}]},
+        {"text": "Redmond, WA", "boundingBox": [0.891, 2.061, 1.8537, 2.061, 1.8537,
+        2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,", "boundingBox": [0.891,
+        2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975], "confidence": 1}, {"text":
+        "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682, 1.8537, 2.1744, 1.6152,
+        2.1744], "confidence": 1}]}, {"text": "555-555-5555", "boundingBox": [6.0105,
+        2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "words": [{"text":
+        "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254,
+        6.0105, 2.2254], "confidence": 1}]}, {"text": "555-555-5555", "boundingBox":
         [0.8852, 2.2887, 1.8119, 2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "words":
         [{"text": "555-555-5555", "boundingBox": [0.8852, 2.2887, 1.8119, 2.2887,
-        1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Item", "boundingBox": [1.0943,
-        3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
+        1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}]}, {"text": "Item", "boundingBox":
+        [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
         "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943,
-        3.109], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996,
-        3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity", "boundingBox":
-        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Price", "boundingBox": [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423,
-        3.109], "words": [{"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
-        2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "A", "boundingBox": [1.0832,
-        3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A",
-        "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116, 3.3202,
-        3.3176, 3.2589, 3.3176], "words": [{"text": "1", "boundingBox": [3.2589, 3.2116,
-        3.3202, 3.2116, 3.3202, 3.3176, 3.2589, 3.3176], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "10.99", "boundingBox":
+        3.109], "confidence": 1}]}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996,
+        3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity",
+        "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371],
+        "confidence": 1}]}, {"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
+        2.9996, 5.7372, 3.109, 5.423, 3.109], "words": [{"text": "Price", "boundingBox":
+        [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence":
+        1}]}, {"text": "A", "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174,
+        3.318, 1.0832, 3.318], "words": [{"text": "A", "boundingBox": [1.0832, 3.2118,
+        1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "confidence": 1}]}, {"text":
+        "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116, 3.3202, 3.3176, 3.2589,
+        3.3176], "words": [{"text": "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116,
+        3.3202, 3.3176, 3.2589, 3.3176], "confidence": 1}]}, {"text": "10.99", "boundingBox":
         [5.4232, 3.2108, 5.7784, 3.2108, 5.7784, 3.319, 5.4232, 3.319], "words": [{"text":
         "10.99", "boundingBox": [5.4232, 3.2108, 5.7784, 3.2108, 5.7784, 3.319, 5.4232,
-        3.319], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637,
-        3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox": [1.0943, 3.4256,
-        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "2", "boundingBox":
-        [3.2541, 3.4241, 3.3199, 3.4241, 3.3199, 3.531, 3.2541, 3.531], "words": [{"text":
-        "2", "boundingBox": [3.2541, 3.4241, 3.3199, 3.4241, 3.3199, 3.531, 3.2541,
-        3.531], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "14.67", "boundingBox": [5.4232, 3.4241, 5.7789, 3.4241, 5.7789,
-        3.5323, 5.4232, 3.5323], "words": [{"text": "14.67", "boundingBox": [5.4232,
-        3.4241, 5.7789, 3.4241, 5.7789, 3.5323, 5.4232, 3.5323], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "C",
+        3.319], "confidence": 1}]}, {"text": "B", "boundingBox": [1.0943, 3.4256,
+        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox":
+        [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence":
+        1}]}, {"text": "2", "boundingBox": [3.2541, 3.4241, 3.3199, 3.4241, 3.3199,
+        3.531, 3.2541, 3.531], "words": [{"text": "2", "boundingBox": [3.2541, 3.4241,
+        3.3199, 3.4241, 3.3199, 3.531, 3.2541, 3.531], "confidence": 1}]}, {"text":
+        "14.67", "boundingBox": [5.4232, 3.4241, 5.7789, 3.4241, 5.7789, 3.5323, 5.4232,
+        3.5323], "words": [{"text": "14.67", "boundingBox": [5.4232, 3.4241, 5.7789,
+        3.4241, 5.7789, 3.5323, 5.4232, 3.5323], "confidence": 1}]}, {"text": "C",
         "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647, 3.7421, 1.0882, 3.7421],
         "words": [{"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647,
-        3.7421, 1.0882, 3.7421], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "4", "boundingBox": [3.2486, 3.6351,
-        3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "words": [{"text": "4", "boundingBox":
-        [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "15.66", "boundingBox": [5.4232, 3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232,
-        3.7423], "words": [{"text": "15.66", "boundingBox": [5.4232, 3.6341, 5.78,
-        3.6341, 5.78, 3.7423, 5.4232, 3.7423], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "D", "boundingBox": [1.0943,
-        3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text":
-        "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943,
-        3.951], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1", "boundingBox": [3.2589, 3.845, 3.3202, 3.845, 3.3202,
+        3.7421, 1.0882, 3.7421], "confidence": 1}]}, {"text": "4", "boundingBox":
+        [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "words":
+        [{"text": "4", "boundingBox": [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413,
+        3.2486, 3.7413], "confidence": 1}]}, {"text": "15.66", "boundingBox": [5.4232,
+        3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232, 3.7423], "words": [{"text": "15.66",
+        "boundingBox": [5.4232, 3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232, 3.7423],
+        "confidence": 1}]}, {"text": "D", "boundingBox": [1.0943, 3.8456, 1.1753,
+        3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text": "D", "boundingBox":
+        [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "confidence":
+        1}]}, {"text": "1", "boundingBox": [3.2589, 3.845, 3.3202, 3.845, 3.3202,
         3.951, 3.2589, 3.951], "words": [{"text": "1", "boundingBox": [3.2589, 3.845,
-        3.3202, 3.845, 3.3202, 3.951, 3.2589, 3.951], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "12.00", "boundingBox":
-        [5.4232, 3.8441, 5.7809, 3.8441, 5.7809, 3.9523, 5.4232, 3.9523], "words":
-        [{"text": "12.00", "boundingBox": [5.4232, 3.8441, 5.7809, 3.8441, 5.7809,
-        3.9523, 5.4232, 3.9523], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "E", "boundingBox": [1.0943, 4.0561,
-        1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "words": [{"text": "E", "boundingBox":
-        [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617, 3.2486,
-        4.1617], "words": [{"text": "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556,
-        3.3244, 4.1617, 3.2486, 4.1617], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "10.00", "boundingBox": [5.4232,
+        3.3202, 3.845, 3.3202, 3.951, 3.2589, 3.951], "confidence": 1}]}, {"text":
+        "12.00", "boundingBox": [5.4232, 3.8441, 5.7809, 3.8441, 5.7809, 3.9523, 5.4232,
+        3.9523], "words": [{"text": "12.00", "boundingBox": [5.4232, 3.8441, 5.7809,
+        3.8441, 5.7809, 3.9523, 5.4232, 3.9523], "confidence": 1}]}, {"text": "E",
+        "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614],
+        "words": [{"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
+        4.1614, 1.0943, 4.1614], "confidence": 1}]}, {"text": "4", "boundingBox":
+        [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617, 3.2486, 4.1617], "words":
+        [{"text": "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617,
+        3.2486, 4.1617], "confidence": 1}]}, {"text": "10.00", "boundingBox": [5.4232,
         4.0546, 5.781, 4.0546, 5.781, 4.1627, 5.4232, 4.1627], "words": [{"text":
         "10.00", "boundingBox": [5.4232, 4.0546, 5.781, 4.0546, 5.781, 4.1627, 5.4232,
-        4.1627], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497,
-        4.3717, 1.0943, 4.3717], "words": [{"text": "F", "boundingBox": [1.0943, 4.2661,
-        1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "6", "boundingBox":
-        [3.2534, 4.2646, 3.3226, 4.2646, 3.3226, 4.3727, 3.2534, 4.3727], "words":
-        [{"text": "6", "boundingBox": [3.2534, 4.2646, 3.3226, 4.2646, 3.3226, 4.3727,
-        3.2534, 4.3727], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "12.00", "boundingBox": [5.4232, 4.2646, 5.7809,
-        4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "words": [{"text": "12.00", "boundingBox":
-        [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877,
-        4.5827], "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746,
-        1.1735, 4.5827, 1.0877, 4.5827], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "8", "boundingBox": [3.2514,
-        4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514, 4.5827], "words": [{"text":
-        "8", "boundingBox": [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514,
-        4.5827], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781,
-        4.5827, 5.4184, 4.5827], "words": [{"text": "22.00", "boundingBox": [5.4184,
-        4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184, 4.5827], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Subtotal:
-        300.00", "boundingBox": [5.5075, 4.8981, 6.632, 4.8981, 6.632, 5.0131, 5.5075,
-        5.0131], "words": [{"text": "Subtotal:", "boundingBox": [5.5075, 4.8981, 6.1249,
-        4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence": 1}, {"text": "300.00",
-        "boundingBox": [6.1794, 4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Tax: 30.00", "boundingBox": [5.5034, 5.1245, 6.2022, 5.1245,
-        6.2022, 5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:", "boundingBox":
-        [5.5034, 5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333], "confidence":
-        1}, {"text": "30.00", "boundingBox": [5.836, 5.1245, 6.2022, 5.1245, 6.2022,
-        5.2333, 5.836, 5.2333], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Tip: 100.00", "boundingBox": [5.5034,
-        5.3412, 6.2587, 5.3412, 6.2587, 5.481, 5.5034, 5.481], "words": [{"text":
+        4.1627], "confidence": 1}]}, {"text": "F", "boundingBox": [1.0943, 4.2661,
+        1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "words": [{"text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "confidence":
+        1}]}, {"text": "6", "boundingBox": [3.2534, 4.2646, 3.3226, 4.2646, 3.3226,
+        4.3727, 3.2534, 4.3727], "words": [{"text": "6", "boundingBox": [3.2534, 4.2646,
+        3.3226, 4.2646, 3.3226, 4.3727, 3.2534, 4.3727], "confidence": 1}]}, {"text":
+        "12.00", "boundingBox": [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232,
+        4.3727], "words": [{"text": "12.00", "boundingBox": [5.4232, 4.2646, 5.7809,
+        4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "confidence": 1}]}, {"text": "G",
+        "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827],
+        "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
+        4.5827, 1.0877, 4.5827], "confidence": 1}]}, {"text": "8", "boundingBox":
+        [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514, 4.5827], "words":
+        [{"text": "8", "boundingBox": [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827,
+        3.2514, 4.5827], "confidence": 1}]}, {"text": "22.00", "boundingBox": [5.4184,
+        4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184, 4.5827], "words": [{"text":
+        "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184,
+        4.5827], "confidence": 1}]}, {"text": "Subtotal: 300.00", "boundingBox": [5.5075,
+        4.8981, 6.632, 4.8981, 6.632, 5.0131, 5.5075, 5.0131], "words": [{"text":
+        "Subtotal:", "boundingBox": [5.5075, 4.8981, 6.1249, 4.8981, 6.1249, 5.0131,
+        5.5075, 5.0131], "confidence": 1}, {"text": "300.00", "boundingBox": [6.1794,
+        4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131], "confidence": 1}]},
+        {"text": "Tax: 30.00", "boundingBox": [5.5034, 5.1245, 6.2022, 5.1245, 6.2022,
+        5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:", "boundingBox": [5.5034,
+        5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333], "confidence": 1},
+        {"text": "30.00", "boundingBox": [5.836, 5.1245, 6.2022, 5.1245, 6.2022, 5.2333,
+        5.836, 5.2333], "confidence": 1}]}, {"text": "Tip: 100.00", "boundingBox":
+        [5.5034, 5.3412, 6.2587, 5.3412, 6.2587, 5.481, 5.5034, 5.481], "words": [{"text":
         "Tip:", "boundingBox": [5.5034, 5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034,
         5.481], "confidence": 1}, {"text": "100.00", "boundingBox": [5.811, 5.3445,
-        6.2587, 5.3445, 6.2587, 5.4533, 5.811, 5.4533], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Total: 430.00",
-        "boundingBox": [5.5034, 5.5583, 6.3987, 5.5583, 6.3987, 5.6733, 5.5034, 5.6733],
-        "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583,
-        5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "430.00", "boundingBox":
-        [5.942, 5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942, 5.6733], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Signature: ____Bilbo Baggins__________", "boundingBox": [1.0055, 6.6553,
-        3.8342, 6.6553, 3.8342, 6.7981, 1.0055, 6.7981], "words": [{"text": "Signature:",
-        "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981, 1.0055, 6.7981],
-        "confidence": 1}, {"text": "____Bilbo", "boundingBox": [1.747, 6.6553, 2.4278,
-        6.6553, 2.4278, 6.7981, 1.747, 6.7981], "confidence": 1}, {"text": "Baggins__________",
-        "boundingBox": [2.4823, 6.6581, 3.8342, 6.6581, 3.8342, 6.7981, 2.4823, 6.7981],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}]}, {"page": 2, "angle": 0, "width": 8.5, "height": 11, "unit": "inch"},
+        6.2587, 5.3445, 6.2587, 5.4533, 5.811, 5.4533], "confidence": 1}]}, {"text":
+        "Total: 430.00", "boundingBox": [5.5034, 5.5583, 6.3987, 5.5583, 6.3987, 5.6733,
+        5.5034, 5.6733], "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583,
+        5.8915, 5.5583, 5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text":
+        "430.00", "boundingBox": [5.942, 5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942,
+        5.6733], "confidence": 1}]}, {"text": "Signature: ____ Bilbo Baggins__________",
+        "boundingBox": [1.0055, 6.6553, 3.8342, 6.6553, 3.8342, 6.7981, 1.0055, 6.7981],
+        "words": [{"text": "Signature:", "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581,
+        1.6987, 6.7981, 1.0055, 6.7981], "confidence": 1}, {"text": "____", "boundingBox":
+        [1.747, 6.7829, 2.0809, 6.7829, 2.0809, 6.7981, 1.747, 6.7981], "confidence":
+        1}, {"text": "Bilbo", "boundingBox": [2.0925, 6.6553, 2.4278, 6.6553, 2.4278,
+        6.7703, 2.0925, 6.7703], "confidence": 1}, {"text": "Baggins__________", "boundingBox":
+        [2.4823, 6.6581, 3.8342, 6.6581, 3.8342, 6.7981, 2.4823, 6.7981], "confidence":
+        1}]}]}, {"page": 2, "angle": 0, "width": 8.5, "height": 11, "unit": "inch"},
         {"page": 3, "angle": 0, "width": 8.5, "height": 11, "unit": "inch", "lines":
         [{"text": "Company B Invoice", "boundingBox": [0.8861, 1.1217, 2.3734, 1.1217,
         2.3734, 1.2812, 0.8861, 1.2812], "words": [{"text": "Company", "boundingBox":
         [0.8861, 1.1232, 1.6203, 1.1232, 1.6203, 1.2812, 0.8861, 1.2812], "confidence":
         1}, {"text": "B", "boundingBox": [1.6836, 1.1248, 1.764, 1.1248, 1.764, 1.2469,
         1.6836, 1.2469], "confidence": 1}, {"text": "Invoice", "boundingBox": [1.8336,
-        1.1217, 2.3734, 1.1217, 2.3734, 1.2485, 1.8336, 1.2485], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Invoice
-        For:", "boundingBox": [6.0211, 1.0656, 7.0357, 1.0656, 7.0357, 1.2121, 6.0211,
-        1.2121], "words": [{"text": "Invoice", "boundingBox": [6.0211, 1.0656, 6.6362,
-        1.0656, 6.6362, 1.2121, 6.0211, 1.2121], "confidence": 1}, {"text": "For:",
-        "boundingBox": [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121, 6.7147, 1.2121],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825,
-        1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text": "Address:", "boundingBox":
-        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Frodo Baggins", "boundingBox": [6.0164, 1.4506, 6.9506, 1.4506, 6.9506, 1.5931,
-        6.0164, 1.5931], "words": [{"text": "Frodo", "boundingBox": [6.0164, 1.4506,
-        6.3895, 1.4506, 6.3895, 1.5649, 6.0164, 1.5649], "confidence": 1}, {"text":
-        "Baggins", "boundingBox": [6.45, 1.4556, 6.9506, 1.4556, 6.9506, 1.5931, 6.45,
-        1.5931], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "123 Hobbit Lane", "boundingBox": [6.0165, 1.6707, 7.1006,
+        1.1217, 2.3734, 1.1217, 2.3734, 1.2485, 1.8336, 1.2485], "confidence": 1}]},
+        {"text": "Invoice For:", "boundingBox": [6.0211, 1.0656, 7.0357, 1.0656, 7.0357,
+        1.2121, 6.0211, 1.2121], "words": [{"text": "Invoice", "boundingBox": [6.0211,
+        1.0656, 6.6362, 1.0656, 6.6362, 1.2121, 6.0211, 1.2121], "confidence": 1},
+        {"text": "For:", "boundingBox": [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121,
+        6.7147, 1.2121], "confidence": 1}]}, {"text": "Address:", "boundingBox": [0.8791,
+        1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text":
+        "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155,
+        0.8791, 1.6155], "confidence": 1}]}, {"text": "Frodo Baggins", "boundingBox":
+        [6.0164, 1.4506, 6.9506, 1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "words":
+        [{"text": "Frodo", "boundingBox": [6.0164, 1.4506, 6.3895, 1.4506, 6.3895,
+        1.5649, 6.0164, 1.5649], "confidence": 1}, {"text": "Baggins", "boundingBox":
+        [6.45, 1.4556, 6.9506, 1.4556, 6.9506, 1.5931, 6.45, 1.5931], "confidence":
+        1}]}, {"text": "123 Hobbit Lane", "boundingBox": [6.0165, 1.6707, 7.1006,
         1.6707, 7.1006, 1.7854, 6.0165, 1.7854], "words": [{"text": "123", "boundingBox":
         [6.0165, 1.6772, 6.2434, 1.6772, 6.2434, 1.7854, 6.0165, 1.7854], "confidence":
         1}, {"text": "Hobbit", "boundingBox": [6.3033, 1.6707, 6.7463, 1.6707, 6.7463,
         1.7854, 6.3033, 1.7854], "confidence": 1}, {"text": "Lane", "boundingBox":
         [6.803, 1.6782, 7.1006, 1.6782, 7.1006, 1.7854, 6.803, 1.7854], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "567 Main St.", "boundingBox": [0.8852, 1.846, 1.713, 1.846, 1.713, 1.9554,
-        0.8852, 1.9554], "words": [{"text": "567", "boundingBox": [0.8852, 1.8472,
-        1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554], "confidence": 1}, {"text":
-        "Main", "boundingBox": [1.1777, 1.846, 1.5022, 1.846, 1.5022, 1.9554, 1.1777,
-        1.9554], "confidence": 1}, {"text": "St.", "boundingBox": [1.5558, 1.8472,
-        1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Redmond, WA", "boundingBox":
-        [6.0164, 1.891, 6.9793, 1.891, 6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text":
-        "Redmond,", "boundingBox": [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275,
-        6.0164, 2.0275], "confidence": 1}, {"text": "WA", "boundingBox": [6.7408,
-        1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408, 2.0044], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Redmond,
-        WA", "boundingBox": [0.891, 2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975],
-        "words": [{"text": "Redmond,", "boundingBox": [0.891, 2.061, 1.5605, 2.061,
-        1.5605, 2.1975, 0.891, 2.1975], "confidence": 1}, {"text": "WA", "boundingBox":
-        [1.6152, 2.0682, 1.8537, 2.0682, 1.8537, 2.1744, 1.6152, 2.1744], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254,
-        6.0105, 2.2254], "words": [{"text": "555-555-5555", "boundingBox": [6.0105,
-        2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "555-555-5555",
+        1}]}, {"text": "567 Main St.", "boundingBox": [0.8852, 1.846, 1.713, 1.846,
+        1.713, 1.9554, 0.8852, 1.9554], "words": [{"text": "567", "boundingBox": [0.8852,
+        1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554], "confidence": 1},
+        {"text": "Main", "boundingBox": [1.1777, 1.846, 1.5022, 1.846, 1.5022, 1.9554,
+        1.1777, 1.9554], "confidence": 1}, {"text": "St.", "boundingBox": [1.5558,
+        1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554], "confidence": 1}]},
+        {"text": "Redmond, WA", "boundingBox": [6.0164, 1.891, 6.9793, 1.891, 6.9793,
+        2.0275, 6.0164, 2.0275], "words": [{"text": "Redmond,", "boundingBox": [6.0164,
+        1.891, 6.6861, 1.891, 6.6861, 2.0275, 6.0164, 2.0275], "confidence": 1}, {"text":
+        "WA", "boundingBox": [6.7408, 1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408,
+        2.0044], "confidence": 1}]}, {"text": "Redmond, WA", "boundingBox": [0.891,
+        2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,",
+        "boundingBox": [0.891, 2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975],
+        "confidence": 1}, {"text": "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682,
+        1.8537, 2.1744, 1.6152, 2.1744], "confidence": 1}]}, {"text": "555-555-5555",
+        "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254],
+        "words": [{"text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371,
+        2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}]}, {"text": "555-555-5555",
         "boundingBox": [0.8852, 2.2887, 1.8119, 2.2887, 1.8119, 2.3954, 0.8852, 2.3954],
         "words": [{"text": "555-555-5555", "boundingBox": [0.8852, 2.2887, 1.8119,
-        2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Item", "boundingBox":
-        [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
-        "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943,
-        3.109], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996,
-        3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity", "boundingBox":
-        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
+        2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}]}, {"text": "Item",
+        "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109],
+        "words": [{"text": "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018,
+        1.3842, 3.109, 1.0943, 3.109], "confidence": 1}]}, {"text": "Quantity", "boundingBox":
+        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "words":
+        [{"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996, 3.8367,
+        3.1371, 3.2527, 3.1371], "confidence": 1}]}, {"text": "Price", "boundingBox":
+        [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423, 3.109], "words": [{"text":
         "Price", "boundingBox": [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423,
-        3.109], "words": [{"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
-        2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "A", "boundingBox": [1.0832,
-        3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A",
-        "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "10", "boundingBox": [3.2589, 3.2108, 3.4067, 3.2108, 3.4067,
+        3.109], "confidence": 1}]}, {"text": "A", "boundingBox": [1.0832, 3.2118,
+        1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A", "boundingBox":
+        [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "confidence":
+        1}]}, {"text": "10", "boundingBox": [3.2589, 3.2108, 3.4067, 3.2108, 3.4067,
         3.319, 3.2589, 3.319], "words": [{"text": "10", "boundingBox": [3.2589, 3.2108,
-        3.4067, 3.2108, 3.4067, 3.319, 3.2589, 3.319], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "100.99", "boundingBox":
-        [5.4232, 3.2108, 5.8617, 3.2108, 5.8617, 3.319, 5.4232, 3.319], "words": [{"text":
+        3.4067, 3.2108, 3.4067, 3.319, 3.2589, 3.319], "confidence": 1}]}, {"text":
         "100.99", "boundingBox": [5.4232, 3.2108, 5.8617, 3.2108, 5.8617, 3.319, 5.4232,
-        3.319], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637,
-        3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox": [1.0943, 3.4256,
-        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "20", "boundingBox":
-        [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323], "words":
-        [{"text": "20", "boundingBox": [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323,
-        3.2541, 3.5323], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "140.67", "boundingBox": [5.4232, 3.4241, 5.8622,
+        3.319], "words": [{"text": "100.99", "boundingBox": [5.4232, 3.2108, 5.8617,
+        3.2108, 5.8617, 3.319, 5.4232, 3.319], "confidence": 1}]}, {"text": "B", "boundingBox":
+        [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "words": [{"text":
+        "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943,
+        3.531], "confidence": 1}]}, {"text": "20", "boundingBox": [3.2541, 3.4241,
+        3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323], "words": [{"text": "20",
+        "boundingBox": [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323],
+        "confidence": 1}]}, {"text": "140.67", "boundingBox": [5.4232, 3.4241, 5.8622,
         3.4241, 5.8622, 3.5323, 5.4232, 3.5323], "words": [{"text": "140.67", "boundingBox":
         [5.4232, 3.4241, 5.8622, 3.4241, 5.8622, 3.5323, 5.4232, 3.5323], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647, 3.7421, 1.0882,
-        3.7421], "words": [{"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343,
-        1.1647, 3.7421, 1.0882, 3.7421], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "40", "boundingBox": [3.2486,
-        3.6341, 3.4067, 3.6341, 3.4067, 3.7423, 3.2486, 3.7423], "words": [{"text":
+        1}]}, {"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647,
+        3.7421, 1.0882, 3.7421], "words": [{"text": "C", "boundingBox": [1.0882, 3.6343,
+        1.1647, 3.6343, 1.1647, 3.7421, 1.0882, 3.7421], "confidence": 1}]}, {"text":
         "40", "boundingBox": [3.2486, 3.6341, 3.4067, 3.6341, 3.4067, 3.7423, 3.2486,
-        3.7423], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "150.66", "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341, 5.8634,
-        3.7423, 5.4232, 3.7423], "words": [{"text": "150.66", "boundingBox": [5.4232,
-        3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "D",
-        "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951],
-        "words": [{"text": "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753,
-        3.951, 1.0943, 3.951], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "10", "boundingBox": [3.2589, 3.8441,
+        3.7423], "words": [{"text": "40", "boundingBox": [3.2486, 3.6341, 3.4067,
+        3.6341, 3.4067, 3.7423, 3.2486, 3.7423], "confidence": 1}]}, {"text": "150.66",
+        "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423],
+        "words": [{"text": "150.66", "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341,
+        5.8634, 3.7423, 5.4232, 3.7423], "confidence": 1}]}, {"text": "D", "boundingBox":
+        [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text":
+        "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943,
+        3.951], "confidence": 1}]}, {"text": "10", "boundingBox": [3.2589, 3.8441,
         3.4067, 3.8441, 3.4067, 3.9523, 3.2589, 3.9523], "words": [{"text": "10",
         "boundingBox": [3.2589, 3.8441, 3.4067, 3.8441, 3.4067, 3.9523, 3.2589, 3.9523],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "120.00", "boundingBox": [5.4232, 3.8441, 5.8642, 3.8441, 5.8642,
-        3.9523, 5.4232, 3.9523], "words": [{"text": "120.00", "boundingBox": [5.4232,
-        3.8441, 5.8642, 3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "E",
-        "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614],
-        "words": [{"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
-        4.1614, 1.0943, 4.1614], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "40", "boundingBox": [3.2486, 4.0546,
-        3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "words": [{"text": "40",
-        "boundingBox": [3.2486, 4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "100.00", "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546, 5.8644,
-        4.1627, 5.4232, 4.1627], "words": [{"text": "100.00", "boundingBox": [5.4232,
-        4.0546, 5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "F",
-        "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717],
-        "words": [{"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497,
-        4.3717, 1.0943, 4.3717], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "60", "boundingBox": [3.2534, 4.2646,
-        3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727], "words": [{"text": "60",
-        "boundingBox": [3.2534, 4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "120.00", "boundingBox": [5.4232, 4.2646, 5.8642, 4.2646, 5.8642,
-        4.3727, 5.4232, 4.3727], "words": [{"text": "120.00", "boundingBox": [5.4232,
-        4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "G",
-        "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827],
-        "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
-        4.5827, 1.0877, 4.5827], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "80", "boundingBox": [3.2514, 4.4746,
-        3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827], "words": [{"text": "80",
-        "boundingBox": [3.2514, 4.4746, 3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "220.00", "boundingBox": [5.4184, 4.4746, 5.8644, 4.4746, 5.8644,
+        "confidence": 1}]}, {"text": "120.00", "boundingBox": [5.4232, 3.8441, 5.8642,
+        3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "words": [{"text": "120.00", "boundingBox":
+        [5.4232, 3.8441, 5.8642, 3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "confidence":
+        1}]}, {"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
+        4.1614, 1.0943, 4.1614], "words": [{"text": "E", "boundingBox": [1.0943, 4.0561,
+        1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "confidence": 1}]}, {"text":
+        "40", "boundingBox": [3.2486, 4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486,
+        4.1627], "words": [{"text": "40", "boundingBox": [3.2486, 4.0546, 3.4067,
+        4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "confidence": 1}]}, {"text": "100.00",
+        "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627],
+        "words": [{"text": "100.00", "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546,
+        5.8644, 4.1627, 5.4232, 4.1627], "confidence": 1}]}, {"text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "words":
+        [{"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717,
+        1.0943, 4.3717], "confidence": 1}]}, {"text": "60", "boundingBox": [3.2534,
+        4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727], "words": [{"text":
+        "60", "boundingBox": [3.2534, 4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534,
+        4.3727], "confidence": 1}]}, {"text": "120.00", "boundingBox": [5.4232, 4.2646,
+        5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "words": [{"text": "120.00",
+        "boundingBox": [5.4232, 4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727],
+        "confidence": 1}]}, {"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735,
+        4.4746, 1.1735, 4.5827, 1.0877, 4.5827], "words": [{"text": "G", "boundingBox":
+        [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827], "confidence":
+        1}]}, {"text": "80", "boundingBox": [3.2514, 4.4746, 3.4067, 4.4746, 3.4067,
+        4.5827, 3.2514, 4.5827], "words": [{"text": "80", "boundingBox": [3.2514,
+        4.4746, 3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827], "confidence": 1}]},
+        {"text": "220.00", "boundingBox": [5.4184, 4.4746, 5.8644, 4.4746, 5.8644,
         4.5827, 5.4184, 4.5827], "words": [{"text": "220.00", "boundingBox": [5.4184,
-        4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Subtotal:
-        3000.00", "boundingBox": [5.5075, 4.8981, 6.7158, 4.8981, 6.7158, 5.0131,
-        5.5075, 5.0131], "words": [{"text": "Subtotal:", "boundingBox": [5.5075, 4.8981,
-        6.1249, 4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence": 1}, {"text":
-        "3000.00", "boundingBox": [6.1794, 4.9042, 6.7158, 4.9042, 6.7158, 5.0131,
-        6.1794, 5.0131], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "Tax: 300.00", "boundingBox": [5.5034, 5.1245,
-        6.2887, 5.1245, 6.2887, 5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:",
-        "boundingBox": [5.5034, 5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333],
-        "confidence": 1}, {"text": "300.00", "boundingBox": [5.836, 5.1245, 6.2887,
-        5.1245, 6.2887, 5.2333, 5.836, 5.2333], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Tip: 1000.00", "boundingBox":
-        [5.5034, 5.3412, 6.3422, 5.3412, 6.3422, 5.481, 5.5034, 5.481], "words": [{"text":
-        "Tip:", "boundingBox": [5.5034, 5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034,
-        5.481], "confidence": 1}, {"text": "1000.00", "boundingBox": [5.811, 5.3445,
-        6.3422, 5.3445, 6.3422, 5.4533, 5.811, 5.4533], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Total: 4300.00",
-        "boundingBox": [5.5034, 5.5583, 6.4825, 5.5583, 6.4825, 5.6733, 5.5034, 5.6733],
-        "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583,
-        5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "4300.00", "boundingBox":
+        4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "confidence": 1}]},
+        {"text": "Subtotal: 3000.00", "boundingBox": [5.5075, 4.8981, 6.7158, 4.8981,
+        6.7158, 5.0131, 5.5075, 5.0131], "words": [{"text": "Subtotal:", "boundingBox":
+        [5.5075, 4.8981, 6.1249, 4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence":
+        1}, {"text": "3000.00", "boundingBox": [6.1794, 4.9042, 6.7158, 4.9042, 6.7158,
+        5.0131, 6.1794, 5.0131], "confidence": 1}]}, {"text": "Tax: 300.00", "boundingBox":
+        [5.5034, 5.1245, 6.2887, 5.1245, 6.2887, 5.2333, 5.5034, 5.2333], "words":
+        [{"text": "Tax:", "boundingBox": [5.5034, 5.1263, 5.7812, 5.1263, 5.7812,
+        5.2333, 5.5034, 5.2333], "confidence": 1}, {"text": "300.00", "boundingBox":
+        [5.836, 5.1245, 6.2887, 5.1245, 6.2887, 5.2333, 5.836, 5.2333], "confidence":
+        1}]}, {"text": "Tip: 1000.00", "boundingBox": [5.5034, 5.3412, 6.3422, 5.3412,
+        6.3422, 5.481, 5.5034, 5.481], "words": [{"text": "Tip:", "boundingBox": [5.5034,
+        5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034, 5.481], "confidence": 1}, {"text":
+        "1000.00", "boundingBox": [5.811, 5.3445, 6.3422, 5.3445, 6.3422, 5.4533,
+        5.811, 5.4533], "confidence": 1}]}, {"text": "Total: 4300.00", "boundingBox":
+        [5.5034, 5.5583, 6.4825, 5.5583, 6.4825, 5.6733, 5.5034, 5.6733], "words":
+        [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583, 5.8915,
+        5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "4300.00", "boundingBox":
         [5.942, 5.5645, 6.4825, 5.5645, 6.4825, 5.6733, 5.942, 5.6733], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Signature: ____Frodo Baggins__________", "boundingBox": [1.0055, 6.6556,
-        3.8842, 6.6556, 3.8842, 6.7981, 1.0055, 6.7981], "words": [{"text": "Signature:",
-        "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981, 1.0055, 6.7981],
-        "confidence": 1}, {"text": "____Frodo", "boundingBox": [1.747, 6.6556, 2.4778,
-        6.6556, 2.4778, 6.7981, 1.747, 6.7981], "confidence": 1}, {"text": "Baggins__________",
-        "boundingBox": [2.5325, 6.6581, 3.8842, 6.6581, 3.8842, 6.7981, 2.5325, 6.7981],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}]}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
+        1}]}, {"text": "Signature: ____ Frodo Baggins__________", "boundingBox": [1.0055,
+        6.6556, 3.8842, 6.6556, 3.8842, 6.7981, 1.0055, 6.7981], "words": [{"text":
+        "Signature:", "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981,
+        1.0055, 6.7981], "confidence": 1}, {"text": "____", "boundingBox": [1.747,
+        6.7829, 2.0809, 6.7829, 2.0809, 6.7981, 1.747, 6.7981], "confidence": 1},
+        {"text": "Frodo", "boundingBox": [2.0925, 6.6556, 2.4778, 6.6556, 2.4778,
+        6.7703, 2.0925, 6.7703], "confidence": 1}, {"text": "Baggins__________", "boundingBox":
+        [2.5325, 6.6581, 3.8842, 6.6581, 3.8842, 6.7981, 2.5325, 6.7981], "confidence":
+        1}]}]}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
         [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString": "Itemized",
-        "confidence": 0.991}, "MerchantName": {"type": "string", "valueString": "Bilbo
+        "confidence": 0.99}, "MerchantName": {"type": "string", "valueString": "Bilbo
         Baggins", "text": "Bilbo Baggins", "boundingBox": [6.0164, 1.4503, 6.8967,
-        1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "page": 1, "confidence": 0.669, "elements":
+        1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "page": 1, "confidence": 0.987, "elements":
         ["#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1"]}, "MerchantAddress":
         {"type": "string", "valueString": "123 Hobbit Lane 567 Main St. Redmond, WA
         Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA",
         "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975, 0.8852, 2.1975],
-        "page": 1, "confidence": 0.345, "elements": ["#/readResults/0/lines/4/words/0",
+        "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/4/words/0",
         "#/readResults/0/lines/4/words/1", "#/readResults/0/lines/4/words/2", "#/readResults/0/lines/5/words/0",
         "#/readResults/0/lines/5/words/1", "#/readResults/0/lines/5/words/2", "#/readResults/0/lines/6/words/0",
         "#/readResults/0/lines/6/words/1", "#/readResults/0/lines/7/words/0", "#/readResults/0/lines/7/words/1"]},
         "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber": "+15555555555",
         "text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371,
-        2.2254, 6.0105, 2.2254], "page": 1, "confidence": 0.932, "elements": ["#/readResults/0/lines/8/words/0"]},
+        2.2254, 6.0105, 2.2254], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/8/words/0"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "F", "text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "page":
+        1, "confidence": 0.964, "elements": ["#/readResults/0/lines/28/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 12, "text": "12.00", "boundingBox":
+        [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "page":
+        1, "confidence": 0.947, "elements": ["#/readResults/0/lines/30/words/0"]}}},
+        {"type": "object", "valueObject": {"TotalPrice": {"type": "number", "valueNumber":
+        22, "text": "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781,
+        4.5827, 5.4184, 4.5827], "page": 1, "confidence": 0.935, "elements": ["#/readResults/0/lines/33/words/0"]}}}]},
         "Subtotal": {"type": "number", "valueNumber": 300, "text": "300.00", "boundingBox":
         [6.1794, 4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131], "page": 1,
-        "confidence": 0.96, "elements": ["#/readResults/0/lines/34/words/1"]}}}, {"docType":
-        "prebuilt:receipt", "pageRange": [2, 2], "fields": {}}, {"docType": "prebuilt:receipt",
-        "pageRange": [3, 3], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Frodo Baggins", "text": "Frodo Baggins", "boundingBox": [6.0164, 1.4506,
-        6.9506, 1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "page": 3, "confidence":
-        0.529, "elements": ["#/readResults/2/lines/3/words/0", "#/readResults/2/lines/3/words/1"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Hobbit Lane 567
-        Main St. Redmond, WA Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond,
-        WA Redmond, WA", "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975,
-        0.8852, 2.1975], "page": 3, "confidence": 0.523, "elements": ["#/readResults/2/lines/4/words/0",
+        "confidence": 0.99, "elements": ["#/readResults/0/lines/34/words/1"]}, "Total":
+        {"type": "number", "valueNumber": 430, "text": "430.00", "boundingBox": [5.942,
+        5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942, 5.6733], "page": 1, "confidence":
+        0.985, "elements": ["#/readResults/0/lines/37/words/1"]}}}, {"docType": "prebuilt:receipt",
+        "pageRange": [2, 2], "fields": {}}, {"docType": "prebuilt:receipt", "pageRange":
+        [3, 3], "fields": {"ReceiptType": {"type": "string", "valueString": "Itemized",
+        "confidence": 0.99}, "MerchantName": {"type": "string", "valueString": "Frodo
+        Baggins", "text": "Frodo Baggins", "boundingBox": [6.0164, 1.4506, 6.9506,
+        1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "page": 3, "confidence": 0.984, "elements":
+        ["#/readResults/2/lines/3/words/0", "#/readResults/2/lines/3/words/1"]}, "MerchantAddress":
+        {"type": "string", "valueString": "123 Hobbit Lane 567 Main St. Redmond, WA
+        Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA",
+        "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975, 0.8852, 2.1975],
+        "page": 3, "confidence": 0.99, "elements": ["#/readResults/2/lines/4/words/0",
         "#/readResults/2/lines/4/words/1", "#/readResults/2/lines/4/words/2", "#/readResults/2/lines/5/words/0",
         "#/readResults/2/lines/5/words/1", "#/readResults/2/lines/5/words/2", "#/readResults/2/lines/6/words/0",
         "#/readResults/2/lines/6/words/1", "#/readResults/2/lines/7/words/0", "#/readResults/2/lines/7/words/1"]},
         "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber": "+15555555555",
         "text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371,
-        2.2254, 6.0105, 2.2254], "page": 3, "confidence": 0.926, "elements": ["#/readResults/2/lines/8/words/0"]},
-        "Subtotal": {"type": "number", "valueNumber": 150.66, "text": "150.66", "boundingBox":
-        [5.4232, 3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423], "page":
-        3, "confidence": 0.664, "elements": ["#/readResults/2/lines/21/words/0"]}}}]}}'
+        2.2254, 6.0105, 2.2254], "page": 3, "confidence": 0.99, "elements": ["#/readResults/2/lines/8/words/0"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "E", "text": "E", "boundingBox":
+        [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "page": 3,
+        "confidence": 0.935, "elements": ["#/readResults/2/lines/25/words/0"]}, "Quantity":
+        {"type": "number", "valueNumber": 40, "text": "40", "boundingBox": [3.2486,
+        4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "page": 3, "confidence":
+        0, "elements": ["#/readResults/2/lines/26/words/0"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 100, "text": "100.00", "boundingBox": [5.4232, 4.0546,
+        5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627], "page": 3, "confidence":
+        0.723, "elements": ["#/readResults/2/lines/27/words/0"]}}}, {"type": "object",
+        "valueObject": {"Name": {"type": "string", "valueString": "F", "text": "F",
+        "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717],
+        "page": 3, "confidence": 0.905, "elements": ["#/readResults/2/lines/28/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 120, "text": "120.00", "boundingBox":
+        [5.4232, 4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "page":
+        3, "confidence": 0.967, "elements": ["#/readResults/2/lines/30/words/0"]}}},
+        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
+        "G", "text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
+        4.5827, 1.0877, 4.5827], "page": 3, "confidence": 0.896, "elements": ["#/readResults/2/lines/31/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 220, "text": "220.00", "boundingBox":
+        [5.4184, 4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "page":
+        3, "confidence": 0.958, "elements": ["#/readResults/2/lines/33/words/0"]}}}]},
+        "Subtotal": {"type": "number", "valueNumber": 3000, "text": "3000.00", "boundingBox":
+        [6.1794, 4.9042, 6.7158, 4.9042, 6.7158, 5.0131, 6.1794, 5.0131], "page":
+        3, "confidence": 0.99, "elements": ["#/readResults/2/lines/34/words/1"]},
+        "Total": {"type": "number", "valueNumber": 1000, "text": "1000.00", "boundingBox":
+        [5.811, 5.3445, 6.3422, 5.3445, 6.3422, 5.4533, 5.811, 5.4533], "page": 3,
+        "confidence": 0.985, "elements": ["#/readResults/2/lines/36/words/1"]}}}]}}'
     headers:
-      apim-request-id: 394b13a7-f8e3-4871-92f1-19305449df62
-      content-length: '26841'
+      apim-request-id: d3f06fcd-13b9-4ffa-a6ba-31b1d4d78b7e
+      content-length: '25475'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:06:03 GMT
+      date: Mon, 16 Nov 2020 19:11:30 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '33'
+      x-envoy-upstream-service-time: '21'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/08399a8d-b126-4959-9438-25ae7ffad6a0
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/ea6e6c9b-8459-47b6-ba7d-8a6c3c022f10
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_png.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_png.yaml
@@ -15,13 +15,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 9a3fbae6-6745-446d-ab29-ea5f9e20a779
+      apim-request-id: f619d92d-4874-4045-915d-fa9a4a400a84
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:06:08 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/9a3fbae6-6745-446d-ab29-ea5f9e20a779
+      date: Mon, 16 Nov 2020 19:11:33 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/f619d92d-4874-4045-915d-fa9a4a400a84
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '508'
+      x-envoy-upstream-service-time: '537'
     status:
       code: 202
       message: Accepted
@@ -32,55 +32,56 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/9a3fbae6-6745-446d-ab29-ea5f9e20a779
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/f619d92d-4874-4045-915d-fa9a4a400a84
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:06:08Z",
-        "lastUpdatedDateTime": "2020-11-11T18:06:11Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": -0.0752, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:11:34Z",
+        "lastUpdatedDateTime": "2020-11-16T19:11:36Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.2511, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [342.9, 238.1,
-        1061, 278.6, 1038.1, 685.5, 320, 645], "page": 1, "confidence": 0.693}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [308.4, 688, 751.3, 689,
-        750.8, 859.6, 308, 858.5], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "text": "123-456-7890", "boundingBox": [303, 1003,
-        623, 1009, 621, 1071, 303, 1064], "page": 1, "confidence": 0.99}, "TransactionDate":
-        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
-        [299, 1221, 494, 1222, 492, 1292, 299, 1292], "page": 1, "confidence": 0.991},
-        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
-        "boundingBox": [508, 1223, 628, 1224, 625, 1292, 506, 1292], "page": 1, "confidence":
-        0.99}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
-        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [327, 1558, 353, 1559, 352, 1623, 327, 1623], "page": 1, "confidence": 0.745}}},
-        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
-        "8GB RAM (Black)", "text": "8GB RAM (Black)", "boundingBox": [358, 1779, 738,
-        1779, 738, 1860, 358, 1860], "page": 1, "confidence": 0.968}, "TotalPrice":
-        {"type": "number", "valueNumber": 999, "text": "999.00", "boundingBox": [967,
-        1792, 1135, 1796, 1133, 1859, 967, 1855], "page": 1, "confidence": 0.97}}},
-        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [315, 2018, 337, 2017, 338, 2084, 316, 2085],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "SurfacePen", "text": "SurfacePen", "boundingBox": [350, 2017, 624, 2013,
-        624, 2079, 351, 2084], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 99.99, "text": "$99.99", "boundingBox": [963, 2025,
-        1128, 2025, 1128, 2092, 963, 2092], "page": 1, "confidence": 0.775}}}]}, "Subtotal":
-        {"type": "number", "valueNumber": 1098.99, "text": "1098.99", "boundingBox":
-        [954, 2255, 1137, 2251, 1138, 2325, 956, 2329], "page": 1, "confidence": 0.986},
-        "Total": {"type": "number", "valueNumber": 104.4, "text": "104.40", "boundingBox":
-        [976, 2370, 1130, 2368, 1131, 2434, 977, 2438], "page": 1, "confidence": 0.668}}}]}}'
+        "Itemized", "confidence": 0.659}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [349.3, 241.3,
+        1058, 284.4, 1033.5, 687.1, 324.8, 644], "page": 1, "confidence": 0.516},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [319.9,
+        689.9, 750.7, 697.5, 747.8, 865.6, 317, 858], "page": 1, "confidence": 0.986},
+        "MerchantPhoneNumber": {"type": "phoneNumber", "text": "123-456-7890", "boundingBox":
+        [306, 1005, 617, 1012, 615, 1069, 305, 1064], "page": 1, "confidence": 0.99},
+        "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019",
+        "boundingBox": [304, 1224, 506, 1224, 504, 1289, 303, 1288], "page": 1, "confidence":
+        0.985}, "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text":
+        "13:59", "boundingBox": [518, 1225, 628, 1228, 627, 1290, 517, 1289], "page":
+        1, "confidence": 0.968}, "Items": {"type": "array", "valueArray": [{"type":
+        "object", "valueObject": {"Name": {"type": "string", "valueString": "8GB RAM
+        (Black)", "text": "8GB RAM (Black)", "boundingBox": [370.7, 1781.5, 731, 1785,
+        730.3, 1854, 370, 1850.6], "page": 1, "confidence": 0.916}, "TotalPrice":
+        {"type": "number", "valueNumber": 999, "text": "$999.00", "boundingBox": [939,
+        1784.6, 1134.4, 1788.3, 1133, 1863, 937.6, 1859.3], "page": 1, "confidence":
+        0.559}}}, {"type": "object", "valueObject": {"Quantity": {"type": "number",
+        "valueNumber": 1, "text": "1", "boundingBox": [321, 2021, 348, 2020, 349,
+        2084, 322, 2084], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "SurfacePen", "text": "SurfacePen", "boundingBox": [360, 2020,
+        626, 2014, 628, 2077, 362, 2083], "page": 1, "confidence": 0.858}, "TotalPrice":
+        {"type": "number", "valueNumber": 99.99, "text": "99.99", "boundingBox": [1007,
+        2028, 1127, 2028, 1126, 2091, 1007, 2091], "page": 1, "confidence": 0.386}}}]},
+        "Subtotal": {"type": "number", "valueNumber": 1098.99, "text": "1098.99",
+        "boundingBox": [963, 2260, 1136, 2254, 1137, 2320, 966, 2325], "page": 1,
+        "confidence": 0.964}, "Tax": {"type": "number", "valueNumber": 104.4, "text":
+        "$104.40", "boundingBox": [942.6, 2367.5, 1132, 2363.7, 1133.4, 2434.2, 944,
+        2438], "page": 1, "confidence": 0.713}, "Total": {"type": "number", "valueNumber":
+        1203.39, "text": "1203.39", "boundingBox": [955, 2594, 1123, 2611, 1115, 2678,
+        949, 2661], "page": 1, "confidence": 0.774}}}]}}'
     headers:
-      apim-request-id: 143c2073-8684-4fce-b815-ce9ffbf2a562
-      content-length: '2548'
+      apim-request-id: 26bd92fb-d2d0-4e46-a12a-9973952521a3
+      content-length: '2561'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:06:13 GMT
+      date: Mon, 16 Nov 2020 19:11:38 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '22'
+      x-envoy-upstream-service-time: '17'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/9a3fbae6-6745-446d-ab29-ea5f9e20a779
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/f619d92d-4874-4045-915d-fa9a4a400a84
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_stream_transform_jpg.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_stream_transform_jpg.yaml
@@ -15,13 +15,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 6bae08c6-4520-4fe9-910a-567632a7a5d0
+      apim-request-id: 32c5e7b9-27b9-4249-990d-006c3d87b6b6
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:06:14 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/6bae08c6-4520-4fe9-910a-567632a7a5d0
+      date: Mon, 16 Nov 2020 19:11:40 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/32c5e7b9-27b9-4249-990d-006c3d87b6b6
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '189'
+      x-envoy-upstream-service-time: '174'
     status:
       code: 202
       message: Accepted
@@ -32,168 +32,141 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/6bae08c6-4520-4fe9-910a-567632a7a5d0
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/32c5e7b9-27b9-4249-990d-006c3d87b6b6
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:06:14Z",
-        "lastUpdatedDateTime": "2020-11-11T18:06:16Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
-        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [306,
-        569, 519, 624, 502, 686, 290, 632], "words": [{"text": "Contoso", "boundingBox":
-        [308, 570, 515, 627, 500, 685, 290, 634], "confidence": 0.806}], "appearance":
-        {"style": {"name": "print", "confidence": 0.996}}}, {"text": "Contoso", "boundingBox":
-        [625, 512, 1089, 465, 1096, 561, 631, 607], "words": [{"text": "Contoso",
-        "boundingBox": [625, 512, 1088, 466, 1093, 562, 631, 607], "confidence": 0.984}],
-        "appearance": {"style": {"name": "print", "confidence": 0.999}}}, {"text":
-        "123 Main Street", "boundingBox": [301, 677, 697, 759, 681, 835, 284, 750],
-        "words": [{"text": "123", "boundingBox": [301, 677, 379, 692, 362, 766, 284,
-        751], "confidence": 0.987}, {"text": "Main", "boundingBox": [393, 695, 520,
-        721, 503, 795, 377, 769], "confidence": 0.985}, {"text": "Street", "boundingBox":
-        [534, 724, 694, 763, 676, 835, 517, 798], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.995}}}, {"text": "Redmond, WA
-        98052", "boundingBox": [284, 784, 823, 855, 814, 925, 275, 868], "words":
-        [{"text": "Redmond,", "boundingBox": [287, 784, 544, 829, 535, 905, 275, 853],
-        "confidence": 0.924}, {"text": "WA", "boundingBox": [558, 830, 640, 840, 632,
-        916, 549, 907], "confidence": 0.985}, {"text": "98052", "boundingBox": [654,
-        842, 822, 855, 817, 925, 646, 917], "confidence": 0.985}], "appearance": {"style":
-        {"name": "print", "confidence": 0.999}}}, {"text": "987-654-3210", "boundingBox":
-        [270, 999, 655, 1049, 646, 1125, 264, 1075], "words": [{"text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "confidence":
-        0.978}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "6/10/2019 13:59", "boundingBox": [258, 1224, 683, 1259, 676, 1341, 255, 1309],
-        "words": [{"text": "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505,
-        1331, 255, 1312], "confidence": 0.951}, {"text": "13:59", "boundingBox": [527,
-        1248, 681, 1262, 675, 1341, 522, 1332], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "Sales Associate:
-        Paul", "boundingBox": [252, 1347, 860, 1378, 859, 1449, 249, 1425], "words":
-        [{"text": "Sales", "boundingBox": [255, 1348, 409, 1358, 405, 1432, 249, 1419],
-        "confidence": 0.983}, {"text": "Associate:", "boundingBox": [423, 1359, 704,
-        1373, 703, 1447, 419, 1434], "confidence": 0.933}, {"text": "Paul", "boundingBox":
-        [718, 1373, 858, 1378, 859, 1449, 717, 1448], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "1 Cappuccino", "boundingBox":
-        [244, 1581, 660, 1597, 658, 1688, 241, 1675], "words": [{"text": "1", "boundingBox":
-        [244, 1581, 288, 1584, 285, 1678, 241, 1675], "confidence": 0.977}, {"text":
-        "Cappuccino", "boundingBox": [306, 1585, 658, 1598, 657, 1688, 304, 1679],
-        "confidence": 0.858}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "$2.20", "boundingBox": [1106, 1580, 1264, 1574, 1268, 1656,
-        1108, 1662], "words": [{"text": "$2.20", "boundingBox": [1106, 1579, 1260,
-        1574, 1263, 1656, 1108, 1662], "confidence": 0.981}], "appearance": {"style":
-        {"name": "print", "confidence": 0.849}}}, {"text": "1 BACON & EGGS", "boundingBox":
-        [226, 1838, 740, 1839, 740, 1924, 226, 1923], "words": [{"text": "1", "boundingBox":
-        [227, 1839, 278, 1839, 277, 1924, 226, 1924], "confidence": 0.986}, {"text":
-        "BACON", "boundingBox": [295, 1839, 493, 1840, 493, 1923, 294, 1924], "confidence":
-        0.984}, {"text": "&", "boundingBox": [510, 1840, 555, 1840, 555, 1923, 510,
-        1923], "confidence": 0.983}, {"text": "EGGS", "boundingBox": [572, 1840, 737,
-        1841, 736, 1924, 572, 1923], "confidence": 0.984}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Sunny-side-up", "boundingBox":
-        [343, 1976, 758, 1974, 759, 2061, 343, 2063], "words": [{"text": "Sunny-side-up",
-        "boundingBox": [343, 1977, 757, 1975, 755, 2063, 346, 2064], "confidence":
-        0.973}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "$9.5", "boundingBox": [1134, 1948, 1253, 1948, 1255, 2041, 1137, 2041], "words":
-        [{"text": "$9.5", "boundingBox": [1134, 1948, 1252, 1948, 1252, 2041, 1134,
-        2041], "confidence": 0.983}], "appearance": {"style": {"name": "print", "confidence":
-        0.932}}}, {"text": "- -", "boundingBox": [218, 2143, 291, 2140, 292, 2158,
-        218, 2161], "words": [{"text": "-", "boundingBox": [236, 2143, 255, 2143,
-        255, 2161, 235, 2161], "confidence": 0.559}, {"text": "-", "boundingBox":
-        [271, 2142, 290, 2141, 291, 2158, 272, 2160], "confidence": 0.985}], "appearance":
-        {"style": {"name": "print", "confidence": 0.67}}}, {"text": "-----", "boundingBox":
-        [277, 2142, 461, 2136, 461, 2155, 278, 2161], "words": [{"text": "-----",
-        "boundingBox": [305, 2141, 457, 2136, 458, 2155, 305, 2161], "confidence":
-        0.69}], "appearance": {"style": {"name": "print", "confidence": 0.467}}},
-        {"text": "----", "boundingBox": [471, 2137, 565, 2133, 566, 2150, 472, 2154],
-        "words": [{"text": "----", "boundingBox": [473, 2138, 566, 2134, 566, 2150,
-        473, 2154], "confidence": 0.559}], "appearance": {"style": {"name": "print",
-        "confidence": 0.703}}}, {"text": "--", "boundingBox": [1252, 2129, 1319, 2127,
-        1320, 2143, 1252, 2146], "words": [{"text": "--", "boundingBox": [1277, 2129,
-        1319, 2127, 1319, 2144, 1276, 2145], "confidence": 0.559}], "appearance":
-        {"style": {"name": "print", "confidence": 0.846}}}, {"text": "Sub-Total",
-        "boundingBox": [434, 2232, 768, 2222, 770, 2312, 437, 2322], "words": [{"text":
-        "Sub-Total", "boundingBox": [434, 2234, 769, 2222, 770, 2313, 442, 2322],
-        "confidence": 0.981}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "$ 11.70", "boundingBox": [1082, 2228, 1309, 2228, 1309, 2313,
-        1084, 2312], "words": [{"text": "$", "boundingBox": [1082, 2228, 1122, 2228,
-        1121, 2313, 1082, 2312], "confidence": 0.654}, {"text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "confidence": 0.984}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "Tax", "boundingBox":
-        [433, 2367, 563, 2363, 565, 2458, 435, 2462], "words": [{"text": "Tax", "boundingBox":
-        [433, 2367, 559, 2363, 562, 2458, 435, 2462], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 0.98}}}, {"text": "$ 1.17", "boundingBox":
-        [1125, 2353, 1306, 2362, 1304, 2451, 1121, 2444], "words": [{"text": "$",
-        "boundingBox": [1125, 2353, 1167, 2355, 1163, 2446, 1121, 2444], "confidence":
-        0.966}, {"text": "1.17", "boundingBox": [1186, 2356, 1307, 2361, 1303, 2452,
-        1182, 2447], "confidence": 0.983}], "appearance": {"style": {"name": "print",
-        "confidence": 0.963}}}, {"text": "Tip", "boundingBox": [439, 2502, 545, 2506,
-        541, 2606, 435, 2602], "words": [{"text": "Tip", "boundingBox": [438, 2502,
-        545, 2506, 541, 2606, 435, 2602], "confidence": 0.987}], "appearance": {"style":
-        {"name": "print", "confidence": 0.943}}}, {"text": "$463", "boundingBox":
-        [1038, 2483, 1271, 2489, 1269, 2583, 1032, 2577], "words": [{"text": "$463",
-        "boundingBox": [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "confidence":
-        0.592}], "appearance": {"style": {"name": "handwriting", "confidence": 0.892}}},
-        {"text": "Total", "boundingBox": [431, 2651, 607, 2646, 610, 2739, 435, 2745],
-        "words": [{"text": "Total", "boundingBox": [431, 2651, 605, 2646, 608, 2739,
-        433, 2745], "confidence": 0.983}], "appearance": {"style": {"name": "print",
-        "confidence": 0.991}}}, {"text": "$14.50", "boundingBox": [1034, 2623, 1381,
-        2642, 1374, 2757, 1027, 2740], "words": [{"text": "$14.50", "boundingBox":
-        [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "confidence": 0.845}], "appearance":
-        {"style": {"name": "handwriting", "confidence": 0.991}}}]}], "documentResults":
-        [{"docType": "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType":
-        {"type": "string", "valueString": "Itemized", "confidence": 0.99}, "MerchantName":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:11:40Z",
+        "lastUpdatedDateTime": "2020-11-16T19:11:41Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
+        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [635,
+        510, 1086, 461, 1098, 558, 643, 604], "words": [{"text": "Contoso", "boundingBox":
+        [639, 510, 1087, 461, 1098, 551, 646, 604], "confidence": 0.955}]}, {"text":
+        "Contoso", "boundingBox": [305, 574, 519, 624, 504, 686, 291, 634], "words":
+        [{"text": "Contoso", "boundingBox": [311, 575, 517, 623, 503, 686, 297, 636],
+        "confidence": 0.435}]}, {"text": "123 Main Street", "boundingBox": [300, 675,
+        703, 767, 686, 844, 284, 749], "words": [{"text": "123", "boundingBox": [302,
+        676, 390, 695, 375, 770, 287, 751], "confidence": 0.935}, {"text": "Main",
+        "boundingBox": [405, 698, 528, 726, 512, 802, 390, 774], "confidence": 0.958},
+        {"text": "Street", "boundingBox": [542, 730, 702, 767, 685, 845, 527, 806],
+        "confidence": 0.959}]}, {"text": "Redmond, WA 98052", "boundingBox": [290,
+        784, 828, 850, 820, 933, 279, 868], "words": [{"text": "Redmond,", "boundingBox":
+        [293, 784, 550, 826, 540, 905, 280, 856], "confidence": 0.762}, {"text": "WA",
+        "boundingBox": [565, 828, 645, 837, 637, 917, 555, 907], "confidence": 0.943},
+        {"text": "98052", "boundingBox": [660, 838, 824, 849, 818, 933, 651, 919],
+        "confidence": 0.959}]}, {"text": "987-654-3210", "boundingBox": [275, 1003,
+        656, 1055, 646, 1123, 269, 1073], "words": [{"text": "987-654-3210", "boundingBox":
+        [278, 1004, 656, 1057, 647, 1123, 271, 1075], "confidence": 0.939}]}, {"text":
+        "6/10/2019 13:59", "boundingBox": [265, 1228, 678, 1258, 671, 1344, 258, 1311],
+        "words": [{"text": "6/10/2019", "boundingBox": [267, 1229, 525, 1247, 517,
+        1332, 259, 1313], "confidence": 0.762}, {"text": "13:59", "boundingBox": [541,
+        1248, 677, 1263, 669, 1345, 533, 1333], "confidence": 0.958}]}, {"text": "Sales
+        Associate: Paul", "boundingBox": [253, 1347, 868, 1379, 863, 1457, 249, 1425],
+        "words": [{"text": "Sales", "boundingBox": [259, 1348, 419, 1359, 414, 1435,
+        252, 1422], "confidence": 0.92}, {"text": "Associate:", "boundingBox": [434,
+        1360, 711, 1374, 707, 1452, 428, 1436], "confidence": 0.909}, {"text": "Paul",
+        "boundingBox": [726, 1374, 865, 1379, 862, 1457, 722, 1452], "confidence":
+        0.959}]}, {"text": "1 Cappuccino", "boundingBox": [244, 1583, 658, 1601, 653,
+        1689, 240, 1674], "words": [{"text": "1", "boundingBox": [245, 1583, 299,
+        1585, 295, 1676, 241, 1671], "confidence": 0.824}, {"text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "confidence":
+        0.727}]}, {"text": "$2.20", "boundingBox": [1106, 1584, 1268, 1574, 1270,
+        1656, 1110, 1666], "words": [{"text": "$2.20", "boundingBox": [1108, 1584,
+        1263, 1574, 1268, 1656, 1113, 1666], "confidence": 0.958}]}, {"text": "1 BACON
+        & EGGS", "boundingBox": [232, 1834, 745, 1840, 744, 1924, 231, 1918], "words":
+        [{"text": "1", "boundingBox": [232, 1834, 286, 1836, 285, 1920, 231, 1920],
+        "confidence": 0.845}, {"text": "BACON", "boundingBox": [308, 1836, 506, 1841,
+        504, 1920, 307, 1920], "confidence": 0.885}, {"text": "&", "boundingBox":
+        [523, 1841, 568, 1842, 566, 1921, 521, 1921], "confidence": 0.799}, {"text":
+        "EGGS", "boundingBox": [585, 1842, 746, 1843, 744, 1924, 583, 1921], "confidence":
+        0.949}]}, {"text": "Sunny-side-up", "boundingBox": [347, 1975, 751, 1977,
+        751, 2061, 347, 2060], "words": [{"text": "Sunny-side-up", "boundingBox":
+        [348, 1975, 749, 1979, 747, 2061, 348, 2061], "confidence": 0.946}]}, {"text":
+        "$9.5", "boundingBox": [1135, 1955, 1262, 1952, 1263, 2035, 1136, 2039], "words":
+        [{"text": "$9.5", "boundingBox": [1135, 1955, 1257, 1952, 1259, 2036, 1136,
+        2039], "confidence": 0.95}]}, {"text": "Sub-Total", "boundingBox": [440, 2229,
+        771, 2219, 773, 2318, 442, 2327], "words": [{"text": "Sub-Total", "boundingBox":
+        [441, 2229, 769, 2220, 774, 2319, 443, 2328], "confidence": 0.856}]}, {"text":
+        "$ 11.70", "boundingBox": [1092, 2221, 1301, 2224, 1299, 2319, 1093, 2317],
+        "words": [{"text": "$", "boundingBox": [1092, 2221, 1127, 2221, 1126, 2317,
+        1092, 2316], "confidence": 0.799}, {"text": "11.70", "boundingBox": [1146,
+        2221, 1297, 2223, 1296, 2319, 1145, 2317], "confidence": 0.948}]}, {"text":
+        "Tax", "boundingBox": [442, 2371, 549, 2367, 552, 2454, 445, 2458], "words":
+        [{"text": "Tax", "boundingBox": [445, 2371, 546, 2367, 549, 2454, 448, 2458],
+        "confidence": 0.958}]}, {"text": "$ 1.17", "boundingBox": [1129, 2359, 1310,
+        2359, 1306, 2456, 1129, 2456], "words": [{"text": "$", "boundingBox": [1129,
+        2359, 1171, 2359, 1171, 2456, 1129, 2456], "confidence": 0.89}, {"text": "1.17",
+        "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "confidence":
+        0.942}]}, {"text": "Tip", "boundingBox": [433, 2505, 539, 2506, 540, 2602,
+        434, 2602], "words": [{"text": "Tip", "boundingBox": [436, 2505, 536, 2505,
+        536, 2602, 436, 2602], "confidence": 0.959}]}, {"text": "$ 1.63", "boundingBox":
+        [1030, 2478, 1269, 2486, 1267, 2591, 1024, 2583], "words": [{"text": "$",
+        "boundingBox": [1027, 2478, 1073, 2478, 1069, 2584, 1024, 2583], "confidence":
+        0.788}, {"text": "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591,
+        1091, 2585], "confidence": 0.284}]}, {"text": "Total", "boundingBox": [433,
+        2652, 611, 2644, 615, 2738, 436, 2747], "words": [{"text": "Total", "boundingBox":
+        [435, 2652, 609, 2644, 613, 2739, 439, 2747], "confidence": 0.866}]}, {"text":
+        "$14.50", "boundingBox": [1034, 2620, 1386, 2637, 1380, 2762, 1029, 2739],
+        "words": [{"text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380,
+        2763, 1030, 2739], "confidence": 0.57}]}]}], "documentResults": [{"docType":
+        "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType": {"type":
+        "string", "valueString": "Itemized", "confidence": 0.692}, "MerchantName":
         {"type": "string", "valueString": "Contoso Contoso", "text": "Contoso Contoso",
-        "boundingBox": [380.9, 282.9, 1116, 473.2, 1025, 824.4, 290, 634], "page":
-        1, "confidence": 0.716, "elements": ["#/readResults/0/lines/1/words/0", "#/readResults/0/lines/0/words/0"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
-        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [298.3,
-        676.5, 844.6, 781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989,
-        "elements": ["#/readResults/0/lines/2/words/0", "#/readResults/0/lines/2/words/1",
-        "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1",
-        "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber": {"type": "phoneNumber",
-        "valuePhoneNumber": "+19876543210", "text": "987-654-3210", "boundingBox":
-        [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence": 0.99,
-        "elements": ["#/readResults/0/lines/4/words/0"]}, "TransactionDate": {"type":
-        "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox": [259,
-        1224, 510, 1246, 505, 1331, 255, 1312], "page": 1, "confidence": 0.99, "elements":
-        ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type": "time",
-        "valueTime": "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681,
-        1262, 675, 1341, 522, 1332], "page": 1, "confidence": 0.989, "elements": ["#/readResults/0/lines/5/words/1"]},
-        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        "boundingBox": [378.2, 292.4, 1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8],
+        "page": 1, "confidence": 0.613, "elements": ["#/readResults/0/lines/0/words/0",
+        "#/readResults/0/lines/1/words/0"]}, "MerchantAddress": {"type": "string",
+        "valueString": "123 Main Street Redmond, WA 98052", "text": "123 Main Street
+        Redmond, WA 98052", "boundingBox": [302, 675.8, 848.1, 793.7, 809.9, 970.4,
+        263.9, 852.5], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/2/words/0",
+        "#/readResults/0/lines/2/words/1", "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0",
+        "#/readResults/0/lines/3/words/1", "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber":
+        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
+        "boundingBox": [278, 1004, 656, 1057, 647, 1123, 271, 1075], "page": 1, "confidence":
+        0.99, "elements": ["#/readResults/0/lines/4/words/0"]}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99,
+        "elements": ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type":
+        "time", "valueTime": "13:59:00", "text": "13:59", "boundingBox": [541, 1248,
+        677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence": 0.977, "elements":
+        ["#/readResults/0/lines/5/words/1"]}, "Items": {"type": "array", "valueArray":
+        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
+        1, "text": "1", "boundingBox": [245, 1583, 299, 1585, 295, 1676, 241, 1671],
+        "page": 1, "confidence": 0.92, "elements": ["#/readResults/0/lines/7/words/0"]},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923, "elements": ["#/readResults/0/lines/7/words/1"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1108, 1584,
+        1263, 1574, 1268, 1656, 1113, 1666], "page": 1, "confidence": 0.918, "elements":
+        ["#/readResults/0/lines/8/words/0"]}}}, {"type": "object", "valueObject":
         {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [244, 1581, 288, 1584, 285, 1678, 241, 1675], "page": 1, "confidence": 0.919,
-        "elements": ["#/readResults/0/lines/7/words/0"]}, "Name": {"type": "string",
-        "valueString": "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585,
-        658, 1598, 657, 1688, 304, 1679], "page": 1, "confidence": 0.959, "elements":
-        ["#/readResults/0/lines/7/words/1"]}, "TotalPrice": {"type": "number", "valueNumber":
-        2.2, "text": "$2.20", "boundingBox": [1106, 1579, 1260, 1574, 1263, 1656,
-        1108, 1662], "page": 1, "confidence": 0.959, "elements": ["#/readResults/0/lines/8/words/0"]}}},
-        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91, "elements": ["#/readResults/0/lines/9/words/0"]},
-        "Name": {"type": "string", "valueString": "BACON & EGGS", "text": "BACON &
-        EGGS", "boundingBox": [294, 1839, 737, 1839, 737, 1924, 294, 1924], "page":
-        1, "confidence": 0.955, "elements": ["#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2",
+        [232, 1834, 286, 1836, 285, 1920, 231, 1920], "page": 1, "confidence": 0.858,
+        "elements": ["#/readResults/0/lines/9/words/0"]}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916,
+        "elements": ["#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2",
         "#/readResults/0/lines/9/words/3"]}, "TotalPrice": {"type": "number", "valueNumber":
-        9.5, "text": "$9.5", "boundingBox": [1134, 1948, 1252, 1948, 1252, 2041, 1134,
-        2041], "page": 1, "confidence": 0.958, "elements": ["#/readResults/0/lines/11/words/0"]}}}]},
+        9.5, "text": "$9.5", "boundingBox": [1135, 1955, 1257, 1952, 1259, 2036, 1136,
+        2039], "page": 1, "confidence": 0.916, "elements": ["#/readResults/0/lines/11/words/0"]}}}]},
         "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923, "elements": ["#/readResults/0/lines/17/words/1"]}, "Tax": {"type":
-        "number", "valueNumber": 1.17, "text": "1.17", "boundingBox": [1186, 2356,
-        1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence": 0.979, "elements":
-        ["#/readResults/0/lines/19/words/1"]}, "Tip": {"type": "number", "valueNumber":
-        463, "text": "$463", "boundingBox": [1034, 2483, 1268, 2488, 1266, 2583, 1032,
-        2577], "page": 1, "confidence": 0.975, "elements": ["#/readResults/0/lines/21/words/0"]},
+        [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1, "confidence":
+        0.955, "elements": ["#/readResults/0/lines/13/words/1"]}, "Tax": {"type":
+        "number", "valueNumber": 1.17, "text": "1.17", "boundingBox": [1190, 2359,
+        1304, 2359, 1304, 2456, 1190, 2456], "page": 1, "confidence": 0.979, "elements":
+        ["#/readResults/0/lines/15/words/1"]}, "Tip": {"type": "number", "valueNumber":
+        1.63, "text": "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591,
+        1091, 2585], "page": 1, "confidence": 0.941, "elements": ["#/readResults/0/lines/17/words/1"]},
         "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50", "boundingBox":
-        [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1, "confidence":
-        0.987, "elements": ["#/readResults/0/lines/23/words/0"]}}}]}}'
+        [1034, 2620, 1384, 2638, 1380, 2763, 1030, 2739], "page": 1, "confidence":
+        0.985, "elements": ["#/readResults/0/lines/19/words/0"]}}}]}}'
     headers:
-      apim-request-id: ce6193e9-9d65-437b-a647-bf9615f5514d
-      content-length: '10546'
+      apim-request-id: 76e9fec0-dcaa-4321-afd5-40d559bef669
+      content-length: '8501'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:06:19 GMT
+      date: Mon, 16 Nov 2020 19:11:45 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '25'
+      x-envoy-upstream-service-time: '20'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/6bae08c6-4520-4fe9-910a-567632a7a5d0
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/32c5e7b9-27b9-4249-990d-006c3d87b6b6
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_stream_transform_png.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_async.test_receipt_stream_transform_png.yaml
@@ -15,13 +15,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 05d7c1e6-41b8-4372-85b9-90274b54500d
+      apim-request-id: 4c9a5ec2-1d32-4a02-b4fd-fa2174ececd2
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:06:23 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/05d7c1e6-41b8-4372-85b9-90274b54500d
+      date: Mon, 16 Nov 2020 19:11:49 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/4c9a5ec2-1d32-4a02-b4fd-fa2174ececd2
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '483'
+      x-envoy-upstream-service-time: '742'
     status:
       code: 202
       message: Accepted
@@ -32,169 +32,144 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/05d7c1e6-41b8-4372-85b9-90274b54500d
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/4c9a5ec2-1d32-4a02-b4fd-fa2174ececd2
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:06:23Z",
-        "lastUpdatedDateTime": "2020-11-11T18:06:25Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": -0.0752, "width": 1688, "height":
-        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [612,
-        287, 1052, 277, 1055, 384, 614, 397], "words": [{"text": "Contoso", "boundingBox":
-        [613, 288, 1051, 278, 1055, 385, 614, 398], "confidence": 0.985}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Contoso", "boundingBox":
-        [322, 590, 503, 599, 500, 654, 319, 644], "words": [{"text": "Contoso", "boundingBox":
-        [324, 590, 501, 601, 498, 654, 320, 645], "confidence": 0.932}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "123 Main Street",
-        "boundingBox": [317, 688, 647, 691, 646, 756, 317, 753], "words": [{"text":
-        "123", "boundingBox": [319, 688, 375, 690, 373, 755, 317, 753], "confidence":
-        0.987}, {"text": "Main", "boundingBox": [388, 691, 490, 694, 489, 756, 386,
-        755], "confidence": 0.986}, {"text": "Street", "boundingBox": [503, 694, 644,
-        695, 644, 754, 502, 756], "confidence": 0.985}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Redmond, WA 98052", "boundingBox":
-        [307, 795, 752, 793, 752, 857, 307, 859], "words": [{"text": "Redmond,", "boundingBox":
-        [310, 796, 516, 796, 514, 859, 308, 858], "confidence": 0.924}, {"text": "WA",
-        "boundingBox": [528, 796, 593, 796, 591, 859, 526, 859], "confidence": 0.987},
-        {"text": "98052", "boundingBox": [605, 795, 751, 793, 749, 854, 603, 859],
-        "confidence": 0.985}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "123-456-7890", "boundingBox": [303, 1003, 623, 1008, 622,
-        1070, 303, 1063], "words": [{"text": "123-456-7890", "boundingBox": [303,
-        1003, 623, 1009, 621, 1071, 303, 1064], "confidence": 0.978}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "6/10/2019 13:59",
-        "boundingBox": [299, 1221, 631, 1222, 631, 1291, 299, 1290], "words": [{"text":
-        "6/10/2019", "boundingBox": [299, 1221, 494, 1222, 492, 1292, 299, 1292],
-        "confidence": 0.955}, {"text": "13:59", "boundingBox": [508, 1223, 628, 1224,
-        625, 1292, 506, 1292], "confidence": 0.985}], "appearance": {"style": {"name":
-        "print", "confidence": 0.998}}}, {"text": "Sales Associate: Paul", "boundingBox":
-        [299, 1335, 772, 1335, 772, 1398, 299, 1396], "words": [{"text": "Sales",
-        "boundingBox": [299, 1335, 406, 1337, 408, 1397, 301, 1396], "confidence":
-        0.986}, {"text": "Associate:", "boundingBox": [418, 1337, 644, 1337, 645,
-        1399, 419, 1397], "confidence": 0.979}, {"text": "Paul", "boundingBox": [656,
-        1337, 771, 1335, 771, 1399, 656, 1399], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "---", "boundingBox":
-        [306, 1470, 370, 1469, 370, 1488, 306, 1489], "words": [{"text": "---", "boundingBox":
-        [307, 1471, 370, 1470, 371, 1489, 307, 1490], "confidence": 0.825}], "appearance":
-        {"style": {"name": "print", "confidence": 0.876}}}, {"text": "--- - -", "boundingBox":
-        [1021, 1474, 1112, 1473, 1112, 1490, 1021, 1491], "words": [{"text": "---",
-        "boundingBox": [1021, 1475, 1061, 1475, 1061, 1491, 1021, 1491], "confidence":
-        0.669}, {"text": "-", "boundingBox": [1068, 1475, 1084, 1474, 1084, 1491,
-        1067, 1491], "confidence": 0.966}, {"text": "-", "boundingBox": [1092, 1474,
-        1109, 1474, 1108, 1491, 1092, 1491], "confidence": 0.968}], "appearance":
-        {"style": {"name": "print", "confidence": 0.996}}}, {"text": "1 Surface Pro
-        6", "boundingBox": [327, 1558, 679, 1560, 678, 1624, 326, 1622], "words":
-        [{"text": "1", "boundingBox": [327, 1558, 353, 1559, 352, 1623, 327, 1623],
-        "confidence": 0.983}, {"text": "Surface", "boundingBox": [366, 1559, 536,
-        1561, 535, 1624, 365, 1623], "confidence": 0.983}, {"text": "Pro", "boundingBox":
-        [549, 1561, 622, 1562, 621, 1624, 548, 1624], "confidence": 0.952}, {"text":
-        "6", "boundingBox": [635, 1562, 677, 1563, 676, 1624, 633, 1624], "confidence":
-        0.986}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "256GB / Intel Core i5 /", "boundingBox": [366, 1666, 850, 1668, 849, 1746,
-        366, 1744], "words": [{"text": "256GB", "boundingBox": [367, 1667, 493, 1668,
-        492, 1745, 366, 1744], "confidence": 0.984}, {"text": "/", "boundingBox":
-        [508, 1668, 518, 1669, 517, 1745, 507, 1745], "confidence": 0.985}, {"text":
-        "Intel", "boundingBox": [533, 1669, 634, 1669, 632, 1746, 532, 1745], "confidence":
-        0.906}, {"text": "Core", "boundingBox": [649, 1669, 745, 1669, 743, 1747,
-        647, 1746], "confidence": 0.986}, {"text": "i5", "boundingBox": [760, 1669,
-        795, 1669, 793, 1747, 758, 1747], "confidence": 0.886}, {"text": "/", "boundingBox":
-        [811, 1669, 851, 1669, 848, 1747, 808, 1747], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "8GB RAM (Black)",
-        "boundingBox": [357, 1779, 738, 1779, 738, 1858, 357, 1859], "words": [{"text":
-        "8GB", "boundingBox": [359, 1779, 434, 1779, 433, 1860, 358, 1860], "confidence":
-        0.942}, {"text": "RAM", "boundingBox": [450, 1779, 546, 1779, 545, 1859, 449,
-        1860], "confidence": 0.986}, {"text": "(Black)", "boundingBox": [562, 1779,
-        738, 1780, 737, 1860, 561, 1859], "confidence": 0.982}], "appearance": {"style":
-        {"name": "print", "confidence": 0.999}}}, {"text": "999.00", "boundingBox":
-        [967, 1792, 1136, 1797, 1134, 1858, 967, 1855], "words": [{"text": "999.00",
-        "boundingBox": [967, 1792, 1135, 1796, 1133, 1859, 967, 1855], "confidence":
-        0.984}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "1 SurfacePen", "boundingBox": [314, 2017, 626, 2013, 627, 2078, 316, 2084],
-        "words": [{"text": "1", "boundingBox": [315, 2018, 337, 2017, 338, 2084, 316,
-        2085], "confidence": 0.986}, {"text": "SurfacePen", "boundingBox": [350, 2017,
-        624, 2013, 624, 2079, 351, 2084], "confidence": 0.979}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "$ 99.99", "boundingBox": [963,
-        2026, 1129, 2025, 1128, 2092, 963, 2092], "words": [{"text": "$", "boundingBox":
-        [963, 2025, 985, 2025, 985, 2092, 963, 2092], "confidence": 0.986}, {"text":
-        "99.99", "boundingBox": [999, 2025, 1128, 2025, 1128, 2092, 999, 2092], "confidence":
-        0.982}], "appearance": {"style": {"name": "print", "confidence": 0.994}}},
-        {"text": "------ ---", "boundingBox": [279, 2166, 491, 2157, 492, 2176, 279,
-        2186], "words": [{"text": "------", "boundingBox": [280, 2167, 421, 2161,
-        421, 2178, 280, 2186], "confidence": 0.638}, {"text": "---", "boundingBox":
-        [428, 2161, 490, 2157, 490, 2177, 427, 2178], "confidence": 0.721}], "appearance":
-        {"style": {"name": "print", "confidence": 0.903}}}, {"text": "Sub-Total",
-        "boundingBox": [464, 2243, 697, 2244, 696, 2310, 464, 2307], "words": [{"text":
-        "Sub-Total", "boundingBox": [465, 2243, 697, 2244, 694, 2311, 465, 2306],
-        "confidence": 0.935}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1098.99", "boundingBox": [952, 2255, 1141, 2251, 1140, 2325,
-        951, 2330], "words": [{"text": "1098.99", "boundingBox": [954, 2255, 1137,
-        2251, 1138, 2325, 956, 2329], "confidence": 0.982}], "appearance": {"style":
-        {"name": "print", "confidence": 0.995}}}, {"text": "Tax", "boundingBox": [564,
-        2349, 662, 2347, 662, 2423, 564, 2425], "words": [{"text": "Tax", "boundingBox":
-        [564, 2349, 657, 2347, 659, 2422, 564, 2424], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 0.993}}}, {"text": "$ 104.40", "boundingBox":
-        [940, 2371, 1131, 2368, 1129, 2433, 942, 2439], "words": [{"text": "$", "boundingBox":
-        [940, 2371, 962, 2370, 964, 2438, 941, 2439], "confidence": 0.987}, {"text":
-        "104.40", "boundingBox": [976, 2370, 1130, 2368, 1131, 2434, 977, 2438], "confidence":
-        0.984}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Total", "boundingBox": [538, 2592, 669, 2590, 669, 2650, 541, 2654], "words":
-        [{"text": "Total", "boundingBox": [538, 2592, 666, 2590, 667, 2651, 539, 2654],
-        "confidence": 0.952}], "appearance": {"style": {"name": "print", "confidence":
-        0.997}}}, {"text": "$ 1203.39", "boundingBox": [914, 2591, 1124, 2610, 1117,
-        2676, 910, 2653], "words": [{"text": "$", "boundingBox": [914, 2591, 935,
-        2593, 931, 2657, 911, 2655], "confidence": 0.987}, {"text": "1203.39", "boundingBox":
-        [947, 2593, 1123, 2612, 1116, 2676, 943, 2659], "confidence": 0.982}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}]}], "documentResults": [{"docType":
-        "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType": {"type":
-        "string", "valueString": "Itemized", "confidence": 0.99}, "MerchantName":
-        {"type": "string", "valueString": "Contoso Contoso", "text": "Contoso Contoso",
-        "boundingBox": [342.9, 238.1, 1061, 278.6, 1038.1, 685.5, 320, 645], "page":
-        1, "confidence": 0.693, "elements": ["#/readResults/0/lines/0/words/0", "#/readResults/0/lines/1/words/0"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
-        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [308.4,
-        688, 751.3, 689, 750.8, 859.6, 308, 858.5], "page": 1, "confidence": 0.989,
-        "elements": ["#/readResults/0/lines/2/words/0", "#/readResults/0/lines/2/words/1",
-        "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1",
-        "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber": {"type": "phoneNumber",
-        "text": "123-456-7890", "boundingBox": [303, 1003, 623, 1009, 621, 1071, 303,
-        1064], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/4/words/0"]},
-        "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019",
-        "boundingBox": [299, 1221, 494, 1222, 492, 1292, 299, 1292], "page": 1, "confidence":
-        0.991, "elements": ["#/readResults/0/lines/5/words/0"]}, "TransactionTime":
-        {"type": "time", "valueTime": "13:59:00", "text": "13:59", "boundingBox":
-        [508, 1223, 628, 1224, 625, 1292, 506, 1292], "page": 1, "confidence": 0.99,
-        "elements": ["#/readResults/0/lines/5/words/1"]}, "Items": {"type": "array",
-        "valueArray": [{"type": "object", "valueObject": {"Quantity": {"type": "number",
-        "valueNumber": 1, "text": "1", "boundingBox": [327, 1558, 353, 1559, 352,
-        1623, 327, 1623], "page": 1, "confidence": 0.745, "elements": ["#/readResults/0/lines/9/words/0"]}}},
-        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
-        "8GB RAM (Black)", "text": "8GB RAM (Black)", "boundingBox": [358, 1779, 738,
-        1779, 738, 1860, 358, 1860], "page": 1, "confidence": 0.968, "elements": ["#/readResults/0/lines/11/words/0",
-        "#/readResults/0/lines/11/words/1", "#/readResults/0/lines/11/words/2"]},
-        "TotalPrice": {"type": "number", "valueNumber": 999, "text": "999.00", "boundingBox":
-        [967, 1792, 1135, 1796, 1133, 1859, 967, 1855], "page": 1, "confidence": 0.97,
-        "elements": ["#/readResults/0/lines/12/words/0"]}}}, {"type": "object", "valueObject":
-        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [315, 2018, 337, 2017, 338, 2084, 316, 2085], "page": 1, "confidence": 0.91,
-        "elements": ["#/readResults/0/lines/13/words/0"]}, "Name": {"type": "string",
-        "valueString": "SurfacePen", "text": "SurfacePen", "boundingBox": [350, 2017,
-        624, 2013, 624, 2079, 351, 2084], "page": 1, "confidence": 0.959, "elements":
-        ["#/readResults/0/lines/13/words/1"]}, "TotalPrice": {"type": "number", "valueNumber":
-        99.99, "text": "$99.99", "boundingBox": [963, 2025, 1128, 2025, 1128, 2092,
-        963, 2092], "page": 1, "confidence": 0.775, "elements": ["#/readResults/0/lines/14/words/0",
-        "#/readResults/0/lines/14/words/1"]}}}]}, "Subtotal": {"type": "number", "valueNumber":
-        1098.99, "text": "1098.99", "boundingBox": [954, 2255, 1137, 2251, 1138, 2325,
-        956, 2329], "page": 1, "confidence": 0.986, "elements": ["#/readResults/0/lines/17/words/0"]},
-        "Total": {"type": "number", "valueNumber": 104.4, "text": "104.40", "boundingBox":
-        [976, 2370, 1130, 2368, 1131, 2434, 977, 2438], "page": 1, "confidence": 0.668,
-        "elements": ["#/readResults/0/lines/19/words/1"]}}}]}}'
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:11:49Z",
+        "lastUpdatedDateTime": "2020-11-16T19:11:51Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.2511, "width": 1688, "height":
+        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [619,
+        291, 1051, 284, 1053, 384, 620, 396], "words": [{"text": "Contoso", "boundingBox":
+        [623, 292, 1051, 284, 1052, 383, 624, 397], "confidence": 0.959}]}, {"text":
+        "Contoso", "boundingBox": [322, 591, 501, 601, 498, 654, 319, 644], "words":
+        [{"text": "Contoso", "boundingBox": [328, 591, 500, 602, 498, 654, 325, 644],
+        "confidence": 0.727}]}, {"text": "123 Main Street", "boundingBox": [319, 690,
+        655, 695, 654, 757, 318, 752], "words": [{"text": "123", "boundingBox": [323,
+        690, 387, 692, 383, 754, 319, 753], "confidence": 0.958}, {"text": "Main",
+        "boundingBox": [399, 692, 502, 694, 498, 756, 395, 754], "confidence": 0.958},
+        {"text": "Street", "boundingBox": [514, 695, 656, 698, 653, 758, 510, 756],
+        "confidence": 0.958}]}, {"text": "Redmond, WA 98052", "boundingBox": [317,
+        795, 751, 795, 752, 859, 317, 860], "words": [{"text": "Redmond,", "boundingBox":
+        [321, 795, 523, 795, 520, 861, 317, 858], "confidence": 0.57}, {"text": "WA",
+        "boundingBox": [535, 795, 597, 795, 595, 861, 532, 861], "confidence": 0.958},
+        {"text": "98052", "boundingBox": [610, 795, 749, 796, 747, 858, 607, 861],
+        "confidence": 0.958}]}, {"text": "123-456-7890", "boundingBox": [306, 1005,
+        618, 1011, 616, 1068, 305, 1062], "words": [{"text": "123-456-7890", "boundingBox":
+        [306, 1005, 617, 1012, 615, 1069, 305, 1064], "confidence": 0.937}]}, {"text":
+        "6/10/2019 13:59", "boundingBox": [303, 1223, 630, 1225, 629, 1289, 302, 1286],
+        "words": [{"text": "6/10/2019", "boundingBox": [304, 1224, 506, 1224, 504,
+        1289, 303, 1288], "confidence": 0.762}, {"text": "13:59", "boundingBox": [518,
+        1225, 628, 1228, 627, 1290, 517, 1289], "confidence": 0.949}]}, {"text": "Sales
+        Associate: Paul", "boundingBox": [294, 1335, 768, 1335, 768, 1401, 294, 1399],
+        "words": [{"text": "Sales", "boundingBox": [302, 1336, 418, 1335, 416, 1399,
+        301, 1399], "confidence": 0.959}, {"text": "Associate:", "boundingBox": [430,
+        1335, 649, 1336, 646, 1401, 428, 1399], "confidence": 0.95}, {"text": "Paul",
+        "boundingBox": [661, 1336, 767, 1336, 764, 1402, 659, 1401], "confidence":
+        0.959}]}, {"text": "1 Surface Pro 6", "boundingBox": [336, 1560, 679, 1561,
+        678, 1625, 336, 1623], "words": [{"text": "1", "boundingBox": [337, 1560,
+        360, 1561, 360, 1625, 337, 1625], "confidence": 0.799}, {"text": "Surface",
+        "boundingBox": [373, 1561, 543, 1562, 542, 1624, 373, 1625], "confidence":
+        0.958}, {"text": "Pro", "boundingBox": [555, 1562, 632, 1563, 631, 1625, 555,
+        1624], "confidence": 0.91}, {"text": "6", "boundingBox": [644, 1563, 676,
+        1563, 675, 1625, 644, 1625], "confidence": 0.762}]}, {"text": "256GB / Intel
+        Core i5 /", "boundingBox": [372, 1669, 846, 1669, 846, 1743, 372, 1742], "words":
+        [{"text": "256GB", "boundingBox": [375, 1670, 506, 1671, 504, 1740, 373, 1740],
+        "confidence": 0.952}, {"text": "/", "boundingBox": [520, 1671, 533, 1671,
+        531, 1740, 517, 1740], "confidence": 0.879}, {"text": "Intel", "boundingBox":
+        [547, 1671, 648, 1671, 646, 1741, 545, 1740], "confidence": 0.879}, {"text":
+        "Core", "boundingBox": [662, 1671, 758, 1670, 756, 1743, 660, 1741], "confidence":
+        0.95}, {"text": "i5", "boundingBox": [772, 1670, 809, 1670, 807, 1744, 770,
+        1743], "confidence": 0.817}, {"text": "/", "boundingBox": [823, 1670, 847,
+        1670, 846, 1744, 821, 1744], "confidence": 0.841}]}, {"text": "8GB RAM (Black)",
+        "boundingBox": [370, 1782, 732, 1785, 731, 1853, 370, 1850], "words": [{"text":
+        "8GB", "boundingBox": [374, 1783, 451, 1783, 448, 1850, 370, 1850], "confidence":
+        0.798}, {"text": "RAM", "boundingBox": [465, 1783, 561, 1784, 559, 1851, 461,
+        1850], "confidence": 0.958}, {"text": "(Black)", "boundingBox": [575, 1784,
+        731, 1785, 729, 1854, 572, 1852], "confidence": 0.959}]}, {"text": "$ 999.00",
+        "boundingBox": [937, 1785, 1139, 1790, 1137, 1862, 936, 1859], "words": [{"text":
+        "$", "boundingBox": [939, 1785, 959, 1785, 958, 1859, 938, 1859], "confidence":
+        0.895}, {"text": "999.00", "boundingBox": [974, 1786, 1134, 1789, 1133, 1863,
+        973, 1860], "confidence": 0.877}]}, {"text": "1 SurfacePen", "boundingBox":
+        [320, 2019, 627, 2013, 629, 2076, 321, 2083], "words": [{"text": "1", "boundingBox":
+        [321, 2021, 348, 2020, 349, 2084, 322, 2084], "confidence": 0.82}, {"text":
+        "SurfacePen", "boundingBox": [360, 2020, 626, 2014, 628, 2077, 362, 2083],
+        "confidence": 0.928}]}, {"text": "$ 99.99", "boundingBox": [967, 2028, 1128,
+        2029, 1127, 2091, 967, 2091], "words": [{"text": "$", "boundingBox": [969,
+        2028, 994, 2028, 994, 2091, 969, 2091], "confidence": 0.888}, {"text": "99.99",
+        "boundingBox": [1007, 2028, 1127, 2028, 1126, 2091, 1007, 2091], "confidence":
+        0.911}]}, {"text": "Sub-Total", "boundingBox": [474, 2242, 697, 2244, 697,
+        2310, 473, 2308], "words": [{"text": "Sub-Total", "boundingBox": [477, 2242,
+        695, 2245, 694, 2310, 474, 2308], "confidence": 0.915}]}, {"text": "$ 1098.99",
+        "boundingBox": [922, 2259, 1136, 2253, 1138, 2318, 924, 2325], "words": [{"text":
+        "$", "boundingBox": [924, 2261, 950, 2260, 954, 2326, 928, 2326], "confidence":
+        0.881}, {"text": "1098.99", "boundingBox": [963, 2260, 1136, 2254, 1137, 2320,
+        966, 2325], "confidence": 0.942}]}, {"text": "Tax", "boundingBox": [570, 2355,
+        655, 2357, 654, 2415, 568, 2413], "words": [{"text": "Tax", "boundingBox":
+        [571, 2355, 654, 2357, 653, 2415, 570, 2413], "confidence": 0.958}]}, {"text":
+        "$ 104.40", "boundingBox": [941, 2368, 1134, 2364, 1137, 2433, 942, 2438],
+        "words": [{"text": "$", "boundingBox": [943, 2368, 966, 2367, 968, 2437, 944,
+        2438], "confidence": 0.892}, {"text": "104.40", "boundingBox": [980, 2367,
+        1132, 2364, 1133, 2434, 982, 2437], "confidence": 0.952}]}, {"text": "Total",
+        "boundingBox": [551, 2591, 672, 2584, 675, 2652, 554, 2659], "words": [{"text":
+        "Total", "boundingBox": [551, 2591, 668, 2584, 672, 2652, 554, 2659], "confidence":
+        0.727}]}, {"text": "$ 1203.39", "boundingBox": [918, 2589, 1123, 2611, 1116,
+        2677, 912, 2656], "words": [{"text": "$", "boundingBox": [918, 2590, 942,
+        2592, 936, 2659, 913, 2656], "confidence": 0.886}, {"text": "1203.39", "boundingBox":
+        [955, 2594, 1123, 2611, 1115, 2678, 949, 2661], "confidence": 0.951}]}]}],
+        "documentResults": [{"docType": "prebuilt:receipt", "pageRange": [1, 1], "fields":
+        {"ReceiptType": {"type": "string", "valueString": "Itemized", "confidence":
+        0.659}, "MerchantName": {"type": "string", "valueString": "Contoso Contoso",
+        "text": "Contoso Contoso", "boundingBox": [349.3, 241.3, 1058, 284.4, 1033.5,
+        687.1, 324.8, 644], "page": 1, "confidence": 0.516, "elements": ["#/readResults/0/lines/0/words/0",
+        "#/readResults/0/lines/1/words/0"]}, "MerchantAddress": {"type": "string",
+        "valueString": "123 Main Street Redmond, WA 98052", "text": "123 Main Street
+        Redmond, WA 98052", "boundingBox": [319.9, 689.9, 750.7, 697.5, 747.8, 865.6,
+        317, 858], "page": 1, "confidence": 0.986, "elements": ["#/readResults/0/lines/2/words/0",
+        "#/readResults/0/lines/2/words/1", "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0",
+        "#/readResults/0/lines/3/words/1", "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber":
+        {"type": "phoneNumber", "text": "123-456-7890", "boundingBox": [306, 1005,
+        617, 1012, 615, 1069, 305, 1064], "page": 1, "confidence": 0.99, "elements":
+        ["#/readResults/0/lines/4/words/0"]}, "TransactionDate": {"type": "date",
+        "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox": [304, 1224,
+        506, 1224, 504, 1289, 303, 1288], "page": 1, "confidence": 0.985, "elements":
+        ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type": "time",
+        "valueTime": "13:59:00", "text": "13:59", "boundingBox": [518, 1225, 628,
+        1228, 627, 1290, 517, 1289], "page": 1, "confidence": 0.968, "elements": ["#/readResults/0/lines/5/words/1"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "8GB RAM (Black)", "text": "8GB
+        RAM (Black)", "boundingBox": [370.7, 1781.5, 731, 1785, 730.3, 1854, 370,
+        1850.6], "page": 1, "confidence": 0.916, "elements": ["#/readResults/0/lines/9/words/0",
+        "#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2"]}, "TotalPrice":
+        {"type": "number", "valueNumber": 999, "text": "$999.00", "boundingBox": [939,
+        1784.6, 1134.4, 1788.3, 1133, 1863, 937.6, 1859.3], "page": 1, "confidence":
+        0.559, "elements": ["#/readResults/0/lines/10/words/0", "#/readResults/0/lines/10/words/1"]}}},
+        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
+        1, "text": "1", "boundingBox": [321, 2021, 348, 2020, 349, 2084, 322, 2084],
+        "page": 1, "confidence": 0.858, "elements": ["#/readResults/0/lines/11/words/0"]},
+        "Name": {"type": "string", "valueString": "SurfacePen", "text": "SurfacePen",
+        "boundingBox": [360, 2020, 626, 2014, 628, 2077, 362, 2083], "page": 1, "confidence":
+        0.858, "elements": ["#/readResults/0/lines/11/words/1"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 99.99, "text": "99.99", "boundingBox": [1007, 2028,
+        1127, 2028, 1126, 2091, 1007, 2091], "page": 1, "confidence": 0.386, "elements":
+        ["#/readResults/0/lines/12/words/1"]}}}]}, "Subtotal": {"type": "number",
+        "valueNumber": 1098.99, "text": "1098.99", "boundingBox": [963, 2260, 1136,
+        2254, 1137, 2320, 966, 2325], "page": 1, "confidence": 0.964, "elements":
+        ["#/readResults/0/lines/14/words/1"]}, "Tax": {"type": "number", "valueNumber":
+        104.4, "text": "$104.40", "boundingBox": [942.6, 2367.5, 1132, 2363.7, 1133.4,
+        2434.2, 944, 2438], "page": 1, "confidence": 0.713, "elements": ["#/readResults/0/lines/16/words/0",
+        "#/readResults/0/lines/16/words/1"]}, "Total": {"type": "number", "valueNumber":
+        1203.39, "text": "1203.39", "boundingBox": [955, 2594, 1123, 2611, 1115, 2678,
+        949, 2661], "page": 1, "confidence": 0.774, "elements": ["#/readResults/0/lines/18/words/1"]}}}]}}'
     headers:
-      apim-request-id: e41d4100-9f76-47db-8556-0b118f2b63c2
-      content-length: '10615'
+      apim-request-id: a45b35f4-9dbe-4e4c-bc33-43a0e92e06f7
+      content-length: '8807'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:06:28 GMT
+      date: Mon, 16 Nov 2020 19:11:54 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '21'
+      x-envoy-upstream-service-time: '22'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/05d7c1e6-41b8-4372-85b9-90274b54500d
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/4c9a5ec2-1d32-4a02-b4fd-fa2174ececd2
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_polling_interval.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_polling_interval.yaml
@@ -21,19 +21,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 994fafbc-b946-4d4b-9950-738cad5810a4
+      - 81ee1673-e581-4bd4-a8ea-b9d8fe034d09
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:06:36 GMT
+      - Mon, 16 Nov 2020 19:12:03 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/994fafbc-b946-4d4b-9950-738cad5810a4
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/81ee1673-e581-4bd4-a8ea-b9d8fe034d09
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '639'
+      - '552'
     status:
       code: 202
       message: Accepted
@@ -49,65 +49,65 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/994fafbc-b946-4d4b-9950-738cad5810a4
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/81ee1673-e581-4bd4-a8ea-b9d8fe034d09
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:06:36Z",
-        "lastUpdatedDateTime": "2020-11-11T18:06:38Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:12:03Z",
+        "lastUpdatedDateTime": "2020-11-16T19:12:06Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [380.9, 282.9,
-        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.716}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [298.3, 676.5, 844.6,
-        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence":
-        0.99}, "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text":
-        "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505, 1331, 255, 1312],
-        "page": 1, "confidence": 0.99}, "TransactionTime": {"type": "time", "valueTime":
-        "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681, 1262, 675, 1341,
-        522, 1332], "page": 1, "confidence": 0.989}, "Items": {"type": "array", "valueArray":
-        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [244, 1581, 288, 1584, 285, 1678, 241, 1675],
-        "page": 1, "confidence": 0.919}, "Name": {"type": "string", "valueString":
-        "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585, 658, 1598,
-        657, 1688, 304, 1679], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1106, 1579,
-        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.959}}}, {"type":
-        "object", "valueObject": {"Quantity": {"type": "number", "valueNumber": 1,
-        "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [294, 1839, 737, 1839,
-        737, 1924, 294, 1924], "page": 1, "confidence": 0.955}, "TotalPrice": {"type":
-        "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox": [1134, 1948,
-        1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence": 0.958}}}]},
-        "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923}, "Tax": {"type": "number", "valueNumber": 1.17, "text": "1.17", "boundingBox":
-        [1186, 2356, 1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence":
-        0.979}, "Tip": {"type": "number", "valueNumber": 463, "text": "$463", "boundingBox":
-        [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "page": 1, "confidence":
-        0.975}, "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50",
-        "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1,
-        "confidence": 0.987}}}]}}'
+        "Itemized", "confidence": 0.692}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [378.2, 292.4,
+        1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8], "page": 1, "confidence": 0.613},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [302,
+        675.8, 848.1, 793.7, 809.9, 970.4, 263.9, 852.5], "page": 1, "confidence":
+        0.99}, "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber":
+        "+19876543210", "text": "987-654-3210", "boundingBox": [278, 1004, 656, 1057,
+        647, 1123, 271, 1075], "page": 1, "confidence": 0.99}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99},
+        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
+        "boundingBox": [541, 1248, 677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence":
+        0.977}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
+        [245, 1583, 299, 1585, 295, 1676, 241, 1671], "page": 1, "confidence": 0.92},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923}, "TotalPrice": {"type": "number", "valueNumber": 2.2, "text": "$2.20",
+        "boundingBox": [1108, 1584, 1263, 1574, 1268, 1656, 1113, 1666], "page": 1,
+        "confidence": 0.918}}}, {"type": "object", "valueObject": {"Quantity": {"type":
+        "number", "valueNumber": 1, "text": "1", "boundingBox": [232, 1834, 286, 1836,
+        285, 1920, 231, 1920], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916},
+        "TotalPrice": {"type": "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox":
+        [1135, 1955, 1257, 1952, 1259, 2036, 1136, 2039], "page": 1, "confidence":
+        0.916}}}]}, "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70",
+        "boundingBox": [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1,
+        "confidence": 0.955}, "Tax": {"type": "number", "valueNumber": 1.17, "text":
+        "1.17", "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "page":
+        1, "confidence": 0.979}, "Tip": {"type": "number", "valueNumber": 1.63, "text":
+        "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591, 1091, 2585], "page":
+        1, "confidence": 0.941}, "Total": {"type": "number", "valueNumber": 14.5,
+        "text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380, 2763, 1030,
+        2739], "page": 1, "confidence": 0.985}}}]}}'
     headers:
       apim-request-id:
-      - a4cfd73c-169e-4411-a242-e764df1380ba
+      - 7ee3cca8-da7a-4265-9fe1-bcfbee654b27
       content-length:
-      - '2820'
+      - '2835'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:06:42 GMT
+      - Mon, 16 Nov 2020 19:12:09 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '28'
+      - '37'
     status:
       code: 200
       message: OK
@@ -133,19 +133,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - eaeeecbc-00d3-4e84-863f-d03dbdf76e67
+      - 5cc6fc7c-b07b-47c6-9911-02d94c6f5eee
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:06:43 GMT
+      - Mon, 16 Nov 2020 19:12:09 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/eaeeecbc-00d3-4e84-863f-d03dbdf76e67
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/5cc6fc7c-b07b-47c6-9911-02d94c6f5eee
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '349'
+      - '348'
     status:
       code: 202
       message: Accepted
@@ -161,65 +161,65 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/eaeeecbc-00d3-4e84-863f-d03dbdf76e67
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/5cc6fc7c-b07b-47c6-9911-02d94c6f5eee
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:06:43Z",
-        "lastUpdatedDateTime": "2020-11-11T18:06:45Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:12:10Z",
+        "lastUpdatedDateTime": "2020-11-16T19:12:12Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [380.9, 282.9,
-        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.716}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [298.3, 676.5, 844.6,
-        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence":
-        0.99}, "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text":
-        "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505, 1331, 255, 1312],
-        "page": 1, "confidence": 0.99}, "TransactionTime": {"type": "time", "valueTime":
-        "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681, 1262, 675, 1341,
-        522, 1332], "page": 1, "confidence": 0.989}, "Items": {"type": "array", "valueArray":
-        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [244, 1581, 288, 1584, 285, 1678, 241, 1675],
-        "page": 1, "confidence": 0.919}, "Name": {"type": "string", "valueString":
-        "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585, 658, 1598,
-        657, 1688, 304, 1679], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1106, 1579,
-        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.959}}}, {"type":
-        "object", "valueObject": {"Quantity": {"type": "number", "valueNumber": 1,
-        "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [294, 1839, 737, 1839,
-        737, 1924, 294, 1924], "page": 1, "confidence": 0.955}, "TotalPrice": {"type":
-        "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox": [1134, 1948,
-        1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence": 0.958}}}]},
-        "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923}, "Tax": {"type": "number", "valueNumber": 1.17, "text": "1.17", "boundingBox":
-        [1186, 2356, 1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence":
-        0.979}, "Tip": {"type": "number", "valueNumber": 463, "text": "$463", "boundingBox":
-        [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "page": 1, "confidence":
-        0.975}, "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50",
-        "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1,
-        "confidence": 0.987}}}]}}'
+        "Itemized", "confidence": 0.692}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [378.2, 292.4,
+        1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8], "page": 1, "confidence": 0.613},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [302,
+        675.8, 848.1, 793.7, 809.9, 970.4, 263.9, 852.5], "page": 1, "confidence":
+        0.99}, "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber":
+        "+19876543210", "text": "987-654-3210", "boundingBox": [278, 1004, 656, 1057,
+        647, 1123, 271, 1075], "page": 1, "confidence": 0.99}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99},
+        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
+        "boundingBox": [541, 1248, 677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence":
+        0.977}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
+        [245, 1583, 299, 1585, 295, 1676, 241, 1671], "page": 1, "confidence": 0.92},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923}, "TotalPrice": {"type": "number", "valueNumber": 2.2, "text": "$2.20",
+        "boundingBox": [1108, 1584, 1263, 1574, 1268, 1656, 1113, 1666], "page": 1,
+        "confidence": 0.918}}}, {"type": "object", "valueObject": {"Quantity": {"type":
+        "number", "valueNumber": 1, "text": "1", "boundingBox": [232, 1834, 286, 1836,
+        285, 1920, 231, 1920], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916},
+        "TotalPrice": {"type": "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox":
+        [1135, 1955, 1257, 1952, 1259, 2036, 1136, 2039], "page": 1, "confidence":
+        0.916}}}]}, "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70",
+        "boundingBox": [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1,
+        "confidence": 0.955}, "Tax": {"type": "number", "valueNumber": 1.17, "text":
+        "1.17", "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "page":
+        1, "confidence": 0.979}, "Tip": {"type": "number", "valueNumber": 1.63, "text":
+        "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591, 1091, 2585], "page":
+        1, "confidence": 0.941}, "Total": {"type": "number", "valueNumber": 14.5,
+        "text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380, 2763, 1030,
+        2739], "page": 1, "confidence": 0.985}}}]}}'
     headers:
       apim-request-id:
-      - 3dd6f686-9db6-4f93-a0ca-57055847238e
+      - 67400892-e0a8-447b-87ff-30a4eb27f4ac
       content-length:
-      - '2820'
+      - '2835'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:06:50 GMT
+      - Mon, 16 Nov 2020 19:12:16 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '25'
+      - '21'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_bad_url.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_bad_url.yaml
@@ -19,23 +19,23 @@ interactions:
   response:
     body:
       string: '{"error": {"code": "FailedToDownloadImage", "innerError": {"requestId":
-        "2c76697b-07ba-48f3-9f89-f615ef7c9a54"}, "message": "Failed to download image
+        "193b4d02-9294-4887-a8fe-f589c54d0e08"}, "message": "Failed to download image
         from input URL."}}'
     headers:
       apim-request-id:
-      - 2c76697b-07ba-48f3-9f89-f615ef7c9a54
+      - 193b4d02-9294-4887-a8fe-f589c54d0e08
       content-length:
       - '161'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:06:53 GMT
+      - Mon, 16 Nov 2020 19:12:21 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '3203'
+      - '3218'
     status:
       code: 400
       message: Bad Request

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_locale_error.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_locale_error.yaml
@@ -19,23 +19,23 @@ interactions:
   response:
     body:
       string: '{"error": {"code": "UnsupportedLocale", "innerError": {"requestId":
-        "d63559c8-6e22-4c6a-af97-47f045e6a1bf"}, "message": "Locale unsupported. Supported
+        "6eb8d956-96ac-4d86-a330-d41094ca667d"}, "message": "Locale unsupported. Supported
         locales include en-AU, en-CA, en-GB, en-IN and en-US."}}'
     headers:
       apim-request-id:
-      - d63559c8-6e22-4c6a-af97-47f045e6a1bf
+      - 6eb8d956-96ac-4d86-a330-d41094ca667d
       content-length:
       - '200'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:07:01 GMT
+      - Mon, 16 Nov 2020 19:12:27 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '171'
+      - '219'
     status:
       code: 400
       message: Bad Request

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_locale_specified.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_locale_specified.yaml
@@ -21,19 +21,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 0304b159-bf7b-404d-af32-5f4863096782
+      - ac6bed64-4679-4473-b5ab-32256a27f055
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:07:01 GMT
+      - Mon, 16 Nov 2020 19:12:28 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/0304b159-bf7b-404d-af32-5f4863096782
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/ac6bed64-4679-4473-b5ab-32256a27f055
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '392'
+      - '300'
     status:
       code: 202
       message: Accepted
@@ -49,20 +49,20 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/0304b159-bf7b-404d-af32-5f4863096782
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/ac6bed64-4679-4473-b5ab-32256a27f055
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:07:01Z",
-        "lastUpdatedDateTime": "2020-11-11T18:07:05Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:12:28Z",
+        "lastUpdatedDateTime": "2020-11-16T19:12:30Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
         "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
         "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [380.9, 282.9,
-        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.989}, "MerchantAddress":
+        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.769}, "MerchantAddress":
         {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
         "123 Main Street Redmond, WA 98052", "boundingBox": [298.3, 676.5, 844.6,
-        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.993}, "MerchantPhoneNumber":
+        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.99}, "MerchantPhoneNumber":
         {"type": "phoneNumber", "valuePhoneNumber": "+919876543210", "text": "987-654-3210",
         "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence":
         0.995}, "TransactionDate": {"type": "date", "valueDate": "2019-10-06", "text":
@@ -72,38 +72,40 @@ interactions:
         522, 1332], "page": 1, "confidence": 0.995}, "Items": {"type": "array", "valueArray":
         [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
         1, "text": "1", "boundingBox": [244, 1581, 288, 1584, 285, 1678, 241, 1675],
-        "page": 1, "confidence": 0.919}, "Name": {"type": "string", "valueString":
+        "page": 1, "confidence": 0.936}, "Name": {"type": "string", "valueString":
         "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585, 658, 1598,
-        657, 1688, 304, 1679], "page": 1, "confidence": 0.982}, "TotalPrice": {"type":
+        657, 1688, 304, 1679], "page": 1, "confidence": 0.976}, "TotalPrice": {"type":
         "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1106, 1579,
-        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.971}}}, {"type":
+        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.988}}}, {"type":
         "object", "valueObject": {"Quantity": {"type": "number", "valueNumber": 1,
         "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.918}, "Name": {"type": "string", "valueString":
-        "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [294, 1839, 737, 1839,
-        737, 1924, 294, 1924], "page": 1, "confidence": 0.892}, "TotalPrice": {"type":
-        "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox": [1134, 1948,
-        1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence": 0.969}}}]},
-        "Tax": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.971}, "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50",
-        "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1,
-        "confidence": 0.99}}}]}}'
+        "page": 1, "confidence": 0.882}, "Name": {"type": "string", "valueString":
+        "BACON & EGGS Sunny-side-up", "text": "BACON & EGGS Sunny-side-up", "boundingBox":
+        [294, 1839, 757, 1839, 757, 2064, 294, 2064], "page": 1, "confidence": 0.506},
+        "TotalPrice": {"type": "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox":
+        [1134, 1948, 1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence":
+        0.987}}}]}, "Tax": {"type": "number", "valueNumber": 1.17, "text": "1.17",
+        "boundingBox": [1186, 2356, 1307, 2361, 1303, 2452, 1182, 2447], "page": 1,
+        "confidence": 0.994}, "Total": {"type": "number", "valueNumber": 14.5, "text":
+        "$14.50", "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740],
+        "page": 1, "confidence": 0.988}, "Subtotal": {"type": "number", "valueNumber":
+        11.7, "text": "11.70", "boundingBox": [1139, 2228, 1309, 2228, 1308, 2313,
+        1138, 2313], "page": 1, "confidence": 0.269}}}]}}'
     headers:
       apim-request-id:
-      - 7ddce746-cf01-474e-99ee-de264d3aa2b0
+      - 5aeb04de-51dc-4670-b196-fc05e460ed7f
       content-length:
-      - '2537'
+      - '2711'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:07:06 GMT
+      - Mon, 16 Nov 2020 19:12:33 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '20'
+      - '23'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_multipage_transform_url.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_multipage_transform_url.yaml
@@ -21,19 +21,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 66731ff1-dbbf-43c9-b0d4-988b81122612
+      - dd7b455a-4871-4444-b566-e398d48872e7
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:07:08 GMT
+      - Mon, 16 Nov 2020 19:12:34 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/66731ff1-dbbf-43c9-b0d4-988b81122612
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/dd7b455a-4871-4444-b566-e398d48872e7
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '551'
+      - '441'
     status:
       code: 202
       message: Accepted
@@ -49,11 +49,11 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/66731ff1-dbbf-43c9-b0d4-988b81122612
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/dd7b455a-4871-4444-b566-e398d48872e7
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:07:08Z",
-        "lastUpdatedDateTime": "2020-11-11T18:07:11Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:12:34Z",
+        "lastUpdatedDateTime": "2020-11-16T19:12:38Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": 0, "width": 8.5, "height": 11,
         "unit": "inch", "lines": [{"text": "Company A Invoice", "boundingBox": [0.8861,
         1.1217, 2.3783, 1.1217, 2.3783, 1.2812, 0.8861, 1.2812], "words": [{"text":
@@ -61,391 +61,371 @@ interactions:
         0.8861, 1.2812], "confidence": 1}, {"text": "A", "boundingBox": [1.6696, 1.1242,
         1.7749, 1.1242, 1.7749, 1.2473, 1.6696, 1.2473], "confidence": 1}, {"text":
         "Invoice", "boundingBox": [1.8389, 1.1217, 2.3783, 1.1217, 2.3783, 1.2485,
-        1.8389, 1.2485], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "Invoice For:", "boundingBox": [6.0211, 1.0656,
-        7.0357, 1.0656, 7.0357, 1.2121, 6.0211, 1.2121], "words": [{"text": "Invoice",
-        "boundingBox": [6.0211, 1.0656, 6.6362, 1.0656, 6.6362, 1.2121, 6.0211, 1.2121],
-        "confidence": 1}, {"text": "For:", "boundingBox": [6.7147, 1.0691, 7.0357,
-        1.0691, 7.0357, 1.2121, 6.7147, 1.2121], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Address:", "boundingBox":
-        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "words":
-        [{"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825, 1.5657,
-        1.6155, 0.8791, 1.6155], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Bilbo Baggins", "boundingBox": [6.0164,
-        1.4503, 6.8967, 1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "words": [{"text":
-        "Bilbo", "boundingBox": [6.0164, 1.4503, 6.3392, 1.4503, 6.3392, 1.5649, 6.0164,
-        1.5649], "confidence": 1}, {"text": "Baggins", "boundingBox": [6.396, 1.4556,
-        6.8967, 1.4556, 6.8967, 1.5931, 6.396, 1.5931], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "123 Hobbit Lane",
-        "boundingBox": [6.0165, 1.6707, 7.1006, 1.6707, 7.1006, 1.7854, 6.0165, 1.7854],
-        "words": [{"text": "123", "boundingBox": [6.0165, 1.6772, 6.2434, 1.6772,
-        6.2434, 1.7854, 6.0165, 1.7854], "confidence": 1}, {"text": "Hobbit", "boundingBox":
-        [6.3033, 1.6707, 6.7463, 1.6707, 6.7463, 1.7854, 6.3033, 1.7854], "confidence":
-        1}, {"text": "Lane", "boundingBox": [6.803, 1.6782, 7.1006, 1.6782, 7.1006,
-        1.7854, 6.803, 1.7854], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "567 Main St.", "boundingBox": [0.8852,
-        1.846, 1.713, 1.846, 1.713, 1.9554, 0.8852, 1.9554], "words": [{"text": "567",
-        "boundingBox": [0.8852, 1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554],
-        "confidence": 1}, {"text": "Main", "boundingBox": [1.1777, 1.846, 1.5022,
-        1.846, 1.5022, 1.9554, 1.1777, 1.9554], "confidence": 1}, {"text": "St.",
-        "boundingBox": [1.5558, 1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Redmond, WA", "boundingBox": [6.0164, 1.891, 6.9793, 1.891,
-        6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text": "Redmond,", "boundingBox":
-        [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275, 6.0164, 2.0275], "confidence":
-        1}, {"text": "WA", "boundingBox": [6.7408, 1.8982, 6.9793, 1.8982, 6.9793,
-        2.0044, 6.7408, 2.0044], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Redmond, WA", "boundingBox": [0.891,
-        2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,",
-        "boundingBox": [0.891, 2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975],
-        "confidence": 1}, {"text": "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682,
-        1.8537, 2.1744, 1.6152, 2.1744], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "555-555-5555", "boundingBox":
-        [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "words":
-        [{"text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187,
-        6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "555-555-5555", "boundingBox":
+        1.8389, 1.2485], "confidence": 1}]}, {"text": "Invoice For:", "boundingBox":
+        [6.0211, 1.0656, 7.0357, 1.0656, 7.0357, 1.2121, 6.0211, 1.2121], "words":
+        [{"text": "Invoice", "boundingBox": [6.0211, 1.0656, 6.6362, 1.0656, 6.6362,
+        1.2121, 6.0211, 1.2121], "confidence": 1}, {"text": "For:", "boundingBox":
+        [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121, 6.7147, 1.2121], "confidence":
+        1}]}, {"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825,
+        1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text": "Address:", "boundingBox":
+        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "confidence":
+        1}]}, {"text": "Bilbo Baggins", "boundingBox": [6.0164, 1.4503, 6.8967, 1.4503,
+        6.8967, 1.5931, 6.0164, 1.5931], "words": [{"text": "Bilbo", "boundingBox":
+        [6.0164, 1.4503, 6.3392, 1.4503, 6.3392, 1.5649, 6.0164, 1.5649], "confidence":
+        1}, {"text": "Baggins", "boundingBox": [6.396, 1.4556, 6.8967, 1.4556, 6.8967,
+        1.5931, 6.396, 1.5931], "confidence": 1}]}, {"text": "123 Hobbit Lane", "boundingBox":
+        [6.0165, 1.6707, 7.1006, 1.6707, 7.1006, 1.7854, 6.0165, 1.7854], "words":
+        [{"text": "123", "boundingBox": [6.0165, 1.6772, 6.2434, 1.6772, 6.2434, 1.7854,
+        6.0165, 1.7854], "confidence": 1}, {"text": "Hobbit", "boundingBox": [6.3033,
+        1.6707, 6.7463, 1.6707, 6.7463, 1.7854, 6.3033, 1.7854], "confidence": 1},
+        {"text": "Lane", "boundingBox": [6.803, 1.6782, 7.1006, 1.6782, 7.1006, 1.7854,
+        6.803, 1.7854], "confidence": 1}]}, {"text": "567 Main St.", "boundingBox":
+        [0.8852, 1.846, 1.713, 1.846, 1.713, 1.9554, 0.8852, 1.9554], "words": [{"text":
+        "567", "boundingBox": [0.8852, 1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852,
+        1.9554], "confidence": 1}, {"text": "Main", "boundingBox": [1.1777, 1.846,
+        1.5022, 1.846, 1.5022, 1.9554, 1.1777, 1.9554], "confidence": 1}, {"text":
+        "St.", "boundingBox": [1.5558, 1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558,
+        1.9554], "confidence": 1}]}, {"text": "Redmond, WA", "boundingBox": [6.0164,
+        1.891, 6.9793, 1.891, 6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text":
+        "Redmond,", "boundingBox": [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275,
+        6.0164, 2.0275], "confidence": 1}, {"text": "WA", "boundingBox": [6.7408,
+        1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408, 2.0044], "confidence": 1}]},
+        {"text": "Redmond, WA", "boundingBox": [0.891, 2.061, 1.8537, 2.061, 1.8537,
+        2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,", "boundingBox": [0.891,
+        2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975], "confidence": 1}, {"text":
+        "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682, 1.8537, 2.1744, 1.6152,
+        2.1744], "confidence": 1}]}, {"text": "555-555-5555", "boundingBox": [6.0105,
+        2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "words": [{"text":
+        "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254,
+        6.0105, 2.2254], "confidence": 1}]}, {"text": "555-555-5555", "boundingBox":
         [0.8852, 2.2887, 1.8119, 2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "words":
         [{"text": "555-555-5555", "boundingBox": [0.8852, 2.2887, 1.8119, 2.2887,
-        1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Item", "boundingBox": [1.0943,
-        3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
+        1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}]}, {"text": "Item", "boundingBox":
+        [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
         "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943,
-        3.109], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996,
-        3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity", "boundingBox":
-        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Price", "boundingBox": [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423,
-        3.109], "words": [{"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
-        2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "A", "boundingBox": [1.0832,
-        3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A",
-        "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116, 3.3202,
-        3.3176, 3.2589, 3.3176], "words": [{"text": "1", "boundingBox": [3.2589, 3.2116,
-        3.3202, 3.2116, 3.3202, 3.3176, 3.2589, 3.3176], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "10.99", "boundingBox":
+        3.109], "confidence": 1}]}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996,
+        3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity",
+        "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371],
+        "confidence": 1}]}, {"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
+        2.9996, 5.7372, 3.109, 5.423, 3.109], "words": [{"text": "Price", "boundingBox":
+        [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence":
+        1}]}, {"text": "A", "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174,
+        3.318, 1.0832, 3.318], "words": [{"text": "A", "boundingBox": [1.0832, 3.2118,
+        1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "confidence": 1}]}, {"text":
+        "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116, 3.3202, 3.3176, 3.2589,
+        3.3176], "words": [{"text": "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116,
+        3.3202, 3.3176, 3.2589, 3.3176], "confidence": 1}]}, {"text": "10.99", "boundingBox":
         [5.4232, 3.2108, 5.7784, 3.2108, 5.7784, 3.319, 5.4232, 3.319], "words": [{"text":
         "10.99", "boundingBox": [5.4232, 3.2108, 5.7784, 3.2108, 5.7784, 3.319, 5.4232,
-        3.319], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637,
-        3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox": [1.0943, 3.4256,
-        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "2", "boundingBox":
-        [3.2541, 3.4241, 3.3199, 3.4241, 3.3199, 3.531, 3.2541, 3.531], "words": [{"text":
-        "2", "boundingBox": [3.2541, 3.4241, 3.3199, 3.4241, 3.3199, 3.531, 3.2541,
-        3.531], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "14.67", "boundingBox": [5.4232, 3.4241, 5.7789, 3.4241, 5.7789,
-        3.5323, 5.4232, 3.5323], "words": [{"text": "14.67", "boundingBox": [5.4232,
-        3.4241, 5.7789, 3.4241, 5.7789, 3.5323, 5.4232, 3.5323], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "C",
+        3.319], "confidence": 1}]}, {"text": "B", "boundingBox": [1.0943, 3.4256,
+        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox":
+        [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence":
+        1}]}, {"text": "2", "boundingBox": [3.2541, 3.4241, 3.3199, 3.4241, 3.3199,
+        3.531, 3.2541, 3.531], "words": [{"text": "2", "boundingBox": [3.2541, 3.4241,
+        3.3199, 3.4241, 3.3199, 3.531, 3.2541, 3.531], "confidence": 1}]}, {"text":
+        "14.67", "boundingBox": [5.4232, 3.4241, 5.7789, 3.4241, 5.7789, 3.5323, 5.4232,
+        3.5323], "words": [{"text": "14.67", "boundingBox": [5.4232, 3.4241, 5.7789,
+        3.4241, 5.7789, 3.5323, 5.4232, 3.5323], "confidence": 1}]}, {"text": "C",
         "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647, 3.7421, 1.0882, 3.7421],
         "words": [{"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647,
-        3.7421, 1.0882, 3.7421], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "4", "boundingBox": [3.2486, 3.6351,
-        3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "words": [{"text": "4", "boundingBox":
-        [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "15.66", "boundingBox": [5.4232, 3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232,
-        3.7423], "words": [{"text": "15.66", "boundingBox": [5.4232, 3.6341, 5.78,
-        3.6341, 5.78, 3.7423, 5.4232, 3.7423], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "D", "boundingBox": [1.0943,
-        3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text":
-        "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943,
-        3.951], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1", "boundingBox": [3.2589, 3.845, 3.3202, 3.845, 3.3202,
+        3.7421, 1.0882, 3.7421], "confidence": 1}]}, {"text": "4", "boundingBox":
+        [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "words":
+        [{"text": "4", "boundingBox": [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413,
+        3.2486, 3.7413], "confidence": 1}]}, {"text": "15.66", "boundingBox": [5.4232,
+        3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232, 3.7423], "words": [{"text": "15.66",
+        "boundingBox": [5.4232, 3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232, 3.7423],
+        "confidence": 1}]}, {"text": "D", "boundingBox": [1.0943, 3.8456, 1.1753,
+        3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text": "D", "boundingBox":
+        [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "confidence":
+        1}]}, {"text": "1", "boundingBox": [3.2589, 3.845, 3.3202, 3.845, 3.3202,
         3.951, 3.2589, 3.951], "words": [{"text": "1", "boundingBox": [3.2589, 3.845,
-        3.3202, 3.845, 3.3202, 3.951, 3.2589, 3.951], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "12.00", "boundingBox":
-        [5.4232, 3.8441, 5.7809, 3.8441, 5.7809, 3.9523, 5.4232, 3.9523], "words":
-        [{"text": "12.00", "boundingBox": [5.4232, 3.8441, 5.7809, 3.8441, 5.7809,
-        3.9523, 5.4232, 3.9523], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "E", "boundingBox": [1.0943, 4.0561,
-        1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "words": [{"text": "E", "boundingBox":
-        [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617, 3.2486,
-        4.1617], "words": [{"text": "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556,
-        3.3244, 4.1617, 3.2486, 4.1617], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "10.00", "boundingBox": [5.4232,
+        3.3202, 3.845, 3.3202, 3.951, 3.2589, 3.951], "confidence": 1}]}, {"text":
+        "12.00", "boundingBox": [5.4232, 3.8441, 5.7809, 3.8441, 5.7809, 3.9523, 5.4232,
+        3.9523], "words": [{"text": "12.00", "boundingBox": [5.4232, 3.8441, 5.7809,
+        3.8441, 5.7809, 3.9523, 5.4232, 3.9523], "confidence": 1}]}, {"text": "E",
+        "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614],
+        "words": [{"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
+        4.1614, 1.0943, 4.1614], "confidence": 1}]}, {"text": "4", "boundingBox":
+        [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617, 3.2486, 4.1617], "words":
+        [{"text": "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617,
+        3.2486, 4.1617], "confidence": 1}]}, {"text": "10.00", "boundingBox": [5.4232,
         4.0546, 5.781, 4.0546, 5.781, 4.1627, 5.4232, 4.1627], "words": [{"text":
         "10.00", "boundingBox": [5.4232, 4.0546, 5.781, 4.0546, 5.781, 4.1627, 5.4232,
-        4.1627], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497,
-        4.3717, 1.0943, 4.3717], "words": [{"text": "F", "boundingBox": [1.0943, 4.2661,
-        1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "6", "boundingBox":
-        [3.2534, 4.2646, 3.3226, 4.2646, 3.3226, 4.3727, 3.2534, 4.3727], "words":
-        [{"text": "6", "boundingBox": [3.2534, 4.2646, 3.3226, 4.2646, 3.3226, 4.3727,
-        3.2534, 4.3727], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "12.00", "boundingBox": [5.4232, 4.2646, 5.7809,
-        4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "words": [{"text": "12.00", "boundingBox":
-        [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877,
-        4.5827], "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746,
-        1.1735, 4.5827, 1.0877, 4.5827], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "8", "boundingBox": [3.2514,
-        4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514, 4.5827], "words": [{"text":
-        "8", "boundingBox": [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514,
-        4.5827], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781,
-        4.5827, 5.4184, 4.5827], "words": [{"text": "22.00", "boundingBox": [5.4184,
-        4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184, 4.5827], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Subtotal:
-        300.00", "boundingBox": [5.5075, 4.8981, 6.632, 4.8981, 6.632, 5.0131, 5.5075,
-        5.0131], "words": [{"text": "Subtotal:", "boundingBox": [5.5075, 4.8981, 6.1249,
-        4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence": 1}, {"text": "300.00",
-        "boundingBox": [6.1794, 4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Tax: 30.00", "boundingBox": [5.5034, 5.1245, 6.2022, 5.1245,
-        6.2022, 5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:", "boundingBox":
-        [5.5034, 5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333], "confidence":
-        1}, {"text": "30.00", "boundingBox": [5.836, 5.1245, 6.2022, 5.1245, 6.2022,
-        5.2333, 5.836, 5.2333], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Tip: 100.00", "boundingBox": [5.5034,
-        5.3412, 6.2587, 5.3412, 6.2587, 5.481, 5.5034, 5.481], "words": [{"text":
+        4.1627], "confidence": 1}]}, {"text": "F", "boundingBox": [1.0943, 4.2661,
+        1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "words": [{"text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "confidence":
+        1}]}, {"text": "6", "boundingBox": [3.2534, 4.2646, 3.3226, 4.2646, 3.3226,
+        4.3727, 3.2534, 4.3727], "words": [{"text": "6", "boundingBox": [3.2534, 4.2646,
+        3.3226, 4.2646, 3.3226, 4.3727, 3.2534, 4.3727], "confidence": 1}]}, {"text":
+        "12.00", "boundingBox": [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232,
+        4.3727], "words": [{"text": "12.00", "boundingBox": [5.4232, 4.2646, 5.7809,
+        4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "confidence": 1}]}, {"text": "G",
+        "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827],
+        "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
+        4.5827, 1.0877, 4.5827], "confidence": 1}]}, {"text": "8", "boundingBox":
+        [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514, 4.5827], "words":
+        [{"text": "8", "boundingBox": [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827,
+        3.2514, 4.5827], "confidence": 1}]}, {"text": "22.00", "boundingBox": [5.4184,
+        4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184, 4.5827], "words": [{"text":
+        "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184,
+        4.5827], "confidence": 1}]}, {"text": "Subtotal: 300.00", "boundingBox": [5.5075,
+        4.8981, 6.632, 4.8981, 6.632, 5.0131, 5.5075, 5.0131], "words": [{"text":
+        "Subtotal:", "boundingBox": [5.5075, 4.8981, 6.1249, 4.8981, 6.1249, 5.0131,
+        5.5075, 5.0131], "confidence": 1}, {"text": "300.00", "boundingBox": [6.1794,
+        4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131], "confidence": 1}]},
+        {"text": "Tax: 30.00", "boundingBox": [5.5034, 5.1245, 6.2022, 5.1245, 6.2022,
+        5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:", "boundingBox": [5.5034,
+        5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333], "confidence": 1},
+        {"text": "30.00", "boundingBox": [5.836, 5.1245, 6.2022, 5.1245, 6.2022, 5.2333,
+        5.836, 5.2333], "confidence": 1}]}, {"text": "Tip: 100.00", "boundingBox":
+        [5.5034, 5.3412, 6.2587, 5.3412, 6.2587, 5.481, 5.5034, 5.481], "words": [{"text":
         "Tip:", "boundingBox": [5.5034, 5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034,
         5.481], "confidence": 1}, {"text": "100.00", "boundingBox": [5.811, 5.3445,
-        6.2587, 5.3445, 6.2587, 5.4533, 5.811, 5.4533], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Total: 430.00",
-        "boundingBox": [5.5034, 5.5583, 6.3987, 5.5583, 6.3987, 5.6733, 5.5034, 5.6733],
-        "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583,
-        5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "430.00", "boundingBox":
-        [5.942, 5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942, 5.6733], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Signature: ____Bilbo Baggins__________", "boundingBox": [1.0055, 6.6553,
-        3.8342, 6.6553, 3.8342, 6.7981, 1.0055, 6.7981], "words": [{"text": "Signature:",
-        "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981, 1.0055, 6.7981],
-        "confidence": 1}, {"text": "____Bilbo", "boundingBox": [1.747, 6.6553, 2.4278,
-        6.6553, 2.4278, 6.7981, 1.747, 6.7981], "confidence": 1}, {"text": "Baggins__________",
-        "boundingBox": [2.4823, 6.6581, 3.8342, 6.6581, 3.8342, 6.7981, 2.4823, 6.7981],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}]}, {"page": 2, "angle": 0, "width": 8.5, "height": 11, "unit": "inch"},
+        6.2587, 5.3445, 6.2587, 5.4533, 5.811, 5.4533], "confidence": 1}]}, {"text":
+        "Total: 430.00", "boundingBox": [5.5034, 5.5583, 6.3987, 5.5583, 6.3987, 5.6733,
+        5.5034, 5.6733], "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583,
+        5.8915, 5.5583, 5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text":
+        "430.00", "boundingBox": [5.942, 5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942,
+        5.6733], "confidence": 1}]}, {"text": "Signature: ____ Bilbo Baggins__________",
+        "boundingBox": [1.0055, 6.6553, 3.8342, 6.6553, 3.8342, 6.7981, 1.0055, 6.7981],
+        "words": [{"text": "Signature:", "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581,
+        1.6987, 6.7981, 1.0055, 6.7981], "confidence": 1}, {"text": "____", "boundingBox":
+        [1.747, 6.7829, 2.0809, 6.7829, 2.0809, 6.7981, 1.747, 6.7981], "confidence":
+        1}, {"text": "Bilbo", "boundingBox": [2.0925, 6.6553, 2.4278, 6.6553, 2.4278,
+        6.7703, 2.0925, 6.7703], "confidence": 1}, {"text": "Baggins__________", "boundingBox":
+        [2.4823, 6.6581, 3.8342, 6.6581, 3.8342, 6.7981, 2.4823, 6.7981], "confidence":
+        1}]}]}, {"page": 2, "angle": 0, "width": 8.5, "height": 11, "unit": "inch"},
         {"page": 3, "angle": 0, "width": 8.5, "height": 11, "unit": "inch", "lines":
         [{"text": "Company B Invoice", "boundingBox": [0.8861, 1.1217, 2.3734, 1.1217,
         2.3734, 1.2812, 0.8861, 1.2812], "words": [{"text": "Company", "boundingBox":
         [0.8861, 1.1232, 1.6203, 1.1232, 1.6203, 1.2812, 0.8861, 1.2812], "confidence":
         1}, {"text": "B", "boundingBox": [1.6836, 1.1248, 1.764, 1.1248, 1.764, 1.2469,
         1.6836, 1.2469], "confidence": 1}, {"text": "Invoice", "boundingBox": [1.8336,
-        1.1217, 2.3734, 1.1217, 2.3734, 1.2485, 1.8336, 1.2485], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Invoice
-        For:", "boundingBox": [6.0211, 1.0656, 7.0357, 1.0656, 7.0357, 1.2121, 6.0211,
-        1.2121], "words": [{"text": "Invoice", "boundingBox": [6.0211, 1.0656, 6.6362,
-        1.0656, 6.6362, 1.2121, 6.0211, 1.2121], "confidence": 1}, {"text": "For:",
-        "boundingBox": [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121, 6.7147, 1.2121],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825,
-        1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text": "Address:", "boundingBox":
-        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Frodo Baggins", "boundingBox": [6.0164, 1.4506, 6.9506, 1.4506, 6.9506, 1.5931,
-        6.0164, 1.5931], "words": [{"text": "Frodo", "boundingBox": [6.0164, 1.4506,
-        6.3895, 1.4506, 6.3895, 1.5649, 6.0164, 1.5649], "confidence": 1}, {"text":
-        "Baggins", "boundingBox": [6.45, 1.4556, 6.9506, 1.4556, 6.9506, 1.5931, 6.45,
-        1.5931], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "123 Hobbit Lane", "boundingBox": [6.0165, 1.6707, 7.1006,
+        1.1217, 2.3734, 1.1217, 2.3734, 1.2485, 1.8336, 1.2485], "confidence": 1}]},
+        {"text": "Invoice For:", "boundingBox": [6.0211, 1.0656, 7.0357, 1.0656, 7.0357,
+        1.2121, 6.0211, 1.2121], "words": [{"text": "Invoice", "boundingBox": [6.0211,
+        1.0656, 6.6362, 1.0656, 6.6362, 1.2121, 6.0211, 1.2121], "confidence": 1},
+        {"text": "For:", "boundingBox": [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121,
+        6.7147, 1.2121], "confidence": 1}]}, {"text": "Address:", "boundingBox": [0.8791,
+        1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text":
+        "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155,
+        0.8791, 1.6155], "confidence": 1}]}, {"text": "Frodo Baggins", "boundingBox":
+        [6.0164, 1.4506, 6.9506, 1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "words":
+        [{"text": "Frodo", "boundingBox": [6.0164, 1.4506, 6.3895, 1.4506, 6.3895,
+        1.5649, 6.0164, 1.5649], "confidence": 1}, {"text": "Baggins", "boundingBox":
+        [6.45, 1.4556, 6.9506, 1.4556, 6.9506, 1.5931, 6.45, 1.5931], "confidence":
+        1}]}, {"text": "123 Hobbit Lane", "boundingBox": [6.0165, 1.6707, 7.1006,
         1.6707, 7.1006, 1.7854, 6.0165, 1.7854], "words": [{"text": "123", "boundingBox":
         [6.0165, 1.6772, 6.2434, 1.6772, 6.2434, 1.7854, 6.0165, 1.7854], "confidence":
         1}, {"text": "Hobbit", "boundingBox": [6.3033, 1.6707, 6.7463, 1.6707, 6.7463,
         1.7854, 6.3033, 1.7854], "confidence": 1}, {"text": "Lane", "boundingBox":
         [6.803, 1.6782, 7.1006, 1.6782, 7.1006, 1.7854, 6.803, 1.7854], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "567 Main St.", "boundingBox": [0.8852, 1.846, 1.713, 1.846, 1.713, 1.9554,
-        0.8852, 1.9554], "words": [{"text": "567", "boundingBox": [0.8852, 1.8472,
-        1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554], "confidence": 1}, {"text":
-        "Main", "boundingBox": [1.1777, 1.846, 1.5022, 1.846, 1.5022, 1.9554, 1.1777,
-        1.9554], "confidence": 1}, {"text": "St.", "boundingBox": [1.5558, 1.8472,
-        1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Redmond, WA", "boundingBox":
-        [6.0164, 1.891, 6.9793, 1.891, 6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text":
-        "Redmond,", "boundingBox": [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275,
-        6.0164, 2.0275], "confidence": 1}, {"text": "WA", "boundingBox": [6.7408,
-        1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408, 2.0044], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Redmond,
-        WA", "boundingBox": [0.891, 2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975],
-        "words": [{"text": "Redmond,", "boundingBox": [0.891, 2.061, 1.5605, 2.061,
-        1.5605, 2.1975, 0.891, 2.1975], "confidence": 1}, {"text": "WA", "boundingBox":
-        [1.6152, 2.0682, 1.8537, 2.0682, 1.8537, 2.1744, 1.6152, 2.1744], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254,
-        6.0105, 2.2254], "words": [{"text": "555-555-5555", "boundingBox": [6.0105,
-        2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "555-555-5555",
+        1}]}, {"text": "567 Main St.", "boundingBox": [0.8852, 1.846, 1.713, 1.846,
+        1.713, 1.9554, 0.8852, 1.9554], "words": [{"text": "567", "boundingBox": [0.8852,
+        1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554], "confidence": 1},
+        {"text": "Main", "boundingBox": [1.1777, 1.846, 1.5022, 1.846, 1.5022, 1.9554,
+        1.1777, 1.9554], "confidence": 1}, {"text": "St.", "boundingBox": [1.5558,
+        1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554], "confidence": 1}]},
+        {"text": "Redmond, WA", "boundingBox": [6.0164, 1.891, 6.9793, 1.891, 6.9793,
+        2.0275, 6.0164, 2.0275], "words": [{"text": "Redmond,", "boundingBox": [6.0164,
+        1.891, 6.6861, 1.891, 6.6861, 2.0275, 6.0164, 2.0275], "confidence": 1}, {"text":
+        "WA", "boundingBox": [6.7408, 1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408,
+        2.0044], "confidence": 1}]}, {"text": "Redmond, WA", "boundingBox": [0.891,
+        2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,",
+        "boundingBox": [0.891, 2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975],
+        "confidence": 1}, {"text": "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682,
+        1.8537, 2.1744, 1.6152, 2.1744], "confidence": 1}]}, {"text": "555-555-5555",
+        "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254],
+        "words": [{"text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371,
+        2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}]}, {"text": "555-555-5555",
         "boundingBox": [0.8852, 2.2887, 1.8119, 2.2887, 1.8119, 2.3954, 0.8852, 2.3954],
         "words": [{"text": "555-555-5555", "boundingBox": [0.8852, 2.2887, 1.8119,
-        2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Item", "boundingBox":
-        [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
-        "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943,
-        3.109], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996,
-        3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity", "boundingBox":
-        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
+        2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}]}, {"text": "Item",
+        "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109],
+        "words": [{"text": "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018,
+        1.3842, 3.109, 1.0943, 3.109], "confidence": 1}]}, {"text": "Quantity", "boundingBox":
+        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "words":
+        [{"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996, 3.8367,
+        3.1371, 3.2527, 3.1371], "confidence": 1}]}, {"text": "Price", "boundingBox":
+        [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423, 3.109], "words": [{"text":
         "Price", "boundingBox": [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423,
-        3.109], "words": [{"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
-        2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "A", "boundingBox": [1.0832,
-        3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A",
-        "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "10", "boundingBox": [3.2589, 3.2108, 3.4067, 3.2108, 3.4067,
+        3.109], "confidence": 1}]}, {"text": "A", "boundingBox": [1.0832, 3.2118,
+        1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A", "boundingBox":
+        [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "confidence":
+        1}]}, {"text": "10", "boundingBox": [3.2589, 3.2108, 3.4067, 3.2108, 3.4067,
         3.319, 3.2589, 3.319], "words": [{"text": "10", "boundingBox": [3.2589, 3.2108,
-        3.4067, 3.2108, 3.4067, 3.319, 3.2589, 3.319], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "100.99", "boundingBox":
-        [5.4232, 3.2108, 5.8617, 3.2108, 5.8617, 3.319, 5.4232, 3.319], "words": [{"text":
+        3.4067, 3.2108, 3.4067, 3.319, 3.2589, 3.319], "confidence": 1}]}, {"text":
         "100.99", "boundingBox": [5.4232, 3.2108, 5.8617, 3.2108, 5.8617, 3.319, 5.4232,
-        3.319], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637,
-        3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox": [1.0943, 3.4256,
-        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "20", "boundingBox":
-        [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323], "words":
-        [{"text": "20", "boundingBox": [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323,
-        3.2541, 3.5323], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "140.67", "boundingBox": [5.4232, 3.4241, 5.8622,
+        3.319], "words": [{"text": "100.99", "boundingBox": [5.4232, 3.2108, 5.8617,
+        3.2108, 5.8617, 3.319, 5.4232, 3.319], "confidence": 1}]}, {"text": "B", "boundingBox":
+        [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "words": [{"text":
+        "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943,
+        3.531], "confidence": 1}]}, {"text": "20", "boundingBox": [3.2541, 3.4241,
+        3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323], "words": [{"text": "20",
+        "boundingBox": [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323],
+        "confidence": 1}]}, {"text": "140.67", "boundingBox": [5.4232, 3.4241, 5.8622,
         3.4241, 5.8622, 3.5323, 5.4232, 3.5323], "words": [{"text": "140.67", "boundingBox":
         [5.4232, 3.4241, 5.8622, 3.4241, 5.8622, 3.5323, 5.4232, 3.5323], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647, 3.7421, 1.0882,
-        3.7421], "words": [{"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343,
-        1.1647, 3.7421, 1.0882, 3.7421], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "40", "boundingBox": [3.2486,
-        3.6341, 3.4067, 3.6341, 3.4067, 3.7423, 3.2486, 3.7423], "words": [{"text":
+        1}]}, {"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647,
+        3.7421, 1.0882, 3.7421], "words": [{"text": "C", "boundingBox": [1.0882, 3.6343,
+        1.1647, 3.6343, 1.1647, 3.7421, 1.0882, 3.7421], "confidence": 1}]}, {"text":
         "40", "boundingBox": [3.2486, 3.6341, 3.4067, 3.6341, 3.4067, 3.7423, 3.2486,
-        3.7423], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "150.66", "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341, 5.8634,
-        3.7423, 5.4232, 3.7423], "words": [{"text": "150.66", "boundingBox": [5.4232,
-        3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "D",
-        "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951],
-        "words": [{"text": "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753,
-        3.951, 1.0943, 3.951], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "10", "boundingBox": [3.2589, 3.8441,
+        3.7423], "words": [{"text": "40", "boundingBox": [3.2486, 3.6341, 3.4067,
+        3.6341, 3.4067, 3.7423, 3.2486, 3.7423], "confidence": 1}]}, {"text": "150.66",
+        "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423],
+        "words": [{"text": "150.66", "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341,
+        5.8634, 3.7423, 5.4232, 3.7423], "confidence": 1}]}, {"text": "D", "boundingBox":
+        [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text":
+        "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943,
+        3.951], "confidence": 1}]}, {"text": "10", "boundingBox": [3.2589, 3.8441,
         3.4067, 3.8441, 3.4067, 3.9523, 3.2589, 3.9523], "words": [{"text": "10",
         "boundingBox": [3.2589, 3.8441, 3.4067, 3.8441, 3.4067, 3.9523, 3.2589, 3.9523],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "120.00", "boundingBox": [5.4232, 3.8441, 5.8642, 3.8441, 5.8642,
-        3.9523, 5.4232, 3.9523], "words": [{"text": "120.00", "boundingBox": [5.4232,
-        3.8441, 5.8642, 3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "E",
-        "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614],
-        "words": [{"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
-        4.1614, 1.0943, 4.1614], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "40", "boundingBox": [3.2486, 4.0546,
-        3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "words": [{"text": "40",
-        "boundingBox": [3.2486, 4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "100.00", "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546, 5.8644,
-        4.1627, 5.4232, 4.1627], "words": [{"text": "100.00", "boundingBox": [5.4232,
-        4.0546, 5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "F",
-        "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717],
-        "words": [{"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497,
-        4.3717, 1.0943, 4.3717], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "60", "boundingBox": [3.2534, 4.2646,
-        3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727], "words": [{"text": "60",
-        "boundingBox": [3.2534, 4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "120.00", "boundingBox": [5.4232, 4.2646, 5.8642, 4.2646, 5.8642,
-        4.3727, 5.4232, 4.3727], "words": [{"text": "120.00", "boundingBox": [5.4232,
-        4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "G",
-        "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827],
-        "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
-        4.5827, 1.0877, 4.5827], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "80", "boundingBox": [3.2514, 4.4746,
-        3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827], "words": [{"text": "80",
-        "boundingBox": [3.2514, 4.4746, 3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "220.00", "boundingBox": [5.4184, 4.4746, 5.8644, 4.4746, 5.8644,
+        "confidence": 1}]}, {"text": "120.00", "boundingBox": [5.4232, 3.8441, 5.8642,
+        3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "words": [{"text": "120.00", "boundingBox":
+        [5.4232, 3.8441, 5.8642, 3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "confidence":
+        1}]}, {"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
+        4.1614, 1.0943, 4.1614], "words": [{"text": "E", "boundingBox": [1.0943, 4.0561,
+        1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "confidence": 1}]}, {"text":
+        "40", "boundingBox": [3.2486, 4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486,
+        4.1627], "words": [{"text": "40", "boundingBox": [3.2486, 4.0546, 3.4067,
+        4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "confidence": 1}]}, {"text": "100.00",
+        "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627],
+        "words": [{"text": "100.00", "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546,
+        5.8644, 4.1627, 5.4232, 4.1627], "confidence": 1}]}, {"text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "words":
+        [{"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717,
+        1.0943, 4.3717], "confidence": 1}]}, {"text": "60", "boundingBox": [3.2534,
+        4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727], "words": [{"text":
+        "60", "boundingBox": [3.2534, 4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534,
+        4.3727], "confidence": 1}]}, {"text": "120.00", "boundingBox": [5.4232, 4.2646,
+        5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "words": [{"text": "120.00",
+        "boundingBox": [5.4232, 4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727],
+        "confidence": 1}]}, {"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735,
+        4.4746, 1.1735, 4.5827, 1.0877, 4.5827], "words": [{"text": "G", "boundingBox":
+        [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827], "confidence":
+        1}]}, {"text": "80", "boundingBox": [3.2514, 4.4746, 3.4067, 4.4746, 3.4067,
+        4.5827, 3.2514, 4.5827], "words": [{"text": "80", "boundingBox": [3.2514,
+        4.4746, 3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827], "confidence": 1}]},
+        {"text": "220.00", "boundingBox": [5.4184, 4.4746, 5.8644, 4.4746, 5.8644,
         4.5827, 5.4184, 4.5827], "words": [{"text": "220.00", "boundingBox": [5.4184,
-        4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Subtotal:
-        3000.00", "boundingBox": [5.5075, 4.8981, 6.7158, 4.8981, 6.7158, 5.0131,
-        5.5075, 5.0131], "words": [{"text": "Subtotal:", "boundingBox": [5.5075, 4.8981,
-        6.1249, 4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence": 1}, {"text":
-        "3000.00", "boundingBox": [6.1794, 4.9042, 6.7158, 4.9042, 6.7158, 5.0131,
-        6.1794, 5.0131], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "Tax: 300.00", "boundingBox": [5.5034, 5.1245,
-        6.2887, 5.1245, 6.2887, 5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:",
-        "boundingBox": [5.5034, 5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333],
-        "confidence": 1}, {"text": "300.00", "boundingBox": [5.836, 5.1245, 6.2887,
-        5.1245, 6.2887, 5.2333, 5.836, 5.2333], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Tip: 1000.00", "boundingBox":
-        [5.5034, 5.3412, 6.3422, 5.3412, 6.3422, 5.481, 5.5034, 5.481], "words": [{"text":
-        "Tip:", "boundingBox": [5.5034, 5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034,
-        5.481], "confidence": 1}, {"text": "1000.00", "boundingBox": [5.811, 5.3445,
-        6.3422, 5.3445, 6.3422, 5.4533, 5.811, 5.4533], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Total: 4300.00",
-        "boundingBox": [5.5034, 5.5583, 6.4825, 5.5583, 6.4825, 5.6733, 5.5034, 5.6733],
-        "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583,
-        5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "4300.00", "boundingBox":
+        4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "confidence": 1}]},
+        {"text": "Subtotal: 3000.00", "boundingBox": [5.5075, 4.8981, 6.7158, 4.8981,
+        6.7158, 5.0131, 5.5075, 5.0131], "words": [{"text": "Subtotal:", "boundingBox":
+        [5.5075, 4.8981, 6.1249, 4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence":
+        1}, {"text": "3000.00", "boundingBox": [6.1794, 4.9042, 6.7158, 4.9042, 6.7158,
+        5.0131, 6.1794, 5.0131], "confidence": 1}]}, {"text": "Tax: 300.00", "boundingBox":
+        [5.5034, 5.1245, 6.2887, 5.1245, 6.2887, 5.2333, 5.5034, 5.2333], "words":
+        [{"text": "Tax:", "boundingBox": [5.5034, 5.1263, 5.7812, 5.1263, 5.7812,
+        5.2333, 5.5034, 5.2333], "confidence": 1}, {"text": "300.00", "boundingBox":
+        [5.836, 5.1245, 6.2887, 5.1245, 6.2887, 5.2333, 5.836, 5.2333], "confidence":
+        1}]}, {"text": "Tip: 1000.00", "boundingBox": [5.5034, 5.3412, 6.3422, 5.3412,
+        6.3422, 5.481, 5.5034, 5.481], "words": [{"text": "Tip:", "boundingBox": [5.5034,
+        5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034, 5.481], "confidence": 1}, {"text":
+        "1000.00", "boundingBox": [5.811, 5.3445, 6.3422, 5.3445, 6.3422, 5.4533,
+        5.811, 5.4533], "confidence": 1}]}, {"text": "Total: 4300.00", "boundingBox":
+        [5.5034, 5.5583, 6.4825, 5.5583, 6.4825, 5.6733, 5.5034, 5.6733], "words":
+        [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583, 5.8915,
+        5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "4300.00", "boundingBox":
         [5.942, 5.5645, 6.4825, 5.5645, 6.4825, 5.6733, 5.942, 5.6733], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Signature: ____Frodo Baggins__________", "boundingBox": [1.0055, 6.6556,
-        3.8842, 6.6556, 3.8842, 6.7981, 1.0055, 6.7981], "words": [{"text": "Signature:",
-        "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981, 1.0055, 6.7981],
-        "confidence": 1}, {"text": "____Frodo", "boundingBox": [1.747, 6.6556, 2.4778,
-        6.6556, 2.4778, 6.7981, 1.747, 6.7981], "confidence": 1}, {"text": "Baggins__________",
-        "boundingBox": [2.5325, 6.6581, 3.8842, 6.6581, 3.8842, 6.7981, 2.5325, 6.7981],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}]}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
+        1}]}, {"text": "Signature: ____ Frodo Baggins__________", "boundingBox": [1.0055,
+        6.6556, 3.8842, 6.6556, 3.8842, 6.7981, 1.0055, 6.7981], "words": [{"text":
+        "Signature:", "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981,
+        1.0055, 6.7981], "confidence": 1}, {"text": "____", "boundingBox": [1.747,
+        6.7829, 2.0809, 6.7829, 2.0809, 6.7981, 1.747, 6.7981], "confidence": 1},
+        {"text": "Frodo", "boundingBox": [2.0925, 6.6556, 2.4778, 6.6556, 2.4778,
+        6.7703, 2.0925, 6.7703], "confidence": 1}, {"text": "Baggins__________", "boundingBox":
+        [2.5325, 6.6581, 3.8842, 6.6581, 3.8842, 6.7981, 2.5325, 6.7981], "confidence":
+        1}]}]}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
         [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString": "Itemized",
-        "confidence": 0.991}, "MerchantName": {"type": "string", "valueString": "Bilbo
+        "confidence": 0.99}, "MerchantName": {"type": "string", "valueString": "Bilbo
         Baggins", "text": "Bilbo Baggins", "boundingBox": [6.0164, 1.4503, 6.8967,
-        1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "page": 1, "confidence": 0.669, "elements":
+        1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "page": 1, "confidence": 0.987, "elements":
         ["#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1"]}, "MerchantAddress":
         {"type": "string", "valueString": "123 Hobbit Lane 567 Main St. Redmond, WA
         Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA",
         "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975, 0.8852, 2.1975],
-        "page": 1, "confidence": 0.345, "elements": ["#/readResults/0/lines/4/words/0",
+        "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/4/words/0",
         "#/readResults/0/lines/4/words/1", "#/readResults/0/lines/4/words/2", "#/readResults/0/lines/5/words/0",
         "#/readResults/0/lines/5/words/1", "#/readResults/0/lines/5/words/2", "#/readResults/0/lines/6/words/0",
         "#/readResults/0/lines/6/words/1", "#/readResults/0/lines/7/words/0", "#/readResults/0/lines/7/words/1"]},
         "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber": "+15555555555",
         "text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371,
-        2.2254, 6.0105, 2.2254], "page": 1, "confidence": 0.932, "elements": ["#/readResults/0/lines/8/words/0"]},
+        2.2254, 6.0105, 2.2254], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/8/words/0"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "F", "text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "page":
+        1, "confidence": 0.964, "elements": ["#/readResults/0/lines/28/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 12, "text": "12.00", "boundingBox":
+        [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "page":
+        1, "confidence": 0.947, "elements": ["#/readResults/0/lines/30/words/0"]}}},
+        {"type": "object", "valueObject": {"TotalPrice": {"type": "number", "valueNumber":
+        22, "text": "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781,
+        4.5827, 5.4184, 4.5827], "page": 1, "confidence": 0.935, "elements": ["#/readResults/0/lines/33/words/0"]}}}]},
         "Subtotal": {"type": "number", "valueNumber": 300, "text": "300.00", "boundingBox":
         [6.1794, 4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131], "page": 1,
-        "confidence": 0.96, "elements": ["#/readResults/0/lines/34/words/1"]}}}, {"docType":
-        "prebuilt:receipt", "pageRange": [2, 2], "fields": {}}, {"docType": "prebuilt:receipt",
-        "pageRange": [3, 3], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Frodo Baggins", "text": "Frodo Baggins", "boundingBox": [6.0164, 1.4506,
-        6.9506, 1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "page": 3, "confidence":
-        0.529, "elements": ["#/readResults/2/lines/3/words/0", "#/readResults/2/lines/3/words/1"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Hobbit Lane 567
-        Main St. Redmond, WA Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond,
-        WA Redmond, WA", "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975,
-        0.8852, 2.1975], "page": 3, "confidence": 0.523, "elements": ["#/readResults/2/lines/4/words/0",
+        "confidence": 0.99, "elements": ["#/readResults/0/lines/34/words/1"]}, "Total":
+        {"type": "number", "valueNumber": 430, "text": "430.00", "boundingBox": [5.942,
+        5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942, 5.6733], "page": 1, "confidence":
+        0.985, "elements": ["#/readResults/0/lines/37/words/1"]}}}, {"docType": "prebuilt:receipt",
+        "pageRange": [2, 2], "fields": {}}, {"docType": "prebuilt:receipt", "pageRange":
+        [3, 3], "fields": {"ReceiptType": {"type": "string", "valueString": "Itemized",
+        "confidence": 0.99}, "MerchantName": {"type": "string", "valueString": "Frodo
+        Baggins", "text": "Frodo Baggins", "boundingBox": [6.0164, 1.4506, 6.9506,
+        1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "page": 3, "confidence": 0.984, "elements":
+        ["#/readResults/2/lines/3/words/0", "#/readResults/2/lines/3/words/1"]}, "MerchantAddress":
+        {"type": "string", "valueString": "123 Hobbit Lane 567 Main St. Redmond, WA
+        Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA",
+        "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975, 0.8852, 2.1975],
+        "page": 3, "confidence": 0.99, "elements": ["#/readResults/2/lines/4/words/0",
         "#/readResults/2/lines/4/words/1", "#/readResults/2/lines/4/words/2", "#/readResults/2/lines/5/words/0",
         "#/readResults/2/lines/5/words/1", "#/readResults/2/lines/5/words/2", "#/readResults/2/lines/6/words/0",
         "#/readResults/2/lines/6/words/1", "#/readResults/2/lines/7/words/0", "#/readResults/2/lines/7/words/1"]},
         "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber": "+15555555555",
         "text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371,
-        2.2254, 6.0105, 2.2254], "page": 3, "confidence": 0.926, "elements": ["#/readResults/2/lines/8/words/0"]},
-        "Subtotal": {"type": "number", "valueNumber": 150.66, "text": "150.66", "boundingBox":
-        [5.4232, 3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423], "page":
-        3, "confidence": 0.664, "elements": ["#/readResults/2/lines/21/words/0"]}}}]}}'
+        2.2254, 6.0105, 2.2254], "page": 3, "confidence": 0.99, "elements": ["#/readResults/2/lines/8/words/0"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "E", "text": "E", "boundingBox":
+        [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "page": 3,
+        "confidence": 0.935, "elements": ["#/readResults/2/lines/25/words/0"]}, "Quantity":
+        {"type": "number", "valueNumber": 40, "text": "40", "boundingBox": [3.2486,
+        4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "page": 3, "confidence":
+        0, "elements": ["#/readResults/2/lines/26/words/0"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 100, "text": "100.00", "boundingBox": [5.4232, 4.0546,
+        5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627], "page": 3, "confidence":
+        0.723, "elements": ["#/readResults/2/lines/27/words/0"]}}}, {"type": "object",
+        "valueObject": {"Name": {"type": "string", "valueString": "F", "text": "F",
+        "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717],
+        "page": 3, "confidence": 0.905, "elements": ["#/readResults/2/lines/28/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 120, "text": "120.00", "boundingBox":
+        [5.4232, 4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "page":
+        3, "confidence": 0.967, "elements": ["#/readResults/2/lines/30/words/0"]}}},
+        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
+        "G", "text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
+        4.5827, 1.0877, 4.5827], "page": 3, "confidence": 0.896, "elements": ["#/readResults/2/lines/31/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 220, "text": "220.00", "boundingBox":
+        [5.4184, 4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "page":
+        3, "confidence": 0.958, "elements": ["#/readResults/2/lines/33/words/0"]}}}]},
+        "Subtotal": {"type": "number", "valueNumber": 3000, "text": "3000.00", "boundingBox":
+        [6.1794, 4.9042, 6.7158, 4.9042, 6.7158, 5.0131, 6.1794, 5.0131], "page":
+        3, "confidence": 0.99, "elements": ["#/readResults/2/lines/34/words/1"]},
+        "Total": {"type": "number", "valueNumber": 1000, "text": "1000.00", "boundingBox":
+        [5.811, 5.3445, 6.3422, 5.3445, 6.3422, 5.4533, 5.811, 5.4533], "page": 3,
+        "confidence": 0.985, "elements": ["#/readResults/2/lines/36/words/1"]}}}]}}'
     headers:
       apim-request-id:
-      - 99dc18b9-bf9b-4bc1-80a9-0c9eeb8e5ace
+      - c8e57de2-da21-4000-9ba7-69471fc7bae7
       content-length:
-      - '26841'
+      - '25475'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:07:13 GMT
+      - Mon, 16 Nov 2020 19:12:39 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '39'
+      - '29'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_multipage_url.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_multipage_url.yaml
@@ -21,19 +21,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - bdcaeb33-a876-4983-85e9-4a0f90d4ab7e
+      - 629b6d9f-830e-4d68-99e0-1bafe25babb7
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:07:14 GMT
+      - Mon, 16 Nov 2020 19:12:39 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/bdcaeb33-a876-4983-85e9-4a0f90d4ab7e
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/629b6d9f-830e-4d68-99e0-1bafe25babb7
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '249'
+      - '91'
     status:
       code: 202
       message: Accepted
@@ -49,11 +49,11 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/bdcaeb33-a876-4983-85e9-4a0f90d4ab7e
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/629b6d9f-830e-4d68-99e0-1bafe25babb7
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:07:14Z",
-        "lastUpdatedDateTime": "2020-11-11T18:07:17Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:12:40Z",
+        "lastUpdatedDateTime": "2020-11-16T19:12:44Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": 0, "width": 8.5, "height": 11,
         "unit": "inch", "lines": [{"text": "Company A Invoice", "boundingBox": [0.8861,
         1.1217, 2.3783, 1.1217, 2.3783, 1.2812, 0.8861, 1.2812], "words": [{"text":
@@ -61,391 +61,371 @@ interactions:
         0.8861, 1.2812], "confidence": 1}, {"text": "A", "boundingBox": [1.6696, 1.1242,
         1.7749, 1.1242, 1.7749, 1.2473, 1.6696, 1.2473], "confidence": 1}, {"text":
         "Invoice", "boundingBox": [1.8389, 1.1217, 2.3783, 1.1217, 2.3783, 1.2485,
-        1.8389, 1.2485], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "Invoice For:", "boundingBox": [6.0211, 1.0656,
-        7.0357, 1.0656, 7.0357, 1.2121, 6.0211, 1.2121], "words": [{"text": "Invoice",
-        "boundingBox": [6.0211, 1.0656, 6.6362, 1.0656, 6.6362, 1.2121, 6.0211, 1.2121],
-        "confidence": 1}, {"text": "For:", "boundingBox": [6.7147, 1.0691, 7.0357,
-        1.0691, 7.0357, 1.2121, 6.7147, 1.2121], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Address:", "boundingBox":
-        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "words":
-        [{"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825, 1.5657,
-        1.6155, 0.8791, 1.6155], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Bilbo Baggins", "boundingBox": [6.0164,
-        1.4503, 6.8967, 1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "words": [{"text":
-        "Bilbo", "boundingBox": [6.0164, 1.4503, 6.3392, 1.4503, 6.3392, 1.5649, 6.0164,
-        1.5649], "confidence": 1}, {"text": "Baggins", "boundingBox": [6.396, 1.4556,
-        6.8967, 1.4556, 6.8967, 1.5931, 6.396, 1.5931], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "123 Hobbit Lane",
-        "boundingBox": [6.0165, 1.6707, 7.1006, 1.6707, 7.1006, 1.7854, 6.0165, 1.7854],
-        "words": [{"text": "123", "boundingBox": [6.0165, 1.6772, 6.2434, 1.6772,
-        6.2434, 1.7854, 6.0165, 1.7854], "confidence": 1}, {"text": "Hobbit", "boundingBox":
-        [6.3033, 1.6707, 6.7463, 1.6707, 6.7463, 1.7854, 6.3033, 1.7854], "confidence":
-        1}, {"text": "Lane", "boundingBox": [6.803, 1.6782, 7.1006, 1.6782, 7.1006,
-        1.7854, 6.803, 1.7854], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "567 Main St.", "boundingBox": [0.8852,
-        1.846, 1.713, 1.846, 1.713, 1.9554, 0.8852, 1.9554], "words": [{"text": "567",
-        "boundingBox": [0.8852, 1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554],
-        "confidence": 1}, {"text": "Main", "boundingBox": [1.1777, 1.846, 1.5022,
-        1.846, 1.5022, 1.9554, 1.1777, 1.9554], "confidence": 1}, {"text": "St.",
-        "boundingBox": [1.5558, 1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Redmond, WA", "boundingBox": [6.0164, 1.891, 6.9793, 1.891,
-        6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text": "Redmond,", "boundingBox":
-        [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275, 6.0164, 2.0275], "confidence":
-        1}, {"text": "WA", "boundingBox": [6.7408, 1.8982, 6.9793, 1.8982, 6.9793,
-        2.0044, 6.7408, 2.0044], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Redmond, WA", "boundingBox": [0.891,
-        2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,",
-        "boundingBox": [0.891, 2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975],
-        "confidence": 1}, {"text": "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682,
-        1.8537, 2.1744, 1.6152, 2.1744], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "555-555-5555", "boundingBox":
-        [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "words":
-        [{"text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187,
-        6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "555-555-5555", "boundingBox":
+        1.8389, 1.2485], "confidence": 1}]}, {"text": "Invoice For:", "boundingBox":
+        [6.0211, 1.0656, 7.0357, 1.0656, 7.0357, 1.2121, 6.0211, 1.2121], "words":
+        [{"text": "Invoice", "boundingBox": [6.0211, 1.0656, 6.6362, 1.0656, 6.6362,
+        1.2121, 6.0211, 1.2121], "confidence": 1}, {"text": "For:", "boundingBox":
+        [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121, 6.7147, 1.2121], "confidence":
+        1}]}, {"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825,
+        1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text": "Address:", "boundingBox":
+        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "confidence":
+        1}]}, {"text": "Bilbo Baggins", "boundingBox": [6.0164, 1.4503, 6.8967, 1.4503,
+        6.8967, 1.5931, 6.0164, 1.5931], "words": [{"text": "Bilbo", "boundingBox":
+        [6.0164, 1.4503, 6.3392, 1.4503, 6.3392, 1.5649, 6.0164, 1.5649], "confidence":
+        1}, {"text": "Baggins", "boundingBox": [6.396, 1.4556, 6.8967, 1.4556, 6.8967,
+        1.5931, 6.396, 1.5931], "confidence": 1}]}, {"text": "123 Hobbit Lane", "boundingBox":
+        [6.0165, 1.6707, 7.1006, 1.6707, 7.1006, 1.7854, 6.0165, 1.7854], "words":
+        [{"text": "123", "boundingBox": [6.0165, 1.6772, 6.2434, 1.6772, 6.2434, 1.7854,
+        6.0165, 1.7854], "confidence": 1}, {"text": "Hobbit", "boundingBox": [6.3033,
+        1.6707, 6.7463, 1.6707, 6.7463, 1.7854, 6.3033, 1.7854], "confidence": 1},
+        {"text": "Lane", "boundingBox": [6.803, 1.6782, 7.1006, 1.6782, 7.1006, 1.7854,
+        6.803, 1.7854], "confidence": 1}]}, {"text": "567 Main St.", "boundingBox":
+        [0.8852, 1.846, 1.713, 1.846, 1.713, 1.9554, 0.8852, 1.9554], "words": [{"text":
+        "567", "boundingBox": [0.8852, 1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852,
+        1.9554], "confidence": 1}, {"text": "Main", "boundingBox": [1.1777, 1.846,
+        1.5022, 1.846, 1.5022, 1.9554, 1.1777, 1.9554], "confidence": 1}, {"text":
+        "St.", "boundingBox": [1.5558, 1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558,
+        1.9554], "confidence": 1}]}, {"text": "Redmond, WA", "boundingBox": [6.0164,
+        1.891, 6.9793, 1.891, 6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text":
+        "Redmond,", "boundingBox": [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275,
+        6.0164, 2.0275], "confidence": 1}, {"text": "WA", "boundingBox": [6.7408,
+        1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408, 2.0044], "confidence": 1}]},
+        {"text": "Redmond, WA", "boundingBox": [0.891, 2.061, 1.8537, 2.061, 1.8537,
+        2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,", "boundingBox": [0.891,
+        2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975], "confidence": 1}, {"text":
+        "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682, 1.8537, 2.1744, 1.6152,
+        2.1744], "confidence": 1}]}, {"text": "555-555-5555", "boundingBox": [6.0105,
+        2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "words": [{"text":
+        "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254,
+        6.0105, 2.2254], "confidence": 1}]}, {"text": "555-555-5555", "boundingBox":
         [0.8852, 2.2887, 1.8119, 2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "words":
         [{"text": "555-555-5555", "boundingBox": [0.8852, 2.2887, 1.8119, 2.2887,
-        1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Item", "boundingBox": [1.0943,
-        3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
+        1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}]}, {"text": "Item", "boundingBox":
+        [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
         "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943,
-        3.109], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996,
-        3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity", "boundingBox":
-        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Price", "boundingBox": [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423,
-        3.109], "words": [{"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
-        2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "A", "boundingBox": [1.0832,
-        3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A",
-        "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116, 3.3202,
-        3.3176, 3.2589, 3.3176], "words": [{"text": "1", "boundingBox": [3.2589, 3.2116,
-        3.3202, 3.2116, 3.3202, 3.3176, 3.2589, 3.3176], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "10.99", "boundingBox":
+        3.109], "confidence": 1}]}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996,
+        3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity",
+        "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371],
+        "confidence": 1}]}, {"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
+        2.9996, 5.7372, 3.109, 5.423, 3.109], "words": [{"text": "Price", "boundingBox":
+        [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence":
+        1}]}, {"text": "A", "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174,
+        3.318, 1.0832, 3.318], "words": [{"text": "A", "boundingBox": [1.0832, 3.2118,
+        1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "confidence": 1}]}, {"text":
+        "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116, 3.3202, 3.3176, 3.2589,
+        3.3176], "words": [{"text": "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116,
+        3.3202, 3.3176, 3.2589, 3.3176], "confidence": 1}]}, {"text": "10.99", "boundingBox":
         [5.4232, 3.2108, 5.7784, 3.2108, 5.7784, 3.319, 5.4232, 3.319], "words": [{"text":
         "10.99", "boundingBox": [5.4232, 3.2108, 5.7784, 3.2108, 5.7784, 3.319, 5.4232,
-        3.319], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637,
-        3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox": [1.0943, 3.4256,
-        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "2", "boundingBox":
-        [3.2541, 3.4241, 3.3199, 3.4241, 3.3199, 3.531, 3.2541, 3.531], "words": [{"text":
-        "2", "boundingBox": [3.2541, 3.4241, 3.3199, 3.4241, 3.3199, 3.531, 3.2541,
-        3.531], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "14.67", "boundingBox": [5.4232, 3.4241, 5.7789, 3.4241, 5.7789,
-        3.5323, 5.4232, 3.5323], "words": [{"text": "14.67", "boundingBox": [5.4232,
-        3.4241, 5.7789, 3.4241, 5.7789, 3.5323, 5.4232, 3.5323], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "C",
+        3.319], "confidence": 1}]}, {"text": "B", "boundingBox": [1.0943, 3.4256,
+        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox":
+        [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence":
+        1}]}, {"text": "2", "boundingBox": [3.2541, 3.4241, 3.3199, 3.4241, 3.3199,
+        3.531, 3.2541, 3.531], "words": [{"text": "2", "boundingBox": [3.2541, 3.4241,
+        3.3199, 3.4241, 3.3199, 3.531, 3.2541, 3.531], "confidence": 1}]}, {"text":
+        "14.67", "boundingBox": [5.4232, 3.4241, 5.7789, 3.4241, 5.7789, 3.5323, 5.4232,
+        3.5323], "words": [{"text": "14.67", "boundingBox": [5.4232, 3.4241, 5.7789,
+        3.4241, 5.7789, 3.5323, 5.4232, 3.5323], "confidence": 1}]}, {"text": "C",
         "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647, 3.7421, 1.0882, 3.7421],
         "words": [{"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647,
-        3.7421, 1.0882, 3.7421], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "4", "boundingBox": [3.2486, 3.6351,
-        3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "words": [{"text": "4", "boundingBox":
-        [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "15.66", "boundingBox": [5.4232, 3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232,
-        3.7423], "words": [{"text": "15.66", "boundingBox": [5.4232, 3.6341, 5.78,
-        3.6341, 5.78, 3.7423, 5.4232, 3.7423], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "D", "boundingBox": [1.0943,
-        3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text":
-        "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943,
-        3.951], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1", "boundingBox": [3.2589, 3.845, 3.3202, 3.845, 3.3202,
+        3.7421, 1.0882, 3.7421], "confidence": 1}]}, {"text": "4", "boundingBox":
+        [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "words":
+        [{"text": "4", "boundingBox": [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413,
+        3.2486, 3.7413], "confidence": 1}]}, {"text": "15.66", "boundingBox": [5.4232,
+        3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232, 3.7423], "words": [{"text": "15.66",
+        "boundingBox": [5.4232, 3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232, 3.7423],
+        "confidence": 1}]}, {"text": "D", "boundingBox": [1.0943, 3.8456, 1.1753,
+        3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text": "D", "boundingBox":
+        [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "confidence":
+        1}]}, {"text": "1", "boundingBox": [3.2589, 3.845, 3.3202, 3.845, 3.3202,
         3.951, 3.2589, 3.951], "words": [{"text": "1", "boundingBox": [3.2589, 3.845,
-        3.3202, 3.845, 3.3202, 3.951, 3.2589, 3.951], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "12.00", "boundingBox":
-        [5.4232, 3.8441, 5.7809, 3.8441, 5.7809, 3.9523, 5.4232, 3.9523], "words":
-        [{"text": "12.00", "boundingBox": [5.4232, 3.8441, 5.7809, 3.8441, 5.7809,
-        3.9523, 5.4232, 3.9523], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "E", "boundingBox": [1.0943, 4.0561,
-        1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "words": [{"text": "E", "boundingBox":
-        [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617, 3.2486,
-        4.1617], "words": [{"text": "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556,
-        3.3244, 4.1617, 3.2486, 4.1617], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "10.00", "boundingBox": [5.4232,
+        3.3202, 3.845, 3.3202, 3.951, 3.2589, 3.951], "confidence": 1}]}, {"text":
+        "12.00", "boundingBox": [5.4232, 3.8441, 5.7809, 3.8441, 5.7809, 3.9523, 5.4232,
+        3.9523], "words": [{"text": "12.00", "boundingBox": [5.4232, 3.8441, 5.7809,
+        3.8441, 5.7809, 3.9523, 5.4232, 3.9523], "confidence": 1}]}, {"text": "E",
+        "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614],
+        "words": [{"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
+        4.1614, 1.0943, 4.1614], "confidence": 1}]}, {"text": "4", "boundingBox":
+        [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617, 3.2486, 4.1617], "words":
+        [{"text": "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617,
+        3.2486, 4.1617], "confidence": 1}]}, {"text": "10.00", "boundingBox": [5.4232,
         4.0546, 5.781, 4.0546, 5.781, 4.1627, 5.4232, 4.1627], "words": [{"text":
         "10.00", "boundingBox": [5.4232, 4.0546, 5.781, 4.0546, 5.781, 4.1627, 5.4232,
-        4.1627], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497,
-        4.3717, 1.0943, 4.3717], "words": [{"text": "F", "boundingBox": [1.0943, 4.2661,
-        1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "6", "boundingBox":
-        [3.2534, 4.2646, 3.3226, 4.2646, 3.3226, 4.3727, 3.2534, 4.3727], "words":
-        [{"text": "6", "boundingBox": [3.2534, 4.2646, 3.3226, 4.2646, 3.3226, 4.3727,
-        3.2534, 4.3727], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "12.00", "boundingBox": [5.4232, 4.2646, 5.7809,
-        4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "words": [{"text": "12.00", "boundingBox":
-        [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877,
-        4.5827], "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746,
-        1.1735, 4.5827, 1.0877, 4.5827], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "8", "boundingBox": [3.2514,
-        4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514, 4.5827], "words": [{"text":
-        "8", "boundingBox": [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514,
-        4.5827], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781,
-        4.5827, 5.4184, 4.5827], "words": [{"text": "22.00", "boundingBox": [5.4184,
-        4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184, 4.5827], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Subtotal:
-        300.00", "boundingBox": [5.5075, 4.8981, 6.632, 4.8981, 6.632, 5.0131, 5.5075,
-        5.0131], "words": [{"text": "Subtotal:", "boundingBox": [5.5075, 4.8981, 6.1249,
-        4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence": 1}, {"text": "300.00",
-        "boundingBox": [6.1794, 4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Tax: 30.00", "boundingBox": [5.5034, 5.1245, 6.2022, 5.1245,
-        6.2022, 5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:", "boundingBox":
-        [5.5034, 5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333], "confidence":
-        1}, {"text": "30.00", "boundingBox": [5.836, 5.1245, 6.2022, 5.1245, 6.2022,
-        5.2333, 5.836, 5.2333], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Tip: 100.00", "boundingBox": [5.5034,
-        5.3412, 6.2587, 5.3412, 6.2587, 5.481, 5.5034, 5.481], "words": [{"text":
+        4.1627], "confidence": 1}]}, {"text": "F", "boundingBox": [1.0943, 4.2661,
+        1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "words": [{"text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "confidence":
+        1}]}, {"text": "6", "boundingBox": [3.2534, 4.2646, 3.3226, 4.2646, 3.3226,
+        4.3727, 3.2534, 4.3727], "words": [{"text": "6", "boundingBox": [3.2534, 4.2646,
+        3.3226, 4.2646, 3.3226, 4.3727, 3.2534, 4.3727], "confidence": 1}]}, {"text":
+        "12.00", "boundingBox": [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232,
+        4.3727], "words": [{"text": "12.00", "boundingBox": [5.4232, 4.2646, 5.7809,
+        4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "confidence": 1}]}, {"text": "G",
+        "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827],
+        "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
+        4.5827, 1.0877, 4.5827], "confidence": 1}]}, {"text": "8", "boundingBox":
+        [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514, 4.5827], "words":
+        [{"text": "8", "boundingBox": [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827,
+        3.2514, 4.5827], "confidence": 1}]}, {"text": "22.00", "boundingBox": [5.4184,
+        4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184, 4.5827], "words": [{"text":
+        "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184,
+        4.5827], "confidence": 1}]}, {"text": "Subtotal: 300.00", "boundingBox": [5.5075,
+        4.8981, 6.632, 4.8981, 6.632, 5.0131, 5.5075, 5.0131], "words": [{"text":
+        "Subtotal:", "boundingBox": [5.5075, 4.8981, 6.1249, 4.8981, 6.1249, 5.0131,
+        5.5075, 5.0131], "confidence": 1}, {"text": "300.00", "boundingBox": [6.1794,
+        4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131], "confidence": 1}]},
+        {"text": "Tax: 30.00", "boundingBox": [5.5034, 5.1245, 6.2022, 5.1245, 6.2022,
+        5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:", "boundingBox": [5.5034,
+        5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333], "confidence": 1},
+        {"text": "30.00", "boundingBox": [5.836, 5.1245, 6.2022, 5.1245, 6.2022, 5.2333,
+        5.836, 5.2333], "confidence": 1}]}, {"text": "Tip: 100.00", "boundingBox":
+        [5.5034, 5.3412, 6.2587, 5.3412, 6.2587, 5.481, 5.5034, 5.481], "words": [{"text":
         "Tip:", "boundingBox": [5.5034, 5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034,
         5.481], "confidence": 1}, {"text": "100.00", "boundingBox": [5.811, 5.3445,
-        6.2587, 5.3445, 6.2587, 5.4533, 5.811, 5.4533], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Total: 430.00",
-        "boundingBox": [5.5034, 5.5583, 6.3987, 5.5583, 6.3987, 5.6733, 5.5034, 5.6733],
-        "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583,
-        5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "430.00", "boundingBox":
-        [5.942, 5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942, 5.6733], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Signature: ____Bilbo Baggins__________", "boundingBox": [1.0055, 6.6553,
-        3.8342, 6.6553, 3.8342, 6.7981, 1.0055, 6.7981], "words": [{"text": "Signature:",
-        "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981, 1.0055, 6.7981],
-        "confidence": 1}, {"text": "____Bilbo", "boundingBox": [1.747, 6.6553, 2.4278,
-        6.6553, 2.4278, 6.7981, 1.747, 6.7981], "confidence": 1}, {"text": "Baggins__________",
-        "boundingBox": [2.4823, 6.6581, 3.8342, 6.6581, 3.8342, 6.7981, 2.4823, 6.7981],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}]}, {"page": 2, "angle": 0, "width": 8.5, "height": 11, "unit": "inch"},
+        6.2587, 5.3445, 6.2587, 5.4533, 5.811, 5.4533], "confidence": 1}]}, {"text":
+        "Total: 430.00", "boundingBox": [5.5034, 5.5583, 6.3987, 5.5583, 6.3987, 5.6733,
+        5.5034, 5.6733], "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583,
+        5.8915, 5.5583, 5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text":
+        "430.00", "boundingBox": [5.942, 5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942,
+        5.6733], "confidence": 1}]}, {"text": "Signature: ____ Bilbo Baggins__________",
+        "boundingBox": [1.0055, 6.6553, 3.8342, 6.6553, 3.8342, 6.7981, 1.0055, 6.7981],
+        "words": [{"text": "Signature:", "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581,
+        1.6987, 6.7981, 1.0055, 6.7981], "confidence": 1}, {"text": "____", "boundingBox":
+        [1.747, 6.7829, 2.0809, 6.7829, 2.0809, 6.7981, 1.747, 6.7981], "confidence":
+        1}, {"text": "Bilbo", "boundingBox": [2.0925, 6.6553, 2.4278, 6.6553, 2.4278,
+        6.7703, 2.0925, 6.7703], "confidence": 1}, {"text": "Baggins__________", "boundingBox":
+        [2.4823, 6.6581, 3.8342, 6.6581, 3.8342, 6.7981, 2.4823, 6.7981], "confidence":
+        1}]}]}, {"page": 2, "angle": 0, "width": 8.5, "height": 11, "unit": "inch"},
         {"page": 3, "angle": 0, "width": 8.5, "height": 11, "unit": "inch", "lines":
         [{"text": "Company B Invoice", "boundingBox": [0.8861, 1.1217, 2.3734, 1.1217,
         2.3734, 1.2812, 0.8861, 1.2812], "words": [{"text": "Company", "boundingBox":
         [0.8861, 1.1232, 1.6203, 1.1232, 1.6203, 1.2812, 0.8861, 1.2812], "confidence":
         1}, {"text": "B", "boundingBox": [1.6836, 1.1248, 1.764, 1.1248, 1.764, 1.2469,
         1.6836, 1.2469], "confidence": 1}, {"text": "Invoice", "boundingBox": [1.8336,
-        1.1217, 2.3734, 1.1217, 2.3734, 1.2485, 1.8336, 1.2485], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Invoice
-        For:", "boundingBox": [6.0211, 1.0656, 7.0357, 1.0656, 7.0357, 1.2121, 6.0211,
-        1.2121], "words": [{"text": "Invoice", "boundingBox": [6.0211, 1.0656, 6.6362,
-        1.0656, 6.6362, 1.2121, 6.0211, 1.2121], "confidence": 1}, {"text": "For:",
-        "boundingBox": [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121, 6.7147, 1.2121],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825,
-        1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text": "Address:", "boundingBox":
-        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Frodo Baggins", "boundingBox": [6.0164, 1.4506, 6.9506, 1.4506, 6.9506, 1.5931,
-        6.0164, 1.5931], "words": [{"text": "Frodo", "boundingBox": [6.0164, 1.4506,
-        6.3895, 1.4506, 6.3895, 1.5649, 6.0164, 1.5649], "confidence": 1}, {"text":
-        "Baggins", "boundingBox": [6.45, 1.4556, 6.9506, 1.4556, 6.9506, 1.5931, 6.45,
-        1.5931], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "123 Hobbit Lane", "boundingBox": [6.0165, 1.6707, 7.1006,
+        1.1217, 2.3734, 1.1217, 2.3734, 1.2485, 1.8336, 1.2485], "confidence": 1}]},
+        {"text": "Invoice For:", "boundingBox": [6.0211, 1.0656, 7.0357, 1.0656, 7.0357,
+        1.2121, 6.0211, 1.2121], "words": [{"text": "Invoice", "boundingBox": [6.0211,
+        1.0656, 6.6362, 1.0656, 6.6362, 1.2121, 6.0211, 1.2121], "confidence": 1},
+        {"text": "For:", "boundingBox": [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121,
+        6.7147, 1.2121], "confidence": 1}]}, {"text": "Address:", "boundingBox": [0.8791,
+        1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text":
+        "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155,
+        0.8791, 1.6155], "confidence": 1}]}, {"text": "Frodo Baggins", "boundingBox":
+        [6.0164, 1.4506, 6.9506, 1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "words":
+        [{"text": "Frodo", "boundingBox": [6.0164, 1.4506, 6.3895, 1.4506, 6.3895,
+        1.5649, 6.0164, 1.5649], "confidence": 1}, {"text": "Baggins", "boundingBox":
+        [6.45, 1.4556, 6.9506, 1.4556, 6.9506, 1.5931, 6.45, 1.5931], "confidence":
+        1}]}, {"text": "123 Hobbit Lane", "boundingBox": [6.0165, 1.6707, 7.1006,
         1.6707, 7.1006, 1.7854, 6.0165, 1.7854], "words": [{"text": "123", "boundingBox":
         [6.0165, 1.6772, 6.2434, 1.6772, 6.2434, 1.7854, 6.0165, 1.7854], "confidence":
         1}, {"text": "Hobbit", "boundingBox": [6.3033, 1.6707, 6.7463, 1.6707, 6.7463,
         1.7854, 6.3033, 1.7854], "confidence": 1}, {"text": "Lane", "boundingBox":
         [6.803, 1.6782, 7.1006, 1.6782, 7.1006, 1.7854, 6.803, 1.7854], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "567 Main St.", "boundingBox": [0.8852, 1.846, 1.713, 1.846, 1.713, 1.9554,
-        0.8852, 1.9554], "words": [{"text": "567", "boundingBox": [0.8852, 1.8472,
-        1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554], "confidence": 1}, {"text":
-        "Main", "boundingBox": [1.1777, 1.846, 1.5022, 1.846, 1.5022, 1.9554, 1.1777,
-        1.9554], "confidence": 1}, {"text": "St.", "boundingBox": [1.5558, 1.8472,
-        1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Redmond, WA", "boundingBox":
-        [6.0164, 1.891, 6.9793, 1.891, 6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text":
-        "Redmond,", "boundingBox": [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275,
-        6.0164, 2.0275], "confidence": 1}, {"text": "WA", "boundingBox": [6.7408,
-        1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408, 2.0044], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Redmond,
-        WA", "boundingBox": [0.891, 2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975],
-        "words": [{"text": "Redmond,", "boundingBox": [0.891, 2.061, 1.5605, 2.061,
-        1.5605, 2.1975, 0.891, 2.1975], "confidence": 1}, {"text": "WA", "boundingBox":
-        [1.6152, 2.0682, 1.8537, 2.0682, 1.8537, 2.1744, 1.6152, 2.1744], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254,
-        6.0105, 2.2254], "words": [{"text": "555-555-5555", "boundingBox": [6.0105,
-        2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "555-555-5555",
+        1}]}, {"text": "567 Main St.", "boundingBox": [0.8852, 1.846, 1.713, 1.846,
+        1.713, 1.9554, 0.8852, 1.9554], "words": [{"text": "567", "boundingBox": [0.8852,
+        1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554], "confidence": 1},
+        {"text": "Main", "boundingBox": [1.1777, 1.846, 1.5022, 1.846, 1.5022, 1.9554,
+        1.1777, 1.9554], "confidence": 1}, {"text": "St.", "boundingBox": [1.5558,
+        1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554], "confidence": 1}]},
+        {"text": "Redmond, WA", "boundingBox": [6.0164, 1.891, 6.9793, 1.891, 6.9793,
+        2.0275, 6.0164, 2.0275], "words": [{"text": "Redmond,", "boundingBox": [6.0164,
+        1.891, 6.6861, 1.891, 6.6861, 2.0275, 6.0164, 2.0275], "confidence": 1}, {"text":
+        "WA", "boundingBox": [6.7408, 1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408,
+        2.0044], "confidence": 1}]}, {"text": "Redmond, WA", "boundingBox": [0.891,
+        2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,",
+        "boundingBox": [0.891, 2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975],
+        "confidence": 1}, {"text": "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682,
+        1.8537, 2.1744, 1.6152, 2.1744], "confidence": 1}]}, {"text": "555-555-5555",
+        "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254],
+        "words": [{"text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371,
+        2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}]}, {"text": "555-555-5555",
         "boundingBox": [0.8852, 2.2887, 1.8119, 2.2887, 1.8119, 2.3954, 0.8852, 2.3954],
         "words": [{"text": "555-555-5555", "boundingBox": [0.8852, 2.2887, 1.8119,
-        2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Item", "boundingBox":
-        [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
-        "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943,
-        3.109], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996,
-        3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity", "boundingBox":
-        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
+        2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}]}, {"text": "Item",
+        "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109],
+        "words": [{"text": "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018,
+        1.3842, 3.109, 1.0943, 3.109], "confidence": 1}]}, {"text": "Quantity", "boundingBox":
+        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "words":
+        [{"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996, 3.8367,
+        3.1371, 3.2527, 3.1371], "confidence": 1}]}, {"text": "Price", "boundingBox":
+        [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423, 3.109], "words": [{"text":
         "Price", "boundingBox": [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423,
-        3.109], "words": [{"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
-        2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "A", "boundingBox": [1.0832,
-        3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A",
-        "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "10", "boundingBox": [3.2589, 3.2108, 3.4067, 3.2108, 3.4067,
+        3.109], "confidence": 1}]}, {"text": "A", "boundingBox": [1.0832, 3.2118,
+        1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A", "boundingBox":
+        [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "confidence":
+        1}]}, {"text": "10", "boundingBox": [3.2589, 3.2108, 3.4067, 3.2108, 3.4067,
         3.319, 3.2589, 3.319], "words": [{"text": "10", "boundingBox": [3.2589, 3.2108,
-        3.4067, 3.2108, 3.4067, 3.319, 3.2589, 3.319], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "100.99", "boundingBox":
-        [5.4232, 3.2108, 5.8617, 3.2108, 5.8617, 3.319, 5.4232, 3.319], "words": [{"text":
+        3.4067, 3.2108, 3.4067, 3.319, 3.2589, 3.319], "confidence": 1}]}, {"text":
         "100.99", "boundingBox": [5.4232, 3.2108, 5.8617, 3.2108, 5.8617, 3.319, 5.4232,
-        3.319], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637,
-        3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox": [1.0943, 3.4256,
-        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "20", "boundingBox":
-        [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323], "words":
-        [{"text": "20", "boundingBox": [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323,
-        3.2541, 3.5323], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "140.67", "boundingBox": [5.4232, 3.4241, 5.8622,
+        3.319], "words": [{"text": "100.99", "boundingBox": [5.4232, 3.2108, 5.8617,
+        3.2108, 5.8617, 3.319, 5.4232, 3.319], "confidence": 1}]}, {"text": "B", "boundingBox":
+        [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "words": [{"text":
+        "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943,
+        3.531], "confidence": 1}]}, {"text": "20", "boundingBox": [3.2541, 3.4241,
+        3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323], "words": [{"text": "20",
+        "boundingBox": [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323],
+        "confidence": 1}]}, {"text": "140.67", "boundingBox": [5.4232, 3.4241, 5.8622,
         3.4241, 5.8622, 3.5323, 5.4232, 3.5323], "words": [{"text": "140.67", "boundingBox":
         [5.4232, 3.4241, 5.8622, 3.4241, 5.8622, 3.5323, 5.4232, 3.5323], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647, 3.7421, 1.0882,
-        3.7421], "words": [{"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343,
-        1.1647, 3.7421, 1.0882, 3.7421], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "40", "boundingBox": [3.2486,
-        3.6341, 3.4067, 3.6341, 3.4067, 3.7423, 3.2486, 3.7423], "words": [{"text":
+        1}]}, {"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647,
+        3.7421, 1.0882, 3.7421], "words": [{"text": "C", "boundingBox": [1.0882, 3.6343,
+        1.1647, 3.6343, 1.1647, 3.7421, 1.0882, 3.7421], "confidence": 1}]}, {"text":
         "40", "boundingBox": [3.2486, 3.6341, 3.4067, 3.6341, 3.4067, 3.7423, 3.2486,
-        3.7423], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "150.66", "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341, 5.8634,
-        3.7423, 5.4232, 3.7423], "words": [{"text": "150.66", "boundingBox": [5.4232,
-        3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "D",
-        "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951],
-        "words": [{"text": "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753,
-        3.951, 1.0943, 3.951], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "10", "boundingBox": [3.2589, 3.8441,
+        3.7423], "words": [{"text": "40", "boundingBox": [3.2486, 3.6341, 3.4067,
+        3.6341, 3.4067, 3.7423, 3.2486, 3.7423], "confidence": 1}]}, {"text": "150.66",
+        "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423],
+        "words": [{"text": "150.66", "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341,
+        5.8634, 3.7423, 5.4232, 3.7423], "confidence": 1}]}, {"text": "D", "boundingBox":
+        [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text":
+        "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943,
+        3.951], "confidence": 1}]}, {"text": "10", "boundingBox": [3.2589, 3.8441,
         3.4067, 3.8441, 3.4067, 3.9523, 3.2589, 3.9523], "words": [{"text": "10",
         "boundingBox": [3.2589, 3.8441, 3.4067, 3.8441, 3.4067, 3.9523, 3.2589, 3.9523],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "120.00", "boundingBox": [5.4232, 3.8441, 5.8642, 3.8441, 5.8642,
-        3.9523, 5.4232, 3.9523], "words": [{"text": "120.00", "boundingBox": [5.4232,
-        3.8441, 5.8642, 3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "E",
-        "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614],
-        "words": [{"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
-        4.1614, 1.0943, 4.1614], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "40", "boundingBox": [3.2486, 4.0546,
-        3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "words": [{"text": "40",
-        "boundingBox": [3.2486, 4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "100.00", "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546, 5.8644,
-        4.1627, 5.4232, 4.1627], "words": [{"text": "100.00", "boundingBox": [5.4232,
-        4.0546, 5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "F",
-        "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717],
-        "words": [{"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497,
-        4.3717, 1.0943, 4.3717], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "60", "boundingBox": [3.2534, 4.2646,
-        3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727], "words": [{"text": "60",
-        "boundingBox": [3.2534, 4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "120.00", "boundingBox": [5.4232, 4.2646, 5.8642, 4.2646, 5.8642,
-        4.3727, 5.4232, 4.3727], "words": [{"text": "120.00", "boundingBox": [5.4232,
-        4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "G",
-        "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827],
-        "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
-        4.5827, 1.0877, 4.5827], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "80", "boundingBox": [3.2514, 4.4746,
-        3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827], "words": [{"text": "80",
-        "boundingBox": [3.2514, 4.4746, 3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "220.00", "boundingBox": [5.4184, 4.4746, 5.8644, 4.4746, 5.8644,
+        "confidence": 1}]}, {"text": "120.00", "boundingBox": [5.4232, 3.8441, 5.8642,
+        3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "words": [{"text": "120.00", "boundingBox":
+        [5.4232, 3.8441, 5.8642, 3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "confidence":
+        1}]}, {"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
+        4.1614, 1.0943, 4.1614], "words": [{"text": "E", "boundingBox": [1.0943, 4.0561,
+        1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "confidence": 1}]}, {"text":
+        "40", "boundingBox": [3.2486, 4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486,
+        4.1627], "words": [{"text": "40", "boundingBox": [3.2486, 4.0546, 3.4067,
+        4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "confidence": 1}]}, {"text": "100.00",
+        "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627],
+        "words": [{"text": "100.00", "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546,
+        5.8644, 4.1627, 5.4232, 4.1627], "confidence": 1}]}, {"text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "words":
+        [{"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717,
+        1.0943, 4.3717], "confidence": 1}]}, {"text": "60", "boundingBox": [3.2534,
+        4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727], "words": [{"text":
+        "60", "boundingBox": [3.2534, 4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534,
+        4.3727], "confidence": 1}]}, {"text": "120.00", "boundingBox": [5.4232, 4.2646,
+        5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "words": [{"text": "120.00",
+        "boundingBox": [5.4232, 4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727],
+        "confidence": 1}]}, {"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735,
+        4.4746, 1.1735, 4.5827, 1.0877, 4.5827], "words": [{"text": "G", "boundingBox":
+        [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827], "confidence":
+        1}]}, {"text": "80", "boundingBox": [3.2514, 4.4746, 3.4067, 4.4746, 3.4067,
+        4.5827, 3.2514, 4.5827], "words": [{"text": "80", "boundingBox": [3.2514,
+        4.4746, 3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827], "confidence": 1}]},
+        {"text": "220.00", "boundingBox": [5.4184, 4.4746, 5.8644, 4.4746, 5.8644,
         4.5827, 5.4184, 4.5827], "words": [{"text": "220.00", "boundingBox": [5.4184,
-        4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Subtotal:
-        3000.00", "boundingBox": [5.5075, 4.8981, 6.7158, 4.8981, 6.7158, 5.0131,
-        5.5075, 5.0131], "words": [{"text": "Subtotal:", "boundingBox": [5.5075, 4.8981,
-        6.1249, 4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence": 1}, {"text":
-        "3000.00", "boundingBox": [6.1794, 4.9042, 6.7158, 4.9042, 6.7158, 5.0131,
-        6.1794, 5.0131], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "Tax: 300.00", "boundingBox": [5.5034, 5.1245,
-        6.2887, 5.1245, 6.2887, 5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:",
-        "boundingBox": [5.5034, 5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333],
-        "confidence": 1}, {"text": "300.00", "boundingBox": [5.836, 5.1245, 6.2887,
-        5.1245, 6.2887, 5.2333, 5.836, 5.2333], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Tip: 1000.00", "boundingBox":
-        [5.5034, 5.3412, 6.3422, 5.3412, 6.3422, 5.481, 5.5034, 5.481], "words": [{"text":
-        "Tip:", "boundingBox": [5.5034, 5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034,
-        5.481], "confidence": 1}, {"text": "1000.00", "boundingBox": [5.811, 5.3445,
-        6.3422, 5.3445, 6.3422, 5.4533, 5.811, 5.4533], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Total: 4300.00",
-        "boundingBox": [5.5034, 5.5583, 6.4825, 5.5583, 6.4825, 5.6733, 5.5034, 5.6733],
-        "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583,
-        5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "4300.00", "boundingBox":
+        4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "confidence": 1}]},
+        {"text": "Subtotal: 3000.00", "boundingBox": [5.5075, 4.8981, 6.7158, 4.8981,
+        6.7158, 5.0131, 5.5075, 5.0131], "words": [{"text": "Subtotal:", "boundingBox":
+        [5.5075, 4.8981, 6.1249, 4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence":
+        1}, {"text": "3000.00", "boundingBox": [6.1794, 4.9042, 6.7158, 4.9042, 6.7158,
+        5.0131, 6.1794, 5.0131], "confidence": 1}]}, {"text": "Tax: 300.00", "boundingBox":
+        [5.5034, 5.1245, 6.2887, 5.1245, 6.2887, 5.2333, 5.5034, 5.2333], "words":
+        [{"text": "Tax:", "boundingBox": [5.5034, 5.1263, 5.7812, 5.1263, 5.7812,
+        5.2333, 5.5034, 5.2333], "confidence": 1}, {"text": "300.00", "boundingBox":
+        [5.836, 5.1245, 6.2887, 5.1245, 6.2887, 5.2333, 5.836, 5.2333], "confidence":
+        1}]}, {"text": "Tip: 1000.00", "boundingBox": [5.5034, 5.3412, 6.3422, 5.3412,
+        6.3422, 5.481, 5.5034, 5.481], "words": [{"text": "Tip:", "boundingBox": [5.5034,
+        5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034, 5.481], "confidence": 1}, {"text":
+        "1000.00", "boundingBox": [5.811, 5.3445, 6.3422, 5.3445, 6.3422, 5.4533,
+        5.811, 5.4533], "confidence": 1}]}, {"text": "Total: 4300.00", "boundingBox":
+        [5.5034, 5.5583, 6.4825, 5.5583, 6.4825, 5.6733, 5.5034, 5.6733], "words":
+        [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583, 5.8915,
+        5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "4300.00", "boundingBox":
         [5.942, 5.5645, 6.4825, 5.5645, 6.4825, 5.6733, 5.942, 5.6733], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Signature: ____Frodo Baggins__________", "boundingBox": [1.0055, 6.6556,
-        3.8842, 6.6556, 3.8842, 6.7981, 1.0055, 6.7981], "words": [{"text": "Signature:",
-        "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981, 1.0055, 6.7981],
-        "confidence": 1}, {"text": "____Frodo", "boundingBox": [1.747, 6.6556, 2.4778,
-        6.6556, 2.4778, 6.7981, 1.747, 6.7981], "confidence": 1}, {"text": "Baggins__________",
-        "boundingBox": [2.5325, 6.6581, 3.8842, 6.6581, 3.8842, 6.7981, 2.5325, 6.7981],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}]}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
+        1}]}, {"text": "Signature: ____ Frodo Baggins__________", "boundingBox": [1.0055,
+        6.6556, 3.8842, 6.6556, 3.8842, 6.7981, 1.0055, 6.7981], "words": [{"text":
+        "Signature:", "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981,
+        1.0055, 6.7981], "confidence": 1}, {"text": "____", "boundingBox": [1.747,
+        6.7829, 2.0809, 6.7829, 2.0809, 6.7981, 1.747, 6.7981], "confidence": 1},
+        {"text": "Frodo", "boundingBox": [2.0925, 6.6556, 2.4778, 6.6556, 2.4778,
+        6.7703, 2.0925, 6.7703], "confidence": 1}, {"text": "Baggins__________", "boundingBox":
+        [2.5325, 6.6581, 3.8842, 6.6581, 3.8842, 6.7981, 2.5325, 6.7981], "confidence":
+        1}]}]}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
         [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString": "Itemized",
-        "confidence": 0.991}, "MerchantName": {"type": "string", "valueString": "Bilbo
+        "confidence": 0.99}, "MerchantName": {"type": "string", "valueString": "Bilbo
         Baggins", "text": "Bilbo Baggins", "boundingBox": [6.0164, 1.4503, 6.8967,
-        1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "page": 1, "confidence": 0.669, "elements":
+        1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "page": 1, "confidence": 0.987, "elements":
         ["#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1"]}, "MerchantAddress":
         {"type": "string", "valueString": "123 Hobbit Lane 567 Main St. Redmond, WA
         Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA",
         "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975, 0.8852, 2.1975],
-        "page": 1, "confidence": 0.345, "elements": ["#/readResults/0/lines/4/words/0",
+        "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/4/words/0",
         "#/readResults/0/lines/4/words/1", "#/readResults/0/lines/4/words/2", "#/readResults/0/lines/5/words/0",
         "#/readResults/0/lines/5/words/1", "#/readResults/0/lines/5/words/2", "#/readResults/0/lines/6/words/0",
         "#/readResults/0/lines/6/words/1", "#/readResults/0/lines/7/words/0", "#/readResults/0/lines/7/words/1"]},
         "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber": "+15555555555",
         "text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371,
-        2.2254, 6.0105, 2.2254], "page": 1, "confidence": 0.932, "elements": ["#/readResults/0/lines/8/words/0"]},
+        2.2254, 6.0105, 2.2254], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/8/words/0"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "F", "text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "page":
+        1, "confidence": 0.964, "elements": ["#/readResults/0/lines/28/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 12, "text": "12.00", "boundingBox":
+        [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "page":
+        1, "confidence": 0.947, "elements": ["#/readResults/0/lines/30/words/0"]}}},
+        {"type": "object", "valueObject": {"TotalPrice": {"type": "number", "valueNumber":
+        22, "text": "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781,
+        4.5827, 5.4184, 4.5827], "page": 1, "confidence": 0.935, "elements": ["#/readResults/0/lines/33/words/0"]}}}]},
         "Subtotal": {"type": "number", "valueNumber": 300, "text": "300.00", "boundingBox":
         [6.1794, 4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131], "page": 1,
-        "confidence": 0.96, "elements": ["#/readResults/0/lines/34/words/1"]}}}, {"docType":
-        "prebuilt:receipt", "pageRange": [2, 2], "fields": {}}, {"docType": "prebuilt:receipt",
-        "pageRange": [3, 3], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Frodo Baggins", "text": "Frodo Baggins", "boundingBox": [6.0164, 1.4506,
-        6.9506, 1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "page": 3, "confidence":
-        0.529, "elements": ["#/readResults/2/lines/3/words/0", "#/readResults/2/lines/3/words/1"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Hobbit Lane 567
-        Main St. Redmond, WA Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond,
-        WA Redmond, WA", "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975,
-        0.8852, 2.1975], "page": 3, "confidence": 0.523, "elements": ["#/readResults/2/lines/4/words/0",
+        "confidence": 0.99, "elements": ["#/readResults/0/lines/34/words/1"]}, "Total":
+        {"type": "number", "valueNumber": 430, "text": "430.00", "boundingBox": [5.942,
+        5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942, 5.6733], "page": 1, "confidence":
+        0.985, "elements": ["#/readResults/0/lines/37/words/1"]}}}, {"docType": "prebuilt:receipt",
+        "pageRange": [2, 2], "fields": {}}, {"docType": "prebuilt:receipt", "pageRange":
+        [3, 3], "fields": {"ReceiptType": {"type": "string", "valueString": "Itemized",
+        "confidence": 0.99}, "MerchantName": {"type": "string", "valueString": "Frodo
+        Baggins", "text": "Frodo Baggins", "boundingBox": [6.0164, 1.4506, 6.9506,
+        1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "page": 3, "confidence": 0.984, "elements":
+        ["#/readResults/2/lines/3/words/0", "#/readResults/2/lines/3/words/1"]}, "MerchantAddress":
+        {"type": "string", "valueString": "123 Hobbit Lane 567 Main St. Redmond, WA
+        Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA",
+        "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975, 0.8852, 2.1975],
+        "page": 3, "confidence": 0.99, "elements": ["#/readResults/2/lines/4/words/0",
         "#/readResults/2/lines/4/words/1", "#/readResults/2/lines/4/words/2", "#/readResults/2/lines/5/words/0",
         "#/readResults/2/lines/5/words/1", "#/readResults/2/lines/5/words/2", "#/readResults/2/lines/6/words/0",
         "#/readResults/2/lines/6/words/1", "#/readResults/2/lines/7/words/0", "#/readResults/2/lines/7/words/1"]},
         "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber": "+15555555555",
         "text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371,
-        2.2254, 6.0105, 2.2254], "page": 3, "confidence": 0.926, "elements": ["#/readResults/2/lines/8/words/0"]},
-        "Subtotal": {"type": "number", "valueNumber": 150.66, "text": "150.66", "boundingBox":
-        [5.4232, 3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423], "page":
-        3, "confidence": 0.664, "elements": ["#/readResults/2/lines/21/words/0"]}}}]}}'
+        2.2254, 6.0105, 2.2254], "page": 3, "confidence": 0.99, "elements": ["#/readResults/2/lines/8/words/0"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "E", "text": "E", "boundingBox":
+        [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "page": 3,
+        "confidence": 0.935, "elements": ["#/readResults/2/lines/25/words/0"]}, "Quantity":
+        {"type": "number", "valueNumber": 40, "text": "40", "boundingBox": [3.2486,
+        4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "page": 3, "confidence":
+        0, "elements": ["#/readResults/2/lines/26/words/0"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 100, "text": "100.00", "boundingBox": [5.4232, 4.0546,
+        5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627], "page": 3, "confidence":
+        0.723, "elements": ["#/readResults/2/lines/27/words/0"]}}}, {"type": "object",
+        "valueObject": {"Name": {"type": "string", "valueString": "F", "text": "F",
+        "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717],
+        "page": 3, "confidence": 0.905, "elements": ["#/readResults/2/lines/28/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 120, "text": "120.00", "boundingBox":
+        [5.4232, 4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "page":
+        3, "confidence": 0.967, "elements": ["#/readResults/2/lines/30/words/0"]}}},
+        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
+        "G", "text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
+        4.5827, 1.0877, 4.5827], "page": 3, "confidence": 0.896, "elements": ["#/readResults/2/lines/31/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 220, "text": "220.00", "boundingBox":
+        [5.4184, 4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "page":
+        3, "confidence": 0.958, "elements": ["#/readResults/2/lines/33/words/0"]}}}]},
+        "Subtotal": {"type": "number", "valueNumber": 3000, "text": "3000.00", "boundingBox":
+        [6.1794, 4.9042, 6.7158, 4.9042, 6.7158, 5.0131, 6.1794, 5.0131], "page":
+        3, "confidence": 0.99, "elements": ["#/readResults/2/lines/34/words/1"]},
+        "Total": {"type": "number", "valueNumber": 1000, "text": "1000.00", "boundingBox":
+        [5.811, 5.3445, 6.3422, 5.3445, 6.3422, 5.4533, 5.811, 5.4533], "page": 3,
+        "confidence": 0.985, "elements": ["#/readResults/2/lines/36/words/1"]}}}]}}'
     headers:
       apim-request-id:
-      - 7db7d3d0-82a2-477c-9ad3-d3a6c28990b9
+      - 9bd2e2be-c8c9-475e-b768-ccfe1b419158
       content-length:
-      - '26841'
+      - '25475'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:07:19 GMT
+      - Mon, 16 Nov 2020 19:12:45 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '29'
+      - '22'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_url_auth_bad_key.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_url_auth_bad_key.yaml
@@ -25,7 +25,7 @@ interactions:
       content-length:
       - '224'
       date:
-      - Wed, 11 Nov 2020 18:07:20 GMT
+      - Mon, 16 Nov 2020 19:12:45 GMT
     status:
       code: 401
       message: PermissionDenied

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_url_auth_successful_key.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_url_auth_successful_key.yaml
@@ -21,19 +21,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 1c4a9533-c697-4fbc-ab9f-988b20ffa210
+      - 1d9208f5-d763-418f-aacc-accda1ffb3c4
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:07:20 GMT
+      - Mon, 16 Nov 2020 19:12:46 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/1c4a9533-c697-4fbc-ab9f-988b20ffa210
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/1d9208f5-d763-418f-aacc-accda1ffb3c4
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '168'
+      - '216'
     status:
       code: 202
       message: Accepted
@@ -49,65 +49,65 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/1c4a9533-c697-4fbc-ab9f-988b20ffa210
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/1d9208f5-d763-418f-aacc-accda1ffb3c4
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:07:20Z",
-        "lastUpdatedDateTime": "2020-11-11T18:07:22Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:12:46Z",
+        "lastUpdatedDateTime": "2020-11-16T19:12:50Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [380.9, 282.9,
-        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.716}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [298.3, 676.5, 844.6,
-        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence":
-        0.99}, "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text":
-        "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505, 1331, 255, 1312],
-        "page": 1, "confidence": 0.99}, "TransactionTime": {"type": "time", "valueTime":
-        "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681, 1262, 675, 1341,
-        522, 1332], "page": 1, "confidence": 0.989}, "Items": {"type": "array", "valueArray":
-        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [244, 1581, 288, 1584, 285, 1678, 241, 1675],
-        "page": 1, "confidence": 0.919}, "Name": {"type": "string", "valueString":
-        "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585, 658, 1598,
-        657, 1688, 304, 1679], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1106, 1579,
-        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.959}}}, {"type":
-        "object", "valueObject": {"Quantity": {"type": "number", "valueNumber": 1,
-        "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [294, 1839, 737, 1839,
-        737, 1924, 294, 1924], "page": 1, "confidence": 0.955}, "TotalPrice": {"type":
-        "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox": [1134, 1948,
-        1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence": 0.958}}}]},
-        "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923}, "Tax": {"type": "number", "valueNumber": 1.17, "text": "1.17", "boundingBox":
-        [1186, 2356, 1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence":
-        0.979}, "Tip": {"type": "number", "valueNumber": 463, "text": "$463", "boundingBox":
-        [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "page": 1, "confidence":
-        0.975}, "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50",
-        "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1,
-        "confidence": 0.987}}}]}}'
+        "Itemized", "confidence": 0.692}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [378.2, 292.4,
+        1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8], "page": 1, "confidence": 0.613},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [302,
+        675.8, 848.1, 793.7, 809.9, 970.4, 263.9, 852.5], "page": 1, "confidence":
+        0.99}, "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber":
+        "+19876543210", "text": "987-654-3210", "boundingBox": [278, 1004, 656, 1057,
+        647, 1123, 271, 1075], "page": 1, "confidence": 0.99}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99},
+        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
+        "boundingBox": [541, 1248, 677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence":
+        0.977}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
+        [245, 1583, 299, 1585, 295, 1676, 241, 1671], "page": 1, "confidence": 0.92},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923}, "TotalPrice": {"type": "number", "valueNumber": 2.2, "text": "$2.20",
+        "boundingBox": [1108, 1584, 1263, 1574, 1268, 1656, 1113, 1666], "page": 1,
+        "confidence": 0.918}}}, {"type": "object", "valueObject": {"Quantity": {"type":
+        "number", "valueNumber": 1, "text": "1", "boundingBox": [232, 1834, 286, 1836,
+        285, 1920, 231, 1920], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916},
+        "TotalPrice": {"type": "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox":
+        [1135, 1955, 1257, 1952, 1259, 2036, 1136, 2039], "page": 1, "confidence":
+        0.916}}}]}, "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70",
+        "boundingBox": [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1,
+        "confidence": 0.955}, "Tax": {"type": "number", "valueNumber": 1.17, "text":
+        "1.17", "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "page":
+        1, "confidence": 0.979}, "Tip": {"type": "number", "valueNumber": 1.63, "text":
+        "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591, 1091, 2585], "page":
+        1, "confidence": 0.941}, "Total": {"type": "number", "valueNumber": 14.5,
+        "text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380, 2763, 1030,
+        2739], "page": 1, "confidence": 0.985}}}]}}'
     headers:
       apim-request-id:
-      - 89221c41-7726-4bb0-b6db-73fbc98e2456
+      - 14997096-9819-4416-8b9f-948c44eb2dc8
       content-length:
-      - '2820'
+      - '2835'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:07:25 GMT
+      - Mon, 16 Nov 2020 19:12:51 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '22'
+      - '23'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_url_include_field_elements.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_url_include_field_elements.yaml
@@ -21,19 +21,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 55e00c64-e5d7-467d-af2f-d01d0edd1d41
+      - 3298be6f-3430-480b-85e8-2f8328834d06
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:07:26 GMT
+      - Mon, 16 Nov 2020 19:12:51 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/55e00c64-e5d7-467d-af2f-d01d0edd1d41
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/3298be6f-3430-480b-85e8-2f8328834d06
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '522'
+      - '342'
     status:
       code: 202
       message: Accepted
@@ -49,173 +49,146 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/55e00c64-e5d7-467d-af2f-d01d0edd1d41
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/3298be6f-3430-480b-85e8-2f8328834d06
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:07:26Z",
-        "lastUpdatedDateTime": "2020-11-11T18:07:28Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
-        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [306,
-        569, 519, 624, 502, 686, 290, 632], "words": [{"text": "Contoso", "boundingBox":
-        [308, 570, 515, 627, 500, 685, 290, 634], "confidence": 0.806}], "appearance":
-        {"style": {"name": "print", "confidence": 0.996}}}, {"text": "Contoso", "boundingBox":
-        [625, 512, 1089, 465, 1096, 561, 631, 607], "words": [{"text": "Contoso",
-        "boundingBox": [625, 512, 1088, 466, 1093, 562, 631, 607], "confidence": 0.984}],
-        "appearance": {"style": {"name": "print", "confidence": 0.999}}}, {"text":
-        "123 Main Street", "boundingBox": [301, 677, 697, 759, 681, 835, 284, 750],
-        "words": [{"text": "123", "boundingBox": [301, 677, 379, 692, 362, 766, 284,
-        751], "confidence": 0.987}, {"text": "Main", "boundingBox": [393, 695, 520,
-        721, 503, 795, 377, 769], "confidence": 0.985}, {"text": "Street", "boundingBox":
-        [534, 724, 694, 763, 676, 835, 517, 798], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.995}}}, {"text": "Redmond, WA
-        98052", "boundingBox": [284, 784, 823, 855, 814, 925, 275, 868], "words":
-        [{"text": "Redmond,", "boundingBox": [287, 784, 544, 829, 535, 905, 275, 853],
-        "confidence": 0.924}, {"text": "WA", "boundingBox": [558, 830, 640, 840, 632,
-        916, 549, 907], "confidence": 0.985}, {"text": "98052", "boundingBox": [654,
-        842, 822, 855, 817, 925, 646, 917], "confidence": 0.985}], "appearance": {"style":
-        {"name": "print", "confidence": 0.999}}}, {"text": "987-654-3210", "boundingBox":
-        [270, 999, 655, 1049, 646, 1125, 264, 1075], "words": [{"text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "confidence":
-        0.978}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "6/10/2019 13:59", "boundingBox": [258, 1224, 683, 1259, 676, 1341, 255, 1309],
-        "words": [{"text": "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505,
-        1331, 255, 1312], "confidence": 0.951}, {"text": "13:59", "boundingBox": [527,
-        1248, 681, 1262, 675, 1341, 522, 1332], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "Sales Associate:
-        Paul", "boundingBox": [252, 1347, 860, 1378, 859, 1449, 249, 1425], "words":
-        [{"text": "Sales", "boundingBox": [255, 1348, 409, 1358, 405, 1432, 249, 1419],
-        "confidence": 0.983}, {"text": "Associate:", "boundingBox": [423, 1359, 704,
-        1373, 703, 1447, 419, 1434], "confidence": 0.933}, {"text": "Paul", "boundingBox":
-        [718, 1373, 858, 1378, 859, 1449, 717, 1448], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "1 Cappuccino", "boundingBox":
-        [244, 1581, 660, 1597, 658, 1688, 241, 1675], "words": [{"text": "1", "boundingBox":
-        [244, 1581, 288, 1584, 285, 1678, 241, 1675], "confidence": 0.977}, {"text":
-        "Cappuccino", "boundingBox": [306, 1585, 658, 1598, 657, 1688, 304, 1679],
-        "confidence": 0.858}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "$2.20", "boundingBox": [1106, 1580, 1264, 1574, 1268, 1656,
-        1108, 1662], "words": [{"text": "$2.20", "boundingBox": [1106, 1579, 1260,
-        1574, 1263, 1656, 1108, 1662], "confidence": 0.981}], "appearance": {"style":
-        {"name": "print", "confidence": 0.849}}}, {"text": "1 BACON & EGGS", "boundingBox":
-        [226, 1838, 740, 1839, 740, 1924, 226, 1923], "words": [{"text": "1", "boundingBox":
-        [227, 1839, 278, 1839, 277, 1924, 226, 1924], "confidence": 0.986}, {"text":
-        "BACON", "boundingBox": [295, 1839, 493, 1840, 493, 1923, 294, 1924], "confidence":
-        0.984}, {"text": "&", "boundingBox": [510, 1840, 555, 1840, 555, 1923, 510,
-        1923], "confidence": 0.983}, {"text": "EGGS", "boundingBox": [572, 1840, 737,
-        1841, 736, 1924, 572, 1923], "confidence": 0.984}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Sunny-side-up", "boundingBox":
-        [343, 1976, 758, 1974, 759, 2061, 343, 2063], "words": [{"text": "Sunny-side-up",
-        "boundingBox": [343, 1977, 757, 1975, 755, 2063, 346, 2064], "confidence":
-        0.973}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "$9.5", "boundingBox": [1134, 1948, 1253, 1948, 1255, 2041, 1137, 2041], "words":
-        [{"text": "$9.5", "boundingBox": [1134, 1948, 1252, 1948, 1252, 2041, 1134,
-        2041], "confidence": 0.983}], "appearance": {"style": {"name": "print", "confidence":
-        0.932}}}, {"text": "- -", "boundingBox": [218, 2143, 291, 2140, 292, 2158,
-        218, 2161], "words": [{"text": "-", "boundingBox": [236, 2143, 255, 2143,
-        255, 2161, 235, 2161], "confidence": 0.559}, {"text": "-", "boundingBox":
-        [271, 2142, 290, 2141, 291, 2158, 272, 2160], "confidence": 0.985}], "appearance":
-        {"style": {"name": "print", "confidence": 0.67}}}, {"text": "-----", "boundingBox":
-        [277, 2142, 461, 2136, 461, 2155, 278, 2161], "words": [{"text": "-----",
-        "boundingBox": [305, 2141, 457, 2136, 458, 2155, 305, 2161], "confidence":
-        0.69}], "appearance": {"style": {"name": "print", "confidence": 0.467}}},
-        {"text": "----", "boundingBox": [471, 2137, 565, 2133, 566, 2150, 472, 2154],
-        "words": [{"text": "----", "boundingBox": [473, 2138, 566, 2134, 566, 2150,
-        473, 2154], "confidence": 0.559}], "appearance": {"style": {"name": "print",
-        "confidence": 0.703}}}, {"text": "--", "boundingBox": [1252, 2129, 1319, 2127,
-        1320, 2143, 1252, 2146], "words": [{"text": "--", "boundingBox": [1277, 2129,
-        1319, 2127, 1319, 2144, 1276, 2145], "confidence": 0.559}], "appearance":
-        {"style": {"name": "print", "confidence": 0.846}}}, {"text": "Sub-Total",
-        "boundingBox": [434, 2232, 768, 2222, 770, 2312, 437, 2322], "words": [{"text":
-        "Sub-Total", "boundingBox": [434, 2234, 769, 2222, 770, 2313, 442, 2322],
-        "confidence": 0.981}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "$ 11.70", "boundingBox": [1082, 2228, 1309, 2228, 1309, 2313,
-        1084, 2312], "words": [{"text": "$", "boundingBox": [1082, 2228, 1122, 2228,
-        1121, 2313, 1082, 2312], "confidence": 0.654}, {"text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "confidence": 0.984}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "Tax", "boundingBox":
-        [433, 2367, 563, 2363, 565, 2458, 435, 2462], "words": [{"text": "Tax", "boundingBox":
-        [433, 2367, 559, 2363, 562, 2458, 435, 2462], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 0.98}}}, {"text": "$ 1.17", "boundingBox":
-        [1125, 2353, 1306, 2362, 1304, 2451, 1121, 2444], "words": [{"text": "$",
-        "boundingBox": [1125, 2353, 1167, 2355, 1163, 2446, 1121, 2444], "confidence":
-        0.966}, {"text": "1.17", "boundingBox": [1186, 2356, 1307, 2361, 1303, 2452,
-        1182, 2447], "confidence": 0.983}], "appearance": {"style": {"name": "print",
-        "confidence": 0.963}}}, {"text": "Tip", "boundingBox": [439, 2502, 545, 2506,
-        541, 2606, 435, 2602], "words": [{"text": "Tip", "boundingBox": [438, 2502,
-        545, 2506, 541, 2606, 435, 2602], "confidence": 0.987}], "appearance": {"style":
-        {"name": "print", "confidence": 0.943}}}, {"text": "$463", "boundingBox":
-        [1038, 2483, 1271, 2489, 1269, 2583, 1032, 2577], "words": [{"text": "$463",
-        "boundingBox": [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "confidence":
-        0.592}], "appearance": {"style": {"name": "handwriting", "confidence": 0.892}}},
-        {"text": "Total", "boundingBox": [431, 2651, 607, 2646, 610, 2739, 435, 2745],
-        "words": [{"text": "Total", "boundingBox": [431, 2651, 605, 2646, 608, 2739,
-        433, 2745], "confidence": 0.983}], "appearance": {"style": {"name": "print",
-        "confidence": 0.991}}}, {"text": "$14.50", "boundingBox": [1034, 2623, 1381,
-        2642, 1374, 2757, 1027, 2740], "words": [{"text": "$14.50", "boundingBox":
-        [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "confidence": 0.845}], "appearance":
-        {"style": {"name": "handwriting", "confidence": 0.991}}}]}], "documentResults":
-        [{"docType": "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType":
-        {"type": "string", "valueString": "Itemized", "confidence": 0.99}, "MerchantName":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:12:52Z",
+        "lastUpdatedDateTime": "2020-11-16T19:12:55Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
+        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [635,
+        510, 1086, 461, 1098, 558, 643, 604], "words": [{"text": "Contoso", "boundingBox":
+        [639, 510, 1087, 461, 1098, 551, 646, 604], "confidence": 0.955}]}, {"text":
+        "Contoso", "boundingBox": [305, 574, 519, 624, 504, 686, 291, 634], "words":
+        [{"text": "Contoso", "boundingBox": [311, 575, 517, 623, 503, 686, 297, 636],
+        "confidence": 0.435}]}, {"text": "123 Main Street", "boundingBox": [300, 675,
+        703, 767, 686, 844, 284, 749], "words": [{"text": "123", "boundingBox": [302,
+        676, 390, 695, 375, 770, 287, 751], "confidence": 0.935}, {"text": "Main",
+        "boundingBox": [405, 698, 528, 726, 512, 802, 390, 774], "confidence": 0.958},
+        {"text": "Street", "boundingBox": [542, 730, 702, 767, 685, 845, 527, 806],
+        "confidence": 0.959}]}, {"text": "Redmond, WA 98052", "boundingBox": [290,
+        784, 828, 850, 820, 933, 279, 868], "words": [{"text": "Redmond,", "boundingBox":
+        [293, 784, 550, 826, 540, 905, 280, 856], "confidence": 0.762}, {"text": "WA",
+        "boundingBox": [565, 828, 645, 837, 637, 917, 555, 907], "confidence": 0.943},
+        {"text": "98052", "boundingBox": [660, 838, 824, 849, 818, 933, 651, 919],
+        "confidence": 0.959}]}, {"text": "987-654-3210", "boundingBox": [275, 1003,
+        656, 1055, 646, 1123, 269, 1073], "words": [{"text": "987-654-3210", "boundingBox":
+        [278, 1004, 656, 1057, 647, 1123, 271, 1075], "confidence": 0.939}]}, {"text":
+        "6/10/2019 13:59", "boundingBox": [265, 1228, 678, 1258, 671, 1344, 258, 1311],
+        "words": [{"text": "6/10/2019", "boundingBox": [267, 1229, 525, 1247, 517,
+        1332, 259, 1313], "confidence": 0.762}, {"text": "13:59", "boundingBox": [541,
+        1248, 677, 1263, 669, 1345, 533, 1333], "confidence": 0.958}]}, {"text": "Sales
+        Associate: Paul", "boundingBox": [253, 1347, 868, 1379, 863, 1457, 249, 1425],
+        "words": [{"text": "Sales", "boundingBox": [259, 1348, 419, 1359, 414, 1435,
+        252, 1422], "confidence": 0.92}, {"text": "Associate:", "boundingBox": [434,
+        1360, 711, 1374, 707, 1452, 428, 1436], "confidence": 0.909}, {"text": "Paul",
+        "boundingBox": [726, 1374, 865, 1379, 862, 1457, 722, 1452], "confidence":
+        0.959}]}, {"text": "1 Cappuccino", "boundingBox": [244, 1583, 658, 1601, 653,
+        1689, 240, 1674], "words": [{"text": "1", "boundingBox": [245, 1583, 299,
+        1585, 295, 1676, 241, 1671], "confidence": 0.824}, {"text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "confidence":
+        0.727}]}, {"text": "$2.20", "boundingBox": [1106, 1584, 1268, 1574, 1270,
+        1656, 1110, 1666], "words": [{"text": "$2.20", "boundingBox": [1108, 1584,
+        1263, 1574, 1268, 1656, 1113, 1666], "confidence": 0.958}]}, {"text": "1 BACON
+        & EGGS", "boundingBox": [232, 1834, 745, 1840, 744, 1924, 231, 1918], "words":
+        [{"text": "1", "boundingBox": [232, 1834, 286, 1836, 285, 1920, 231, 1920],
+        "confidence": 0.845}, {"text": "BACON", "boundingBox": [308, 1836, 506, 1841,
+        504, 1920, 307, 1920], "confidence": 0.885}, {"text": "&", "boundingBox":
+        [523, 1841, 568, 1842, 566, 1921, 521, 1921], "confidence": 0.799}, {"text":
+        "EGGS", "boundingBox": [585, 1842, 746, 1843, 744, 1924, 583, 1921], "confidence":
+        0.949}]}, {"text": "Sunny-side-up", "boundingBox": [347, 1975, 751, 1977,
+        751, 2061, 347, 2060], "words": [{"text": "Sunny-side-up", "boundingBox":
+        [348, 1975, 749, 1979, 747, 2061, 348, 2061], "confidence": 0.946}]}, {"text":
+        "$9.5", "boundingBox": [1135, 1955, 1262, 1952, 1263, 2035, 1136, 2039], "words":
+        [{"text": "$9.5", "boundingBox": [1135, 1955, 1257, 1952, 1259, 2036, 1136,
+        2039], "confidence": 0.95}]}, {"text": "Sub-Total", "boundingBox": [440, 2229,
+        771, 2219, 773, 2318, 442, 2327], "words": [{"text": "Sub-Total", "boundingBox":
+        [441, 2229, 769, 2220, 774, 2319, 443, 2328], "confidence": 0.856}]}, {"text":
+        "$ 11.70", "boundingBox": [1092, 2221, 1301, 2224, 1299, 2319, 1093, 2317],
+        "words": [{"text": "$", "boundingBox": [1092, 2221, 1127, 2221, 1126, 2317,
+        1092, 2316], "confidence": 0.799}, {"text": "11.70", "boundingBox": [1146,
+        2221, 1297, 2223, 1296, 2319, 1145, 2317], "confidence": 0.948}]}, {"text":
+        "Tax", "boundingBox": [442, 2371, 549, 2367, 552, 2454, 445, 2458], "words":
+        [{"text": "Tax", "boundingBox": [445, 2371, 546, 2367, 549, 2454, 448, 2458],
+        "confidence": 0.958}]}, {"text": "$ 1.17", "boundingBox": [1129, 2359, 1310,
+        2359, 1306, 2456, 1129, 2456], "words": [{"text": "$", "boundingBox": [1129,
+        2359, 1171, 2359, 1171, 2456, 1129, 2456], "confidence": 0.89}, {"text": "1.17",
+        "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "confidence":
+        0.942}]}, {"text": "Tip", "boundingBox": [433, 2505, 539, 2506, 540, 2602,
+        434, 2602], "words": [{"text": "Tip", "boundingBox": [436, 2505, 536, 2505,
+        536, 2602, 436, 2602], "confidence": 0.959}]}, {"text": "$ 1.63", "boundingBox":
+        [1030, 2478, 1269, 2486, 1267, 2591, 1024, 2583], "words": [{"text": "$",
+        "boundingBox": [1027, 2478, 1073, 2478, 1069, 2584, 1024, 2583], "confidence":
+        0.788}, {"text": "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591,
+        1091, 2585], "confidence": 0.284}]}, {"text": "Total", "boundingBox": [433,
+        2652, 611, 2644, 615, 2738, 436, 2747], "words": [{"text": "Total", "boundingBox":
+        [435, 2652, 609, 2644, 613, 2739, 439, 2747], "confidence": 0.866}]}, {"text":
+        "$14.50", "boundingBox": [1034, 2620, 1386, 2637, 1380, 2762, 1029, 2739],
+        "words": [{"text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380,
+        2763, 1030, 2739], "confidence": 0.57}]}]}], "documentResults": [{"docType":
+        "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType": {"type":
+        "string", "valueString": "Itemized", "confidence": 0.692}, "MerchantName":
         {"type": "string", "valueString": "Contoso Contoso", "text": "Contoso Contoso",
-        "boundingBox": [380.9, 282.9, 1116, 473.2, 1025, 824.4, 290, 634], "page":
-        1, "confidence": 0.716, "elements": ["#/readResults/0/lines/1/words/0", "#/readResults/0/lines/0/words/0"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
-        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [298.3,
-        676.5, 844.6, 781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989,
-        "elements": ["#/readResults/0/lines/2/words/0", "#/readResults/0/lines/2/words/1",
-        "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1",
-        "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber": {"type": "phoneNumber",
-        "valuePhoneNumber": "+19876543210", "text": "987-654-3210", "boundingBox":
-        [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence": 0.99,
-        "elements": ["#/readResults/0/lines/4/words/0"]}, "TransactionDate": {"type":
-        "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox": [259,
-        1224, 510, 1246, 505, 1331, 255, 1312], "page": 1, "confidence": 0.99, "elements":
-        ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type": "time",
-        "valueTime": "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681,
-        1262, 675, 1341, 522, 1332], "page": 1, "confidence": 0.989, "elements": ["#/readResults/0/lines/5/words/1"]},
-        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        "boundingBox": [378.2, 292.4, 1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8],
+        "page": 1, "confidence": 0.613, "elements": ["#/readResults/0/lines/0/words/0",
+        "#/readResults/0/lines/1/words/0"]}, "MerchantAddress": {"type": "string",
+        "valueString": "123 Main Street Redmond, WA 98052", "text": "123 Main Street
+        Redmond, WA 98052", "boundingBox": [302, 675.8, 848.1, 793.7, 809.9, 970.4,
+        263.9, 852.5], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/2/words/0",
+        "#/readResults/0/lines/2/words/1", "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0",
+        "#/readResults/0/lines/3/words/1", "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber":
+        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
+        "boundingBox": [278, 1004, 656, 1057, 647, 1123, 271, 1075], "page": 1, "confidence":
+        0.99, "elements": ["#/readResults/0/lines/4/words/0"]}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99,
+        "elements": ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type":
+        "time", "valueTime": "13:59:00", "text": "13:59", "boundingBox": [541, 1248,
+        677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence": 0.977, "elements":
+        ["#/readResults/0/lines/5/words/1"]}, "Items": {"type": "array", "valueArray":
+        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
+        1, "text": "1", "boundingBox": [245, 1583, 299, 1585, 295, 1676, 241, 1671],
+        "page": 1, "confidence": 0.92, "elements": ["#/readResults/0/lines/7/words/0"]},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923, "elements": ["#/readResults/0/lines/7/words/1"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1108, 1584,
+        1263, 1574, 1268, 1656, 1113, 1666], "page": 1, "confidence": 0.918, "elements":
+        ["#/readResults/0/lines/8/words/0"]}}}, {"type": "object", "valueObject":
         {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [244, 1581, 288, 1584, 285, 1678, 241, 1675], "page": 1, "confidence": 0.919,
-        "elements": ["#/readResults/0/lines/7/words/0"]}, "Name": {"type": "string",
-        "valueString": "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585,
-        658, 1598, 657, 1688, 304, 1679], "page": 1, "confidence": 0.959, "elements":
-        ["#/readResults/0/lines/7/words/1"]}, "TotalPrice": {"type": "number", "valueNumber":
-        2.2, "text": "$2.20", "boundingBox": [1106, 1579, 1260, 1574, 1263, 1656,
-        1108, 1662], "page": 1, "confidence": 0.959, "elements": ["#/readResults/0/lines/8/words/0"]}}},
-        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91, "elements": ["#/readResults/0/lines/9/words/0"]},
-        "Name": {"type": "string", "valueString": "BACON & EGGS", "text": "BACON &
-        EGGS", "boundingBox": [294, 1839, 737, 1839, 737, 1924, 294, 1924], "page":
-        1, "confidence": 0.955, "elements": ["#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2",
+        [232, 1834, 286, 1836, 285, 1920, 231, 1920], "page": 1, "confidence": 0.858,
+        "elements": ["#/readResults/0/lines/9/words/0"]}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916,
+        "elements": ["#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2",
         "#/readResults/0/lines/9/words/3"]}, "TotalPrice": {"type": "number", "valueNumber":
-        9.5, "text": "$9.5", "boundingBox": [1134, 1948, 1252, 1948, 1252, 2041, 1134,
-        2041], "page": 1, "confidence": 0.958, "elements": ["#/readResults/0/lines/11/words/0"]}}}]},
+        9.5, "text": "$9.5", "boundingBox": [1135, 1955, 1257, 1952, 1259, 2036, 1136,
+        2039], "page": 1, "confidence": 0.916, "elements": ["#/readResults/0/lines/11/words/0"]}}}]},
         "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923, "elements": ["#/readResults/0/lines/17/words/1"]}, "Tax": {"type":
-        "number", "valueNumber": 1.17, "text": "1.17", "boundingBox": [1186, 2356,
-        1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence": 0.979, "elements":
-        ["#/readResults/0/lines/19/words/1"]}, "Tip": {"type": "number", "valueNumber":
-        463, "text": "$463", "boundingBox": [1034, 2483, 1268, 2488, 1266, 2583, 1032,
-        2577], "page": 1, "confidence": 0.975, "elements": ["#/readResults/0/lines/21/words/0"]},
+        [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1, "confidence":
+        0.955, "elements": ["#/readResults/0/lines/13/words/1"]}, "Tax": {"type":
+        "number", "valueNumber": 1.17, "text": "1.17", "boundingBox": [1190, 2359,
+        1304, 2359, 1304, 2456, 1190, 2456], "page": 1, "confidence": 0.979, "elements":
+        ["#/readResults/0/lines/15/words/1"]}, "Tip": {"type": "number", "valueNumber":
+        1.63, "text": "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591,
+        1091, 2585], "page": 1, "confidence": 0.941, "elements": ["#/readResults/0/lines/17/words/1"]},
         "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50", "boundingBox":
-        [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1, "confidence":
-        0.987, "elements": ["#/readResults/0/lines/23/words/0"]}}}]}}'
+        [1034, 2620, 1384, 2638, 1380, 2763, 1030, 2739], "page": 1, "confidence":
+        0.985, "elements": ["#/readResults/0/lines/19/words/0"]}}}]}}'
     headers:
       apim-request-id:
-      - d64c91b5-87d0-4f2c-863e-c4d7d9b3a82d
+      - 5cab6af3-0d13-4ed7-998e-c6272f2880be
       content-length:
-      - '10546'
+      - '8501'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:07:31 GMT
+      - Mon, 16 Nov 2020 19:12:57 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '20'
+      - '18'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_url_jpg.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_url_jpg.yaml
@@ -21,19 +21,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 51126ddb-3b32-42fc-a5f2-460d6dcadf88
+      - 0e6e0f56-19f5-4303-99e4-0870bfd9ba1b
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:07:32 GMT
+      - Mon, 16 Nov 2020 19:12:58 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/51126ddb-3b32-42fc-a5f2-460d6dcadf88
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/0e6e0f56-19f5-4303-99e4-0870bfd9ba1b
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '198'
+      - '395'
     status:
       code: 202
       message: Accepted
@@ -49,65 +49,65 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/51126ddb-3b32-42fc-a5f2-460d6dcadf88
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/0e6e0f56-19f5-4303-99e4-0870bfd9ba1b
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:07:32Z",
-        "lastUpdatedDateTime": "2020-11-11T18:07:34Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:12:58Z",
+        "lastUpdatedDateTime": "2020-11-16T19:13:01Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [380.9, 282.9,
-        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.716}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [298.3, 676.5, 844.6,
-        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence":
-        0.99}, "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text":
-        "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505, 1331, 255, 1312],
-        "page": 1, "confidence": 0.99}, "TransactionTime": {"type": "time", "valueTime":
-        "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681, 1262, 675, 1341,
-        522, 1332], "page": 1, "confidence": 0.989}, "Items": {"type": "array", "valueArray":
-        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [244, 1581, 288, 1584, 285, 1678, 241, 1675],
-        "page": 1, "confidence": 0.919}, "Name": {"type": "string", "valueString":
-        "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585, 658, 1598,
-        657, 1688, 304, 1679], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1106, 1579,
-        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.959}}}, {"type":
-        "object", "valueObject": {"Quantity": {"type": "number", "valueNumber": 1,
-        "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [294, 1839, 737, 1839,
-        737, 1924, 294, 1924], "page": 1, "confidence": 0.955}, "TotalPrice": {"type":
-        "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox": [1134, 1948,
-        1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence": 0.958}}}]},
-        "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923}, "Tax": {"type": "number", "valueNumber": 1.17, "text": "1.17", "boundingBox":
-        [1186, 2356, 1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence":
-        0.979}, "Tip": {"type": "number", "valueNumber": 463, "text": "$463", "boundingBox":
-        [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "page": 1, "confidence":
-        0.975}, "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50",
-        "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1,
-        "confidence": 0.987}}}]}}'
+        "Itemized", "confidence": 0.692}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [378.2, 292.4,
+        1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8], "page": 1, "confidence": 0.613},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [302,
+        675.8, 848.1, 793.7, 809.9, 970.4, 263.9, 852.5], "page": 1, "confidence":
+        0.99}, "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber":
+        "+19876543210", "text": "987-654-3210", "boundingBox": [278, 1004, 656, 1057,
+        647, 1123, 271, 1075], "page": 1, "confidence": 0.99}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99},
+        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
+        "boundingBox": [541, 1248, 677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence":
+        0.977}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
+        [245, 1583, 299, 1585, 295, 1676, 241, 1671], "page": 1, "confidence": 0.92},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923}, "TotalPrice": {"type": "number", "valueNumber": 2.2, "text": "$2.20",
+        "boundingBox": [1108, 1584, 1263, 1574, 1268, 1656, 1113, 1666], "page": 1,
+        "confidence": 0.918}}}, {"type": "object", "valueObject": {"Quantity": {"type":
+        "number", "valueNumber": 1, "text": "1", "boundingBox": [232, 1834, 286, 1836,
+        285, 1920, 231, 1920], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916},
+        "TotalPrice": {"type": "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox":
+        [1135, 1955, 1257, 1952, 1259, 2036, 1136, 2039], "page": 1, "confidence":
+        0.916}}}]}, "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70",
+        "boundingBox": [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1,
+        "confidence": 0.955}, "Tax": {"type": "number", "valueNumber": 1.17, "text":
+        "1.17", "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "page":
+        1, "confidence": 0.979}, "Tip": {"type": "number", "valueNumber": 1.63, "text":
+        "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591, 1091, 2585], "page":
+        1, "confidence": 0.941}, "Total": {"type": "number", "valueNumber": 14.5,
+        "text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380, 2763, 1030,
+        2739], "page": 1, "confidence": 0.985}}}]}}'
     headers:
       apim-request-id:
-      - 8664cfcc-486f-4b1f-a94a-cc6824686eb4
+      - 4e3e937a-3c19-4e04-9375-b8c2309d2462
       content-length:
-      - '2820'
+      - '2835'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:07:36 GMT
+      - Mon, 16 Nov 2020 19:13:03 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '26'
+      - '17'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_url_pass_stream.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_url_pass_stream.yaml
@@ -18,23 +18,23 @@ interactions:
     uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyze?includeTextDetails=false
   response:
     body:
-      string: '{"error": {"code": "InvalidImageURL", "innerError": {"requestId": "12135335-f868-4b86-8723-fdd893f0029a"},
+      string: '{"error": {"code": "InvalidImageURL", "innerError": {"requestId": "c2d1d648-e729-4da2-93d2-679f5c49291a"},
         "message": "Image URL is badly formatted."}}'
     headers:
       apim-request-id:
-      - 12135335-f868-4b86-8723-fdd893f0029a
+      - c2d1d648-e729-4da2-93d2-679f5c49291a
       content-length:
       - '144'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:07:38 GMT
+      - Mon, 16 Nov 2020 19:13:03 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '4'
+      - '2'
     status:
       code: 400
       message: Bad Request

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_url_png.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_url_png.yaml
@@ -21,19 +21,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - a1c10a42-a1aa-4a8e-9e83-b3f3dab88e0e
+      - 8b14109a-56f1-4ffb-80ae-480f5b86a877
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:07:38 GMT
+      - Mon, 16 Nov 2020 19:13:05 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/a1c10a42-a1aa-4a8e-9e83-b3f3dab88e0e
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/8b14109a-56f1-4ffb-80ae-480f5b86a877
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '746'
+      - '678'
     status:
       code: 202
       message: Accepted
@@ -49,60 +49,61 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/a1c10a42-a1aa-4a8e-9e83-b3f3dab88e0e
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/8b14109a-56f1-4ffb-80ae-480f5b86a877
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:07:39Z",
-        "lastUpdatedDateTime": "2020-11-11T18:07:41Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": -0.0752, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:13:05Z",
+        "lastUpdatedDateTime": "2020-11-16T19:13:07Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.2511, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [342.9, 238.1,
-        1061, 278.6, 1038.1, 685.5, 320, 645], "page": 1, "confidence": 0.693}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [308.4, 688, 751.3, 689,
-        750.8, 859.6, 308, 858.5], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "text": "123-456-7890", "boundingBox": [303, 1003,
-        623, 1009, 621, 1071, 303, 1064], "page": 1, "confidence": 0.99}, "TransactionDate":
-        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
-        [299, 1221, 494, 1222, 492, 1292, 299, 1292], "page": 1, "confidence": 0.991},
-        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
-        "boundingBox": [508, 1223, 628, 1224, 625, 1292, 506, 1292], "page": 1, "confidence":
-        0.99}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
-        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [327, 1558, 353, 1559, 352, 1623, 327, 1623], "page": 1, "confidence": 0.745}}},
-        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
-        "8GB RAM (Black)", "text": "8GB RAM (Black)", "boundingBox": [358, 1779, 738,
-        1779, 738, 1860, 358, 1860], "page": 1, "confidence": 0.968}, "TotalPrice":
-        {"type": "number", "valueNumber": 999, "text": "999.00", "boundingBox": [967,
-        1792, 1135, 1796, 1133, 1859, 967, 1855], "page": 1, "confidence": 0.97}}},
-        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [315, 2018, 337, 2017, 338, 2084, 316, 2085],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "SurfacePen", "text": "SurfacePen", "boundingBox": [350, 2017, 624, 2013,
-        624, 2079, 351, 2084], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 99.99, "text": "$99.99", "boundingBox": [963, 2025,
-        1128, 2025, 1128, 2092, 963, 2092], "page": 1, "confidence": 0.775}}}]}, "Subtotal":
-        {"type": "number", "valueNumber": 1098.99, "text": "1098.99", "boundingBox":
-        [954, 2255, 1137, 2251, 1138, 2325, 956, 2329], "page": 1, "confidence": 0.986},
-        "Total": {"type": "number", "valueNumber": 104.4, "text": "104.40", "boundingBox":
-        [976, 2370, 1130, 2368, 1131, 2434, 977, 2438], "page": 1, "confidence": 0.668}}}]}}'
+        "Itemized", "confidence": 0.659}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [349.3, 241.3,
+        1058, 284.4, 1033.5, 687.1, 324.8, 644], "page": 1, "confidence": 0.516},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [319.9,
+        689.9, 750.7, 697.5, 747.8, 865.6, 317, 858], "page": 1, "confidence": 0.986},
+        "MerchantPhoneNumber": {"type": "phoneNumber", "text": "123-456-7890", "boundingBox":
+        [306, 1005, 617, 1012, 615, 1069, 305, 1064], "page": 1, "confidence": 0.99},
+        "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019",
+        "boundingBox": [304, 1224, 506, 1224, 504, 1289, 303, 1288], "page": 1, "confidence":
+        0.985}, "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text":
+        "13:59", "boundingBox": [518, 1225, 628, 1228, 627, 1290, 517, 1289], "page":
+        1, "confidence": 0.968}, "Items": {"type": "array", "valueArray": [{"type":
+        "object", "valueObject": {"Name": {"type": "string", "valueString": "8GB RAM
+        (Black)", "text": "8GB RAM (Black)", "boundingBox": [370.7, 1781.5, 731, 1785,
+        730.3, 1854, 370, 1850.6], "page": 1, "confidence": 0.916}, "TotalPrice":
+        {"type": "number", "valueNumber": 999, "text": "$999.00", "boundingBox": [939,
+        1784.6, 1134.4, 1788.3, 1133, 1863, 937.6, 1859.3], "page": 1, "confidence":
+        0.559}}}, {"type": "object", "valueObject": {"Quantity": {"type": "number",
+        "valueNumber": 1, "text": "1", "boundingBox": [321, 2021, 348, 2020, 349,
+        2084, 322, 2084], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "SurfacePen", "text": "SurfacePen", "boundingBox": [360, 2020,
+        626, 2014, 628, 2077, 362, 2083], "page": 1, "confidence": 0.858}, "TotalPrice":
+        {"type": "number", "valueNumber": 99.99, "text": "99.99", "boundingBox": [1007,
+        2028, 1127, 2028, 1126, 2091, 1007, 2091], "page": 1, "confidence": 0.386}}}]},
+        "Subtotal": {"type": "number", "valueNumber": 1098.99, "text": "1098.99",
+        "boundingBox": [963, 2260, 1136, 2254, 1137, 2320, 966, 2325], "page": 1,
+        "confidence": 0.964}, "Tax": {"type": "number", "valueNumber": 104.4, "text":
+        "$104.40", "boundingBox": [942.6, 2367.5, 1132, 2363.7, 1133.4, 2434.2, 944,
+        2438], "page": 1, "confidence": 0.713}, "Total": {"type": "number", "valueNumber":
+        1203.39, "text": "1203.39", "boundingBox": [955, 2594, 1123, 2611, 1115, 2678,
+        949, 2661], "page": 1, "confidence": 0.774}}}]}}'
     headers:
       apim-request-id:
-      - 82a5ee13-4b70-4374-8190-31d9fbf82d25
+      - 19964352-acfe-43c3-b9ab-2379f7c0ed6d
       content-length:
-      - '2548'
+      - '2561'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:07:44 GMT
+      - Mon, 16 Nov 2020 19:13:10 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '35'
+      - '21'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_url_transform_jpg.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_url_transform_jpg.yaml
@@ -21,19 +21,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 48d55633-6f46-468f-ba0e-99853deb49e0
+      - ea1d5080-cf65-4716-8cf9-2e7742d287a7
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:07:44 GMT
+      - Mon, 16 Nov 2020 19:13:11 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/48d55633-6f46-468f-ba0e-99853deb49e0
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/ea1d5080-cf65-4716-8cf9-2e7742d287a7
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '240'
+      - '189'
     status:
       code: 202
       message: Accepted
@@ -49,173 +49,146 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/48d55633-6f46-468f-ba0e-99853deb49e0
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/ea1d5080-cf65-4716-8cf9-2e7742d287a7
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:07:45Z",
-        "lastUpdatedDateTime": "2020-11-11T18:07:46Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
-        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [306,
-        569, 519, 624, 502, 686, 290, 632], "words": [{"text": "Contoso", "boundingBox":
-        [308, 570, 515, 627, 500, 685, 290, 634], "confidence": 0.806}], "appearance":
-        {"style": {"name": "print", "confidence": 0.996}}}, {"text": "Contoso", "boundingBox":
-        [625, 512, 1089, 465, 1096, 561, 631, 607], "words": [{"text": "Contoso",
-        "boundingBox": [625, 512, 1088, 466, 1093, 562, 631, 607], "confidence": 0.984}],
-        "appearance": {"style": {"name": "print", "confidence": 0.999}}}, {"text":
-        "123 Main Street", "boundingBox": [301, 677, 697, 759, 681, 835, 284, 750],
-        "words": [{"text": "123", "boundingBox": [301, 677, 379, 692, 362, 766, 284,
-        751], "confidence": 0.987}, {"text": "Main", "boundingBox": [393, 695, 520,
-        721, 503, 795, 377, 769], "confidence": 0.985}, {"text": "Street", "boundingBox":
-        [534, 724, 694, 763, 676, 835, 517, 798], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.995}}}, {"text": "Redmond, WA
-        98052", "boundingBox": [284, 784, 823, 855, 814, 925, 275, 868], "words":
-        [{"text": "Redmond,", "boundingBox": [287, 784, 544, 829, 535, 905, 275, 853],
-        "confidence": 0.924}, {"text": "WA", "boundingBox": [558, 830, 640, 840, 632,
-        916, 549, 907], "confidence": 0.985}, {"text": "98052", "boundingBox": [654,
-        842, 822, 855, 817, 925, 646, 917], "confidence": 0.985}], "appearance": {"style":
-        {"name": "print", "confidence": 0.999}}}, {"text": "987-654-3210", "boundingBox":
-        [270, 999, 655, 1049, 646, 1125, 264, 1075], "words": [{"text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "confidence":
-        0.978}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "6/10/2019 13:59", "boundingBox": [258, 1224, 683, 1259, 676, 1341, 255, 1309],
-        "words": [{"text": "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505,
-        1331, 255, 1312], "confidence": 0.951}, {"text": "13:59", "boundingBox": [527,
-        1248, 681, 1262, 675, 1341, 522, 1332], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "Sales Associate:
-        Paul", "boundingBox": [252, 1347, 860, 1378, 859, 1449, 249, 1425], "words":
-        [{"text": "Sales", "boundingBox": [255, 1348, 409, 1358, 405, 1432, 249, 1419],
-        "confidence": 0.983}, {"text": "Associate:", "boundingBox": [423, 1359, 704,
-        1373, 703, 1447, 419, 1434], "confidence": 0.933}, {"text": "Paul", "boundingBox":
-        [718, 1373, 858, 1378, 859, 1449, 717, 1448], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "1 Cappuccino", "boundingBox":
-        [244, 1581, 660, 1597, 658, 1688, 241, 1675], "words": [{"text": "1", "boundingBox":
-        [244, 1581, 288, 1584, 285, 1678, 241, 1675], "confidence": 0.977}, {"text":
-        "Cappuccino", "boundingBox": [306, 1585, 658, 1598, 657, 1688, 304, 1679],
-        "confidence": 0.858}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "$2.20", "boundingBox": [1106, 1580, 1264, 1574, 1268, 1656,
-        1108, 1662], "words": [{"text": "$2.20", "boundingBox": [1106, 1579, 1260,
-        1574, 1263, 1656, 1108, 1662], "confidence": 0.981}], "appearance": {"style":
-        {"name": "print", "confidence": 0.849}}}, {"text": "1 BACON & EGGS", "boundingBox":
-        [226, 1838, 740, 1839, 740, 1924, 226, 1923], "words": [{"text": "1", "boundingBox":
-        [227, 1839, 278, 1839, 277, 1924, 226, 1924], "confidence": 0.986}, {"text":
-        "BACON", "boundingBox": [295, 1839, 493, 1840, 493, 1923, 294, 1924], "confidence":
-        0.984}, {"text": "&", "boundingBox": [510, 1840, 555, 1840, 555, 1923, 510,
-        1923], "confidence": 0.983}, {"text": "EGGS", "boundingBox": [572, 1840, 737,
-        1841, 736, 1924, 572, 1923], "confidence": 0.984}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Sunny-side-up", "boundingBox":
-        [343, 1976, 758, 1974, 759, 2061, 343, 2063], "words": [{"text": "Sunny-side-up",
-        "boundingBox": [343, 1977, 757, 1975, 755, 2063, 346, 2064], "confidence":
-        0.973}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "$9.5", "boundingBox": [1134, 1948, 1253, 1948, 1255, 2041, 1137, 2041], "words":
-        [{"text": "$9.5", "boundingBox": [1134, 1948, 1252, 1948, 1252, 2041, 1134,
-        2041], "confidence": 0.983}], "appearance": {"style": {"name": "print", "confidence":
-        0.932}}}, {"text": "- -", "boundingBox": [218, 2143, 291, 2140, 292, 2158,
-        218, 2161], "words": [{"text": "-", "boundingBox": [236, 2143, 255, 2143,
-        255, 2161, 235, 2161], "confidence": 0.559}, {"text": "-", "boundingBox":
-        [271, 2142, 290, 2141, 291, 2158, 272, 2160], "confidence": 0.985}], "appearance":
-        {"style": {"name": "print", "confidence": 0.67}}}, {"text": "-----", "boundingBox":
-        [277, 2142, 461, 2136, 461, 2155, 278, 2161], "words": [{"text": "-----",
-        "boundingBox": [305, 2141, 457, 2136, 458, 2155, 305, 2161], "confidence":
-        0.69}], "appearance": {"style": {"name": "print", "confidence": 0.467}}},
-        {"text": "----", "boundingBox": [471, 2137, 565, 2133, 566, 2150, 472, 2154],
-        "words": [{"text": "----", "boundingBox": [473, 2138, 566, 2134, 566, 2150,
-        473, 2154], "confidence": 0.559}], "appearance": {"style": {"name": "print",
-        "confidence": 0.703}}}, {"text": "--", "boundingBox": [1252, 2129, 1319, 2127,
-        1320, 2143, 1252, 2146], "words": [{"text": "--", "boundingBox": [1277, 2129,
-        1319, 2127, 1319, 2144, 1276, 2145], "confidence": 0.559}], "appearance":
-        {"style": {"name": "print", "confidence": 0.846}}}, {"text": "Sub-Total",
-        "boundingBox": [434, 2232, 768, 2222, 770, 2312, 437, 2322], "words": [{"text":
-        "Sub-Total", "boundingBox": [434, 2234, 769, 2222, 770, 2313, 442, 2322],
-        "confidence": 0.981}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "$ 11.70", "boundingBox": [1082, 2228, 1309, 2228, 1309, 2313,
-        1084, 2312], "words": [{"text": "$", "boundingBox": [1082, 2228, 1122, 2228,
-        1121, 2313, 1082, 2312], "confidence": 0.654}, {"text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "confidence": 0.984}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "Tax", "boundingBox":
-        [433, 2367, 563, 2363, 565, 2458, 435, 2462], "words": [{"text": "Tax", "boundingBox":
-        [433, 2367, 559, 2363, 562, 2458, 435, 2462], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 0.98}}}, {"text": "$ 1.17", "boundingBox":
-        [1125, 2353, 1306, 2362, 1304, 2451, 1121, 2444], "words": [{"text": "$",
-        "boundingBox": [1125, 2353, 1167, 2355, 1163, 2446, 1121, 2444], "confidence":
-        0.966}, {"text": "1.17", "boundingBox": [1186, 2356, 1307, 2361, 1303, 2452,
-        1182, 2447], "confidence": 0.983}], "appearance": {"style": {"name": "print",
-        "confidence": 0.963}}}, {"text": "Tip", "boundingBox": [439, 2502, 545, 2506,
-        541, 2606, 435, 2602], "words": [{"text": "Tip", "boundingBox": [438, 2502,
-        545, 2506, 541, 2606, 435, 2602], "confidence": 0.987}], "appearance": {"style":
-        {"name": "print", "confidence": 0.943}}}, {"text": "$463", "boundingBox":
-        [1038, 2483, 1271, 2489, 1269, 2583, 1032, 2577], "words": [{"text": "$463",
-        "boundingBox": [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "confidence":
-        0.592}], "appearance": {"style": {"name": "handwriting", "confidence": 0.892}}},
-        {"text": "Total", "boundingBox": [431, 2651, 607, 2646, 610, 2739, 435, 2745],
-        "words": [{"text": "Total", "boundingBox": [431, 2651, 605, 2646, 608, 2739,
-        433, 2745], "confidence": 0.983}], "appearance": {"style": {"name": "print",
-        "confidence": 0.991}}}, {"text": "$14.50", "boundingBox": [1034, 2623, 1381,
-        2642, 1374, 2757, 1027, 2740], "words": [{"text": "$14.50", "boundingBox":
-        [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "confidence": 0.845}], "appearance":
-        {"style": {"name": "handwriting", "confidence": 0.991}}}]}], "documentResults":
-        [{"docType": "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType":
-        {"type": "string", "valueString": "Itemized", "confidence": 0.99}, "MerchantName":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:13:11Z",
+        "lastUpdatedDateTime": "2020-11-16T19:13:13Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
+        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [635,
+        510, 1086, 461, 1098, 558, 643, 604], "words": [{"text": "Contoso", "boundingBox":
+        [639, 510, 1087, 461, 1098, 551, 646, 604], "confidence": 0.955}]}, {"text":
+        "Contoso", "boundingBox": [305, 574, 519, 624, 504, 686, 291, 634], "words":
+        [{"text": "Contoso", "boundingBox": [311, 575, 517, 623, 503, 686, 297, 636],
+        "confidence": 0.435}]}, {"text": "123 Main Street", "boundingBox": [300, 675,
+        703, 767, 686, 844, 284, 749], "words": [{"text": "123", "boundingBox": [302,
+        676, 390, 695, 375, 770, 287, 751], "confidence": 0.935}, {"text": "Main",
+        "boundingBox": [405, 698, 528, 726, 512, 802, 390, 774], "confidence": 0.958},
+        {"text": "Street", "boundingBox": [542, 730, 702, 767, 685, 845, 527, 806],
+        "confidence": 0.959}]}, {"text": "Redmond, WA 98052", "boundingBox": [290,
+        784, 828, 850, 820, 933, 279, 868], "words": [{"text": "Redmond,", "boundingBox":
+        [293, 784, 550, 826, 540, 905, 280, 856], "confidence": 0.762}, {"text": "WA",
+        "boundingBox": [565, 828, 645, 837, 637, 917, 555, 907], "confidence": 0.943},
+        {"text": "98052", "boundingBox": [660, 838, 824, 849, 818, 933, 651, 919],
+        "confidence": 0.959}]}, {"text": "987-654-3210", "boundingBox": [275, 1003,
+        656, 1055, 646, 1123, 269, 1073], "words": [{"text": "987-654-3210", "boundingBox":
+        [278, 1004, 656, 1057, 647, 1123, 271, 1075], "confidence": 0.939}]}, {"text":
+        "6/10/2019 13:59", "boundingBox": [265, 1228, 678, 1258, 671, 1344, 258, 1311],
+        "words": [{"text": "6/10/2019", "boundingBox": [267, 1229, 525, 1247, 517,
+        1332, 259, 1313], "confidence": 0.762}, {"text": "13:59", "boundingBox": [541,
+        1248, 677, 1263, 669, 1345, 533, 1333], "confidence": 0.958}]}, {"text": "Sales
+        Associate: Paul", "boundingBox": [253, 1347, 868, 1379, 863, 1457, 249, 1425],
+        "words": [{"text": "Sales", "boundingBox": [259, 1348, 419, 1359, 414, 1435,
+        252, 1422], "confidence": 0.92}, {"text": "Associate:", "boundingBox": [434,
+        1360, 711, 1374, 707, 1452, 428, 1436], "confidence": 0.909}, {"text": "Paul",
+        "boundingBox": [726, 1374, 865, 1379, 862, 1457, 722, 1452], "confidence":
+        0.959}]}, {"text": "1 Cappuccino", "boundingBox": [244, 1583, 658, 1601, 653,
+        1689, 240, 1674], "words": [{"text": "1", "boundingBox": [245, 1583, 299,
+        1585, 295, 1676, 241, 1671], "confidence": 0.824}, {"text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "confidence":
+        0.727}]}, {"text": "$2.20", "boundingBox": [1106, 1584, 1268, 1574, 1270,
+        1656, 1110, 1666], "words": [{"text": "$2.20", "boundingBox": [1108, 1584,
+        1263, 1574, 1268, 1656, 1113, 1666], "confidence": 0.958}]}, {"text": "1 BACON
+        & EGGS", "boundingBox": [232, 1834, 745, 1840, 744, 1924, 231, 1918], "words":
+        [{"text": "1", "boundingBox": [232, 1834, 286, 1836, 285, 1920, 231, 1920],
+        "confidence": 0.845}, {"text": "BACON", "boundingBox": [308, 1836, 506, 1841,
+        504, 1920, 307, 1920], "confidence": 0.885}, {"text": "&", "boundingBox":
+        [523, 1841, 568, 1842, 566, 1921, 521, 1921], "confidence": 0.799}, {"text":
+        "EGGS", "boundingBox": [585, 1842, 746, 1843, 744, 1924, 583, 1921], "confidence":
+        0.949}]}, {"text": "Sunny-side-up", "boundingBox": [347, 1975, 751, 1977,
+        751, 2061, 347, 2060], "words": [{"text": "Sunny-side-up", "boundingBox":
+        [348, 1975, 749, 1979, 747, 2061, 348, 2061], "confidence": 0.946}]}, {"text":
+        "$9.5", "boundingBox": [1135, 1955, 1262, 1952, 1263, 2035, 1136, 2039], "words":
+        [{"text": "$9.5", "boundingBox": [1135, 1955, 1257, 1952, 1259, 2036, 1136,
+        2039], "confidence": 0.95}]}, {"text": "Sub-Total", "boundingBox": [440, 2229,
+        771, 2219, 773, 2318, 442, 2327], "words": [{"text": "Sub-Total", "boundingBox":
+        [441, 2229, 769, 2220, 774, 2319, 443, 2328], "confidence": 0.856}]}, {"text":
+        "$ 11.70", "boundingBox": [1092, 2221, 1301, 2224, 1299, 2319, 1093, 2317],
+        "words": [{"text": "$", "boundingBox": [1092, 2221, 1127, 2221, 1126, 2317,
+        1092, 2316], "confidence": 0.799}, {"text": "11.70", "boundingBox": [1146,
+        2221, 1297, 2223, 1296, 2319, 1145, 2317], "confidence": 0.948}]}, {"text":
+        "Tax", "boundingBox": [442, 2371, 549, 2367, 552, 2454, 445, 2458], "words":
+        [{"text": "Tax", "boundingBox": [445, 2371, 546, 2367, 549, 2454, 448, 2458],
+        "confidence": 0.958}]}, {"text": "$ 1.17", "boundingBox": [1129, 2359, 1310,
+        2359, 1306, 2456, 1129, 2456], "words": [{"text": "$", "boundingBox": [1129,
+        2359, 1171, 2359, 1171, 2456, 1129, 2456], "confidence": 0.89}, {"text": "1.17",
+        "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "confidence":
+        0.942}]}, {"text": "Tip", "boundingBox": [433, 2505, 539, 2506, 540, 2602,
+        434, 2602], "words": [{"text": "Tip", "boundingBox": [436, 2505, 536, 2505,
+        536, 2602, 436, 2602], "confidence": 0.959}]}, {"text": "$ 1.63", "boundingBox":
+        [1030, 2478, 1269, 2486, 1267, 2591, 1024, 2583], "words": [{"text": "$",
+        "boundingBox": [1027, 2478, 1073, 2478, 1069, 2584, 1024, 2583], "confidence":
+        0.788}, {"text": "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591,
+        1091, 2585], "confidence": 0.284}]}, {"text": "Total", "boundingBox": [433,
+        2652, 611, 2644, 615, 2738, 436, 2747], "words": [{"text": "Total", "boundingBox":
+        [435, 2652, 609, 2644, 613, 2739, 439, 2747], "confidence": 0.866}]}, {"text":
+        "$14.50", "boundingBox": [1034, 2620, 1386, 2637, 1380, 2762, 1029, 2739],
+        "words": [{"text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380,
+        2763, 1030, 2739], "confidence": 0.57}]}]}], "documentResults": [{"docType":
+        "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType": {"type":
+        "string", "valueString": "Itemized", "confidence": 0.692}, "MerchantName":
         {"type": "string", "valueString": "Contoso Contoso", "text": "Contoso Contoso",
-        "boundingBox": [380.9, 282.9, 1116, 473.2, 1025, 824.4, 290, 634], "page":
-        1, "confidence": 0.716, "elements": ["#/readResults/0/lines/1/words/0", "#/readResults/0/lines/0/words/0"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
-        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [298.3,
-        676.5, 844.6, 781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989,
-        "elements": ["#/readResults/0/lines/2/words/0", "#/readResults/0/lines/2/words/1",
-        "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1",
-        "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber": {"type": "phoneNumber",
-        "valuePhoneNumber": "+19876543210", "text": "987-654-3210", "boundingBox":
-        [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence": 0.99,
-        "elements": ["#/readResults/0/lines/4/words/0"]}, "TransactionDate": {"type":
-        "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox": [259,
-        1224, 510, 1246, 505, 1331, 255, 1312], "page": 1, "confidence": 0.99, "elements":
-        ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type": "time",
-        "valueTime": "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681,
-        1262, 675, 1341, 522, 1332], "page": 1, "confidence": 0.989, "elements": ["#/readResults/0/lines/5/words/1"]},
-        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        "boundingBox": [378.2, 292.4, 1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8],
+        "page": 1, "confidence": 0.613, "elements": ["#/readResults/0/lines/0/words/0",
+        "#/readResults/0/lines/1/words/0"]}, "MerchantAddress": {"type": "string",
+        "valueString": "123 Main Street Redmond, WA 98052", "text": "123 Main Street
+        Redmond, WA 98052", "boundingBox": [302, 675.8, 848.1, 793.7, 809.9, 970.4,
+        263.9, 852.5], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/2/words/0",
+        "#/readResults/0/lines/2/words/1", "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0",
+        "#/readResults/0/lines/3/words/1", "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber":
+        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
+        "boundingBox": [278, 1004, 656, 1057, 647, 1123, 271, 1075], "page": 1, "confidence":
+        0.99, "elements": ["#/readResults/0/lines/4/words/0"]}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99,
+        "elements": ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type":
+        "time", "valueTime": "13:59:00", "text": "13:59", "boundingBox": [541, 1248,
+        677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence": 0.977, "elements":
+        ["#/readResults/0/lines/5/words/1"]}, "Items": {"type": "array", "valueArray":
+        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
+        1, "text": "1", "boundingBox": [245, 1583, 299, 1585, 295, 1676, 241, 1671],
+        "page": 1, "confidence": 0.92, "elements": ["#/readResults/0/lines/7/words/0"]},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923, "elements": ["#/readResults/0/lines/7/words/1"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1108, 1584,
+        1263, 1574, 1268, 1656, 1113, 1666], "page": 1, "confidence": 0.918, "elements":
+        ["#/readResults/0/lines/8/words/0"]}}}, {"type": "object", "valueObject":
         {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [244, 1581, 288, 1584, 285, 1678, 241, 1675], "page": 1, "confidence": 0.919,
-        "elements": ["#/readResults/0/lines/7/words/0"]}, "Name": {"type": "string",
-        "valueString": "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585,
-        658, 1598, 657, 1688, 304, 1679], "page": 1, "confidence": 0.959, "elements":
-        ["#/readResults/0/lines/7/words/1"]}, "TotalPrice": {"type": "number", "valueNumber":
-        2.2, "text": "$2.20", "boundingBox": [1106, 1579, 1260, 1574, 1263, 1656,
-        1108, 1662], "page": 1, "confidence": 0.959, "elements": ["#/readResults/0/lines/8/words/0"]}}},
-        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91, "elements": ["#/readResults/0/lines/9/words/0"]},
-        "Name": {"type": "string", "valueString": "BACON & EGGS", "text": "BACON &
-        EGGS", "boundingBox": [294, 1839, 737, 1839, 737, 1924, 294, 1924], "page":
-        1, "confidence": 0.955, "elements": ["#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2",
+        [232, 1834, 286, 1836, 285, 1920, 231, 1920], "page": 1, "confidence": 0.858,
+        "elements": ["#/readResults/0/lines/9/words/0"]}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916,
+        "elements": ["#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2",
         "#/readResults/0/lines/9/words/3"]}, "TotalPrice": {"type": "number", "valueNumber":
-        9.5, "text": "$9.5", "boundingBox": [1134, 1948, 1252, 1948, 1252, 2041, 1134,
-        2041], "page": 1, "confidence": 0.958, "elements": ["#/readResults/0/lines/11/words/0"]}}}]},
+        9.5, "text": "$9.5", "boundingBox": [1135, 1955, 1257, 1952, 1259, 2036, 1136,
+        2039], "page": 1, "confidence": 0.916, "elements": ["#/readResults/0/lines/11/words/0"]}}}]},
         "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923, "elements": ["#/readResults/0/lines/17/words/1"]}, "Tax": {"type":
-        "number", "valueNumber": 1.17, "text": "1.17", "boundingBox": [1186, 2356,
-        1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence": 0.979, "elements":
-        ["#/readResults/0/lines/19/words/1"]}, "Tip": {"type": "number", "valueNumber":
-        463, "text": "$463", "boundingBox": [1034, 2483, 1268, 2488, 1266, 2583, 1032,
-        2577], "page": 1, "confidence": 0.975, "elements": ["#/readResults/0/lines/21/words/0"]},
+        [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1, "confidence":
+        0.955, "elements": ["#/readResults/0/lines/13/words/1"]}, "Tax": {"type":
+        "number", "valueNumber": 1.17, "text": "1.17", "boundingBox": [1190, 2359,
+        1304, 2359, 1304, 2456, 1190, 2456], "page": 1, "confidence": 0.979, "elements":
+        ["#/readResults/0/lines/15/words/1"]}, "Tip": {"type": "number", "valueNumber":
+        1.63, "text": "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591,
+        1091, 2585], "page": 1, "confidence": 0.941, "elements": ["#/readResults/0/lines/17/words/1"]},
         "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50", "boundingBox":
-        [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1, "confidence":
-        0.987, "elements": ["#/readResults/0/lines/23/words/0"]}}}]}}'
+        [1034, 2620, 1384, 2638, 1380, 2763, 1030, 2739], "page": 1, "confidence":
+        0.985, "elements": ["#/readResults/0/lines/19/words/0"]}}}]}}'
     headers:
       apim-request-id:
-      - 05247374-8135-4dca-81e8-5271c8263da1
+      - 3cec6114-4945-4079-ac25-4c580d2d7548
       content-length:
-      - '10546'
+      - '8501'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:07:49 GMT
+      - Mon, 16 Nov 2020 19:13:16 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '23'
+      - '17'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_url_transform_png.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipt_url_transform_png.yaml
@@ -21,19 +21,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 64db4656-cee7-4d02-9bd1-f8aa3cf3fb73
+      - 4d583f1a-606e-4357-bfc7-020da8378deb
       content-length:
       - '0'
       date:
-      - Wed, 11 Nov 2020 18:07:50 GMT
+      - Mon, 16 Nov 2020 19:13:16 GMT
       operation-location:
-      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/64db4656-cee7-4d02-9bd1-f8aa3cf3fb73
+      - https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/4d583f1a-606e-4357-bfc7-020da8378deb
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '368'
+      - '252'
     status:
       code: 202
       message: Accepted
@@ -49,174 +49,149 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/64db4656-cee7-4d02-9bd1-f8aa3cf3fb73
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/4d583f1a-606e-4357-bfc7-020da8378deb
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:07:51Z",
-        "lastUpdatedDateTime": "2020-11-11T18:07:53Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": -0.0752, "width": 1688, "height":
-        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [612,
-        287, 1052, 277, 1055, 384, 614, 397], "words": [{"text": "Contoso", "boundingBox":
-        [613, 288, 1051, 278, 1055, 385, 614, 398], "confidence": 0.985}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Contoso", "boundingBox":
-        [322, 590, 503, 599, 500, 654, 319, 644], "words": [{"text": "Contoso", "boundingBox":
-        [324, 590, 501, 601, 498, 654, 320, 645], "confidence": 0.932}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "123 Main Street",
-        "boundingBox": [317, 688, 647, 691, 646, 756, 317, 753], "words": [{"text":
-        "123", "boundingBox": [319, 688, 375, 690, 373, 755, 317, 753], "confidence":
-        0.987}, {"text": "Main", "boundingBox": [388, 691, 490, 694, 489, 756, 386,
-        755], "confidence": 0.986}, {"text": "Street", "boundingBox": [503, 694, 644,
-        695, 644, 754, 502, 756], "confidence": 0.985}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Redmond, WA 98052", "boundingBox":
-        [307, 795, 752, 793, 752, 857, 307, 859], "words": [{"text": "Redmond,", "boundingBox":
-        [310, 796, 516, 796, 514, 859, 308, 858], "confidence": 0.924}, {"text": "WA",
-        "boundingBox": [528, 796, 593, 796, 591, 859, 526, 859], "confidence": 0.987},
-        {"text": "98052", "boundingBox": [605, 795, 751, 793, 749, 854, 603, 859],
-        "confidence": 0.985}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "123-456-7890", "boundingBox": [303, 1003, 623, 1008, 622,
-        1070, 303, 1063], "words": [{"text": "123-456-7890", "boundingBox": [303,
-        1003, 623, 1009, 621, 1071, 303, 1064], "confidence": 0.978}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "6/10/2019 13:59",
-        "boundingBox": [299, 1221, 631, 1222, 631, 1291, 299, 1290], "words": [{"text":
-        "6/10/2019", "boundingBox": [299, 1221, 494, 1222, 492, 1292, 299, 1292],
-        "confidence": 0.955}, {"text": "13:59", "boundingBox": [508, 1223, 628, 1224,
-        625, 1292, 506, 1292], "confidence": 0.985}], "appearance": {"style": {"name":
-        "print", "confidence": 0.998}}}, {"text": "Sales Associate: Paul", "boundingBox":
-        [299, 1335, 772, 1335, 772, 1398, 299, 1396], "words": [{"text": "Sales",
-        "boundingBox": [299, 1335, 406, 1337, 408, 1397, 301, 1396], "confidence":
-        0.986}, {"text": "Associate:", "boundingBox": [418, 1337, 644, 1337, 645,
-        1399, 419, 1397], "confidence": 0.979}, {"text": "Paul", "boundingBox": [656,
-        1337, 771, 1335, 771, 1399, 656, 1399], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "---", "boundingBox":
-        [306, 1470, 370, 1469, 370, 1488, 306, 1489], "words": [{"text": "---", "boundingBox":
-        [307, 1471, 370, 1470, 371, 1489, 307, 1490], "confidence": 0.825}], "appearance":
-        {"style": {"name": "print", "confidence": 0.876}}}, {"text": "--- - -", "boundingBox":
-        [1021, 1474, 1112, 1473, 1112, 1490, 1021, 1491], "words": [{"text": "---",
-        "boundingBox": [1021, 1475, 1061, 1475, 1061, 1491, 1021, 1491], "confidence":
-        0.669}, {"text": "-", "boundingBox": [1068, 1475, 1084, 1474, 1084, 1491,
-        1067, 1491], "confidence": 0.966}, {"text": "-", "boundingBox": [1092, 1474,
-        1109, 1474, 1108, 1491, 1092, 1491], "confidence": 0.968}], "appearance":
-        {"style": {"name": "print", "confidence": 0.996}}}, {"text": "1 Surface Pro
-        6", "boundingBox": [327, 1558, 679, 1560, 678, 1624, 326, 1622], "words":
-        [{"text": "1", "boundingBox": [327, 1558, 353, 1559, 352, 1623, 327, 1623],
-        "confidence": 0.983}, {"text": "Surface", "boundingBox": [366, 1559, 536,
-        1561, 535, 1624, 365, 1623], "confidence": 0.983}, {"text": "Pro", "boundingBox":
-        [549, 1561, 622, 1562, 621, 1624, 548, 1624], "confidence": 0.952}, {"text":
-        "6", "boundingBox": [635, 1562, 677, 1563, 676, 1624, 633, 1624], "confidence":
-        0.986}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "256GB / Intel Core i5 /", "boundingBox": [366, 1666, 850, 1668, 849, 1746,
-        366, 1744], "words": [{"text": "256GB", "boundingBox": [367, 1667, 493, 1668,
-        492, 1745, 366, 1744], "confidence": 0.984}, {"text": "/", "boundingBox":
-        [508, 1668, 518, 1669, 517, 1745, 507, 1745], "confidence": 0.985}, {"text":
-        "Intel", "boundingBox": [533, 1669, 634, 1669, 632, 1746, 532, 1745], "confidence":
-        0.906}, {"text": "Core", "boundingBox": [649, 1669, 745, 1669, 743, 1747,
-        647, 1746], "confidence": 0.986}, {"text": "i5", "boundingBox": [760, 1669,
-        795, 1669, 793, 1747, 758, 1747], "confidence": 0.886}, {"text": "/", "boundingBox":
-        [811, 1669, 851, 1669, 848, 1747, 808, 1747], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "8GB RAM (Black)",
-        "boundingBox": [357, 1779, 738, 1779, 738, 1858, 357, 1859], "words": [{"text":
-        "8GB", "boundingBox": [359, 1779, 434, 1779, 433, 1860, 358, 1860], "confidence":
-        0.942}, {"text": "RAM", "boundingBox": [450, 1779, 546, 1779, 545, 1859, 449,
-        1860], "confidence": 0.986}, {"text": "(Black)", "boundingBox": [562, 1779,
-        738, 1780, 737, 1860, 561, 1859], "confidence": 0.982}], "appearance": {"style":
-        {"name": "print", "confidence": 0.999}}}, {"text": "999.00", "boundingBox":
-        [967, 1792, 1136, 1797, 1134, 1858, 967, 1855], "words": [{"text": "999.00",
-        "boundingBox": [967, 1792, 1135, 1796, 1133, 1859, 967, 1855], "confidence":
-        0.984}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "1 SurfacePen", "boundingBox": [314, 2017, 626, 2013, 627, 2078, 316, 2084],
-        "words": [{"text": "1", "boundingBox": [315, 2018, 337, 2017, 338, 2084, 316,
-        2085], "confidence": 0.986}, {"text": "SurfacePen", "boundingBox": [350, 2017,
-        624, 2013, 624, 2079, 351, 2084], "confidence": 0.979}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "$ 99.99", "boundingBox": [963,
-        2026, 1129, 2025, 1128, 2092, 963, 2092], "words": [{"text": "$", "boundingBox":
-        [963, 2025, 985, 2025, 985, 2092, 963, 2092], "confidence": 0.986}, {"text":
-        "99.99", "boundingBox": [999, 2025, 1128, 2025, 1128, 2092, 999, 2092], "confidence":
-        0.982}], "appearance": {"style": {"name": "print", "confidence": 0.994}}},
-        {"text": "------ ---", "boundingBox": [279, 2166, 491, 2157, 492, 2176, 279,
-        2186], "words": [{"text": "------", "boundingBox": [280, 2167, 421, 2161,
-        421, 2178, 280, 2186], "confidence": 0.638}, {"text": "---", "boundingBox":
-        [428, 2161, 490, 2157, 490, 2177, 427, 2178], "confidence": 0.721}], "appearance":
-        {"style": {"name": "print", "confidence": 0.903}}}, {"text": "Sub-Total",
-        "boundingBox": [464, 2243, 697, 2244, 696, 2310, 464, 2307], "words": [{"text":
-        "Sub-Total", "boundingBox": [465, 2243, 697, 2244, 694, 2311, 465, 2306],
-        "confidence": 0.935}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1098.99", "boundingBox": [952, 2255, 1141, 2251, 1140, 2325,
-        951, 2330], "words": [{"text": "1098.99", "boundingBox": [954, 2255, 1137,
-        2251, 1138, 2325, 956, 2329], "confidence": 0.982}], "appearance": {"style":
-        {"name": "print", "confidence": 0.995}}}, {"text": "Tax", "boundingBox": [564,
-        2349, 662, 2347, 662, 2423, 564, 2425], "words": [{"text": "Tax", "boundingBox":
-        [564, 2349, 657, 2347, 659, 2422, 564, 2424], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 0.993}}}, {"text": "$ 104.40", "boundingBox":
-        [940, 2371, 1131, 2368, 1129, 2433, 942, 2439], "words": [{"text": "$", "boundingBox":
-        [940, 2371, 962, 2370, 964, 2438, 941, 2439], "confidence": 0.987}, {"text":
-        "104.40", "boundingBox": [976, 2370, 1130, 2368, 1131, 2434, 977, 2438], "confidence":
-        0.984}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Total", "boundingBox": [538, 2592, 669, 2590, 669, 2650, 541, 2654], "words":
-        [{"text": "Total", "boundingBox": [538, 2592, 666, 2590, 667, 2651, 539, 2654],
-        "confidence": 0.952}], "appearance": {"style": {"name": "print", "confidence":
-        0.997}}}, {"text": "$ 1203.39", "boundingBox": [914, 2591, 1124, 2610, 1117,
-        2676, 910, 2653], "words": [{"text": "$", "boundingBox": [914, 2591, 935,
-        2593, 931, 2657, 911, 2655], "confidence": 0.987}, {"text": "1203.39", "boundingBox":
-        [947, 2593, 1123, 2612, 1116, 2676, 943, 2659], "confidence": 0.982}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}]}], "documentResults": [{"docType":
-        "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType": {"type":
-        "string", "valueString": "Itemized", "confidence": 0.99}, "MerchantName":
-        {"type": "string", "valueString": "Contoso Contoso", "text": "Contoso Contoso",
-        "boundingBox": [342.9, 238.1, 1061, 278.6, 1038.1, 685.5, 320, 645], "page":
-        1, "confidence": 0.693, "elements": ["#/readResults/0/lines/0/words/0", "#/readResults/0/lines/1/words/0"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
-        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [308.4,
-        688, 751.3, 689, 750.8, 859.6, 308, 858.5], "page": 1, "confidence": 0.989,
-        "elements": ["#/readResults/0/lines/2/words/0", "#/readResults/0/lines/2/words/1",
-        "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1",
-        "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber": {"type": "phoneNumber",
-        "text": "123-456-7890", "boundingBox": [303, 1003, 623, 1009, 621, 1071, 303,
-        1064], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/4/words/0"]},
-        "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019",
-        "boundingBox": [299, 1221, 494, 1222, 492, 1292, 299, 1292], "page": 1, "confidence":
-        0.991, "elements": ["#/readResults/0/lines/5/words/0"]}, "TransactionTime":
-        {"type": "time", "valueTime": "13:59:00", "text": "13:59", "boundingBox":
-        [508, 1223, 628, 1224, 625, 1292, 506, 1292], "page": 1, "confidence": 0.99,
-        "elements": ["#/readResults/0/lines/5/words/1"]}, "Items": {"type": "array",
-        "valueArray": [{"type": "object", "valueObject": {"Quantity": {"type": "number",
-        "valueNumber": 1, "text": "1", "boundingBox": [327, 1558, 353, 1559, 352,
-        1623, 327, 1623], "page": 1, "confidence": 0.745, "elements": ["#/readResults/0/lines/9/words/0"]}}},
-        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
-        "8GB RAM (Black)", "text": "8GB RAM (Black)", "boundingBox": [358, 1779, 738,
-        1779, 738, 1860, 358, 1860], "page": 1, "confidence": 0.968, "elements": ["#/readResults/0/lines/11/words/0",
-        "#/readResults/0/lines/11/words/1", "#/readResults/0/lines/11/words/2"]},
-        "TotalPrice": {"type": "number", "valueNumber": 999, "text": "999.00", "boundingBox":
-        [967, 1792, 1135, 1796, 1133, 1859, 967, 1855], "page": 1, "confidence": 0.97,
-        "elements": ["#/readResults/0/lines/12/words/0"]}}}, {"type": "object", "valueObject":
-        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [315, 2018, 337, 2017, 338, 2084, 316, 2085], "page": 1, "confidence": 0.91,
-        "elements": ["#/readResults/0/lines/13/words/0"]}, "Name": {"type": "string",
-        "valueString": "SurfacePen", "text": "SurfacePen", "boundingBox": [350, 2017,
-        624, 2013, 624, 2079, 351, 2084], "page": 1, "confidence": 0.959, "elements":
-        ["#/readResults/0/lines/13/words/1"]}, "TotalPrice": {"type": "number", "valueNumber":
-        99.99, "text": "$99.99", "boundingBox": [963, 2025, 1128, 2025, 1128, 2092,
-        963, 2092], "page": 1, "confidence": 0.775, "elements": ["#/readResults/0/lines/14/words/0",
-        "#/readResults/0/lines/14/words/1"]}}}]}, "Subtotal": {"type": "number", "valueNumber":
-        1098.99, "text": "1098.99", "boundingBox": [954, 2255, 1137, 2251, 1138, 2325,
-        956, 2329], "page": 1, "confidence": 0.986, "elements": ["#/readResults/0/lines/17/words/0"]},
-        "Total": {"type": "number", "valueNumber": 104.4, "text": "104.40", "boundingBox":
-        [976, 2370, 1130, 2368, 1131, 2434, 977, 2438], "page": 1, "confidence": 0.668,
-        "elements": ["#/readResults/0/lines/19/words/1"]}}}]}}'
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:13:17Z",
+        "lastUpdatedDateTime": "2020-11-16T19:13:19Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.2511, "width": 1688, "height":
+        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [619,
+        291, 1051, 284, 1053, 384, 620, 396], "words": [{"text": "Contoso", "boundingBox":
+        [623, 292, 1051, 284, 1052, 383, 624, 397], "confidence": 0.959}]}, {"text":
+        "Contoso", "boundingBox": [322, 591, 501, 601, 498, 654, 319, 644], "words":
+        [{"text": "Contoso", "boundingBox": [328, 591, 500, 602, 498, 654, 325, 644],
+        "confidence": 0.727}]}, {"text": "123 Main Street", "boundingBox": [319, 690,
+        655, 695, 654, 757, 318, 752], "words": [{"text": "123", "boundingBox": [323,
+        690, 387, 692, 383, 754, 319, 753], "confidence": 0.958}, {"text": "Main",
+        "boundingBox": [399, 692, 502, 694, 498, 756, 395, 754], "confidence": 0.958},
+        {"text": "Street", "boundingBox": [514, 695, 656, 698, 653, 758, 510, 756],
+        "confidence": 0.958}]}, {"text": "Redmond, WA 98052", "boundingBox": [317,
+        795, 751, 795, 752, 859, 317, 860], "words": [{"text": "Redmond,", "boundingBox":
+        [321, 795, 523, 795, 520, 861, 317, 858], "confidence": 0.57}, {"text": "WA",
+        "boundingBox": [535, 795, 597, 795, 595, 861, 532, 861], "confidence": 0.958},
+        {"text": "98052", "boundingBox": [610, 795, 749, 796, 747, 858, 607, 861],
+        "confidence": 0.958}]}, {"text": "123-456-7890", "boundingBox": [306, 1005,
+        618, 1011, 616, 1068, 305, 1062], "words": [{"text": "123-456-7890", "boundingBox":
+        [306, 1005, 617, 1012, 615, 1069, 305, 1064], "confidence": 0.937}]}, {"text":
+        "6/10/2019 13:59", "boundingBox": [303, 1223, 630, 1225, 629, 1289, 302, 1286],
+        "words": [{"text": "6/10/2019", "boundingBox": [304, 1224, 506, 1224, 504,
+        1289, 303, 1288], "confidence": 0.762}, {"text": "13:59", "boundingBox": [518,
+        1225, 628, 1228, 627, 1290, 517, 1289], "confidence": 0.949}]}, {"text": "Sales
+        Associate: Paul", "boundingBox": [294, 1335, 768, 1335, 768, 1401, 294, 1399],
+        "words": [{"text": "Sales", "boundingBox": [302, 1336, 418, 1335, 416, 1399,
+        301, 1399], "confidence": 0.959}, {"text": "Associate:", "boundingBox": [430,
+        1335, 649, 1336, 646, 1401, 428, 1399], "confidence": 0.95}, {"text": "Paul",
+        "boundingBox": [661, 1336, 767, 1336, 764, 1402, 659, 1401], "confidence":
+        0.959}]}, {"text": "1 Surface Pro 6", "boundingBox": [336, 1560, 679, 1561,
+        678, 1625, 336, 1623], "words": [{"text": "1", "boundingBox": [337, 1560,
+        360, 1561, 360, 1625, 337, 1625], "confidence": 0.799}, {"text": "Surface",
+        "boundingBox": [373, 1561, 543, 1562, 542, 1624, 373, 1625], "confidence":
+        0.958}, {"text": "Pro", "boundingBox": [555, 1562, 632, 1563, 631, 1625, 555,
+        1624], "confidence": 0.91}, {"text": "6", "boundingBox": [644, 1563, 676,
+        1563, 675, 1625, 644, 1625], "confidence": 0.762}]}, {"text": "256GB / Intel
+        Core i5 /", "boundingBox": [372, 1669, 846, 1669, 846, 1743, 372, 1742], "words":
+        [{"text": "256GB", "boundingBox": [375, 1670, 506, 1671, 504, 1740, 373, 1740],
+        "confidence": 0.952}, {"text": "/", "boundingBox": [520, 1671, 533, 1671,
+        531, 1740, 517, 1740], "confidence": 0.879}, {"text": "Intel", "boundingBox":
+        [547, 1671, 648, 1671, 646, 1741, 545, 1740], "confidence": 0.879}, {"text":
+        "Core", "boundingBox": [662, 1671, 758, 1670, 756, 1743, 660, 1741], "confidence":
+        0.95}, {"text": "i5", "boundingBox": [772, 1670, 809, 1670, 807, 1744, 770,
+        1743], "confidence": 0.817}, {"text": "/", "boundingBox": [823, 1670, 847,
+        1670, 846, 1744, 821, 1744], "confidence": 0.841}]}, {"text": "8GB RAM (Black)",
+        "boundingBox": [370, 1782, 732, 1785, 731, 1853, 370, 1850], "words": [{"text":
+        "8GB", "boundingBox": [374, 1783, 451, 1783, 448, 1850, 370, 1850], "confidence":
+        0.798}, {"text": "RAM", "boundingBox": [465, 1783, 561, 1784, 559, 1851, 461,
+        1850], "confidence": 0.958}, {"text": "(Black)", "boundingBox": [575, 1784,
+        731, 1785, 729, 1854, 572, 1852], "confidence": 0.959}]}, {"text": "$ 999.00",
+        "boundingBox": [937, 1785, 1139, 1790, 1137, 1862, 936, 1859], "words": [{"text":
+        "$", "boundingBox": [939, 1785, 959, 1785, 958, 1859, 938, 1859], "confidence":
+        0.895}, {"text": "999.00", "boundingBox": [974, 1786, 1134, 1789, 1133, 1863,
+        973, 1860], "confidence": 0.877}]}, {"text": "1 SurfacePen", "boundingBox":
+        [320, 2019, 627, 2013, 629, 2076, 321, 2083], "words": [{"text": "1", "boundingBox":
+        [321, 2021, 348, 2020, 349, 2084, 322, 2084], "confidence": 0.82}, {"text":
+        "SurfacePen", "boundingBox": [360, 2020, 626, 2014, 628, 2077, 362, 2083],
+        "confidence": 0.928}]}, {"text": "$ 99.99", "boundingBox": [967, 2028, 1128,
+        2029, 1127, 2091, 967, 2091], "words": [{"text": "$", "boundingBox": [969,
+        2028, 994, 2028, 994, 2091, 969, 2091], "confidence": 0.888}, {"text": "99.99",
+        "boundingBox": [1007, 2028, 1127, 2028, 1126, 2091, 1007, 2091], "confidence":
+        0.911}]}, {"text": "Sub-Total", "boundingBox": [474, 2242, 697, 2244, 697,
+        2310, 473, 2308], "words": [{"text": "Sub-Total", "boundingBox": [477, 2242,
+        695, 2245, 694, 2310, 474, 2308], "confidence": 0.915}]}, {"text": "$ 1098.99",
+        "boundingBox": [922, 2259, 1136, 2253, 1138, 2318, 924, 2325], "words": [{"text":
+        "$", "boundingBox": [924, 2261, 950, 2260, 954, 2326, 928, 2326], "confidence":
+        0.881}, {"text": "1098.99", "boundingBox": [963, 2260, 1136, 2254, 1137, 2320,
+        966, 2325], "confidence": 0.942}]}, {"text": "Tax", "boundingBox": [570, 2355,
+        655, 2357, 654, 2415, 568, 2413], "words": [{"text": "Tax", "boundingBox":
+        [571, 2355, 654, 2357, 653, 2415, 570, 2413], "confidence": 0.958}]}, {"text":
+        "$ 104.40", "boundingBox": [941, 2368, 1134, 2364, 1137, 2433, 942, 2438],
+        "words": [{"text": "$", "boundingBox": [943, 2368, 966, 2367, 968, 2437, 944,
+        2438], "confidence": 0.892}, {"text": "104.40", "boundingBox": [980, 2367,
+        1132, 2364, 1133, 2434, 982, 2437], "confidence": 0.952}]}, {"text": "Total",
+        "boundingBox": [551, 2591, 672, 2584, 675, 2652, 554, 2659], "words": [{"text":
+        "Total", "boundingBox": [551, 2591, 668, 2584, 672, 2652, 554, 2659], "confidence":
+        0.727}]}, {"text": "$ 1203.39", "boundingBox": [918, 2589, 1123, 2611, 1116,
+        2677, 912, 2656], "words": [{"text": "$", "boundingBox": [918, 2590, 942,
+        2592, 936, 2659, 913, 2656], "confidence": 0.886}, {"text": "1203.39", "boundingBox":
+        [955, 2594, 1123, 2611, 1115, 2678, 949, 2661], "confidence": 0.951}]}]}],
+        "documentResults": [{"docType": "prebuilt:receipt", "pageRange": [1, 1], "fields":
+        {"ReceiptType": {"type": "string", "valueString": "Itemized", "confidence":
+        0.659}, "MerchantName": {"type": "string", "valueString": "Contoso Contoso",
+        "text": "Contoso Contoso", "boundingBox": [349.3, 241.3, 1058, 284.4, 1033.5,
+        687.1, 324.8, 644], "page": 1, "confidence": 0.516, "elements": ["#/readResults/0/lines/0/words/0",
+        "#/readResults/0/lines/1/words/0"]}, "MerchantAddress": {"type": "string",
+        "valueString": "123 Main Street Redmond, WA 98052", "text": "123 Main Street
+        Redmond, WA 98052", "boundingBox": [319.9, 689.9, 750.7, 697.5, 747.8, 865.6,
+        317, 858], "page": 1, "confidence": 0.986, "elements": ["#/readResults/0/lines/2/words/0",
+        "#/readResults/0/lines/2/words/1", "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0",
+        "#/readResults/0/lines/3/words/1", "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber":
+        {"type": "phoneNumber", "text": "123-456-7890", "boundingBox": [306, 1005,
+        617, 1012, 615, 1069, 305, 1064], "page": 1, "confidence": 0.99, "elements":
+        ["#/readResults/0/lines/4/words/0"]}, "TransactionDate": {"type": "date",
+        "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox": [304, 1224,
+        506, 1224, 504, 1289, 303, 1288], "page": 1, "confidence": 0.985, "elements":
+        ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type": "time",
+        "valueTime": "13:59:00", "text": "13:59", "boundingBox": [518, 1225, 628,
+        1228, 627, 1290, 517, 1289], "page": 1, "confidence": 0.968, "elements": ["#/readResults/0/lines/5/words/1"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "8GB RAM (Black)", "text": "8GB
+        RAM (Black)", "boundingBox": [370.7, 1781.5, 731, 1785, 730.3, 1854, 370,
+        1850.6], "page": 1, "confidence": 0.916, "elements": ["#/readResults/0/lines/9/words/0",
+        "#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2"]}, "TotalPrice":
+        {"type": "number", "valueNumber": 999, "text": "$999.00", "boundingBox": [939,
+        1784.6, 1134.4, 1788.3, 1133, 1863, 937.6, 1859.3], "page": 1, "confidence":
+        0.559, "elements": ["#/readResults/0/lines/10/words/0", "#/readResults/0/lines/10/words/1"]}}},
+        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
+        1, "text": "1", "boundingBox": [321, 2021, 348, 2020, 349, 2084, 322, 2084],
+        "page": 1, "confidence": 0.858, "elements": ["#/readResults/0/lines/11/words/0"]},
+        "Name": {"type": "string", "valueString": "SurfacePen", "text": "SurfacePen",
+        "boundingBox": [360, 2020, 626, 2014, 628, 2077, 362, 2083], "page": 1, "confidence":
+        0.858, "elements": ["#/readResults/0/lines/11/words/1"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 99.99, "text": "99.99", "boundingBox": [1007, 2028,
+        1127, 2028, 1126, 2091, 1007, 2091], "page": 1, "confidence": 0.386, "elements":
+        ["#/readResults/0/lines/12/words/1"]}}}]}, "Subtotal": {"type": "number",
+        "valueNumber": 1098.99, "text": "1098.99", "boundingBox": [963, 2260, 1136,
+        2254, 1137, 2320, 966, 2325], "page": 1, "confidence": 0.964, "elements":
+        ["#/readResults/0/lines/14/words/1"]}, "Tax": {"type": "number", "valueNumber":
+        104.4, "text": "$104.40", "boundingBox": [942.6, 2367.5, 1132, 2363.7, 1133.4,
+        2434.2, 944, 2438], "page": 1, "confidence": 0.713, "elements": ["#/readResults/0/lines/16/words/0",
+        "#/readResults/0/lines/16/words/1"]}, "Total": {"type": "number", "valueNumber":
+        1203.39, "text": "1203.39", "boundingBox": [955, 2594, 1123, 2611, 1115, 2678,
+        949, 2661], "page": 1, "confidence": 0.774, "elements": ["#/readResults/0/lines/18/words/1"]}}}]}}'
     headers:
       apim-request-id:
-      - 79056360-5fb2-4523-8949-6fbe2e24d9ef
+      - 70e688ff-4755-4e14-bbb8-fee95bde374c
       content-length:
-      - '10615'
+      - '8807'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:07:56 GMT
+      - Mon, 16 Nov 2020 19:13:22 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '20'
+      - '22'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipts_encoded_url.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url.test_receipts_encoded_url.yaml
@@ -19,23 +19,23 @@ interactions:
   response:
     body:
       string: '{"error": {"code": "FailedToDownloadImage", "innerError": {"requestId":
-        "4d052b2e-0731-42c7-b87a-42ed3d3ccc65"}, "message": "Failed to download image
+        "6bc34ef9-ec67-4e2c-acf9-25b49ca271e0"}, "message": "Failed to download image
         from input URL."}}'
     headers:
       apim-request-id:
-      - 4d052b2e-0731-42c7-b87a-42ed3d3ccc65
+      - 6bc34ef9-ec67-4e2c-acf9-25b49ca271e0
       content-length:
       - '161'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 11 Nov 2020 18:07:59 GMT
+      - Mon, 16 Nov 2020 19:13:25 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '3258'
+      - '3230'
     status:
       code: 400
       message: Bad Request

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_polling_interval.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_polling_interval.yaml
@@ -16,13 +16,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 6b565d3b-9f3a-4559-a98a-17d4ddb79fd8
+      apim-request-id: 0100cae2-b796-4368-a2e0-18ff5a5f07df
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:08:07 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/6b565d3b-9f3a-4559-a98a-17d4ddb79fd8
+      date: Mon, 16 Nov 2020 19:13:33 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/0100cae2-b796-4368-a2e0-18ff5a5f07df
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '334'
+      x-envoy-upstream-service-time: '176'
     status:
       code: 202
       message: Accepted
@@ -33,62 +33,62 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/6b565d3b-9f3a-4559-a98a-17d4ddb79fd8
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/0100cae2-b796-4368-a2e0-18ff5a5f07df
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:08:06Z",
-        "lastUpdatedDateTime": "2020-11-11T18:08:09Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:13:33Z",
+        "lastUpdatedDateTime": "2020-11-16T19:13:35Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [380.9, 282.9,
-        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.716}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [298.3, 676.5, 844.6,
-        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence":
-        0.99}, "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text":
-        "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505, 1331, 255, 1312],
-        "page": 1, "confidence": 0.99}, "TransactionTime": {"type": "time", "valueTime":
-        "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681, 1262, 675, 1341,
-        522, 1332], "page": 1, "confidence": 0.989}, "Items": {"type": "array", "valueArray":
-        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [244, 1581, 288, 1584, 285, 1678, 241, 1675],
-        "page": 1, "confidence": 0.919}, "Name": {"type": "string", "valueString":
-        "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585, 658, 1598,
-        657, 1688, 304, 1679], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1106, 1579,
-        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.959}}}, {"type":
-        "object", "valueObject": {"Quantity": {"type": "number", "valueNumber": 1,
-        "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [294, 1839, 737, 1839,
-        737, 1924, 294, 1924], "page": 1, "confidence": 0.955}, "TotalPrice": {"type":
-        "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox": [1134, 1948,
-        1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence": 0.958}}}]},
-        "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923}, "Tax": {"type": "number", "valueNumber": 1.17, "text": "1.17", "boundingBox":
-        [1186, 2356, 1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence":
-        0.979}, "Tip": {"type": "number", "valueNumber": 463, "text": "$463", "boundingBox":
-        [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "page": 1, "confidence":
-        0.975}, "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50",
-        "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1,
-        "confidence": 0.987}}}]}}'
+        "Itemized", "confidence": 0.692}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [378.2, 292.4,
+        1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8], "page": 1, "confidence": 0.613},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [302,
+        675.8, 848.1, 793.7, 809.9, 970.4, 263.9, 852.5], "page": 1, "confidence":
+        0.99}, "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber":
+        "+19876543210", "text": "987-654-3210", "boundingBox": [278, 1004, 656, 1057,
+        647, 1123, 271, 1075], "page": 1, "confidence": 0.99}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99},
+        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
+        "boundingBox": [541, 1248, 677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence":
+        0.977}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
+        [245, 1583, 299, 1585, 295, 1676, 241, 1671], "page": 1, "confidence": 0.92},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923}, "TotalPrice": {"type": "number", "valueNumber": 2.2, "text": "$2.20",
+        "boundingBox": [1108, 1584, 1263, 1574, 1268, 1656, 1113, 1666], "page": 1,
+        "confidence": 0.918}}}, {"type": "object", "valueObject": {"Quantity": {"type":
+        "number", "valueNumber": 1, "text": "1", "boundingBox": [232, 1834, 286, 1836,
+        285, 1920, 231, 1920], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916},
+        "TotalPrice": {"type": "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox":
+        [1135, 1955, 1257, 1952, 1259, 2036, 1136, 2039], "page": 1, "confidence":
+        0.916}}}]}, "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70",
+        "boundingBox": [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1,
+        "confidence": 0.955}, "Tax": {"type": "number", "valueNumber": 1.17, "text":
+        "1.17", "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "page":
+        1, "confidence": 0.979}, "Tip": {"type": "number", "valueNumber": 1.63, "text":
+        "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591, 1091, 2585], "page":
+        1, "confidence": 0.941}, "Total": {"type": "number", "valueNumber": 14.5,
+        "text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380, 2763, 1030,
+        2739], "page": 1, "confidence": 0.985}}}]}}'
     headers:
-      apim-request-id: a57dcc8a-3839-4cc9-aa04-78260649fd14
-      content-length: '2820'
+      apim-request-id: 683e1662-56ed-43ea-ba55-b70f8461bb68
+      content-length: '2835'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:08:12 GMT
+      date: Mon, 16 Nov 2020 19:13:38 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '20'
+      x-envoy-upstream-service-time: '21'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/6b565d3b-9f3a-4559-a98a-17d4ddb79fd8
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/0100cae2-b796-4368-a2e0-18ff5a5f07df
 - request:
     body: 'b''{"source": "https://raw.githubusercontent.com/Azure/azure-sdk-for-python/master/sdk/formrecognizer/azure-ai-formrecognizer/tests/sample_forms/receipt/contoso-allinone.jpg"}'''
     headers:
@@ -106,13 +106,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 1df5a5f7-c791-44a2-8e8c-7665fa16a1bf
+      apim-request-id: d3757678-6eb2-48c8-8e41-e7642b9a10a8
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:08:13 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/1df5a5f7-c791-44a2-8e8c-7665fa16a1bf
+      date: Mon, 16 Nov 2020 19:13:39 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/d3757678-6eb2-48c8-8e41-e7642b9a10a8
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '242'
+      x-envoy-upstream-service-time: '187'
     status:
       code: 202
       message: Accepted
@@ -123,60 +123,60 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/1df5a5f7-c791-44a2-8e8c-7665fa16a1bf
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/d3757678-6eb2-48c8-8e41-e7642b9a10a8
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:08:13Z",
-        "lastUpdatedDateTime": "2020-11-11T18:08:16Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:13:39Z",
+        "lastUpdatedDateTime": "2020-11-16T19:13:41Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [380.9, 282.9,
-        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.716}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [298.3, 676.5, 844.6,
-        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence":
-        0.99}, "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text":
-        "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505, 1331, 255, 1312],
-        "page": 1, "confidence": 0.99}, "TransactionTime": {"type": "time", "valueTime":
-        "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681, 1262, 675, 1341,
-        522, 1332], "page": 1, "confidence": 0.989}, "Items": {"type": "array", "valueArray":
-        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [244, 1581, 288, 1584, 285, 1678, 241, 1675],
-        "page": 1, "confidence": 0.919}, "Name": {"type": "string", "valueString":
-        "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585, 658, 1598,
-        657, 1688, 304, 1679], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1106, 1579,
-        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.959}}}, {"type":
-        "object", "valueObject": {"Quantity": {"type": "number", "valueNumber": 1,
-        "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [294, 1839, 737, 1839,
-        737, 1924, 294, 1924], "page": 1, "confidence": 0.955}, "TotalPrice": {"type":
-        "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox": [1134, 1948,
-        1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence": 0.958}}}]},
-        "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923}, "Tax": {"type": "number", "valueNumber": 1.17, "text": "1.17", "boundingBox":
-        [1186, 2356, 1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence":
-        0.979}, "Tip": {"type": "number", "valueNumber": 463, "text": "$463", "boundingBox":
-        [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "page": 1, "confidence":
-        0.975}, "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50",
-        "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1,
-        "confidence": 0.987}}}]}}'
+        "Itemized", "confidence": 0.692}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [378.2, 292.4,
+        1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8], "page": 1, "confidence": 0.613},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [302,
+        675.8, 848.1, 793.7, 809.9, 970.4, 263.9, 852.5], "page": 1, "confidence":
+        0.99}, "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber":
+        "+19876543210", "text": "987-654-3210", "boundingBox": [278, 1004, 656, 1057,
+        647, 1123, 271, 1075], "page": 1, "confidence": 0.99}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99},
+        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
+        "boundingBox": [541, 1248, 677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence":
+        0.977}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
+        [245, 1583, 299, 1585, 295, 1676, 241, 1671], "page": 1, "confidence": 0.92},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923}, "TotalPrice": {"type": "number", "valueNumber": 2.2, "text": "$2.20",
+        "boundingBox": [1108, 1584, 1263, 1574, 1268, 1656, 1113, 1666], "page": 1,
+        "confidence": 0.918}}}, {"type": "object", "valueObject": {"Quantity": {"type":
+        "number", "valueNumber": 1, "text": "1", "boundingBox": [232, 1834, 286, 1836,
+        285, 1920, 231, 1920], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916},
+        "TotalPrice": {"type": "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox":
+        [1135, 1955, 1257, 1952, 1259, 2036, 1136, 2039], "page": 1, "confidence":
+        0.916}}}]}, "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70",
+        "boundingBox": [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1,
+        "confidence": 0.955}, "Tax": {"type": "number", "valueNumber": 1.17, "text":
+        "1.17", "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "page":
+        1, "confidence": 0.979}, "Tip": {"type": "number", "valueNumber": 1.63, "text":
+        "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591, 1091, 2585], "page":
+        1, "confidence": 0.941}, "Total": {"type": "number", "valueNumber": 14.5,
+        "text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380, 2763, 1030,
+        2739], "page": 1, "confidence": 0.985}}}]}}'
     headers:
-      apim-request-id: 82fbce3c-fc83-4d24-bd7f-cbfefc349301
-      content-length: '2820'
+      apim-request-id: ff8208f6-27a0-4835-a55f-d3f0b8da50e1
+      content-length: '2835'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:08:20 GMT
+      date: Mon, 16 Nov 2020 19:13:46 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '55'
+      x-envoy-upstream-service-time: '34'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/1df5a5f7-c791-44a2-8e8c-7665fa16a1bf
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/d3757678-6eb2-48c8-8e41-e7642b9a10a8
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_bad_url.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_bad_url.yaml
@@ -15,16 +15,16 @@ interactions:
   response:
     body:
       string: '{"error": {"code": "FailedToDownloadImage", "innerError": {"requestId":
-        "bb15a804-e4e4-4a5b-8a06-82a5ef966f46"}, "message": "Failed to download image
+        "e9cdf0a3-fd5d-48f6-beb4-a0597734f7b4"}, "message": "Failed to download image
         from input URL."}}'
     headers:
-      apim-request-id: bb15a804-e4e4-4a5b-8a06-82a5ef966f46
+      apim-request-id: e9cdf0a3-fd5d-48f6-beb4-a0597734f7b4
       content-length: '161'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:08:24 GMT
+      date: Mon, 16 Nov 2020 19:13:50 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '3226'
+      x-envoy-upstream-service-time: '3272'
     status:
       code: 400
       message: Bad Request

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_locale_error.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_locale_error.yaml
@@ -15,16 +15,16 @@ interactions:
   response:
     body:
       string: '{"error": {"code": "UnsupportedLocale", "innerError": {"requestId":
-        "89e11016-5450-465d-90c9-be057c5c15dc"}, "message": "Locale unsupported. Supported
+        "b666a7a8-889c-42bd-853b-fa53b837122d"}, "message": "Locale unsupported. Supported
         locales include en-AU, en-CA, en-GB, en-IN and en-US."}}'
     headers:
-      apim-request-id: 89e11016-5450-465d-90c9-be057c5c15dc
+      apim-request-id: b666a7a8-889c-42bd-853b-fa53b837122d
       content-length: '200'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:08:35 GMT
+      date: Mon, 16 Nov 2020 19:14:01 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '141'
+      x-envoy-upstream-service-time: '153'
     status:
       code: 400
       message: Bad Request

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_locale_specified.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_locale_specified.yaml
@@ -16,13 +16,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 3a8ed3c8-7a25-4e75-ad01-4bcca10d9040
+      apim-request-id: 22e58283-3869-48a0-a1d9-7d8ae941b9fb
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:08:35 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/3a8ed3c8-7a25-4e75-ad01-4bcca10d9040
+      date: Mon, 16 Nov 2020 19:14:02 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/22e58283-3869-48a0-a1d9-7d8ae941b9fb
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '205'
+      x-envoy-upstream-service-time: '184'
     status:
       code: 202
       message: Accepted
@@ -33,20 +33,20 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/3a8ed3c8-7a25-4e75-ad01-4bcca10d9040
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/22e58283-3869-48a0-a1d9-7d8ae941b9fb
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:08:36Z",
-        "lastUpdatedDateTime": "2020-11-11T18:08:39Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:14:02Z",
+        "lastUpdatedDateTime": "2020-11-16T19:14:05Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
         "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
         "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [380.9, 282.9,
-        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.989}, "MerchantAddress":
+        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.769}, "MerchantAddress":
         {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
         "123 Main Street Redmond, WA 98052", "boundingBox": [298.3, 676.5, 844.6,
-        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.993}, "MerchantPhoneNumber":
+        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.99}, "MerchantPhoneNumber":
         {"type": "phoneNumber", "valuePhoneNumber": "+919876543210", "text": "987-654-3210",
         "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence":
         0.995}, "TransactionDate": {"type": "date", "valueDate": "2019-10-06", "text":
@@ -56,33 +56,35 @@ interactions:
         522, 1332], "page": 1, "confidence": 0.995}, "Items": {"type": "array", "valueArray":
         [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
         1, "text": "1", "boundingBox": [244, 1581, 288, 1584, 285, 1678, 241, 1675],
-        "page": 1, "confidence": 0.919}, "Name": {"type": "string", "valueString":
+        "page": 1, "confidence": 0.936}, "Name": {"type": "string", "valueString":
         "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585, 658, 1598,
-        657, 1688, 304, 1679], "page": 1, "confidence": 0.982}, "TotalPrice": {"type":
+        657, 1688, 304, 1679], "page": 1, "confidence": 0.976}, "TotalPrice": {"type":
         "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1106, 1579,
-        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.971}}}, {"type":
+        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.988}}}, {"type":
         "object", "valueObject": {"Quantity": {"type": "number", "valueNumber": 1,
         "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.918}, "Name": {"type": "string", "valueString":
-        "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [294, 1839, 737, 1839,
-        737, 1924, 294, 1924], "page": 1, "confidence": 0.892}, "TotalPrice": {"type":
-        "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox": [1134, 1948,
-        1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence": 0.969}}}]},
-        "Tax": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.971}, "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50",
-        "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1,
-        "confidence": 0.99}}}]}}'
+        "page": 1, "confidence": 0.882}, "Name": {"type": "string", "valueString":
+        "BACON & EGGS Sunny-side-up", "text": "BACON & EGGS Sunny-side-up", "boundingBox":
+        [294, 1839, 757, 1839, 757, 2064, 294, 2064], "page": 1, "confidence": 0.506},
+        "TotalPrice": {"type": "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox":
+        [1134, 1948, 1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence":
+        0.987}}}]}, "Tax": {"type": "number", "valueNumber": 1.17, "text": "1.17",
+        "boundingBox": [1186, 2356, 1307, 2361, 1303, 2452, 1182, 2447], "page": 1,
+        "confidence": 0.994}, "Total": {"type": "number", "valueNumber": 14.5, "text":
+        "$14.50", "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740],
+        "page": 1, "confidence": 0.988}, "Subtotal": {"type": "number", "valueNumber":
+        11.7, "text": "11.70", "boundingBox": [1139, 2228, 1309, 2228, 1308, 2313,
+        1138, 2313], "page": 1, "confidence": 0.269}}}]}}'
     headers:
-      apim-request-id: d56d567f-41b3-4184-a676-6bdc9665b696
-      content-length: '2537'
+      apim-request-id: f90f5d34-64d6-4032-a785-11c38b2747f0
+      content-length: '2711'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:08:41 GMT
+      date: Mon, 16 Nov 2020 19:14:07 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '22'
+      x-envoy-upstream-service-time: '16'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/3a8ed3c8-7a25-4e75-ad01-4bcca10d9040
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/22e58283-3869-48a0-a1d9-7d8ae941b9fb
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_multipage_transform_url.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_multipage_transform_url.yaml
@@ -16,13 +16,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 14f7679b-b288-46e1-b8af-4f43a57223b4
+      apim-request-id: 4f36a414-19f4-42fc-b2d3-f481c8733e55
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:08:41 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/14f7679b-b288-46e1-b8af-4f43a57223b4
+      date: Mon, 16 Nov 2020 19:14:07 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/4f36a414-19f4-42fc-b2d3-f481c8733e55
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '103'
+      x-envoy-upstream-service-time: '105'
     status:
       code: 202
       message: Accepted
@@ -33,11 +33,11 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/14f7679b-b288-46e1-b8af-4f43a57223b4
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/4f36a414-19f4-42fc-b2d3-f481c8733e55
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:08:41Z",
-        "lastUpdatedDateTime": "2020-11-11T18:08:44Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:14:08Z",
+        "lastUpdatedDateTime": "2020-11-16T19:14:12Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": 0, "width": 8.5, "height": 11,
         "unit": "inch", "lines": [{"text": "Company A Invoice", "boundingBox": [0.8861,
         1.1217, 2.3783, 1.1217, 2.3783, 1.2812, 0.8861, 1.2812], "words": [{"text":
@@ -45,386 +45,366 @@ interactions:
         0.8861, 1.2812], "confidence": 1}, {"text": "A", "boundingBox": [1.6696, 1.1242,
         1.7749, 1.1242, 1.7749, 1.2473, 1.6696, 1.2473], "confidence": 1}, {"text":
         "Invoice", "boundingBox": [1.8389, 1.1217, 2.3783, 1.1217, 2.3783, 1.2485,
-        1.8389, 1.2485], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "Invoice For:", "boundingBox": [6.0211, 1.0656,
-        7.0357, 1.0656, 7.0357, 1.2121, 6.0211, 1.2121], "words": [{"text": "Invoice",
-        "boundingBox": [6.0211, 1.0656, 6.6362, 1.0656, 6.6362, 1.2121, 6.0211, 1.2121],
-        "confidence": 1}, {"text": "For:", "boundingBox": [6.7147, 1.0691, 7.0357,
-        1.0691, 7.0357, 1.2121, 6.7147, 1.2121], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Address:", "boundingBox":
-        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "words":
-        [{"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825, 1.5657,
-        1.6155, 0.8791, 1.6155], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Bilbo Baggins", "boundingBox": [6.0164,
-        1.4503, 6.8967, 1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "words": [{"text":
-        "Bilbo", "boundingBox": [6.0164, 1.4503, 6.3392, 1.4503, 6.3392, 1.5649, 6.0164,
-        1.5649], "confidence": 1}, {"text": "Baggins", "boundingBox": [6.396, 1.4556,
-        6.8967, 1.4556, 6.8967, 1.5931, 6.396, 1.5931], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "123 Hobbit Lane",
-        "boundingBox": [6.0165, 1.6707, 7.1006, 1.6707, 7.1006, 1.7854, 6.0165, 1.7854],
-        "words": [{"text": "123", "boundingBox": [6.0165, 1.6772, 6.2434, 1.6772,
-        6.2434, 1.7854, 6.0165, 1.7854], "confidence": 1}, {"text": "Hobbit", "boundingBox":
-        [6.3033, 1.6707, 6.7463, 1.6707, 6.7463, 1.7854, 6.3033, 1.7854], "confidence":
-        1}, {"text": "Lane", "boundingBox": [6.803, 1.6782, 7.1006, 1.6782, 7.1006,
-        1.7854, 6.803, 1.7854], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "567 Main St.", "boundingBox": [0.8852,
-        1.846, 1.713, 1.846, 1.713, 1.9554, 0.8852, 1.9554], "words": [{"text": "567",
-        "boundingBox": [0.8852, 1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554],
-        "confidence": 1}, {"text": "Main", "boundingBox": [1.1777, 1.846, 1.5022,
-        1.846, 1.5022, 1.9554, 1.1777, 1.9554], "confidence": 1}, {"text": "St.",
-        "boundingBox": [1.5558, 1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Redmond, WA", "boundingBox": [6.0164, 1.891, 6.9793, 1.891,
-        6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text": "Redmond,", "boundingBox":
-        [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275, 6.0164, 2.0275], "confidence":
-        1}, {"text": "WA", "boundingBox": [6.7408, 1.8982, 6.9793, 1.8982, 6.9793,
-        2.0044, 6.7408, 2.0044], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Redmond, WA", "boundingBox": [0.891,
-        2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,",
-        "boundingBox": [0.891, 2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975],
-        "confidence": 1}, {"text": "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682,
-        1.8537, 2.1744, 1.6152, 2.1744], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "555-555-5555", "boundingBox":
-        [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "words":
-        [{"text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187,
-        6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "555-555-5555", "boundingBox":
+        1.8389, 1.2485], "confidence": 1}]}, {"text": "Invoice For:", "boundingBox":
+        [6.0211, 1.0656, 7.0357, 1.0656, 7.0357, 1.2121, 6.0211, 1.2121], "words":
+        [{"text": "Invoice", "boundingBox": [6.0211, 1.0656, 6.6362, 1.0656, 6.6362,
+        1.2121, 6.0211, 1.2121], "confidence": 1}, {"text": "For:", "boundingBox":
+        [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121, 6.7147, 1.2121], "confidence":
+        1}]}, {"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825,
+        1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text": "Address:", "boundingBox":
+        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "confidence":
+        1}]}, {"text": "Bilbo Baggins", "boundingBox": [6.0164, 1.4503, 6.8967, 1.4503,
+        6.8967, 1.5931, 6.0164, 1.5931], "words": [{"text": "Bilbo", "boundingBox":
+        [6.0164, 1.4503, 6.3392, 1.4503, 6.3392, 1.5649, 6.0164, 1.5649], "confidence":
+        1}, {"text": "Baggins", "boundingBox": [6.396, 1.4556, 6.8967, 1.4556, 6.8967,
+        1.5931, 6.396, 1.5931], "confidence": 1}]}, {"text": "123 Hobbit Lane", "boundingBox":
+        [6.0165, 1.6707, 7.1006, 1.6707, 7.1006, 1.7854, 6.0165, 1.7854], "words":
+        [{"text": "123", "boundingBox": [6.0165, 1.6772, 6.2434, 1.6772, 6.2434, 1.7854,
+        6.0165, 1.7854], "confidence": 1}, {"text": "Hobbit", "boundingBox": [6.3033,
+        1.6707, 6.7463, 1.6707, 6.7463, 1.7854, 6.3033, 1.7854], "confidence": 1},
+        {"text": "Lane", "boundingBox": [6.803, 1.6782, 7.1006, 1.6782, 7.1006, 1.7854,
+        6.803, 1.7854], "confidence": 1}]}, {"text": "567 Main St.", "boundingBox":
+        [0.8852, 1.846, 1.713, 1.846, 1.713, 1.9554, 0.8852, 1.9554], "words": [{"text":
+        "567", "boundingBox": [0.8852, 1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852,
+        1.9554], "confidence": 1}, {"text": "Main", "boundingBox": [1.1777, 1.846,
+        1.5022, 1.846, 1.5022, 1.9554, 1.1777, 1.9554], "confidence": 1}, {"text":
+        "St.", "boundingBox": [1.5558, 1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558,
+        1.9554], "confidence": 1}]}, {"text": "Redmond, WA", "boundingBox": [6.0164,
+        1.891, 6.9793, 1.891, 6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text":
+        "Redmond,", "boundingBox": [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275,
+        6.0164, 2.0275], "confidence": 1}, {"text": "WA", "boundingBox": [6.7408,
+        1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408, 2.0044], "confidence": 1}]},
+        {"text": "Redmond, WA", "boundingBox": [0.891, 2.061, 1.8537, 2.061, 1.8537,
+        2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,", "boundingBox": [0.891,
+        2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975], "confidence": 1}, {"text":
+        "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682, 1.8537, 2.1744, 1.6152,
+        2.1744], "confidence": 1}]}, {"text": "555-555-5555", "boundingBox": [6.0105,
+        2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "words": [{"text":
+        "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254,
+        6.0105, 2.2254], "confidence": 1}]}, {"text": "555-555-5555", "boundingBox":
         [0.8852, 2.2887, 1.8119, 2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "words":
         [{"text": "555-555-5555", "boundingBox": [0.8852, 2.2887, 1.8119, 2.2887,
-        1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Item", "boundingBox": [1.0943,
-        3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
+        1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}]}, {"text": "Item", "boundingBox":
+        [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
         "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943,
-        3.109], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996,
-        3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity", "boundingBox":
-        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Price", "boundingBox": [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423,
-        3.109], "words": [{"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
-        2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "A", "boundingBox": [1.0832,
-        3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A",
-        "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116, 3.3202,
-        3.3176, 3.2589, 3.3176], "words": [{"text": "1", "boundingBox": [3.2589, 3.2116,
-        3.3202, 3.2116, 3.3202, 3.3176, 3.2589, 3.3176], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "10.99", "boundingBox":
+        3.109], "confidence": 1}]}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996,
+        3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity",
+        "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371],
+        "confidence": 1}]}, {"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
+        2.9996, 5.7372, 3.109, 5.423, 3.109], "words": [{"text": "Price", "boundingBox":
+        [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence":
+        1}]}, {"text": "A", "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174,
+        3.318, 1.0832, 3.318], "words": [{"text": "A", "boundingBox": [1.0832, 3.2118,
+        1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "confidence": 1}]}, {"text":
+        "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116, 3.3202, 3.3176, 3.2589,
+        3.3176], "words": [{"text": "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116,
+        3.3202, 3.3176, 3.2589, 3.3176], "confidence": 1}]}, {"text": "10.99", "boundingBox":
         [5.4232, 3.2108, 5.7784, 3.2108, 5.7784, 3.319, 5.4232, 3.319], "words": [{"text":
         "10.99", "boundingBox": [5.4232, 3.2108, 5.7784, 3.2108, 5.7784, 3.319, 5.4232,
-        3.319], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637,
-        3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox": [1.0943, 3.4256,
-        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "2", "boundingBox":
-        [3.2541, 3.4241, 3.3199, 3.4241, 3.3199, 3.531, 3.2541, 3.531], "words": [{"text":
-        "2", "boundingBox": [3.2541, 3.4241, 3.3199, 3.4241, 3.3199, 3.531, 3.2541,
-        3.531], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "14.67", "boundingBox": [5.4232, 3.4241, 5.7789, 3.4241, 5.7789,
-        3.5323, 5.4232, 3.5323], "words": [{"text": "14.67", "boundingBox": [5.4232,
-        3.4241, 5.7789, 3.4241, 5.7789, 3.5323, 5.4232, 3.5323], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "C",
+        3.319], "confidence": 1}]}, {"text": "B", "boundingBox": [1.0943, 3.4256,
+        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox":
+        [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence":
+        1}]}, {"text": "2", "boundingBox": [3.2541, 3.4241, 3.3199, 3.4241, 3.3199,
+        3.531, 3.2541, 3.531], "words": [{"text": "2", "boundingBox": [3.2541, 3.4241,
+        3.3199, 3.4241, 3.3199, 3.531, 3.2541, 3.531], "confidence": 1}]}, {"text":
+        "14.67", "boundingBox": [5.4232, 3.4241, 5.7789, 3.4241, 5.7789, 3.5323, 5.4232,
+        3.5323], "words": [{"text": "14.67", "boundingBox": [5.4232, 3.4241, 5.7789,
+        3.4241, 5.7789, 3.5323, 5.4232, 3.5323], "confidence": 1}]}, {"text": "C",
         "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647, 3.7421, 1.0882, 3.7421],
         "words": [{"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647,
-        3.7421, 1.0882, 3.7421], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "4", "boundingBox": [3.2486, 3.6351,
-        3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "words": [{"text": "4", "boundingBox":
-        [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "15.66", "boundingBox": [5.4232, 3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232,
-        3.7423], "words": [{"text": "15.66", "boundingBox": [5.4232, 3.6341, 5.78,
-        3.6341, 5.78, 3.7423, 5.4232, 3.7423], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "D", "boundingBox": [1.0943,
-        3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text":
-        "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943,
-        3.951], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1", "boundingBox": [3.2589, 3.845, 3.3202, 3.845, 3.3202,
+        3.7421, 1.0882, 3.7421], "confidence": 1}]}, {"text": "4", "boundingBox":
+        [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "words":
+        [{"text": "4", "boundingBox": [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413,
+        3.2486, 3.7413], "confidence": 1}]}, {"text": "15.66", "boundingBox": [5.4232,
+        3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232, 3.7423], "words": [{"text": "15.66",
+        "boundingBox": [5.4232, 3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232, 3.7423],
+        "confidence": 1}]}, {"text": "D", "boundingBox": [1.0943, 3.8456, 1.1753,
+        3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text": "D", "boundingBox":
+        [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "confidence":
+        1}]}, {"text": "1", "boundingBox": [3.2589, 3.845, 3.3202, 3.845, 3.3202,
         3.951, 3.2589, 3.951], "words": [{"text": "1", "boundingBox": [3.2589, 3.845,
-        3.3202, 3.845, 3.3202, 3.951, 3.2589, 3.951], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "12.00", "boundingBox":
-        [5.4232, 3.8441, 5.7809, 3.8441, 5.7809, 3.9523, 5.4232, 3.9523], "words":
-        [{"text": "12.00", "boundingBox": [5.4232, 3.8441, 5.7809, 3.8441, 5.7809,
-        3.9523, 5.4232, 3.9523], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "E", "boundingBox": [1.0943, 4.0561,
-        1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "words": [{"text": "E", "boundingBox":
-        [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617, 3.2486,
-        4.1617], "words": [{"text": "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556,
-        3.3244, 4.1617, 3.2486, 4.1617], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "10.00", "boundingBox": [5.4232,
+        3.3202, 3.845, 3.3202, 3.951, 3.2589, 3.951], "confidence": 1}]}, {"text":
+        "12.00", "boundingBox": [5.4232, 3.8441, 5.7809, 3.8441, 5.7809, 3.9523, 5.4232,
+        3.9523], "words": [{"text": "12.00", "boundingBox": [5.4232, 3.8441, 5.7809,
+        3.8441, 5.7809, 3.9523, 5.4232, 3.9523], "confidence": 1}]}, {"text": "E",
+        "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614],
+        "words": [{"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
+        4.1614, 1.0943, 4.1614], "confidence": 1}]}, {"text": "4", "boundingBox":
+        [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617, 3.2486, 4.1617], "words":
+        [{"text": "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617,
+        3.2486, 4.1617], "confidence": 1}]}, {"text": "10.00", "boundingBox": [5.4232,
         4.0546, 5.781, 4.0546, 5.781, 4.1627, 5.4232, 4.1627], "words": [{"text":
         "10.00", "boundingBox": [5.4232, 4.0546, 5.781, 4.0546, 5.781, 4.1627, 5.4232,
-        4.1627], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497,
-        4.3717, 1.0943, 4.3717], "words": [{"text": "F", "boundingBox": [1.0943, 4.2661,
-        1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "6", "boundingBox":
-        [3.2534, 4.2646, 3.3226, 4.2646, 3.3226, 4.3727, 3.2534, 4.3727], "words":
-        [{"text": "6", "boundingBox": [3.2534, 4.2646, 3.3226, 4.2646, 3.3226, 4.3727,
-        3.2534, 4.3727], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "12.00", "boundingBox": [5.4232, 4.2646, 5.7809,
-        4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "words": [{"text": "12.00", "boundingBox":
-        [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877,
-        4.5827], "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746,
-        1.1735, 4.5827, 1.0877, 4.5827], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "8", "boundingBox": [3.2514,
-        4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514, 4.5827], "words": [{"text":
-        "8", "boundingBox": [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514,
-        4.5827], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781,
-        4.5827, 5.4184, 4.5827], "words": [{"text": "22.00", "boundingBox": [5.4184,
-        4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184, 4.5827], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Subtotal:
-        300.00", "boundingBox": [5.5075, 4.8981, 6.632, 4.8981, 6.632, 5.0131, 5.5075,
-        5.0131], "words": [{"text": "Subtotal:", "boundingBox": [5.5075, 4.8981, 6.1249,
-        4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence": 1}, {"text": "300.00",
-        "boundingBox": [6.1794, 4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Tax: 30.00", "boundingBox": [5.5034, 5.1245, 6.2022, 5.1245,
-        6.2022, 5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:", "boundingBox":
-        [5.5034, 5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333], "confidence":
-        1}, {"text": "30.00", "boundingBox": [5.836, 5.1245, 6.2022, 5.1245, 6.2022,
-        5.2333, 5.836, 5.2333], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Tip: 100.00", "boundingBox": [5.5034,
-        5.3412, 6.2587, 5.3412, 6.2587, 5.481, 5.5034, 5.481], "words": [{"text":
+        4.1627], "confidence": 1}]}, {"text": "F", "boundingBox": [1.0943, 4.2661,
+        1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "words": [{"text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "confidence":
+        1}]}, {"text": "6", "boundingBox": [3.2534, 4.2646, 3.3226, 4.2646, 3.3226,
+        4.3727, 3.2534, 4.3727], "words": [{"text": "6", "boundingBox": [3.2534, 4.2646,
+        3.3226, 4.2646, 3.3226, 4.3727, 3.2534, 4.3727], "confidence": 1}]}, {"text":
+        "12.00", "boundingBox": [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232,
+        4.3727], "words": [{"text": "12.00", "boundingBox": [5.4232, 4.2646, 5.7809,
+        4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "confidence": 1}]}, {"text": "G",
+        "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827],
+        "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
+        4.5827, 1.0877, 4.5827], "confidence": 1}]}, {"text": "8", "boundingBox":
+        [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514, 4.5827], "words":
+        [{"text": "8", "boundingBox": [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827,
+        3.2514, 4.5827], "confidence": 1}]}, {"text": "22.00", "boundingBox": [5.4184,
+        4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184, 4.5827], "words": [{"text":
+        "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184,
+        4.5827], "confidence": 1}]}, {"text": "Subtotal: 300.00", "boundingBox": [5.5075,
+        4.8981, 6.632, 4.8981, 6.632, 5.0131, 5.5075, 5.0131], "words": [{"text":
+        "Subtotal:", "boundingBox": [5.5075, 4.8981, 6.1249, 4.8981, 6.1249, 5.0131,
+        5.5075, 5.0131], "confidence": 1}, {"text": "300.00", "boundingBox": [6.1794,
+        4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131], "confidence": 1}]},
+        {"text": "Tax: 30.00", "boundingBox": [5.5034, 5.1245, 6.2022, 5.1245, 6.2022,
+        5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:", "boundingBox": [5.5034,
+        5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333], "confidence": 1},
+        {"text": "30.00", "boundingBox": [5.836, 5.1245, 6.2022, 5.1245, 6.2022, 5.2333,
+        5.836, 5.2333], "confidence": 1}]}, {"text": "Tip: 100.00", "boundingBox":
+        [5.5034, 5.3412, 6.2587, 5.3412, 6.2587, 5.481, 5.5034, 5.481], "words": [{"text":
         "Tip:", "boundingBox": [5.5034, 5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034,
         5.481], "confidence": 1}, {"text": "100.00", "boundingBox": [5.811, 5.3445,
-        6.2587, 5.3445, 6.2587, 5.4533, 5.811, 5.4533], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Total: 430.00",
-        "boundingBox": [5.5034, 5.5583, 6.3987, 5.5583, 6.3987, 5.6733, 5.5034, 5.6733],
-        "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583,
-        5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "430.00", "boundingBox":
-        [5.942, 5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942, 5.6733], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Signature: ____Bilbo Baggins__________", "boundingBox": [1.0055, 6.6553,
-        3.8342, 6.6553, 3.8342, 6.7981, 1.0055, 6.7981], "words": [{"text": "Signature:",
-        "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981, 1.0055, 6.7981],
-        "confidence": 1}, {"text": "____Bilbo", "boundingBox": [1.747, 6.6553, 2.4278,
-        6.6553, 2.4278, 6.7981, 1.747, 6.7981], "confidence": 1}, {"text": "Baggins__________",
-        "boundingBox": [2.4823, 6.6581, 3.8342, 6.6581, 3.8342, 6.7981, 2.4823, 6.7981],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}]}, {"page": 2, "angle": 0, "width": 8.5, "height": 11, "unit": "inch"},
+        6.2587, 5.3445, 6.2587, 5.4533, 5.811, 5.4533], "confidence": 1}]}, {"text":
+        "Total: 430.00", "boundingBox": [5.5034, 5.5583, 6.3987, 5.5583, 6.3987, 5.6733,
+        5.5034, 5.6733], "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583,
+        5.8915, 5.5583, 5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text":
+        "430.00", "boundingBox": [5.942, 5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942,
+        5.6733], "confidence": 1}]}, {"text": "Signature: ____ Bilbo Baggins__________",
+        "boundingBox": [1.0055, 6.6553, 3.8342, 6.6553, 3.8342, 6.7981, 1.0055, 6.7981],
+        "words": [{"text": "Signature:", "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581,
+        1.6987, 6.7981, 1.0055, 6.7981], "confidence": 1}, {"text": "____", "boundingBox":
+        [1.747, 6.7829, 2.0809, 6.7829, 2.0809, 6.7981, 1.747, 6.7981], "confidence":
+        1}, {"text": "Bilbo", "boundingBox": [2.0925, 6.6553, 2.4278, 6.6553, 2.4278,
+        6.7703, 2.0925, 6.7703], "confidence": 1}, {"text": "Baggins__________", "boundingBox":
+        [2.4823, 6.6581, 3.8342, 6.6581, 3.8342, 6.7981, 2.4823, 6.7981], "confidence":
+        1}]}]}, {"page": 2, "angle": 0, "width": 8.5, "height": 11, "unit": "inch"},
         {"page": 3, "angle": 0, "width": 8.5, "height": 11, "unit": "inch", "lines":
         [{"text": "Company B Invoice", "boundingBox": [0.8861, 1.1217, 2.3734, 1.1217,
         2.3734, 1.2812, 0.8861, 1.2812], "words": [{"text": "Company", "boundingBox":
         [0.8861, 1.1232, 1.6203, 1.1232, 1.6203, 1.2812, 0.8861, 1.2812], "confidence":
         1}, {"text": "B", "boundingBox": [1.6836, 1.1248, 1.764, 1.1248, 1.764, 1.2469,
         1.6836, 1.2469], "confidence": 1}, {"text": "Invoice", "boundingBox": [1.8336,
-        1.1217, 2.3734, 1.1217, 2.3734, 1.2485, 1.8336, 1.2485], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Invoice
-        For:", "boundingBox": [6.0211, 1.0656, 7.0357, 1.0656, 7.0357, 1.2121, 6.0211,
-        1.2121], "words": [{"text": "Invoice", "boundingBox": [6.0211, 1.0656, 6.6362,
-        1.0656, 6.6362, 1.2121, 6.0211, 1.2121], "confidence": 1}, {"text": "For:",
-        "boundingBox": [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121, 6.7147, 1.2121],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825,
-        1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text": "Address:", "boundingBox":
-        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Frodo Baggins", "boundingBox": [6.0164, 1.4506, 6.9506, 1.4506, 6.9506, 1.5931,
-        6.0164, 1.5931], "words": [{"text": "Frodo", "boundingBox": [6.0164, 1.4506,
-        6.3895, 1.4506, 6.3895, 1.5649, 6.0164, 1.5649], "confidence": 1}, {"text":
-        "Baggins", "boundingBox": [6.45, 1.4556, 6.9506, 1.4556, 6.9506, 1.5931, 6.45,
-        1.5931], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "123 Hobbit Lane", "boundingBox": [6.0165, 1.6707, 7.1006,
+        1.1217, 2.3734, 1.1217, 2.3734, 1.2485, 1.8336, 1.2485], "confidence": 1}]},
+        {"text": "Invoice For:", "boundingBox": [6.0211, 1.0656, 7.0357, 1.0656, 7.0357,
+        1.2121, 6.0211, 1.2121], "words": [{"text": "Invoice", "boundingBox": [6.0211,
+        1.0656, 6.6362, 1.0656, 6.6362, 1.2121, 6.0211, 1.2121], "confidence": 1},
+        {"text": "For:", "boundingBox": [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121,
+        6.7147, 1.2121], "confidence": 1}]}, {"text": "Address:", "boundingBox": [0.8791,
+        1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text":
+        "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155,
+        0.8791, 1.6155], "confidence": 1}]}, {"text": "Frodo Baggins", "boundingBox":
+        [6.0164, 1.4506, 6.9506, 1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "words":
+        [{"text": "Frodo", "boundingBox": [6.0164, 1.4506, 6.3895, 1.4506, 6.3895,
+        1.5649, 6.0164, 1.5649], "confidence": 1}, {"text": "Baggins", "boundingBox":
+        [6.45, 1.4556, 6.9506, 1.4556, 6.9506, 1.5931, 6.45, 1.5931], "confidence":
+        1}]}, {"text": "123 Hobbit Lane", "boundingBox": [6.0165, 1.6707, 7.1006,
         1.6707, 7.1006, 1.7854, 6.0165, 1.7854], "words": [{"text": "123", "boundingBox":
         [6.0165, 1.6772, 6.2434, 1.6772, 6.2434, 1.7854, 6.0165, 1.7854], "confidence":
         1}, {"text": "Hobbit", "boundingBox": [6.3033, 1.6707, 6.7463, 1.6707, 6.7463,
         1.7854, 6.3033, 1.7854], "confidence": 1}, {"text": "Lane", "boundingBox":
         [6.803, 1.6782, 7.1006, 1.6782, 7.1006, 1.7854, 6.803, 1.7854], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "567 Main St.", "boundingBox": [0.8852, 1.846, 1.713, 1.846, 1.713, 1.9554,
-        0.8852, 1.9554], "words": [{"text": "567", "boundingBox": [0.8852, 1.8472,
-        1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554], "confidence": 1}, {"text":
-        "Main", "boundingBox": [1.1777, 1.846, 1.5022, 1.846, 1.5022, 1.9554, 1.1777,
-        1.9554], "confidence": 1}, {"text": "St.", "boundingBox": [1.5558, 1.8472,
-        1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Redmond, WA", "boundingBox":
-        [6.0164, 1.891, 6.9793, 1.891, 6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text":
-        "Redmond,", "boundingBox": [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275,
-        6.0164, 2.0275], "confidence": 1}, {"text": "WA", "boundingBox": [6.7408,
-        1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408, 2.0044], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Redmond,
-        WA", "boundingBox": [0.891, 2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975],
-        "words": [{"text": "Redmond,", "boundingBox": [0.891, 2.061, 1.5605, 2.061,
-        1.5605, 2.1975, 0.891, 2.1975], "confidence": 1}, {"text": "WA", "boundingBox":
-        [1.6152, 2.0682, 1.8537, 2.0682, 1.8537, 2.1744, 1.6152, 2.1744], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254,
-        6.0105, 2.2254], "words": [{"text": "555-555-5555", "boundingBox": [6.0105,
-        2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "555-555-5555",
+        1}]}, {"text": "567 Main St.", "boundingBox": [0.8852, 1.846, 1.713, 1.846,
+        1.713, 1.9554, 0.8852, 1.9554], "words": [{"text": "567", "boundingBox": [0.8852,
+        1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554], "confidence": 1},
+        {"text": "Main", "boundingBox": [1.1777, 1.846, 1.5022, 1.846, 1.5022, 1.9554,
+        1.1777, 1.9554], "confidence": 1}, {"text": "St.", "boundingBox": [1.5558,
+        1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554], "confidence": 1}]},
+        {"text": "Redmond, WA", "boundingBox": [6.0164, 1.891, 6.9793, 1.891, 6.9793,
+        2.0275, 6.0164, 2.0275], "words": [{"text": "Redmond,", "boundingBox": [6.0164,
+        1.891, 6.6861, 1.891, 6.6861, 2.0275, 6.0164, 2.0275], "confidence": 1}, {"text":
+        "WA", "boundingBox": [6.7408, 1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408,
+        2.0044], "confidence": 1}]}, {"text": "Redmond, WA", "boundingBox": [0.891,
+        2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,",
+        "boundingBox": [0.891, 2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975],
+        "confidence": 1}, {"text": "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682,
+        1.8537, 2.1744, 1.6152, 2.1744], "confidence": 1}]}, {"text": "555-555-5555",
+        "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254],
+        "words": [{"text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371,
+        2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}]}, {"text": "555-555-5555",
         "boundingBox": [0.8852, 2.2887, 1.8119, 2.2887, 1.8119, 2.3954, 0.8852, 2.3954],
         "words": [{"text": "555-555-5555", "boundingBox": [0.8852, 2.2887, 1.8119,
-        2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Item", "boundingBox":
-        [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
-        "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943,
-        3.109], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996,
-        3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity", "boundingBox":
-        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
+        2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}]}, {"text": "Item",
+        "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109],
+        "words": [{"text": "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018,
+        1.3842, 3.109, 1.0943, 3.109], "confidence": 1}]}, {"text": "Quantity", "boundingBox":
+        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "words":
+        [{"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996, 3.8367,
+        3.1371, 3.2527, 3.1371], "confidence": 1}]}, {"text": "Price", "boundingBox":
+        [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423, 3.109], "words": [{"text":
         "Price", "boundingBox": [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423,
-        3.109], "words": [{"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
-        2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "A", "boundingBox": [1.0832,
-        3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A",
-        "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "10", "boundingBox": [3.2589, 3.2108, 3.4067, 3.2108, 3.4067,
+        3.109], "confidence": 1}]}, {"text": "A", "boundingBox": [1.0832, 3.2118,
+        1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A", "boundingBox":
+        [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "confidence":
+        1}]}, {"text": "10", "boundingBox": [3.2589, 3.2108, 3.4067, 3.2108, 3.4067,
         3.319, 3.2589, 3.319], "words": [{"text": "10", "boundingBox": [3.2589, 3.2108,
-        3.4067, 3.2108, 3.4067, 3.319, 3.2589, 3.319], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "100.99", "boundingBox":
-        [5.4232, 3.2108, 5.8617, 3.2108, 5.8617, 3.319, 5.4232, 3.319], "words": [{"text":
+        3.4067, 3.2108, 3.4067, 3.319, 3.2589, 3.319], "confidence": 1}]}, {"text":
         "100.99", "boundingBox": [5.4232, 3.2108, 5.8617, 3.2108, 5.8617, 3.319, 5.4232,
-        3.319], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637,
-        3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox": [1.0943, 3.4256,
-        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "20", "boundingBox":
-        [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323], "words":
-        [{"text": "20", "boundingBox": [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323,
-        3.2541, 3.5323], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "140.67", "boundingBox": [5.4232, 3.4241, 5.8622,
+        3.319], "words": [{"text": "100.99", "boundingBox": [5.4232, 3.2108, 5.8617,
+        3.2108, 5.8617, 3.319, 5.4232, 3.319], "confidence": 1}]}, {"text": "B", "boundingBox":
+        [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "words": [{"text":
+        "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943,
+        3.531], "confidence": 1}]}, {"text": "20", "boundingBox": [3.2541, 3.4241,
+        3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323], "words": [{"text": "20",
+        "boundingBox": [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323],
+        "confidence": 1}]}, {"text": "140.67", "boundingBox": [5.4232, 3.4241, 5.8622,
         3.4241, 5.8622, 3.5323, 5.4232, 3.5323], "words": [{"text": "140.67", "boundingBox":
         [5.4232, 3.4241, 5.8622, 3.4241, 5.8622, 3.5323, 5.4232, 3.5323], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647, 3.7421, 1.0882,
-        3.7421], "words": [{"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343,
-        1.1647, 3.7421, 1.0882, 3.7421], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "40", "boundingBox": [3.2486,
-        3.6341, 3.4067, 3.6341, 3.4067, 3.7423, 3.2486, 3.7423], "words": [{"text":
+        1}]}, {"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647,
+        3.7421, 1.0882, 3.7421], "words": [{"text": "C", "boundingBox": [1.0882, 3.6343,
+        1.1647, 3.6343, 1.1647, 3.7421, 1.0882, 3.7421], "confidence": 1}]}, {"text":
         "40", "boundingBox": [3.2486, 3.6341, 3.4067, 3.6341, 3.4067, 3.7423, 3.2486,
-        3.7423], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "150.66", "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341, 5.8634,
-        3.7423, 5.4232, 3.7423], "words": [{"text": "150.66", "boundingBox": [5.4232,
-        3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "D",
-        "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951],
-        "words": [{"text": "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753,
-        3.951, 1.0943, 3.951], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "10", "boundingBox": [3.2589, 3.8441,
+        3.7423], "words": [{"text": "40", "boundingBox": [3.2486, 3.6341, 3.4067,
+        3.6341, 3.4067, 3.7423, 3.2486, 3.7423], "confidence": 1}]}, {"text": "150.66",
+        "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423],
+        "words": [{"text": "150.66", "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341,
+        5.8634, 3.7423, 5.4232, 3.7423], "confidence": 1}]}, {"text": "D", "boundingBox":
+        [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text":
+        "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943,
+        3.951], "confidence": 1}]}, {"text": "10", "boundingBox": [3.2589, 3.8441,
         3.4067, 3.8441, 3.4067, 3.9523, 3.2589, 3.9523], "words": [{"text": "10",
         "boundingBox": [3.2589, 3.8441, 3.4067, 3.8441, 3.4067, 3.9523, 3.2589, 3.9523],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "120.00", "boundingBox": [5.4232, 3.8441, 5.8642, 3.8441, 5.8642,
-        3.9523, 5.4232, 3.9523], "words": [{"text": "120.00", "boundingBox": [5.4232,
-        3.8441, 5.8642, 3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "E",
-        "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614],
-        "words": [{"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
-        4.1614, 1.0943, 4.1614], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "40", "boundingBox": [3.2486, 4.0546,
-        3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "words": [{"text": "40",
-        "boundingBox": [3.2486, 4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "100.00", "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546, 5.8644,
-        4.1627, 5.4232, 4.1627], "words": [{"text": "100.00", "boundingBox": [5.4232,
-        4.0546, 5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "F",
-        "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717],
-        "words": [{"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497,
-        4.3717, 1.0943, 4.3717], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "60", "boundingBox": [3.2534, 4.2646,
-        3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727], "words": [{"text": "60",
-        "boundingBox": [3.2534, 4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "120.00", "boundingBox": [5.4232, 4.2646, 5.8642, 4.2646, 5.8642,
-        4.3727, 5.4232, 4.3727], "words": [{"text": "120.00", "boundingBox": [5.4232,
-        4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "G",
-        "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827],
-        "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
-        4.5827, 1.0877, 4.5827], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "80", "boundingBox": [3.2514, 4.4746,
-        3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827], "words": [{"text": "80",
-        "boundingBox": [3.2514, 4.4746, 3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "220.00", "boundingBox": [5.4184, 4.4746, 5.8644, 4.4746, 5.8644,
+        "confidence": 1}]}, {"text": "120.00", "boundingBox": [5.4232, 3.8441, 5.8642,
+        3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "words": [{"text": "120.00", "boundingBox":
+        [5.4232, 3.8441, 5.8642, 3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "confidence":
+        1}]}, {"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
+        4.1614, 1.0943, 4.1614], "words": [{"text": "E", "boundingBox": [1.0943, 4.0561,
+        1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "confidence": 1}]}, {"text":
+        "40", "boundingBox": [3.2486, 4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486,
+        4.1627], "words": [{"text": "40", "boundingBox": [3.2486, 4.0546, 3.4067,
+        4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "confidence": 1}]}, {"text": "100.00",
+        "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627],
+        "words": [{"text": "100.00", "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546,
+        5.8644, 4.1627, 5.4232, 4.1627], "confidence": 1}]}, {"text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "words":
+        [{"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717,
+        1.0943, 4.3717], "confidence": 1}]}, {"text": "60", "boundingBox": [3.2534,
+        4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727], "words": [{"text":
+        "60", "boundingBox": [3.2534, 4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534,
+        4.3727], "confidence": 1}]}, {"text": "120.00", "boundingBox": [5.4232, 4.2646,
+        5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "words": [{"text": "120.00",
+        "boundingBox": [5.4232, 4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727],
+        "confidence": 1}]}, {"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735,
+        4.4746, 1.1735, 4.5827, 1.0877, 4.5827], "words": [{"text": "G", "boundingBox":
+        [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827], "confidence":
+        1}]}, {"text": "80", "boundingBox": [3.2514, 4.4746, 3.4067, 4.4746, 3.4067,
+        4.5827, 3.2514, 4.5827], "words": [{"text": "80", "boundingBox": [3.2514,
+        4.4746, 3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827], "confidence": 1}]},
+        {"text": "220.00", "boundingBox": [5.4184, 4.4746, 5.8644, 4.4746, 5.8644,
         4.5827, 5.4184, 4.5827], "words": [{"text": "220.00", "boundingBox": [5.4184,
-        4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Subtotal:
-        3000.00", "boundingBox": [5.5075, 4.8981, 6.7158, 4.8981, 6.7158, 5.0131,
-        5.5075, 5.0131], "words": [{"text": "Subtotal:", "boundingBox": [5.5075, 4.8981,
-        6.1249, 4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence": 1}, {"text":
-        "3000.00", "boundingBox": [6.1794, 4.9042, 6.7158, 4.9042, 6.7158, 5.0131,
-        6.1794, 5.0131], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "Tax: 300.00", "boundingBox": [5.5034, 5.1245,
-        6.2887, 5.1245, 6.2887, 5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:",
-        "boundingBox": [5.5034, 5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333],
-        "confidence": 1}, {"text": "300.00", "boundingBox": [5.836, 5.1245, 6.2887,
-        5.1245, 6.2887, 5.2333, 5.836, 5.2333], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Tip: 1000.00", "boundingBox":
-        [5.5034, 5.3412, 6.3422, 5.3412, 6.3422, 5.481, 5.5034, 5.481], "words": [{"text":
-        "Tip:", "boundingBox": [5.5034, 5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034,
-        5.481], "confidence": 1}, {"text": "1000.00", "boundingBox": [5.811, 5.3445,
-        6.3422, 5.3445, 6.3422, 5.4533, 5.811, 5.4533], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Total: 4300.00",
-        "boundingBox": [5.5034, 5.5583, 6.4825, 5.5583, 6.4825, 5.6733, 5.5034, 5.6733],
-        "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583,
-        5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "4300.00", "boundingBox":
+        4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "confidence": 1}]},
+        {"text": "Subtotal: 3000.00", "boundingBox": [5.5075, 4.8981, 6.7158, 4.8981,
+        6.7158, 5.0131, 5.5075, 5.0131], "words": [{"text": "Subtotal:", "boundingBox":
+        [5.5075, 4.8981, 6.1249, 4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence":
+        1}, {"text": "3000.00", "boundingBox": [6.1794, 4.9042, 6.7158, 4.9042, 6.7158,
+        5.0131, 6.1794, 5.0131], "confidence": 1}]}, {"text": "Tax: 300.00", "boundingBox":
+        [5.5034, 5.1245, 6.2887, 5.1245, 6.2887, 5.2333, 5.5034, 5.2333], "words":
+        [{"text": "Tax:", "boundingBox": [5.5034, 5.1263, 5.7812, 5.1263, 5.7812,
+        5.2333, 5.5034, 5.2333], "confidence": 1}, {"text": "300.00", "boundingBox":
+        [5.836, 5.1245, 6.2887, 5.1245, 6.2887, 5.2333, 5.836, 5.2333], "confidence":
+        1}]}, {"text": "Tip: 1000.00", "boundingBox": [5.5034, 5.3412, 6.3422, 5.3412,
+        6.3422, 5.481, 5.5034, 5.481], "words": [{"text": "Tip:", "boundingBox": [5.5034,
+        5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034, 5.481], "confidence": 1}, {"text":
+        "1000.00", "boundingBox": [5.811, 5.3445, 6.3422, 5.3445, 6.3422, 5.4533,
+        5.811, 5.4533], "confidence": 1}]}, {"text": "Total: 4300.00", "boundingBox":
+        [5.5034, 5.5583, 6.4825, 5.5583, 6.4825, 5.6733, 5.5034, 5.6733], "words":
+        [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583, 5.8915,
+        5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "4300.00", "boundingBox":
         [5.942, 5.5645, 6.4825, 5.5645, 6.4825, 5.6733, 5.942, 5.6733], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Signature: ____Frodo Baggins__________", "boundingBox": [1.0055, 6.6556,
-        3.8842, 6.6556, 3.8842, 6.7981, 1.0055, 6.7981], "words": [{"text": "Signature:",
-        "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981, 1.0055, 6.7981],
-        "confidence": 1}, {"text": "____Frodo", "boundingBox": [1.747, 6.6556, 2.4778,
-        6.6556, 2.4778, 6.7981, 1.747, 6.7981], "confidence": 1}, {"text": "Baggins__________",
-        "boundingBox": [2.5325, 6.6581, 3.8842, 6.6581, 3.8842, 6.7981, 2.5325, 6.7981],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}]}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
+        1}]}, {"text": "Signature: ____ Frodo Baggins__________", "boundingBox": [1.0055,
+        6.6556, 3.8842, 6.6556, 3.8842, 6.7981, 1.0055, 6.7981], "words": [{"text":
+        "Signature:", "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981,
+        1.0055, 6.7981], "confidence": 1}, {"text": "____", "boundingBox": [1.747,
+        6.7829, 2.0809, 6.7829, 2.0809, 6.7981, 1.747, 6.7981], "confidence": 1},
+        {"text": "Frodo", "boundingBox": [2.0925, 6.6556, 2.4778, 6.6556, 2.4778,
+        6.7703, 2.0925, 6.7703], "confidence": 1}, {"text": "Baggins__________", "boundingBox":
+        [2.5325, 6.6581, 3.8842, 6.6581, 3.8842, 6.7981, 2.5325, 6.7981], "confidence":
+        1}]}]}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
         [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString": "Itemized",
-        "confidence": 0.991}, "MerchantName": {"type": "string", "valueString": "Bilbo
+        "confidence": 0.99}, "MerchantName": {"type": "string", "valueString": "Bilbo
         Baggins", "text": "Bilbo Baggins", "boundingBox": [6.0164, 1.4503, 6.8967,
-        1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "page": 1, "confidence": 0.669, "elements":
+        1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "page": 1, "confidence": 0.987, "elements":
         ["#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1"]}, "MerchantAddress":
         {"type": "string", "valueString": "123 Hobbit Lane 567 Main St. Redmond, WA
         Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA",
         "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975, 0.8852, 2.1975],
-        "page": 1, "confidence": 0.345, "elements": ["#/readResults/0/lines/4/words/0",
+        "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/4/words/0",
         "#/readResults/0/lines/4/words/1", "#/readResults/0/lines/4/words/2", "#/readResults/0/lines/5/words/0",
         "#/readResults/0/lines/5/words/1", "#/readResults/0/lines/5/words/2", "#/readResults/0/lines/6/words/0",
         "#/readResults/0/lines/6/words/1", "#/readResults/0/lines/7/words/0", "#/readResults/0/lines/7/words/1"]},
         "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber": "+15555555555",
         "text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371,
-        2.2254, 6.0105, 2.2254], "page": 1, "confidence": 0.932, "elements": ["#/readResults/0/lines/8/words/0"]},
+        2.2254, 6.0105, 2.2254], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/8/words/0"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "F", "text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "page":
+        1, "confidence": 0.964, "elements": ["#/readResults/0/lines/28/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 12, "text": "12.00", "boundingBox":
+        [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "page":
+        1, "confidence": 0.947, "elements": ["#/readResults/0/lines/30/words/0"]}}},
+        {"type": "object", "valueObject": {"TotalPrice": {"type": "number", "valueNumber":
+        22, "text": "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781,
+        4.5827, 5.4184, 4.5827], "page": 1, "confidence": 0.935, "elements": ["#/readResults/0/lines/33/words/0"]}}}]},
         "Subtotal": {"type": "number", "valueNumber": 300, "text": "300.00", "boundingBox":
         [6.1794, 4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131], "page": 1,
-        "confidence": 0.96, "elements": ["#/readResults/0/lines/34/words/1"]}}}, {"docType":
-        "prebuilt:receipt", "pageRange": [2, 2], "fields": {}}, {"docType": "prebuilt:receipt",
-        "pageRange": [3, 3], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Frodo Baggins", "text": "Frodo Baggins", "boundingBox": [6.0164, 1.4506,
-        6.9506, 1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "page": 3, "confidence":
-        0.529, "elements": ["#/readResults/2/lines/3/words/0", "#/readResults/2/lines/3/words/1"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Hobbit Lane 567
-        Main St. Redmond, WA Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond,
-        WA Redmond, WA", "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975,
-        0.8852, 2.1975], "page": 3, "confidence": 0.523, "elements": ["#/readResults/2/lines/4/words/0",
+        "confidence": 0.99, "elements": ["#/readResults/0/lines/34/words/1"]}, "Total":
+        {"type": "number", "valueNumber": 430, "text": "430.00", "boundingBox": [5.942,
+        5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942, 5.6733], "page": 1, "confidence":
+        0.985, "elements": ["#/readResults/0/lines/37/words/1"]}}}, {"docType": "prebuilt:receipt",
+        "pageRange": [2, 2], "fields": {}}, {"docType": "prebuilt:receipt", "pageRange":
+        [3, 3], "fields": {"ReceiptType": {"type": "string", "valueString": "Itemized",
+        "confidence": 0.99}, "MerchantName": {"type": "string", "valueString": "Frodo
+        Baggins", "text": "Frodo Baggins", "boundingBox": [6.0164, 1.4506, 6.9506,
+        1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "page": 3, "confidence": 0.984, "elements":
+        ["#/readResults/2/lines/3/words/0", "#/readResults/2/lines/3/words/1"]}, "MerchantAddress":
+        {"type": "string", "valueString": "123 Hobbit Lane 567 Main St. Redmond, WA
+        Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA",
+        "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975, 0.8852, 2.1975],
+        "page": 3, "confidence": 0.99, "elements": ["#/readResults/2/lines/4/words/0",
         "#/readResults/2/lines/4/words/1", "#/readResults/2/lines/4/words/2", "#/readResults/2/lines/5/words/0",
         "#/readResults/2/lines/5/words/1", "#/readResults/2/lines/5/words/2", "#/readResults/2/lines/6/words/0",
         "#/readResults/2/lines/6/words/1", "#/readResults/2/lines/7/words/0", "#/readResults/2/lines/7/words/1"]},
         "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber": "+15555555555",
         "text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371,
-        2.2254, 6.0105, 2.2254], "page": 3, "confidence": 0.926, "elements": ["#/readResults/2/lines/8/words/0"]},
-        "Subtotal": {"type": "number", "valueNumber": 150.66, "text": "150.66", "boundingBox":
-        [5.4232, 3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423], "page":
-        3, "confidence": 0.664, "elements": ["#/readResults/2/lines/21/words/0"]}}}]}}'
+        2.2254, 6.0105, 2.2254], "page": 3, "confidence": 0.99, "elements": ["#/readResults/2/lines/8/words/0"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "E", "text": "E", "boundingBox":
+        [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "page": 3,
+        "confidence": 0.935, "elements": ["#/readResults/2/lines/25/words/0"]}, "Quantity":
+        {"type": "number", "valueNumber": 40, "text": "40", "boundingBox": [3.2486,
+        4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "page": 3, "confidence":
+        0, "elements": ["#/readResults/2/lines/26/words/0"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 100, "text": "100.00", "boundingBox": [5.4232, 4.0546,
+        5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627], "page": 3, "confidence":
+        0.723, "elements": ["#/readResults/2/lines/27/words/0"]}}}, {"type": "object",
+        "valueObject": {"Name": {"type": "string", "valueString": "F", "text": "F",
+        "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717],
+        "page": 3, "confidence": 0.905, "elements": ["#/readResults/2/lines/28/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 120, "text": "120.00", "boundingBox":
+        [5.4232, 4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "page":
+        3, "confidence": 0.967, "elements": ["#/readResults/2/lines/30/words/0"]}}},
+        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
+        "G", "text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
+        4.5827, 1.0877, 4.5827], "page": 3, "confidence": 0.896, "elements": ["#/readResults/2/lines/31/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 220, "text": "220.00", "boundingBox":
+        [5.4184, 4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "page":
+        3, "confidence": 0.958, "elements": ["#/readResults/2/lines/33/words/0"]}}}]},
+        "Subtotal": {"type": "number", "valueNumber": 3000, "text": "3000.00", "boundingBox":
+        [6.1794, 4.9042, 6.7158, 4.9042, 6.7158, 5.0131, 6.1794, 5.0131], "page":
+        3, "confidence": 0.99, "elements": ["#/readResults/2/lines/34/words/1"]},
+        "Total": {"type": "number", "valueNumber": 1000, "text": "1000.00", "boundingBox":
+        [5.811, 5.3445, 6.3422, 5.3445, 6.3422, 5.4533, 5.811, 5.4533], "page": 3,
+        "confidence": 0.985, "elements": ["#/readResults/2/lines/36/words/1"]}}}]}}'
     headers:
-      apim-request-id: 17590dcb-8a73-497e-a1f7-cbfc417697d8
-      content-length: '26841'
+      apim-request-id: 2cb920c1-8969-4f7b-8050-cb8829da843b
+      content-length: '25475'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:08:47 GMT
+      date: Mon, 16 Nov 2020 19:14:12 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '27'
+      x-envoy-upstream-service-time: '20'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/14f7679b-b288-46e1-b8af-4f43a57223b4
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/4f36a414-19f4-42fc-b2d3-f481c8733e55
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_multipage_url.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_multipage_url.yaml
@@ -16,13 +16,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 26bb545d-dc6f-4b77-aad5-09770a86457e
+      apim-request-id: 8db67d3b-f762-4a83-9b6b-a6055fc8f908
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:08:47 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/26bb545d-dc6f-4b77-aad5-09770a86457e
+      date: Mon, 16 Nov 2020 19:14:14 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/8db67d3b-f762-4a83-9b6b-a6055fc8f908
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '90'
+      x-envoy-upstream-service-time: '91'
     status:
       code: 202
       message: Accepted
@@ -33,11 +33,11 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/26bb545d-dc6f-4b77-aad5-09770a86457e
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/8db67d3b-f762-4a83-9b6b-a6055fc8f908
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:08:47Z",
-        "lastUpdatedDateTime": "2020-11-11T18:08:49Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:14:14Z",
+        "lastUpdatedDateTime": "2020-11-16T19:14:18Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": 0, "width": 8.5, "height": 11,
         "unit": "inch", "lines": [{"text": "Company A Invoice", "boundingBox": [0.8861,
         1.1217, 2.3783, 1.1217, 2.3783, 1.2812, 0.8861, 1.2812], "words": [{"text":
@@ -45,386 +45,366 @@ interactions:
         0.8861, 1.2812], "confidence": 1}, {"text": "A", "boundingBox": [1.6696, 1.1242,
         1.7749, 1.1242, 1.7749, 1.2473, 1.6696, 1.2473], "confidence": 1}, {"text":
         "Invoice", "boundingBox": [1.8389, 1.1217, 2.3783, 1.1217, 2.3783, 1.2485,
-        1.8389, 1.2485], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "Invoice For:", "boundingBox": [6.0211, 1.0656,
-        7.0357, 1.0656, 7.0357, 1.2121, 6.0211, 1.2121], "words": [{"text": "Invoice",
-        "boundingBox": [6.0211, 1.0656, 6.6362, 1.0656, 6.6362, 1.2121, 6.0211, 1.2121],
-        "confidence": 1}, {"text": "For:", "boundingBox": [6.7147, 1.0691, 7.0357,
-        1.0691, 7.0357, 1.2121, 6.7147, 1.2121], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Address:", "boundingBox":
-        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "words":
-        [{"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825, 1.5657,
-        1.6155, 0.8791, 1.6155], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Bilbo Baggins", "boundingBox": [6.0164,
-        1.4503, 6.8967, 1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "words": [{"text":
-        "Bilbo", "boundingBox": [6.0164, 1.4503, 6.3392, 1.4503, 6.3392, 1.5649, 6.0164,
-        1.5649], "confidence": 1}, {"text": "Baggins", "boundingBox": [6.396, 1.4556,
-        6.8967, 1.4556, 6.8967, 1.5931, 6.396, 1.5931], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "123 Hobbit Lane",
-        "boundingBox": [6.0165, 1.6707, 7.1006, 1.6707, 7.1006, 1.7854, 6.0165, 1.7854],
-        "words": [{"text": "123", "boundingBox": [6.0165, 1.6772, 6.2434, 1.6772,
-        6.2434, 1.7854, 6.0165, 1.7854], "confidence": 1}, {"text": "Hobbit", "boundingBox":
-        [6.3033, 1.6707, 6.7463, 1.6707, 6.7463, 1.7854, 6.3033, 1.7854], "confidence":
-        1}, {"text": "Lane", "boundingBox": [6.803, 1.6782, 7.1006, 1.6782, 7.1006,
-        1.7854, 6.803, 1.7854], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "567 Main St.", "boundingBox": [0.8852,
-        1.846, 1.713, 1.846, 1.713, 1.9554, 0.8852, 1.9554], "words": [{"text": "567",
-        "boundingBox": [0.8852, 1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554],
-        "confidence": 1}, {"text": "Main", "boundingBox": [1.1777, 1.846, 1.5022,
-        1.846, 1.5022, 1.9554, 1.1777, 1.9554], "confidence": 1}, {"text": "St.",
-        "boundingBox": [1.5558, 1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Redmond, WA", "boundingBox": [6.0164, 1.891, 6.9793, 1.891,
-        6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text": "Redmond,", "boundingBox":
-        [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275, 6.0164, 2.0275], "confidence":
-        1}, {"text": "WA", "boundingBox": [6.7408, 1.8982, 6.9793, 1.8982, 6.9793,
-        2.0044, 6.7408, 2.0044], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Redmond, WA", "boundingBox": [0.891,
-        2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,",
-        "boundingBox": [0.891, 2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975],
-        "confidence": 1}, {"text": "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682,
-        1.8537, 2.1744, 1.6152, 2.1744], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "555-555-5555", "boundingBox":
-        [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "words":
-        [{"text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187,
-        6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "555-555-5555", "boundingBox":
+        1.8389, 1.2485], "confidence": 1}]}, {"text": "Invoice For:", "boundingBox":
+        [6.0211, 1.0656, 7.0357, 1.0656, 7.0357, 1.2121, 6.0211, 1.2121], "words":
+        [{"text": "Invoice", "boundingBox": [6.0211, 1.0656, 6.6362, 1.0656, 6.6362,
+        1.2121, 6.0211, 1.2121], "confidence": 1}, {"text": "For:", "boundingBox":
+        [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121, 6.7147, 1.2121], "confidence":
+        1}]}, {"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825,
+        1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text": "Address:", "boundingBox":
+        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "confidence":
+        1}]}, {"text": "Bilbo Baggins", "boundingBox": [6.0164, 1.4503, 6.8967, 1.4503,
+        6.8967, 1.5931, 6.0164, 1.5931], "words": [{"text": "Bilbo", "boundingBox":
+        [6.0164, 1.4503, 6.3392, 1.4503, 6.3392, 1.5649, 6.0164, 1.5649], "confidence":
+        1}, {"text": "Baggins", "boundingBox": [6.396, 1.4556, 6.8967, 1.4556, 6.8967,
+        1.5931, 6.396, 1.5931], "confidence": 1}]}, {"text": "123 Hobbit Lane", "boundingBox":
+        [6.0165, 1.6707, 7.1006, 1.6707, 7.1006, 1.7854, 6.0165, 1.7854], "words":
+        [{"text": "123", "boundingBox": [6.0165, 1.6772, 6.2434, 1.6772, 6.2434, 1.7854,
+        6.0165, 1.7854], "confidence": 1}, {"text": "Hobbit", "boundingBox": [6.3033,
+        1.6707, 6.7463, 1.6707, 6.7463, 1.7854, 6.3033, 1.7854], "confidence": 1},
+        {"text": "Lane", "boundingBox": [6.803, 1.6782, 7.1006, 1.6782, 7.1006, 1.7854,
+        6.803, 1.7854], "confidence": 1}]}, {"text": "567 Main St.", "boundingBox":
+        [0.8852, 1.846, 1.713, 1.846, 1.713, 1.9554, 0.8852, 1.9554], "words": [{"text":
+        "567", "boundingBox": [0.8852, 1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852,
+        1.9554], "confidence": 1}, {"text": "Main", "boundingBox": [1.1777, 1.846,
+        1.5022, 1.846, 1.5022, 1.9554, 1.1777, 1.9554], "confidence": 1}, {"text":
+        "St.", "boundingBox": [1.5558, 1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558,
+        1.9554], "confidence": 1}]}, {"text": "Redmond, WA", "boundingBox": [6.0164,
+        1.891, 6.9793, 1.891, 6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text":
+        "Redmond,", "boundingBox": [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275,
+        6.0164, 2.0275], "confidence": 1}, {"text": "WA", "boundingBox": [6.7408,
+        1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408, 2.0044], "confidence": 1}]},
+        {"text": "Redmond, WA", "boundingBox": [0.891, 2.061, 1.8537, 2.061, 1.8537,
+        2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,", "boundingBox": [0.891,
+        2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975], "confidence": 1}, {"text":
+        "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682, 1.8537, 2.1744, 1.6152,
+        2.1744], "confidence": 1}]}, {"text": "555-555-5555", "boundingBox": [6.0105,
+        2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "words": [{"text":
+        "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254,
+        6.0105, 2.2254], "confidence": 1}]}, {"text": "555-555-5555", "boundingBox":
         [0.8852, 2.2887, 1.8119, 2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "words":
         [{"text": "555-555-5555", "boundingBox": [0.8852, 2.2887, 1.8119, 2.2887,
-        1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Item", "boundingBox": [1.0943,
-        3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
+        1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}]}, {"text": "Item", "boundingBox":
+        [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
         "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943,
-        3.109], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996,
-        3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity", "boundingBox":
-        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Price", "boundingBox": [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423,
-        3.109], "words": [{"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
-        2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "A", "boundingBox": [1.0832,
-        3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A",
-        "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116, 3.3202,
-        3.3176, 3.2589, 3.3176], "words": [{"text": "1", "boundingBox": [3.2589, 3.2116,
-        3.3202, 3.2116, 3.3202, 3.3176, 3.2589, 3.3176], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "10.99", "boundingBox":
+        3.109], "confidence": 1}]}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996,
+        3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity",
+        "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371],
+        "confidence": 1}]}, {"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
+        2.9996, 5.7372, 3.109, 5.423, 3.109], "words": [{"text": "Price", "boundingBox":
+        [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence":
+        1}]}, {"text": "A", "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174,
+        3.318, 1.0832, 3.318], "words": [{"text": "A", "boundingBox": [1.0832, 3.2118,
+        1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "confidence": 1}]}, {"text":
+        "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116, 3.3202, 3.3176, 3.2589,
+        3.3176], "words": [{"text": "1", "boundingBox": [3.2589, 3.2116, 3.3202, 3.2116,
+        3.3202, 3.3176, 3.2589, 3.3176], "confidence": 1}]}, {"text": "10.99", "boundingBox":
         [5.4232, 3.2108, 5.7784, 3.2108, 5.7784, 3.319, 5.4232, 3.319], "words": [{"text":
         "10.99", "boundingBox": [5.4232, 3.2108, 5.7784, 3.2108, 5.7784, 3.319, 5.4232,
-        3.319], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637,
-        3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox": [1.0943, 3.4256,
-        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "2", "boundingBox":
-        [3.2541, 3.4241, 3.3199, 3.4241, 3.3199, 3.531, 3.2541, 3.531], "words": [{"text":
-        "2", "boundingBox": [3.2541, 3.4241, 3.3199, 3.4241, 3.3199, 3.531, 3.2541,
-        3.531], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "14.67", "boundingBox": [5.4232, 3.4241, 5.7789, 3.4241, 5.7789,
-        3.5323, 5.4232, 3.5323], "words": [{"text": "14.67", "boundingBox": [5.4232,
-        3.4241, 5.7789, 3.4241, 5.7789, 3.5323, 5.4232, 3.5323], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "C",
+        3.319], "confidence": 1}]}, {"text": "B", "boundingBox": [1.0943, 3.4256,
+        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox":
+        [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence":
+        1}]}, {"text": "2", "boundingBox": [3.2541, 3.4241, 3.3199, 3.4241, 3.3199,
+        3.531, 3.2541, 3.531], "words": [{"text": "2", "boundingBox": [3.2541, 3.4241,
+        3.3199, 3.4241, 3.3199, 3.531, 3.2541, 3.531], "confidence": 1}]}, {"text":
+        "14.67", "boundingBox": [5.4232, 3.4241, 5.7789, 3.4241, 5.7789, 3.5323, 5.4232,
+        3.5323], "words": [{"text": "14.67", "boundingBox": [5.4232, 3.4241, 5.7789,
+        3.4241, 5.7789, 3.5323, 5.4232, 3.5323], "confidence": 1}]}, {"text": "C",
         "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647, 3.7421, 1.0882, 3.7421],
         "words": [{"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647,
-        3.7421, 1.0882, 3.7421], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "4", "boundingBox": [3.2486, 3.6351,
-        3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "words": [{"text": "4", "boundingBox":
-        [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "15.66", "boundingBox": [5.4232, 3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232,
-        3.7423], "words": [{"text": "15.66", "boundingBox": [5.4232, 3.6341, 5.78,
-        3.6341, 5.78, 3.7423, 5.4232, 3.7423], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "D", "boundingBox": [1.0943,
-        3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text":
-        "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943,
-        3.951], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1", "boundingBox": [3.2589, 3.845, 3.3202, 3.845, 3.3202,
+        3.7421, 1.0882, 3.7421], "confidence": 1}]}, {"text": "4", "boundingBox":
+        [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413, 3.2486, 3.7413], "words":
+        [{"text": "4", "boundingBox": [3.2486, 3.6351, 3.3244, 3.6351, 3.3244, 3.7413,
+        3.2486, 3.7413], "confidence": 1}]}, {"text": "15.66", "boundingBox": [5.4232,
+        3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232, 3.7423], "words": [{"text": "15.66",
+        "boundingBox": [5.4232, 3.6341, 5.78, 3.6341, 5.78, 3.7423, 5.4232, 3.7423],
+        "confidence": 1}]}, {"text": "D", "boundingBox": [1.0943, 3.8456, 1.1753,
+        3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text": "D", "boundingBox":
+        [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "confidence":
+        1}]}, {"text": "1", "boundingBox": [3.2589, 3.845, 3.3202, 3.845, 3.3202,
         3.951, 3.2589, 3.951], "words": [{"text": "1", "boundingBox": [3.2589, 3.845,
-        3.3202, 3.845, 3.3202, 3.951, 3.2589, 3.951], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "12.00", "boundingBox":
-        [5.4232, 3.8441, 5.7809, 3.8441, 5.7809, 3.9523, 5.4232, 3.9523], "words":
-        [{"text": "12.00", "boundingBox": [5.4232, 3.8441, 5.7809, 3.8441, 5.7809,
-        3.9523, 5.4232, 3.9523], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "E", "boundingBox": [1.0943, 4.0561,
-        1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "words": [{"text": "E", "boundingBox":
-        [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617, 3.2486,
-        4.1617], "words": [{"text": "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556,
-        3.3244, 4.1617, 3.2486, 4.1617], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "10.00", "boundingBox": [5.4232,
+        3.3202, 3.845, 3.3202, 3.951, 3.2589, 3.951], "confidence": 1}]}, {"text":
+        "12.00", "boundingBox": [5.4232, 3.8441, 5.7809, 3.8441, 5.7809, 3.9523, 5.4232,
+        3.9523], "words": [{"text": "12.00", "boundingBox": [5.4232, 3.8441, 5.7809,
+        3.8441, 5.7809, 3.9523, 5.4232, 3.9523], "confidence": 1}]}, {"text": "E",
+        "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614],
+        "words": [{"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
+        4.1614, 1.0943, 4.1614], "confidence": 1}]}, {"text": "4", "boundingBox":
+        [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617, 3.2486, 4.1617], "words":
+        [{"text": "4", "boundingBox": [3.2486, 4.0556, 3.3244, 4.0556, 3.3244, 4.1617,
+        3.2486, 4.1617], "confidence": 1}]}, {"text": "10.00", "boundingBox": [5.4232,
         4.0546, 5.781, 4.0546, 5.781, 4.1627, 5.4232, 4.1627], "words": [{"text":
         "10.00", "boundingBox": [5.4232, 4.0546, 5.781, 4.0546, 5.781, 4.1627, 5.4232,
-        4.1627], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497,
-        4.3717, 1.0943, 4.3717], "words": [{"text": "F", "boundingBox": [1.0943, 4.2661,
-        1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "6", "boundingBox":
-        [3.2534, 4.2646, 3.3226, 4.2646, 3.3226, 4.3727, 3.2534, 4.3727], "words":
-        [{"text": "6", "boundingBox": [3.2534, 4.2646, 3.3226, 4.2646, 3.3226, 4.3727,
-        3.2534, 4.3727], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "12.00", "boundingBox": [5.4232, 4.2646, 5.7809,
-        4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "words": [{"text": "12.00", "boundingBox":
-        [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877,
-        4.5827], "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746,
-        1.1735, 4.5827, 1.0877, 4.5827], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "8", "boundingBox": [3.2514,
-        4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514, 4.5827], "words": [{"text":
-        "8", "boundingBox": [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514,
-        4.5827], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781,
-        4.5827, 5.4184, 4.5827], "words": [{"text": "22.00", "boundingBox": [5.4184,
-        4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184, 4.5827], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Subtotal:
-        300.00", "boundingBox": [5.5075, 4.8981, 6.632, 4.8981, 6.632, 5.0131, 5.5075,
-        5.0131], "words": [{"text": "Subtotal:", "boundingBox": [5.5075, 4.8981, 6.1249,
-        4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence": 1}, {"text": "300.00",
-        "boundingBox": [6.1794, 4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Tax: 30.00", "boundingBox": [5.5034, 5.1245, 6.2022, 5.1245,
-        6.2022, 5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:", "boundingBox":
-        [5.5034, 5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333], "confidence":
-        1}, {"text": "30.00", "boundingBox": [5.836, 5.1245, 6.2022, 5.1245, 6.2022,
-        5.2333, 5.836, 5.2333], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Tip: 100.00", "boundingBox": [5.5034,
-        5.3412, 6.2587, 5.3412, 6.2587, 5.481, 5.5034, 5.481], "words": [{"text":
+        4.1627], "confidence": 1}]}, {"text": "F", "boundingBox": [1.0943, 4.2661,
+        1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "words": [{"text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "confidence":
+        1}]}, {"text": "6", "boundingBox": [3.2534, 4.2646, 3.3226, 4.2646, 3.3226,
+        4.3727, 3.2534, 4.3727], "words": [{"text": "6", "boundingBox": [3.2534, 4.2646,
+        3.3226, 4.2646, 3.3226, 4.3727, 3.2534, 4.3727], "confidence": 1}]}, {"text":
+        "12.00", "boundingBox": [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232,
+        4.3727], "words": [{"text": "12.00", "boundingBox": [5.4232, 4.2646, 5.7809,
+        4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "confidence": 1}]}, {"text": "G",
+        "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827],
+        "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
+        4.5827, 1.0877, 4.5827], "confidence": 1}]}, {"text": "8", "boundingBox":
+        [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827, 3.2514, 4.5827], "words":
+        [{"text": "8", "boundingBox": [3.2514, 4.4746, 3.3224, 4.4746, 3.3224, 4.5827,
+        3.2514, 4.5827], "confidence": 1}]}, {"text": "22.00", "boundingBox": [5.4184,
+        4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184, 4.5827], "words": [{"text":
+        "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781, 4.5827, 5.4184,
+        4.5827], "confidence": 1}]}, {"text": "Subtotal: 300.00", "boundingBox": [5.5075,
+        4.8981, 6.632, 4.8981, 6.632, 5.0131, 5.5075, 5.0131], "words": [{"text":
+        "Subtotal:", "boundingBox": [5.5075, 4.8981, 6.1249, 4.8981, 6.1249, 5.0131,
+        5.5075, 5.0131], "confidence": 1}, {"text": "300.00", "boundingBox": [6.1794,
+        4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131], "confidence": 1}]},
+        {"text": "Tax: 30.00", "boundingBox": [5.5034, 5.1245, 6.2022, 5.1245, 6.2022,
+        5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:", "boundingBox": [5.5034,
+        5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333], "confidence": 1},
+        {"text": "30.00", "boundingBox": [5.836, 5.1245, 6.2022, 5.1245, 6.2022, 5.2333,
+        5.836, 5.2333], "confidence": 1}]}, {"text": "Tip: 100.00", "boundingBox":
+        [5.5034, 5.3412, 6.2587, 5.3412, 6.2587, 5.481, 5.5034, 5.481], "words": [{"text":
         "Tip:", "boundingBox": [5.5034, 5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034,
         5.481], "confidence": 1}, {"text": "100.00", "boundingBox": [5.811, 5.3445,
-        6.2587, 5.3445, 6.2587, 5.4533, 5.811, 5.4533], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Total: 430.00",
-        "boundingBox": [5.5034, 5.5583, 6.3987, 5.5583, 6.3987, 5.6733, 5.5034, 5.6733],
-        "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583,
-        5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "430.00", "boundingBox":
-        [5.942, 5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942, 5.6733], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Signature: ____Bilbo Baggins__________", "boundingBox": [1.0055, 6.6553,
-        3.8342, 6.6553, 3.8342, 6.7981, 1.0055, 6.7981], "words": [{"text": "Signature:",
-        "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981, 1.0055, 6.7981],
-        "confidence": 1}, {"text": "____Bilbo", "boundingBox": [1.747, 6.6553, 2.4278,
-        6.6553, 2.4278, 6.7981, 1.747, 6.7981], "confidence": 1}, {"text": "Baggins__________",
-        "boundingBox": [2.4823, 6.6581, 3.8342, 6.6581, 3.8342, 6.7981, 2.4823, 6.7981],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}]}, {"page": 2, "angle": 0, "width": 8.5, "height": 11, "unit": "inch"},
+        6.2587, 5.3445, 6.2587, 5.4533, 5.811, 5.4533], "confidence": 1}]}, {"text":
+        "Total: 430.00", "boundingBox": [5.5034, 5.5583, 6.3987, 5.5583, 6.3987, 5.6733,
+        5.5034, 5.6733], "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583,
+        5.8915, 5.5583, 5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text":
+        "430.00", "boundingBox": [5.942, 5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942,
+        5.6733], "confidence": 1}]}, {"text": "Signature: ____ Bilbo Baggins__________",
+        "boundingBox": [1.0055, 6.6553, 3.8342, 6.6553, 3.8342, 6.7981, 1.0055, 6.7981],
+        "words": [{"text": "Signature:", "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581,
+        1.6987, 6.7981, 1.0055, 6.7981], "confidence": 1}, {"text": "____", "boundingBox":
+        [1.747, 6.7829, 2.0809, 6.7829, 2.0809, 6.7981, 1.747, 6.7981], "confidence":
+        1}, {"text": "Bilbo", "boundingBox": [2.0925, 6.6553, 2.4278, 6.6553, 2.4278,
+        6.7703, 2.0925, 6.7703], "confidence": 1}, {"text": "Baggins__________", "boundingBox":
+        [2.4823, 6.6581, 3.8342, 6.6581, 3.8342, 6.7981, 2.4823, 6.7981], "confidence":
+        1}]}]}, {"page": 2, "angle": 0, "width": 8.5, "height": 11, "unit": "inch"},
         {"page": 3, "angle": 0, "width": 8.5, "height": 11, "unit": "inch", "lines":
         [{"text": "Company B Invoice", "boundingBox": [0.8861, 1.1217, 2.3734, 1.1217,
         2.3734, 1.2812, 0.8861, 1.2812], "words": [{"text": "Company", "boundingBox":
         [0.8861, 1.1232, 1.6203, 1.1232, 1.6203, 1.2812, 0.8861, 1.2812], "confidence":
         1}, {"text": "B", "boundingBox": [1.6836, 1.1248, 1.764, 1.1248, 1.764, 1.2469,
         1.6836, 1.2469], "confidence": 1}, {"text": "Invoice", "boundingBox": [1.8336,
-        1.1217, 2.3734, 1.1217, 2.3734, 1.2485, 1.8336, 1.2485], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Invoice
-        For:", "boundingBox": [6.0211, 1.0656, 7.0357, 1.0656, 7.0357, 1.2121, 6.0211,
-        1.2121], "words": [{"text": "Invoice", "boundingBox": [6.0211, 1.0656, 6.6362,
-        1.0656, 6.6362, 1.2121, 6.0211, 1.2121], "confidence": 1}, {"text": "For:",
-        "boundingBox": [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121, 6.7147, 1.2121],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825,
-        1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text": "Address:", "boundingBox":
-        [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Frodo Baggins", "boundingBox": [6.0164, 1.4506, 6.9506, 1.4506, 6.9506, 1.5931,
-        6.0164, 1.5931], "words": [{"text": "Frodo", "boundingBox": [6.0164, 1.4506,
-        6.3895, 1.4506, 6.3895, 1.5649, 6.0164, 1.5649], "confidence": 1}, {"text":
-        "Baggins", "boundingBox": [6.45, 1.4556, 6.9506, 1.4556, 6.9506, 1.5931, 6.45,
-        1.5931], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "123 Hobbit Lane", "boundingBox": [6.0165, 1.6707, 7.1006,
+        1.1217, 2.3734, 1.1217, 2.3734, 1.2485, 1.8336, 1.2485], "confidence": 1}]},
+        {"text": "Invoice For:", "boundingBox": [6.0211, 1.0656, 7.0357, 1.0656, 7.0357,
+        1.2121, 6.0211, 1.2121], "words": [{"text": "Invoice", "boundingBox": [6.0211,
+        1.0656, 6.6362, 1.0656, 6.6362, 1.2121, 6.0211, 1.2121], "confidence": 1},
+        {"text": "For:", "boundingBox": [6.7147, 1.0691, 7.0357, 1.0691, 7.0357, 1.2121,
+        6.7147, 1.2121], "confidence": 1}]}, {"text": "Address:", "boundingBox": [0.8791,
+        1.4825, 1.5657, 1.4825, 1.5657, 1.6155, 0.8791, 1.6155], "words": [{"text":
+        "Address:", "boundingBox": [0.8791, 1.4825, 1.5657, 1.4825, 1.5657, 1.6155,
+        0.8791, 1.6155], "confidence": 1}]}, {"text": "Frodo Baggins", "boundingBox":
+        [6.0164, 1.4506, 6.9506, 1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "words":
+        [{"text": "Frodo", "boundingBox": [6.0164, 1.4506, 6.3895, 1.4506, 6.3895,
+        1.5649, 6.0164, 1.5649], "confidence": 1}, {"text": "Baggins", "boundingBox":
+        [6.45, 1.4556, 6.9506, 1.4556, 6.9506, 1.5931, 6.45, 1.5931], "confidence":
+        1}]}, {"text": "123 Hobbit Lane", "boundingBox": [6.0165, 1.6707, 7.1006,
         1.6707, 7.1006, 1.7854, 6.0165, 1.7854], "words": [{"text": "123", "boundingBox":
         [6.0165, 1.6772, 6.2434, 1.6772, 6.2434, 1.7854, 6.0165, 1.7854], "confidence":
         1}, {"text": "Hobbit", "boundingBox": [6.3033, 1.6707, 6.7463, 1.6707, 6.7463,
         1.7854, 6.3033, 1.7854], "confidence": 1}, {"text": "Lane", "boundingBox":
         [6.803, 1.6782, 7.1006, 1.6782, 7.1006, 1.7854, 6.803, 1.7854], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "567 Main St.", "boundingBox": [0.8852, 1.846, 1.713, 1.846, 1.713, 1.9554,
-        0.8852, 1.9554], "words": [{"text": "567", "boundingBox": [0.8852, 1.8472,
-        1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554], "confidence": 1}, {"text":
-        "Main", "boundingBox": [1.1777, 1.846, 1.5022, 1.846, 1.5022, 1.9554, 1.1777,
-        1.9554], "confidence": 1}, {"text": "St.", "boundingBox": [1.5558, 1.8472,
-        1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Redmond, WA", "boundingBox":
-        [6.0164, 1.891, 6.9793, 1.891, 6.9793, 2.0275, 6.0164, 2.0275], "words": [{"text":
-        "Redmond,", "boundingBox": [6.0164, 1.891, 6.6861, 1.891, 6.6861, 2.0275,
-        6.0164, 2.0275], "confidence": 1}, {"text": "WA", "boundingBox": [6.7408,
-        1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408, 2.0044], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Redmond,
-        WA", "boundingBox": [0.891, 2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975],
-        "words": [{"text": "Redmond,", "boundingBox": [0.891, 2.061, 1.5605, 2.061,
-        1.5605, 2.1975, 0.891, 2.1975], "confidence": 1}, {"text": "WA", "boundingBox":
-        [1.6152, 2.0682, 1.8537, 2.0682, 1.8537, 2.1744, 1.6152, 2.1744], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254,
-        6.0105, 2.2254], "words": [{"text": "555-555-5555", "boundingBox": [6.0105,
-        2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "555-555-5555",
+        1}]}, {"text": "567 Main St.", "boundingBox": [0.8852, 1.846, 1.713, 1.846,
+        1.713, 1.9554, 0.8852, 1.9554], "words": [{"text": "567", "boundingBox": [0.8852,
+        1.8472, 1.1203, 1.8472, 1.1203, 1.9554, 0.8852, 1.9554], "confidence": 1},
+        {"text": "Main", "boundingBox": [1.1777, 1.846, 1.5022, 1.846, 1.5022, 1.9554,
+        1.1777, 1.9554], "confidence": 1}, {"text": "St.", "boundingBox": [1.5558,
+        1.8472, 1.713, 1.8472, 1.713, 1.9554, 1.5558, 1.9554], "confidence": 1}]},
+        {"text": "Redmond, WA", "boundingBox": [6.0164, 1.891, 6.9793, 1.891, 6.9793,
+        2.0275, 6.0164, 2.0275], "words": [{"text": "Redmond,", "boundingBox": [6.0164,
+        1.891, 6.6861, 1.891, 6.6861, 2.0275, 6.0164, 2.0275], "confidence": 1}, {"text":
+        "WA", "boundingBox": [6.7408, 1.8982, 6.9793, 1.8982, 6.9793, 2.0044, 6.7408,
+        2.0044], "confidence": 1}]}, {"text": "Redmond, WA", "boundingBox": [0.891,
+        2.061, 1.8537, 2.061, 1.8537, 2.1975, 0.891, 2.1975], "words": [{"text": "Redmond,",
+        "boundingBox": [0.891, 2.061, 1.5605, 2.061, 1.5605, 2.1975, 0.891, 2.1975],
+        "confidence": 1}, {"text": "WA", "boundingBox": [1.6152, 2.0682, 1.8537, 2.0682,
+        1.8537, 2.1744, 1.6152, 2.1744], "confidence": 1}]}, {"text": "555-555-5555",
+        "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371, 2.2254, 6.0105, 2.2254],
+        "words": [{"text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371,
+        2.1187, 6.9371, 2.2254, 6.0105, 2.2254], "confidence": 1}]}, {"text": "555-555-5555",
         "boundingBox": [0.8852, 2.2887, 1.8119, 2.2887, 1.8119, 2.3954, 0.8852, 2.3954],
         "words": [{"text": "555-555-5555", "boundingBox": [0.8852, 2.2887, 1.8119,
-        2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Item", "boundingBox":
-        [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109], "words": [{"text":
-        "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943,
-        3.109], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996,
-        3.8367, 3.1371, 3.2527, 3.1371], "words": [{"text": "Quantity", "boundingBox":
-        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
+        2.2887, 1.8119, 2.3954, 0.8852, 2.3954], "confidence": 1}]}, {"text": "Item",
+        "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018, 1.3842, 3.109, 1.0943, 3.109],
+        "words": [{"text": "Item", "boundingBox": [1.0943, 3.0018, 1.3842, 3.0018,
+        1.3842, 3.109, 1.0943, 3.109], "confidence": 1}]}, {"text": "Quantity", "boundingBox":
+        [3.2527, 2.9996, 3.8367, 2.9996, 3.8367, 3.1371, 3.2527, 3.1371], "words":
+        [{"text": "Quantity", "boundingBox": [3.2527, 2.9996, 3.8367, 2.9996, 3.8367,
+        3.1371, 3.2527, 3.1371], "confidence": 1}]}, {"text": "Price", "boundingBox":
+        [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423, 3.109], "words": [{"text":
         "Price", "boundingBox": [5.423, 2.9996, 5.7372, 2.9996, 5.7372, 3.109, 5.423,
-        3.109], "words": [{"text": "Price", "boundingBox": [5.423, 2.9996, 5.7372,
-        2.9996, 5.7372, 3.109, 5.423, 3.109], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "A", "boundingBox": [1.0832,
-        3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A",
-        "boundingBox": [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "10", "boundingBox": [3.2589, 3.2108, 3.4067, 3.2108, 3.4067,
+        3.109], "confidence": 1}]}, {"text": "A", "boundingBox": [1.0832, 3.2118,
+        1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "words": [{"text": "A", "boundingBox":
+        [1.0832, 3.2118, 1.174, 3.2118, 1.174, 3.318, 1.0832, 3.318], "confidence":
+        1}]}, {"text": "10", "boundingBox": [3.2589, 3.2108, 3.4067, 3.2108, 3.4067,
         3.319, 3.2589, 3.319], "words": [{"text": "10", "boundingBox": [3.2589, 3.2108,
-        3.4067, 3.2108, 3.4067, 3.319, 3.2589, 3.319], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "100.99", "boundingBox":
-        [5.4232, 3.2108, 5.8617, 3.2108, 5.8617, 3.319, 5.4232, 3.319], "words": [{"text":
+        3.4067, 3.2108, 3.4067, 3.319, 3.2589, 3.319], "confidence": 1}]}, {"text":
         "100.99", "boundingBox": [5.4232, 3.2108, 5.8617, 3.2108, 5.8617, 3.319, 5.4232,
-        3.319], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637,
-        3.531, 1.0943, 3.531], "words": [{"text": "B", "boundingBox": [1.0943, 3.4256,
-        1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "20", "boundingBox":
-        [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323], "words":
-        [{"text": "20", "boundingBox": [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323,
-        3.2541, 3.5323], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "140.67", "boundingBox": [5.4232, 3.4241, 5.8622,
+        3.319], "words": [{"text": "100.99", "boundingBox": [5.4232, 3.2108, 5.8617,
+        3.2108, 5.8617, 3.319, 5.4232, 3.319], "confidence": 1}]}, {"text": "B", "boundingBox":
+        [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943, 3.531], "words": [{"text":
+        "B", "boundingBox": [1.0943, 3.4256, 1.1637, 3.4256, 1.1637, 3.531, 1.0943,
+        3.531], "confidence": 1}]}, {"text": "20", "boundingBox": [3.2541, 3.4241,
+        3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323], "words": [{"text": "20",
+        "boundingBox": [3.2541, 3.4241, 3.4067, 3.4241, 3.4067, 3.5323, 3.2541, 3.5323],
+        "confidence": 1}]}, {"text": "140.67", "boundingBox": [5.4232, 3.4241, 5.8622,
         3.4241, 5.8622, 3.5323, 5.4232, 3.5323], "words": [{"text": "140.67", "boundingBox":
         [5.4232, 3.4241, 5.8622, 3.4241, 5.8622, 3.5323, 5.4232, 3.5323], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647, 3.7421, 1.0882,
-        3.7421], "words": [{"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343,
-        1.1647, 3.7421, 1.0882, 3.7421], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "40", "boundingBox": [3.2486,
-        3.6341, 3.4067, 3.6341, 3.4067, 3.7423, 3.2486, 3.7423], "words": [{"text":
+        1}]}, {"text": "C", "boundingBox": [1.0882, 3.6343, 1.1647, 3.6343, 1.1647,
+        3.7421, 1.0882, 3.7421], "words": [{"text": "C", "boundingBox": [1.0882, 3.6343,
+        1.1647, 3.6343, 1.1647, 3.7421, 1.0882, 3.7421], "confidence": 1}]}, {"text":
         "40", "boundingBox": [3.2486, 3.6341, 3.4067, 3.6341, 3.4067, 3.7423, 3.2486,
-        3.7423], "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "150.66", "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341, 5.8634,
-        3.7423, 5.4232, 3.7423], "words": [{"text": "150.66", "boundingBox": [5.4232,
-        3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "D",
-        "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951],
-        "words": [{"text": "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753,
-        3.951, 1.0943, 3.951], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "10", "boundingBox": [3.2589, 3.8441,
+        3.7423], "words": [{"text": "40", "boundingBox": [3.2486, 3.6341, 3.4067,
+        3.6341, 3.4067, 3.7423, 3.2486, 3.7423], "confidence": 1}]}, {"text": "150.66",
+        "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423],
+        "words": [{"text": "150.66", "boundingBox": [5.4232, 3.6341, 5.8634, 3.6341,
+        5.8634, 3.7423, 5.4232, 3.7423], "confidence": 1}]}, {"text": "D", "boundingBox":
+        [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943, 3.951], "words": [{"text":
+        "D", "boundingBox": [1.0943, 3.8456, 1.1753, 3.8456, 1.1753, 3.951, 1.0943,
+        3.951], "confidence": 1}]}, {"text": "10", "boundingBox": [3.2589, 3.8441,
         3.4067, 3.8441, 3.4067, 3.9523, 3.2589, 3.9523], "words": [{"text": "10",
         "boundingBox": [3.2589, 3.8441, 3.4067, 3.8441, 3.4067, 3.9523, 3.2589, 3.9523],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "120.00", "boundingBox": [5.4232, 3.8441, 5.8642, 3.8441, 5.8642,
-        3.9523, 5.4232, 3.9523], "words": [{"text": "120.00", "boundingBox": [5.4232,
-        3.8441, 5.8642, 3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "E",
-        "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614],
-        "words": [{"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
-        4.1614, 1.0943, 4.1614], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "40", "boundingBox": [3.2486, 4.0546,
-        3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "words": [{"text": "40",
-        "boundingBox": [3.2486, 4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "100.00", "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546, 5.8644,
-        4.1627, 5.4232, 4.1627], "words": [{"text": "100.00", "boundingBox": [5.4232,
-        4.0546, 5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "F",
-        "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717],
-        "words": [{"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497,
-        4.3717, 1.0943, 4.3717], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "60", "boundingBox": [3.2534, 4.2646,
-        3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727], "words": [{"text": "60",
-        "boundingBox": [3.2534, 4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "120.00", "boundingBox": [5.4232, 4.2646, 5.8642, 4.2646, 5.8642,
-        4.3727, 5.4232, 4.3727], "words": [{"text": "120.00", "boundingBox": [5.4232,
-        4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "G",
-        "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827],
-        "words": [{"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
-        4.5827, 1.0877, 4.5827], "confidence": 1}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "80", "boundingBox": [3.2514, 4.4746,
-        3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827], "words": [{"text": "80",
-        "boundingBox": [3.2514, 4.4746, 3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "220.00", "boundingBox": [5.4184, 4.4746, 5.8644, 4.4746, 5.8644,
+        "confidence": 1}]}, {"text": "120.00", "boundingBox": [5.4232, 3.8441, 5.8642,
+        3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "words": [{"text": "120.00", "boundingBox":
+        [5.4232, 3.8441, 5.8642, 3.8441, 5.8642, 3.9523, 5.4232, 3.9523], "confidence":
+        1}]}, {"text": "E", "boundingBox": [1.0943, 4.0561, 1.153, 4.0561, 1.153,
+        4.1614, 1.0943, 4.1614], "words": [{"text": "E", "boundingBox": [1.0943, 4.0561,
+        1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "confidence": 1}]}, {"text":
+        "40", "boundingBox": [3.2486, 4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486,
+        4.1627], "words": [{"text": "40", "boundingBox": [3.2486, 4.0546, 3.4067,
+        4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "confidence": 1}]}, {"text": "100.00",
+        "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627],
+        "words": [{"text": "100.00", "boundingBox": [5.4232, 4.0546, 5.8644, 4.0546,
+        5.8644, 4.1627, 5.4232, 4.1627], "confidence": 1}]}, {"text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "words":
+        [{"text": "F", "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717,
+        1.0943, 4.3717], "confidence": 1}]}, {"text": "60", "boundingBox": [3.2534,
+        4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534, 4.3727], "words": [{"text":
+        "60", "boundingBox": [3.2534, 4.2646, 3.4067, 4.2646, 3.4067, 4.3727, 3.2534,
+        4.3727], "confidence": 1}]}, {"text": "120.00", "boundingBox": [5.4232, 4.2646,
+        5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "words": [{"text": "120.00",
+        "boundingBox": [5.4232, 4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727],
+        "confidence": 1}]}, {"text": "G", "boundingBox": [1.0877, 4.4746, 1.1735,
+        4.4746, 1.1735, 4.5827, 1.0877, 4.5827], "words": [{"text": "G", "boundingBox":
+        [1.0877, 4.4746, 1.1735, 4.4746, 1.1735, 4.5827, 1.0877, 4.5827], "confidence":
+        1}]}, {"text": "80", "boundingBox": [3.2514, 4.4746, 3.4067, 4.4746, 3.4067,
+        4.5827, 3.2514, 4.5827], "words": [{"text": "80", "boundingBox": [3.2514,
+        4.4746, 3.4067, 4.4746, 3.4067, 4.5827, 3.2514, 4.5827], "confidence": 1}]},
+        {"text": "220.00", "boundingBox": [5.4184, 4.4746, 5.8644, 4.4746, 5.8644,
         4.5827, 5.4184, 4.5827], "words": [{"text": "220.00", "boundingBox": [5.4184,
-        4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "confidence": 1}],
-        "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text": "Subtotal:
-        3000.00", "boundingBox": [5.5075, 4.8981, 6.7158, 4.8981, 6.7158, 5.0131,
-        5.5075, 5.0131], "words": [{"text": "Subtotal:", "boundingBox": [5.5075, 4.8981,
-        6.1249, 4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence": 1}, {"text":
-        "3000.00", "boundingBox": [6.1794, 4.9042, 6.7158, 4.9042, 6.7158, 5.0131,
-        6.1794, 5.0131], "confidence": 1}], "appearance": {"style": {"name": "print",
-        "confidence": 1}}}, {"text": "Tax: 300.00", "boundingBox": [5.5034, 5.1245,
-        6.2887, 5.1245, 6.2887, 5.2333, 5.5034, 5.2333], "words": [{"text": "Tax:",
-        "boundingBox": [5.5034, 5.1263, 5.7812, 5.1263, 5.7812, 5.2333, 5.5034, 5.2333],
-        "confidence": 1}, {"text": "300.00", "boundingBox": [5.836, 5.1245, 6.2887,
-        5.1245, 6.2887, 5.2333, 5.836, 5.2333], "confidence": 1}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Tip: 1000.00", "boundingBox":
-        [5.5034, 5.3412, 6.3422, 5.3412, 6.3422, 5.481, 5.5034, 5.481], "words": [{"text":
-        "Tip:", "boundingBox": [5.5034, 5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034,
-        5.481], "confidence": 1}, {"text": "1000.00", "boundingBox": [5.811, 5.3445,
-        6.3422, 5.3445, 6.3422, 5.4533, 5.811, 5.4533], "confidence": 1}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Total: 4300.00",
-        "boundingBox": [5.5034, 5.5583, 6.4825, 5.5583, 6.4825, 5.6733, 5.5034, 5.6733],
-        "words": [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583,
-        5.8915, 5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "4300.00", "boundingBox":
+        4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "confidence": 1}]},
+        {"text": "Subtotal: 3000.00", "boundingBox": [5.5075, 4.8981, 6.7158, 4.8981,
+        6.7158, 5.0131, 5.5075, 5.0131], "words": [{"text": "Subtotal:", "boundingBox":
+        [5.5075, 4.8981, 6.1249, 4.8981, 6.1249, 5.0131, 5.5075, 5.0131], "confidence":
+        1}, {"text": "3000.00", "boundingBox": [6.1794, 4.9042, 6.7158, 4.9042, 6.7158,
+        5.0131, 6.1794, 5.0131], "confidence": 1}]}, {"text": "Tax: 300.00", "boundingBox":
+        [5.5034, 5.1245, 6.2887, 5.1245, 6.2887, 5.2333, 5.5034, 5.2333], "words":
+        [{"text": "Tax:", "boundingBox": [5.5034, 5.1263, 5.7812, 5.1263, 5.7812,
+        5.2333, 5.5034, 5.2333], "confidence": 1}, {"text": "300.00", "boundingBox":
+        [5.836, 5.1245, 6.2887, 5.1245, 6.2887, 5.2333, 5.836, 5.2333], "confidence":
+        1}]}, {"text": "Tip: 1000.00", "boundingBox": [5.5034, 5.3412, 6.3422, 5.3412,
+        6.3422, 5.481, 5.5034, 5.481], "words": [{"text": "Tip:", "boundingBox": [5.5034,
+        5.3412, 5.7515, 5.3412, 5.7515, 5.481, 5.5034, 5.481], "confidence": 1}, {"text":
+        "1000.00", "boundingBox": [5.811, 5.3445, 6.3422, 5.3445, 6.3422, 5.4533,
+        5.811, 5.4533], "confidence": 1}]}, {"text": "Total: 4300.00", "boundingBox":
+        [5.5034, 5.5583, 6.4825, 5.5583, 6.4825, 5.6733, 5.5034, 5.6733], "words":
+        [{"text": "Total:", "boundingBox": [5.5034, 5.5583, 5.8915, 5.5583, 5.8915,
+        5.6733, 5.5034, 5.6733], "confidence": 1}, {"text": "4300.00", "boundingBox":
         [5.942, 5.5645, 6.4825, 5.5645, 6.4825, 5.6733, 5.942, 5.6733], "confidence":
-        1}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Signature: ____Frodo Baggins__________", "boundingBox": [1.0055, 6.6556,
-        3.8842, 6.6556, 3.8842, 6.7981, 1.0055, 6.7981], "words": [{"text": "Signature:",
-        "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981, 1.0055, 6.7981],
-        "confidence": 1}, {"text": "____Frodo", "boundingBox": [1.747, 6.6556, 2.4778,
-        6.6556, 2.4778, 6.7981, 1.747, 6.7981], "confidence": 1}, {"text": "Baggins__________",
-        "boundingBox": [2.5325, 6.6581, 3.8842, 6.6581, 3.8842, 6.7981, 2.5325, 6.7981],
-        "confidence": 1}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}]}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
+        1}]}, {"text": "Signature: ____ Frodo Baggins__________", "boundingBox": [1.0055,
+        6.6556, 3.8842, 6.6556, 3.8842, 6.7981, 1.0055, 6.7981], "words": [{"text":
+        "Signature:", "boundingBox": [1.0055, 6.6581, 1.6987, 6.6581, 1.6987, 6.7981,
+        1.0055, 6.7981], "confidence": 1}, {"text": "____", "boundingBox": [1.747,
+        6.7829, 2.0809, 6.7829, 2.0809, 6.7981, 1.747, 6.7981], "confidence": 1},
+        {"text": "Frodo", "boundingBox": [2.0925, 6.6556, 2.4778, 6.6556, 2.4778,
+        6.7703, 2.0925, 6.7703], "confidence": 1}, {"text": "Baggins__________", "boundingBox":
+        [2.5325, 6.6581, 3.8842, 6.6581, 3.8842, 6.7981, 2.5325, 6.7981], "confidence":
+        1}]}]}], "documentResults": [{"docType": "prebuilt:receipt", "pageRange":
         [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString": "Itemized",
-        "confidence": 0.991}, "MerchantName": {"type": "string", "valueString": "Bilbo
+        "confidence": 0.99}, "MerchantName": {"type": "string", "valueString": "Bilbo
         Baggins", "text": "Bilbo Baggins", "boundingBox": [6.0164, 1.4503, 6.8967,
-        1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "page": 1, "confidence": 0.669, "elements":
+        1.4503, 6.8967, 1.5931, 6.0164, 1.5931], "page": 1, "confidence": 0.987, "elements":
         ["#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1"]}, "MerchantAddress":
         {"type": "string", "valueString": "123 Hobbit Lane 567 Main St. Redmond, WA
         Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA",
         "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975, 0.8852, 2.1975],
-        "page": 1, "confidence": 0.345, "elements": ["#/readResults/0/lines/4/words/0",
+        "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/4/words/0",
         "#/readResults/0/lines/4/words/1", "#/readResults/0/lines/4/words/2", "#/readResults/0/lines/5/words/0",
         "#/readResults/0/lines/5/words/1", "#/readResults/0/lines/5/words/2", "#/readResults/0/lines/6/words/0",
         "#/readResults/0/lines/6/words/1", "#/readResults/0/lines/7/words/0", "#/readResults/0/lines/7/words/1"]},
         "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber": "+15555555555",
         "text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371,
-        2.2254, 6.0105, 2.2254], "page": 1, "confidence": 0.932, "elements": ["#/readResults/0/lines/8/words/0"]},
+        2.2254, 6.0105, 2.2254], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/8/words/0"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "F", "text": "F", "boundingBox":
+        [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717], "page":
+        1, "confidence": 0.964, "elements": ["#/readResults/0/lines/28/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 12, "text": "12.00", "boundingBox":
+        [5.4232, 4.2646, 5.7809, 4.2646, 5.7809, 4.3727, 5.4232, 4.3727], "page":
+        1, "confidence": 0.947, "elements": ["#/readResults/0/lines/30/words/0"]}}},
+        {"type": "object", "valueObject": {"TotalPrice": {"type": "number", "valueNumber":
+        22, "text": "22.00", "boundingBox": [5.4184, 4.4746, 5.781, 4.4746, 5.781,
+        4.5827, 5.4184, 4.5827], "page": 1, "confidence": 0.935, "elements": ["#/readResults/0/lines/33/words/0"]}}}]},
         "Subtotal": {"type": "number", "valueNumber": 300, "text": "300.00", "boundingBox":
         [6.1794, 4.9042, 6.632, 4.9042, 6.632, 5.0131, 6.1794, 5.0131], "page": 1,
-        "confidence": 0.96, "elements": ["#/readResults/0/lines/34/words/1"]}}}, {"docType":
-        "prebuilt:receipt", "pageRange": [2, 2], "fields": {}}, {"docType": "prebuilt:receipt",
-        "pageRange": [3, 3], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Frodo Baggins", "text": "Frodo Baggins", "boundingBox": [6.0164, 1.4506,
-        6.9506, 1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "page": 3, "confidence":
-        0.529, "elements": ["#/readResults/2/lines/3/words/0", "#/readResults/2/lines/3/words/1"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Hobbit Lane 567
-        Main St. Redmond, WA Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond,
-        WA Redmond, WA", "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975,
-        0.8852, 2.1975], "page": 3, "confidence": 0.523, "elements": ["#/readResults/2/lines/4/words/0",
+        "confidence": 0.99, "elements": ["#/readResults/0/lines/34/words/1"]}, "Total":
+        {"type": "number", "valueNumber": 430, "text": "430.00", "boundingBox": [5.942,
+        5.5645, 6.3987, 5.5645, 6.3987, 5.6733, 5.942, 5.6733], "page": 1, "confidence":
+        0.985, "elements": ["#/readResults/0/lines/37/words/1"]}}}, {"docType": "prebuilt:receipt",
+        "pageRange": [2, 2], "fields": {}}, {"docType": "prebuilt:receipt", "pageRange":
+        [3, 3], "fields": {"ReceiptType": {"type": "string", "valueString": "Itemized",
+        "confidence": 0.99}, "MerchantName": {"type": "string", "valueString": "Frodo
+        Baggins", "text": "Frodo Baggins", "boundingBox": [6.0164, 1.4506, 6.9506,
+        1.4506, 6.9506, 1.5931, 6.0164, 1.5931], "page": 3, "confidence": 0.984, "elements":
+        ["#/readResults/2/lines/3/words/0", "#/readResults/2/lines/3/words/1"]}, "MerchantAddress":
+        {"type": "string", "valueString": "123 Hobbit Lane 567 Main St. Redmond, WA
+        Redmond, WA", "text": "123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA",
+        "boundingBox": [0.8852, 1.6707, 7.1006, 1.6707, 7.1006, 2.1975, 0.8852, 2.1975],
+        "page": 3, "confidence": 0.99, "elements": ["#/readResults/2/lines/4/words/0",
         "#/readResults/2/lines/4/words/1", "#/readResults/2/lines/4/words/2", "#/readResults/2/lines/5/words/0",
         "#/readResults/2/lines/5/words/1", "#/readResults/2/lines/5/words/2", "#/readResults/2/lines/6/words/0",
         "#/readResults/2/lines/6/words/1", "#/readResults/2/lines/7/words/0", "#/readResults/2/lines/7/words/1"]},
         "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber": "+15555555555",
         "text": "555-555-5555", "boundingBox": [6.0105, 2.1187, 6.9371, 2.1187, 6.9371,
-        2.2254, 6.0105, 2.2254], "page": 3, "confidence": 0.926, "elements": ["#/readResults/2/lines/8/words/0"]},
-        "Subtotal": {"type": "number", "valueNumber": 150.66, "text": "150.66", "boundingBox":
-        [5.4232, 3.6341, 5.8634, 3.6341, 5.8634, 3.7423, 5.4232, 3.7423], "page":
-        3, "confidence": 0.664, "elements": ["#/readResults/2/lines/21/words/0"]}}}]}}'
+        2.2254, 6.0105, 2.2254], "page": 3, "confidence": 0.99, "elements": ["#/readResults/2/lines/8/words/0"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "E", "text": "E", "boundingBox":
+        [1.0943, 4.0561, 1.153, 4.0561, 1.153, 4.1614, 1.0943, 4.1614], "page": 3,
+        "confidence": 0.935, "elements": ["#/readResults/2/lines/25/words/0"]}, "Quantity":
+        {"type": "number", "valueNumber": 40, "text": "40", "boundingBox": [3.2486,
+        4.0546, 3.4067, 4.0546, 3.4067, 4.1627, 3.2486, 4.1627], "page": 3, "confidence":
+        0, "elements": ["#/readResults/2/lines/26/words/0"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 100, "text": "100.00", "boundingBox": [5.4232, 4.0546,
+        5.8644, 4.0546, 5.8644, 4.1627, 5.4232, 4.1627], "page": 3, "confidence":
+        0.723, "elements": ["#/readResults/2/lines/27/words/0"]}}}, {"type": "object",
+        "valueObject": {"Name": {"type": "string", "valueString": "F", "text": "F",
+        "boundingBox": [1.0943, 4.2661, 1.1497, 4.2661, 1.1497, 4.3717, 1.0943, 4.3717],
+        "page": 3, "confidence": 0.905, "elements": ["#/readResults/2/lines/28/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 120, "text": "120.00", "boundingBox":
+        [5.4232, 4.2646, 5.8642, 4.2646, 5.8642, 4.3727, 5.4232, 4.3727], "page":
+        3, "confidence": 0.967, "elements": ["#/readResults/2/lines/30/words/0"]}}},
+        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
+        "G", "text": "G", "boundingBox": [1.0877, 4.4746, 1.1735, 4.4746, 1.1735,
+        4.5827, 1.0877, 4.5827], "page": 3, "confidence": 0.896, "elements": ["#/readResults/2/lines/31/words/0"]},
+        "TotalPrice": {"type": "number", "valueNumber": 220, "text": "220.00", "boundingBox":
+        [5.4184, 4.4746, 5.8644, 4.4746, 5.8644, 4.5827, 5.4184, 4.5827], "page":
+        3, "confidence": 0.958, "elements": ["#/readResults/2/lines/33/words/0"]}}}]},
+        "Subtotal": {"type": "number", "valueNumber": 3000, "text": "3000.00", "boundingBox":
+        [6.1794, 4.9042, 6.7158, 4.9042, 6.7158, 5.0131, 6.1794, 5.0131], "page":
+        3, "confidence": 0.99, "elements": ["#/readResults/2/lines/34/words/1"]},
+        "Total": {"type": "number", "valueNumber": 1000, "text": "1000.00", "boundingBox":
+        [5.811, 5.3445, 6.3422, 5.3445, 6.3422, 5.4533, 5.811, 5.4533], "page": 3,
+        "confidence": 0.985, "elements": ["#/readResults/2/lines/36/words/1"]}}}]}}'
     headers:
-      apim-request-id: a6185624-6893-40e5-8f00-c7f2d8bfdbba
-      content-length: '26841'
+      apim-request-id: 494b496a-5861-4b06-a6b9-5ff807ae3b3a
+      content-length: '25475'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:08:52 GMT
+      date: Mon, 16 Nov 2020 19:14:18 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '25'
+      x-envoy-upstream-service-time: '29'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/26bb545d-dc6f-4b77-aad5-09770a86457e
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/8db67d3b-f762-4a83-9b6b-a6055fc8f908
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_url_auth_bad_key.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_url_auth_bad_key.yaml
@@ -19,7 +19,7 @@ interactions:
         an active subscription and use a correct regional API endpoint for your resource."}}'
     headers:
       content-length: '224'
-      date: Wed, 11 Nov 2020 18:08:53 GMT
+      date: Mon, 16 Nov 2020 19:14:18 GMT
     status:
       code: 401
       message: PermissionDenied

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_url_auth_successful_key.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_url_auth_successful_key.yaml
@@ -16,13 +16,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 3b813664-ed3f-4d72-91b7-9997dd96ed7d
+      apim-request-id: 8f941af5-42eb-4349-a9e6-deb7a1c27795
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:08:53 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/3b813664-ed3f-4d72-91b7-9997dd96ed7d
+      date: Mon, 16 Nov 2020 19:14:20 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/8f941af5-42eb-4349-a9e6-deb7a1c27795
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '211'
+      x-envoy-upstream-service-time: '194'
     status:
       code: 202
       message: Accepted
@@ -33,60 +33,60 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/3b813664-ed3f-4d72-91b7-9997dd96ed7d
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/8f941af5-42eb-4349-a9e6-deb7a1c27795
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:08:53Z",
-        "lastUpdatedDateTime": "2020-11-11T18:08:55Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:14:20Z",
+        "lastUpdatedDateTime": "2020-11-16T19:14:22Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [380.9, 282.9,
-        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.716}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [298.3, 676.5, 844.6,
-        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence":
-        0.99}, "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text":
-        "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505, 1331, 255, 1312],
-        "page": 1, "confidence": 0.99}, "TransactionTime": {"type": "time", "valueTime":
-        "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681, 1262, 675, 1341,
-        522, 1332], "page": 1, "confidence": 0.989}, "Items": {"type": "array", "valueArray":
-        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [244, 1581, 288, 1584, 285, 1678, 241, 1675],
-        "page": 1, "confidence": 0.919}, "Name": {"type": "string", "valueString":
-        "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585, 658, 1598,
-        657, 1688, 304, 1679], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1106, 1579,
-        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.959}}}, {"type":
-        "object", "valueObject": {"Quantity": {"type": "number", "valueNumber": 1,
-        "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [294, 1839, 737, 1839,
-        737, 1924, 294, 1924], "page": 1, "confidence": 0.955}, "TotalPrice": {"type":
-        "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox": [1134, 1948,
-        1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence": 0.958}}}]},
-        "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923}, "Tax": {"type": "number", "valueNumber": 1.17, "text": "1.17", "boundingBox":
-        [1186, 2356, 1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence":
-        0.979}, "Tip": {"type": "number", "valueNumber": 463, "text": "$463", "boundingBox":
-        [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "page": 1, "confidence":
-        0.975}, "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50",
-        "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1,
-        "confidence": 0.987}}}]}}'
+        "Itemized", "confidence": 0.692}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [378.2, 292.4,
+        1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8], "page": 1, "confidence": 0.613},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [302,
+        675.8, 848.1, 793.7, 809.9, 970.4, 263.9, 852.5], "page": 1, "confidence":
+        0.99}, "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber":
+        "+19876543210", "text": "987-654-3210", "boundingBox": [278, 1004, 656, 1057,
+        647, 1123, 271, 1075], "page": 1, "confidence": 0.99}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99},
+        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
+        "boundingBox": [541, 1248, 677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence":
+        0.977}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
+        [245, 1583, 299, 1585, 295, 1676, 241, 1671], "page": 1, "confidence": 0.92},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923}, "TotalPrice": {"type": "number", "valueNumber": 2.2, "text": "$2.20",
+        "boundingBox": [1108, 1584, 1263, 1574, 1268, 1656, 1113, 1666], "page": 1,
+        "confidence": 0.918}}}, {"type": "object", "valueObject": {"Quantity": {"type":
+        "number", "valueNumber": 1, "text": "1", "boundingBox": [232, 1834, 286, 1836,
+        285, 1920, 231, 1920], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916},
+        "TotalPrice": {"type": "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox":
+        [1135, 1955, 1257, 1952, 1259, 2036, 1136, 2039], "page": 1, "confidence":
+        0.916}}}]}, "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70",
+        "boundingBox": [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1,
+        "confidence": 0.955}, "Tax": {"type": "number", "valueNumber": 1.17, "text":
+        "1.17", "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "page":
+        1, "confidence": 0.979}, "Tip": {"type": "number", "valueNumber": 1.63, "text":
+        "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591, 1091, 2585], "page":
+        1, "confidence": 0.941}, "Total": {"type": "number", "valueNumber": 14.5,
+        "text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380, 2763, 1030,
+        2739], "page": 1, "confidence": 0.985}}}]}}'
     headers:
-      apim-request-id: 430a2994-649c-46ac-a2b8-0c9cce8a51c2
-      content-length: '2820'
+      apim-request-id: 39ccf8d5-c787-4893-991f-45beb280ef0e
+      content-length: '2835'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:08:58 GMT
+      date: Mon, 16 Nov 2020 19:14:24 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '21'
+      x-envoy-upstream-service-time: '22'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/3b813664-ed3f-4d72-91b7-9997dd96ed7d
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/8f941af5-42eb-4349-a9e6-deb7a1c27795
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_url_include_field_elements.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_url_include_field_elements.yaml
@@ -16,13 +16,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 981eb1c8-55cd-41b4-a3b0-591d012bf767
+      apim-request-id: bfe9ce0d-6a1a-4e9f-94d7-274ba6ef1267
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:08:59 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/981eb1c8-55cd-41b4-a3b0-591d012bf767
+      date: Mon, 16 Nov 2020 19:14:26 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/bfe9ce0d-6a1a-4e9f-94d7-274ba6ef1267
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '264'
+      x-envoy-upstream-service-time: '519'
     status:
       code: 202
       message: Accepted
@@ -33,168 +33,141 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/981eb1c8-55cd-41b4-a3b0-591d012bf767
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/bfe9ce0d-6a1a-4e9f-94d7-274ba6ef1267
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:08:59Z",
-        "lastUpdatedDateTime": "2020-11-11T18:09:01Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
-        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [306,
-        569, 519, 624, 502, 686, 290, 632], "words": [{"text": "Contoso", "boundingBox":
-        [308, 570, 515, 627, 500, 685, 290, 634], "confidence": 0.806}], "appearance":
-        {"style": {"name": "print", "confidence": 0.996}}}, {"text": "Contoso", "boundingBox":
-        [625, 512, 1089, 465, 1096, 561, 631, 607], "words": [{"text": "Contoso",
-        "boundingBox": [625, 512, 1088, 466, 1093, 562, 631, 607], "confidence": 0.984}],
-        "appearance": {"style": {"name": "print", "confidence": 0.999}}}, {"text":
-        "123 Main Street", "boundingBox": [301, 677, 697, 759, 681, 835, 284, 750],
-        "words": [{"text": "123", "boundingBox": [301, 677, 379, 692, 362, 766, 284,
-        751], "confidence": 0.987}, {"text": "Main", "boundingBox": [393, 695, 520,
-        721, 503, 795, 377, 769], "confidence": 0.985}, {"text": "Street", "boundingBox":
-        [534, 724, 694, 763, 676, 835, 517, 798], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.995}}}, {"text": "Redmond, WA
-        98052", "boundingBox": [284, 784, 823, 855, 814, 925, 275, 868], "words":
-        [{"text": "Redmond,", "boundingBox": [287, 784, 544, 829, 535, 905, 275, 853],
-        "confidence": 0.924}, {"text": "WA", "boundingBox": [558, 830, 640, 840, 632,
-        916, 549, 907], "confidence": 0.985}, {"text": "98052", "boundingBox": [654,
-        842, 822, 855, 817, 925, 646, 917], "confidence": 0.985}], "appearance": {"style":
-        {"name": "print", "confidence": 0.999}}}, {"text": "987-654-3210", "boundingBox":
-        [270, 999, 655, 1049, 646, 1125, 264, 1075], "words": [{"text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "confidence":
-        0.978}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "6/10/2019 13:59", "boundingBox": [258, 1224, 683, 1259, 676, 1341, 255, 1309],
-        "words": [{"text": "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505,
-        1331, 255, 1312], "confidence": 0.951}, {"text": "13:59", "boundingBox": [527,
-        1248, 681, 1262, 675, 1341, 522, 1332], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "Sales Associate:
-        Paul", "boundingBox": [252, 1347, 860, 1378, 859, 1449, 249, 1425], "words":
-        [{"text": "Sales", "boundingBox": [255, 1348, 409, 1358, 405, 1432, 249, 1419],
-        "confidence": 0.983}, {"text": "Associate:", "boundingBox": [423, 1359, 704,
-        1373, 703, 1447, 419, 1434], "confidence": 0.933}, {"text": "Paul", "boundingBox":
-        [718, 1373, 858, 1378, 859, 1449, 717, 1448], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "1 Cappuccino", "boundingBox":
-        [244, 1581, 660, 1597, 658, 1688, 241, 1675], "words": [{"text": "1", "boundingBox":
-        [244, 1581, 288, 1584, 285, 1678, 241, 1675], "confidence": 0.977}, {"text":
-        "Cappuccino", "boundingBox": [306, 1585, 658, 1598, 657, 1688, 304, 1679],
-        "confidence": 0.858}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "$2.20", "boundingBox": [1106, 1580, 1264, 1574, 1268, 1656,
-        1108, 1662], "words": [{"text": "$2.20", "boundingBox": [1106, 1579, 1260,
-        1574, 1263, 1656, 1108, 1662], "confidence": 0.981}], "appearance": {"style":
-        {"name": "print", "confidence": 0.849}}}, {"text": "1 BACON & EGGS", "boundingBox":
-        [226, 1838, 740, 1839, 740, 1924, 226, 1923], "words": [{"text": "1", "boundingBox":
-        [227, 1839, 278, 1839, 277, 1924, 226, 1924], "confidence": 0.986}, {"text":
-        "BACON", "boundingBox": [295, 1839, 493, 1840, 493, 1923, 294, 1924], "confidence":
-        0.984}, {"text": "&", "boundingBox": [510, 1840, 555, 1840, 555, 1923, 510,
-        1923], "confidence": 0.983}, {"text": "EGGS", "boundingBox": [572, 1840, 737,
-        1841, 736, 1924, 572, 1923], "confidence": 0.984}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Sunny-side-up", "boundingBox":
-        [343, 1976, 758, 1974, 759, 2061, 343, 2063], "words": [{"text": "Sunny-side-up",
-        "boundingBox": [343, 1977, 757, 1975, 755, 2063, 346, 2064], "confidence":
-        0.973}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "$9.5", "boundingBox": [1134, 1948, 1253, 1948, 1255, 2041, 1137, 2041], "words":
-        [{"text": "$9.5", "boundingBox": [1134, 1948, 1252, 1948, 1252, 2041, 1134,
-        2041], "confidence": 0.983}], "appearance": {"style": {"name": "print", "confidence":
-        0.932}}}, {"text": "- -", "boundingBox": [218, 2143, 291, 2140, 292, 2158,
-        218, 2161], "words": [{"text": "-", "boundingBox": [236, 2143, 255, 2143,
-        255, 2161, 235, 2161], "confidence": 0.559}, {"text": "-", "boundingBox":
-        [271, 2142, 290, 2141, 291, 2158, 272, 2160], "confidence": 0.985}], "appearance":
-        {"style": {"name": "print", "confidence": 0.67}}}, {"text": "-----", "boundingBox":
-        [277, 2142, 461, 2136, 461, 2155, 278, 2161], "words": [{"text": "-----",
-        "boundingBox": [305, 2141, 457, 2136, 458, 2155, 305, 2161], "confidence":
-        0.69}], "appearance": {"style": {"name": "print", "confidence": 0.467}}},
-        {"text": "----", "boundingBox": [471, 2137, 565, 2133, 566, 2150, 472, 2154],
-        "words": [{"text": "----", "boundingBox": [473, 2138, 566, 2134, 566, 2150,
-        473, 2154], "confidence": 0.559}], "appearance": {"style": {"name": "print",
-        "confidence": 0.703}}}, {"text": "--", "boundingBox": [1252, 2129, 1319, 2127,
-        1320, 2143, 1252, 2146], "words": [{"text": "--", "boundingBox": [1277, 2129,
-        1319, 2127, 1319, 2144, 1276, 2145], "confidence": 0.559}], "appearance":
-        {"style": {"name": "print", "confidence": 0.846}}}, {"text": "Sub-Total",
-        "boundingBox": [434, 2232, 768, 2222, 770, 2312, 437, 2322], "words": [{"text":
-        "Sub-Total", "boundingBox": [434, 2234, 769, 2222, 770, 2313, 442, 2322],
-        "confidence": 0.981}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "$ 11.70", "boundingBox": [1082, 2228, 1309, 2228, 1309, 2313,
-        1084, 2312], "words": [{"text": "$", "boundingBox": [1082, 2228, 1122, 2228,
-        1121, 2313, 1082, 2312], "confidence": 0.654}, {"text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "confidence": 0.984}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "Tax", "boundingBox":
-        [433, 2367, 563, 2363, 565, 2458, 435, 2462], "words": [{"text": "Tax", "boundingBox":
-        [433, 2367, 559, 2363, 562, 2458, 435, 2462], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 0.98}}}, {"text": "$ 1.17", "boundingBox":
-        [1125, 2353, 1306, 2362, 1304, 2451, 1121, 2444], "words": [{"text": "$",
-        "boundingBox": [1125, 2353, 1167, 2355, 1163, 2446, 1121, 2444], "confidence":
-        0.966}, {"text": "1.17", "boundingBox": [1186, 2356, 1307, 2361, 1303, 2452,
-        1182, 2447], "confidence": 0.983}], "appearance": {"style": {"name": "print",
-        "confidence": 0.963}}}, {"text": "Tip", "boundingBox": [439, 2502, 545, 2506,
-        541, 2606, 435, 2602], "words": [{"text": "Tip", "boundingBox": [438, 2502,
-        545, 2506, 541, 2606, 435, 2602], "confidence": 0.987}], "appearance": {"style":
-        {"name": "print", "confidence": 0.943}}}, {"text": "$463", "boundingBox":
-        [1038, 2483, 1271, 2489, 1269, 2583, 1032, 2577], "words": [{"text": "$463",
-        "boundingBox": [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "confidence":
-        0.592}], "appearance": {"style": {"name": "handwriting", "confidence": 0.892}}},
-        {"text": "Total", "boundingBox": [431, 2651, 607, 2646, 610, 2739, 435, 2745],
-        "words": [{"text": "Total", "boundingBox": [431, 2651, 605, 2646, 608, 2739,
-        433, 2745], "confidence": 0.983}], "appearance": {"style": {"name": "print",
-        "confidence": 0.991}}}, {"text": "$14.50", "boundingBox": [1034, 2623, 1381,
-        2642, 1374, 2757, 1027, 2740], "words": [{"text": "$14.50", "boundingBox":
-        [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "confidence": 0.845}], "appearance":
-        {"style": {"name": "handwriting", "confidence": 0.991}}}]}], "documentResults":
-        [{"docType": "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType":
-        {"type": "string", "valueString": "Itemized", "confidence": 0.99}, "MerchantName":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:14:26Z",
+        "lastUpdatedDateTime": "2020-11-16T19:14:29Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
+        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [635,
+        510, 1086, 461, 1098, 558, 643, 604], "words": [{"text": "Contoso", "boundingBox":
+        [639, 510, 1087, 461, 1098, 551, 646, 604], "confidence": 0.955}]}, {"text":
+        "Contoso", "boundingBox": [305, 574, 519, 624, 504, 686, 291, 634], "words":
+        [{"text": "Contoso", "boundingBox": [311, 575, 517, 623, 503, 686, 297, 636],
+        "confidence": 0.435}]}, {"text": "123 Main Street", "boundingBox": [300, 675,
+        703, 767, 686, 844, 284, 749], "words": [{"text": "123", "boundingBox": [302,
+        676, 390, 695, 375, 770, 287, 751], "confidence": 0.935}, {"text": "Main",
+        "boundingBox": [405, 698, 528, 726, 512, 802, 390, 774], "confidence": 0.958},
+        {"text": "Street", "boundingBox": [542, 730, 702, 767, 685, 845, 527, 806],
+        "confidence": 0.959}]}, {"text": "Redmond, WA 98052", "boundingBox": [290,
+        784, 828, 850, 820, 933, 279, 868], "words": [{"text": "Redmond,", "boundingBox":
+        [293, 784, 550, 826, 540, 905, 280, 856], "confidence": 0.762}, {"text": "WA",
+        "boundingBox": [565, 828, 645, 837, 637, 917, 555, 907], "confidence": 0.943},
+        {"text": "98052", "boundingBox": [660, 838, 824, 849, 818, 933, 651, 919],
+        "confidence": 0.959}]}, {"text": "987-654-3210", "boundingBox": [275, 1003,
+        656, 1055, 646, 1123, 269, 1073], "words": [{"text": "987-654-3210", "boundingBox":
+        [278, 1004, 656, 1057, 647, 1123, 271, 1075], "confidence": 0.939}]}, {"text":
+        "6/10/2019 13:59", "boundingBox": [265, 1228, 678, 1258, 671, 1344, 258, 1311],
+        "words": [{"text": "6/10/2019", "boundingBox": [267, 1229, 525, 1247, 517,
+        1332, 259, 1313], "confidence": 0.762}, {"text": "13:59", "boundingBox": [541,
+        1248, 677, 1263, 669, 1345, 533, 1333], "confidence": 0.958}]}, {"text": "Sales
+        Associate: Paul", "boundingBox": [253, 1347, 868, 1379, 863, 1457, 249, 1425],
+        "words": [{"text": "Sales", "boundingBox": [259, 1348, 419, 1359, 414, 1435,
+        252, 1422], "confidence": 0.92}, {"text": "Associate:", "boundingBox": [434,
+        1360, 711, 1374, 707, 1452, 428, 1436], "confidence": 0.909}, {"text": "Paul",
+        "boundingBox": [726, 1374, 865, 1379, 862, 1457, 722, 1452], "confidence":
+        0.959}]}, {"text": "1 Cappuccino", "boundingBox": [244, 1583, 658, 1601, 653,
+        1689, 240, 1674], "words": [{"text": "1", "boundingBox": [245, 1583, 299,
+        1585, 295, 1676, 241, 1671], "confidence": 0.824}, {"text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "confidence":
+        0.727}]}, {"text": "$2.20", "boundingBox": [1106, 1584, 1268, 1574, 1270,
+        1656, 1110, 1666], "words": [{"text": "$2.20", "boundingBox": [1108, 1584,
+        1263, 1574, 1268, 1656, 1113, 1666], "confidence": 0.958}]}, {"text": "1 BACON
+        & EGGS", "boundingBox": [232, 1834, 745, 1840, 744, 1924, 231, 1918], "words":
+        [{"text": "1", "boundingBox": [232, 1834, 286, 1836, 285, 1920, 231, 1920],
+        "confidence": 0.845}, {"text": "BACON", "boundingBox": [308, 1836, 506, 1841,
+        504, 1920, 307, 1920], "confidence": 0.885}, {"text": "&", "boundingBox":
+        [523, 1841, 568, 1842, 566, 1921, 521, 1921], "confidence": 0.799}, {"text":
+        "EGGS", "boundingBox": [585, 1842, 746, 1843, 744, 1924, 583, 1921], "confidence":
+        0.949}]}, {"text": "Sunny-side-up", "boundingBox": [347, 1975, 751, 1977,
+        751, 2061, 347, 2060], "words": [{"text": "Sunny-side-up", "boundingBox":
+        [348, 1975, 749, 1979, 747, 2061, 348, 2061], "confidence": 0.946}]}, {"text":
+        "$9.5", "boundingBox": [1135, 1955, 1262, 1952, 1263, 2035, 1136, 2039], "words":
+        [{"text": "$9.5", "boundingBox": [1135, 1955, 1257, 1952, 1259, 2036, 1136,
+        2039], "confidence": 0.95}]}, {"text": "Sub-Total", "boundingBox": [440, 2229,
+        771, 2219, 773, 2318, 442, 2327], "words": [{"text": "Sub-Total", "boundingBox":
+        [441, 2229, 769, 2220, 774, 2319, 443, 2328], "confidence": 0.856}]}, {"text":
+        "$ 11.70", "boundingBox": [1092, 2221, 1301, 2224, 1299, 2319, 1093, 2317],
+        "words": [{"text": "$", "boundingBox": [1092, 2221, 1127, 2221, 1126, 2317,
+        1092, 2316], "confidence": 0.799}, {"text": "11.70", "boundingBox": [1146,
+        2221, 1297, 2223, 1296, 2319, 1145, 2317], "confidence": 0.948}]}, {"text":
+        "Tax", "boundingBox": [442, 2371, 549, 2367, 552, 2454, 445, 2458], "words":
+        [{"text": "Tax", "boundingBox": [445, 2371, 546, 2367, 549, 2454, 448, 2458],
+        "confidence": 0.958}]}, {"text": "$ 1.17", "boundingBox": [1129, 2359, 1310,
+        2359, 1306, 2456, 1129, 2456], "words": [{"text": "$", "boundingBox": [1129,
+        2359, 1171, 2359, 1171, 2456, 1129, 2456], "confidence": 0.89}, {"text": "1.17",
+        "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "confidence":
+        0.942}]}, {"text": "Tip", "boundingBox": [433, 2505, 539, 2506, 540, 2602,
+        434, 2602], "words": [{"text": "Tip", "boundingBox": [436, 2505, 536, 2505,
+        536, 2602, 436, 2602], "confidence": 0.959}]}, {"text": "$ 1.63", "boundingBox":
+        [1030, 2478, 1269, 2486, 1267, 2591, 1024, 2583], "words": [{"text": "$",
+        "boundingBox": [1027, 2478, 1073, 2478, 1069, 2584, 1024, 2583], "confidence":
+        0.788}, {"text": "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591,
+        1091, 2585], "confidence": 0.284}]}, {"text": "Total", "boundingBox": [433,
+        2652, 611, 2644, 615, 2738, 436, 2747], "words": [{"text": "Total", "boundingBox":
+        [435, 2652, 609, 2644, 613, 2739, 439, 2747], "confidence": 0.866}]}, {"text":
+        "$14.50", "boundingBox": [1034, 2620, 1386, 2637, 1380, 2762, 1029, 2739],
+        "words": [{"text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380,
+        2763, 1030, 2739], "confidence": 0.57}]}]}], "documentResults": [{"docType":
+        "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType": {"type":
+        "string", "valueString": "Itemized", "confidence": 0.692}, "MerchantName":
         {"type": "string", "valueString": "Contoso Contoso", "text": "Contoso Contoso",
-        "boundingBox": [380.9, 282.9, 1116, 473.2, 1025, 824.4, 290, 634], "page":
-        1, "confidence": 0.716, "elements": ["#/readResults/0/lines/1/words/0", "#/readResults/0/lines/0/words/0"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
-        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [298.3,
-        676.5, 844.6, 781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989,
-        "elements": ["#/readResults/0/lines/2/words/0", "#/readResults/0/lines/2/words/1",
-        "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1",
-        "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber": {"type": "phoneNumber",
-        "valuePhoneNumber": "+19876543210", "text": "987-654-3210", "boundingBox":
-        [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence": 0.99,
-        "elements": ["#/readResults/0/lines/4/words/0"]}, "TransactionDate": {"type":
-        "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox": [259,
-        1224, 510, 1246, 505, 1331, 255, 1312], "page": 1, "confidence": 0.99, "elements":
-        ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type": "time",
-        "valueTime": "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681,
-        1262, 675, 1341, 522, 1332], "page": 1, "confidence": 0.989, "elements": ["#/readResults/0/lines/5/words/1"]},
-        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        "boundingBox": [378.2, 292.4, 1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8],
+        "page": 1, "confidence": 0.613, "elements": ["#/readResults/0/lines/0/words/0",
+        "#/readResults/0/lines/1/words/0"]}, "MerchantAddress": {"type": "string",
+        "valueString": "123 Main Street Redmond, WA 98052", "text": "123 Main Street
+        Redmond, WA 98052", "boundingBox": [302, 675.8, 848.1, 793.7, 809.9, 970.4,
+        263.9, 852.5], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/2/words/0",
+        "#/readResults/0/lines/2/words/1", "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0",
+        "#/readResults/0/lines/3/words/1", "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber":
+        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
+        "boundingBox": [278, 1004, 656, 1057, 647, 1123, 271, 1075], "page": 1, "confidence":
+        0.99, "elements": ["#/readResults/0/lines/4/words/0"]}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99,
+        "elements": ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type":
+        "time", "valueTime": "13:59:00", "text": "13:59", "boundingBox": [541, 1248,
+        677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence": 0.977, "elements":
+        ["#/readResults/0/lines/5/words/1"]}, "Items": {"type": "array", "valueArray":
+        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
+        1, "text": "1", "boundingBox": [245, 1583, 299, 1585, 295, 1676, 241, 1671],
+        "page": 1, "confidence": 0.92, "elements": ["#/readResults/0/lines/7/words/0"]},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923, "elements": ["#/readResults/0/lines/7/words/1"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1108, 1584,
+        1263, 1574, 1268, 1656, 1113, 1666], "page": 1, "confidence": 0.918, "elements":
+        ["#/readResults/0/lines/8/words/0"]}}}, {"type": "object", "valueObject":
         {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [244, 1581, 288, 1584, 285, 1678, 241, 1675], "page": 1, "confidence": 0.919,
-        "elements": ["#/readResults/0/lines/7/words/0"]}, "Name": {"type": "string",
-        "valueString": "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585,
-        658, 1598, 657, 1688, 304, 1679], "page": 1, "confidence": 0.959, "elements":
-        ["#/readResults/0/lines/7/words/1"]}, "TotalPrice": {"type": "number", "valueNumber":
-        2.2, "text": "$2.20", "boundingBox": [1106, 1579, 1260, 1574, 1263, 1656,
-        1108, 1662], "page": 1, "confidence": 0.959, "elements": ["#/readResults/0/lines/8/words/0"]}}},
-        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91, "elements": ["#/readResults/0/lines/9/words/0"]},
-        "Name": {"type": "string", "valueString": "BACON & EGGS", "text": "BACON &
-        EGGS", "boundingBox": [294, 1839, 737, 1839, 737, 1924, 294, 1924], "page":
-        1, "confidence": 0.955, "elements": ["#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2",
+        [232, 1834, 286, 1836, 285, 1920, 231, 1920], "page": 1, "confidence": 0.858,
+        "elements": ["#/readResults/0/lines/9/words/0"]}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916,
+        "elements": ["#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2",
         "#/readResults/0/lines/9/words/3"]}, "TotalPrice": {"type": "number", "valueNumber":
-        9.5, "text": "$9.5", "boundingBox": [1134, 1948, 1252, 1948, 1252, 2041, 1134,
-        2041], "page": 1, "confidence": 0.958, "elements": ["#/readResults/0/lines/11/words/0"]}}}]},
+        9.5, "text": "$9.5", "boundingBox": [1135, 1955, 1257, 1952, 1259, 2036, 1136,
+        2039], "page": 1, "confidence": 0.916, "elements": ["#/readResults/0/lines/11/words/0"]}}}]},
         "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923, "elements": ["#/readResults/0/lines/17/words/1"]}, "Tax": {"type":
-        "number", "valueNumber": 1.17, "text": "1.17", "boundingBox": [1186, 2356,
-        1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence": 0.979, "elements":
-        ["#/readResults/0/lines/19/words/1"]}, "Tip": {"type": "number", "valueNumber":
-        463, "text": "$463", "boundingBox": [1034, 2483, 1268, 2488, 1266, 2583, 1032,
-        2577], "page": 1, "confidence": 0.975, "elements": ["#/readResults/0/lines/21/words/0"]},
+        [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1, "confidence":
+        0.955, "elements": ["#/readResults/0/lines/13/words/1"]}, "Tax": {"type":
+        "number", "valueNumber": 1.17, "text": "1.17", "boundingBox": [1190, 2359,
+        1304, 2359, 1304, 2456, 1190, 2456], "page": 1, "confidence": 0.979, "elements":
+        ["#/readResults/0/lines/15/words/1"]}, "Tip": {"type": "number", "valueNumber":
+        1.63, "text": "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591,
+        1091, 2585], "page": 1, "confidence": 0.941, "elements": ["#/readResults/0/lines/17/words/1"]},
         "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50", "boundingBox":
-        [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1, "confidence":
-        0.987, "elements": ["#/readResults/0/lines/23/words/0"]}}}]}}'
+        [1034, 2620, 1384, 2638, 1380, 2763, 1030, 2739], "page": 1, "confidence":
+        0.985, "elements": ["#/readResults/0/lines/19/words/0"]}}}]}}'
     headers:
-      apim-request-id: 155eae0a-72db-4b33-9e4f-5631ae3d7fb9
-      content-length: '10546'
+      apim-request-id: 30fe329a-5218-4bd3-92a2-4cdf50a331fe
+      content-length: '8501'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:09:04 GMT
+      date: Mon, 16 Nov 2020 19:14:31 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '22'
+      x-envoy-upstream-service-time: '18'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/981eb1c8-55cd-41b4-a3b0-591d012bf767
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/bfe9ce0d-6a1a-4e9f-94d7-274ba6ef1267
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_url_jpg.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_url_jpg.yaml
@@ -16,13 +16,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: 667ad306-3e57-4ed0-8b4d-09d1d77e19d9
+      apim-request-id: bbef1146-31f4-422c-8538-75fa66029509
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:09:05 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/667ad306-3e57-4ed0-8b4d-09d1d77e19d9
+      date: Mon, 16 Nov 2020 19:14:32 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/bbef1146-31f4-422c-8538-75fa66029509
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '425'
+      x-envoy-upstream-service-time: '213'
     status:
       code: 202
       message: Accepted
@@ -33,60 +33,60 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/667ad306-3e57-4ed0-8b4d-09d1d77e19d9
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/bbef1146-31f4-422c-8538-75fa66029509
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:09:05Z",
-        "lastUpdatedDateTime": "2020-11-11T18:09:07Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:14:32Z",
+        "lastUpdatedDateTime": "2020-11-16T19:14:35Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [380.9, 282.9,
-        1116, 473.2, 1025, 824.4, 290, 634], "page": 1, "confidence": 0.716}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [298.3, 676.5, 844.6,
-        781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence":
-        0.99}, "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text":
-        "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505, 1331, 255, 1312],
-        "page": 1, "confidence": 0.99}, "TransactionTime": {"type": "time", "valueTime":
-        "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681, 1262, 675, 1341,
-        522, 1332], "page": 1, "confidence": 0.989}, "Items": {"type": "array", "valueArray":
-        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [244, 1581, 288, 1584, 285, 1678, 241, 1675],
-        "page": 1, "confidence": 0.919}, "Name": {"type": "string", "valueString":
-        "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585, 658, 1598,
-        657, 1688, 304, 1679], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1106, 1579,
-        1260, 1574, 1263, 1656, 1108, 1662], "page": 1, "confidence": 0.959}}}, {"type":
-        "object", "valueObject": {"Quantity": {"type": "number", "valueNumber": 1,
-        "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [294, 1839, 737, 1839,
-        737, 1924, 294, 1924], "page": 1, "confidence": 0.955}, "TotalPrice": {"type":
-        "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox": [1134, 1948,
-        1252, 1948, 1252, 2041, 1134, 2041], "page": 1, "confidence": 0.958}}}]},
-        "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923}, "Tax": {"type": "number", "valueNumber": 1.17, "text": "1.17", "boundingBox":
-        [1186, 2356, 1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence":
-        0.979}, "Tip": {"type": "number", "valueNumber": 463, "text": "$463", "boundingBox":
-        [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "page": 1, "confidence":
-        0.975}, "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50",
-        "boundingBox": [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1,
-        "confidence": 0.987}}}]}}'
+        "Itemized", "confidence": 0.692}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [378.2, 292.4,
+        1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8], "page": 1, "confidence": 0.613},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [302,
+        675.8, 848.1, 793.7, 809.9, 970.4, 263.9, 852.5], "page": 1, "confidence":
+        0.99}, "MerchantPhoneNumber": {"type": "phoneNumber", "valuePhoneNumber":
+        "+19876543210", "text": "987-654-3210", "boundingBox": [278, 1004, 656, 1057,
+        647, 1123, 271, 1075], "page": 1, "confidence": 0.99}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99},
+        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
+        "boundingBox": [541, 1248, 677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence":
+        0.977}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
+        [245, 1583, 299, 1585, 295, 1676, 241, 1671], "page": 1, "confidence": 0.92},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923}, "TotalPrice": {"type": "number", "valueNumber": 2.2, "text": "$2.20",
+        "boundingBox": [1108, 1584, 1263, 1574, 1268, 1656, 1113, 1666], "page": 1,
+        "confidence": 0.918}}}, {"type": "object", "valueObject": {"Quantity": {"type":
+        "number", "valueNumber": 1, "text": "1", "boundingBox": [232, 1834, 286, 1836,
+        285, 1920, 231, 1920], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916},
+        "TotalPrice": {"type": "number", "valueNumber": 9.5, "text": "$9.5", "boundingBox":
+        [1135, 1955, 1257, 1952, 1259, 2036, 1136, 2039], "page": 1, "confidence":
+        0.916}}}]}, "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70",
+        "boundingBox": [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1,
+        "confidence": 0.955}, "Tax": {"type": "number", "valueNumber": 1.17, "text":
+        "1.17", "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "page":
+        1, "confidence": 0.979}, "Tip": {"type": "number", "valueNumber": 1.63, "text":
+        "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591, 1091, 2585], "page":
+        1, "confidence": 0.941}, "Total": {"type": "number", "valueNumber": 14.5,
+        "text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380, 2763, 1030,
+        2739], "page": 1, "confidence": 0.985}}}]}}'
     headers:
-      apim-request-id: 2222a333-6138-43d1-895f-e6e2688f4bb2
-      content-length: '2820'
+      apim-request-id: 1655b35b-0988-4966-b046-8110786874ce
+      content-length: '2835'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:09:10 GMT
+      date: Mon, 16 Nov 2020 19:14:37 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '24'
+      x-envoy-upstream-service-time: '20'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/667ad306-3e57-4ed0-8b4d-09d1d77e19d9
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/bbef1146-31f4-422c-8538-75fa66029509
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_url_pass_stream.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_url_pass_stream.yaml
@@ -14,16 +14,16 @@ interactions:
     uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyze?includeTextDetails=false
   response:
     body:
-      string: '{"error": {"code": "InvalidImageURL", "innerError": {"requestId": "aae1526a-b2a9-4070-9dbc-94211d0d9379"},
+      string: '{"error": {"code": "InvalidImageURL", "innerError": {"requestId": "42a6bd69-98b4-44e4-ab2d-bdaea3b609d6"},
         "message": "Image URL is badly formatted."}}'
     headers:
-      apim-request-id: aae1526a-b2a9-4070-9dbc-94211d0d9379
+      apim-request-id: 42a6bd69-98b4-44e4-ab2d-bdaea3b609d6
       content-length: '144'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:09:10 GMT
+      date: Mon, 16 Nov 2020 19:14:38 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '4'
+      x-envoy-upstream-service-time: '3'
     status:
       code: 400
       message: Bad Request

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_url_png.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_url_png.yaml
@@ -16,13 +16,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: e8f0eb8c-4058-4005-a745-3ea9bd361293
+      apim-request-id: 877216a5-1ef2-4738-90df-7e5e0154256f
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:09:11 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/e8f0eb8c-4058-4005-a745-3ea9bd361293
+      date: Mon, 16 Nov 2020 19:14:38 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/877216a5-1ef2-4738-90df-7e5e0154256f
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '361'
+      x-envoy-upstream-service-time: '263'
     status:
       code: 202
       message: Accepted
@@ -33,55 +33,56 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/e8f0eb8c-4058-4005-a745-3ea9bd361293
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/877216a5-1ef2-4738-90df-7e5e0154256f
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:09:12Z",
-        "lastUpdatedDateTime": "2020-11-11T18:09:15Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": -0.0752, "width": 1688, "height":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:14:38Z",
+        "lastUpdatedDateTime": "2020-11-16T19:14:40Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.2511, "width": 1688, "height":
         3000, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:receipt",
         "pageRange": [1, 1], "fields": {"ReceiptType": {"type": "string", "valueString":
-        "Itemized", "confidence": 0.99}, "MerchantName": {"type": "string", "valueString":
-        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [342.9, 238.1,
-        1061, 278.6, 1038.1, 685.5, 320, 645], "page": 1, "confidence": 0.693}, "MerchantAddress":
-        {"type": "string", "valueString": "123 Main Street Redmond, WA 98052", "text":
-        "123 Main Street Redmond, WA 98052", "boundingBox": [308.4, 688, 751.3, 689,
-        750.8, 859.6, 308, 858.5], "page": 1, "confidence": 0.989}, "MerchantPhoneNumber":
-        {"type": "phoneNumber", "text": "123-456-7890", "boundingBox": [303, 1003,
-        623, 1009, 621, 1071, 303, 1064], "page": 1, "confidence": 0.99}, "TransactionDate":
-        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
-        [299, 1221, 494, 1222, 492, 1292, 299, 1292], "page": 1, "confidence": 0.991},
-        "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text": "13:59",
-        "boundingBox": [508, 1223, 628, 1224, 625, 1292, 506, 1292], "page": 1, "confidence":
-        0.99}, "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
-        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [327, 1558, 353, 1559, 352, 1623, 327, 1623], "page": 1, "confidence": 0.745}}},
-        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
-        "8GB RAM (Black)", "text": "8GB RAM (Black)", "boundingBox": [358, 1779, 738,
-        1779, 738, 1860, 358, 1860], "page": 1, "confidence": 0.968}, "TotalPrice":
-        {"type": "number", "valueNumber": 999, "text": "999.00", "boundingBox": [967,
-        1792, 1135, 1796, 1133, 1859, 967, 1855], "page": 1, "confidence": 0.97}}},
-        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [315, 2018, 337, 2017, 338, 2084, 316, 2085],
-        "page": 1, "confidence": 0.91}, "Name": {"type": "string", "valueString":
-        "SurfacePen", "text": "SurfacePen", "boundingBox": [350, 2017, 624, 2013,
-        624, 2079, 351, 2084], "page": 1, "confidence": 0.959}, "TotalPrice": {"type":
-        "number", "valueNumber": 99.99, "text": "$99.99", "boundingBox": [963, 2025,
-        1128, 2025, 1128, 2092, 963, 2092], "page": 1, "confidence": 0.775}}}]}, "Subtotal":
-        {"type": "number", "valueNumber": 1098.99, "text": "1098.99", "boundingBox":
-        [954, 2255, 1137, 2251, 1138, 2325, 956, 2329], "page": 1, "confidence": 0.986},
-        "Total": {"type": "number", "valueNumber": 104.4, "text": "104.40", "boundingBox":
-        [976, 2370, 1130, 2368, 1131, 2434, 977, 2438], "page": 1, "confidence": 0.668}}}]}}'
+        "Itemized", "confidence": 0.659}, "MerchantName": {"type": "string", "valueString":
+        "Contoso Contoso", "text": "Contoso Contoso", "boundingBox": [349.3, 241.3,
+        1058, 284.4, 1033.5, 687.1, 324.8, 644], "page": 1, "confidence": 0.516},
+        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
+        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [319.9,
+        689.9, 750.7, 697.5, 747.8, 865.6, 317, 858], "page": 1, "confidence": 0.986},
+        "MerchantPhoneNumber": {"type": "phoneNumber", "text": "123-456-7890", "boundingBox":
+        [306, 1005, 617, 1012, 615, 1069, 305, 1064], "page": 1, "confidence": 0.99},
+        "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019",
+        "boundingBox": [304, 1224, 506, 1224, 504, 1289, 303, 1288], "page": 1, "confidence":
+        0.985}, "TransactionTime": {"type": "time", "valueTime": "13:59:00", "text":
+        "13:59", "boundingBox": [518, 1225, 628, 1228, 627, 1290, 517, 1289], "page":
+        1, "confidence": 0.964}, "Items": {"type": "array", "valueArray": [{"type":
+        "object", "valueObject": {"Name": {"type": "string", "valueString": "8GB RAM
+        (Black)", "text": "8GB RAM (Black)", "boundingBox": [370.7, 1781.5, 731, 1785,
+        730.3, 1854, 370, 1850.6], "page": 1, "confidence": 0.916}, "TotalPrice":
+        {"type": "number", "valueNumber": 999, "text": "$999.00", "boundingBox": [939,
+        1784.6, 1134.4, 1788.3, 1133, 1863, 937.6, 1859.3], "page": 1, "confidence":
+        0.559}}}, {"type": "object", "valueObject": {"Quantity": {"type": "number",
+        "valueNumber": 1, "text": "1", "boundingBox": [321, 2021, 348, 2020, 349,
+        2084, 322, 2084], "page": 1, "confidence": 0.858}, "Name": {"type": "string",
+        "valueString": "SurfacePen", "text": "SurfacePen", "boundingBox": [360, 2020,
+        626, 2014, 628, 2077, 362, 2083], "page": 1, "confidence": 0.858}, "TotalPrice":
+        {"type": "number", "valueNumber": 99.99, "text": "99.99", "boundingBox": [1007,
+        2028, 1127, 2028, 1126, 2091, 1007, 2091], "page": 1, "confidence": 0.386}}}]},
+        "Subtotal": {"type": "number", "valueNumber": 1098.99, "text": "1098.99",
+        "boundingBox": [963, 2260, 1136, 2254, 1137, 2320, 966, 2325], "page": 1,
+        "confidence": 0.964}, "Tax": {"type": "number", "valueNumber": 104.4, "text":
+        "$104.40", "boundingBox": [942.6, 2367.5, 1132, 2363.7, 1133.4, 2434.2, 944,
+        2438], "page": 1, "confidence": 0.713}, "Total": {"type": "number", "valueNumber":
+        1203.39, "text": "1203.39", "boundingBox": [955, 2594, 1123, 2611, 1115, 2678,
+        949, 2661], "page": 1, "confidence": 0.774}}}]}}'
     headers:
-      apim-request-id: a94fa92b-63f5-4552-9f3c-60626059f8af
-      content-length: '2548'
+      apim-request-id: 1b1296f7-e759-4a05-9a57-f2c7a9a8e2be
+      content-length: '2561'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:09:16 GMT
+      date: Mon, 16 Nov 2020 19:14:43 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '25'
+      x-envoy-upstream-service-time: '21'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/e8f0eb8c-4058-4005-a745-3ea9bd361293
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/877216a5-1ef2-4738-90df-7e5e0154256f
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_url_transform_jpg.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_url_transform_jpg.yaml
@@ -16,13 +16,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: d4ce8f1c-4900-454f-8cb6-9b42b9538cfa
+      apim-request-id: 8ea89443-5659-4378-83f4-96136ddb1f23
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:09:17 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/d4ce8f1c-4900-454f-8cb6-9b42b9538cfa
+      date: Mon, 16 Nov 2020 19:14:43 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/8ea89443-5659-4378-83f4-96136ddb1f23
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '176'
+      x-envoy-upstream-service-time: '218'
     status:
       code: 202
       message: Accepted
@@ -33,168 +33,141 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/d4ce8f1c-4900-454f-8cb6-9b42b9538cfa
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/8ea89443-5659-4378-83f4-96136ddb1f23
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:09:17Z",
-        "lastUpdatedDateTime": "2020-11-11T18:09:19Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": 0.1273, "width": 1688, "height":
-        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [306,
-        569, 519, 624, 502, 686, 290, 632], "words": [{"text": "Contoso", "boundingBox":
-        [308, 570, 515, 627, 500, 685, 290, 634], "confidence": 0.806}], "appearance":
-        {"style": {"name": "print", "confidence": 0.996}}}, {"text": "Contoso", "boundingBox":
-        [625, 512, 1089, 465, 1096, 561, 631, 607], "words": [{"text": "Contoso",
-        "boundingBox": [625, 512, 1088, 466, 1093, 562, 631, 607], "confidence": 0.984}],
-        "appearance": {"style": {"name": "print", "confidence": 0.999}}}, {"text":
-        "123 Main Street", "boundingBox": [301, 677, 697, 759, 681, 835, 284, 750],
-        "words": [{"text": "123", "boundingBox": [301, 677, 379, 692, 362, 766, 284,
-        751], "confidence": 0.987}, {"text": "Main", "boundingBox": [393, 695, 520,
-        721, 503, 795, 377, 769], "confidence": 0.985}, {"text": "Street", "boundingBox":
-        [534, 724, 694, 763, 676, 835, 517, 798], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.995}}}, {"text": "Redmond, WA
-        98052", "boundingBox": [284, 784, 823, 855, 814, 925, 275, 868], "words":
-        [{"text": "Redmond,", "boundingBox": [287, 784, 544, 829, 535, 905, 275, 853],
-        "confidence": 0.924}, {"text": "WA", "boundingBox": [558, 830, 640, 840, 632,
-        916, 549, 907], "confidence": 0.985}, {"text": "98052", "boundingBox": [654,
-        842, 822, 855, 817, 925, 646, 917], "confidence": 0.985}], "appearance": {"style":
-        {"name": "print", "confidence": 0.999}}}, {"text": "987-654-3210", "boundingBox":
-        [270, 999, 655, 1049, 646, 1125, 264, 1075], "words": [{"text": "987-654-3210",
-        "boundingBox": [271, 1000, 651, 1049, 643, 1125, 264, 1075], "confidence":
-        0.978}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "6/10/2019 13:59", "boundingBox": [258, 1224, 683, 1259, 676, 1341, 255, 1309],
-        "words": [{"text": "6/10/2019", "boundingBox": [259, 1224, 510, 1246, 505,
-        1331, 255, 1312], "confidence": 0.951}, {"text": "13:59", "boundingBox": [527,
-        1248, 681, 1262, 675, 1341, 522, 1332], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "Sales Associate:
-        Paul", "boundingBox": [252, 1347, 860, 1378, 859, 1449, 249, 1425], "words":
-        [{"text": "Sales", "boundingBox": [255, 1348, 409, 1358, 405, 1432, 249, 1419],
-        "confidence": 0.983}, {"text": "Associate:", "boundingBox": [423, 1359, 704,
-        1373, 703, 1447, 419, 1434], "confidence": 0.933}, {"text": "Paul", "boundingBox":
-        [718, 1373, 858, 1378, 859, 1449, 717, 1448], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "1 Cappuccino", "boundingBox":
-        [244, 1581, 660, 1597, 658, 1688, 241, 1675], "words": [{"text": "1", "boundingBox":
-        [244, 1581, 288, 1584, 285, 1678, 241, 1675], "confidence": 0.977}, {"text":
-        "Cappuccino", "boundingBox": [306, 1585, 658, 1598, 657, 1688, 304, 1679],
-        "confidence": 0.858}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "$2.20", "boundingBox": [1106, 1580, 1264, 1574, 1268, 1656,
-        1108, 1662], "words": [{"text": "$2.20", "boundingBox": [1106, 1579, 1260,
-        1574, 1263, 1656, 1108, 1662], "confidence": 0.981}], "appearance": {"style":
-        {"name": "print", "confidence": 0.849}}}, {"text": "1 BACON & EGGS", "boundingBox":
-        [226, 1838, 740, 1839, 740, 1924, 226, 1923], "words": [{"text": "1", "boundingBox":
-        [227, 1839, 278, 1839, 277, 1924, 226, 1924], "confidence": 0.986}, {"text":
-        "BACON", "boundingBox": [295, 1839, 493, 1840, 493, 1923, 294, 1924], "confidence":
-        0.984}, {"text": "&", "boundingBox": [510, 1840, 555, 1840, 555, 1923, 510,
-        1923], "confidence": 0.983}, {"text": "EGGS", "boundingBox": [572, 1840, 737,
-        1841, 736, 1924, 572, 1923], "confidence": 0.984}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "Sunny-side-up", "boundingBox":
-        [343, 1976, 758, 1974, 759, 2061, 343, 2063], "words": [{"text": "Sunny-side-up",
-        "boundingBox": [343, 1977, 757, 1975, 755, 2063, 346, 2064], "confidence":
-        0.973}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "$9.5", "boundingBox": [1134, 1948, 1253, 1948, 1255, 2041, 1137, 2041], "words":
-        [{"text": "$9.5", "boundingBox": [1134, 1948, 1252, 1948, 1252, 2041, 1134,
-        2041], "confidence": 0.983}], "appearance": {"style": {"name": "print", "confidence":
-        0.932}}}, {"text": "- -", "boundingBox": [218, 2143, 291, 2140, 292, 2158,
-        218, 2161], "words": [{"text": "-", "boundingBox": [236, 2143, 255, 2143,
-        255, 2161, 235, 2161], "confidence": 0.559}, {"text": "-", "boundingBox":
-        [271, 2142, 290, 2141, 291, 2158, 272, 2160], "confidence": 0.985}], "appearance":
-        {"style": {"name": "print", "confidence": 0.67}}}, {"text": "-----", "boundingBox":
-        [277, 2142, 461, 2136, 461, 2155, 278, 2161], "words": [{"text": "-----",
-        "boundingBox": [305, 2141, 457, 2136, 458, 2155, 305, 2161], "confidence":
-        0.69}], "appearance": {"style": {"name": "print", "confidence": 0.467}}},
-        {"text": "----", "boundingBox": [471, 2137, 565, 2133, 566, 2150, 472, 2154],
-        "words": [{"text": "----", "boundingBox": [473, 2138, 566, 2134, 566, 2150,
-        473, 2154], "confidence": 0.559}], "appearance": {"style": {"name": "print",
-        "confidence": 0.703}}}, {"text": "--", "boundingBox": [1252, 2129, 1319, 2127,
-        1320, 2143, 1252, 2146], "words": [{"text": "--", "boundingBox": [1277, 2129,
-        1319, 2127, 1319, 2144, 1276, 2145], "confidence": 0.559}], "appearance":
-        {"style": {"name": "print", "confidence": 0.846}}}, {"text": "Sub-Total",
-        "boundingBox": [434, 2232, 768, 2222, 770, 2312, 437, 2322], "words": [{"text":
-        "Sub-Total", "boundingBox": [434, 2234, 769, 2222, 770, 2313, 442, 2322],
-        "confidence": 0.981}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "$ 11.70", "boundingBox": [1082, 2228, 1309, 2228, 1309, 2313,
-        1084, 2312], "words": [{"text": "$", "boundingBox": [1082, 2228, 1122, 2228,
-        1121, 2313, 1082, 2312], "confidence": 0.654}, {"text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "confidence": 0.984}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "Tax", "boundingBox":
-        [433, 2367, 563, 2363, 565, 2458, 435, 2462], "words": [{"text": "Tax", "boundingBox":
-        [433, 2367, 559, 2363, 562, 2458, 435, 2462], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 0.98}}}, {"text": "$ 1.17", "boundingBox":
-        [1125, 2353, 1306, 2362, 1304, 2451, 1121, 2444], "words": [{"text": "$",
-        "boundingBox": [1125, 2353, 1167, 2355, 1163, 2446, 1121, 2444], "confidence":
-        0.966}, {"text": "1.17", "boundingBox": [1186, 2356, 1307, 2361, 1303, 2452,
-        1182, 2447], "confidence": 0.983}], "appearance": {"style": {"name": "print",
-        "confidence": 0.963}}}, {"text": "Tip", "boundingBox": [439, 2502, 545, 2506,
-        541, 2606, 435, 2602], "words": [{"text": "Tip", "boundingBox": [438, 2502,
-        545, 2506, 541, 2606, 435, 2602], "confidence": 0.987}], "appearance": {"style":
-        {"name": "print", "confidence": 0.943}}}, {"text": "$463", "boundingBox":
-        [1038, 2483, 1271, 2489, 1269, 2583, 1032, 2577], "words": [{"text": "$463",
-        "boundingBox": [1034, 2483, 1268, 2488, 1266, 2583, 1032, 2577], "confidence":
-        0.592}], "appearance": {"style": {"name": "handwriting", "confidence": 0.892}}},
-        {"text": "Total", "boundingBox": [431, 2651, 607, 2646, 610, 2739, 435, 2745],
-        "words": [{"text": "Total", "boundingBox": [431, 2651, 605, 2646, 608, 2739,
-        433, 2745], "confidence": 0.983}], "appearance": {"style": {"name": "print",
-        "confidence": 0.991}}}, {"text": "$14.50", "boundingBox": [1034, 2623, 1381,
-        2642, 1374, 2757, 1027, 2740], "words": [{"text": "$14.50", "boundingBox":
-        [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "confidence": 0.845}], "appearance":
-        {"style": {"name": "handwriting", "confidence": 0.991}}}]}], "documentResults":
-        [{"docType": "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType":
-        {"type": "string", "valueString": "Itemized", "confidence": 0.99}, "MerchantName":
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:14:44Z",
+        "lastUpdatedDateTime": "2020-11-16T19:14:45Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.6893, "width": 1688, "height":
+        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [635,
+        510, 1086, 461, 1098, 558, 643, 604], "words": [{"text": "Contoso", "boundingBox":
+        [639, 510, 1087, 461, 1098, 551, 646, 604], "confidence": 0.955}]}, {"text":
+        "Contoso", "boundingBox": [305, 574, 519, 624, 504, 686, 291, 634], "words":
+        [{"text": "Contoso", "boundingBox": [311, 575, 517, 623, 503, 686, 297, 636],
+        "confidence": 0.435}]}, {"text": "123 Main Street", "boundingBox": [300, 675,
+        703, 767, 686, 844, 284, 749], "words": [{"text": "123", "boundingBox": [302,
+        676, 390, 695, 375, 770, 287, 751], "confidence": 0.935}, {"text": "Main",
+        "boundingBox": [405, 698, 528, 726, 512, 802, 390, 774], "confidence": 0.958},
+        {"text": "Street", "boundingBox": [542, 730, 702, 767, 685, 845, 527, 806],
+        "confidence": 0.959}]}, {"text": "Redmond, WA 98052", "boundingBox": [290,
+        784, 828, 850, 820, 933, 279, 868], "words": [{"text": "Redmond,", "boundingBox":
+        [293, 784, 550, 826, 540, 905, 280, 856], "confidence": 0.762}, {"text": "WA",
+        "boundingBox": [565, 828, 645, 837, 637, 917, 555, 907], "confidence": 0.943},
+        {"text": "98052", "boundingBox": [660, 838, 824, 849, 818, 933, 651, 919],
+        "confidence": 0.959}]}, {"text": "987-654-3210", "boundingBox": [275, 1003,
+        656, 1055, 646, 1123, 269, 1073], "words": [{"text": "987-654-3210", "boundingBox":
+        [278, 1004, 656, 1057, 647, 1123, 271, 1075], "confidence": 0.939}]}, {"text":
+        "6/10/2019 13:59", "boundingBox": [265, 1228, 678, 1258, 671, 1344, 258, 1311],
+        "words": [{"text": "6/10/2019", "boundingBox": [267, 1229, 525, 1247, 517,
+        1332, 259, 1313], "confidence": 0.762}, {"text": "13:59", "boundingBox": [541,
+        1248, 677, 1263, 669, 1345, 533, 1333], "confidence": 0.958}]}, {"text": "Sales
+        Associate: Paul", "boundingBox": [253, 1347, 868, 1379, 863, 1457, 249, 1425],
+        "words": [{"text": "Sales", "boundingBox": [259, 1348, 419, 1359, 414, 1435,
+        252, 1422], "confidence": 0.92}, {"text": "Associate:", "boundingBox": [434,
+        1360, 711, 1374, 707, 1452, 428, 1436], "confidence": 0.909}, {"text": "Paul",
+        "boundingBox": [726, 1374, 865, 1379, 862, 1457, 722, 1452], "confidence":
+        0.959}]}, {"text": "1 Cappuccino", "boundingBox": [244, 1583, 658, 1601, 653,
+        1689, 240, 1674], "words": [{"text": "1", "boundingBox": [245, 1583, 299,
+        1585, 295, 1676, 241, 1671], "confidence": 0.824}, {"text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "confidence":
+        0.727}]}, {"text": "$2.20", "boundingBox": [1106, 1584, 1268, 1574, 1270,
+        1656, 1110, 1666], "words": [{"text": "$2.20", "boundingBox": [1108, 1584,
+        1263, 1574, 1268, 1656, 1113, 1666], "confidence": 0.958}]}, {"text": "1 BACON
+        & EGGS", "boundingBox": [232, 1834, 745, 1840, 744, 1924, 231, 1918], "words":
+        [{"text": "1", "boundingBox": [232, 1834, 286, 1836, 285, 1920, 231, 1920],
+        "confidence": 0.845}, {"text": "BACON", "boundingBox": [308, 1836, 506, 1841,
+        504, 1920, 307, 1920], "confidence": 0.885}, {"text": "&", "boundingBox":
+        [523, 1841, 568, 1842, 566, 1921, 521, 1921], "confidence": 0.799}, {"text":
+        "EGGS", "boundingBox": [585, 1842, 746, 1843, 744, 1924, 583, 1921], "confidence":
+        0.949}]}, {"text": "Sunny-side-up", "boundingBox": [347, 1975, 751, 1977,
+        751, 2061, 347, 2060], "words": [{"text": "Sunny-side-up", "boundingBox":
+        [348, 1975, 749, 1979, 747, 2061, 348, 2061], "confidence": 0.946}]}, {"text":
+        "$9.5", "boundingBox": [1135, 1955, 1262, 1952, 1263, 2035, 1136, 2039], "words":
+        [{"text": "$9.5", "boundingBox": [1135, 1955, 1257, 1952, 1259, 2036, 1136,
+        2039], "confidence": 0.95}]}, {"text": "Sub-Total", "boundingBox": [440, 2229,
+        771, 2219, 773, 2318, 442, 2327], "words": [{"text": "Sub-Total", "boundingBox":
+        [441, 2229, 769, 2220, 774, 2319, 443, 2328], "confidence": 0.856}]}, {"text":
+        "$ 11.70", "boundingBox": [1092, 2221, 1301, 2224, 1299, 2319, 1093, 2317],
+        "words": [{"text": "$", "boundingBox": [1092, 2221, 1127, 2221, 1126, 2317,
+        1092, 2316], "confidence": 0.799}, {"text": "11.70", "boundingBox": [1146,
+        2221, 1297, 2223, 1296, 2319, 1145, 2317], "confidence": 0.948}]}, {"text":
+        "Tax", "boundingBox": [442, 2371, 549, 2367, 552, 2454, 445, 2458], "words":
+        [{"text": "Tax", "boundingBox": [445, 2371, 546, 2367, 549, 2454, 448, 2458],
+        "confidence": 0.958}]}, {"text": "$ 1.17", "boundingBox": [1129, 2359, 1310,
+        2359, 1306, 2456, 1129, 2456], "words": [{"text": "$", "boundingBox": [1129,
+        2359, 1171, 2359, 1171, 2456, 1129, 2456], "confidence": 0.89}, {"text": "1.17",
+        "boundingBox": [1190, 2359, 1304, 2359, 1304, 2456, 1190, 2456], "confidence":
+        0.942}]}, {"text": "Tip", "boundingBox": [433, 2505, 539, 2506, 540, 2602,
+        434, 2602], "words": [{"text": "Tip", "boundingBox": [436, 2505, 536, 2505,
+        536, 2602, 436, 2602], "confidence": 0.959}]}, {"text": "$ 1.63", "boundingBox":
+        [1030, 2478, 1269, 2486, 1267, 2591, 1024, 2583], "words": [{"text": "$",
+        "boundingBox": [1027, 2478, 1073, 2478, 1069, 2584, 1024, 2583], "confidence":
+        0.788}, {"text": "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591,
+        1091, 2585], "confidence": 0.284}]}, {"text": "Total", "boundingBox": [433,
+        2652, 611, 2644, 615, 2738, 436, 2747], "words": [{"text": "Total", "boundingBox":
+        [435, 2652, 609, 2644, 613, 2739, 439, 2747], "confidence": 0.866}]}, {"text":
+        "$14.50", "boundingBox": [1034, 2620, 1386, 2637, 1380, 2762, 1029, 2739],
+        "words": [{"text": "$14.50", "boundingBox": [1034, 2620, 1384, 2638, 1380,
+        2763, 1030, 2739], "confidence": 0.57}]}]}], "documentResults": [{"docType":
+        "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType": {"type":
+        "string", "valueString": "Itemized", "confidence": 0.692}, "MerchantName":
         {"type": "string", "valueString": "Contoso Contoso", "text": "Contoso Contoso",
-        "boundingBox": [380.9, 282.9, 1116, 473.2, 1025, 824.4, 290, 634], "page":
-        1, "confidence": 0.716, "elements": ["#/readResults/0/lines/1/words/0", "#/readResults/0/lines/0/words/0"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
-        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [298.3,
-        676.5, 844.6, 781.5, 810.7, 958, 264.4, 853], "page": 1, "confidence": 0.989,
-        "elements": ["#/readResults/0/lines/2/words/0", "#/readResults/0/lines/2/words/1",
-        "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1",
-        "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber": {"type": "phoneNumber",
-        "valuePhoneNumber": "+19876543210", "text": "987-654-3210", "boundingBox":
-        [271, 1000, 651, 1049, 643, 1125, 264, 1075], "page": 1, "confidence": 0.99,
-        "elements": ["#/readResults/0/lines/4/words/0"]}, "TransactionDate": {"type":
-        "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox": [259,
-        1224, 510, 1246, 505, 1331, 255, 1312], "page": 1, "confidence": 0.99, "elements":
-        ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type": "time",
-        "valueTime": "13:59:00", "text": "13:59", "boundingBox": [527, 1248, 681,
-        1262, 675, 1341, 522, 1332], "page": 1, "confidence": 0.989, "elements": ["#/readResults/0/lines/5/words/1"]},
-        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        "boundingBox": [378.2, 292.4, 1117.7, 468.3, 1035.7, 812.7, 296.3, 636.8],
+        "page": 1, "confidence": 0.613, "elements": ["#/readResults/0/lines/0/words/0",
+        "#/readResults/0/lines/1/words/0"]}, "MerchantAddress": {"type": "string",
+        "valueString": "123 Main Street Redmond, WA 98052", "text": "123 Main Street
+        Redmond, WA 98052", "boundingBox": [302, 675.8, 848.1, 793.7, 809.9, 970.4,
+        263.9, 852.5], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/2/words/0",
+        "#/readResults/0/lines/2/words/1", "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0",
+        "#/readResults/0/lines/3/words/1", "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber":
+        {"type": "phoneNumber", "valuePhoneNumber": "+19876543210", "text": "987-654-3210",
+        "boundingBox": [278, 1004, 656, 1057, 647, 1123, 271, 1075], "page": 1, "confidence":
+        0.99, "elements": ["#/readResults/0/lines/4/words/0"]}, "TransactionDate":
+        {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox":
+        [267, 1229, 525, 1247, 517, 1332, 259, 1313], "page": 1, "confidence": 0.99,
+        "elements": ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type":
+        "time", "valueTime": "13:59:00", "text": "13:59", "boundingBox": [541, 1248,
+        677, 1263, 669, 1345, 533, 1333], "page": 1, "confidence": 0.977, "elements":
+        ["#/readResults/0/lines/5/words/1"]}, "Items": {"type": "array", "valueArray":
+        [{"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
+        1, "text": "1", "boundingBox": [245, 1583, 299, 1585, 295, 1676, 241, 1671],
+        "page": 1, "confidence": 0.92, "elements": ["#/readResults/0/lines/7/words/0"]},
+        "Name": {"type": "string", "valueString": "Cappuccino", "text": "Cappuccino",
+        "boundingBox": [322, 1586, 654, 1605, 648, 1689, 318, 1678], "page": 1, "confidence":
+        0.923, "elements": ["#/readResults/0/lines/7/words/1"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 2.2, "text": "$2.20", "boundingBox": [1108, 1584,
+        1263, 1574, 1268, 1656, 1113, 1666], "page": 1, "confidence": 0.918, "elements":
+        ["#/readResults/0/lines/8/words/0"]}}}, {"type": "object", "valueObject":
         {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [244, 1581, 288, 1584, 285, 1678, 241, 1675], "page": 1, "confidence": 0.919,
-        "elements": ["#/readResults/0/lines/7/words/0"]}, "Name": {"type": "string",
-        "valueString": "Cappuccino", "text": "Cappuccino", "boundingBox": [306, 1585,
-        658, 1598, 657, 1688, 304, 1679], "page": 1, "confidence": 0.959, "elements":
-        ["#/readResults/0/lines/7/words/1"]}, "TotalPrice": {"type": "number", "valueNumber":
-        2.2, "text": "$2.20", "boundingBox": [1106, 1579, 1260, 1574, 1263, 1656,
-        1108, 1662], "page": 1, "confidence": 0.959, "elements": ["#/readResults/0/lines/8/words/0"]}}},
-        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
-        1, "text": "1", "boundingBox": [227, 1839, 278, 1839, 277, 1924, 226, 1924],
-        "page": 1, "confidence": 0.91, "elements": ["#/readResults/0/lines/9/words/0"]},
-        "Name": {"type": "string", "valueString": "BACON & EGGS", "text": "BACON &
-        EGGS", "boundingBox": [294, 1839, 737, 1839, 737, 1924, 294, 1924], "page":
-        1, "confidence": 0.955, "elements": ["#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2",
+        [232, 1834, 286, 1836, 285, 1920, 231, 1920], "page": 1, "confidence": 0.858,
+        "elements": ["#/readResults/0/lines/9/words/0"]}, "Name": {"type": "string",
+        "valueString": "BACON & EGGS", "text": "BACON & EGGS", "boundingBox": [308,
+        1836, 746, 1841.4, 745, 1925.4, 307, 1920], "page": 1, "confidence": 0.916,
+        "elements": ["#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2",
         "#/readResults/0/lines/9/words/3"]}, "TotalPrice": {"type": "number", "valueNumber":
-        9.5, "text": "$9.5", "boundingBox": [1134, 1948, 1252, 1948, 1252, 2041, 1134,
-        2041], "page": 1, "confidence": 0.958, "elements": ["#/readResults/0/lines/11/words/0"]}}}]},
+        9.5, "text": "$9.5", "boundingBox": [1135, 1955, 1257, 1952, 1259, 2036, 1136,
+        2039], "page": 1, "confidence": 0.916, "elements": ["#/readResults/0/lines/11/words/0"]}}}]},
         "Subtotal": {"type": "number", "valueNumber": 11.7, "text": "11.70", "boundingBox":
-        [1139, 2228, 1309, 2228, 1308, 2313, 1138, 2313], "page": 1, "confidence":
-        0.923, "elements": ["#/readResults/0/lines/17/words/1"]}, "Tax": {"type":
-        "number", "valueNumber": 1.17, "text": "1.17", "boundingBox": [1186, 2356,
-        1307, 2361, 1303, 2452, 1182, 2447], "page": 1, "confidence": 0.979, "elements":
-        ["#/readResults/0/lines/19/words/1"]}, "Tip": {"type": "number", "valueNumber":
-        463, "text": "$463", "boundingBox": [1034, 2483, 1268, 2488, 1266, 2583, 1032,
-        2577], "page": 1, "confidence": 0.975, "elements": ["#/readResults/0/lines/21/words/0"]},
+        [1146, 2221, 1297, 2223, 1296, 2319, 1145, 2317], "page": 1, "confidence":
+        0.955, "elements": ["#/readResults/0/lines/13/words/1"]}, "Tax": {"type":
+        "number", "valueNumber": 1.17, "text": "1.17", "boundingBox": [1190, 2359,
+        1304, 2359, 1304, 2456, 1190, 2456], "page": 1, "confidence": 0.979, "elements":
+        ["#/readResults/0/lines/15/words/1"]}, "Tip": {"type": "number", "valueNumber":
+        1.63, "text": "1.63", "boundingBox": [1094, 2479, 1267, 2485, 1264, 2591,
+        1091, 2585], "page": 1, "confidence": 0.941, "elements": ["#/readResults/0/lines/17/words/1"]},
         "Total": {"type": "number", "valueNumber": 14.5, "text": "$14.50", "boundingBox":
-        [1033, 2623, 1376, 2641, 1370, 2758, 1027, 2740], "page": 1, "confidence":
-        0.987, "elements": ["#/readResults/0/lines/23/words/0"]}}}]}}'
+        [1034, 2620, 1384, 2638, 1380, 2763, 1030, 2739], "page": 1, "confidence":
+        0.985, "elements": ["#/readResults/0/lines/19/words/0"]}}}]}}'
     headers:
-      apim-request-id: b408696a-5a60-4cfd-b8f0-7d010032cbc6
-      content-length: '10546'
+      apim-request-id: f17447c3-b60b-4280-9ed3-19856ad9e622
+      content-length: '8501'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:09:22 GMT
+      date: Mon, 16 Nov 2020 19:14:49 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '24'
+      x-envoy-upstream-service-time: '23'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/d4ce8f1c-4900-454f-8cb6-9b42b9538cfa
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/8ea89443-5659-4378-83f4-96136ddb1f23
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_url_transform_png.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipt_url_transform_png.yaml
@@ -16,13 +16,13 @@ interactions:
     body:
       string: ''
     headers:
-      apim-request-id: fc0293a0-e7a5-4a78-9826-a29081a973fb
+      apim-request-id: a13da294-038f-4b40-b2b3-998cae8b49f8
       content-length: '0'
-      date: Wed, 11 Nov 2020 18:09:23 GMT
-      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/fc0293a0-e7a5-4a78-9826-a29081a973fb
+      date: Mon, 16 Nov 2020 19:14:49 GMT
+      operation-location: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/a13da294-038f-4b40-b2b3-998cae8b49f8
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '266'
+      x-envoy-upstream-service-time: '322'
     status:
       code: 202
       message: Accepted
@@ -33,169 +33,144 @@ interactions:
       User-Agent:
       - azsdk-python-ai-formrecognizer/3.1.0b1 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/fc0293a0-e7a5-4a78-9826-a29081a973fb
+    uri: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/a13da294-038f-4b40-b2b3-998cae8b49f8
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2020-11-11T18:09:23Z",
-        "lastUpdatedDateTime": "2020-11-11T18:09:25Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": -0.0752, "width": 1688, "height":
-        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [612,
-        287, 1052, 277, 1055, 384, 614, 397], "words": [{"text": "Contoso", "boundingBox":
-        [613, 288, 1051, 278, 1055, 385, 614, 398], "confidence": 0.985}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "Contoso", "boundingBox":
-        [322, 590, 503, 599, 500, 654, 319, 644], "words": [{"text": "Contoso", "boundingBox":
-        [324, 590, 501, 601, 498, 654, 320, 645], "confidence": 0.932}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "123 Main Street",
-        "boundingBox": [317, 688, 647, 691, 646, 756, 317, 753], "words": [{"text":
-        "123", "boundingBox": [319, 688, 375, 690, 373, 755, 317, 753], "confidence":
-        0.987}, {"text": "Main", "boundingBox": [388, 691, 490, 694, 489, 756, 386,
-        755], "confidence": 0.986}, {"text": "Street", "boundingBox": [503, 694, 644,
-        695, 644, 754, 502, 756], "confidence": 0.985}], "appearance": {"style": {"name":
-        "print", "confidence": 1}}}, {"text": "Redmond, WA 98052", "boundingBox":
-        [307, 795, 752, 793, 752, 857, 307, 859], "words": [{"text": "Redmond,", "boundingBox":
-        [310, 796, 516, 796, 514, 859, 308, 858], "confidence": 0.924}, {"text": "WA",
-        "boundingBox": [528, 796, 593, 796, 591, 859, 526, 859], "confidence": 0.987},
-        {"text": "98052", "boundingBox": [605, 795, 751, 793, 749, 854, 603, 859],
-        "confidence": 0.985}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "123-456-7890", "boundingBox": [303, 1003, 623, 1008, 622,
-        1070, 303, 1063], "words": [{"text": "123-456-7890", "boundingBox": [303,
-        1003, 623, 1009, 621, 1071, 303, 1064], "confidence": 0.978}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "6/10/2019 13:59",
-        "boundingBox": [299, 1221, 631, 1222, 631, 1291, 299, 1290], "words": [{"text":
-        "6/10/2019", "boundingBox": [299, 1221, 494, 1222, 492, 1292, 299, 1292],
-        "confidence": 0.955}, {"text": "13:59", "boundingBox": [508, 1223, 628, 1224,
-        625, 1292, 506, 1292], "confidence": 0.985}], "appearance": {"style": {"name":
-        "print", "confidence": 0.998}}}, {"text": "Sales Associate: Paul", "boundingBox":
-        [299, 1335, 772, 1335, 772, 1398, 299, 1396], "words": [{"text": "Sales",
-        "boundingBox": [299, 1335, 406, 1337, 408, 1397, 301, 1396], "confidence":
-        0.986}, {"text": "Associate:", "boundingBox": [418, 1337, 644, 1337, 645,
-        1399, 419, 1397], "confidence": 0.979}, {"text": "Paul", "boundingBox": [656,
-        1337, 771, 1335, 771, 1399, 656, 1399], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}, {"text": "---", "boundingBox":
-        [306, 1470, 370, 1469, 370, 1488, 306, 1489], "words": [{"text": "---", "boundingBox":
-        [307, 1471, 370, 1470, 371, 1489, 307, 1490], "confidence": 0.825}], "appearance":
-        {"style": {"name": "print", "confidence": 0.876}}}, {"text": "--- - -", "boundingBox":
-        [1021, 1474, 1112, 1473, 1112, 1490, 1021, 1491], "words": [{"text": "---",
-        "boundingBox": [1021, 1475, 1061, 1475, 1061, 1491, 1021, 1491], "confidence":
-        0.669}, {"text": "-", "boundingBox": [1068, 1475, 1084, 1474, 1084, 1491,
-        1067, 1491], "confidence": 0.966}, {"text": "-", "boundingBox": [1092, 1474,
-        1109, 1474, 1108, 1491, 1092, 1491], "confidence": 0.968}], "appearance":
-        {"style": {"name": "print", "confidence": 0.996}}}, {"text": "1 Surface Pro
-        6", "boundingBox": [327, 1558, 679, 1560, 678, 1624, 326, 1622], "words":
-        [{"text": "1", "boundingBox": [327, 1558, 353, 1559, 352, 1623, 327, 1623],
-        "confidence": 0.983}, {"text": "Surface", "boundingBox": [366, 1559, 536,
-        1561, 535, 1624, 365, 1623], "confidence": 0.983}, {"text": "Pro", "boundingBox":
-        [549, 1561, 622, 1562, 621, 1624, 548, 1624], "confidence": 0.952}, {"text":
-        "6", "boundingBox": [635, 1562, 677, 1563, 676, 1624, 633, 1624], "confidence":
-        0.986}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "256GB / Intel Core i5 /", "boundingBox": [366, 1666, 850, 1668, 849, 1746,
-        366, 1744], "words": [{"text": "256GB", "boundingBox": [367, 1667, 493, 1668,
-        492, 1745, 366, 1744], "confidence": 0.984}, {"text": "/", "boundingBox":
-        [508, 1668, 518, 1669, 517, 1745, 507, 1745], "confidence": 0.985}, {"text":
-        "Intel", "boundingBox": [533, 1669, 634, 1669, 632, 1746, 532, 1745], "confidence":
-        0.906}, {"text": "Core", "boundingBox": [649, 1669, 745, 1669, 743, 1747,
-        647, 1746], "confidence": 0.986}, {"text": "i5", "boundingBox": [760, 1669,
-        795, 1669, 793, 1747, 758, 1747], "confidence": 0.886}, {"text": "/", "boundingBox":
-        [811, 1669, 851, 1669, 848, 1747, 808, 1747], "confidence": 0.983}], "appearance":
-        {"style": {"name": "print", "confidence": 0.999}}}, {"text": "8GB RAM (Black)",
-        "boundingBox": [357, 1779, 738, 1779, 738, 1858, 357, 1859], "words": [{"text":
-        "8GB", "boundingBox": [359, 1779, 434, 1779, 433, 1860, 358, 1860], "confidence":
-        0.942}, {"text": "RAM", "boundingBox": [450, 1779, 546, 1779, 545, 1859, 449,
-        1860], "confidence": 0.986}, {"text": "(Black)", "boundingBox": [562, 1779,
-        738, 1780, 737, 1860, 561, 1859], "confidence": 0.982}], "appearance": {"style":
-        {"name": "print", "confidence": 0.999}}}, {"text": "999.00", "boundingBox":
-        [967, 1792, 1136, 1797, 1134, 1858, 967, 1855], "words": [{"text": "999.00",
-        "boundingBox": [967, 1792, 1135, 1796, 1133, 1859, 967, 1855], "confidence":
-        0.984}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "1 SurfacePen", "boundingBox": [314, 2017, 626, 2013, 627, 2078, 316, 2084],
-        "words": [{"text": "1", "boundingBox": [315, 2018, 337, 2017, 338, 2084, 316,
-        2085], "confidence": 0.986}, {"text": "SurfacePen", "boundingBox": [350, 2017,
-        624, 2013, 624, 2079, 351, 2084], "confidence": 0.979}], "appearance": {"style":
-        {"name": "print", "confidence": 1}}}, {"text": "$ 99.99", "boundingBox": [963,
-        2026, 1129, 2025, 1128, 2092, 963, 2092], "words": [{"text": "$", "boundingBox":
-        [963, 2025, 985, 2025, 985, 2092, 963, 2092], "confidence": 0.986}, {"text":
-        "99.99", "boundingBox": [999, 2025, 1128, 2025, 1128, 2092, 999, 2092], "confidence":
-        0.982}], "appearance": {"style": {"name": "print", "confidence": 0.994}}},
-        {"text": "------ ---", "boundingBox": [279, 2166, 491, 2157, 492, 2176, 279,
-        2186], "words": [{"text": "------", "boundingBox": [280, 2167, 421, 2161,
-        421, 2178, 280, 2186], "confidence": 0.638}, {"text": "---", "boundingBox":
-        [428, 2161, 490, 2157, 490, 2177, 427, 2178], "confidence": 0.721}], "appearance":
-        {"style": {"name": "print", "confidence": 0.903}}}, {"text": "Sub-Total",
-        "boundingBox": [464, 2243, 697, 2244, 696, 2310, 464, 2307], "words": [{"text":
-        "Sub-Total", "boundingBox": [465, 2243, 697, 2244, 694, 2311, 465, 2306],
-        "confidence": 0.935}], "appearance": {"style": {"name": "print", "confidence":
-        1}}}, {"text": "1098.99", "boundingBox": [952, 2255, 1141, 2251, 1140, 2325,
-        951, 2330], "words": [{"text": "1098.99", "boundingBox": [954, 2255, 1137,
-        2251, 1138, 2325, 956, 2329], "confidence": 0.982}], "appearance": {"style":
-        {"name": "print", "confidence": 0.995}}}, {"text": "Tax", "boundingBox": [564,
-        2349, 662, 2347, 662, 2423, 564, 2425], "words": [{"text": "Tax", "boundingBox":
-        [564, 2349, 657, 2347, 659, 2422, 564, 2424], "confidence": 0.987}], "appearance":
-        {"style": {"name": "print", "confidence": 0.993}}}, {"text": "$ 104.40", "boundingBox":
-        [940, 2371, 1131, 2368, 1129, 2433, 942, 2439], "words": [{"text": "$", "boundingBox":
-        [940, 2371, 962, 2370, 964, 2438, 941, 2439], "confidence": 0.987}, {"text":
-        "104.40", "boundingBox": [976, 2370, 1130, 2368, 1131, 2434, 977, 2438], "confidence":
-        0.984}], "appearance": {"style": {"name": "print", "confidence": 1}}}, {"text":
-        "Total", "boundingBox": [538, 2592, 669, 2590, 669, 2650, 541, 2654], "words":
-        [{"text": "Total", "boundingBox": [538, 2592, 666, 2590, 667, 2651, 539, 2654],
-        "confidence": 0.952}], "appearance": {"style": {"name": "print", "confidence":
-        0.997}}}, {"text": "$ 1203.39", "boundingBox": [914, 2591, 1124, 2610, 1117,
-        2676, 910, 2653], "words": [{"text": "$", "boundingBox": [914, 2591, 935,
-        2593, 931, 2657, 911, 2655], "confidence": 0.987}, {"text": "1203.39", "boundingBox":
-        [947, 2593, 1123, 2612, 1116, 2676, 943, 2659], "confidence": 0.982}], "appearance":
-        {"style": {"name": "print", "confidence": 1}}}]}], "documentResults": [{"docType":
-        "prebuilt:receipt", "pageRange": [1, 1], "fields": {"ReceiptType": {"type":
-        "string", "valueString": "Itemized", "confidence": 0.99}, "MerchantName":
-        {"type": "string", "valueString": "Contoso Contoso", "text": "Contoso Contoso",
-        "boundingBox": [342.9, 238.1, 1061, 278.6, 1038.1, 685.5, 320, 645], "page":
-        1, "confidence": 0.693, "elements": ["#/readResults/0/lines/0/words/0", "#/readResults/0/lines/1/words/0"]},
-        "MerchantAddress": {"type": "string", "valueString": "123 Main Street Redmond,
-        WA 98052", "text": "123 Main Street Redmond, WA 98052", "boundingBox": [308.4,
-        688, 751.3, 689, 750.8, 859.6, 308, 858.5], "page": 1, "confidence": 0.989,
-        "elements": ["#/readResults/0/lines/2/words/0", "#/readResults/0/lines/2/words/1",
-        "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0", "#/readResults/0/lines/3/words/1",
-        "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber": {"type": "phoneNumber",
-        "text": "123-456-7890", "boundingBox": [303, 1003, 623, 1009, 621, 1071, 303,
-        1064], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/4/words/0"]},
-        "TransactionDate": {"type": "date", "valueDate": "2019-06-10", "text": "6/10/2019",
-        "boundingBox": [299, 1221, 494, 1222, 492, 1292, 299, 1292], "page": 1, "confidence":
-        0.991, "elements": ["#/readResults/0/lines/5/words/0"]}, "TransactionTime":
-        {"type": "time", "valueTime": "13:59:00", "text": "13:59", "boundingBox":
-        [508, 1223, 628, 1224, 625, 1292, 506, 1292], "page": 1, "confidence": 0.99,
-        "elements": ["#/readResults/0/lines/5/words/1"]}, "Items": {"type": "array",
-        "valueArray": [{"type": "object", "valueObject": {"Quantity": {"type": "number",
-        "valueNumber": 1, "text": "1", "boundingBox": [327, 1558, 353, 1559, 352,
-        1623, 327, 1623], "page": 1, "confidence": 0.745, "elements": ["#/readResults/0/lines/9/words/0"]}}},
-        {"type": "object", "valueObject": {"Name": {"type": "string", "valueString":
-        "8GB RAM (Black)", "text": "8GB RAM (Black)", "boundingBox": [358, 1779, 738,
-        1779, 738, 1860, 358, 1860], "page": 1, "confidence": 0.968, "elements": ["#/readResults/0/lines/11/words/0",
-        "#/readResults/0/lines/11/words/1", "#/readResults/0/lines/11/words/2"]},
-        "TotalPrice": {"type": "number", "valueNumber": 999, "text": "999.00", "boundingBox":
-        [967, 1792, 1135, 1796, 1133, 1859, 967, 1855], "page": 1, "confidence": 0.97,
-        "elements": ["#/readResults/0/lines/12/words/0"]}}}, {"type": "object", "valueObject":
-        {"Quantity": {"type": "number", "valueNumber": 1, "text": "1", "boundingBox":
-        [315, 2018, 337, 2017, 338, 2084, 316, 2085], "page": 1, "confidence": 0.91,
-        "elements": ["#/readResults/0/lines/13/words/0"]}, "Name": {"type": "string",
-        "valueString": "SurfacePen", "text": "SurfacePen", "boundingBox": [350, 2017,
-        624, 2013, 624, 2079, 351, 2084], "page": 1, "confidence": 0.959, "elements":
-        ["#/readResults/0/lines/13/words/1"]}, "TotalPrice": {"type": "number", "valueNumber":
-        99.99, "text": "$99.99", "boundingBox": [963, 2025, 1128, 2025, 1128, 2092,
-        963, 2092], "page": 1, "confidence": 0.775, "elements": ["#/readResults/0/lines/14/words/0",
-        "#/readResults/0/lines/14/words/1"]}}}]}, "Subtotal": {"type": "number", "valueNumber":
-        1098.99, "text": "1098.99", "boundingBox": [954, 2255, 1137, 2251, 1138, 2325,
-        956, 2329], "page": 1, "confidence": 0.986, "elements": ["#/readResults/0/lines/17/words/0"]},
-        "Total": {"type": "number", "valueNumber": 104.4, "text": "104.40", "boundingBox":
-        [976, 2370, 1130, 2368, 1131, 2434, 977, 2438], "page": 1, "confidence": 0.668,
-        "elements": ["#/readResults/0/lines/19/words/1"]}}}]}}'
+      string: '{"status": "succeeded", "createdDateTime": "2020-11-16T19:14:50Z",
+        "lastUpdatedDateTime": "2020-11-16T19:14:53Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": 0.2511, "width": 1688, "height":
+        3000, "unit": "pixel", "lines": [{"text": "Contoso", "boundingBox": [619,
+        291, 1051, 284, 1053, 384, 620, 396], "words": [{"text": "Contoso", "boundingBox":
+        [623, 292, 1051, 284, 1052, 383, 624, 397], "confidence": 0.959}]}, {"text":
+        "Contoso", "boundingBox": [322, 591, 501, 601, 498, 654, 319, 644], "words":
+        [{"text": "Contoso", "boundingBox": [328, 591, 500, 602, 498, 654, 325, 644],
+        "confidence": 0.727}]}, {"text": "123 Main Street", "boundingBox": [319, 690,
+        655, 695, 654, 757, 318, 752], "words": [{"text": "123", "boundingBox": [323,
+        690, 387, 692, 383, 754, 319, 753], "confidence": 0.958}, {"text": "Main",
+        "boundingBox": [399, 692, 502, 694, 498, 756, 395, 754], "confidence": 0.958},
+        {"text": "Street", "boundingBox": [514, 695, 656, 698, 653, 758, 510, 756],
+        "confidence": 0.958}]}, {"text": "Redmond, WA 98052", "boundingBox": [317,
+        795, 751, 795, 752, 859, 317, 860], "words": [{"text": "Redmond,", "boundingBox":
+        [321, 795, 523, 795, 520, 861, 317, 858], "confidence": 0.57}, {"text": "WA",
+        "boundingBox": [535, 795, 597, 795, 595, 861, 532, 861], "confidence": 0.958},
+        {"text": "98052", "boundingBox": [610, 795, 749, 796, 747, 858, 607, 861],
+        "confidence": 0.958}]}, {"text": "123-456-7890", "boundingBox": [306, 1005,
+        618, 1011, 616, 1068, 305, 1062], "words": [{"text": "123-456-7890", "boundingBox":
+        [306, 1005, 617, 1012, 615, 1069, 305, 1064], "confidence": 0.937}]}, {"text":
+        "6/10/2019 13:59", "boundingBox": [303, 1223, 630, 1225, 629, 1289, 302, 1286],
+        "words": [{"text": "6/10/2019", "boundingBox": [304, 1224, 506, 1224, 504,
+        1289, 303, 1288], "confidence": 0.762}, {"text": "13:59", "boundingBox": [518,
+        1225, 628, 1228, 627, 1290, 517, 1289], "confidence": 0.949}]}, {"text": "Sales
+        Associate: Paul", "boundingBox": [294, 1335, 768, 1335, 768, 1401, 294, 1399],
+        "words": [{"text": "Sales", "boundingBox": [302, 1336, 418, 1335, 416, 1399,
+        301, 1399], "confidence": 0.959}, {"text": "Associate:", "boundingBox": [430,
+        1335, 649, 1336, 646, 1401, 428, 1399], "confidence": 0.95}, {"text": "Paul",
+        "boundingBox": [661, 1336, 767, 1336, 764, 1402, 659, 1401], "confidence":
+        0.959}]}, {"text": "1 Surface Pro 6", "boundingBox": [336, 1560, 679, 1561,
+        678, 1625, 336, 1623], "words": [{"text": "1", "boundingBox": [337, 1560,
+        360, 1561, 360, 1625, 337, 1625], "confidence": 0.799}, {"text": "Surface",
+        "boundingBox": [373, 1561, 543, 1562, 542, 1624, 373, 1625], "confidence":
+        0.958}, {"text": "Pro", "boundingBox": [555, 1562, 632, 1563, 631, 1625, 555,
+        1624], "confidence": 0.91}, {"text": "6", "boundingBox": [644, 1563, 676,
+        1563, 675, 1625, 644, 1625], "confidence": 0.762}]}, {"text": "256GB / Intel
+        Core i5 /", "boundingBox": [372, 1669, 846, 1669, 846, 1743, 372, 1742], "words":
+        [{"text": "256GB", "boundingBox": [375, 1670, 506, 1671, 504, 1740, 373, 1740],
+        "confidence": 0.952}, {"text": "/", "boundingBox": [520, 1671, 533, 1671,
+        531, 1740, 517, 1740], "confidence": 0.879}, {"text": "Intel", "boundingBox":
+        [547, 1671, 648, 1671, 646, 1741, 545, 1740], "confidence": 0.879}, {"text":
+        "Core", "boundingBox": [662, 1671, 758, 1670, 756, 1743, 660, 1741], "confidence":
+        0.95}, {"text": "i5", "boundingBox": [772, 1670, 809, 1670, 807, 1744, 770,
+        1743], "confidence": 0.817}, {"text": "/", "boundingBox": [823, 1670, 847,
+        1670, 846, 1744, 821, 1744], "confidence": 0.841}]}, {"text": "8GB RAM (Black)",
+        "boundingBox": [370, 1782, 732, 1785, 731, 1853, 370, 1850], "words": [{"text":
+        "8GB", "boundingBox": [374, 1783, 451, 1783, 448, 1850, 370, 1850], "confidence":
+        0.798}, {"text": "RAM", "boundingBox": [465, 1783, 561, 1784, 559, 1851, 461,
+        1850], "confidence": 0.958}, {"text": "(Black)", "boundingBox": [575, 1784,
+        731, 1785, 729, 1854, 572, 1852], "confidence": 0.959}]}, {"text": "$ 999.00",
+        "boundingBox": [937, 1785, 1139, 1790, 1137, 1862, 936, 1859], "words": [{"text":
+        "$", "boundingBox": [939, 1785, 959, 1785, 958, 1859, 938, 1859], "confidence":
+        0.895}, {"text": "999.00", "boundingBox": [974, 1786, 1134, 1789, 1133, 1863,
+        973, 1860], "confidence": 0.877}]}, {"text": "1 SurfacePen", "boundingBox":
+        [320, 2019, 627, 2013, 629, 2076, 321, 2083], "words": [{"text": "1", "boundingBox":
+        [321, 2021, 348, 2020, 349, 2084, 322, 2084], "confidence": 0.82}, {"text":
+        "SurfacePen", "boundingBox": [360, 2020, 626, 2014, 628, 2077, 362, 2083],
+        "confidence": 0.928}]}, {"text": "$ 99.99", "boundingBox": [967, 2028, 1128,
+        2029, 1127, 2091, 967, 2091], "words": [{"text": "$", "boundingBox": [969,
+        2028, 994, 2028, 994, 2091, 969, 2091], "confidence": 0.888}, {"text": "99.99",
+        "boundingBox": [1007, 2028, 1127, 2028, 1126, 2091, 1007, 2091], "confidence":
+        0.911}]}, {"text": "Sub-Total", "boundingBox": [474, 2242, 697, 2244, 697,
+        2310, 473, 2308], "words": [{"text": "Sub-Total", "boundingBox": [477, 2242,
+        695, 2245, 694, 2310, 474, 2308], "confidence": 0.915}]}, {"text": "$ 1098.99",
+        "boundingBox": [922, 2259, 1136, 2253, 1138, 2318, 924, 2325], "words": [{"text":
+        "$", "boundingBox": [924, 2261, 950, 2260, 954, 2326, 928, 2326], "confidence":
+        0.881}, {"text": "1098.99", "boundingBox": [963, 2260, 1136, 2254, 1137, 2320,
+        966, 2325], "confidence": 0.942}]}, {"text": "Tax", "boundingBox": [570, 2355,
+        655, 2357, 654, 2415, 568, 2413], "words": [{"text": "Tax", "boundingBox":
+        [571, 2355, 654, 2357, 653, 2415, 570, 2413], "confidence": 0.958}]}, {"text":
+        "$ 104.40", "boundingBox": [941, 2368, 1134, 2364, 1137, 2433, 942, 2438],
+        "words": [{"text": "$", "boundingBox": [943, 2368, 966, 2367, 968, 2437, 944,
+        2438], "confidence": 0.892}, {"text": "104.40", "boundingBox": [980, 2367,
+        1132, 2364, 1133, 2434, 982, 2437], "confidence": 0.952}]}, {"text": "Total",
+        "boundingBox": [551, 2591, 672, 2584, 675, 2652, 554, 2659], "words": [{"text":
+        "Total", "boundingBox": [551, 2591, 668, 2584, 672, 2652, 554, 2659], "confidence":
+        0.727}]}, {"text": "$ 1203.39", "boundingBox": [918, 2589, 1123, 2611, 1116,
+        2677, 912, 2656], "words": [{"text": "$", "boundingBox": [918, 2590, 942,
+        2592, 936, 2659, 913, 2656], "confidence": 0.886}, {"text": "1203.39", "boundingBox":
+        [955, 2594, 1123, 2611, 1115, 2678, 949, 2661], "confidence": 0.951}]}]}],
+        "documentResults": [{"docType": "prebuilt:receipt", "pageRange": [1, 1], "fields":
+        {"ReceiptType": {"type": "string", "valueString": "Itemized", "confidence":
+        0.659}, "MerchantName": {"type": "string", "valueString": "Contoso Contoso",
+        "text": "Contoso Contoso", "boundingBox": [349.3, 241.3, 1058, 284.4, 1033.5,
+        687.1, 324.8, 644], "page": 1, "confidence": 0.516, "elements": ["#/readResults/0/lines/0/words/0",
+        "#/readResults/0/lines/1/words/0"]}, "MerchantAddress": {"type": "string",
+        "valueString": "123 Main Street Redmond, WA 98052", "text": "123 Main Street
+        Redmond, WA 98052", "boundingBox": [319.9, 689.9, 750.7, 697.5, 747.8, 865.6,
+        317, 858], "page": 1, "confidence": 0.986, "elements": ["#/readResults/0/lines/2/words/0",
+        "#/readResults/0/lines/2/words/1", "#/readResults/0/lines/2/words/2", "#/readResults/0/lines/3/words/0",
+        "#/readResults/0/lines/3/words/1", "#/readResults/0/lines/3/words/2"]}, "MerchantPhoneNumber":
+        {"type": "phoneNumber", "text": "123-456-7890", "boundingBox": [306, 1005,
+        617, 1012, 615, 1069, 305, 1064], "page": 1, "confidence": 0.99, "elements":
+        ["#/readResults/0/lines/4/words/0"]}, "TransactionDate": {"type": "date",
+        "valueDate": "2019-06-10", "text": "6/10/2019", "boundingBox": [304, 1224,
+        506, 1224, 504, 1289, 303, 1288], "page": 1, "confidence": 0.985, "elements":
+        ["#/readResults/0/lines/5/words/0"]}, "TransactionTime": {"type": "time",
+        "valueTime": "13:59:00", "text": "13:59", "boundingBox": [518, 1225, 628,
+        1228, 627, 1290, 517, 1289], "page": 1, "confidence": 0.968, "elements": ["#/readResults/0/lines/5/words/1"]},
+        "Items": {"type": "array", "valueArray": [{"type": "object", "valueObject":
+        {"Name": {"type": "string", "valueString": "8GB RAM (Black)", "text": "8GB
+        RAM (Black)", "boundingBox": [370.7, 1781.5, 731, 1785, 730.3, 1854, 370,
+        1850.6], "page": 1, "confidence": 0.916, "elements": ["#/readResults/0/lines/9/words/0",
+        "#/readResults/0/lines/9/words/1", "#/readResults/0/lines/9/words/2"]}, "TotalPrice":
+        {"type": "number", "valueNumber": 999, "text": "$999.00", "boundingBox": [939,
+        1784.6, 1134.4, 1788.3, 1133, 1863, 937.6, 1859.3], "page": 1, "confidence":
+        0.559, "elements": ["#/readResults/0/lines/10/words/0", "#/readResults/0/lines/10/words/1"]}}},
+        {"type": "object", "valueObject": {"Quantity": {"type": "number", "valueNumber":
+        1, "text": "1", "boundingBox": [321, 2021, 348, 2020, 349, 2084, 322, 2084],
+        "page": 1, "confidence": 0.858, "elements": ["#/readResults/0/lines/11/words/0"]},
+        "Name": {"type": "string", "valueString": "SurfacePen", "text": "SurfacePen",
+        "boundingBox": [360, 2020, 626, 2014, 628, 2077, 362, 2083], "page": 1, "confidence":
+        0.858, "elements": ["#/readResults/0/lines/11/words/1"]}, "TotalPrice": {"type":
+        "number", "valueNumber": 99.99, "text": "99.99", "boundingBox": [1007, 2028,
+        1127, 2028, 1126, 2091, 1007, 2091], "page": 1, "confidence": 0.386, "elements":
+        ["#/readResults/0/lines/12/words/1"]}}}]}, "Subtotal": {"type": "number",
+        "valueNumber": 1098.99, "text": "1098.99", "boundingBox": [963, 2260, 1136,
+        2254, 1137, 2320, 966, 2325], "page": 1, "confidence": 0.964, "elements":
+        ["#/readResults/0/lines/14/words/1"]}, "Tax": {"type": "number", "valueNumber":
+        104.4, "text": "$104.40", "boundingBox": [942.6, 2367.5, 1132, 2363.7, 1133.4,
+        2434.2, 944, 2438], "page": 1, "confidence": 0.713, "elements": ["#/readResults/0/lines/16/words/0",
+        "#/readResults/0/lines/16/words/1"]}, "Total": {"type": "number", "valueNumber":
+        1203.39, "text": "1203.39", "boundingBox": [955, 2594, 1123, 2611, 1115, 2678,
+        949, 2661], "page": 1, "confidence": 0.774, "elements": ["#/readResults/0/lines/18/words/1"]}}}]}}'
     headers:
-      apim-request-id: cd5b4229-6a67-4175-ad40-cb262e5b7f4c
-      content-length: '10615'
+      apim-request-id: 7d884c29-bb9c-41e9-9da6-dc373ad73577
+      content-length: '8807'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:09:28 GMT
+      date: Mon, 16 Nov 2020 19:14:55 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '18'
+      x-envoy-upstream-service-time: '25'
     status:
       code: 200
       message: OK
-    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/fc0293a0-e7a5-4a78-9826-a29081a973fb
+    url: https://centraluseuap.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyzeResults/a13da294-038f-4b40-b2b3-998cae8b49f8
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipts_encoded_url.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_receipt_from_url_async.test_receipts_encoded_url.yaml
@@ -15,16 +15,16 @@ interactions:
   response:
     body:
       string: '{"error": {"code": "FailedToDownloadImage", "innerError": {"requestId":
-        "d48deb09-856f-4232-bf37-764bd044d0e6"}, "message": "Failed to download image
+        "164e52cc-1eb3-4f10-9d49-67856b2d87d8"}, "message": "Failed to download image
         from input URL."}}'
     headers:
-      apim-request-id: d48deb09-856f-4232-bf37-764bd044d0e6
+      apim-request-id: 164e52cc-1eb3-4f10-9d49-67856b2d87d8
       content-length: '161'
       content-type: application/json; charset=utf-8
-      date: Wed, 11 Nov 2020 18:09:32 GMT
+      date: Mon, 16 Nov 2020 19:14:58 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '3224'
+      x-envoy-upstream-service-time: '3234'
     status:
       code: 400
       message: Bad Request

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt.py
@@ -227,7 +227,7 @@ class TestReceiptFromStream(FormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantPhoneNumber").value, '+19876543210')
         self.assertEqual(receipt.fields.get("Subtotal").value, 11.7)
         self.assertEqual(receipt.fields.get("Tax").value, 1.17)
-        # self.assertEqual(receipt.fields.get("Tip").value, 1.63) # FIXME: Service sees this as 463.0
+        self.assertEqual(receipt.fields.get("Tip").value, 1.63)
         self.assertEqual(receipt.fields.get("Total").value, 14.5)
         self.assertEqual(receipt.fields.get("TransactionDate").value, date(year=2019, month=6, day=10))
         self.assertEqual(receipt.fields.get("TransactionTime").value, time(hour=13, minute=59, second=0))
@@ -252,8 +252,8 @@ class TestReceiptFromStream(FormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantAddress").value, '123 Main Street Redmond, WA 98052')
         self.assertEqual(receipt.fields.get("MerchantName").value, 'Contoso Contoso')
         self.assertEqual(receipt.fields.get("Subtotal").value, 1098.99)
-        # self.assertEqual(receipt.fields.get("Tax").value, 104.4)  # FIXME: Service not finding Tax
-        # self.assertEqual(receipt.fields.get("Total").value, 1203.39) # FIXME: Service sees Tax as Total
+        self.assertEqual(receipt.fields.get("Tax").value, 104.4)
+        self.assertEqual(receipt.fields.get("Total").value, 1203.39)
         self.assertEqual(receipt.fields.get("TransactionDate").value, date(year=2019, month=6, day=10))
         self.assertEqual(receipt.fields.get("TransactionTime").value, time(hour=13, minute=59, second=0))
         self.assertEqual(receipt.page_range.first_page_number, 1)
@@ -295,7 +295,7 @@ class TestReceiptFromStream(FormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantName").value, 'Bilbo Baggins')
         self.assertEqual(receipt.fields.get("MerchantPhoneNumber").value, '+15555555555')
         self.assertEqual(receipt.fields.get("Subtotal").value, 300.0)
-        # self.assertEqual(receipt.fields.get("Total").value, 430.0)  # FIXME: Service not seeing Total
+        self.assertEqual(receipt.fields.get("Total").value, 430.0)
         self.assertEqual(receipt.page_range.first_page_number, 1)
         self.assertEqual(receipt.page_range.last_page_number, 1)
         self.assertFormPagesHasValues(receipt.pages)
@@ -306,8 +306,8 @@ class TestReceiptFromStream(FormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantAddress").value, '123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA')
         self.assertEqual(receipt.fields.get("MerchantName").value, 'Frodo Baggins')
         self.assertEqual(receipt.fields.get("MerchantPhoneNumber").value, '+15555555555')
-        # self.assertEqual(receipt.fields.get("Subtotal").value, 3000.0)   # FIXME: Service returning wrong value
-        # self.assertEqual(receipt.fields.get("Total").value, 1000.0)  # FIXME: Service not seeing Total
+        self.assertEqual(receipt.fields.get("Subtotal").value, 3000.0)
+        self.assertEqual(receipt.fields.get("Total").value, 1000.0)
         self.assertEqual(receipt.page_range.first_page_number, 3)
         self.assertEqual(receipt.page_range.last_page_number, 3)
         self.assertFormPagesHasValues(receipt.pages)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_async.py
@@ -253,7 +253,7 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantPhoneNumber").value, '+19876543210')
         self.assertEqual(receipt.fields.get("Subtotal").value, 11.7)
         self.assertEqual(receipt.fields.get("Tax").value, 1.17)
-        # self.assertEqual(receipt.fields.get("Tip").value, 1.63) # FIXME: Service sees this as 463.0
+        self.assertEqual(receipt.fields.get("Tip").value, 1.63)
         self.assertEqual(receipt.fields.get("Total").value, 14.5)
         self.assertEqual(receipt.fields.get("TransactionDate").value, date(year=2019, month=6, day=10))
         self.assertEqual(receipt.fields.get("TransactionTime").value, time(hour=13, minute=59, second=0))
@@ -279,8 +279,8 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantAddress").value, '123 Main Street Redmond, WA 98052')
         self.assertEqual(receipt.fields.get("MerchantName").value, 'Contoso Contoso')
         self.assertEqual(receipt.fields.get("Subtotal").value, 1098.99)
-        # self.assertEqual(receipt.fields.get("Tax").value, 104.4)  # FIXME: Service not finding Tax
-        # self.assertEqual(receipt.fields.get("Total").value, 1203.39) # FIXME: Service sees Tax as Total
+        self.assertEqual(receipt.fields.get("Tax").value, 104.4)
+        self.assertEqual(receipt.fields.get("Total").value, 1203.39)
         self.assertEqual(receipt.fields.get("TransactionDate").value, date(year=2019, month=6, day=10))
         self.assertEqual(receipt.fields.get("TransactionTime").value, time(hour=13, minute=59, second=0))
         self.assertEqual(receipt.page_range.first_page_number, 1)
@@ -323,7 +323,7 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantName").value, 'Bilbo Baggins')
         self.assertEqual(receipt.fields.get("MerchantPhoneNumber").value, '+15555555555')
         self.assertEqual(receipt.fields.get("Subtotal").value, 300.0)
-        # self.assertEqual(receipt.fields.get("Total").value, 430.0)  # FIXME: Service not seeing Total
+        self.assertEqual(receipt.fields.get("Total").value, 430.0)
         self.assertEqual(receipt.page_range.first_page_number, 1)
         self.assertEqual(receipt.page_range.last_page_number, 1)
         self.assertFormPagesHasValues(receipt.pages)
@@ -334,8 +334,8 @@ class TestReceiptFromStreamAsync(AsyncFormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantAddress").value, '123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA')
         self.assertEqual(receipt.fields.get("MerchantName").value, 'Frodo Baggins')
         self.assertEqual(receipt.fields.get("MerchantPhoneNumber").value, '+15555555555')
-        # self.assertEqual(receipt.fields.get("Subtotal").value, 3000.0)   # FIXME: Service returning wrong value
-        # self.assertEqual(receipt.fields.get("Total").value, 1000.0)  # FIXME: Service not seeing Total
+        self.assertEqual(receipt.fields.get("Subtotal").value, 3000.0)
+        self.assertEqual(receipt.fields.get("Total").value, 1000.0)
         self.assertEqual(receipt.page_range.first_page_number, 3)
         self.assertEqual(receipt.page_range.last_page_number, 3)
         self.assertFormPagesHasValues(receipt.pages)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url.py
@@ -185,7 +185,7 @@ class TestReceiptFromUrl(FormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantPhoneNumber").value, '+19876543210')
         self.assertEqual(receipt.fields.get("Subtotal").value, 11.7)
         self.assertEqual(receipt.fields.get("Tax").value, 1.17)
-        # self.assertEqual(receipt.fields.get("Tip").value, 1.63) # FIXME: Service sees this as 463.0
+        self.assertEqual(receipt.fields.get("Tip").value, 1.63)
         self.assertEqual(receipt.fields.get("Total").value, 14.5)
         self.assertEqual(receipt.fields.get("TransactionDate").value, date(year=2019, month=6, day=10))
         self.assertEqual(receipt.fields.get("TransactionTime").value, time(hour=13, minute=59, second=0))
@@ -209,8 +209,8 @@ class TestReceiptFromUrl(FormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantAddress").value, '123 Main Street Redmond, WA 98052')
         self.assertEqual(receipt.fields.get("MerchantName").value, 'Contoso Contoso')
         self.assertEqual(receipt.fields.get("Subtotal").value, 1098.99)
-        # self.assertEqual(receipt.fields.get("Tax").value, 104.4)  # FIXME: Service not finding Tax
-        # self.assertEqual(receipt.fields.get("Total").value, 1203.39) # FIXME: Service sees Tax as Total
+        self.assertEqual(receipt.fields.get("Tax").value, 104.4)
+        self.assertEqual(receipt.fields.get("Total").value, 1203.39)
         self.assertEqual(receipt.fields.get("TransactionDate").value, date(year=2019, month=6, day=10))
         self.assertEqual(receipt.fields.get("TransactionTime").value, time(hour=13, minute=59, second=0))
         self.assertEqual(receipt.page_range.first_page_number, 1)
@@ -233,7 +233,7 @@ class TestReceiptFromUrl(FormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantName").value, 'Bilbo Baggins')
         self.assertEqual(receipt.fields.get("MerchantPhoneNumber").value, '+15555555555')
         self.assertEqual(receipt.fields.get("Subtotal").value, 300.0)
-        # self.assertEqual(receipt.fields.get("Total").value, 430.0)  # FIXME: Service not seeing Total
+        self.assertEqual(receipt.fields.get("Total").value, 430.0)
         self.assertEqual(receipt.page_range.first_page_number, 1)
         self.assertEqual(receipt.page_range.last_page_number, 1)
         self.assertFormPagesHasValues(receipt.pages)
@@ -244,8 +244,8 @@ class TestReceiptFromUrl(FormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantAddress").value, '123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA')
         self.assertEqual(receipt.fields.get("MerchantName").value, 'Frodo Baggins')
         self.assertEqual(receipt.fields.get("MerchantPhoneNumber").value, '+15555555555')
-        # self.assertEqual(receipt.fields.get("Subtotal").value, 3000.0)   # FIXME: Service returning wrong value
-        # self.assertEqual(receipt.fields.get("Total").value, 1000.0)  # FIXME: Service not seeing Total
+        self.assertEqual(receipt.fields.get("Subtotal").value, 3000.0)
+        self.assertEqual(receipt.fields.get("Total").value, 1000.0)
         self.assertEqual(receipt.page_range.first_page_number, 3)
         self.assertEqual(receipt.page_range.last_page_number, 3)
         self.assertFormPagesHasValues(receipt.pages)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url_async.py
@@ -216,7 +216,7 @@ class TestReceiptFromUrlAsync(AsyncFormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantPhoneNumber").value, '+19876543210')
         self.assertEqual(receipt.fields.get("Subtotal").value, 11.7)
         self.assertEqual(receipt.fields.get("Tax").value, 1.17)
-        # self.assertEqual(receipt.fields.get("Tip").value, 1.63) # FIXME: Service sees this as 463.0
+        self.assertEqual(receipt.fields.get("Tip").value, 1.63)
         self.assertEqual(receipt.fields.get("Total").value, 14.5)
         self.assertEqual(receipt.fields.get("TransactionDate").value, date(year=2019, month=6, day=10))
         self.assertEqual(receipt.fields.get("TransactionTime").value, time(hour=13, minute=59, second=0))
@@ -241,8 +241,8 @@ class TestReceiptFromUrlAsync(AsyncFormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantAddress").value, '123 Main Street Redmond, WA 98052')
         self.assertEqual(receipt.fields.get("MerchantName").value, 'Contoso Contoso')
         self.assertEqual(receipt.fields.get("Subtotal").value, 1098.99)
-        # self.assertEqual(receipt.fields.get("Tax").value, 104.4)  # FIXME: Service not finding Tax
-        # self.assertEqual(receipt.fields.get("Total").value, 1203.39) # FIXME: Service sees Tax as Total
+        self.assertEqual(receipt.fields.get("Tax").value, 104.4)
+        self.assertEqual(receipt.fields.get("Total").value, 1203.39)
         self.assertEqual(receipt.fields.get("TransactionDate").value, date(year=2019, month=6, day=10))
         self.assertEqual(receipt.fields.get("TransactionTime").value, time(hour=13, minute=59, second=0))
         self.assertEqual(receipt.page_range.first_page_number, 1)
@@ -266,7 +266,7 @@ class TestReceiptFromUrlAsync(AsyncFormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantName").value, 'Bilbo Baggins')
         self.assertEqual(receipt.fields.get("MerchantPhoneNumber").value, '+15555555555')
         self.assertEqual(receipt.fields.get("Subtotal").value, 300.0)
-        # self.assertEqual(receipt.fields.get("Total").value, 430.0)  # FIXME: Service not seeing Total
+        self.assertEqual(receipt.fields.get("Total").value, 430.0)
         self.assertEqual(receipt.page_range.first_page_number, 1)
         self.assertEqual(receipt.page_range.last_page_number, 1)
         self.assertFormPagesHasValues(receipt.pages)
@@ -277,8 +277,8 @@ class TestReceiptFromUrlAsync(AsyncFormRecognizerTest):
         self.assertEqual(receipt.fields.get("MerchantAddress").value, '123 Hobbit Lane 567 Main St. Redmond, WA Redmond, WA')
         self.assertEqual(receipt.fields.get("MerchantName").value, 'Frodo Baggins')
         self.assertEqual(receipt.fields.get("MerchantPhoneNumber").value, '+15555555555')
-        # self.assertEqual(receipt.fields.get("Subtotal").value, 3000.0)   # FIXME: Service returning wrong value
-        # self.assertEqual(receipt.fields.get("Total").value, 1000.0)  # FIXME: Service not seeing Total
+        self.assertEqual(receipt.fields.get("Subtotal").value, 3000.0)
+        self.assertEqual(receipt.fields.get("Total").value, 1000.0)
         self.assertEqual(receipt.page_range.first_page_number, 3)
         self.assertEqual(receipt.page_range.last_page_number, 3)
         self.assertFormPagesHasValues(receipt.pages)


### PR DESCRIPTION
Fix is in canary. Re-recording all receipt tests just in case.