### PR TITLE
Fix AttributeError when CryptographyClient created with key ID

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 4.3.1 (2020-12-03)
+### Fixed
+- `CryptographyClient` operations no longer raise `AttributeError` when
+  the client was constructed with a key ID
+  ([#15608](https://github.com/Azure/azure-sdk-for-python/issues/15608))
+
 ## 4.3.0 (2020-10-06)
 ### Changed
 - `CryptographyClient` can perform decrypt and sign operations locally

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_version.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "4.3.0"
+VERSION = "4.3.1"

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
@@ -87,9 +87,10 @@ class CryptographyClient(KeyVaultClientBase):
         # try to get the key material, if we don't have it and aren't forbidden to do so
         if not (self._key or self._keys_get_forbidden):
             try:
-                self._key = self._client.get_key(
+                key_bundle = self._client.get_key(
                     self._key_id.vault_url, self._key_id.name, self._key_id.version, **kwargs
                 )
+                self._key = KeyVaultKey._from_key_bundle(key_bundle)  # pylint:disable=protected-access
             except HttpResponseError as ex:
                 # if we got a 403, we don't have keys/get permission and won't try to get the key again
                 # (other errors may be transient)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
@@ -83,9 +83,10 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         # try to get the key material, if we don't have it and aren't forbidden to do so
         if not (self._key or self._keys_get_forbidden):
             try:
-                self._key = await self._client.get_key(
+                key_bundle = await self._client.get_key(
                     self._key_id.vault_url, self._key_id.name, self._key_id.version, **kwargs
                 )
+                self._key = KeyVaultKey._from_key_bundle(key_bundle)  # pylint:disable=protected-access
             except HttpResponseError as ex:
                 # if we got a 403, we don't have keys/get permission and won't try to get the key again
                 # (other errors may be transient)

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.test_ec_key_id.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.test_ec_key_id.yaml
@@ -1,0 +1,146 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.3.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/eckeye9470d88/create?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
+        or PoP token."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '87'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 02 Dec 2020 20:50:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.2.80.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"kty": "EC"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.3.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/eckeye9470d88/create?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/eckeye9470d88/6e2cecdbf94c445e94f803e7718005be","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"JHuxTma0kqxGE158ricCGgzbYHx8wDoHFyiY_ew7LVs","y":"nkFZV0C0Mg-_ao0hkHY2Byx829BaSNEV_UBiRRgs8E4"},"attributes":{"enabled":true,"created":1606942258,"updated":1606942258,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '404'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 02 Dec 2020 20:50:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.2.80.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.3.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/eckeye9470d88/6e2cecdbf94c445e94f803e7718005be?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/eckeye9470d88/6e2cecdbf94c445e94f803e7718005be","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"JHuxTma0kqxGE158ricCGgzbYHx8wDoHFyiY_ew7LVs","y":"nkFZV0C0Mg-_ao0hkHY2Byx829BaSNEV_UBiRRgs8E4"},"attributes":{"enabled":true,"created":1606942258,"updated":1606942258,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '404'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 02 Dec 2020 20:50:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.2.80.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.test_rsa_key_id.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.test_rsa_key_id.yaml
@@ -1,0 +1,146 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.3.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/rsakeyf8150e06/create?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
+        or PoP token."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '87'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 02 Dec 2020 20:51:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.2.80.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.3.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/rsakeyf8150e06/create?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/rsakeyf8150e06/ed780da8294a47aa906f65b4d3fff7d3","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"4ChGYiIT14cljCPVD6BEK23HeZ5Wzbm4JRLMtzLj7tpuUL3S0LBqcQRESEUkZ_La2olPa4lAwUhGN2cEQvhM0oNa1uGLubD9Q1V3g5yYeqj5faW5tdF_UXEcdSeODj7egV8miXO9IAKR0-L-8_-x8p_CkJSEk9DXSiiLtHUaxAb4EG2E8RyC3-Mw-Fb2cMxVC50X-S4dIs_9iKFenzqqWuYsIVme3Qritn2DMiOcswnr2LeCcFfruDTlFoLnAg-29dK0giOEYQmKOH3cM9EDZ93kKiiGcA6QLZefm8HbjqugvsAYoZDCtUvJkNBlCsc4YIM1FZYVXTDnWEddzB3CqQ","e":"AQAB"},"attributes":{"enabled":true,"created":1606942262,"updated":1606942262,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '694'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 02 Dec 2020 20:51:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.2.80.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.3.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/rsakeyf8150e06/ed780da8294a47aa906f65b4d3fff7d3?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/rsakeyf8150e06/ed780da8294a47aa906f65b4d3fff7d3","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"4ChGYiIT14cljCPVD6BEK23HeZ5Wzbm4JRLMtzLj7tpuUL3S0LBqcQRESEUkZ_La2olPa4lAwUhGN2cEQvhM0oNa1uGLubD9Q1V3g5yYeqj5faW5tdF_UXEcdSeODj7egV8miXO9IAKR0-L-8_-x8p_CkJSEk9DXSiiLtHUaxAb4EG2E8RyC3-Mw-Fb2cMxVC50X-S4dIs_9iKFenzqqWuYsIVme3Qritn2DMiOcswnr2LeCcFfruDTlFoLnAg-29dK0giOEYQmKOH3cM9EDZ93kKiiGcA6QLZefm8HbjqugvsAYoZDCtUvJkNBlCsc4YIM1FZYVXTDnWEddzB3CqQ","e":"AQAB"},"attributes":{"enabled":true,"created":1606942262,"updated":1606942262,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '694'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 02 Dec 2020 20:51:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.2.80.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.test_ec_key_id.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.test_ec_key_id.yaml
@@ -1,0 +1,100 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.3.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/eckey44f81005/create?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
+        or PoP token."}}'
+    headers:
+      cache-control: no-cache
+      content-length: '87'
+      content-type: application/json; charset=utf-8
+      date: Wed, 02 Dec 2020 21:00:26 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      www-authenticate: Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.2.80.0
+      x-powered-by: ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+    url: https://rksctajf3sdkivnhyff4gbsk.vault.azure.net/keys/eckey44f81005/create?api-version=7.1
+- request:
+    body: '{"kty": "EC"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.3.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/eckey44f81005/create?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/eckey44f81005/07e60fbae4674040aac1f6124925c269","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"bYvD5tgZo-5Nm4wVmTm_FbX4GTIaKHFHWLRgVz7CFv4","y":"qgjnEWGAD6T3ew3xQuzUPAdwI-jyZ85MrsTUSRxSc54"},"attributes":{"enabled":true,"created":1606942828,"updated":1606942828,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control: no-cache
+      content-length: '404'
+      content-type: application/json; charset=utf-8
+      date: Wed, 02 Dec 2020 21:00:27 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.2.80.0
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://rksctajf3sdkivnhyff4gbsk.vault.azure.net/keys/eckey44f81005/create?api-version=7.1
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.3.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/eckey44f81005/07e60fbae4674040aac1f6124925c269?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/eckey44f81005/07e60fbae4674040aac1f6124925c269","kty":"EC","key_ops":["sign","verify"],"crv":"P-256","x":"bYvD5tgZo-5Nm4wVmTm_FbX4GTIaKHFHWLRgVz7CFv4","y":"qgjnEWGAD6T3ew3xQuzUPAdwI-jyZ85MrsTUSRxSc54"},"attributes":{"enabled":true,"created":1606942828,"updated":1606942828,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control: no-cache
+      content-length: '404'
+      content-type: application/json; charset=utf-8
+      date: Wed, 02 Dec 2020 21:00:28 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.2.80.0
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://rksctajf3sdkivnhyff4gbsk.vault.azure.net/keys/eckey44f81005/07e60fbae4674040aac1f6124925c269?api-version=7.1
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.test_rsa_key_id.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.test_rsa_key_id.yaml
@@ -1,0 +1,100 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.3.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/rsakey56431083/create?api-version=7.1
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
+        or PoP token."}}'
+    headers:
+      cache-control: no-cache
+      content-length: '87'
+      content-type: application/json; charset=utf-8
+      date: Wed, 02 Dec 2020 21:00:26 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      www-authenticate: Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.2.80.0
+      x-powered-by: ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+    url: https://zpmogjxo3k2yc2sgurhm4smw.vault.azure.net/keys/rsakey56431083/create?api-version=7.1
+- request:
+    body: '{"kty": "RSA"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.3.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/keys/rsakey56431083/create?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/rsakey56431083/947300c2102a4bc59ebe97b63deb93af","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"0H_kpPaMhtTaJ_jG1Mj8tFDeHY-ZiYwa5emuv8aOtag8RGGKMmS2sPUAa3LIz3xmS_uDgY4Tfo_n_CBkgvGb1fJkb3kn5t6Y5FBh7U7bRZ0qtjDwgXd_B3n1MUq4Af1cQIXZLO58-Lzo4_varSIqF8Eaie8CQHTYZrA1mXq9USaknn4Mn2aBwUbCudFdFYNTRD9T1-grnz1OTA-SFPIRC0qi5I0M4BHDoTxYvJMGT6tCdQykQrkAoWBPg9hIEQcnqzXu0ZluOmx7uIGtxJwaaL2nBTdq9nIFAZhKhavx3T0_08wUtotewoNHkSj0HlTNkNYs2t_o4ORP5iXOto7TRQ","e":"AQAB"},"attributes":{"enabled":true,"created":1606942828,"updated":1606942828,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control: no-cache
+      content-length: '694'
+      content-type: application/json; charset=utf-8
+      date: Wed, 02 Dec 2020 21:00:30 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.2.80.0
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://zpmogjxo3k2yc2sgurhm4smw.vault.azure.net/keys/rsakey56431083/create?api-version=7.1
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.3.1 Python/3.5.4 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/keys/rsakey56431083/947300c2102a4bc59ebe97b63deb93af?api-version=7.1
+  response:
+    body:
+      string: '{"key":{"kid":"https://vaultname.vault.azure.net/keys/rsakey56431083/947300c2102a4bc59ebe97b63deb93af","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"0H_kpPaMhtTaJ_jG1Mj8tFDeHY-ZiYwa5emuv8aOtag8RGGKMmS2sPUAa3LIz3xmS_uDgY4Tfo_n_CBkgvGb1fJkb3kn5t6Y5FBh7U7bRZ0qtjDwgXd_B3n1MUq4Af1cQIXZLO58-Lzo4_varSIqF8Eaie8CQHTYZrA1mXq9USaknn4Mn2aBwUbCudFdFYNTRD9T1-grnz1OTA-SFPIRC0qi5I0M4BHDoTxYvJMGT6tCdQykQrkAoWBPg9hIEQcnqzXu0ZluOmx7uIGtxJwaaL2nBTdq9nIFAZhKhavx3T0_08wUtotewoNHkSj0HlTNkNYs2t_o4ORP5iXOto7TRQ","e":"AQAB"},"attributes":{"enabled":true,"created":1606942828,"updated":1606942828,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+    headers:
+      cache-control: no-cache
+      content-length: '694'
+      content-type: application/json; charset=utf-8
+      date: Wed, 02 Dec 2020 21:00:29 GMT
+      expires: '-1'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000;includeSubDomains
+      x-content-type-options: nosniff
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=24.17.201.78;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region: westus
+      x-ms-keyvault-service-version: 1.2.80.0
+      x-powered-by: ASP.NET
+    status:
+      code: 200
+      message: OK
+    url: https://zpmogjxo3k2yc2sgurhm4smw.vault.azure.net/keys/rsakey56431083/947300c2102a4bc59ebe97b63deb93af?api-version=7.1
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -85,6 +85,42 @@ class CryptoClientTests(KeyVaultTestCase):
         return imported_key
 
     @ResourceGroupPreparer(random_name_enabled=True)
+    @KeyVaultPreparer()
+    @CryptoClientPreparer()
+    def test_ec_key_id(self, key_client, credential, **kwargs):
+        """When initialized with a key ID, the client should retrieve the key and perform public operations locally"""
+
+        key = key_client.create_ec_key(self.create_random_name("eckey"))
+
+        crypto_client = CryptographyClient(key.id, credential)
+        crypto_client._initialize()
+        assert crypto_client.key_id == key.id
+
+        # ensure all remote crypto operations will fail
+        crypto_client._client = None
+
+        crypto_client.verify(SignatureAlgorithm.es256_k, hashlib.sha256(self.plaintext).digest(), self.plaintext)
+
+    @ResourceGroupPreparer(random_name_enabled=True)
+    @KeyVaultPreparer()
+    @CryptoClientPreparer()
+    def test_rsa_key_id(self, key_client, credential, **kwargs):
+        """When initialized with a key ID, the client should retrieve the key and perform public operations locally"""
+
+        key = key_client.create_rsa_key(self.create_random_name("rsakey"))
+
+        crypto_client = CryptographyClient(key.id, credential)
+        crypto_client._initialize()
+        assert crypto_client.key_id == key.id
+
+        # ensure all remote crypto operations will fail
+        crypto_client._client = None
+
+        crypto_client.encrypt(EncryptionAlgorithm.rsa_oaep, self.plaintext)
+        crypto_client.verify(SignatureAlgorithm.rs256, hashlib.sha256(self.plaintext).digest(), self.plaintext)
+        crypto_client.wrap_key(KeyWrapAlgorithm.rsa_oaep, self.plaintext)
+
+    @ResourceGroupPreparer(random_name_enabled=True)
     @KeyVaultPreparer(permissions=NO_GET)
     @CryptoClientPreparer()
     def test_encrypt_and_decrypt(self, key_client, credential, **kwargs):
@@ -286,17 +322,21 @@ def test_initialization_given_key():
 def test_initialization_get_key_successful():
     """If the client is able to get key material, it shouldn't do so again"""
 
-    mock_client = mock.Mock()
-    mock_client.get_key.return_value = mock.Mock(spec=KeyVaultKey)
-    client = CryptographyClient("https://localhost/fake/key/version", mock.Mock())
-    client._client = mock_client
+    key_id = "https://localhost/fake/key/version"
     mock_key = mock.Mock()
+    mock_key.key.kid = key_id
+    mock_client = mock.Mock()
     mock_client.get_key.return_value = mock_key
+
+    client = CryptographyClient(key_id, mock.Mock())
+    client._client = mock_client
 
     assert mock_client.get_key.call_count == 0
     with mock.patch(CryptographyClient.__module__ + ".get_local_cryptography_provider") as get_provider:
         client.verify(SignatureAlgorithm.rs256, b"...", b"...")
-    get_provider.assert_called_once_with(mock_key)
+
+    args, _ = get_provider.call_args
+    assert len(args) == 1 and isinstance(args[0], KeyVaultKey) and args[0].id == key_id
 
     for _ in range(3):
         assert mock_client.get_key.call_count == 1


### PR DESCRIPTION
As described in #15608, in version 4.3.0 CryptographyClient operations can raise AttributeError when the client is created with a key ID rather than a KeyVaultKey. This happens because the client passes an autorest generated KeyBundle to a function that expects a KeyVaultKey. This PR ensures the client has the correct model type, and adds test coverage.