### PR TITLE
run samples even if tests fail

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -70,6 +70,7 @@ steps:
 
   - ${{ if eq(parameters['TestSamples'], true) }}:
     - task: PythonScript@0
+      condition: succeededOrFailed()
       displayName: 'Test Samples'
       inputs:
         scriptPath: 'scripts/devops_tasks/setup_execute_tests.py'


### PR DESCRIPTION
Currently if tests fail, samples are skipped in the pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=655301&view=logs&j=e4797745-1ad6-5989-d345-8ffe02e82111&t=89a0f654-1963-5cb5-5df3-6e3f7fc697ab