### PR TITLE
Extend Timeout of Regressions Again

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -173,7 +173,7 @@ jobs:
   - job: 'RunRegression'
     condition: and(succeededOrFailed(), or(eq(variables['Run.Regression'], 'true'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['System.TeamProject'],'internal'))))
     displayName: 'Run Regression'
-    timeoutInMinutes: 90
+    timeoutInMinutes: 120
     variables:
     - template: ../variables/globals.yml
 


### PR DESCRIPTION
Core nightly testing is facing a timeout issue. 

Right now. We have the following:

```
<target folder set, select packages within>
<run whl/sdist tests>
<run tests against min/max deps for each package within target_folder>
<run regression against packages that are taken as dependencies from other packages outside the target_folder>
```

Which means that the `core` regression tests are just running longer and longer as we move more packages to track 2.

Couple of things we can do here:

1) remove "latest" regression test. Very similar to our latest tests
2) move the regression testing for `core` into each service folder. If you take a dep on core, you will get a core regression test.

Or some other combination. Either way, let's get the immediate concern out of the way.
