### PR TITLE
fixed typo in EH sample + readme

### DIFF
--- a/sdk/eventhub/azure-eventhub/README.md
+++ b/sdk/eventhub/azure-eventhub/README.md
@@ -197,7 +197,7 @@ with client:
 
 ### Publish events to an Event Hub asynchronously
 
-Use the `create_batch` method on `EventHubProcuer` to create an `EventDataBatch` object which can then be sent using the `send_batch` method.
+Use the `create_batch` method on `EventHubProducer` to create an `EventDataBatch` object which can then be sent using the `send_batch` method.
 Events may be added to the `EventDataBatch` using the `add` method until the maximum batch size limit in bytes has been reached.
 ```python
 import asyncio

--- a/sdk/eventhub/azure-eventhub/samples/sync_samples/authenticate_with_sas_token.py
+++ b/sdk/eventhub/azure-eventhub/samples/sync_samples/authenticate_with_sas_token.py
@@ -6,7 +6,7 @@
 # --------------------------------------------------------------------------------------------
 
 """
-Example to demonstrate utilizing SAS (Shared Access Signature) tokens to authenticate with ServiceBus
+Example to demonstrate utilizing SAS (Shared Access Signature) tokens to authenticate with EventHub
 """
 
 # pylint: disable=C0111


### PR DESCRIPTION
Typos indicated in issue: #15114 
* [EventHub docs](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/eventhub/azure-eventhub#publish-events-to-an-event-hub-asynchronously): fix "EventHubProcuer" typo
* [authenticate_with_sas_token.py, Line 9](https://github.com/Azure/azure-sdk-for-python/blob/da34e9d3bc41ec56c46a1a8c281b4a69d735bdc6/sdk/eventhub/azure-eventhub/samples/sync_samples/authenticate_with_sas_token.py#L9): replace ServiceBus with EventHub 