### PR TITLE
[Bug][Blob][Datalake][Queue][Fileshare]Fixed socket not closing after session closure across parent clients

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_service_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_service_client.py
@@ -3,8 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-
 import functools
+from copy import deepcopy
 from typing import (  # pylint: disable=unused-import
     Union, Optional, Any, Iterable, Dict, List,
     TYPE_CHECKING
@@ -22,7 +22,7 @@ from azure.core.pipeline import Pipeline
 from azure.core.tracing.decorator import distributed_trace
 
 from ._shared.models import LocationMode
-from ._shared.base_client import StorageAccountHostsMixin, TransportWrapper, parse_connection_str, parse_query
+from ._shared.base_client import StorageAccountHostsMixin, parse_connection_str, parse_query
 from ._shared.parser import _to_utc_datetime
 from ._shared.response_handlers import return_response_headers, process_storage_error, \
     parse_to_internal_user_delegation_key
@@ -633,7 +633,7 @@ class BlobServiceClient(StorageAccountHostsMixin):
         except AttributeError:
             container_name = container
         _pipeline = Pipeline(
-            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return ContainerClient(
@@ -686,7 +686,7 @@ class BlobServiceClient(StorageAccountHostsMixin):
         except AttributeError:
             blob_name = blob
         _pipeline = Pipeline(
-            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return BlobClient( # type: ignore

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
@@ -6,6 +6,7 @@
 # --------------------------------------------------------------------------
 
 import functools
+from copy import deepcopy
 from typing import (  # pylint: disable=unused-import
     Union, Optional, Any, Iterable, AnyStr, Dict, List, Tuple, IO, Iterator,
     TYPE_CHECKING
@@ -27,7 +28,7 @@ from azure.core.tracing.decorator import distributed_trace
 from azure.core.pipeline import Pipeline
 from azure.core.pipeline.transport import HttpRequest
 
-from ._shared.base_client import StorageAccountHostsMixin, TransportWrapper, parse_connection_str, parse_query
+from ._shared.base_client import StorageAccountHostsMixin, parse_connection_str, parse_query
 from ._shared.request_handlers import add_metadata_headers, serialize_iso
 from ._shared.response_handlers import (
     process_storage_error,
@@ -1462,7 +1463,7 @@ class ContainerClient(StorageAccountHostsMixin):
         """
         blob_name = _get_blob_name(blob)
         _pipeline = Pipeline(
-            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return BlobClient(

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
@@ -313,29 +313,6 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         except HttpResponseError as error:
             process_storage_error(error)
 
-class TransportWrapper(HttpTransport):
-    """Wrapper class that ensures that an inner client created
-    by a `get_client` method does not close the outer transport for the parent
-    when used in a context manager.
-    """
-    def __init__(self, transport):
-        self._transport = transport
-
-    def send(self, request, **kwargs):
-        return self._transport.send(request, **kwargs)
-
-    def open(self):
-        pass
-
-    def close(self):
-        pass
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, *args):  # pylint: disable=arguments-differ
-        pass
-
 
 def _format_shared_key_credential(account_name, credential):
     if isinstance(credential, six.string_types):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client_async.py
@@ -163,27 +163,3 @@ class AsyncStorageAccountHostsMixin(object):
             return parts
         except HttpResponseError as error:
             process_storage_error(error)
-
-
-class AsyncTransportWrapper(AsyncHttpTransport):
-    """Wrapper class that ensures that an inner client created
-    by a `get_client` method does not close the outer transport for the parent
-    when used in a context manager.
-    """
-    def __init__(self, async_transport):
-        self._transport = async_transport
-
-    async def send(self, request, **kwargs):
-        return await self._transport.send(request, **kwargs)
-
-    async def open(self):
-        pass
-
-    async def close(self):
-        pass
-
-    async def __aenter__(self):
-        pass
-
-    async def __aexit__(self, *args):  # pylint: disable=arguments-differ
-        pass

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_service_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_service_client_async.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 # pylint: disable=invalid-overridden-method
 import functools
+from copy import deepcopy
 from typing import (  # pylint: disable=unused-import
     Union, Optional, Any, Iterable, Dict, List,
     TYPE_CHECKING
@@ -18,7 +19,7 @@ from azure.core.async_paging import AsyncItemPaged
 
 from .._shared.models import LocationMode
 from .._shared.policies_async import ExponentialRetry
-from .._shared.base_client_async import AsyncStorageAccountHostsMixin, AsyncTransportWrapper
+from .._shared.base_client_async import AsyncStorageAccountHostsMixin
 from .._shared.response_handlers import return_response_headers, process_storage_error
 from .._shared.parser import _to_utc_datetime
 from .._shared.response_handlers import parse_to_internal_user_delegation_key
@@ -581,7 +582,7 @@ class BlobServiceClient(AsyncStorageAccountHostsMixin, BlobServiceClientBase):
         except AttributeError:
             container_name = container
         _pipeline = AsyncPipeline(
-            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return ContainerClient(
@@ -636,7 +637,7 @@ class BlobServiceClient(AsyncStorageAccountHostsMixin, BlobServiceClientBase):
         except AttributeError:
             blob_name = blob
         _pipeline = AsyncPipeline(
-            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return BlobClient( # type: ignore

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_container_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_container_client_async.py
@@ -6,6 +6,7 @@
 # --------------------------------------------------------------------------
 # pylint: disable=invalid-overridden-method
 import functools
+from copy import deepcopy
 from typing import (  # pylint: disable=unused-import
     Union, Optional, Any, Iterable, AnyStr, Dict, List, IO, AsyncIterator,
     TYPE_CHECKING
@@ -18,7 +19,7 @@ from azure.core.async_paging import AsyncItemPaged
 from azure.core.pipeline import AsyncPipeline
 from azure.core.pipeline.transport import AsyncHttpResponse
 
-from .._shared.base_client_async import AsyncStorageAccountHostsMixin, AsyncTransportWrapper
+from .._shared.base_client_async import AsyncStorageAccountHostsMixin
 from .._shared.policies_async import ExponentialRetry
 from .._shared.request_handlers import add_metadata_headers, serialize_iso
 from .._shared.response_handlers import (
@@ -1130,7 +1131,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase):
         """
         blob_name = _get_blob_name(blob)
         _pipeline = AsyncPipeline(
-            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return BlobClient(

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
@@ -3,13 +3,15 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+from copy import deepcopy
+
 try:
     from urllib.parse import quote, unquote
 except ImportError:
     from urllib2 import quote, unquote # type: ignore
 from azure.core.pipeline import Pipeline
 from ._deserialize import deserialize_dir_properties
-from ._shared.base_client import TransportWrapper, parse_connection_str
+from ._shared.base_client import parse_connection_str
 from ._data_lake_file_client import DataLakeFileClient
 from ._models import DirectoryProperties
 from ._path_client import PathClient
@@ -510,7 +512,7 @@ class DataLakeDirectoryClient(PathClient):
             file_path = self.path_name + '/' + file
 
         _pipeline = Pipeline(
-            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return DataLakeFileClient(
@@ -540,7 +542,7 @@ class DataLakeDirectoryClient(PathClient):
             subdir_path = self.path_name + '/' + sub_directory
 
         _pipeline = Pipeline(
-            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return DataLakeDirectoryClient(

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_service_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_service_client.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-
+from copy import deepcopy
 try:
     from urllib.parse import urlparse
 except ImportError:
@@ -13,7 +13,7 @@ from azure.core.paging import ItemPaged
 from azure.core.pipeline import Pipeline
 
 from azure.storage.blob import BlobServiceClient
-from ._shared.base_client import TransportWrapper, StorageAccountHostsMixin, parse_query, parse_connection_str
+from ._shared.base_client import StorageAccountHostsMixin, parse_query, parse_connection_str
 from ._file_system_client import FileSystemClient
 from ._data_lake_directory_client import DataLakeDirectoryClient
 from ._data_lake_file_client import DataLakeFileClient
@@ -332,7 +332,7 @@ class DataLakeServiceClient(StorageAccountHostsMixin):
             file_system_name = file_system
 
         _pipeline = Pipeline(
-            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return FileSystemClient(self.url, file_system_name, credential=self._raw_credential,
@@ -379,7 +379,7 @@ class DataLakeServiceClient(StorageAccountHostsMixin):
             directory_name = directory
 
         _pipeline = Pipeline(
-            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return DataLakeDirectoryClient(self.url, file_system_name, directory_name=directory_name,
@@ -429,7 +429,7 @@ class DataLakeServiceClient(StorageAccountHostsMixin):
             pass
 
         _pipeline = Pipeline(
-            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return DataLakeFileClient(

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 import functools
+from copy import deepcopy
 
 try:
     from urllib.parse import urlparse, quote
@@ -15,7 +16,7 @@ import six
 from azure.core.pipeline import Pipeline
 from azure.core.paging import ItemPaged
 from azure.storage.blob import ContainerClient
-from ._shared.base_client import TransportWrapper, StorageAccountHostsMixin, parse_query, parse_connection_str
+from ._shared.base_client import StorageAccountHostsMixin, parse_query, parse_connection_str
 from ._serialize import convert_dfs_url_to_blob_url
 from ._models import LocationMode, FileSystemProperties, PublicAccess
 from ._list_paths_helper import PathPropertiesPaged
@@ -742,7 +743,7 @@ class FileSystemClient(StorageAccountHostsMixin):
         except AttributeError:
             directory_name = directory
         _pipeline = Pipeline(
-            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return DataLakeDirectoryClient(self.url, self.file_system_name, directory_name=directory_name,
@@ -782,7 +783,7 @@ class FileSystemClient(StorageAccountHostsMixin):
         except AttributeError:
             pass
         _pipeline = Pipeline(
-            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return DataLakeFileClient(

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py
@@ -307,29 +307,6 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         except HttpResponseError as error:
             process_storage_error(error)
 
-class TransportWrapper(HttpTransport):
-    """Wrapper class that ensures that an inner client created
-    by a `get_client` method does not close the outer transport for the parent
-    when used in a context manager.
-    """
-    def __init__(self, transport):
-        self._transport = transport
-
-    def send(self, request, **kwargs):
-        return self._transport.send(request, **kwargs)
-
-    def open(self):
-        pass
-
-    def close(self):
-        pass
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, *args):  # pylint: disable=arguments-differ
-        pass
-
 
 def _format_shared_key_credential(account_name, credential):
     if isinstance(credential, six.string_types):

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client_async.py
@@ -157,27 +157,3 @@ class AsyncStorageAccountHostsMixin(object):
             return parts
         except HttpResponseError as error:
             process_storage_error(error)
-
-
-class AsyncTransportWrapper(AsyncHttpTransport):
-    """Wrapper class that ensures that an inner client created
-    by a `get_client` method does not close the outer transport for the parent
-    when used in a context manager.
-    """
-    def __init__(self, async_transport):
-        self._transport = async_transport
-
-    async def send(self, request, **kwargs):
-        return await self._transport.send(request, **kwargs)
-
-    async def open(self):
-        pass
-
-    async def close(self):
-        pass
-
-    async def __aenter__(self):
-        pass
-
-    async def __aexit__(self, *args):  # pylint: disable=arguments-differ
-        pass

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_directory_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_directory_client_async.py
@@ -4,6 +4,8 @@
 # license information.
 # --------------------------------------------------------------------------
 # pylint: disable=invalid-overridden-method
+from copy import deepcopy
+
 try:
     from urllib.parse import quote, unquote
 except ImportError:
@@ -14,7 +16,6 @@ from .._data_lake_directory_client import DataLakeDirectoryClient as DataLakeDir
 from .._models import DirectoryProperties
 from .._deserialize import deserialize_dir_properties
 from ._path_client_async import PathClient
-from .._shared.base_client_async import AsyncTransportWrapper
 
 
 class DataLakeDirectoryClient(PathClient, DataLakeDirectoryClientBase):
@@ -488,7 +489,7 @@ class DataLakeDirectoryClient(PathClient, DataLakeDirectoryClientBase):
             file_path = self.path_name + '/' + file
 
         _pipeline = AsyncPipeline(
-            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return DataLakeFileClient(
@@ -527,7 +528,7 @@ class DataLakeDirectoryClient(PathClient, DataLakeDirectoryClientBase):
             subdir_path = self.path_name + '/' + sub_directory
 
         _pipeline = AsyncPipeline(
-            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return DataLakeDirectoryClient(

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_service_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_service_client_async.py
@@ -4,13 +4,14 @@
 # license information.
 # --------------------------------------------------------------------------
 # pylint: disable=invalid-overridden-method
+from copy import deepcopy
 
 from azure.core.paging import ItemPaged
 from azure.core.pipeline import AsyncPipeline
 
 from azure.storage.blob.aio import BlobServiceClient
 from .._generated.aio import AzureDataLakeStorageRESTAPI
-from .._shared.base_client_async import AsyncTransportWrapper, AsyncStorageAccountHostsMixin
+from .._shared.base_client_async import AsyncStorageAccountHostsMixin
 from ._file_system_client_async import FileSystemClient
 from .._data_lake_service_client import DataLakeServiceClient as DataLakeServiceClientBase
 from .._shared.policies_async import ExponentialRetry
@@ -282,7 +283,7 @@ class DataLakeServiceClient(AsyncStorageAccountHostsMixin, DataLakeServiceClient
             file_system_name = file_system
 
         _pipeline = AsyncPipeline(
-            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return FileSystemClient(self.url, file_system_name, credential=self._raw_credential,
@@ -329,7 +330,7 @@ class DataLakeServiceClient(AsyncStorageAccountHostsMixin, DataLakeServiceClient
             directory_name = directory
 
         _pipeline = AsyncPipeline(
-            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return DataLakeDirectoryClient(self.url, file_system_name, directory_name=directory_name,
@@ -379,7 +380,7 @@ class DataLakeServiceClient(AsyncStorageAccountHostsMixin, DataLakeServiceClient
             pass
 
         _pipeline = AsyncPipeline(
-            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return DataLakeFileClient(

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
@@ -7,6 +7,7 @@
 # pylint: disable=invalid-overridden-method
 
 import functools
+from copy import deepcopy
 from typing import (  # pylint: disable=unused-import
     Union, Optional, Any, Dict, TYPE_CHECKING
 )
@@ -25,7 +26,7 @@ from ._models import PathPropertiesPaged
 from ._data_lake_lease_async import DataLakeLeaseClient
 from .._file_system_client import FileSystemClient as FileSystemClientBase
 from .._generated.aio import AzureDataLakeStorageRESTAPI
-from .._shared.base_client_async import AsyncTransportWrapper, AsyncStorageAccountHostsMixin
+from .._shared.base_client_async import AsyncStorageAccountHostsMixin
 from .._shared.policies_async import ExponentialRetry
 from .._models import FileSystemProperties, PublicAccess
 
@@ -702,7 +703,7 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
         except AttributeError:
             directory_name = directory
         _pipeline = AsyncPipeline(
-            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return DataLakeDirectoryClient(self.url, self.file_system_name, directory_name=directory_name,
@@ -743,7 +744,7 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
         except AttributeError:
             pass
         _pipeline = AsyncPipeline(
-            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return DataLakeFileClient(

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
@@ -6,6 +6,7 @@
 
 import functools
 import time
+from copy import deepcopy
 from typing import (  # pylint: disable=unused-import
     Optional, Union, Any, Dict, TYPE_CHECKING
 )
@@ -24,7 +25,7 @@ from azure.core.pipeline import Pipeline
 from azure.core.tracing.decorator import distributed_trace
 
 from ._generated import AzureFileStorage
-from ._shared.base_client import StorageAccountHostsMixin, TransportWrapper, parse_connection_str, parse_query
+from ._shared.base_client import StorageAccountHostsMixin, parse_connection_str, parse_query
 from ._shared.request_handlers import add_metadata_headers
 from ._shared.response_handlers import return_response_headers, process_storage_error
 from ._shared.parser import _str
@@ -223,7 +224,7 @@ class ShareDirectoryClient(StorageAccountHostsMixin):
             file_name = self.directory_path.rstrip('/') + "/" + file_name
 
         _pipeline = Pipeline(
-            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return ShareFileClient(
@@ -255,7 +256,7 @@ class ShareDirectoryClient(StorageAccountHostsMixin):
         directory_path = self.directory_path.rstrip('/') + "/" + directory_name
 
         _pipeline = Pipeline(
-            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return ShareDirectoryClient(

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-
+from copy import deepcopy
 from typing import (  # pylint: disable=unused-import
     Optional, Union, Dict, Any, Iterable, TYPE_CHECKING
 )
@@ -19,7 +19,7 @@ import six
 from azure.core.exceptions import HttpResponseError
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.pipeline import Pipeline
-from ._shared.base_client import StorageAccountHostsMixin, TransportWrapper, parse_connection_str, parse_query
+from ._shared.base_client import StorageAccountHostsMixin, parse_connection_str, parse_query
 from ._shared.request_handlers import add_metadata_headers, serialize_iso
 from ._shared.response_handlers import (
     return_response_headers,
@@ -233,7 +233,7 @@ class ShareClient(StorageAccountHostsMixin):
         :rtype: ~azure.storage.fileshare.ShareDirectoryClient
         """
         _pipeline = Pipeline(
-            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
 
@@ -254,7 +254,7 @@ class ShareClient(StorageAccountHostsMixin):
         :rtype: ~azure.storage.fileshare.ShareFileClient
         """
         _pipeline = Pipeline(
-            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_service_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_service_client.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 
 import functools
+from copy import deepcopy
 from typing import (  # pylint: disable=unused-import
     Union, Optional, Any, Dict, List,
     TYPE_CHECKING
@@ -20,7 +21,7 @@ from azure.core.exceptions import HttpResponseError
 from azure.core.paging import ItemPaged
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.pipeline import Pipeline
-from ._shared.base_client import StorageAccountHostsMixin, TransportWrapper, parse_connection_str, parse_query
+from ._shared.base_client import StorageAccountHostsMixin, parse_connection_str, parse_query
 from ._shared.response_handlers import process_storage_error
 from ._generated import AzureFileStorage
 from ._generated.models import StorageServiceProperties
@@ -411,7 +412,7 @@ class ShareServiceClient(StorageAccountHostsMixin):
             share_name = share
 
         _pipeline = Pipeline(
-            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return ShareClient(

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py
@@ -307,29 +307,6 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         except HttpResponseError as error:
             process_storage_error(error)
 
-class TransportWrapper(HttpTransport):
-    """Wrapper class that ensures that an inner client created
-    by a `get_client` method does not close the outer transport for the parent
-    when used in a context manager.
-    """
-    def __init__(self, transport):
-        self._transport = transport
-
-    def send(self, request, **kwargs):
-        return self._transport.send(request, **kwargs)
-
-    def open(self):
-        pass
-
-    def close(self):
-        pass
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, *args):  # pylint: disable=arguments-differ
-        pass
-
 
 def _format_shared_key_credential(account_name, credential):
     if isinstance(credential, six.string_types):

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client_async.py
@@ -157,27 +157,3 @@ class AsyncStorageAccountHostsMixin(object):
             return parts
         except HttpResponseError as error:
             process_storage_error(error)
-
-
-class AsyncTransportWrapper(AsyncHttpTransport):
-    """Wrapper class that ensures that an inner client created
-    by a `get_client` method does not close the outer transport for the parent
-    when used in a context manager.
-    """
-    def __init__(self, async_transport):
-        self._transport = async_transport
-
-    async def send(self, request, **kwargs):
-        return await self._transport.send(request, **kwargs)
-
-    async def open(self):
-        pass
-
-    async def close(self):
-        pass
-
-    async def __aenter__(self):
-        pass
-
-    async def __aexit__(self, *args):  # pylint: disable=arguments-differ
-        pass

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_directory_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_directory_client_async.py
@@ -6,6 +6,7 @@
 # pylint: disable=invalid-overridden-method
 import functools
 import time
+from copy import deepcopy
 from typing import ( # pylint: disable=unused-import
     Optional, Union, Any, Dict, TYPE_CHECKING
 )
@@ -19,7 +20,7 @@ from .._parser import _get_file_permission, _datetime_to_str
 from .._shared.parser import _str
 
 from .._generated.aio import AzureFileStorage
-from .._shared.base_client_async import AsyncStorageAccountHostsMixin, AsyncTransportWrapper
+from .._shared.base_client_async import AsyncStorageAccountHostsMixin
 from .._shared.policies_async import ExponentialRetry
 from .._shared.request_handlers import add_metadata_headers
 from .._shared.response_handlers import return_response_headers, process_storage_error
@@ -109,7 +110,7 @@ class ShareDirectoryClient(AsyncStorageAccountHostsMixin, ShareDirectoryClientBa
             file_name = self.directory_path.rstrip('/') + "/" + file_name
 
         _pipeline = AsyncPipeline(
-            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return ShareFileClient(
@@ -140,7 +141,7 @@ class ShareDirectoryClient(AsyncStorageAccountHostsMixin, ShareDirectoryClientBa
         directory_path = self.directory_path.rstrip('/') + "/" + directory_name
 
         _pipeline = AsyncPipeline(
-            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return ShareDirectoryClient(

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 # pylint: disable=invalid-overridden-method
+from copy import deepcopy
 from typing import ( # pylint: disable=unused-import
     Optional, Union, Dict, Any, Iterable, TYPE_CHECKING
 )
@@ -13,7 +14,7 @@ from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.core.pipeline import AsyncPipeline
 from .._shared.policies_async import ExponentialRetry
-from .._shared.base_client_async import AsyncStorageAccountHostsMixin, AsyncTransportWrapper
+from .._shared.base_client_async import AsyncStorageAccountHostsMixin
 from .._shared.request_handlers import add_metadata_headers, serialize_iso
 from .._shared.response_handlers import (
     return_response_headers,
@@ -100,7 +101,7 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
         :rtype: ~azure.storage.fileshare.aio.ShareDirectoryClient
         """
         _pipeline = AsyncPipeline(
-            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
 
@@ -120,7 +121,7 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
         :rtype: ~azure.storage.fileshare.aio.ShareFileClient
         """
         _pipeline = AsyncPipeline(
-            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_service_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_service_client_async.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 # pylint: disable=invalid-overridden-method
 import functools
+from copy import deepcopy
 from typing import (  # pylint: disable=unused-import
     Union, Optional, Any, Iterable, Dict, List,
     TYPE_CHECKING
@@ -16,7 +17,7 @@ from azure.core.tracing.decorator import distributed_trace
 from azure.core.pipeline import AsyncPipeline
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from .._shared.base_client_async import AsyncStorageAccountHostsMixin, AsyncTransportWrapper
+from .._shared.base_client_async import AsyncStorageAccountHostsMixin
 from .._shared.response_handlers import process_storage_error
 from .._shared.policies_async import ExponentialRetry
 from .._generated.aio import AzureFileStorage
@@ -361,7 +362,7 @@ class ShareServiceClient(AsyncStorageAccountHostsMixin, ShareServiceClientBase):
             share_name = share
 
         _pipeline = AsyncPipeline(
-            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
         return ShareClient(

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_service_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_service_client.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 
 import functools
+from copy import deepcopy
 from typing import (  # pylint: disable=unused-import
     Union, Optional, Any, Iterable, Dict, List,
     TYPE_CHECKING)
@@ -18,7 +19,7 @@ from azure.core.paging import ItemPaged
 from azure.core.pipeline import Pipeline
 from azure.core.tracing.decorator import distributed_trace
 from ._shared.models import LocationMode
-from ._shared.base_client import StorageAccountHostsMixin, TransportWrapper, parse_connection_str, parse_query
+from ._shared.base_client import StorageAccountHostsMixin, parse_connection_str, parse_query
 from ._shared.response_handlers import process_storage_error
 from ._generated import AzureQueueStorage
 from ._generated.models import StorageServiceProperties
@@ -418,7 +419,7 @@ class QueueServiceClient(StorageAccountHostsMixin):
             queue_name = queue
 
         _pipeline = Pipeline(
-            transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py
@@ -307,29 +307,6 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         except HttpResponseError as error:
             process_storage_error(error)
 
-class TransportWrapper(HttpTransport):
-    """Wrapper class that ensures that an inner client created
-    by a `get_client` method does not close the outer transport for the parent
-    when used in a context manager.
-    """
-    def __init__(self, transport):
-        self._transport = transport
-
-    def send(self, request, **kwargs):
-        return self._transport.send(request, **kwargs)
-
-    def open(self):
-        pass
-
-    def close(self):
-        pass
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, *args):  # pylint: disable=arguments-differ
-        pass
-
 
 def _format_shared_key_credential(account_name, credential):
     if isinstance(credential, six.string_types):

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client_async.py
@@ -156,27 +156,3 @@ class AsyncStorageAccountHostsMixin(object):
             return parts
         except HttpResponseError as error:
             process_storage_error(error)
-
-
-class AsyncTransportWrapper(AsyncHttpTransport):
-    """Wrapper class that ensures that an inner client created
-    by a `get_client` method does not close the outer transport for the parent
-    when used in a context manager.
-    """
-    def __init__(self, async_transport):
-        self._transport = async_transport
-
-    async def send(self, request, **kwargs):
-        return await self._transport.send(request, **kwargs)
-
-    async def open(self):
-        pass
-
-    async def close(self):
-        pass
-
-    async def __aenter__(self):
-        pass
-
-    async def __aexit__(self, *args):  # pylint: disable=arguments-differ
-        pass

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_service_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_service_client_async.py
@@ -6,6 +6,7 @@
 # pylint: disable=invalid-overridden-method
 
 import functools
+from copy import deepcopy
 from typing import (  # pylint: disable=unused-import
     Union, Optional, Any, Iterable, Dict, List,
     TYPE_CHECKING)
@@ -23,7 +24,7 @@ from azure.core.tracing.decorator_async import distributed_trace_async
 from .._shared.policies_async import ExponentialRetry
 from .._queue_service_client import QueueServiceClient as QueueServiceClientBase
 from .._shared.models import LocationMode
-from .._shared.base_client_async import AsyncStorageAccountHostsMixin, AsyncTransportWrapper
+from .._shared.base_client_async import AsyncStorageAccountHostsMixin
 from .._shared.response_handlers import process_storage_error
 from .._generated.aio import AzureQueueStorage
 from .._generated.models import StorageServiceProperties
@@ -375,7 +376,7 @@ class QueueServiceClient(AsyncStorageAccountHostsMixin, QueueServiceClientBase):
             queue_name = queue
 
         _pipeline = AsyncPipeline(
-            transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access
+            transport=deepcopy(self._pipeline._transport), # pylint: disable = protected-access
             policies=self._pipeline._impl_policies # pylint: disable = protected-access
         )
 


### PR DESCRIPTION
This resolves: https://github.com/Azure/azure-sdk-for-python/issues/14565
Currently sockets are not being closed after context manager ends session or `close()` is called. This is happening because `TransportLayer` is used which does not have a proper `close()`  (currently just passes) and even if we added `self._transport.close()` it would beat the purpose of the class since this would close parent sessions as well causing them to break (sharing the same transport object/session). 

For example:
```
        with BlobServiceClient(self.account_url(storage_account, "blob"), credential=storage_account_key) as bsc:
            with bsc.get_blob_client("test", "blob.txt") as bc:
                bc.download_blob().readall()
            with bsc.get_blob_client("test", "blob.txt") as bc1:  #--------> fails here
                bc1.download_blob().readall()
```
Would fail since bsc session would also be closed/set to None.
Instead of using TransportLayer, do a `deepcopy`