### PR TITLE
Download code cov

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -112,3 +112,10 @@ jobs:
             parameters:
               ServiceDirectory: '${{ parameters.ServiceDirectory }}'
               SubscriptionConfiguration: ${{ cloudConfig.value.SubscriptionConfiguration }}
+
+  - stage: Combine Code Coverage
+    jobs:
+    - template: ../jobs/publish-code-cov-from-artifacts.yml
+      parameters:
+        PublishCodeCov: true
+        CoverageDirectory: $(Pipeline.Workspace)

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -113,8 +113,8 @@ jobs:
               ServiceDirectory: '${{ parameters.ServiceDirectory }}'
               SubscriptionConfiguration: ${{ cloudConfig.value.SubscriptionConfiguration }}
 
-  - stage: Combine Code Coverage
-    jobs:
+  - job: Combine Code Coverage
+    # jobs:
     - template: ../jobs/publish-code-cov-from-artifacts.yml
       parameters:
         PublishCodeCov: true

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -113,9 +113,9 @@ jobs:
               ServiceDirectory: '${{ parameters.ServiceDirectory }}'
               SubscriptionConfiguration: ${{ cloudConfig.value.SubscriptionConfiguration }}
 
-  - job: Combine Code Coverage
-    # jobs:
-    - template: ../jobs/publish-code-cov-from-artifacts.yml
-      parameters:
-        PublishCodeCov: true
-        CoverageDirectory: $(Pipeline.Workspace)
+  # - job: Combine Code Coverage
+  #   # jobs:
+  #   - template: ../jobs/publish-code-cov-from-artifacts.yml
+  #     parameters:
+  #       PublishCodeCov: true
+  #       CoverageDirectory: $(Pipeline.Workspace)

--- a/eng/pipelines/templates/jobs/publish-code-cov-from-artifacts.yml
+++ b/eng/pipelines/templates/jobs/publish-code-cov-from-artifacts.yml
@@ -16,21 +16,21 @@ steps:
   - pwsh: 'List all XML files'
     Get-ChildItem $(Pipeline.Workspace)
 
-  - task: PythonScript@0
-    displayName: 'Run Tests'
-    inputs:
-      scriptPath: 'scripts/devops_tasks/combine_cov_xmls.py'
-      arguments: >-
-        --coverage-directory=$(Pipeline.Workspace)
-      #   "${{ parameters.BuildTargetingString }}"
-      #   ${{ parameters.AdditionalTestArgs }}
-      #   ${{ parameters.CoverageArg }}
-      #   --mark_arg="${{ parameters.TestMarkArgument }}"
-      #   --service="${{ parameters.ServiceDirectory }}"
-      #   --toxenv="${{ parameters.ToxTestEnv }}"
-      #   --injected-packages="${{ parameters.InjectedPackages }}"
-      #   ${{ parameters.ToxEnvParallel }}
-    env: ${{ parameters.EnvVars }}
+  # - task: PythonScript@0
+  #   displayName: 'Run Tests'
+  #   inputs:
+  #     scriptPath: 'scripts/devops_tasks/combine_cov_xmls.py'
+  #     arguments: >-
+  #       --coverage-directory=$(Pipeline.Workspace)
+  #     #   "${{ parameters.BuildTargetingString }}"
+  #     #   ${{ parameters.AdditionalTestArgs }}
+  #     #   ${{ parameters.CoverageArg }}
+  #     #   --mark_arg="${{ parameters.TestMarkArgument }}"
+  #     #   --service="${{ parameters.ServiceDirectory }}"
+  #     #   --toxenv="${{ parameters.ToxTestEnv }}"
+  #     #   --injected-packages="${{ parameters.InjectedPackages }}"
+  #     #   ${{ parameters.ToxEnvParallel }}
+  #   env: ${{ parameters.EnvVars }}
 
 
   # - job: 'Combine'

--- a/eng/pipelines/templates/jobs/publish-code-cov-from-artifacts.yml
+++ b/eng/pipelines/templates/jobs/publish-code-cov-from-artifacts.yml
@@ -2,19 +2,42 @@ parameters:
   - name: PublishCodeCov
     type: boolean
     default: true
+  - name: CoverageDirectory
+    type: string
+    default: ''
 
-jobs:
+steps:
   - job: 'Download'
     steps:
       - task: DownloadPipelineArtifact@2
         inputs:
-          artifact: '**/*.html'
+          artifact: '**/*.xml'
 
-  - job: 'Combine'
-    steps:
-      # Python script here
+  - pwsh: 'List all XML files'
+    Get-ChildItem $(Pipeline.Workspace)
 
-  - job: 'Publish'
-    - task: PublishCodeCoverageResults@1
-      inputs:
-        summaryFileLocation: final_report.html
+  - task: PythonScript@0
+    displayName: 'Run Tests'
+    inputs:
+      scriptPath: 'scripts/devops_tasks/combine_cov_xmls.py'
+      arguments: >-
+        --coverage-directory=$(Pipeline.Workspace)
+      #   "${{ parameters.BuildTargetingString }}"
+      #   ${{ parameters.AdditionalTestArgs }}
+      #   ${{ parameters.CoverageArg }}
+      #   --mark_arg="${{ parameters.TestMarkArgument }}"
+      #   --service="${{ parameters.ServiceDirectory }}"
+      #   --toxenv="${{ parameters.ToxTestEnv }}"
+      #   --injected-packages="${{ parameters.InjectedPackages }}"
+      #   ${{ parameters.ToxEnvParallel }}
+    env: ${{ parameters.EnvVars }}
+
+
+  # - job: 'Combine'
+  #   steps:
+  #     # Python script here
+
+  # - job: 'Publish'
+  #   - task: PublishCodeCoverageResults@1
+  #     inputs:
+  #       summaryFileLocation: final_report.html

--- a/eng/pipelines/templates/jobs/publish-code-cov-from-artifacts.yml
+++ b/eng/pipelines/templates/jobs/publish-code-cov-from-artifacts.yml
@@ -1,0 +1,20 @@
+parameters:
+  - name: PublishCodeCov
+    type: boolean
+    default: true
+
+jobs:
+  - job: 'Download'
+    steps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          artifact: '**/*.html'
+
+  - job: 'Combine'
+    steps:
+      # Python script here
+
+  - job: 'Publish'
+    - task: PublishCodeCoverageResults@1
+      inputs:
+        summaryFileLocation: final_report.html

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -61,6 +61,10 @@ stages:
         WindowsPool: ${{ parameters.WindowsPool }}
         LinuxPool: ${{ parameters.LinuxPool }}
 
+  - stage: Combine Code Coverage
+    jobs:
+    - template: ../jobs/publish-code-cov-from-artifacts.yml
+
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
     - template: archetype-python-release.yml

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -62,9 +62,13 @@ stages:
         LinuxPool: ${{ parameters.LinuxPool }}
 
   # Step for combining code coverage
-  # - stage: Combine Code Coverage
-  #   jobs:
-  #   - template: ../jobs/publish-code-cov-from-artifacts.yml
+  - stage: Combine Code Coverage
+    jobs:
+    - template: ../jobs/publish-code-cov-from-artifacts.yml
+      parameters:
+        PublishCodeCov: true
+        CoverageDirectory: $(Pipeline.Workspace)
+
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -61,9 +61,10 @@ stages:
         WindowsPool: ${{ parameters.WindowsPool }}
         LinuxPool: ${{ parameters.LinuxPool }}
 
-  - stage: Combine Code Coverage
-    jobs:
-    - template: ../jobs/publish-code-cov-from-artifacts.yml
+  # Step for combining code coverage
+  # - stage: Combine Code Coverage
+  #   jobs:
+  #   - template: ../jobs/publish-code-cov-from-artifacts.yml
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -53,14 +53,6 @@ steps:
         ${{ parameters.ToxEnvParallel }}
     env: ${{ parameters.EnvVars }}
 
-  - pwsh: |
-      mv coverage.xml coverage-$(BuildTargetingString).xml
-    displayName: 'Rename coverage.xml file'
-
-  - task: PublishPipelineArtifact@1
-    inputs:
-      targetPath: $(System.DefaultWorkingDirectory)/coverage-*.xml
-
   - ${{ parameters.AfterTestSteps }}
 
   - task: PublishTestResults@2

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -33,7 +33,7 @@ steps:
 
   - ${{if eq(variables['System.TeamProject'], 'internal') }}:
     - template: ../steps/auth-dev-feed.yml
-      parameters: 
+      parameters:
         DevFeedName: ${{ parameters.DevFeedName }}
 
   - ${{ parameters.BeforeTestSteps }}
@@ -52,6 +52,11 @@ steps:
         --injected-packages="${{ parameters.InjectedPackages }}"
         ${{ parameters.ToxEnvParallel }}
     env: ${{ parameters.EnvVars }}
+
+  - pwsh: |
+      mv coverage.xml coverage-$(BuildTargetingString).xml
+    displayName: 'Rename coverage.xml file'
+
 
   - ${{ parameters.AfterTestSteps }}
 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -50,6 +50,7 @@ steps:
         --service="${{ parameters.ServiceDirectory }}"
         --toxenv="${{ parameters.ToxTestEnv }}"
         --injected-packages="${{ parameters.InjectedPackages }}"
+        --package-name="{{ parameters.BuildTargetingString }}"
         ${{ parameters.ToxEnvParallel }}
     env: ${{ parameters.EnvVars }}
 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -57,6 +57,9 @@ steps:
       mv coverage.xml coverage-$(BuildTargetingString).xml
     displayName: 'Rename coverage.xml file'
 
+  -task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: $(System.DefaultWorkingDirectory)/coverage-*.xml
 
   - ${{ parameters.AfterTestSteps }}
 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -50,7 +50,7 @@ steps:
         --service="${{ parameters.ServiceDirectory }}"
         --toxenv="${{ parameters.ToxTestEnv }}"
         --injected-packages="${{ parameters.InjectedPackages }}"
-        --package-name="{{ parameters.BuildTargetingString }}"
+        --package-name="${{ parameters.BuildTargetingString }}"
         ${{ parameters.ToxEnvParallel }}
     env: ${{ parameters.EnvVars }}
 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -57,7 +57,7 @@ steps:
       mv coverage.xml coverage-$(BuildTargetingString).xml
     displayName: 'Rename coverage.xml file'
 
-  -task: PublishPipelineArtifact@1
+  - task: PublishPipelineArtifact@1
     inputs:
       targetPath: $(System.DefaultWorkingDirectory)/coverage-*.xml
 

--- a/eng/pipelines/templates/steps/publish-coverage.yml
+++ b/eng/pipelines/templates/steps/publish-coverage.yml
@@ -9,6 +9,16 @@ steps:
     continueOnError: true
     condition: and(ne(variables['codecov-python-repository-token'], ''), succeededOrFailed(), ${{ parameters.RunCoverage }})
 
+  - pwsh: |
+      mv coverage.xml coverage-$(BuildTargetingString).xml
+    displayName: 'Rename coverage.xml file'
+    condition: and(succeededOrFailed(), ${{ parameters.RunCoverage }})
+
+  - task: PublishPipelineArtifact@1
+    condition: and(succeededOrFailed(), ${{ parameters.RunCoverage }})
+    inputs:
+      targetPath: $(System.DefaultWorkingDirectory)/coverage-*.xml
+
   # This task should be the new last step
   # Pausing this step for now
   # - task: PublishCodeCoverageResults@1

--- a/eng/pipelines/templates/steps/publish-coverage.yml
+++ b/eng/pipelines/templates/steps/publish-coverage.yml
@@ -10,14 +10,14 @@ steps:
     condition: and(ne(variables['codecov-python-repository-token'], ''), succeededOrFailed(), ${{ parameters.RunCoverage }})
 
   - pwsh: |
-      mv coverage.xml coverage-$(BuildTargetingString).xml
+      mv coverage.xml coverage-$(BuildTargetingString).xml; ls
     displayName: 'Rename coverage.xml file'
     condition: and(succeededOrFailed(), ${{ parameters.RunCoverage }})
 
   - task: PublishPipelineArtifact@1
     condition: and(succeededOrFailed(), ${{ parameters.RunCoverage }})
     inputs:
-      targetPath: $(System.DefaultWorkingDirectory)/coverage-*.xml
+      targetPath: $(System.DefaultWorkingDirectory)/coverage-$(BuildTargetingString).xml
 
   # This task should be the new last step
   # Pausing this step for now

--- a/eng/pipelines/templates/steps/publish-coverage.yml
+++ b/eng/pipelines/templates/steps/publish-coverage.yml
@@ -10,10 +10,11 @@ steps:
     condition: and(ne(variables['codecov-python-repository-token'], ''), succeededOrFailed(), ${{ parameters.RunCoverage }})
 
   # This task should be the new last step
-  - task: PublishCodeCoverageResults@1
-    displayName: 'Publish Code Coverage to DevOps'
-    continueOnError: true
-    condition: and(succeededOrFailed(), ${{ parameters.RunCoverage }})
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: '$(Build.SourcesDirectory)/coverage.xml'
+  # Pausing this step for now
+  # - task: PublishCodeCoverageResults@1
+  #   displayName: 'Publish Code Coverage to DevOps'
+  #   continueOnError: true
+  #   condition: and(succeededOrFailed(), ${{ parameters.RunCoverage }})
+  #   inputs:
+  #     codeCoverageTool: Cobertura
+  #     summaryFileLocation: '$(Build.SourcesDirectory)/coverage.xml'

--- a/eng/pipelines/templates/steps/publish-coverage.yml
+++ b/eng/pipelines/templates/steps/publish-coverage.yml
@@ -1,4 +1,4 @@
-parameters: 
+parameters:
   RunCoverage: false
 
 steps:
@@ -9,6 +9,7 @@ steps:
     continueOnError: true
     condition: and(ne(variables['codecov-python-repository-token'], ''), succeededOrFailed(), ${{ parameters.RunCoverage }})
 
+  # This task should be the new last step
   - task: PublishCodeCoverageResults@1
     displayName: 'Publish Code Coverage to DevOps'
     continueOnError: true

--- a/eng/pipelines/templates/steps/publish-coverage.yml
+++ b/eng/pipelines/templates/steps/publish-coverage.yml
@@ -9,10 +9,10 @@ steps:
     continueOnError: true
     condition: and(ne(variables['codecov-python-repository-token'], ''), succeededOrFailed(), ${{ parameters.RunCoverage }})
 
-  - pwsh: |
-      Move-Item coverage.xml coverage-$(BuildTargetingString).xml; Get-ChildItem
-    displayName: 'Rename coverage.xml file'
-    condition: and(succeededOrFailed(), ${{ parameters.RunCoverage }})
+  # - pwsh: |
+  #     Move-Item coverage.xml coverage-$(BuildTargetingString).xml; Get-ChildItem
+  #   displayName: 'Rename coverage.xml file'
+  #   condition: and(succeededOrFailed(), ${{ parameters.RunCoverage }})
 
   - task: PublishPipelineArtifact@1
     condition: and(succeededOrFailed(), ${{ parameters.RunCoverage }})

--- a/eng/pipelines/templates/steps/publish-coverage.yml
+++ b/eng/pipelines/templates/steps/publish-coverage.yml
@@ -10,7 +10,7 @@ steps:
     condition: and(ne(variables['codecov-python-repository-token'], ''), succeededOrFailed(), ${{ parameters.RunCoverage }})
 
   - pwsh: |
-      mv coverage.xml coverage-$(BuildTargetingString).xml; ls
+      Move-Item coverage.xml coverage-$(BuildTargetingString).xml; Get-ChildItem
     displayName: 'Rename coverage.xml file'
     condition: and(succeededOrFailed(), ${{ parameters.RunCoverage }})
 

--- a/scripts/devops_tasks/combine_cov_xmls.py
+++ b/scripts/devops_tasks/combine_cov_xmls.py
@@ -1,0 +1,28 @@
+import argparse
+import os
+
+def combine_xml_files(dir):
+    print("Parsing from {}".format(dir))
+
+    cov_files = [f for f in os.listdir(mypath) if os.path.isfile(os.path.join(mypath, f))]
+
+    print("Found {} coverage files: {}".format(len(cov_files), cov_files))
+
+
+print("Combining code coverage files")
+
+parser = argparse.ArgumentParser(
+    description="Install Dependencies, Install Packages, Test Azure Packages' Samples, Called from DevOps YAML Pipeline"
+)
+
+parser.add_argument(
+    "-c",
+    "--coverage-directory",
+    dest="coverage_directory",
+    help="The target directory holding coverage XML files.",
+    required=True,
+)
+
+print(parser.coverage_directory)
+
+combine_xml_files(parser.coverage_directory)

--- a/scripts/devops_tasks/setup_execute_tests.py
+++ b/scripts/devops_tasks/setup_execute_tests.py
@@ -283,6 +283,11 @@ if __name__ == "__main__":
         choices=['Build', "Docs", "Regression", "Omit_management"]
     )
 
+    parser.add_argument(
+        "--package-name",
+        dest="package_name",
+        help="Name of the azure package installable."
+    )
 
     args = parser.parse_args()
 

--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -105,7 +105,7 @@ def combine_coverage_files(targeted_packages):
         logging.error("tox.ini is not found in path {}".format(root_dir))
 
 
-def collect_tox_coverage_files(targeted_packages):
+def collect_tox_coverage_files(targeted_packages, package_name):
     root_coverage_dir = os.path.join(root_dir, "_coverage/")
 
     clean_coverage(coverage_dir)
@@ -139,14 +139,14 @@ def collect_tox_coverage_files(targeted_packages):
 
         shutil.move(source, dest)
         # Generate coverage XML
-        generate_coverage_xml()
+        generate_coverage_xml(package_name)
 
 
-def generate_coverage_xml():
+def generate_coverage_xml(package_name):
     coverage_path = os.path.join(root_dir, ".coverage")
     if os.path.exists(coverage_path):
         logging.info("Generating coverage XML")
-        commands = ["coverage", "xml", "-i", "--omit", '"*test*,*example*"']
+        commands = ["coverage", "xml", "-i", "--omit", '"*test*,*example*"', "-o", "coverage-{}.xml".format(package_name)]
         run_check_call(commands, root_dir, always_exit = False)
     else:
         logging.error("Coverage file is not available in {} to generate coverage XML".format(coverage_path))
@@ -399,6 +399,7 @@ def prep_and_run_tox(targeted_packages, parsed_args, options_array=[]):
         return_code = execute_tox_serial(tox_command_tuples)
 
     if not parsed_args.disablecov:
-        collect_tox_coverage_files(targeted_packages)
+        print(parsed_args.package_name)
+        collect_tox_coverage_files(targeted_packages, parsed_args.package_name)
 
     sys.exit(return_code)

--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -144,7 +144,7 @@ def collect_tox_coverage_files(targeted_packages, package_name):
 
 def get_coverage_name():
     files = [f for f in os.listdir(mypath) if os.path.isfile(os.path.join(mypath, f))]
-    cov_files = sum([1 for f in files if re.match("coverage*.xml", f) else 0])
+    cov_files = sum([1 if re.match("coverage*.xml", f) else 0 for f in files])
     return "coverage-{}.xml".format(cov_files)
 
 

--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -119,6 +119,7 @@ def collect_tox_coverage_files(targeted_packages, package_name):
     for package_dir in [package for package in targeted_packages]:
         coverage_file = os.path.join(package_dir, ".coverage")
         if os.path.isfile(coverage_file):
+            # Combine all of these .coverage files after final tests have run
             destination_file = os.path.join(
                 root_coverage_dir, ".coverage_{}".format(os.path.basename(package_dir))
             )
@@ -143,9 +144,9 @@ def collect_tox_coverage_files(targeted_packages, package_name):
 
 
 def get_coverage_name():
-    files = [f for f in os.listdir(mypath) if os.path.isfile(os.path.join(mypath, f))]
-    cov_files = sum([1 if re.match("coverage*.xml", f) else 0 for f in files])
-    return "coverage-{}.xml".format(cov_files)
+    files = [f for f in os.listdir() if os.path.isfile(f)]
+    num_cov_files = sum([1 for f in files if re.match("^coverage*.xml", f)])
+    return "coverage-{}.xml".format(num_cov_files)
 
 
 def generate_coverage_xml(package_name):

--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -142,11 +142,19 @@ def collect_tox_coverage_files(targeted_packages, package_name):
         generate_coverage_xml(package_name)
 
 
+def get_coverage_name():
+    files = [f for f in os.listdir(mypath) if os.path.isfile(os.path.join(mypath, f))]
+    cov_files = sum([1 for f in files if re.match("coverage*.xml", f) else 0])
+    return "coverage-{}.xml".format(cov_files)
+
+
 def generate_coverage_xml(package_name):
     coverage_path = os.path.join(root_dir, ".coverage")
     if os.path.exists(coverage_path):
         logging.info("Generating coverage XML")
-        commands = ["coverage", "xml", "-i", "--omit", '"*test*,*example*"', "-o", "coverage-{}.xml".format(package_name)]
+        coverage_name = get_coverage_name()
+        print(coverage_name)
+        commands = ["coverage", "xml", "-i", "--omit", '"*test*,*example*"', "-o", "{}.xml".format(coverage_name)]
         run_check_call(commands, root_dir, always_exit = False)
     else:
         logging.error("Coverage file is not available in {} to generate coverage XML".format(coverage_path))


### PR DESCRIPTION
Steps to do this:

- [ ]  Create coverage.xml report
- [ ]  Step for renaming coverage.xml -> coverage-{package-name}.xml
- [ ]  Publish the xml file to pipeline artifacts
- [ ]  After completion of all runs, download all pipeline xml artifacts
- [ ]  Run python script to combine all xml files into one single coverage.xml file
- [ ]  Run the PublishCodeCoverageResults@1 step to publish final results to Code Coverage tab