### PR TITLE
Run mypy in azure-identity CI

### DIFF
--- a/eng/tox/mypy_hard_failure_packages.py
+++ b/eng/tox/mypy_hard_failure_packages.py
@@ -8,6 +8,7 @@
 MYPY_HARD_FAILURE_OPTED = [
   "azure-core",
   "azure-eventhub",
+  "azure-identity",
   "azure-servicebus",
   "azure-ai-textanalytics",
   "azure-ai-formrecognizer",

--- a/sdk/identity/azure-identity/azure/identity/_credentials/app_service.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/app_service.py
@@ -25,13 +25,14 @@ class AppServiceCredential(GetTokenMixin):
 
         client_args = _get_client_args(**kwargs)
         if client_args:
+            self._available = True
             self._client = ManagedIdentityClient(**client_args)
         else:
-            self._client = None
+            self._available = False
 
     def get_token(self, *scopes, **kwargs):
         # type: (*str, **Any) -> AccessToken
-        if not self._client:
+        if not self._available:
             raise CredentialUnavailableError(
                 message="App Service managed identity configuration not found in environment"
             )

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -22,8 +22,8 @@ except ImportError:
     TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    from typing import Any
-    from azure.core.credentials import AccessToken
+    from typing import Any, List
+    from azure.core.credentials import AccessToken, TokenCredential
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -101,7 +101,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
         exclude_cli_credential = kwargs.pop("exclude_cli_credential", False)
         exclude_interactive_browser_credential = kwargs.pop("exclude_interactive_browser_credential", True)
 
-        credentials = []
+        credentials = []  # type: List[TokenCredential]
         if not exclude_environment_credential:
             credentials.append(EnvironmentCredential(authority=authority, **kwargs))
         if not exclude_managed_identity_credential:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -33,6 +33,7 @@ except ImportError:
 if TYPE_CHECKING:
     # pylint:disable=unused-import
     from typing import Any, Optional, Type
+    from azure.core.credentials import TokenCredential
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,7 +53,7 @@ class ManagedIdentityCredential(object):
 
     def __init__(self, **kwargs):
         # type: (**Any) -> None
-        self._credential = None
+        self._credential = None  # type: Optional[TokenCredential]
         if os.environ.get(EnvironmentVariables.MSI_ENDPOINT):
             if os.environ.get(EnvironmentVariables.MSI_SECRET):
                 _LOGGER.info("%s will use App Service managed identity", self.__class__.__name__)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/service_fabric.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/service_fabric.py
@@ -25,13 +25,14 @@ class ServiceFabricCredential(GetTokenMixin):
 
         client_args = _get_client_args(**kwargs)
         if client_args:
+            self._available = True
             self._client = ManagedIdentityClient(**client_args)
         else:
-            self._client = None
+            self._available = False
 
     def get_token(self, *scopes, **kwargs):
         # type: (*str, **Any) -> AccessToken
-        if not self._client:
+        if not self._available:
             raise CredentialUnavailableError(
                 message="Service Fabric managed identity configuration not found in environment"
             )

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -130,6 +130,11 @@ class SharedTokenCacheCredential(SharedTokenCacheBase):
         # type: (*str, **Any) -> AccessToken
         """Silently acquire a token from MSAL. Requires an AuthenticationRecord."""
 
+        # self._auth_record and ._app will not be None when this method is called by get_token
+        # but should either be None anyway (and to satisfy mypy) we raise
+        if self._app is None or self._auth_record is None:
+            raise CredentialUnavailableError("Initialization failed")
+
         result = None
 
         accounts_for_user = self._app.get_accounts(username=self._auth_record.username)

--- a/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
@@ -33,8 +33,8 @@ VALID_TENANT_ID_CHARACTERS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn
 
 
 def validate_tenant_id(tenant_id):
-    """Raise ValueError if tenant_id is empty or contains a character invalid for a tenant id"""
     # type: (str) -> None
+    """Raise ValueError if tenant_id is empty or contains a character invalid for a tenant id"""
     if not tenant_id or any(c not in VALID_TENANT_ID_CHARACTERS for c in tenant_id):
         raise ValueError(
             "Invalid tenant id provided. You can locate your tenant id by following the instructions here: "

--- a/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
@@ -26,7 +26,9 @@ class GetTokenMixin(ABC):
     def __init__(self, *args, **kwargs):
         # type: (*Any, **Any) -> None
         self._last_request_time = 0
-        super(GetTokenMixin, self).__init__(*args, **kwargs)
+
+        # https://github.com/python/mypy/issues/5887
+        super(GetTokenMixin, self).__init__(*args, **kwargs)  # type: ignore
 
     @abc.abstractmethod
     def _acquire_token_silently(self, *scopes):

--- a/sdk/identity/azure-identity/azure/identity/_internal/linux_vscode_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/linux_vscode_adapter.py
@@ -46,7 +46,7 @@ try:
     _libsecret.secret_password_lookup_sync.restype = ct.c_char_p
     _libsecret.secret_password_free.argtypes = [ct.c_char_p]
 except OSError:
-    _libsecret = None
+    _libsecret = None  # type: ignore
 
 
 def _get_user_settings_path():

--- a/sdk/identity/azure-identity/azure/identity/_internal/win_vscode_adapter.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/win_vscode_adapter.py
@@ -39,7 +39,7 @@ class _CREDENTIAL(ct.Structure):
 
 _PCREDENTIAL = ct.POINTER(_CREDENTIAL)
 
-_advapi = ct.WinDLL("advapi32")
+_advapi = ct.WinDLL("advapi32")  # type: ignore
 _advapi.CredReadW.argtypes = [wt.LPCWSTR, wt.DWORD, wt.DWORD, ct.POINTER(_PCREDENTIAL)]
 _advapi.CredReadW.restype = wt.BOOL
 _advapi.CredFree.argtypes = [_PCREDENTIAL]

--- a/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_authn_client.py
@@ -23,9 +23,11 @@ from .._authn_client import AuthnClientBase
 from .._internal.user_agent import USER_AGENT
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Iterable, Mapping, Optional
-    from azure.core.pipeline.policies import HTTPPolicy
+    from typing import Any, Dict, Iterable, List, Mapping, Optional, Union
+    from azure.core.pipeline.policies import AsyncHTTPPolicy, SansIOHTTPPolicy
     from azure.core.pipeline.transport import AsyncHttpTransport
+
+    PolicyListType = List[Union[AsyncHTTPPolicy, SansIOHTTPPolicy]]
 
 
 class AsyncAuthnClient(AuthnClientBase):  # pylint:disable=async-client-bad-name
@@ -35,7 +37,7 @@ class AsyncAuthnClient(AuthnClientBase):  # pylint:disable=async-client-bad-name
     def __init__(
         self,
         config: "Optional[Configuration]" = None,
-        policies: "Optional[Iterable[HTTPPolicy]]" = None,
+        policies: "Optional[PolicyListType]" = None,
         transport: "Optional[AsyncHttpTransport]" = None,
         **kwargs: "Any"
     ) -> None:
@@ -51,7 +53,7 @@ class AsyncAuthnClient(AuthnClientBase):  # pylint:disable=async-client-bad-name
         ]
         if not transport:
             transport = AioHttpTransport(**kwargs)
-        self._pipeline = AsyncPipeline(transport=transport, policies=policies)
+        self._pipeline = AsyncPipeline(transport=transport, policies=policies)  # type: AsyncPipeline
         super().__init__(**kwargs)
 
     async def __aenter__(self):
@@ -67,7 +69,7 @@ class AsyncAuthnClient(AuthnClientBase):  # pylint:disable=async-client-bad-name
     async def request_token(  # pylint:disable=invalid-overridden-method
         self,
         scopes: "Iterable[str]",
-        method: "Optional[str]" = "POST",
+        method: str = "POST",
         headers: "Optional[Mapping[str, str]]" = None,
         form_data: "Optional[Mapping[str, str]]" = None,
         params: "Optional[Dict[str, str]]" = None,

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/app_service.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/app_service.py
@@ -21,14 +21,15 @@ class AppServiceCredential(AsyncContextManager, GetTokenMixin):
 
         client_args = _get_client_args(**kwargs)
         if client_args:
+            self._available = True
             self._client = AsyncManagedIdentityClient(**client_args)
         else:
-            self._client = None
+            self._available = False
 
     async def get_token(  # pylint:disable=invalid-overridden-method
         self, *scopes: str, **kwargs: "Any"
     ) -> "AccessToken":
-        if not self._client:
+        if not self._available:
             raise CredentialUnavailableError(
                 message="App Service managed identity configuration not found in environment"
             )

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_arc.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_arc.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from typing import Any, List, Optional, Union
     from azure.core.configuration import Configuration
     from azure.core.credentials import AccessToken
-    from azure.core.pipeline import PipelineRequest
+    from azure.core.pipeline import PipelineRequest, PipelineResponse
     from azure.core.pipeline.policies import SansIOHTTPPolicy
     from azure.core.pipeline.transport import AsyncHttpResponse
 
@@ -39,25 +39,23 @@ class AzureArcCredential(AsyncContextManager, GetTokenMixin):
         super().__init__()
 
         url = os.environ.get(EnvironmentVariables.IDENTITY_ENDPOINT)
-        if not url:
-            # Azure Arc managed identity isn't available in this environment
-            self._client = None
-            return
-        identity_config = kwargs.pop("_identity_config", None) or {}
-        config = _get_configuration()
-        client_args = dict(
-            kwargs,
-            _identity_config=identity_config,
-            policies=_get_policies(config),
-            request_factory=functools.partial(_get_request, url),
-        )
+        imds = os.environ.get(EnvironmentVariables.IMDS_ENDPOINT)
+        self._available = url and imds
+        if self._available:
+            identity_config = kwargs.pop("_identity_config", None) or {}
+            config = _get_configuration()
 
-        self._client = AsyncManagedIdentityClient(**client_args)
+            self._client = AsyncManagedIdentityClient(
+                _identity_config=identity_config,
+                policies=_get_policies(config),
+                request_factory=functools.partial(_get_request, url),
+                **kwargs
+            )
 
     async def get_token(  # pylint:disable=invalid-overridden-method
         self, *scopes: str, **kwargs: "Any"
     ) -> "AccessToken":
-        if not self._client:
+        if not self._available:
             raise CredentialUnavailableError(
                 message="Service Fabric managed identity configuration not found in environment"
             )
@@ -89,7 +87,7 @@ def _get_policies(config: "Configuration", **kwargs: "Any") -> "List[PolicyType]
 class ArcChallengeAuthPolicy(AsyncHTTPPolicy):
     """Policy for handling Azure Arc's challenge authentication"""
 
-    async def send(self, request: "PipelineRequest") -> "AsyncHttpResponse":
+    async def send(self, request: "PipelineRequest") -> "PipelineResponse":
         request.http_request.headers["Metadata"] = "true"
         response = await self.next.send(request)
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_arc.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_arc.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from azure.core.credentials import AccessToken
     from azure.core.pipeline import PipelineRequest, PipelineResponse
     from azure.core.pipeline.policies import SansIOHTTPPolicy
-    from azure.core.pipeline.transport import AsyncHttpResponse
+    from azure.core.pipeline.transport import AsyncHttpResponse, AsyncHttpTransport
 
     PolicyType = Union[AsyncHTTPPolicy, SansIOHTTPPolicy]
 
@@ -86,6 +86,11 @@ def _get_policies(config: "Configuration", **kwargs: "Any") -> "List[PolicyType]
 
 class ArcChallengeAuthPolicy(AsyncHTTPPolicy):
     """Policy for handling Azure Arc's challenge authentication"""
+
+    def __init__(self):
+        # workaround for https://github.com/Azure/azure-sdk-for-python/issues/5797
+        super().__init__()
+        self.next = None  # type: Union[AsyncHTTPPolicy, AsyncHttpTransport]
 
     async def send(self, request: "PipelineRequest") -> "PipelineResponse":
         request.http_request.headers["Metadata"] = "true"

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -16,7 +16,8 @@ from .shared_cache import SharedTokenCacheCredential
 from .vscode import VisualStudioCodeCredential
 
 if TYPE_CHECKING:
-    from typing import Any
+    from typing import Any, List
+    from azure.core.credentials_async import AsyncTokenCredential
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,7 +84,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
         exclude_managed_identity_credential = kwargs.pop("exclude_managed_identity_credential", False)
         exclude_shared_token_cache_credential = kwargs.pop("exclude_shared_token_cache_credential", False)
 
-        credentials = []
+        credentials = []  # type: List[AsyncTokenCredential]
         if not exclude_environment_credential:
             credentials.append(EnvironmentCredential(authority=authority, **kwargs))
         if not exclude_managed_identity_credential:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -21,6 +21,7 @@ from ..._credentials.managed_identity import _ManagedIdentityBase
 if TYPE_CHECKING:
     from typing import Any, Optional
     from azure.core.configuration import Configuration
+    from azure.core.credentials_async import AsyncTokenCredential
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,7 +40,7 @@ class ManagedIdentityCredential(AsyncContextManager):
     """
 
     def __init__(self, **kwargs: "Any") -> None:
-        self._credential = None
+        self._credential = None  # type: Optional[AsyncTokenCredential]
 
         if os.environ.get(EnvironmentVariables.MSI_ENDPOINT):
             if os.environ.get(EnvironmentVariables.MSI_SECRET):

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/service_fabric.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/service_fabric.py
@@ -21,14 +21,15 @@ class ServiceFabricCredential(AsyncContextManager, GetTokenMixin):
 
         client_args = _get_client_args(**kwargs)
         if client_args:
+            self._available = True
             self._client = AsyncManagedIdentityClient(**client_args)
         else:
-            self._client = None
+            self._available = False
 
     async def get_token(  # pylint:disable=invalid-overridden-method
         self, *scopes: str, **kwargs: "Any"
     ) -> "AccessToken":
-        if not self._client:
+        if not self._available:
             raise CredentialUnavailableError(
                 message="Service Fabric managed identity configuration not found in environment"
             )

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
@@ -20,7 +20,9 @@ _LOGGER = logging.getLogger(__name__)
 class GetTokenMixin(abc.ABC):
     def __init__(self, *args: "Any", **kwargs: "Any") -> None:
         self._last_request_time = 0
-        super(GetTokenMixin, self).__init__(*args, **kwargs)
+
+        # https://github.com/python/mypy/issues/5887
+        super(GetTokenMixin, self).__init__(*args, **kwargs)  # type: ignore
 
     @abc.abstractmethod
     async def _acquire_token_silently(self, *scopes: str) -> "Optional[AccessToken]":

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/managed_identity_client.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/managed_identity_client.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from typing import Any, Callable, List, Optional, Union
     from azure.core.credentials import AccessToken
     from azure.core.pipeline.policies import AsyncHTTPPolicy, SansIOHTTPPolicy
-    from azure.core.pipeline.transport import HttpTransport, HttpRequest
+    from azure.core.pipeline.transport import AsyncHttpTransport, HttpRequest
 
     Policy = Union[AsyncHTTPPolicy, SansIOHTTPPolicy]
 
@@ -44,7 +44,7 @@ class AsyncManagedIdentityClient(ManagedIdentityClientBase):
         self,
         config: Configuration,
         policies: "Optional[List[Policy]]" = None,
-        transport: "Optional[HttpTransport]" = None,
+        transport: "Optional[AsyncHttpTransport]" = None,
         **kwargs: "Any"
     ) -> AsyncPipeline:
         if policies is None:  # [] is a valid policy list

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/managed_identity_client.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/managed_identity_client.py
@@ -10,7 +10,7 @@ from azure.core.pipeline import AsyncPipeline
 from azure.core.pipeline.policies import AsyncRetryPolicy
 
 from ..._internal import _scopes_to_resource
-from ..._internal.managed_identity_client import ManagedIdentityClient, _get_policies
+from ..._internal.managed_identity_client import ManagedIdentityClientBase, _get_policies
 
 if TYPE_CHECKING:
     # pylint:disable=ungrouped-imports
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 
 # pylint:disable=async-client-bad-name,missing-client-constructor-parameter-credential
-class AsyncManagedIdentityClient(ManagedIdentityClient):
+class AsyncManagedIdentityClient(ManagedIdentityClientBase):
     def __init__(self, request_factory: "Callable[[str, dict], HttpRequest]", **kwargs: "Any") -> None:
         config = _get_configuration(**kwargs)
         super().__init__(request_factory, _config=config, **kwargs)


### PR DESCRIPTION
This closes #10599 by fixing today's mypy errors and configuring CI runs to fail when new ones appear. The fixes are small, excepting a refactoring to prevent errors due to the async ManagedIdentityClient inheriting its non-async equivalent.