### PR TITLE
[Communication] Fix CommunicationTokenCredential constructor in for communication live test failure

### DIFF
--- a/sdk/communication/azure-communication-chat/tests/test_chat_thread_client_e2e_async.py
+++ b/sdk/communication/azure-communication-chat/tests/test_chat_thread_client_e2e_async.py
@@ -12,7 +12,8 @@ from msrest.serialization import TZ_UTC
 from azure.communication.administration import CommunicationIdentityClient
 from azure.communication.chat.aio import (
     ChatClient,
-    CommunicationTokenCredential
+    CommunicationTokenCredential,
+    CommunicationTokenRefreshOptions
 )
 from azure.communication.chat import (
     ChatThreadMember,
@@ -50,7 +51,8 @@ class ChatThreadClientTestAsync(AsyncCommunicationTestCase):
         self.new_user = self.identity_client.create_user()
 
         # create ChatClient
-        self.chat_client = ChatClient(self.endpoint, CommunicationTokenCredential(self.token))
+        refresh_option = CommunicationTokenRefreshOptions(self.token)
+        self.chat_client = ChatClient(self.endpoint, CommunicationTokenCredential(refresh_option))
 
     def tearDown(self):
         super(ChatThreadClientTestAsync, self).tearDown()


### PR DESCRIPTION
Fix communication live test failure. Fix CommunicationTokenCredential constructor in test_chat_client_e2e.py