### PR TITLE
Fix #13060

### DIFF
--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_blobstoragecsaio.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_blobstoragecsaio.py
@@ -146,7 +146,7 @@ class BlobCheckpointStore(CheckpointStore):
                     "eventhub_name": eventhub_name,
                     "consumer_group": consumer_group,
                     "partition_id": blob.name.split("/")[-1],
-                    "owner_id": blob.metadata["ownerid"],
+                    "owner_id": blob.metadata.get("ownerid"),
                     "etag": blob.etag,
                     "last_modified_time": blob.last_modified.timestamp()
                     if blob.last_modified


### PR DESCRIPTION
Fix the cause of the error message:
```
EventProcessor instance 'xxxxxxxxxxx' of eventhub <name of my eventhub> consumer group <name of my consumer group>. An error occurred while load-balancing and claiming ownership. The exception is KeyError('ownerid'). Retrying after xxxx seconds
```

Mentioned in #13060