### PR TITLE
[EventHubs] Enable DeleteAfter Tag for test resource group

### DIFF
--- a/sdk/eventhub/azure-eventhub/conftest.py
+++ b/sdk/eventhub/azure-eventhub/conftest.py
@@ -9,6 +9,7 @@ import pytest
 import logging
 import uuid
 import warnings
+import datetime
 from logging.handlers import RotatingFileHandler
 
 from azure.identity import EnvironmentCredential
@@ -82,9 +83,13 @@ def resource_group():
         return
     resource_client = ResourceManagementClient(EnvironmentCredential(), SUBSCRIPTION_ID)
     resource_group_name = RES_GROUP_PREFIX + str(uuid.uuid4())
+    parameters = {"location": LOCATION}
+    expiry = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+    parameters['tags'] = {'DeleteAfter': expiry.replace(microsecond=0).isoformat()}
     try:
         rg = resource_client.resource_groups.create_or_update(
-           resource_group_name, {"location": LOCATION}
+            resource_group_name,
+            parameters
         )
         yield rg
     finally:

--- a/sdk/servicebus/azure-servicebus/dev_requirements.txt
+++ b/sdk/servicebus/azure-servicebus/dev_requirements.txt
@@ -1,4 +1,5 @@
 -e ../../core/azure-core
+-e ../../identity/azure-identity
 -e ../../../tools/azure-devtools
 -e ../../../tools/azure-sdk-tools
 azure-mgmt-servicebus~=1.0.0

--- a/sdk/servicebus/azure-servicebus/dev_requirements.txt
+++ b/sdk/servicebus/azure-servicebus/dev_requirements.txt
@@ -1,5 +1,4 @@
 -e ../../core/azure-core
--e ../../identity/azure-identity
 -e ../../../tools/azure-devtools
 -e ../../../tools/azure-sdk-tools
 azure-mgmt-servicebus~=1.0.0


### PR DESCRIPTION
This is a temporary workaround to enable the `DeleteAfter` tag for the fixture test preparer before we start the work on migrating to eventhub preparer: https://github.com/Azure/azure-sdk-for-python/issues/12616.

code copied from https://github.com/Azure/azure-sdk-for-python/blob/49befdc8ff58dba7f210d5865018e31470442f0d/tools/azure-sdk-tools/devtools_testutils/resource_testcase.py#L61-L63