### PR TITLE
[formrecognizer] unexpose api_version property

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - `Appearance` is renamed to `TextAppearance`
 - `Style` is renamed to `TextStyle`
-
+- Client property `api_version` is no longer exposed. Pass keyword argument `api_version` into the client to select the
+API version
 
 ## 3.1.0b2 (2021-01-12)
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_form_base_client.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_form_base_client.py
@@ -24,8 +24,8 @@ class FormRecognizerClientBase(object):
         # type: (str, Union[AzureKeyCredential, TokenCredential], Any) -> None
         self._endpoint = endpoint
         self._credential = credential
-        self.api_version = kwargs.pop('api_version', FormRecognizerApiVersion.V2_1_PREVIEW)
-        validate_api_version(self.api_version)
+        self._api_version = kwargs.pop('api_version', FormRecognizerApiVersion.V2_1_PREVIEW)
+        validate_api_version(self._api_version)
 
         authentication_policy = get_authentication_policy(credential)
         polling_interval = kwargs.pop("polling_interval", POLLING_INTERVAL)
@@ -57,12 +57,12 @@ class FormRecognizerClientBase(object):
         self._client = FormRecognizer(
             endpoint=endpoint,
             credential=credential,  # type: ignore
-            api_version=self.api_version,
+            api_version=self._api_version,
             sdk_moniker=USER_AGENT,
             authentication_policy=authentication_policy,
             http_logging_policy=http_logging_policy,
             polling_interval=polling_interval,
             **kwargs
         )
-        self._deserialize = _get_deserialize(self.api_version)
-        self._generated_models = self._client.models(self.api_version)
+        self._deserialize = _get_deserialize(self._api_version)
+        self._generated_models = self._client.models(self._api_version)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_form_recognizer_client.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_form_recognizer_client.py
@@ -122,7 +122,7 @@ class FormRecognizerClient(FormRecognizerClientBase):
         # FIXME: part of this code will be removed once autorest can handle diff mixin
         # signatures across API versions
         if locale:
-            if self.api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
+            if self._api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
                 kwargs.update({"locale": locale})
             else:
                 raise ValueError("'locale' is only available for API version V2_1_PREVIEW and up")
@@ -179,7 +179,7 @@ class FormRecognizerClient(FormRecognizerClientBase):
         # FIXME: part of this code will be removed once autorest can handle diff mixin
         # signatures across API versions
         if locale:
-            if self.api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
+            if self._api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
                 kwargs.update({"locale": locale})
             else:
                 raise ValueError("'locale' is only available for API version V2_1_PREVIEW and up")
@@ -488,13 +488,13 @@ class FormRecognizerClient(FormRecognizerClientBase):
         # FIXME: part of this code will be removed once autorest can handle diff mixin
         # signatures across API versions
         if pages:
-            if self.api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
+            if self._api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
                 kwargs.update({"pages": pages})
             else:
                 raise ValueError("'pages' is only available for API version V2_1_PREVIEW and up")
 
         if language:
-            if self.api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
+            if self._api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
                 kwargs.update({"language": language})
             else:
                 raise ValueError("'language' is only available for API version V2_1_PREVIEW and up")
@@ -541,13 +541,13 @@ class FormRecognizerClient(FormRecognizerClientBase):
         # FIXME: part of this code will be removed once autorest can handle diff mixin
         # signatures across API versions
         if pages:
-            if self.api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
+            if self._api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
                 kwargs.update({"pages": pages})
             else:
                 raise ValueError("'pages' is only available for API version V2_1_PREVIEW and up")
 
         if language:
-            if self.api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
+            if self._api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
                 kwargs.update({"language": language})
             else:
                 raise ValueError("'language' is only available for API version V2_1_PREVIEW and up")

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_form_training_client.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_form_training_client.py
@@ -123,20 +123,20 @@ class FormTrainingClient(FormRecognizerClientBase):
 
         def callback_v2_0(raw_response):
             model = self._deserialize(self._generated_models.Model, raw_response)
-            return CustomFormModel._from_generated(model, api_version=self.api_version)
+            return CustomFormModel._from_generated(model, api_version=self._api_version)
 
         def callback_v2_1(raw_response, _, headers):  # pylint: disable=unused-argument
             model = self._deserialize(self._generated_models.Model, raw_response)
-            return CustomFormModel._from_generated(model, api_version=self.api_version)
+            return CustomFormModel._from_generated(model, api_version=self._api_version)
 
         cls = kwargs.pop("cls", None)
         model_name = kwargs.pop("model_name", None)
-        if model_name and self.api_version == "2.0":
+        if model_name and self._api_version == "2.0":
             raise ValueError("'model_name' is only available for API version V2_1_PREVIEW and up")
         continuation_token = kwargs.pop("continuation_token", None)
         polling_interval = kwargs.pop("polling_interval", self._client._config.polling_interval)
 
-        if self.api_version == "2.0":
+        if self._api_version == "2.0":
             deserialization_callback = cls if cls else callback_v2_0
             if continuation_token:
                 return LROPoller.from_continuation_token(
@@ -232,7 +232,7 @@ class FormTrainingClient(FormRecognizerClientBase):
         """
         return self._client.list_custom_models(  # type: ignore
             cls=kwargs.pop("cls", lambda objs:
-            [CustomFormModelInfo._from_generated(x, api_version=self.api_version) for x in objs]),
+            [CustomFormModelInfo._from_generated(x, api_version=self._api_version) for x in objs]),
             **kwargs
         )
 
@@ -285,7 +285,7 @@ class FormTrainingClient(FormRecognizerClientBase):
         response = self._client.get_custom_model(model_id=model_id, include_keys=True, **kwargs)
         if hasattr(response, "composed_train_results") and response.composed_train_results:
             return CustomFormModel._from_generated_composed(response)
-        return CustomFormModel._from_generated(response, api_version=self.api_version)
+        return CustomFormModel._from_generated(response, api_version=self._api_version)
 
     @distributed_trace
     def get_copy_authorization(self, resource_id, resource_region, **kwargs):
@@ -369,12 +369,12 @@ class FormTrainingClient(FormRecognizerClientBase):
             copy_operation = self._deserialize(self._generated_models.CopyOperationResult, raw_response)
             model_id = copy_operation.copy_result.model_id if hasattr(copy_operation, "copy_result") else None
             if model_id:
-                return CustomFormModelInfo._from_generated(copy_operation, model_id, api_version=self.api_version)
+                return CustomFormModelInfo._from_generated(copy_operation, model_id, api_version=self._api_version)
             if target:
                 return CustomFormModelInfo._from_generated(
-                    copy_operation, target["model_id"], api_version=self.api_version
+                    copy_operation, target["model_id"], api_version=self._api_version
                 )
-            return CustomFormModelInfo._from_generated(copy_operation, None, api_version=self.api_version)
+            return CustomFormModelInfo._from_generated(copy_operation, None, api_version=self._api_version)
 
         return self._client.begin_copy_custom_model(  # type: ignore
             model_id=model_id,
@@ -465,7 +465,7 @@ class FormTrainingClient(FormRecognizerClientBase):
             endpoint=self._endpoint,
             credential=self._credential,
             pipeline=_pipeline,
-            api_version=self.api_version,
+            api_version=self._api_version,
             **kwargs
         )
         # need to share config, but can't pass as a keyword into client

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/aio/_form_base_client_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/aio/_form_base_client_async.py
@@ -29,8 +29,8 @@ class FormRecognizerClientBaseAsync(object):
     ) -> None:
         self._endpoint = endpoint
         self._credential = credential
-        self.api_version = kwargs.pop('api_version', FormRecognizerApiVersion.V2_1_PREVIEW)
-        validate_api_version(self.api_version)
+        self._api_version = kwargs.pop('api_version', FormRecognizerApiVersion.V2_1_PREVIEW)
+        validate_api_version(self._api_version)
 
         authentication_policy = get_authentication_policy(credential)
         polling_interval = kwargs.pop("polling_interval", POLLING_INTERVAL)
@@ -57,12 +57,12 @@ class FormRecognizerClientBaseAsync(object):
         self._client = FormRecognizer(
             endpoint=endpoint,
             credential=credential,  # type: ignore
-            api_version=self.api_version,
+            api_version=self._api_version,
             sdk_moniker=USER_AGENT,
             authentication_policy=authentication_policy,
             http_logging_policy=http_logging_policy,
             polling_interval=polling_interval,
             **kwargs
         )
-        self._deserialize = _get_deserialize(self.api_version)
-        self._generated_models = self._client.models(self.api_version)
+        self._deserialize = _get_deserialize(self._api_version)
+        self._generated_models = self._client.models(self._api_version)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/aio/_form_recognizer_client_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/aio/_form_recognizer_client_async.py
@@ -122,7 +122,7 @@ class FormRecognizerClient(FormRecognizerClientBaseAsync):
         # FIXME: part of this code will be removed once autorest can handle diff mixin
         # signatures across API versions
         if locale:
-            if self.api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
+            if self._api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
                 kwargs.update({"locale": locale})
             else:
                 raise ValueError("'locale' is only available for API version V2_1_PREVIEW and up")
@@ -182,7 +182,7 @@ class FormRecognizerClient(FormRecognizerClientBaseAsync):
         # FIXME: part of this code will be removed once autorest can handle diff mixin
         # signatures across API versions
         if locale:
-            if self.api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
+            if self._api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
                 kwargs.update({"locale": locale})
             else:
                 raise ValueError("'locale' is only available for API version V2_1_PREVIEW and up")
@@ -490,13 +490,13 @@ class FormRecognizerClient(FormRecognizerClientBaseAsync):
         # FIXME: part of this code will be removed once autorest can handle diff mixin
         # signatures across API versions
         if pages:
-            if self.api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
+            if self._api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
                 kwargs.update({"pages": pages})
             else:
                 raise ValueError("'pages' is only available for API version V2_1_PREVIEW and up")
 
         if language:
-            if self.api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
+            if self._api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
                 kwargs.update({"language": language})
             else:
                 raise ValueError("'language' is only available for API version V2_1_PREVIEW and up")
@@ -542,13 +542,13 @@ class FormRecognizerClient(FormRecognizerClientBaseAsync):
         # FIXME: part of this code will be removed once autorest can handle diff mixin
         # signatures across API versions
         if pages:
-            if self.api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
+            if self._api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
                 kwargs.update({"pages": pages})
             else:
                 raise ValueError("'pages' is only available for API version V2_1_PREVIEW and up")
 
         if language:
-            if self.api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
+            if self._api_version == FormRecognizerApiVersion.V2_1_PREVIEW:
                 kwargs.update({"language": language})
             else:
                 raise ValueError("'language' is only available for API version V2_1_PREVIEW and up")

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/aio/_form_training_client_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/aio/_form_training_client_async.py
@@ -125,20 +125,20 @@ class FormTrainingClient(FormRecognizerClientBaseAsync):
 
         def callback_v2_0(raw_response):
             model = self._deserialize(self._generated_models.Model, raw_response)
-            return CustomFormModel._from_generated(model, api_version=self.api_version)
+            return CustomFormModel._from_generated(model, api_version=self._api_version)
 
         def callback_v2_1(raw_response, _, headers):  # pylint: disable=unused-argument
             model = self._deserialize(self._generated_models.Model, raw_response)
-            return CustomFormModel._from_generated(model, api_version=self.api_version)
+            return CustomFormModel._from_generated(model, api_version=self._api_version)
 
         cls = kwargs.pop("cls", None)
         model_name = kwargs.pop("model_name", None)
-        if model_name and self.api_version == "2.0":
+        if model_name and self._api_version == "2.0":
             raise ValueError("'model_name' is only available for API version V2_1_PREVIEW and up")
         continuation_token = kwargs.pop("continuation_token", None)
         polling_interval = kwargs.pop("polling_interval", self._client._config.polling_interval)
 
-        if self.api_version == "2.0":
+        if self._api_version == "2.0":
             deserialization_callback = cls if cls else callback_v2_0
             if continuation_token:
                 return AsyncLROPoller.from_continuation_token(
@@ -238,7 +238,7 @@ class FormTrainingClient(FormRecognizerClientBaseAsync):
         """
         return self._client.list_custom_models(  # type: ignore
             cls=kwargs.pop("cls", lambda objs:
-            [CustomFormModelInfo._from_generated(x, api_version=self.api_version) for x in objs]),
+            [CustomFormModelInfo._from_generated(x, api_version=self._api_version) for x in objs]),
             **kwargs
         )
 
@@ -291,7 +291,7 @@ class FormTrainingClient(FormRecognizerClientBaseAsync):
         )
         if hasattr(response, "composed_train_results") and response.composed_train_results:
             return CustomFormModel._from_generated_composed(response)
-        return CustomFormModel._from_generated(response, api_version=self.api_version)
+        return CustomFormModel._from_generated(response, api_version=self._api_version)
 
     @distributed_trace_async
     async def get_copy_authorization(
@@ -378,12 +378,12 @@ class FormTrainingClient(FormRecognizerClientBaseAsync):
             copy_operation = self._deserialize(self._generated_models.CopyOperationResult, raw_response)
             model_id = copy_operation.copy_result.model_id if hasattr(copy_operation, "copy_result") else None
             if model_id:
-                return CustomFormModelInfo._from_generated(copy_operation, model_id, api_version=self.api_version)
+                return CustomFormModelInfo._from_generated(copy_operation, model_id, api_version=self._api_version)
             if target:
                 return CustomFormModelInfo._from_generated(
-                    copy_operation, target["model_id"], api_version=self.api_version
+                    copy_operation, target["model_id"], api_version=self._api_version
                 )
-            return CustomFormModelInfo._from_generated(copy_operation, None, api_version=self.api_version)
+            return CustomFormModelInfo._from_generated(copy_operation, None, api_version=self._api_version)
 
         return await self._client.begin_copy_custom_model(  # type: ignore
             model_id=model_id,
@@ -476,7 +476,7 @@ class FormTrainingClient(FormRecognizerClientBaseAsync):
             endpoint=self._endpoint,
             credential=self._credential,
             pipeline=_pipeline,
-            api_version=self.api_version,
+            api_version=self._api_version,
             **kwargs
         )
         # need to share config, but can't pass as a keyword into client

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_training.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_training.py
@@ -109,7 +109,7 @@ class TestTraining(FormRecognizerTest):
 
         def callback(response, _, headers):
             raw_model = client._deserialize(Model, response)
-            custom_model = CustomFormModel._from_generated(raw_model, client.api_version)
+            custom_model = CustomFormModel._from_generated(raw_model, client._api_version)
             raw_response.append(raw_model)
             raw_response.append(custom_model)
 
@@ -128,7 +128,7 @@ class TestTraining(FormRecognizerTest):
 
         def callback(response, _, headers):
             raw_model = client._deserialize(Model, response)
-            custom_model = CustomFormModel._from_generated(raw_model, client.api_version)
+            custom_model = CustomFormModel._from_generated(raw_model, client._api_version)
             raw_response.append(raw_model)
             raw_response.append(custom_model)
 
@@ -196,7 +196,7 @@ class TestTraining(FormRecognizerTest):
 
         def callback(response, _, headers):
             raw_model = client._deserialize(Model, response)
-            custom_model = CustomFormModel._from_generated(raw_model, client.api_version)
+            custom_model = CustomFormModel._from_generated(raw_model, client._api_version)
             raw_response.append(raw_model)
             raw_response.append(custom_model)
 
@@ -215,7 +215,7 @@ class TestTraining(FormRecognizerTest):
 
         def callback(response, _, headers):
             raw_model = client._deserialize(Model, response)
-            custom_model = CustomFormModel._from_generated(raw_model, client.api_version)
+            custom_model = CustomFormModel._from_generated(raw_model, client._api_version)
             raw_response.append(raw_model)
             raw_response.append(custom_model)
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_training_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_training_async.py
@@ -117,7 +117,7 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
 
         def callback(response, _, headers):
             raw_model = client._deserialize(Model, response)
-            custom_model = CustomFormModel._from_generated(raw_model, client.api_version)
+            custom_model = CustomFormModel._from_generated(raw_model, client._api_version)
             raw_response.append(raw_model)
             raw_response.append(custom_model)
 
@@ -140,7 +140,7 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
 
         def callback(response, _, headers):
             raw_model = client._deserialize(Model, response)
-            custom_model = CustomFormModel._from_generated(raw_model, client.api_version)
+            custom_model = CustomFormModel._from_generated(raw_model, client._api_version)
             raw_response.append(raw_model)
             raw_response.append(custom_model)
 
@@ -208,7 +208,7 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
 
         def callback(response, _, headers):
             raw_model = client._deserialize(Model, response)
-            custom_model = CustomFormModel._from_generated(raw_model, client.api_version)
+            custom_model = CustomFormModel._from_generated(raw_model, client._api_version)
             raw_response.append(raw_model)
             raw_response.append(custom_model)
 
@@ -228,7 +228,7 @@ class TestTrainingAsync(AsyncFormRecognizerTest):
 
         def callback(response, _, headers):
             raw_model = client._deserialize(Model, response)
-            custom_model = CustomFormModel._from_generated(raw_model, client.api_version)
+            custom_model = CustomFormModel._from_generated(raw_model, client._api_version)
             raw_response.append(raw_model)
             raw_response.append(custom_model)
 


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/16265

Unexpose for now until there is a good reason to make it a public property. Thanks for pointing this out @iscai-msft !