### PR TITLE
[EventHub] Fix keyerror issue in BlobCheckpointStore

### DIFF
--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## 1.1.2 (Unreleased)
 
+**Bug fixes**
+- Fixed a bug that `BlobCheckpointStore.list_ownership` and `BlobCheckpointStore.list_checkpoints` triggering `KeyError` due to reading empty metadata of parent node when working with Data Lake enabled Blob Storage.
 
 ## 1.1.1 (2020-09-08)
+
 **Bug fixes**
 - Fixed a bug that may gradually slow down retrieving checkpoint data from the storage blob if the storage account "File share soft delete" is enabled. #12836
-
 
 ## 1.1.0 (2020-03-09)
 

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_blobstoragecsaio.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_blobstoragecsaio.py
@@ -133,7 +133,7 @@ class BlobCheckpointStore(CheckpointStore):
         self, fully_qualified_namespace: str, eventhub_name: str, consumer_group: str
     ) -> Iterable[Dict[str, Any]]:
         try:
-            blob_prefix = "{}/{}/{}/ownership".format(
+            blob_prefix = "{}/{}/{}/ownership/".format(
                 fully_qualified_namespace, eventhub_name, consumer_group
             )
             blobs = self._container_client.list_blobs(
@@ -237,7 +237,7 @@ class BlobCheckpointStore(CheckpointStore):
     async def list_checkpoints(
         self, fully_qualified_namespace, eventhub_name, consumer_group
     ):
-        blob_prefix = "{}/{}/{}/checkpoint".format(
+        blob_prefix = "{}/{}/{}/checkpoint/".format(
             fully_qualified_namespace, eventhub_name, consumer_group
         )
         blobs = self._container_client.list_blobs(

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/tests/test_storage_blob_partition_manager_aio.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/tests/test_storage_blob_partition_manager_aio.py
@@ -14,22 +14,25 @@ import asyncio
 from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
 from azure.eventhub.extensions.checkpointstoreblobaio._vendor.storage.blob import BlobServiceClient
 
+STORAGE_ENV_KEYS = [
+    "AZURE_STORAGE_CONN_STR",
+    "AZURE_STORAGE_DATA_LAKE_ENABLED_CONN_STR"
+]
 
-def get_live_storage_blob_client():
+
+def get_live_storage_blob_client(conn_str_env_key):
     try:
-        storage_connection_str = os.environ['AZURE_STORAGE_CONN_STR']
-    except KeyError:
-        return None, None
+        storage_connection_str = os.environ[conn_str_env_key]
+        container_name = str(uuid.uuid4())
+        blob_service_client = BlobServiceClient.from_connection_string(storage_connection_str)
+        blob_service_client.create_container(container_name)
+        return storage_connection_str, container_name
+    except:
+        pytest.skip("Storage blob client can't be created")
 
-    container_str = str(uuid.uuid4())
-    blob_service_client = BlobServiceClient.from_connection_string(storage_connection_str)
-    blob_service_client.create_container(container_str)
-    return storage_connection_str, container_str
 
-
-def remove_live_storage_blob_client(container_str):
+def remove_live_storage_blob_client(storage_connection_str, container_str):
     try:
-        storage_connection_str = os.environ['AZURE_STORAGE_CONN_STR']
         blob_service_client = BlobServiceClient.from_connection_string(storage_connection_str)
         blob_service_client.delete_container(container_str)
     except:
@@ -71,18 +74,6 @@ async def _claim_and_list_ownership(connection_str, container_name):
         assert len(ownership_list) == ownership_cnt
 
 
-@pytest.mark.liveTest
-def test_claim_and_list_ownership():
-    connection_str, container_name = get_live_storage_blob_client()
-    if not connection_str:
-        pytest.skip("Storage blob client can't be created")
-    try:
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(_claim_and_list_ownership(connection_str, container_name))
-    finally:
-        remove_live_storage_blob_client(container_name)
-
-
 async def _update_checkpoint(connection_str, container_name):
     fully_qualified_namespace = 'test_namespace'
     eventhub_name = 'eventhub'
@@ -112,13 +103,23 @@ async def _update_checkpoint(connection_str, container_name):
             assert checkpoint['sequence_number'] == 20
 
 
+@pytest.mark.parametrize("conn_str_env_key", STORAGE_ENV_KEYS)
 @pytest.mark.liveTest
-def test_update_checkpoint():
-    connection_str, container_name = get_live_storage_blob_client()
-    if not connection_str:
-        pytest.skip("Storage blob client can't be created")
+def test_claim_and_list_ownership(conn_str_env_key):
+    storage_connection_str, container_name = get_live_storage_blob_client(conn_str_env_key)
     try:
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(_update_checkpoint(connection_str, container_name))
+        loop.run_until_complete(_claim_and_list_ownership(storage_connection_str, container_name))
     finally:
-        remove_live_storage_blob_client(container_name)
+        remove_live_storage_blob_client(storage_connection_str, container_name)
+
+
+@pytest.mark.parametrize("conn_str_env_key", STORAGE_ENV_KEYS)
+@pytest.mark.liveTest
+def test_update_checkpoint(conn_str_env_key):
+    storage_connection_str, container_name = get_live_storage_blob_client(conn_str_env_key)
+    try:
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(_update_checkpoint(storage_connection_str, container_name))
+    finally:
+        remove_live_storage_blob_client(storage_connection_str, container_name)

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## 1.1.2 (Unreleased)
 
+**Bug fixes**
+- Fixed a bug that `BlobCheckpointStore.list_ownership` and `BlobCheckpointStore.list_checkpoints` triggering `KeyError` due to reading empty metadata of parent node when working with Data Lake enabled Blob Storage.
 
 ## 1.1.1 (2020-09-08)
+
 **Bug fixes**
 - Fixed a bug that may gradually slow down retrieving checkpoint data from the storage blob if the storage account "File share soft delete" is enabled. #12836
 

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_blobstoragecs.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_blobstoragecs.py
@@ -152,7 +152,7 @@ class BlobCheckpointStore(CheckpointStore):
 
     def list_ownership(self, fully_qualified_namespace, eventhub_name, consumer_group):
         try:
-            blob_prefix = "{}/{}/{}/ownership".format(
+            blob_prefix = "{}/{}/{}/ownership/".format(
                 fully_qualified_namespace, eventhub_name, consumer_group
             )
             blobs = self._container_client.list_blobs(
@@ -252,7 +252,7 @@ class BlobCheckpointStore(CheckpointStore):
     def list_checkpoints(
         self, fully_qualified_namespace, eventhub_name, consumer_group
     ):
-        blob_prefix = "{}/{}/{}/checkpoint".format(
+        blob_prefix = "{}/{}/{}/checkpoint/".format(
             fully_qualified_namespace, eventhub_name, consumer_group
         )
         blobs = self._container_client.list_blobs(

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -22,6 +22,7 @@ jobs:
         AZURE_STORAGE_ACCOUNT: $(python-eh-livetest-event-hub-storage-account)
         AZURE_STORAGE_ACCESS_KEY: $(python-eh-livetest-event-hub-storage-access-key)
         AZURE_STORAGE_CONN_STR: $(python-eh-livetest-event-hub-storage-conn-str)
+        AZURE_STORAGE_DATA_LAKE_ENABLED_CONN_STR: $(python-eh-livetest-event-hub-storage-data-lake-enabled-conn-str)
         EVENT_HUB_CONN_STR: $(python-eh-livetest-event-hub-conn-str)
         EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
         EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)


### PR DESCRIPTION
Addressing issue: https://github.com/Azure/azure-sdk-for-python/issues/13060
stack overflow issue: https://stackoverflow.com/questions/63354884/azure-eventhubs-python-checkpointing-with-blob-storage-keyerror-issue-in-ev

also added a test resource storage blob v2 with data lake enabled to verify the fix

--------------

--- echoing the context here ---

The root cause of KeyError is that the `list_blobs` functionality when called on a v2 storage blob with data lake enabled (hierarchical namespace) will not only get the per-partition checkpoint/ownership but also get the parent blob node which contains no metadata.

To illustrate this better, let's say we have the following blob structures:
```
- fullqualifiednamespace (directory)
  - eventhubname (directory)
    - $default (directory)
        - ownership (directory)
          - 0 (blob)
          - 1 (blob)
          ...
```

in v2 storage with data lake enabled (hierarchical namespace), when the code was using prefix
`{<fully_qualified_namespace>/<eventhub_name>/<consumer_group>/ownership` to search for blobs, the `{<fully_qualified_namespace>/<eventhub_name>/<consumer_group>/ownership` directory itself would also be returned containing no metadata leading to the `KeyError` when we're trying to extract information.

What we want is the per-partition blob, the the fix is easy: we add a `/` at the end of the prefix search string such that `list_blobs` won't return the parent node.
`{<fully_qualified_namespace>/<eventhub_name>/<consumer_group>/ownership/`

(Checkpoint would encounter the same problem)