### PR TITLE
Remove azure-sdk-tools from the dev requirements

### DIFF
--- a/sdk/eventhub/azure-eventhub/dev_requirements.txt
+++ b/sdk/eventhub/azure-eventhub/dev_requirements.txt
@@ -1,4 +1,3 @@
--e ../../../tools/azure-sdk-tools
 ../../core/azure-core
 -e ../../identity/azure-identity
 -e ../azure-mgmt-eventhub


### PR DESCRIPTION
The current state of the repo fails to run tests upon a clean clone. 
Removing `azure-sdk-tools` from the dev-dependencies fixes this (see Github issue). 
Re-adding dependency afterward does not break the test pipeline, so I'm wondering if that is the reason this has not been caught.

This fixes #15759