### PR TITLE
Better error from InteractiveBrowserCredential for invalid redirect_uri

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -50,6 +50,7 @@ class InteractiveBrowserCredential(InteractiveCredential):
     :keyword bool allow_unencrypted_cache: if True, the credential will fall back to a plaintext cache on platforms
           where encryption is unavailable. Default to False. Has no effect when `enable_persistent_cache` is False.
     :keyword int timeout: seconds to wait for the user to complete authentication. Defaults to 300 (5 minutes).
+    :raises ValueError: invalid `redirect_uri`
     """
 
     def __init__(self, **kwargs):

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -37,7 +37,7 @@ class InteractiveBrowserCredential(InteractiveCredential):
     :keyword str tenant_id: an Azure Active Directory tenant ID. Defaults to the 'organizations' tenant, which can
           authenticate work or school accounts.
     :keyword str client_id: Client ID of the Azure Active Directory application users will sign in to. If
-          unspecified, the Azure CLI's ID will be used.
+          unspecified, users will authenticate to an Azure development application.
     :keyword str redirect_uri: a redirect URI for the application identified by `client_id` as configured in Azure
           Active Directory, for example "http://localhost:8400". This is only required when passing a value for
           `client_id`, and must match a redirect URI in the application's registration. The credential must be able to

--- a/sdk/identity/azure-identity/azure/identity/_internal/auth_code_redirect_handler.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/auth_code_redirect_handler.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 from typing import TYPE_CHECKING
 
-from six.moves.urllib_parse import parse_qs, urlparse
+from six.moves.urllib_parse import parse_qs
 
 try:
     from http.server import HTTPServer, BaseHTTPRequestHandler
@@ -45,10 +45,9 @@ class AuthCodeRedirectServer(HTTPServer):
 
     query_params = {}  # type: Mapping[str, Any]
 
-    def __init__(self, uri, timeout):
-        # type: (str, int) -> None
-        parsed = urlparse(uri)
-        HTTPServer.__init__(self, (parsed.hostname, parsed.port), AuthCodeRedirectHandler)
+    def __init__(self, hostname, port, timeout):
+        # type: (str, int, int) -> None
+        HTTPServer.__init__(self, (hostname, port), AuthCodeRedirectHandler)
         self.timeout = timeout
 
     def wait_for_redirect(self):

--- a/sdk/identity/azure-identity/tests/test_browser_credential.py
+++ b/sdk/identity/azure-identity/tests/test_browser_credential.py
@@ -323,6 +323,14 @@ def test_no_browser():
         credential.get_token("scope")
 
 
+@pytest.mark.parametrize("redirect_uri", ("http://localhost", "host", "host:42"))
+def test_invalid_redirect_uri(redirect_uri):
+    """The credential should raise ValueError when redirect_uri is invalid or doesn't include a port"""
+
+    with pytest.raises(ValueError):
+        InteractiveBrowserCredential(redirect_uri=redirect_uri)
+
+
 def test_cannot_bind_port():
     """get_token should raise CredentialUnavailableError when the redirect listener can't bind a port"""
 


### PR DESCRIPTION
InteractiveBrowserCredential's optional `redirect_uri` argument must be a URL with a port. That's okay but the credential doesn't fail until it first tries to use the URL, so when you construct a credential with an invalid URL, you won't know it's invalid until you try to get a token and the error message is unhelpful:
```
>>> credential = InteractiveBrowserCredential(redirect_uri="http://localhost")
>>> credential.get_token("...")
azure.core.exceptions.ClientAuthenticationError: Authentication failed: an integer is required (got type NoneType)
```


This PR refactors the credential's usage of this argument such that the credential can validate the URL at initialization and raise a better error:
```
>>> credential = InteractiveBrowserCredential(redirect_uri="http://localhost")
ValueError: "redirect_uri" must be a URL with port number, for example "http://localhost:8400"
```