### PR TITLE
adding live code-coverage for just python39

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,3 +13,4 @@ exclude_lines =
 	if custom_headers:
 	if headers:
 	if response.status_code not in
+	if TYPE_CHECKING:

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -18,18 +18,23 @@ parameters:
     Linux_Python35:
       OSVmImage: 'ubuntu-18.04'
       PythonVersion: '3.5'
+      CoverageArg: '--disablecov'
     MacOs_Python37:
       OSVmImage: 'macOS-10.15'
       PythonVersion: '3.7'
+      CoverageArg: '--disablecov'
     Windows_Python27:
       OSVmImage: 'windows-2019'
       PythonVersion: '2.7'
+      CoverageArg: '--disablecov'
     Linux_PyPy3:
       OSVmImage: 'ubuntu-18.04'
       PythonVersion: 'pypy3'
+      CoverageArg: '--disablecov'
     Linux_Python39:
       OSVmImage: 'ubuntu-18.04'
       PythonVersion: '3.9'
+      CoverageArg: ''
   CloudConfigurations:
     AzureCloud:
       SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
@@ -39,7 +44,6 @@ jobs:
     - job: ${{ parameters.JobName }}
       variables:
         skipComponentGovernanceDetection: true
-        CoverageArg: --disablecov
 
       timeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
       strategy:

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -9,15 +9,19 @@ jobs:
         Linux_Python35:
           OSVmImage: 'ubuntu-18.04'
           PythonVersion: '3.5'
+          CoverageArg: '--disablecov'
         Linux_Python39:
           OSVmImage: 'ubuntu-18.04'
           PythonVersion: '3.9.0'
+          CoverageArg: ''
         Windows_Python27:
           OSVmImage: 'windows-2019'
           PythonVersion: '2.7'
+          CoverageArg: '--disablecov'
         MacOs_Python37:
           OSVmImage: 'macOS-10.15'
           PythonVersion: '3.7'
+          CoverageArg: '--disablecov'
       EnvVars:
         AZURE_STORAGE_ACCOUNT: $(python-eh-livetest-event-hub-storage-account)
         AZURE_STORAGE_ACCESS_KEY: $(python-eh-livetest-event-hub-storage-access-key)

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -21,7 +21,7 @@ jobs:
         MacOs_Python37:
           OSVmImage: 'macOS-10.15'
           PythonVersion: '3.7'
-          CoverageArg: '--disablecov'
+          CoverageArg: ''
       EnvVars:
         AZURE_STORAGE_ACCOUNT: $(python-eh-livetest-event-hub-storage-account)
         AZURE_STORAGE_ACCESS_KEY: $(python-eh-livetest-event-hub-storage-access-key)

--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -14,29 +14,37 @@ jobs:
           Linux_Python35:
             OSVmImage: 'ubuntu-18.04'
             PythonVersion: '3.5'
+            CoverageArg: '--disablecov'
           MacOs_Python37:
             OSVmImage: 'macOS-10.15'
             PythonVersion: '3.7'
+            CoverageArg: '--disablecov'
           Windows_Python27:
             OSVmImage: 'windows-2019'
             PythonVersion: '2.7'
+            CoverageArg: '--disablecov'
           Linux_PyPy3:
             OSVmImage: 'ubuntu-18.04'
             PythonVersion: 'pypy3'
+            CoverageArg: '--disablecov'
           Linux_Python39:
             OSVmImage: 'ubuntu-18.04'
             PythonVersion: '3.9.0'
+            CoverageArg: ''
       ${{ if not(contains(variables['Build.DefinitionName'], 'prod')) }}:
         Matrix:
           Linux_Python35:
             OSVmImage: 'ubuntu-18.04'
             PythonVersion: '3.5'
+            CoverageArg: '--disablecov'
           Windows_Python27:
             OSVmImage: 'windows-2019'
             PythonVersion: '2.7'
+            CoverageArg: '--disablecov'
           Linux_Python39:
             OSVmImage: 'ubuntu-18.04'
             PythonVersion: '3.9.0'
+            CoverageArg: '--disablecov'
       EnvVars:
         AZURE_FORM_RECOGNIZER_PYTHON_CANARY_API_KEY: $(python-formrecognizer-test-canary-api-key)
         AZURE_FORM_RECOGNIZER_PYTHON_API_KEY: $(python-formrecognizer-test-api-key)

--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -44,7 +44,7 @@ jobs:
           Linux_Python39:
             OSVmImage: 'ubuntu-18.04'
             PythonVersion: '3.9.0'
-            CoverageArg: '--disablecov'
+            CoverageArg: ''
       EnvVars:
         AZURE_FORM_RECOGNIZER_PYTHON_CANARY_API_KEY: $(python-formrecognizer-test-canary-api-key)
         AZURE_FORM_RECOGNIZER_PYTHON_API_KEY: $(python-formrecognizer-test-api-key)

--- a/sdk/monitor/tests.yml
+++ b/sdk/monitor/tests.yml
@@ -24,4 +24,4 @@ jobs:
         Linux_Python39:
           OSVmImage: 'ubuntu-18.04'
           PythonVersion: '3.9.0'
-          CoverageArg: ''
+          CoverageArg: '--disablecov'

--- a/sdk/monitor/tests.yml
+++ b/sdk/monitor/tests.yml
@@ -16,9 +16,12 @@ jobs:
         Linux_Python35:
           OSVmImage: 'ubuntu-18.04'
           PythonVersion: '3.5'
+          CoverageArg: '--disablecov'
         MacOs_Python37:
           OSVmImage: 'macOS-10.15'
           PythonVersion: '3.7'
+          CoverageArg: '--disablecov'
         Linux_Python39:
           OSVmImage: 'ubuntu-18.04'
           PythonVersion: '3.9.0'
+          CoverageArg: ''

--- a/sdk/monitor/tests.yml
+++ b/sdk/monitor/tests.yml
@@ -24,4 +24,4 @@ jobs:
         Linux_Python39:
           OSVmImage: 'ubuntu-18.04'
           PythonVersion: '3.9.0'
-          CoverageArg: '--disablecov'
+          CoverageArg: ''

--- a/sdk/schemaregistry/tests.yml
+++ b/sdk/schemaregistry/tests.yml
@@ -32,4 +32,4 @@ jobs:
         Linux_Python38:
           OSVmImage: 'ubuntu-18.04'
           PythonVersion: '3.8'
-          CoverageArg: '--disablecov'
+          CoverageArg: ''

--- a/sdk/schemaregistry/tests.yml
+++ b/sdk/schemaregistry/tests.yml
@@ -20,12 +20,16 @@ jobs:
         Linux_Python35:
           OSVmImage: 'ubuntu-18.04'
           PythonVersion: '3.5'
+          CoverageArg: '--disablecov'
         MacOs_Python37:
           OSVmImage: 'macOS-10.15'
           PythonVersion: '3.7'
+          CoverageArg: '--disablecov'
         Windows_Python27:
           OSVmImage: 'windows-2019'
           PythonVersion: '2.7'
+          CoverageArg: '--disablecov'
         Linux_Python38:
           OSVmImage: 'ubuntu-18.04'
           PythonVersion: '3.8'
+          CoverageArg: '--disablecov'

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -16,12 +16,16 @@ jobs:
         Linux_Python35:
           OSVmImage: 'ubuntu-18.04'
           PythonVersion: '3.5'
+          CoverageArg: '--disablecov'
         MacOs_Python37:
           OSVmImage: 'macOS-10.15'
           PythonVersion: '3.7'
+          CoverageArg: '--disablecov'
         Windows_Python27:
           OSVmImage: 'windows-2019'
           PythonVersion: '2.7'
+          CoverageArg: '--disablecov'
         Linux_Python39:
           OSVmImage: 'ubuntu-18.04'
           PythonVersion: '3.9.0'
+          CoverageArg: ''


### PR DESCRIPTION
Breaking PR #15577 into two PRs, the latter will focus on the report generation. This PR is just for enabling code coverage