### PR TITLE
OT Exporter retry when there are network issues

### DIFF
--- a/sdk/monitor/azure-opentelemetry-exporter-azuremonitor/CHANGELOG.md
+++ b/sdk/monitor/azure-opentelemetry-exporter-azuremonitor/CHANGELOG.md
@@ -2,18 +2,21 @@
 
 ## 1.0.0b2 (Unreleased)
 
+- Fix to only retry upon request error
+  ([#15344](https://github.com/Azure/azure-sdk-for-python/pull/15344))
+
   **Breaking Changes**
   - Rename Azure Trace exporter class, only allow connection string configuration
     ([#15349](https://github.com/Azure/azure-sdk-for-python/pull/15349))
 
-- OpenTelemetry Exporter use Resources API to retrieve cloud role props
-  ([#15816](https://github.com/Azure/azure-sdk-for-python/pull/15816))
+  - OpenTelemetry Exporter use Resources API to retrieve cloud role props
+    ([#15816](https://github.com/Azure/azure-sdk-for-python/pull/15816))
 
-- Change span to envelope conversion to adhere to common schema and other languages
-  ([#15344](https://github.com/Azure/azure-sdk-for-python/pull/15344))
+  - Change span to envelope conversion to adhere to common schema and other languages
+    ([#15344](https://github.com/Azure/azure-sdk-for-python/pull/15344))
 
-- This library is renamed to `azure-opentelemetry-exporter-azuremonitor`.
-  ([#15344](https://github.com/Azure/azure-sdk-for-python/pull/15344))
+  - This library is renamed to `azure-opentelemetry-exporter-azuremonitor`.
+    ([#16030](https://github.com/Azure/azure-sdk-for-python/pull/16030))
 
 ## 1.0.0b1 (2020-11-13)
 

--- a/sdk/monitor/azure-opentelemetry-exporter-azuremonitor/CHANGELOG.md
+++ b/sdk/monitor/azure-opentelemetry-exporter-azuremonitor/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.0.0b2 (Unreleased)
 
 - Fix to only retry upon request error
-  ([#15344](https://github.com/Azure/azure-sdk-for-python/pull/15344))
+  ([#16087](https://github.com/Azure/azure-sdk-for-python/pull/16087))
 
   **Breaking Changes**
   - Rename Azure Trace exporter class, only allow connection string configuration

--- a/sdk/monitor/azure-opentelemetry-exporter-azuremonitor/azure/opentelemetry/exporter/azuremonitor/export/_base.py
+++ b/sdk/monitor/azure-opentelemetry-exporter-azuremonitor/azure/opentelemetry/exporter/azuremonitor/export/_base.py
@@ -141,7 +141,7 @@ class BaseExporter:
                 return ExportResult.FAILED_RETRYABLE
             except Exception as ex:
                 logger.error(
-                    "Envelopes could not be exported and are not retriable: %s.", ex
+                    "Envelopes could not be exported and are not retryable: %s.", ex
                 )
                 return ExportResult.FAILED_NOT_RETRYABLE
             return ExportResult.FAILED_NOT_RETRYABLE
@@ -159,6 +159,7 @@ def is_retryable_code(response_code: int) -> bool:
         429,  # Throttle, too Many Requests
         439,  # Quota, too Many Requests over extended time
         500,  # Internal Server Error
+        502,  # BadGateway
         503,  # Service Unavailable
         504,  # Gateway timeout
     ))


### PR DESCRIPTION
Status codes taken from [retry policy](https://github.com/Azure/azure-sdk-for-python/blob/7669b31437e839c877ef7fa0a756fb55c46f25e1/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py#L269)

Network error logic taken from [retry policy](https://github.com/Azure/azure-sdk-for-python/blob/7669b31437e839c877ef7fa0a756fb55c46f25e1/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py#L229)