### PR TITLE
converge management documentation generation to the same methodology …

### DIFF
--- a/eng/tox/run_sphinx_apidoc.py
+++ b/eng/tox/run_sphinx_apidoc.py
@@ -120,9 +120,6 @@ if __name__ == "__main__":
     pkg_name, namespace, pkg_version = get_package_details(os.path.join(package_dir, 'setup.py'))
 
     if should_build_docs(pkg_name):
-        if is_mgmt_package(pkg_name):
-            mgmt_apidoc(output_directory, namespace)
-        else:
-            sphinx_apidoc(args.working_directory)
+        sphinx_apidoc(args.working_directory)
     else:
         logging.info("Skipping sphinx source generation for {}".format(pkg_name))

--- a/eng/tox/run_sphinx_apidoc.py
+++ b/eng/tox/run_sphinx_apidoc.py
@@ -20,10 +20,6 @@ import shutil
 logging.getLogger().setLevel(logging.INFO)
 
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", ".."))
-generate_mgmt_script = os.path.join(root_dir, "doc/sphinx/generate_doc.py")
-
-def is_mgmt_package(package_dir):
-    return "mgmt"  in pkg_name or "cognitiveservices" in pkg_name
 
 def copy_existing_docs(source, target):
     for file in os.listdir(source):
@@ -60,31 +56,6 @@ def sphinx_apidoc(working_directory):
     except CalledProcessError as e:
         logging.error(
             "sphinx-apidoc failed for path {} exited with error {}".format(
-                args.working_directory, e.returncode
-            )
-        )
-        exit(1)
-
-def mgmt_apidoc(working_directory, namespace):
-    command_array = [
-        sys.executable,
-        generate_mgmt_script,
-        "-p",
-        namespace,
-        "-o",
-        working_directory,
-        "--verbose"
-        ]
-
-    try:
-        logging.info("Command to generate management sphinx sources: {}".format(command_array))
-
-        check_call(
-            command_array
-        )
-    except CalledProcessError as e:
-        logging.error(
-            "script failed for path {} exited with error {}".format(
                 args.working_directory, e.returncode
             )
         )


### PR DESCRIPTION
…in preparation for deleting generate_doc.py

Hey @changlong-liu this is out of the blue, but @sima-zhu tagged me on another PR that prompted me to start this process.

When you get a few minutes, can you please take a look at this PR? It has some changes of substance for what you see on github.io, but nothing gamebreaking. 

You don't need to worry about getting a direct comparison, I've gotten that done for you already!

For acceptance, please compare the results of a `sphinx` run of `azure-mgmt-storage`. 

Grab these two artifacts:
- [Before](https://docsupport.blob.core.windows.net/repackaged/mgmt-storage-before.zip)
- [After](https://docsupport.blob.core.windows.net/repackaged/mgmt-storage-after.zip)

And compare them.

Really the main difference is how the ToC is generated. 

![image](https://user-images.githubusercontent.com/45376673/105933953-2281ce00-6004-11eb-83f9-6d3e041ea7ef.png)
![image](https://user-images.githubusercontent.com/45376673/105933984-31688080-6004-11eb-846b-42dc7c72b537.png)


