### PR TITLE
Move mindependency and latestdependency common dependencies to a file

### DIFF
--- a/eng/dependency_tools.txt
+++ b/eng/dependency_tools.txt
@@ -1,0 +1,4 @@
+../../../tools/azure-sdk-tools
+azure-mgmt-keyvault<7.0.0
+azure-mgmt-resource<15.0.0
+azure-mgmt-storage<15.0.0

--- a/eng/dependency_tools.txt
+++ b/eng/dependency_tools.txt
@@ -1,4 +1,1 @@
 ../../../tools/azure-sdk-tools
-azure-mgmt-keyvault<7.0.0
-azure-mgmt-resource<15.0.0
-azure-mgmt-storage<15.0.0

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -214,6 +214,9 @@ commands =
 
 [testenv:mindependency]
 deps = 
+  azure-mgmt-keyvault<7.0.0
+  azure-mgmt-resource<15.0.0
+  azure-mgmt-storage<15.0.0
   {[dependencytools]deps}
   {[tools]deps}
 changedir = {toxinidir}

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -21,20 +21,19 @@ deps =
   -rdev_requirements.txt
   {[tools]deps}
 
-
+[dependencytools]
+deps =
+    -r ../../../eng/dependency_tools.txt
 
 [packaging]
 pkgs = 
     wheel==0.34.2
     packaging==20.4
 
-
 [testenv]
 ignore_args=--ignore=.tox --ignore=build --ignore=.eggs
 default_pytest_params = --junitxml={toxinidir}/test-junit-{envname}.xml --verbose --durations=10 --ignore=azure {[testenv]ignore_args}
 parallel_show_output =True
-pre-deps =
-  {[packaging]pkgs}
 skip_install = true
 skipsdist = true
 usedevelop = false
@@ -179,8 +178,6 @@ commands =
 
 
 [testenv:devtest]
-pre-deps =
-  {[packaging]pkgs}
 deps = {[base]deps}
 changedir = {toxinidir}
 commands = 
@@ -195,6 +192,7 @@ commands =
 
 [deptestcommands]
 commands =
+    {envbindir}/python {toxinidir}/../../../eng/tox/install_if_not_present.py -t {toxinidir} -d {env:DEPENDENCY_TYPE:} -w {envtmpdir}
     {envbindir}/python {toxinidir}/../../../eng/tox/install_depend_packages.py -t {toxinidir} -d {env:DEPENDENCY_TYPE:} -w {envtmpdir}
     {envbindir}/python {toxinidir}/../../../eng/tox/create_package_and_install.py -d {envtmpdir} -p {toxinidir} -w {envtmpdir}
     {envbindir}/python -m pip freeze
@@ -203,10 +201,11 @@ commands =
 
 
 [testenv:latestdependency]
-pre-deps =
-  {[packaging]pkgs}
-deps = {[tools]deps}
-changedir = {toxinidir}
+deps = 
+  {[dependencytools]deps}
+  {[tools]deps}
+changedir = 
+  {toxinidir}
 passenv = *
 setenv =
   DEPENDENCY_TYPE=Latest
@@ -215,12 +214,8 @@ commands =
 
 
 [testenv:mindependency]
-pre-deps =
-  {[packaging]pkgs}
 deps = 
-  azure-mgmt-keyvault<7.0.0
-  azure-mgmt-resource<15.0.0
-  azure-mgmt-storage<15.0.0
+  {[dependencytools]deps}
   {[tools]deps}
 changedir = {toxinidir}
 passenv = *

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -192,7 +192,6 @@ commands =
 
 [deptestcommands]
 commands =
-    {envbindir}/python {toxinidir}/../../../eng/tox/install_if_not_present.py -t {toxinidir} -d {env:DEPENDENCY_TYPE:} -w {envtmpdir}
     {envbindir}/python {toxinidir}/../../../eng/tox/install_depend_packages.py -t {toxinidir} -d {env:DEPENDENCY_TYPE:} -w {envtmpdir}
     {envbindir}/python {toxinidir}/../../../eng/tox/create_package_and_install.py -d {envtmpdir} -p {toxinidir} -w {envtmpdir}
     {envbindir}/python -m pip freeze

--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -36,7 +36,7 @@ pool_size = multiprocessing.cpu_count() * 2
 DEFAULT_TOX_INI_LOCATION = os.path.join(root_dir, "eng/tox/tox.ini")
 IGNORED_TOX_INIS = ["azure-cosmos"]
 test_tools_path = os.path.join(root_dir, "eng", "test_tools.txt")
-
+dependency_tools_path = os.path.join(root_dir, "eng", "dependency_tools.txt")
 
 class ToxWorkItem:
     def __init__(self, target_package_path, tox_env, options_array):
@@ -376,6 +376,7 @@ def prep_and_run_tox(targeted_packages, parsed_args, options_array=[]):
         if in_ci():
             replace_dev_reqs(destination_dev_req, package_dir)
             replace_dev_reqs(test_tools_path, package_dir)
+            replace_dev_reqs(dependency_tools_path, package_dir)
             os.environ["TOX_PARALLEL_NO_SPINNER"] = "1"
 
         inject_custom_reqs(


### PR DESCRIPTION
- Process that file as part of CI to ensure we re-use the same wheel (instead of hitting issues when multiple tox environments try to build it at once)
- In `mindependency` or `latestdependency` we only use use default tool install + your package reqs. NO dev_requirements are used.

This is the piece that I forgot when merging the [the other PR](https://github.com/Azure/azure-sdk-for-python/pull/16313). We need it to work both with a default `tox` install, but also in CI where parallelism comes into play.

This PR should meet the needs of both.