### PR TITLE
Skip automatic API review for management packages

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -185,6 +185,13 @@ function Find-python-Artifacts-For-Apireview($artifactDir, $artifactName)
 {
   # Find wheel file in given artifact directory
   # Make sure to pick only package with given artifact name
+  # Skip auto API review creation for management packages
+  if ($artifactName -match "mgmt")
+  {
+    Write-Host "Skipping automatic API review for management artifact $($artifactName)"
+    return $null
+  }
+
   $packageName = $artifactName + "-"
   Write-Host "Searching for $($packageName) wheel in artifact path $($artifactDir)"
   $files = Get-ChildItem "${artifactDir}" | Where-Object -FilterScript {$_.Name.StartsWith($packageName) -and $_.Name.EndsWith(".whl")}


### PR DESCRIPTION
Skip automatic review creation for management packages since these are not currently reviewed by architects