### PR TITLE
Fix preparer resource does not exist

### DIFF
--- a/sdk/servicebus/azure-servicebus/tests/servicebus_preparer.py
+++ b/sdk/servicebus/azure-servicebus/tests/servicebus_preparer.py
@@ -228,7 +228,7 @@ class ServiceBusSubscriptionPreparer(_ServiceBusChildResourcePreparer):
                     )
                     break
                 except Exception as ex:
-                    error = "The requested resource {} does not exist".format(self.resource)
+                    error = "The requested resource {} does not exist".format(namespace)
                     if error not in str(ex) or i == retries - 1:
                         raise
                     time.sleep(3)


### PR DESCRIPTION
Fixes #13747 

Couple of points to be noted before merging this PR:
- This error did not occur since October 1 
- It was not possible to reproduce this since it's very rare, so consequently tough to test it


Another frame of thought - update this in the abstract preparer as a common solution since this has been occasionally observed in few other levels. Thoughts on this?
