### PR TITLE
[Identity] Let GetTokenMixin.get_token pass kwargs to MSAL

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/app_service.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/app_service.py
@@ -38,9 +38,9 @@ class AppServiceCredential(GetTokenMixin):
             )
         return super(AppServiceCredential, self).get_token(*scopes, **kwargs)
 
-    def _acquire_token_silently(self, *scopes):
-        # type: (*str) -> Optional[AccessToken]
-        return self._client.get_cached_token(*scopes)
+    def _acquire_token_silently(self, *scopes, **kwargs):
+        # type: (*str, **Any) -> Optional[AccessToken]
+        return self._client.get_cached_token(*scopes, **kwargs)
 
     def _request_token(self, *scopes, **kwargs):
         # type: (*str, **Any) -> AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_arc.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_arc.py
@@ -60,9 +60,9 @@ class AzureArcCredential(GetTokenMixin):
             )
         return super(AzureArcCredential, self).get_token(*scopes, **kwargs)
 
-    def _acquire_token_silently(self, *scopes):
-        # type: (*str) -> Optional[AccessToken]
-        return self._client.get_cached_token(*scopes)
+    def _acquire_token_silently(self, *scopes, **kwargs):
+        # type: (*str, **Any) -> Optional[AccessToken]
+        return self._client.get_cached_token(*scopes, **kwargs)
 
     def _request_token(self, *scopes, **kwargs):
         # type: (*str, **Any) -> AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/cloud_shell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/cloud_shell.py
@@ -42,9 +42,9 @@ class CloudShellCredential(GetTokenMixin):
             )
         return super(CloudShellCredential, self).get_token(*scopes, **kwargs)
 
-    def _acquire_token_silently(self, *scopes):
-        # type: (*str) -> Optional[AccessToken]
-        return self._client.get_cached_token(*scopes)
+    def _acquire_token_silently(self, *scopes, **kwargs):
+        # type: (*str, **Any) -> Optional[AccessToken]
+        return self._client.get_cached_token(*scopes, **kwargs)
 
     def _request_token(self, *scopes, **kwargs):
         # type: (*str, **Any) -> AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/service_fabric.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/service_fabric.py
@@ -38,9 +38,9 @@ class ServiceFabricCredential(GetTokenMixin):
             )
         return super(ServiceFabricCredential, self).get_token(*scopes, **kwargs)
 
-    def _acquire_token_silently(self, *scopes):
-        # type: (*str) -> Optional[AccessToken]
-        return self._client.get_cached_token(*scopes)
+    def _acquire_token_silently(self, *scopes, **kwargs):
+        # type: (*str, **Any) -> Optional[AccessToken]
+        return self._client.get_cached_token(*scopes, **kwargs)
 
     def _request_token(self, *scopes, **kwargs):
         # type: (*str, **Any) -> AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_internal/client_credential_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/client_credential_base.py
@@ -45,7 +45,7 @@ class ClientCredentialBase(MsalCredential, GetTokenMixin):
         # type: (*str, **Any) -> Optional[AccessToken]
         app = self._get_app()
         request_time = int(time.time())
-        result = app.acquire_token_for_client(list(scopes))
+        result = app.acquire_token_for_client(list(scopes), **kwargs)
         if "access_token" not in result:
             message = "Authentication failed: {}".format(result.get("error_description") or result.get("error"))
             raise ClientAuthenticationError(message=message)

--- a/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
@@ -31,8 +31,8 @@ class GetTokenMixin(ABC):
         super(GetTokenMixin, self).__init__(*args, **kwargs)  # type: ignore
 
     @abc.abstractmethod
-    def _acquire_token_silently(self, *scopes):
-        # type: (*str) -> Optional[AccessToken]
+    def _acquire_token_silently(self, *scopes, **kwargs):
+        # type: (*str, **Any) -> Optional[AccessToken]
         """Attempt to acquire an access token from a cache or by redeeming a refresh token"""
 
     @abc.abstractmethod
@@ -66,10 +66,10 @@ class GetTokenMixin(ABC):
             raise ValueError('"get_token" requires at least one scope')
 
         try:
-            token = self._acquire_token_silently(*scopes)
+            token = self._acquire_token_silently(*scopes, **kwargs)
             if not token:
                 self._last_request_time = int(time.time())
-                token = self._request_token(*scopes)
+                token = self._request_token(*scopes, **kwargs)
             elif self._should_refresh(token):
                 try:
                     self._last_request_time = int(time.time())

--- a/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_client.py
@@ -84,8 +84,8 @@ class ManagedIdentityClientBase(ABC):
 
         return token
 
-    def get_cached_token(self, *scopes):
-        # type: (*str) -> Optional[AccessToken]
+    def get_cached_token(self, *scopes, **kwargs):   # pylint:disable=unused-argument
+        # type: (*str, **Any) -> Optional[AccessToken]
         resource = _scopes_to_resource(*scopes)
         tokens = self._cache.find(TokenCache.CredentialType.ACCESS_TOKEN, target=[resource])
         for token in tokens:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/app_service.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/app_service.py
@@ -39,8 +39,8 @@ class AppServiceCredential(AsyncContextManager, GetTokenMixin):
     async def close(self) -> None:
         await self._client.close()  # pylint:disable=no-member
 
-    async def _acquire_token_silently(self, *scopes: str) -> "Optional[AccessToken]":
-        return self._client.get_cached_token(*scopes)
+    async def _acquire_token_silently(self, *scopes: str, **kwargs: "Any") -> "Optional[AccessToken]":
+        return self._client.get_cached_token(*scopes, **kwargs)
 
     async def _request_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":
         return await self._client.request_token(*scopes, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_arc.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_arc.py
@@ -65,8 +65,8 @@ class AzureArcCredential(AsyncContextManager, GetTokenMixin):
     async def close(self) -> None:
         await self._client.close()  # pylint:disable=no-member
 
-    async def _acquire_token_silently(self, *scopes: str) -> "Optional[AccessToken]":
-        return self._client.get_cached_token(*scopes)
+    async def _acquire_token_silently(self, *scopes: str, **kwargs: "Any") -> "Optional[AccessToken]":
+        return self._client.get_cached_token(*scopes, **kwargs)
 
     async def _request_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":
         return await self._client.request_token(*scopes, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/cloud_shell.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/cloud_shell.py
@@ -43,8 +43,8 @@ class CloudShellCredential(AsyncContextManager, GetTokenMixin):
     async def close(self) -> None:
         await self._client.close()
 
-    async def _acquire_token_silently(self, *scopes: str) -> "Optional[AccessToken]":
-        return self._client.get_cached_token(*scopes)
+    async def _acquire_token_silently(self, *scopes: str, **kwargs: "Any") -> "Optional[AccessToken]":
+        return self._client.get_cached_token(*scopes, **kwargs)
 
     async def _request_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":
         return await self._client.request_token(*scopes, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/service_fabric.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/service_fabric.py
@@ -39,8 +39,8 @@ class ServiceFabricCredential(AsyncContextManager, GetTokenMixin):
     async def close(self) -> None:
         await self._client.close()  # pylint:disable=no-member
 
-    async def _acquire_token_silently(self, *scopes: str) -> "Optional[AccessToken]":
-        return self._client.get_cached_token(*scopes)
+    async def _acquire_token_silently(self, *scopes: str, **kwargs: "Any") -> "Optional[AccessToken]":
+        return self._client.get_cached_token(*scopes, **kwargs)
 
     async def _request_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":
         return await self._client.request_token(*scopes, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
@@ -25,7 +25,7 @@ class GetTokenMixin(abc.ABC):
         super(GetTokenMixin, self).__init__(*args, **kwargs)  # type: ignore
 
     @abc.abstractmethod
-    async def _acquire_token_silently(self, *scopes: str) -> "Optional[AccessToken]":
+    async def _acquire_token_silently(self, *scopes: str, **kwargs: "Any") -> "Optional[AccessToken]":
         """Attempt to acquire an access token from a cache or by redeeming a refresh token"""
 
     @abc.abstractmethod

--- a/sdk/identity/azure-identity/tests/test_get_token_mixin.py
+++ b/sdk/identity/azure-identity/tests/test_get_token_mixin.py
@@ -24,8 +24,8 @@ class MockCredential(GetTokenMixin):
         self.request_token = mock.Mock(return_value=MockCredential.NEW_TOKEN)
         self.acquire_token_silently = mock.Mock(return_value=cached_token)
 
-    def _acquire_token_silently(self, *scopes):
-        return self.acquire_token_silently(*scopes)
+    def _acquire_token_silently(self, *scopes, **kwargs):
+        return self.acquire_token_silently(*scopes, **kwargs)
 
     def _request_token(self, *scopes, **kwargs):
         return self.request_token(*scopes, **kwargs)

--- a/sdk/identity/azure-identity/tests/test_get_token_mixin_async.py
+++ b/sdk/identity/azure-identity/tests/test_get_token_mixin_async.py
@@ -23,8 +23,8 @@ class MockCredential(GetTokenMixin):
         self.request_token = mock.Mock(return_value=MockCredential.NEW_TOKEN)
         self.acquire_token_silently = mock.Mock(return_value=cached_token)
 
-    async def _acquire_token_silently(self, *scopes):
-        return self.acquire_token_silently(*scopes)
+    async def _acquire_token_silently(self, *scopes, **kwargs):
+        return self.acquire_token_silently(*scopes, **kwargs)
 
     async def _request_token(self, *scopes, **kwargs):
         return self.request_token(*scopes, **kwargs)


### PR DESCRIPTION
`GetTokenMixin` is inherited by 

- `ClientSecretCredential`
- `CertificateCredential`
- `ManagedIdentityCredential` 

However, `GetTokenMixin.get_token` discards `**kwargs` when calling MSAL, making it impossible to get an SSH certificate with a Service Principal credential.

After applying this PR, the network trace shows `req_cnf` is sent correctly:

```
azure.core.pipeline.policies._universal: Request URL: 'https://login.microsoftonline.com/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/oauth2/v2.0/token'
azure.core.pipeline.policies._universal: Request method: 'POST'
...
azure.core.pipeline.policies._universal: Request body:
azure.core.pipeline.policies._universal: 
{
    'client_id': 'ee01ddbe-2865-4d12-95ef-cd75ac9285a8', 
    'grant_type': 'client_credentials', 
    'client_info': 1, 
    'client_secret': 'UKx11...', 
    'token_type': 'ssh-cert', 
    'req_cnf': '{
        "kty": "RSA", 
        "n": "...", 
        "e": "AQAB", 
        "kid": "a83576e..."
    }', 
    'key_id': 'a83576e2adc1a2654003f3744486fa1f2595851e5539c6d213011854be1377fb', 
    'scope': 'https://pas.windows.net/CheckMyAccess/Linux/.default'
}
```