### PR TITLE
Temporarily Disable Changelog Verify

### DIFF
--- a/eng/common/pipelines/templates/steps/verify-changelog.yml
+++ b/eng/common/pipelines/templates/steps/verify-changelog.yml
@@ -13,6 +13,10 @@ parameters:
   default: false
 
 steps:
+  - pwsh: | 
+      pip install packaging==20.4
+    displayName: Install Requirements
+
   - task: Powershell@2
     inputs:
       filePath: $(Build.SourcesDirectory)/eng/common/scripts/Verify-ChangeLog.ps1

--- a/eng/common/pipelines/templates/steps/verify-changelog.yml
+++ b/eng/common/pipelines/templates/steps/verify-changelog.yml
@@ -13,10 +13,6 @@ parameters:
   default: false
 
 steps:
-  - pwsh: | 
-      pip install packaging==20.4
-    displayName: Install Requirements
-
   - task: Powershell@2
     inputs:
       filePath: $(Build.SourcesDirectory)/eng/common/scripts/Verify-ChangeLog.ps1

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -37,12 +37,13 @@ stages:
                           pwsh: true
                           workingDirectory: $(Build.SourcesDirectory)
                           filePath: eng/scripts/SetTestPipelineVersion.ps1
-                    - ${{if ne(artifact.skipVerifyChangeLog, 'true')}}:
-                      - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
-                        parameters:
-                          PackageName: ${{artifact.name}}
-                          ServiceName: ${{parameters.ServiceDirectory}}
-                          ForRelease: true
+                    # TEMPORARILY DISABLING 11/16. Will re-enable after patch to common tooling.
+                    # - ${{if ne(artifact.skipVerifyChangeLog, 'true')}}:
+                    #   - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
+                    #     parameters:
+                    #       PackageName: ${{artifact.name}}
+                    #       ServiceName: ${{parameters.ServiceDirectory}}
+                    #       ForRelease: true
                     - template: /eng/pipelines/templates/steps/stage-filtered-artifacts.yml
                       parameters:
                         SourceFolder: ${{parameters.ArtifactName}} 


### PR DESCRIPTION
The release phase doesn't install deps that are actually required.

@chidozieononiwu please take a look. I've got another PR going to sdk-tools soon that will also adjust this in the template yaml itself.