### PR TITLE
Use Precached Python 3.9 instead of installing from gh manifest

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -43,7 +43,7 @@ parameters:
       RunForPR: false
     Linux_Python39:
       OSVmImage: 'ubuntu-18.04'
-      PythonVersion: '3.9.0'
+      PythonVersion: '3.9'
       CoverageArg: ''
       RunForPR: true
   AdditionalTestMatrix: []

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -27,7 +27,7 @@ parameters:
       PythonVersion: 'pypy3'
     Linux_Python39:
       OSVmImage: 'ubuntu-18.04'
-      PythonVersion: '3.9.0'
+      PythonVersion: '3.9'
 
 jobs:
   - job: ${{ parameters.JobName }}

--- a/scripts/devops_tasks/install_python_version.py
+++ b/scripts/devops_tasks/install_python_version.py
@@ -20,7 +20,7 @@ MANIFEST_LOCATION = "https://raw.githubusercontent.com/actions/python-versions/m
 
 MAX_INSTALLER_RETRY = 3
 CURRENT_UBUNTU_VERSION = "18.04"  # full title is ubuntu-18.04
-MAX_PRECACHED_VERSION = "3.8.9"
+MAX_PRECACHED_VERSION = "3.9.0"
 
 UNIX_INSTALL_ARRAY = ["sh", "setup.sh"]
 WIN_INSTALL_ARRAY = ["pwsh", "setup.ps1"]


### PR DESCRIPTION
Py39 is native to the images now. Don't need to download and install it anymore.