### PR TITLE
Setting up template to use 1ES hosted pool.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -1,53 +1,87 @@
 parameters:
-  ServiceDirectory: ''
-  Artifacts: []
-  TestPipeline: false
-  BeforePublishSteps: []
-  TestMarkArgument: ''
-  BuildTargetingString: 'azure-*'
-  TestTimeoutInMinutes: 0
-  ToxEnvParallel: '--tenvparallel'
-  InjectedPackages: ''
-  BuildDocs: true
-  SkipPythonVersion: ''
-  TestMatrix:
-    Linux_Python27:
-      OSVmImage: 'ubuntu-18.04'
-      PythonVersion: '2.7'
-      CoverageArg: ''
-      RunForPR: true
-    Linux_Python35:
-      OSVmImage: 'ubuntu-18.04'
-      PythonVersion: '3.5'
-      CoverageArg: ''
-      RunForPR: false
-    Linux_Python38:
-      OSVmImage: 'ubuntu-18.04'
-      PythonVersion: '3.8'
-      CoverageArg: ''
-      RunForPR: true
-    Windows_Python35:
-      OSVmImage: 'windows-2019'
-      PythonVersion: '3.5'
-      CoverageArg: ''
-      RunForPR: true
-    MacOS_Python27:
-      OSVmImage: 'macOS-10.15'
-      PythonVersion: '2.7'
-      CoverageArg: ''
-      RunForPR: false
-    Linux_pypy3:
-      OSVmImage: 'ubuntu-18.04'
-      PythonVersion: 'pypy3'
-      CoverageArg: '--disablecov'
-      RunForPR: false
-    Linux_Python39:
-      OSVmImage: 'ubuntu-18.04'
-      PythonVersion: '3.9'
-      CoverageArg: ''
-      RunForPR: true
-  AdditionalTestMatrix: []
-  DevFeedName: 'public/azure-sdk-for-python'
+  - name: ServiceDirectory
+    type: string
+    default: ''
+  - name: Artifacts
+    type: object
+    default: []
+  - name: TestPipeline
+    type: boolean
+    default: false
+  - name: BeforePublishSteps
+    type: object
+    default: []
+  - name: TestMarkArgument
+    type: string
+    default: ''
+  - name: BuildTargetingString
+    type: string
+    default: 'azure-*'
+  - name: TestTimeoutInMinutes
+    type: number
+    default: 0
+  - name: ToxEnvParallel
+    type: string
+    default: '--tenvparallel'
+  - name: InjectedPackages
+    type: string
+    default: ''
+  - name: BuildDocs
+    type: boolean
+    default: true
+  - name: SkipPythonVersion
+    type: string
+    default: ''
+  - name: TestMatrix
+    type: object
+    default:
+      Linux_Python27:
+        OSVmImage: $(LinuxPool)
+        PythonVersion: '2.7'
+        CoverageArg: ''
+        RunForPR: true
+      Linux_Python35:
+        OSVmImage: $(LinuxPool)
+        PythonVersion: '3.5'
+        CoverageArg: ''
+        RunForPR: false
+      Linux_Python38:
+        OSVmImage: $(LinuxPool)
+        PythonVersion: '3.8'
+        CoverageArg: ''
+        RunForPR: true
+      Windows_Python35:
+        OSVmImage: $(WindowsPool)
+        PythonVersion: '3.5'
+        CoverageArg: ''
+        RunForPR: true
+      MacOS_Python27:
+        OSVmImage: 'macOS-10.15'
+        PythonVersion: '2.7'
+        CoverageArg: ''
+        RunForPR: false
+      Linux_pypy3:
+        OSVmImage: $(LinuxPool)
+        PythonVersion: 'pypy3'
+        CoverageArg: '--disablecov'
+        RunForPR: false
+      Linux_Python39:
+        OSVmImage: $(LinuxPool)
+        PythonVersion: '3.9'
+        CoverageArg: ''
+        RunForPR: true
+  - name: AdditionalTestMatrix
+    type: object
+    default: []
+  - name: DevFeedName
+    type: string
+    default: 'public/azure-sdk-for-python'
+  - name: WindowsPool
+    type: string
+    default: azsdk-pool-mms-win-2019-general
+  - name: LinuxPool
+    type: string
+    default: azsdk-pool-mms-ubuntu-1804-general
 
 jobs:
   - job: 'Build'
@@ -55,7 +89,7 @@ jobs:
     - template: ../variables/globals.yml
 
     pool:
-      vmImage: 'ubuntu-18.04'
+      name: ${{ parameters.LinuxPool }}
 
     steps:
     - template: ../steps/build-artifacts.yml
@@ -79,7 +113,7 @@ jobs:
       - 'Build'
 
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: ${{ parameters.LinuxPool }}
 
     steps:
     - template: /eng/common/pipelines/templates/steps/verify-links.yml
@@ -106,7 +140,11 @@ jobs:
     - template: ../variables/globals.yml
     - name: InjectedPackages
       value: ${{ parameters.InjectedPackages }}
-    
+    - name: WindowsPool
+      value: ${{ parameters.WindowsPool }}
+    - name: LinuxPool
+      value: ${{ parameters.LinuxPool }}
+
     dependsOn:
        - 'Build'
 
@@ -123,10 +161,10 @@ jobs:
           ${{ if or(eq(matrixEntry.value.RunForPR, 'true'), ne(variables['Build.Reason'], 'PullRequest')) }}:
             ${{ matrixEntry.key }}:
               ${{ insert }}: ${{ matrixEntry.value }}
-
         
     pool:
-      vmImage: '$(OSVmImage)'
+      name: $[coalesce(variables['Pool'], '')]
+      vmImage: $[coalesce(variables['OSVmImage'], '')]
 
     steps:
     - ${{if eq(parameters.TestPipeline, 'true')}}:
@@ -188,7 +226,7 @@ jobs:
       - 'Build'
 
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: ${{ parameters.LinuxPool }}
 
     steps:
     - template: ../steps/test_regression.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -36,37 +36,44 @@ parameters:
     type: object
     default:
       Linux_Python27:
-        OSVmImage: $(LinuxPool)
+        Pool: $(LinuxPool)
+        OSVmImage:
         PythonVersion: '2.7'
         CoverageArg: ''
         RunForPR: true
       Linux_Python35:
-        OSVmImage: $(LinuxPool)
+        Pool: $(LinuxPool)
+        OSVmImage:
         PythonVersion: '3.5'
         CoverageArg: ''
         RunForPR: false
       Linux_Python38:
-        OSVmImage: $(LinuxPool)
+        Pool: $(LinuxPool)
+        OSVmImage:
         PythonVersion: '3.8'
         CoverageArg: ''
         RunForPR: true
       Windows_Python35:
-        OSVmImage: $(WindowsPool)
+        Pool: $(WindowsPool)
+        OSVmImage:
         PythonVersion: '3.5'
         CoverageArg: ''
         RunForPR: true
       MacOS_Python27:
+        Pool:
         OSVmImage: 'macOS-10.15'
         PythonVersion: '2.7'
         CoverageArg: ''
         RunForPR: false
       Linux_pypy3:
-        OSVmImage: $(LinuxPool)
+        Pool: $(LinuxPool)
+        OSVmImage:
         PythonVersion: 'pypy3'
         CoverageArg: '--disablecov'
         RunForPR: false
       Linux_Python39:
-        OSVmImage: $(LinuxPool)
+        Pool: $(LinuxPool)
+        OSVmImage:
         PythonVersion: '3.9'
         CoverageArg: ''
         RunForPR: true

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -113,7 +113,7 @@ jobs:
       - 'Build'
 
     pool:
-      vmImage: ${{ parameters.LinuxPool }}
+      name: ${{ parameters.LinuxPool }}
 
     steps:
     - template: /eng/common/pipelines/templates/steps/verify-links.yml

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -35,7 +35,12 @@ parameters:
 - name: BuildTargetingString
   type: string
   default: azure-*
-  
+- name: WindowsPool
+  type: string
+  default: azsdk-pool-mms-win-2019-general
+- name: LinuxPool
+  type: string
+  default: azsdk-pool-mms-ubuntu-1804-general
 
 stages:
   - stage: Build
@@ -52,6 +57,8 @@ stages:
         AdditionalTestMatrix: ${{ parameters.AdditionalTestMatrix }}
         DevFeedName: ${{ parameters.DevFeedName }}
         BuildTargetingString: ${{ parameters.BuildTargetingString }}
+        WindowsPool: ${{ parameters.WindowsPool }}
+        LinuxPool: ${{ parameters.LinuxPool }}
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -24,8 +24,6 @@ steps:
     parameters:
       versionSpec: '${{ parameters.PythonVersion }}'
 
-  - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
-
   - script: |
       python -m pip install pip==20.1
       pip install -r eng/ci_tools.txt


### PR DESCRIPTION
This PR modifies the Python pipelines to use the 1ES hosted pools for WIndows/Linux build/test legs. It has a few aspects:

1. Change to the stage template to define a WindowsPool and LinuxPool.
2. Change to the job template to define a WindowsPool and LinuxPool
3. Maps WindowsLinux and LinuxPool to variables in the test job so that they can be used in the matrix.