### PR TITLE
[Communication] Move core dependency to setup.py from dev_requirements in communication management package

### DIFF
--- a/sdk/communication/azure-communication-chat/dev_requirements.txt
+++ b/sdk/communication/azure-communication-chat/dev_requirements.txt
@@ -1,6 +1,5 @@
 -e ../../../tools/azure-devtools
 -e ../../../tools/azure-sdk-tools
--e ../../core/azure-core
 ../azure-communication-nspkg
 -e ../azure-communication-administration
 aiohttp>=3.0; python_version >= '3.5'

--- a/sdk/communication/azure-mgmt-communication/setup.py
+++ b/sdk/communication/azure-mgmt-communication/setup.py
@@ -84,6 +84,7 @@ setup(
         'msrest>=0.5.0',
         'msrestazure>=0.4.32,<2.0.0',
         'azure-common~=1.1',
+        "azure-core<2.0.0,>=1.9.0"
     ],
     extras_require={
         ":python_version<'3.0'": ['azure-mgmt-nspkg'],

--- a/sdk/communication/azure-mgmt-communication/setup.py
+++ b/sdk/communication/azure-mgmt-communication/setup.py
@@ -84,7 +84,7 @@ setup(
         'msrest>=0.5.0',
         'msrestazure>=0.4.32,<2.0.0',
         'azure-common~=1.1',
-        "azure-core<2.0.0,>=1.2.0"
+        "azure-core<2.0.0,>=1.2.2"
     ],
     extras_require={
         ":python_version<'3.0'": ['azure-mgmt-nspkg'],

--- a/sdk/communication/azure-mgmt-communication/setup.py
+++ b/sdk/communication/azure-mgmt-communication/setup.py
@@ -84,7 +84,7 @@ setup(
         'msrest>=0.5.0',
         'msrestazure>=0.4.32,<2.0.0',
         'azure-common~=1.1',
-        "azure-core<2.0.0,>=1.9.0"
+        "azure-core<2.0.0,>=1.2.0"
     ],
     extras_require={
         ":python_version<'3.0'": ['azure-mgmt-nspkg'],


### PR DESCRIPTION
We had this [PR ](https://github.com/Azure/azure-sdk-for-python/pull/15969) to solve the dependency issue. 
However the tests still failing for the scheduled runs of the pipeline. Moving that into setup.py