### PR TITLE
[SeriviceBus/EventHub] Update 3.9.0 to 3.9 in test yml

### DIFF
--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -12,7 +12,7 @@ jobs:
           CoverageArg: '--disablecov'
         Linux_Python39:
           OSVmImage: 'ubuntu-18.04'
-          PythonVersion: '3.9.0'
+          PythonVersion: '3.9'
           CoverageArg: ''
         Windows_Python27:
           OSVmImage: 'windows-2019'

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -27,5 +27,5 @@ jobs:
           CoverageArg: '--disablecov'
         Linux_Python39:
           OSVmImage: 'ubuntu-18.04'
-          PythonVersion: '3.9.0'
+          PythonVersion: '3.9'
           CoverageArg: ''


### PR DESCRIPTION
echoing: https://github.com/Azure/azure-sdk-for-python/pull/15493
Py39 is native to the images now. Don't need to download and install it anymore. Accommodating for EH/SB