### PR TITLE
Fix put_encrypted_blob function not encrypting blob

### DIFF
--- a/sdk/storage/azure-storage-blob/samples/blob_samples_client_side_encryption.py
+++ b/sdk/storage/azure-storage-blob/samples/blob_samples_client_side_encryption.py
@@ -142,7 +142,7 @@ class BlobEncryptionSamples():
             # this property will tell the service to encrypt the blob. Blob encryption
             # is supported only for uploading whole blobs and only at the time of creation.
             kek = KeyWrapper('key1')
-            self.container_client.key_resolver_function = kek
+            self.container_client.key_encryption_key = kek
 
             self.container_client.upload_blob(block_blob_name, u'ABC', )
 


### PR DESCRIPTION
The function put_encrypted_blob was setting key_resolver_function instead of key_encryption_key. Due to this, the blob uploaded to the container was not encrypted. 