### PR TITLE
DetectLastPoint should be be detect_last_point...

### DIFF
--- a/sdk/anomalydetector/azure-ai-anomalydetector/CHANGELOG.md
+++ b/sdk/anomalydetector/azure-ai-anomalydetector/CHANGELOG.md
@@ -9,8 +9,8 @@
   - Renamed `entire_detect` to `detect_entire_series`
   - Renamed `APIError` to `AnomalyDetectorError`
   - Renamed `Request` to `DetectRequest`
-  - Renamed `LastDetect` to `DetectLastPoint`
-  - Renamed `ChangePointDetect` to `DetectChangePoint`
+  - Renamed `LastDetect` to `detect_last_point`
+  - Renamed `ChangePointDetect` to `detect_change_point`
   - Renamed `Granularity` to `TimeGranularity`
   - Renamed `minutely` and `secondly` to `per_minute` and `per_second`
   - Renamed `Point` to `TimeSeriesPoint`

--- a/sdk/anomalydetector/azure-ai-anomalydetector/CHANGELOG.md
+++ b/sdk/anomalydetector/azure-ai-anomalydetector/CHANGELOG.md
@@ -9,8 +9,8 @@
   - Renamed `entire_detect` to `detect_entire_series`
   - Renamed `APIError` to `AnomalyDetectorError`
   - Renamed `Request` to `DetectRequest`
-  - Renamed `LastDetect` to `detect_last_point`
-  - Renamed `ChangePointDetect` to `detect_change_point`
+  - Renamed `last_detect` to `detect_last_point`
+  - Renamed `change_point_detect` to `detect_change_point`
   - Renamed `Granularity` to `TimeGranularity`
   - Renamed `minutely` and `secondly` to `per_minute` and `per_second`
   - Renamed `Point` to `TimeSeriesPoint`


### PR DESCRIPTION
It looks like "DetectLastPoint" doesn't exist in this codebase, but [detect-last-point](https://github.com/Azure/azure-sdk-for-python/blob/bf9d44f2a50aea46a59c4cb83ccfccaff5e2b218/sdk/anomalydetector/azure-ai-anomalydetector/azure/ai/anomalydetector/operations/_anomaly_detector_client_operations.py#L87) does exist.

Same issue with "DetectChangePoint" there is a [detect_change_point](https://github.com/Azure/azure-sdk-for-python/blob/bf9d44f2a50aea46a59c4cb83ccfccaff5e2b218/sdk/anomalydetector/azure-ai-anomalydetector/azure/ai/anomalydetector/operations/_anomaly_detector_client_operations.py#L148).