### PR TITLE
Remove aiodns from our CI

### DIFF
--- a/sdk/core/azure-core/dev_requirements.txt
+++ b/sdk/core/azure-core/dev_requirements.txt
@@ -1,7 +1,6 @@
 msrest
 trio; python_version >= '3.5'
 aiohttp>=3.0; python_version >= '3.5'
-aiodns>=2.0; python_version >= '3.5'
 typing_extensions>=3.7.2
 opencensus>=0.6.0
 opencensus-ext-azure>=0.3.1

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -112,7 +112,6 @@ uamqp~=1.2.0
 enum34>=1.0.4
 certifi>=2017.4.17
 aiohttp>=3.0
-aiodns>=2.0
 python-dateutil>=2.8.0
 six>=1.6
 isodate>=0.6.0

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -112,6 +112,7 @@ uamqp~=1.2.0
 enum34>=1.0.4
 certifi>=2017.4.17
 aiohttp>=3.0
+aiodns>=2.0
 python-dateutil>=2.8.0
 six>=1.6
 isodate>=0.6.0


### PR DESCRIPTION
aiodns is an optional dependency to make DNS resolution faster for aiohttp. That itself should enough to not install it on CI, but on top of that, it depends on "pycares" that is not available on Python 3.9 as wheels, and makes Windows installation complex. this creates situations where contributors can't setup a dev venv on 3.9 Windows, for a package that is not necessary for dev in the first place.
So killing it.