### PR TITLE
[formrecognizer] fix specified py3.9 version in tests.yml

### DIFF
--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -30,7 +30,7 @@ jobs:
             CoverageArg: '--disablecov'
           Linux_Python39:
             OSVmImage: 'ubuntu-18.04'
-            PythonVersion: '3.9.0'
+            PythonVersion: '3.9'
             CoverageArg: ''
       ${{ if not(contains(variables['Build.DefinitionName'], 'prod')) }}:
         Matrix:
@@ -44,7 +44,7 @@ jobs:
             CoverageArg: '--disablecov'
           Linux_Python39:
             OSVmImage: 'ubuntu-18.04'
-            PythonVersion: '3.9.0'
+            PythonVersion: '3.9'
             CoverageArg: ''
       EnvVars:
         AZURE_FORM_RECOGNIZER_PYTHON_CANARY_API_KEY: $(python-formrecognizer-test-canary-api-key)


### PR DESCRIPTION
Devops can't find specific version == 3.9.0 so change to just 3.9. Form Recognizer has a custom matrix so this isn't a problem globally.

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=657059&view=logs&j=ee7075db-cef6-5179-b1aa-99257e6c4c16&t=7b27ccf4-ea16-59a3-0c84-9fbb8a114e86