### PR TITLE
Add Update-python-CIConfig

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -133,7 +133,7 @@ jobs:
           pwsh: true
           workingDirectory: $(Build.SourcesDirectory)
           filePath: eng/scripts/SetTestPipelineVersion.ps1
-          arguments: '-BuildNumber $(Build.BuildNumber)'
+          arguments: '-BuildID $(Build.BuildId)'
 
     - pwsh: |
         $toxenvvar = "whl,sdist"

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -37,6 +37,7 @@ stages:
                           pwsh: true
                           workingDirectory: $(Build.SourcesDirectory)
                           filePath: eng/scripts/SetTestPipelineVersion.ps1
+                          arguments: '-BuildID $(Build.BuildId)'
                     # TEMPORARILY DISABLING 11/16. Will re-enable after patch to common tooling.
                     # - ${{if ne(artifact.skipVerifyChangeLog, 'true')}}:
                     #   - template: /eng/common/pipelines/templates/steps/verify-changelog.yml

--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -14,7 +14,7 @@ steps:
         pwsh: true
         workingDirectory: $(Build.SourcesDirectory)
         filePath: eng/scripts/SetTestPipelineVersion.ps1
-        arguments: '-BuildNumber $(Build.BuildNumber)'
+        arguments: '-BuildID $(Build.BuildId)'
 
   - script: |
       echo "##vso[build.addbuildtag]Scheduled"

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -166,7 +166,7 @@ function Update-python-CIConfig($pkgs, $ciRepo, $locationInDocRepo, $monikerId=$
             install_type = "pypi"
             name=$releasingPkg.PackageId
           }
-          excludePath = @("test*","example*","sample*","doc*")
+          exclude_path = @("test*","example*","sample*","doc*")
         }
       $allJson.packages += $newItem
     }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -118,3 +118,61 @@ function Get-python-GithubIoDocIndex() {
   # Generate yml/md toc files and build site.
   GenerateDocfxTocContent -tocContent $tocContent -lang "Python"
 }
+
+# Updates a python CI configuration json.
+# For "latest", the version attribute is cleared, as default behavior is to pull latest "non-preview".
+# For "preview", we update to >= the target releasing package version.
+function Update-python-CIConfig($pkgs, $ciRepo, $locationInDocRepo, $monikerId=$null){
+  $pkgJsonLoc = (Join-Path -Path $ciRepo -ChildPath $locationInDocRepo)
+
+  if (-not (Test-Path $pkgJsonLoc)) {
+    Write-Error "Unable to locate package json at location $pkgJsonLoc, exiting."
+    exit(1)
+  }
+
+  $allJson  = Get-Content $pkgJsonLoc | ConvertFrom-Json
+  $visibleInCI = @{}
+
+  for ($i=0; $i -lt $allJson.packages.Length; $i++) {
+    $pkgDef = $allJson.packages[$i]
+
+    if ($pkgDef.package_info.name) {
+      $visibleInCI[$pkgDef.package_info.name] = $i
+    }
+  }
+
+  foreach ($releasingPkg in $pkgs) {
+    if ($visibleInCI.ContainsKey($releasingPkg.PackageId)) {
+      $packagesIndex = $visibleInCI[$releasingPkg.PackageId]
+      $existingPackageDef = $allJson.packages[$packagesIndex]
+
+      if ($releasingPkg.IsPrerelease) {
+        if (-not $existingPackageDef.package_info.version) {
+          $existingPackageDef.package_info | Add-Member -NotePropertyName version -NotePropertyValue ""
+        }
+
+        $existingPackageDef.package_info.version = ">=$($releasingPkg.PackageVersion)"
+      }
+      else {
+        if ($def.version) {
+          $def.PSObject.Properties.Remove('version')  
+        }
+      }
+    }
+    else {
+      $newItem = New-Object PSObject -Property @{ 
+          package_info = New-Object PSObject -Property @{ 
+            prefer_source_distribution = "true"
+            install_type = "pypi"
+            name=$releasingPkg.PackageId
+          }
+          excludePath = @("test*","example*","sample*","doc*")
+        }
+      $allJson.packages += $newItem
+    }
+  }
+
+  $jsonContent = $allJson | ConvertTo-Json -Depth 10 | % {$_ -replace "(?m)  (?<=^(?:  )*)", "  " }
+
+  Set-Content -Path $pkgJsonLoc -Value $jsonContent
+}

--- a/eng/scripts/SetTestPipelineVersion.ps1
+++ b/eng/scripts/SetTestPipelineVersion.ps1
@@ -3,7 +3,7 @@
 
 param (
   [Parameter(mandatory = $true)]
-  $BuildNumber
+  $BuildID
 )
 
 . "${PSScriptRoot}\..\common\scripts\common.ps1"
@@ -23,7 +23,7 @@ LogDebug "Last Published Version $($semVarsSorted[0])"
 
 $newVersion = [AzureEngSemanticVersion]::ParsePythonVersionString($semVarsSorted[0])
 $newVersion.PrereleaseLabel = "b"
-$newVersion.PrereleaseNumber = $BuildNumber
+$newVersion.PrereleaseNumber = $BuildID
 
 LogDebug "Version to publish [ $($newVersion.ToString()) ]"
 


### PR DESCRIPTION
- Move `UpdateParamsJsonPython` from `https://github.com/Azure/azure-sdk-tools/blob/master/eng/common/scripts/update-docs-ci.ps1` to LanguageSettings.ps1.
- Rename function to `Update-python-CIConfig`
- Add default `$monikerId=$null` argument to help function reuse across the languages.
- Switch from `BuildNumber` to `BuildID` for test release version.