### PR TITLE
[Key Vault] Link fix for azure-keyvault 1.1.0 README

### DIFF
--- a/azure-keyvault/README.rst
+++ b/azure-keyvault/README.rst
@@ -31,7 +31,7 @@ Usage
 =====
 
 For code examples, see `Key Vault
-<https://docs.microsoft.com/python/api/overview/azure/key-vault>`__
+<https://docs.microsoft.com/python/api/overview/azure/keyvault>`__
 on docs.microsoft.com.
 
 


### PR DESCRIPTION
Part of fix for #15796.

After getting the fixed link checked in, we'll need to replace the current `azure-keyvault_1.1.0` tag with one from this commit.