### PR TITLE
Run Dependency Tests in all internal builds

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -141,9 +141,11 @@ jobs:
           $toxenvvar = "whl,sdist,depends,latestdependency,mindependency"
         }
 
-        Write-Host 'Outputting non-existent var'
-        Write-Host '$(Run.ToxCustomEnvs)'
-
+        # ensure that the variable is unset. if it isn't, use the value discovered there
+        if ('$(Run.ToxCustomEnvs)' -ne ('$' + '(Run.ToxCustomEnvs)'))
+        {
+          $toxenvvar = '$(Run.ToxCustomEnvs)'
+        }
         
         echo "##vso[task.setvariable variable=toxenv]$toxenvvar"
       displayName: "Set Tox Environment"

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -137,13 +137,14 @@ jobs:
 
     - pwsh: |
         $toxenvvar = "whl,sdist"
-        if (('$(Build.Reason)' -eq 'Schedule') -and ('$(System.TeamProject)' -eq 'internal')) {
+        if ('$(System.TeamProject)' -eq 'internal') {
           $toxenvvar = "whl,sdist,depends,latestdependency,mindependency"
         }
 
-        if ('$(Run.DependencyTest)' -eq 'true') {
-          $toxenvvar = "whl,sdist,depends,latestdependency,mindependency"
-        }
+        Write-Host 'Outputting non-existent var'
+        Write-Host '$(Run.ToxCustomEnvs)'
+
+        
         echo "##vso[task.setvariable variable=toxenv]$toxenvvar"
       displayName: "Set Tox Environment"
 


### PR DESCRIPTION
instead of just nightly scheduled and/or when `Run.DependencyTests` is set to true.

