### PR TITLE
[formrecognizer] add convenience to prebuilt models

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_form_recognizer_client.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_form_recognizer_client.py
@@ -65,9 +65,9 @@ class FormRecognizerClient(FormRecognizerClientBase):
             :caption: Creating the FormRecognizerClient with a token credential.
     """
 
-    def _prebuilt_callback(self, raw_response, _, headers):  # pylint: disable=unused-argument
-        analyze_result = self._deserialize(self._generated_models.AnalyzeOperationResult, raw_response)
-        return prepare_prebuilt_models(analyze_result)
+    def _prebuilt_callback(self, response, prebuilt_type):
+        analyze_result = self._deserialize(self._generated_models.AnalyzeOperationResult, response)
+        return prepare_prebuilt_models(analyze_result, prebuilt_type)
 
     @distributed_trace
     def begin_recognize_receipts(self, receipt, **kwargs):
@@ -115,7 +115,7 @@ class FormRecognizerClient(FormRecognizerClientBase):
         include_field_elements = kwargs.pop("include_field_elements", False)
         if content_type == "application/json":
             raise TypeError("Call begin_recognize_receipts_from_url() to analyze a receipt from a URL.")
-        cls = kwargs.pop("cls", self._prebuilt_callback)
+        cls = kwargs.pop("cls", lambda response, _, headers: self._prebuilt_callback(response, "Receipt"))
         if content_type is None and kwargs.get("continuation_token", None) is None:
             content_type = get_content_type(receipt)
 
@@ -174,7 +174,7 @@ class FormRecognizerClient(FormRecognizerClientBase):
         """
         locale = kwargs.pop("locale", None)
         include_field_elements = kwargs.pop("include_field_elements", False)
-        cls = kwargs.pop("cls", self._prebuilt_callback)
+        cls = kwargs.pop("cls", lambda response, _, headers: self._prebuilt_callback(response, "Receipt"))
 
         # FIXME: part of this code will be removed once autorest can handle diff mixin
         # signatures across API versions
@@ -250,7 +250,7 @@ class FormRecognizerClient(FormRecognizerClientBase):
                 file_stream=business_card,
                 content_type=content_type,
                 include_text_details=include_field_elements,
-                cls=kwargs.pop("cls", self._prebuilt_callback),
+                cls=kwargs.pop("cls", lambda response, _, headers: self._prebuilt_callback(response, "BusinessCard")),
                 polling=True,
                 **kwargs
             )
@@ -300,7 +300,7 @@ class FormRecognizerClient(FormRecognizerClientBase):
             return self._client.begin_analyze_business_card_async(  # type: ignore
                 file_stream={"source": business_card_url},
                 include_text_details=include_field_elements,
-                cls=kwargs.pop("cls", self._prebuilt_callback),
+                cls=kwargs.pop("cls", lambda response, _, headers: self._prebuilt_callback(response, "BusinessCard")),
                 polling=True,
                 **kwargs
             )
@@ -370,7 +370,7 @@ class FormRecognizerClient(FormRecognizerClientBase):
                 file_stream=invoice,
                 content_type=content_type,
                 include_text_details=include_field_elements,
-                cls=kwargs.pop("cls", self._prebuilt_callback),
+                cls=kwargs.pop("cls", lambda response, _, headers: self._prebuilt_callback(response, "Invoice")),
                 polling=True,
                 **kwargs
             )
@@ -418,7 +418,7 @@ class FormRecognizerClient(FormRecognizerClientBase):
             return self._client.begin_analyze_invoice_async(  # type: ignore
                 file_stream={"source": invoice_url},
                 include_text_details=include_field_elements,
-                cls=kwargs.pop("cls", self._prebuilt_callback),
+                cls=kwargs.pop("cls", lambda response, _, headers: self._prebuilt_callback(response, "Invoice")),
                 polling=True,
                 **kwargs
             )

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
@@ -225,7 +225,7 @@ class RecognizedForm(object):
             if attr in self.fields:
                 field = self.fields[attr]
                 return field
-            if attr in SCHEMA[self._prebuilt] and SCHEMA[self._prebuilt][attr] == "list":
+            if SCHEMA[self._prebuilt][attr] == "list":
                 return FormField(value=[])
             return FormField()
         raise AttributeError("'RecognizedForm' object has no attribute '{}'".format(attr))

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
@@ -203,6 +203,7 @@ class RecognizedForm(object):
         self.pages = kwargs.get("pages", None)
         self.model_id = kwargs.get('model_id', None)
         self.form_type_confidence = kwargs.get('form_type_confidence', None)
+        self._prebuilt = kwargs.get("prebuilt", True)
 
     def __repr__(self):
         return "RecognizedForm(form_type={}, fields={}, page_range={}, pages={}, form_type_confidence={}, " \
@@ -215,6 +216,13 @@ class RecognizedForm(object):
                 self.form_type_confidence,
                 self.model_id
             )[:1024]
+
+    def __getattr__(self, attr):
+        if self._prebuilt and attr not in ["fields", "form_type", "page_range", "pages", "model_id", "form_type_confidence"]:
+            if attr in self.fields:
+                field = self.fields[attr]
+                return field
+        raise AttributeError
 
 
 class FormField(object):
@@ -278,6 +286,11 @@ class FormField(object):
                 repr(self.value),
                 self.confidence
             )[:1024]
+
+    def __getattr__(self, attr):
+        if self.value_type == "dictionary" and attr not in ["value_type", "value_data", "value", "label_data", "name", "confidence"]:
+            if attr in self.value:
+                return self.value[attr]
 
 
 class FieldData(object):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
@@ -225,7 +225,7 @@ class RecognizedForm(object):
             if attr in self.fields:
                 field = self.fields[attr]
                 return field
-            elif attr in SCHEMA[self._prebuilt] and SCHEMA[self._prebuilt][attr] == "list":
+            if attr in SCHEMA[self._prebuilt] and SCHEMA[self._prebuilt][attr] == "list":
                 return FormField(value=[])
             return FormField()
         raise AttributeError("'RecognizedForm' object has no attribute '{}'".format(attr))

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_prebuilt_names.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_prebuilt_names.py
@@ -1,0 +1,70 @@
+# coding=utf-8
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+SCHEMA = {
+    "BusinessCard": {
+        "ContactNames": {
+            "FirstName": "string",
+            "LastName": "string",
+        },
+        "CompanyNames": "list",
+        "Departments": "list",
+        "JobTitles": "list",
+        "Emails": "list",
+        "Websites": "list",
+        "Addresses": "list",
+        "MobilePhones": "list",
+        "Faxes": "list",
+        "WorkPhones": "list",
+        "OtherPhones": "list"
+    },
+    "Receipt": {
+        "ReceiptType": "string",
+        "MerchantName": "string",
+        "MerchantPhoneNumber": "phoneNumber",
+        "MerchantAddress": "string",
+        "TransactionDate": "date",
+        "TransactionTime": "time",
+        "Total": "float",
+        "Subtotal": "float",
+        "Tax": "float",
+        "Tip": "float",
+        "Items": {
+            "Name": "string",
+            "Quantity": "float",
+            "Price": "float",
+            "TotalPrice": "float",
+        }
+    },
+    "Invoice": {
+        "CustomerName": "string",
+        "CustomerId": "string",
+        "PurchaseOrder": "string",
+        "InvoiceId": "string",
+        "InvoiceDate": "date",
+        "DueDate": "date",
+        "VendorName": "string",
+        "VendorAddress": "string",
+        "VendorAddressRecipient": "string",
+        "CustomerAddress": "string",
+        "CustomerAddressRecipient": "string",
+        "BillingAddress": "string",
+        "BillingAddressRecipient": "string",
+        "ShippingAddress": "string",
+        "ShippingAddressRecipient": "string",
+        "SubTotal": "float",
+        "TotalTax": "float",
+        "InvoiceTotal": "float",
+        "PreviousUnpaidBalance": "float",
+        "AmountDue": "float",
+        "ServiceStartDate": "date",
+        "ServiceEndDate": "date",
+        "ServiceAddress": "string",
+        "ServiceAddressRecipient": "string",
+        "RemittanceAddress": "string",
+        "RemittanceAddressRecipient": "string",
+    }
+}

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_response_handlers.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_response_handlers.py
@@ -20,7 +20,7 @@ from ._models import (
 )
 
 
-def prepare_prebuilt_models(response):
+def prepare_prebuilt_models(response, prebuilt_type):
     prebuilt_models = []
     read_result = response.analyze_result.read_results
     document_result = response.analyze_result.document_results
@@ -36,11 +36,12 @@ def prepare_prebuilt_models(response):
             pages=form_page[page.page_range[0]-1:page.page_range[1]],
             form_type=page.doc_type,
             fields={
-                key: FormField._from_generated(key, value, read_result)
+                key: FormField._from_generated(key, value, read_result, prebuilt=prebuilt_type)
                 for key, value in page.fields.items()
             } if page.fields else None,
             form_type_confidence=doc_type_confidence,
-            model_id=model_id
+            model_id=model_id,
+            _prebuilt=prebuilt_type
         )
 
         prebuilt_models.append(prebuilt_model)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_response_handlers.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_response_handlers.py
@@ -20,7 +20,7 @@ from ._models import (
 )
 
 
-def prepare_prebuilt_models(response, prebuilt_type):
+def prepare_prebuilt_models(response, prebuilt_type=False):
     prebuilt_models = []
     read_result = response.analyze_result.read_results
     document_result = response.analyze_result.document_results

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/aio/_form_recognizer_client_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/aio/_form_recognizer_client_async.py
@@ -62,9 +62,9 @@ class FormRecognizerClient(FormRecognizerClientBaseAsync):
             :caption: Creating the FormRecognizerClient with a token credential.
     """
 
-    def _prebuilt_callback(self, raw_response, _, headers):  # pylint: disable=unused-argument
-        analyze_result = self._deserialize(self._generated_models.AnalyzeOperationResult, raw_response)
-        return prepare_prebuilt_models(analyze_result)
+    def _prebuilt_callback(self, response, prebuilt_type):
+        analyze_result = self._deserialize(self._generated_models.AnalyzeOperationResult, response)
+        return prepare_prebuilt_models(analyze_result, prebuilt_type)
 
     @distributed_trace_async
     async def begin_recognize_receipts(
@@ -131,7 +131,7 @@ class FormRecognizerClient(FormRecognizerClientBaseAsync):
             file_stream=receipt,
             content_type=content_type,
             include_text_details=include_field_elements,
-            cls=kwargs.pop("cls", self._prebuilt_callback),
+            cls=kwargs.pop("cls", lambda response, _, headers: self._prebuilt_callback(response, "Receipt")),
             polling=True,
             **kwargs
         )
@@ -190,7 +190,7 @@ class FormRecognizerClient(FormRecognizerClientBaseAsync):
         return await self._client.begin_analyze_receipt_async(  # type: ignore
             file_stream={"source": receipt_url},
             include_text_details=include_field_elements,
-            cls=kwargs.pop("cls", self._prebuilt_callback),
+            cls=kwargs.pop("cls", lambda response, _, headers: self._prebuilt_callback(response, "Receipt")),
             polling=True,
             **kwargs
         )
@@ -253,7 +253,7 @@ class FormRecognizerClient(FormRecognizerClientBaseAsync):
                 file_stream=business_card,
                 content_type=content_type,
                 include_text_details=include_field_elements,
-                cls=kwargs.pop("cls", self._prebuilt_callback),
+                cls=kwargs.pop("cls", lambda response, _, headers: self._prebuilt_callback(response, "BusinessCard")),
                 polling=True,
                 **kwargs
             )
@@ -301,7 +301,7 @@ class FormRecognizerClient(FormRecognizerClientBaseAsync):
             return await self._client.begin_analyze_business_card_async(  # type: ignore
                 file_stream={"source": business_card_url},
                 include_text_details=include_field_elements,
-                cls=kwargs.pop("cls", self._prebuilt_callback),
+                cls=kwargs.pop("cls", lambda response, _, headers: self._prebuilt_callback(response, "BusinessCard")),
                 polling=True,
                 **kwargs
             )
@@ -370,7 +370,7 @@ class FormRecognizerClient(FormRecognizerClientBaseAsync):
                 file_stream=invoice,
                 content_type=content_type,
                 include_text_details=include_field_elements,
-                cls=kwargs.pop("cls", self._prebuilt_callback),
+                cls=kwargs.pop("cls", lambda response, _, headers: self._prebuilt_callback(response, "Invoice")),
                 polling=True,
                 **kwargs
             )
@@ -417,7 +417,7 @@ class FormRecognizerClient(FormRecognizerClientBaseAsync):
             return await self._client.begin_analyze_invoice_async(  # type: ignore
                 file_stream={"source": invoice_url},
                 include_text_details=include_field_elements,
-                cls=kwargs.pop("cls", self._prebuilt_callback),
+                cls=kwargs.pop("cls", lambda response, _, headers: self._prebuilt_callback(response, "Invoice")),
                 polling=True,
                 **kwargs
             )

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_simple_prebuilts.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_simple_prebuilts.py
@@ -1,0 +1,130 @@
+# coding: utf-8
+
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import os
+
+
+class SimplePrebuilt(object):
+
+    def simple_receipts(self):
+        from azure.core.credentials import AzureKeyCredential
+        from azure.ai.formrecognizer import FormRecognizerClient
+
+        endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
+        key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
+
+        form_recognizer_client = FormRecognizerClient(
+            endpoint=endpoint, credential=AzureKeyCredential(key)
+        )
+        url = "https://raw.githubusercontent.com/Azure/azure-sdk-for-python/master/sdk/formrecognizer/azure-ai-formrecognizer/tests/sample_forms/receipt/contoso-receipt.png"
+        poller = form_recognizer_client.begin_recognize_receipts_from_url(receipt_url=url)
+        receipts = poller.result()
+
+        for receipt in receipts:
+            print("Receipt Type: {} has confidence: {}".format(receipt.ReceiptType.value, receipt.ReceiptType.confidence))
+            print("Merchant Name: {} has confidence: {}".format(receipt.MerchantName.value, receipt.MerchantName.confidence))
+            print("Transaction Date: {} has confidence: {}".format(receipt.TransactionDate.value, receipt.TransactionDate.confidence))
+            print("Receipt items:")
+            for item in receipt.Items.value:
+                print("...Item Name: {} has confidence: {}".format(item.Name.value, item.Name.confidence))
+                print("...Item Quantity: {} has confidence: {}".format(item.Quantity.value, item.Quantity.confidence))
+                print("...Individual Item Price: {} has confidence: {}".format(item.Price.value, item.Price.confidence))
+                print("...Total Item Price: {} has confidence: {}".format(item.TotalPrice.value, item.TotalPrice.confidence))
+            print("Subtotal: {} has confidence: {}".format(receipt.Subtotal.value, receipt.Subtotal.confidence))
+            print("Tax: {} has confidence: {}".format(receipt.Tax.value, receipt.Tax.confidence))
+            print("Tip: {} has confidence: {}".format(receipt.Tip.value, receipt.Tip.confidence))
+            print("Total: {} has confidence: {}".format(receipt.Total.value, receipt.Total.confidence))
+
+    def simple_business_cards(self):
+        from azure.core.credentials import AzureKeyCredential
+        from azure.ai.formrecognizer import FormRecognizerClient
+
+        endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
+        key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
+        path_to_sample_forms = os.path.abspath(os.path.join(os.path.abspath(__file__),
+                                                            "..", "./sample_forms/business_cards/business-card-english.jpg"))
+        form_recognizer_client = FormRecognizerClient(
+            endpoint=endpoint, credential=AzureKeyCredential(key)
+        )
+        with open(path_to_sample_forms, "rb") as f:
+            poller = form_recognizer_client.begin_recognize_business_cards(business_card=f, locale="en-US")
+
+        business_cards = poller.result()
+
+        for business_card in business_cards:
+            print("Contact Names:")
+            for contact_name in business_card.ContactNames.value:
+                print("...FirstName: {} has confidence {}".format(contact_name.FirstName.value, contact_name.FirstName.confidence))
+                print("...LastName: {} has confidence {}".format(contact_name.LastName.value, contact_name.LastName.confidence))
+            for dept in business_card.Departments.value:
+                print("Departments: {} has confidence {}".format(dept.value, dept.confidence))
+            for company_name in business_card.CompanyNames.value:
+                print("CompanyNames: {} has confidence {}".format(company_name.value, company_name.confidence))
+            for job_title in business_card.JobTitles.value:
+                print("JobTitles: {} has confidence {}".format(job_title.value, job_title.confidence))
+            for email in business_card.Emails.value:
+                print("Emails: {} has confidence {}".format(email.value, email.confidence))
+            for website in business_card.Websites.value:
+                print("Websites: {} has confidence {}".format(website.value, website.confidence))
+            for address in business_card.Addresses.value:
+                print("Addresses: {} has confidence {}".format(address.value, address.confidence))
+            for phone in business_card.MobilePhones.value:
+                print("MobilePhones: {} has confidence {}".format(phone.value, phone.confidence))
+            for phone in business_card.WorkPhones.value:
+                print("WorkPhones: {} has confidence {}".format(phone.value, phone.confidence))
+            for phone in business_card.OtherPhones.value:
+                print("OtherPhones: {} has confidence {}".format(phone.value, phone.confidence))
+
+    def simple_invoices(self):
+        from azure.core.credentials import AzureKeyCredential
+        from azure.ai.formrecognizer import FormRecognizerClient
+
+        endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
+        key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
+
+        form_recognizer_client = FormRecognizerClient(
+            endpoint=endpoint, credential=AzureKeyCredential(key)
+        )
+
+        poller = form_recognizer_client.begin_recognize_invoices_from_url("https://docs.microsoft.com/en-us/azure/cognitive-services/form-recognizer/media/sample-invoice.jpg")
+        invoices = poller.result()
+
+        for invoice in invoices:
+            print("CustomerName: {} has confidence {}".format(invoice.CustomerName.value, invoice.CustomerName.confidence))
+            print("CustomerId: {} has confidence {}".format(invoice.CustomerId.value, invoice.CustomerId.confidence))
+            print("PurchaseOrder: {} has confidence {}".format(invoice.PurchaseOrder.value, invoice.PurchaseOrder.confidence))
+            print("InvoiceId: {} has confidence {}".format(invoice.InvoiceId.value, invoice.InvoiceId.confidence))
+            print("InvoiceDate: {} has confidence {}".format(invoice.InvoiceDate.value, invoice.InvoiceDate.confidence))
+            print("DueDate: {} has confidence {}".format(invoice.DueDate.value, invoice.DueDate.confidence))
+            print("VendorName: {} has confidence {}".format(invoice.VendorName.value, invoice.VendorName.confidence))
+            print("VendorAddress: {} has confidence {}".format(invoice.VendorAddress.value, invoice.VendorAddress.confidence))
+            print("VendorAddressRecipient: {} has confidence {}".format(invoice.VendorAddressRecipient.value, invoice.VendorAddressRecipient.confidence))
+            print("CustomerAddress: {} has confidence {}".format(invoice.CustomerAddress.value, invoice.CustomerAddress.confidence))
+            print("CustomerAddressRecipient: {} has confidence {}".format(invoice.CustomerAddressRecipient.value, invoice.CustomerAddressRecipient.confidence))
+            print("BillingAddress: {} has confidence {}".format(invoice.BillingAddress.value, invoice.BillingAddress.confidence))
+            print("BillingAddressRecipient: {} has confidence {}".format(invoice.BillingAddressRecipient.value, invoice.BillingAddressRecipient.confidence))
+            print("ShippingAddress: {} has confidence {}".format(invoice.ShippingAddress.value, invoice.ShippingAddress.confidence))
+            print("ShippingAddressRecipient: {} has confidence {}".format(invoice.ShippingAddressRecipient.value, invoice.ShippingAddressRecipient.confidence))
+            print("SubTotal: {} has confidence {}".format(invoice.SubTotal.value, invoice.SubTotal.confidence))
+            print("TotalTax: {} has confidence {}".format(invoice.TotalTax.value, invoice.TotalTax.confidence))
+            print("InvoiceTotal: {} has confidence {}".format(invoice.InvoiceTotal.value, invoice.InvoiceTotal.confidence))
+            print("PreviousUnpaidBalance: {} has confidence {}".format(invoice.PreviousUnpaidBalance.value, invoice.PreviousUnpaidBalance.confidence))
+            print("AmountDue: {} has confidence {}".format(invoice.AmountDue.value, invoice.AmountDue.confidence))
+            print("ServiceStartDate: {} has confidence {}".format(invoice.ServiceStartDate.value, invoice.ServiceStartDate.confidence))
+            print("ServiceEndDate: {} has confidence {}".format(invoice.ServiceEndDate.value, invoice.ServiceEndDate.confidence))
+            print("ServiceAddress: {} has confidence {}".format(invoice.ServiceAddress.value, invoice.ServiceAddress.confidence))
+            print("ServiceAddressRecipient: {} has confidence {}".format(invoice.ServiceAddressRecipient.value, invoice.ServiceAddressRecipient.confidence))
+            print("RemittanceAddress: {} has confidence {}".format(invoice.RemittanceAddress.value, invoice.RemittanceAddress.confidence))
+            print("RemittanceAddressRecipient: {} has confidence {}".format(invoice.RemittanceAddressRecipient.value, invoice.RemittanceAddressRecipient.confidence))
+
+
+if __name__ == '__main__':
+    sample = SimplePrebuilt()
+    sample.simple_receipts()
+    sample.simple_business_cards()
+    sample.simple_invoices()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url.py
@@ -204,21 +204,38 @@ class TestReceiptFromUrl(FormRecognizerTest):
         poller = client.begin_recognize_receipts_from_url(self.receipt_url_png)
 
         result = poller.result()
-        self.assertEqual(len(result), 1)
-        receipt = result[0]
-        self.assertEqual(receipt.fields.get("MerchantAddress").value, '123 Main Street Redmond, WA 98052')
-        self.assertEqual(receipt.fields.get("MerchantName").value, 'Contoso Contoso')
-        self.assertEqual(receipt.fields.get("Subtotal").value, 1098.99)
-        # self.assertEqual(receipt.fields.get("Tax").value, 104.4)  # FIXME: Service not finding Tax
-        # self.assertEqual(receipt.fields.get("Total").value, 1203.39) # FIXME: Service sees Tax as Total
-        self.assertEqual(receipt.fields.get("TransactionDate").value, date(year=2019, month=6, day=10))
-        self.assertEqual(receipt.fields.get("TransactionTime").value, time(hour=13, minute=59, second=0))
-        self.assertEqual(receipt.page_range.first_page_number, 1)
-        self.assertEqual(receipt.page_range.last_page_number, 1)
-        self.assertFormPagesHasValues(receipt.pages)
-        receipt_type = receipt.fields.get("ReceiptType")
-        self.assertIsNotNone(receipt_type.confidence)
-        self.assertEqual(receipt_type.value, 'Itemized')
+        for idx, receipt in enumerate(result):
+            print("Receipt Type: {} has confidence: {}".format(receipt.ReceiptType.value, receipt.ReceiptType.confidence))
+            print("Merchant Name: {} has confidence: {}".format(receipt.MerchantName.value, receipt.MerchantName.confidence))
+            print("Transaction Date: {} has confidence: {}".format(receipt.TransactionDate.value, receipt.TransactionDate.confidence))
+            print("Receipt items:")
+            for item in receipt.Items.value:
+                print("...Item Name: {} has confidence: {}".format(item.Name.value, item.Name.confidence))
+                print("...Item Quantity: {} has confidence: {}".format(item.Quantity.value, item.Quantity.confidence))
+                print("...Individual Item Price: {} has confidence: {}".format(item.Price.value, item.Price.confidence))
+                print("...Total Item Price: {} has confidence: {}".format(item.TotalPrice.value, item.TotalPrice.confidence))
+            print("Subtotal: {} has confidence: {}".format(receipt.Subtotal.value, receipt.Subtotal.confidence))
+            print("Tax: {} has confidence: {}".format(receipt.Tax.value, receipt.Tax.confidence))
+            print("Tip: {} has confidence: {}".format(receipt.Tip.value, receipt.Tip.confidence))
+            print("Total: {} has confidence: {}".format(receipt.Total.value, receipt.Total.confidence))
+            print("--------------------------------------")
+
+
+        # self.assertEqual(len(result), 1)
+        # receipt = result[0]
+        # self.assertEqual(receipt.fields.get("MerchantAddress").value, '123 Main Street Redmond, WA 98052')
+        # self.assertEqual(receipt.fields.get("MerchantName").value, 'Contoso Contoso')
+        # self.assertEqual(receipt.fields.get("Subtotal").value, 1098.99)
+        # # self.assertEqual(receipt.fields.get("Tax").value, 104.4)  # FIXME: Service not finding Tax
+        # # self.assertEqual(receipt.fields.get("Total").value, 1203.39) # FIXME: Service sees Tax as Total
+        # self.assertEqual(receipt.fields.get("TransactionDate").value, date(year=2019, month=6, day=10))
+        # self.assertEqual(receipt.fields.get("TransactionTime").value, time(hour=13, minute=59, second=0))
+        # self.assertEqual(receipt.page_range.first_page_number, 1)
+        # self.assertEqual(receipt.page_range.last_page_number, 1)
+        # self.assertFormPagesHasValues(receipt.pages)
+        # receipt_type = receipt.fields.get("ReceiptType")
+        # self.assertIsNotNone(receipt_type.confidence)
+        # self.assertEqual(receipt_type.value, 'Itemized')
 
     @GlobalFormRecognizerAccountPreparer()
     @GlobalClientPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_receipt_from_url.py
@@ -204,38 +204,21 @@ class TestReceiptFromUrl(FormRecognizerTest):
         poller = client.begin_recognize_receipts_from_url(self.receipt_url_png)
 
         result = poller.result()
-        for idx, receipt in enumerate(result):
-            print("Receipt Type: {} has confidence: {}".format(receipt.ReceiptType.value, receipt.ReceiptType.confidence))
-            print("Merchant Name: {} has confidence: {}".format(receipt.MerchantName.value, receipt.MerchantName.confidence))
-            print("Transaction Date: {} has confidence: {}".format(receipt.TransactionDate.value, receipt.TransactionDate.confidence))
-            print("Receipt items:")
-            for item in receipt.Items.value:
-                print("...Item Name: {} has confidence: {}".format(item.Name.value, item.Name.confidence))
-                print("...Item Quantity: {} has confidence: {}".format(item.Quantity.value, item.Quantity.confidence))
-                print("...Individual Item Price: {} has confidence: {}".format(item.Price.value, item.Price.confidence))
-                print("...Total Item Price: {} has confidence: {}".format(item.TotalPrice.value, item.TotalPrice.confidence))
-            print("Subtotal: {} has confidence: {}".format(receipt.Subtotal.value, receipt.Subtotal.confidence))
-            print("Tax: {} has confidence: {}".format(receipt.Tax.value, receipt.Tax.confidence))
-            print("Tip: {} has confidence: {}".format(receipt.Tip.value, receipt.Tip.confidence))
-            print("Total: {} has confidence: {}".format(receipt.Total.value, receipt.Total.confidence))
-            print("--------------------------------------")
-
-
-        # self.assertEqual(len(result), 1)
-        # receipt = result[0]
-        # self.assertEqual(receipt.fields.get("MerchantAddress").value, '123 Main Street Redmond, WA 98052')
-        # self.assertEqual(receipt.fields.get("MerchantName").value, 'Contoso Contoso')
-        # self.assertEqual(receipt.fields.get("Subtotal").value, 1098.99)
-        # # self.assertEqual(receipt.fields.get("Tax").value, 104.4)  # FIXME: Service not finding Tax
-        # # self.assertEqual(receipt.fields.get("Total").value, 1203.39) # FIXME: Service sees Tax as Total
-        # self.assertEqual(receipt.fields.get("TransactionDate").value, date(year=2019, month=6, day=10))
-        # self.assertEqual(receipt.fields.get("TransactionTime").value, time(hour=13, minute=59, second=0))
-        # self.assertEqual(receipt.page_range.first_page_number, 1)
-        # self.assertEqual(receipt.page_range.last_page_number, 1)
-        # self.assertFormPagesHasValues(receipt.pages)
-        # receipt_type = receipt.fields.get("ReceiptType")
-        # self.assertIsNotNone(receipt_type.confidence)
-        # self.assertEqual(receipt_type.value, 'Itemized')
+        self.assertEqual(len(result), 1)
+        receipt = result[0]
+        self.assertEqual(receipt.fields.get("MerchantAddress").value, '123 Main Street Redmond, WA 98052')
+        self.assertEqual(receipt.fields.get("MerchantName").value, 'Contoso Contoso')
+        self.assertEqual(receipt.fields.get("Subtotal").value, 1098.99)
+        # self.assertEqual(receipt.fields.get("Tax").value, 104.4)  # FIXME: Service not finding Tax
+        # self.assertEqual(receipt.fields.get("Total").value, 1203.39) # FIXME: Service sees Tax as Total
+        self.assertEqual(receipt.fields.get("TransactionDate").value, date(year=2019, month=6, day=10))
+        self.assertEqual(receipt.fields.get("TransactionTime").value, time(hour=13, minute=59, second=0))
+        self.assertEqual(receipt.page_range.first_page_number, 1)
+        self.assertEqual(receipt.page_range.last_page_number, 1)
+        self.assertFormPagesHasValues(receipt.pages)
+        receipt_type = receipt.fields.get("ReceiptType")
+        self.assertIsNotNone(receipt_type.confidence)
+        self.assertEqual(receipt_type.value, 'Itemized')
 
     @GlobalFormRecognizerAccountPreparer()
     @GlobalClientPreparer()


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-python/issues/14814

Work-in-progress. All attributes are "dynamic" and don't actually exist on the `RecognizedForm` - we reach into the `fields` dictionary to get the `FormField` result when a particular attribute is accessed by name. 
Because `list[{name: FormField}]` types exist, we also need to add some `getattr` magic to the `FormField` class.

Some thoughts...

__Flaws__:
- We have to maintain the "[schema](https://github.com/Azure/azure-sdk-for-python/blob/1ac330b1d7c266e3f09f6f422f1efc340b178ba3/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_prebuilt_names.py)" for each prebuilt model in code which includes the fields possible and their types.
    - First question, is this even reasonable? Schema can change during preview but shouldn't after service GA. 
    - Why do I think this is necessary?
        - Without the _known_ fields possible, we can no longer guarantee the normal behavior of `__getattr__`. In other 
           words, this would be silently ignored: `field = receipt.field_that_doesnt_exist_lalala`
        - Since we know the fields, if a certain field wasn't detected on the form, and doesn't exist in the fields dictionary, we        can return an empty `FormField` in its place (instead of an `AttributeError`) which in my opinion gives a much better userexperience. (I don't have to write such defensive code and constantly check if something exists before I .value into it).    
           E.g. I can write this:
           `merchant_name = receipt.MerchantName.value`
           instead of...

           ```
           merchant_name = receipt.MerchantName
           if merchant_name:
               merchant_name_value = receipt.MerchantName.value
          ```
          The above code really not being too different/convenient from that of accessing `MerchantName` through the `fields` dictionary.
        - Knowing if a certain field is normally returned as a FormField of type list lets us return an empty iterable `FormField` in its place when it's not found in the dict.
          ```
          for email in business_cards.Emails.value:   # returns empty list instead of TypeError
             print(email)
          ```

- Keeping hardcoded schema in code means that if service starts returning a new field, we won't have an attribute for it yet (counterargument - they can always access new field in the top-level fields dictionary so not a _huge_ deal )
- This will only work for prebuilts, not for custom models (which also return `RecognizedForm`). Might be weird to have this behavior for only one and not the other? Custom is difficult because a user can label a field as the same name as one of the public `RecognizedForm` attributes (wouldn't be able to resolve the name) or can label a field to begin with spaces/numbers.
- This isn't really discoverable by any means. Unless you look at the samples.

__Good things__:
- Additive and works for stuff we already GA'd
- Doesn't add properties to `RecognizedForm`. Since this is the return type for both custom models and prebuilts it's nice that this doesn't really affect the custom scenario in any negative way.
- Avoids `AttributeError`s and having to write "defensive" code with many "if exists" statements
- normal `__getattr__` behavior is preserved
- Samples!
    - [receipts](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_receipts_from_url.py#L33) vs ["simple" receipts](https://github.com/Azure/azure-sdk-for-python/blob/1ac330b1d7c266e3f09f6f422f1efc340b178ba3/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_simple_prebuilts.py#L14)
    - [business cards](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_business_cards.py#L31) vs ["simple" business cards ](https://github.com/Azure/azure-sdk-for-python/blob/1ac330b1d7c266e3f09f6f422f1efc340b178ba3/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_simple_prebuilts.py#L43)
    - [invoices](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_invoices.py#L31) vs ["simple" invoices](https://github.com/Azure/azure-sdk-for-python/blob/1ac330b1d7c266e3f09f6f422f1efc340b178ba3/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_simple_prebuilts.py#L83)