### PR TITLE
Fix to unblock loganalytics release.

### DIFF
--- a/sdk/loganalytics/azure-loganalytics/dev_requirements.txt
+++ b/sdk/loganalytics/azure-loganalytics/dev_requirements.txt
@@ -1,2 +1,3 @@
 -e ../../../tools/azure-sdk-tools
+../../core/azure-core
 msrestazure


### PR DESCRIPTION
This PR should fix the log analytics build failures which are blocking the release of the log analytics management plane libraries.