### PR TITLE
[Key Vault] Increase wait times for purging in test samples

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates.py
@@ -216,7 +216,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         certificate_client.purge_deleted_certificate(certificate_name=cert_name)
 
         if self.is_live:
-            time.sleep(15)
+            time.sleep(60)
 
         # [START restore_certificate]
         # restore a certificate backup

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates_async.py
@@ -206,7 +206,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         await certificate_client.purge_deleted_certificate(certificate_name=cert_name)
 
         if self.is_live:
-            await asyncio.sleep(15)
+            await asyncio.sleep(60)
 
         # [START restore_certificate]
         # restores a certificate backup

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -189,7 +189,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         key_client.purge_deleted_key(key_name)
 
         if self.is_live:
-            time.sleep(15)
+            time.sleep(60)
 
         # [START restore_key_backup]
         # restore a key backup

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -183,7 +183,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         await key_client.purge_deleted_key(key_name)
 
         if self.is_live:
-            await asyncio.sleep(15)
+            await asyncio.sleep(60)
 
         # [START restore_key_backup]
         # restores a backup

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets.py
@@ -163,7 +163,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         secret_client.purge_deleted_secret("secret-name")
 
         if self.is_live:
-            time.sleep(15)
+            time.sleep(60)
 
         # [START restore_secret_backup]
         # restores a backed up secret

--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
@@ -158,7 +158,7 @@ class TestExamplesKeyVault(KeyVaultTestCase):
         await secret_client.purge_deleted_secret(created_secret.name)
 
         if self.is_live:
-            await asyncio.sleep(15)
+            await asyncio.sleep(60)
 
         # [START restore_secret_backup]
         # restores a backed up secret


### PR DESCRIPTION
This is to make tests less flaky in cases where we have to wait for purge operations to complete before restoring a resource. [This test run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=639342&view=results) saw most of these cases fail when waiting for 15 seconds, so I've bumped it to a minute.