### PR TITLE
fixed syntax error in EH async auth sample

### DIFF
--- a/sdk/eventhub/azure-eventhub/samples/async_samples/connection_string_authentication_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/connection_string_authentication_async.py
@@ -8,17 +8,22 @@
 An example to show authentication using a connection string obtained via the Azure Portal, or the Azure CLI toolkit.
 """
 
+import asyncio
 import os
 from azure.eventhub.aio import EventHubConsumerClient
 
 CONNECTION_STR = os.environ["EVENT_HUB_CONN_STR"]
 EVENTHUB_NAME = os.environ['EVENT_HUB_NAME']
 
-consumer_client = EventHubConsumerClient.from_connection_string(
-    conn_str=CONNECTION_STR,
-    consumer_group='$Default',
-    eventhub_name=EVENTHUB_NAME,
-)
+async def main():
+    consumer_client = EventHubConsumerClient.from_connection_string(
+        conn_str=CONNECTION_STR,
+        consumer_group='$Default',
+        eventhub_name=EVENTHUB_NAME,
+    )
+    async with consumer_client:
+        pass # consumer_client is now ready to be used.
 
-async with consumer_client:
-    pass # consumer_client is now ready to be used.
+if __name__ == '__main__':
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())


### PR DESCRIPTION
addressing: #15114 

* connection_string_authentication_async.py
> [line 23](https://github.com/Azure/azure-sdk-for-python/blob/fc38db1cea8e6b7f22b29f3218c7bcf0f24668ca/sdk/eventhub/azure-eventhub/samples/async_samples/connection_string_authentication_async.py#L23): results in "SyntaxError: 'async with' outside async function"