### PR TITLE
Improvement of changelog tool

### DIFF
--- a/tools/azure-devtools/src/azure_devtools/ci_tools/git_tools.py
+++ b/tools/azure-devtools/src/azure_devtools/ci_tools/git_tools.py
@@ -88,3 +88,10 @@ def get_files_in_commit(git_folder, commit_id="HEAD"):
     repo = Repo(str(git_folder))
     output = repo.git.diff("--name-only", commit_id+"^", commit_id)
     return output.splitlines()
+
+def get_diff_file_list(git_folder):
+    """List of unstaged files.
+    """
+    repo = Repo(str(git_folder))
+    output = repo.git.diff("--name-only")
+    return output.splitlines()

--- a/tools/azure-sdk-tools/packaging_tools/change_log.py
+++ b/tools/azure-sdk-tools/packaging_tools/change_log.py
@@ -171,6 +171,18 @@ def get_report_from_parameter(input_parameter):
         return json.load(fd)
 
 
+def main(base, latest):
+    old_report = get_report_from_parameter(base)
+    new_report = get_report_from_parameter(latest)
+
+    # result = diff(old_report, new_report)
+    # with open("result.json", "w") as fd:
+    #     json.dump(result, fd)
+
+    change_log = build_change_log(old_report, new_report)
+    return change_log.build_md()
+
+
 if __name__ == "__main__":
     import argparse
 
@@ -190,12 +202,4 @@ if __name__ == "__main__":
 
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
 
-    old_report = get_report_from_parameter(args.base)
-    new_report = get_report_from_parameter(args.latest)
-
-    # result = diff(old_report, new_report)
-    # with open("result.json", "w") as fd:
-    #     json.dump(result, fd)
-
-    change_log = build_change_log(old_report, new_report)
-    print(change_log.build_md())
+    print(main(args.base, args.latest))


### PR DESCRIPTION
Allow to do changelog in a oneliner like:
```
python -m packaging_tools.change_log azure-synapse:pypi azure-synapse:latest
```

We skip the code_report now. This is backward compatible, this is just adding new things you could do.