### PR TITLE
[WIP][Not Ready]Bookmarks for CLI/Python content should uses underscore `_` 

### DIFF
--- a/sdk/storage/azure-storage-blob/README.md
+++ b/sdk/storage/azure-storage-blob/README.md
@@ -57,7 +57,7 @@ service = BlobServiceClient(account_url="https://<my-storage-account-name>.blob.
 You can find the storage account's blob service URL using the 
 [Azure Portal](https://docs.microsoft.com/azure/storage/common/storage-account-overview#storage-account-endpoints),
 [Azure PowerShell](https://docs.microsoft.com/powershell/module/az.storage/get-azstorageaccount),
-or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az-storage-account-show):
+or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az_storage_account_show):
 
 ```bash
 # Get the blob service account url for the storage account

--- a/sdk/storage/azure-storage-file-share/README.md
+++ b/sdk/storage/azure-storage-file-share/README.md
@@ -54,7 +54,7 @@ service = ShareServiceClient(account_url="https://<my-storage-account-name>.file
 You can find the storage account's file service URL using the
 [Azure Portal](https://docs.microsoft.com/azure/storage/common/storage-account-overview#storage-account-endpoints),
 [Azure PowerShell](https://docs.microsoft.com/powershell/module/az.storage/get-azstorageaccount),
-or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az-storage-account-show):
+or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az_storage_account_show):
 
 ```bash
 # Get the file service URL for the storage account

--- a/sdk/storage/azure-storage-queue/README.md
+++ b/sdk/storage/azure-storage-queue/README.md
@@ -54,7 +54,7 @@ service = QueueServiceClient(account_url="https://<my-storage-account-name>.queu
 You can find the storage account's queue service URL using the 
 [Azure Portal](https://docs.microsoft.com/azure/storage/common/storage-account-overview#storage-account-endpoints),
 [Azure PowerShell](https://docs.microsoft.com/powershell/module/az.storage/get-azstorageaccount),
-or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az-storage-account-show):
+or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az_storage_account_show):
 
 ```bash
 # Get the queue service URL for the storage account

--- a/sdk/tables/azure-data-tables/README.md
+++ b/sdk/tables/azure-data-tables/README.md
@@ -332,7 +332,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][msft_oss_co
 [azure_powershell_create_account]:https://docs.microsoft.com/azure/storage/common/storage-account-create?tabs=azure-powershell
 [azure_cli_create_account]: https://docs.microsoft.com/azure/storage/common/storage-account-create?tabs=azure-cli
 
-[azure_cli_account_url]:https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az-storage-account-show
+[azure_cli_account_url]:https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az_storage_account_show
 [azure_powershell_account_url]:https://docs.microsoft.com/powershell/module/az.storage/get-azstorageaccount?view=azps-4.6.1
 [azure_portal_account_url]:https://docs.microsoft.com/azure/storage/common/storage-account-overview#storage-account-endpoints
 


### PR DESCRIPTION
I'm doing this content fix for unblocking the docfx v3 migration for repository [`MicrosoftDocs/azure-docs-sdk-python`](https://github.com/MicrosoftDocs/azure-docs-sdk-python/pull/954).