### PR TITLE
[Communication] Remove test_list_read_receipts e2e test for chat 

### DIFF
--- a/sdk/communication/azure-communication-chat/tests/test_chat_thread_client_e2e.py
+++ b/sdk/communication/azure-communication-chat/tests/test_chat_thread_client_e2e.py
@@ -200,21 +200,3 @@ class ChatThreadClientTest(CommunicationTestCase):
         self._send_message()
 
         self.chat_thread_client.send_read_receipt(self.message_id)
-
-    @pytest.mark.live_test_only
-    def test_list_read_receipts(self):
-        self._create_thread()
-        self._send_message()
-
-        # send read receipts first
-        self.chat_thread_client.send_read_receipt(self.message_id)
-        if self.is_live:
-            time.sleep(2)
-
-        # list read receipts
-        read_receipts = self.chat_thread_client.list_read_receipts()
-
-        items = []
-        for item in read_receipts:
-            items.append(item)
-        assert len(items) > 0

--- a/sdk/communication/azure-communication-chat/tests/test_chat_thread_client_e2e_async.py
+++ b/sdk/communication/azure-communication-chat/tests/test_chat_thread_client_e2e_async.py
@@ -277,29 +277,3 @@ class ChatThreadClientTestAsync(AsyncCommunicationTestCase):
 
             if not self.is_playback():
                 await self.chat_client.delete_chat_thread(self.thread_id)
-
-    @pytest.mark.live_test_only
-    @AsyncCommunicationTestCase.await_prepared_test
-    async def test_list_read_receipts(self):
-        async with self.chat_client:
-            await self._create_thread()
-
-            async with self.chat_thread_client:
-                await self._send_message()
-
-                # send read receipts first
-                await self.chat_thread_client.send_read_receipt(self.message_id)
-                if self.is_live:
-                    await asyncio.sleep(2)
-
-                # list read receipts
-                read_receipts = self.chat_thread_client.list_read_receipts()
-
-                items = []
-                async for item in read_receipts:
-                    items.append(item)
-
-                assert len(items) > 0
-
-            if not self.is_playback():
-                await self.chat_client.delete_chat_thread(self.thread_id)


### PR DESCRIPTION
This tests fails from time to time due to the fact that the api is eventually consistent. 
There is already a unit test covering this case. Therefore removing this until we have a proper way of doing e2e tests for this case