### PR TITLE
Enable 1ES pools for live tests.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -17,23 +17,28 @@ parameters:
   Location: ''
   Matrix:
     Linux_Python35:
-      OSVmImage: 'ubuntu-18.04'
+      Pool: azsdk-pool-mms-ubuntu-1804-general
+      OSVmImage: MMSUbuntu18.04
       PythonVersion: '3.5'
       CoverageArg: '--disablecov'
     MacOs_Python37:
+      Pool: Azure Pipelines
       OSVmImage: 'macOS-10.15'
       PythonVersion: '3.7'
       CoverageArg: '--disablecov'
     Windows_Python27:
-      OSVmImage: 'windows-2019'
+      Pool: azsdk-pool-mms-win-2019-general
+      OSVmImage: MMS2019
       PythonVersion: '2.7'
       CoverageArg: '--disablecov'
     Linux_PyPy3:
-      OSVmImage: 'ubuntu-18.04'
+      Pool: azsdk-pool-mms-ubuntu-1804-general
+      OSVmImage: MMSUbuntu18.04
       PythonVersion: 'pypy3'
       CoverageArg: '--disablecov'
     Linux_Python39:
-      OSVmImage: 'ubuntu-18.04'
+      Pool: azsdk-pool-mms-ubuntu-1804-general
+      OSVmImage: MMSUbuntu18.04
       PythonVersion: '3.9'
       CoverageArg: ''
   CloudConfigurations:
@@ -53,6 +58,7 @@ jobs:
       continueOnError: false
 
       pool:
+        name: $(Pool)
         vmImage: $(OSVmImage)
 
       steps:

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -7,18 +7,22 @@ jobs:
       ServiceDirectory: eventhub
       Matrix:
         Linux_Python35:
-          OSVmImage: 'ubuntu-18.04'
+          Pool: azsdk-pool-mms-ubuntu-1804-general          
+          OSVmImage: MMSUbuntu18.04
           PythonVersion: '3.5'
           CoverageArg: '--disablecov'
         Linux_Python39:
-          OSVmImage: 'ubuntu-18.04'
+          Pool: azsdk-pool-mms-ubuntu-1804-general          
+          OSVmImage: MMSUbuntu18.04
           PythonVersion: '3.9'
           CoverageArg: ''
         Windows_Python27:
-          OSVmImage: 'windows-2019'
+          Pool: azsdk-pool-mms-win-2019-general          
+          OSVmImage: MMS2019
           PythonVersion: '2.7'
           CoverageArg: '--disablecov'
         MacOs_Python37:
+          Pool: Azure Pipelines
           OSVmImage: 'macOS-10.15'
           PythonVersion: '3.7'
           CoverageArg: ''

--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -13,37 +13,45 @@ jobs:
       ${{ if contains(variables['Build.DefinitionName'], 'prod') }}:
         Matrix:
           Linux_Python35:
-            OSVmImage: 'ubuntu-18.04'
+            Pool: azsdk-pool-mms-ubuntu-1804-general          
+            OSVmImage: MMSUbuntu18.04
             PythonVersion: '3.5'
             CoverageArg: '--disablecov'
           MacOs_Python37:
+            Pool: Azure Pipelines
             OSVmImage: 'macOS-10.15'
             PythonVersion: '3.7'
             CoverageArg: '--disablecov'
           Windows_Python27:
-            OSVmImage: 'windows-2019'
+            Pool: azsdk-pool-mms-win-2019-general          
+            OSVmImage: MMS2019
             PythonVersion: '2.7'
             CoverageArg: '--disablecov'
           Linux_PyPy3:
-            OSVmImage: 'ubuntu-18.04'
+            Pool: azsdk-pool-mms-ubuntu-1804-general          
+            OSVmImage: MMSUbuntu18.04
             PythonVersion: 'pypy3'
             CoverageArg: '--disablecov'
           Linux_Python39:
-            OSVmImage: 'ubuntu-18.04'
+            Pool: azsdk-pool-mms-ubuntu-1804-general          
+            OSVmImage: MMSUbuntu18.04
             PythonVersion: '3.9'
             CoverageArg: ''
       ${{ if not(contains(variables['Build.DefinitionName'], 'prod')) }}:
         Matrix:
           Linux_Python35:
-            OSVmImage: 'ubuntu-18.04'
+            Pool: azsdk-pool-mms-ubuntu-1804-general          
+            OSVmImage: MMSUbuntu18.04
             PythonVersion: '3.5'
             CoverageArg: '--disablecov'
           Windows_Python27:
-            OSVmImage: 'windows-2019'
+            Pool: azsdk-pool-mms-win-2019-general          
+            OSVmImage: MMS2019
             PythonVersion: '2.7'
             CoverageArg: '--disablecov'
           Linux_Python39:
-            OSVmImage: 'ubuntu-18.04'
+            Pool: azsdk-pool-mms-ubuntu-1804-general          
+            OSVmImage: MMSUbuntu18.04
             PythonVersion: '3.9'
             CoverageArg: ''
       EnvVars:

--- a/sdk/monitor/tests.yml
+++ b/sdk/monitor/tests.yml
@@ -14,14 +14,17 @@ jobs:
         AZURE_TEST_RUN_LIVE: 'true'
       Matrix:
         Linux_Python35:
-          OSVmImage: 'ubuntu-18.04'
+          Pool: azsdk-pool-mms-ubuntu-1804-general          
+          OSVmImage: MMSUbuntu18.04
           PythonVersion: '3.5'
           CoverageArg: '--disablecov'
         MacOs_Python37:
+          Pool: Azure Pipelines
           OSVmImage: 'macOS-10.15'
           PythonVersion: '3.7'
           CoverageArg: '--disablecov'
         Linux_Python39:
-          OSVmImage: 'ubuntu-18.04'
+          Pool: azsdk-pool-mms-ubuntu-1804-general          
+          OSVmImage: MMSUbuntu18.04
           PythonVersion: '3.9'
           CoverageArg: ''

--- a/sdk/schemaregistry/tests.yml
+++ b/sdk/schemaregistry/tests.yml
@@ -18,18 +18,22 @@ jobs:
         AZURE_TEST_RUN_LIVE: 'true'
       Matrix:
         Linux_Python35:
-          OSVmImage: 'ubuntu-18.04'
+          Pool: azsdk-pool-mms-ubuntu-1804-general          
+          OSVmImage: MMSUbuntu18.04
           PythonVersion: '3.5'
           CoverageArg: '--disablecov'
         MacOs_Python37:
+          Pool: Azure Pipelines
           OSVmImage: 'macOS-10.15'
           PythonVersion: '3.7'
           CoverageArg: '--disablecov'
         Windows_Python27:
-          OSVmImage: 'windows-2019'
+          Pool: azsdk-pool-mms-win-2019-general          
+          OSVmImage: MMS2019
           PythonVersion: '2.7'
           CoverageArg: '--disablecov'
         Linux_Python38:
-          OSVmImage: 'ubuntu-18.04'
+          Pool: azsdk-pool-mms-ubuntu-1804-general          
+          OSVmImage: MMSUbuntu18.04
           PythonVersion: '3.8'
           CoverageArg: ''

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -14,18 +14,22 @@ jobs:
         AZURE_TEST_RUN_LIVE: 'true'
       Matrix:
         Linux_Python35:
-          OSVmImage: 'ubuntu-18.04'
+          Pool: azsdk-pool-mms-ubuntu-1804-general          
+          OSVmImage: MMSUbuntu18.04
           PythonVersion: '3.5'
           CoverageArg: '--disablecov'
         MacOs_Python37:
+          Pool: Azure Pipelines
           OSVmImage: 'macOS-10.15'
           PythonVersion: '3.7'
           CoverageArg: '--disablecov'
         Windows_Python27:
-          OSVmImage: 'windows-2019'
+          Pool: azsdk-pool-mms-win-2019-general          
+          OSVmImage: MMS2019
           PythonVersion: '2.7'
           CoverageArg: '--disablecov'
         Linux_Python39:
-          OSVmImage: 'ubuntu-18.04'
+          Pool: azsdk-pool-mms-ubuntu-1804-general          
+          OSVmImage: MMSUbuntu18.04
           PythonVersion: '3.9'
           CoverageArg: ''


### PR DESCRIPTION
This PR sets up the Python live test pipelines to use the 1ES hosted pools. It does this by adding a new variable to the matrix called ```Pool```. Moving forward we'll specify both Pool and OSVmImage. For the macOS images the pool is ```Azure Pipelines``` but we use 1ES hosted pool names and image names for Windows and Linux.