### PR TITLE
fixing read from mgmt settings real for the azure credentials

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/azure_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/azure_testcase.py
@@ -194,9 +194,9 @@ class AzureTestCase(ReplayableTest):
 
     def get_credential(self, client_class, **kwargs):
 
-        tenant_id = os.environ.get("AZURE_TENANT_ID", None)
-        client_id = os.environ.get("AZURE_CLIENT_ID", None)
-        secret = os.environ.get("AZURE_CLIENT_SECRET", None)
+        tenant_id = os.environ.get("AZURE_TENANT_ID", self._real_settings.TENANT_ID or None)
+        client_id = os.environ.get("AZURE_CLIENT_ID", self._real_settings.CLIENT_ID or None)
+        secret = os.environ.get("AZURE_CLIENT_SECRET", self._real_settings.CLIENT_SECRET or None)
         is_async = kwargs.pop("is_async", False)
 
         if tenant_id and client_id and secret and self.is_live:

--- a/tools/azure-sdk-tools/devtools_testutils/azure_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/azure_testcase.py
@@ -194,9 +194,9 @@ class AzureTestCase(ReplayableTest):
 
     def get_credential(self, client_class, **kwargs):
 
-        tenant_id = os.environ.get("AZURE_TENANT_ID", self._real_settings.TENANT_ID or None)
-        client_id = os.environ.get("AZURE_CLIENT_ID", self._real_settings.CLIENT_ID or None)
-        secret = os.environ.get("AZURE_CLIENT_SECRET", self._real_settings.CLIENT_SECRET or None)
+        tenant_id = os.environ.get("AZURE_TENANT_ID", getattr(self._real_settings, "TENANT_ID", None))
+        client_id = os.environ.get("AZURE_CLIENT_ID", getattr(self._real_settings, "CLIENT_ID", None))
+        secret = os.environ.get("AZURE_CLIENT_SECRET", getattr(self._real_settings, "CLIENT_SECRET", None))
         is_async = kwargs.pop("is_async", False)
 
         if tenant_id and client_id and secret and self.is_live:


### PR DESCRIPTION
Reads TENANT_ID, CLIENT_ID, CLIENT_SECRET from the mgmt_settings_real file if they are not set in environment variables.