### PR TITLE
Fix datalake regression failure

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_deserialize.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_deserialize.py
@@ -70,7 +70,10 @@ def normalize_headers(headers):
 
 
 def deserialize_metadata(response, obj, headers):  # pylint: disable=unused-argument
-    raw_metadata = {k: v for k, v in response.http_response.headers.items() if k.startswith("x-ms-meta-")}
+    try:
+        raw_metadata = {k: v for k, v in response.http_response.headers.items() if k.startswith("x-ms-meta-")}
+    except AttributeError:
+        raw_metadata = {k: v for k, v in response.headers.items() if k.startswith("x-ms-meta-")}
     return {k[10:]: v for k, v in raw_metadata.items()}
 
 


### PR DESCRIPTION
Currently, datalake is use a cls method that's fetching the `http_response` attribute which did not exist in previous blob versions. This is now handled by a simple try, except.