### PR TITLE
Adding .env file support for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ sdk/cosmos/azure-cosmos/test/test_config.py
 
 # temp path to to run regression test
 .tmp_code_path/
+
+# env vars
+.env

--- a/doc/dev/dev_setup.md
+++ b/doc/dev/dev_setup.md
@@ -41,3 +41,8 @@ or execute the various commands available in the toolbox.
     ```
     python scripts/dev_setup.py -p azure-mgmt-service
     ```
+
+5.  Create a .env file to store your secrets.
+
+    The recommended place to store your .env file is one directory higher than the `azure-sdk-for-python` location.
+    This ensures the secrets will be loaded by the interpreter and most importantly not be committed to Git history.

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -30,3 +30,6 @@ pylint==2.5.2; python_version >= '3.4'
 
 ../../../tools/azure-devtools
 ../../../tools/azure-sdk-tools
+
+# python-dotenv
+python-dotenv==0.15.0

--- a/tools/azure-sdk-tools/devtools_testutils/azure_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/azure_testcase.py
@@ -15,6 +15,7 @@ except ImportError:
     from inspect import getargspec as get_arg_spec
 
 import pytest
+from dotenv import load_dotenv, find_dotenv
 
 from azure_devtools.scenario_tests import (
     ReplayableTest, AzureTestError,
@@ -101,6 +102,7 @@ class AzureTestCase(ReplayableTest):
         config_file = config_file or os.path.join(self.working_folder, TEST_SETTING_FILENAME)
         if not os.path.exists(config_file):
             config_file = None
+        load_dotenv(find_dotenv())
         super(AzureTestCase, self).__init__(
             method_name,
             config_file=config_file,


### PR DESCRIPTION
adding python-dotenv to the test-tools, and loading in init of `AzureTestCase`