### PR TITLE
Resolve Failing Template Build

### DIFF
--- a/sdk/template/azure-template/dev_requirements.txt
+++ b/sdk/template/azure-template/dev_requirements.txt
@@ -1,1 +1,2 @@
 -e ../../../tools/azure-sdk-tools
+../../core/azure-core


### PR DESCRIPTION
Take dependency on azure-core for mindependency test invocation. azure-template does not require any version of azure-core, so the import in azure-sdk-tools fails.