### PR TITLE
Adopt new MSAL auth code flow API

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Release History
 
 ## 1.5.1 (Unreleased)
-- Bumped `six` requirement from `1.6` to `1.12.0`.
+### Changed
+- Raised minimum msal version to 1.7.0
+- Raised minimum six version to 1.12.0
 
 ## 1.5.0 (2020-11-11)
 ### Breaking Changes

--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Raised minimum msal version to 1.7.0
 - Raised minimum six version to 1.12.0
 
+### Added
+- `InteractiveBrowserCredential` uses PKCE internally to protect authorization
+  codes
+
 ## 1.5.0 (2020-11-11)
 ### Breaking Changes
 - Renamed optional `CertificateCredential` keyword argument `send_certificate`

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -27,7 +27,8 @@ class InteractiveBrowserCredential(InteractiveCredential):
     """Opens a browser to interactively authenticate a user.
 
     :func:`~get_token` opens a browser to a login URL provided by Azure Active Directory and authenticates a user
-    there with the authorization code flow. Azure Active Directory documentation describes this flow in more detail:
+    there with the authorization code flow, using PKCE (Proof Key for Code Exchange) internally to protect the code.
+    Azure Active Directory documentation describes the authentication flow in more detail:
     https://docs.microsoft.com/azure/active-directory/develop/v1-protocols-oauth-code
 
     :keyword str authority: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -93,9 +93,8 @@ class InteractiveBrowserCredential(InteractiveCredential):
 
         # get the url the user must visit to authenticate
         scopes = list(scopes)  # type: ignore
-        app = self._get_app()
-
         claims = kwargs.get("claims")
+        app = self._get_app()
         flow = app.initiate_auth_code_flow(
             scopes, redirect_uri=redirect_uri, prompt="select_account", claims_challenge=claims
         )

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import socket
-import uuid
 import webbrowser
 
 from six.moves.urllib_parse import urlparse
@@ -21,7 +20,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import
-    from typing import Any, List, Mapping
+    from typing import Any
 
 
 class InteractiveBrowserCredential(InteractiveCredential):
@@ -94,14 +93,16 @@ class InteractiveBrowserCredential(InteractiveCredential):
 
         # get the url the user must visit to authenticate
         scopes = list(scopes)  # type: ignore
-        request_state = str(uuid.uuid4())
         app = self._get_app()
-        auth_url = app.get_authorization_request_url(
-            scopes, redirect_uri=redirect_uri, state=request_state, prompt="select_account"
-        )
 
-        # open browser to that url
-        if not webbrowser.open(auth_url):
+        claims = kwargs.get("claims")
+        flow = app.initiate_auth_code_flow(
+            scopes, redirect_uri=redirect_uri, prompt="select_account", claims_challenge=claims
+        )
+        if "auth_uri" not in flow:
+            raise CredentialUnavailableError("Failed to begin authentication flow")
+
+        if not webbrowser.open(flow["auth_uri"]):
             raise CredentialUnavailableError(message="Failed to open a browser")
 
         # block until the server times out or receives the post-authentication redirect
@@ -112,32 +113,4 @@ class InteractiveBrowserCredential(InteractiveCredential):
             )
 
         # redeem the authorization code for a token
-        code = self._parse_response(request_state, response)
-        return app.acquire_token_by_authorization_code(
-            code, scopes=scopes, redirect_uri=redirect_uri, claims_challenge=kwargs.get("claims")
-        )
-
-    @staticmethod
-    def _parse_response(request_state, response):
-        # type: (str, Mapping[str, Any]) -> List[str]
-        """Validates ``response`` and returns the authorization code it contains, if authentication succeeded.
-
-        Raises :class:`azure.core.exceptions.ClientAuthenticationError`, if authentication failed or ``response`` is
-        malformed.
-        """
-
-        if "error" in response:
-            message = "Authentication failed: {}".format(response.get("error_description") or response["error"])
-            raise ClientAuthenticationError(message=message)
-        if "code" not in response:
-            # a response with no error or code is malformed; we don't know what to do with it
-            message = "Authentication server didn't send an authorization code"
-            raise ClientAuthenticationError(message=message)
-
-        # response must include the state sent in the auth request
-        if "state" not in response:
-            raise ClientAuthenticationError(message="Authentication response doesn't include OAuth state")
-        if response["state"][0] != request_state:
-            raise ClientAuthenticationError(message="Authentication response's OAuth state doesn't match the request's")
-
-        return response["code"]
+        return app.acquire_token_by_auth_code_flow(flow, response, scopes=scopes, claims_challenge=claims)

--- a/sdk/identity/azure-identity/azure/identity/_internal/auth_code_redirect_handler.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/auth_code_redirect_handler.py
@@ -27,8 +27,8 @@ class AuthCodeRedirectHandler(BaseHTTPRequestHandler):
             return
 
         query = self.path.split("?", 1)[-1]
-        query = parse_qs(query, keep_blank_values=True)
-        self.server.query_params = query
+        parsed = parse_qs(query, keep_blank_values=True)
+        self.server.query_params = {k: v[0] if isinstance(v, list) and len(v) == 1 else v for k, v in parsed.items()}
 
         self.send_response(200)
         self.send_header("Content-Type", "text/html")

--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -74,7 +74,7 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.0.0",
         "cryptography>=2.1.4",
-        "msal<2.0.0,>=1.6.0",
+        "msal<2.0.0,>=1.7.0",
         "msal-extensions~=0.3.0",
         "six>=1.12.0",
     ],

--- a/sdk/identity/azure-identity/tests/test_browser_credential.py
+++ b/sdk/identity/azure-identity/tests/test_browser_credential.py
@@ -40,7 +40,7 @@ WEBBROWSER_OPEN = InteractiveBrowserCredential.__module__ + ".webbrowser.open"
 def test_browser_credential():
     transport = Mock(wraps=RequestsTransport())
     credential = InteractiveBrowserCredential(transport=transport)
-    scope = "https://vault.azure.net/.default"
+    scope = "https://management.azure.com/.default"  # N.B. this is valid only in Public Cloud
 
     record = credential.authenticate(scopes=(scope,))
     assert record.authority

--- a/sdk/identity/azure-identity/tests/test_browser_credential.py
+++ b/sdk/identity/azure-identity/tests/test_browser_credential.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-import functools
 import random
 import socket
 import threading
@@ -10,12 +9,13 @@ import time
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.pipeline.policies import SansIOHTTPPolicy
+from azure.core.pipeline.transport import RequestsTransport
 from azure.identity import AuthenticationRequiredError, CredentialUnavailableError, InteractiveBrowserCredential
 from azure.identity._internal import AuthCodeRedirectServer
 from azure.identity._internal.user_agent import USER_AGENT
 from msal import TokenCache
 import pytest
-from six.moves import urllib, urllib_parse
+from six.moves import urllib
 
 from helpers import (
     build_aad_response,
@@ -23,7 +23,6 @@ from helpers import (
     get_discovery_response,
     id_token_claims,
     mock_response,
-    msal_validating_transport,
     Request,
     validating_transport,
 )
@@ -35,6 +34,38 @@ except ImportError:  # python < 3.3
 
 
 WEBBROWSER_OPEN = InteractiveBrowserCredential.__module__ + ".webbrowser.open"
+
+
+@pytest.mark.manual
+def test_browser_credential():
+    transport = Mock(wraps=RequestsTransport())
+    credential = InteractiveBrowserCredential(transport=transport)
+    scope = "https://vault.azure.net/.default"
+
+    record = credential.authenticate(scopes=(scope,))
+    assert record.authority
+    assert record.home_account_id
+    assert record.tenant_id
+    assert record.username
+
+    # credential should have a cached access token for the scope used in authenticate
+    with patch(WEBBROWSER_OPEN, Mock(side_effect=Exception("credential should authenticate silently"))):
+        token = credential.get_token(scope)
+    assert token.token
+
+    credential = InteractiveBrowserCredential(transport=transport)
+    token = credential.get_token(scope)
+    assert token.token
+
+    with patch(WEBBROWSER_OPEN, Mock(side_effect=Exception("credential should authenticate silently"))):
+        second_token = credential.get_token(scope)
+    assert second_token.token == token.token
+
+    # every request should have the correct User-Agent
+    for call in transport.send.call_args_list:
+        args, _ = call
+        request = args[0]
+        assert request.headers["User-Agent"] == USER_AGENT
 
 
 def test_tenant_id_validation():
@@ -57,58 +88,6 @@ def test_no_scopes():
         InteractiveBrowserCredential().get_token()
 
 
-def test_authenticate():
-    client_id = "client-id"
-    environment = "localhost"
-    issuer = "https://" + environment
-    tenant_id = "some-tenant"
-    authority = issuer + "/" + tenant_id
-
-    access_token = "***"
-    scope = "scope"
-
-    # mock AAD response with id token
-    object_id = "object-id"
-    home_tenant = "home-tenant-id"
-    username = "me@work.com"
-    id_token = build_id_token(aud=client_id, iss=issuer, object_id=object_id, tenant_id=home_tenant, username=username)
-    auth_response = build_aad_response(
-        uid=object_id, utid=home_tenant, access_token=access_token, refresh_token="**", id_token=id_token
-    )
-
-    transport = validating_transport(
-        requests=[Request(url_substring=issuer)] * 3,
-        responses=[get_discovery_response(authority)] * 2 + [mock_response(json_payload=auth_response)],
-    )
-
-    # mock local server fakes successful authentication by immediately returning a well-formed response
-    oauth_state = "state"
-    auth_code_response = {"code": "authorization-code", "state": [oauth_state]}
-    server_class = Mock(return_value=Mock(wait_for_redirect=lambda: auth_code_response))
-
-    with patch(InteractiveBrowserCredential.__module__ + ".uuid.uuid4", lambda: oauth_state):
-        with patch(WEBBROWSER_OPEN, lambda _: True):
-            credential = InteractiveBrowserCredential(
-                _cache=TokenCache(),
-                authority=environment,
-                client_id=client_id,
-                _server_class=server_class,
-                tenant_id=tenant_id,
-                transport=transport,
-            )
-            record = credential.authenticate(scopes=(scope,))
-
-    assert record.authority == environment
-    assert record.home_account_id == object_id + "." + home_tenant
-    assert record.tenant_id == home_tenant
-    assert record.username == username
-
-    # credential should have a cached access token for the scope used in authenticate
-    with patch(WEBBROWSER_OPEN, Mock(side_effect=Exception("credential should authenticate silently"))):
-        token = credential.get_token(scope)
-    assert token.token == access_token
-
-
 def test_disable_automatic_authentication():
     """When configured for strict silent auth, the credential should raise when silent auth fails"""
 
@@ -123,140 +102,18 @@ def test_disable_automatic_authentication():
             credential.get_token("scope")
 
 
-@patch("azure.identity._credentials.browser.webbrowser.open", lambda _: True)
 def test_policies_configurable():
-    policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
-    client_id = "client-id"
-    transport = validating_transport(
-        requests=[Request()] * 2,
-        responses=[
-            get_discovery_response(),
-            mock_response(json_payload=build_aad_response(access_token="**", id_token=build_id_token(aud=client_id))),
-        ],
-    )
+    # the policy raises an exception so this test can run without authenticating i.e. opening a browser
+    expected_message = "test_policies_configurable"
+    policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock(side_effect=Exception(expected_message)))
 
-    # mock local server fakes successful authentication by immediately returning a well-formed response
-    oauth_state = "oauth-state"
-    auth_code_response = {"code": "authorization-code", "state": [oauth_state]}
-    server_class = Mock(return_value=Mock(wait_for_redirect=lambda: auth_code_response))
+    credential = InteractiveBrowserCredential(policies=[policy])
 
-    credential = InteractiveBrowserCredential(
-        policies=[policy], client_id=client_id, transport=transport, _server_class=server_class, _cache=TokenCache()
-    )
-
-    with patch("azure.identity._credentials.browser.uuid.uuid4", lambda: oauth_state):
+    with pytest.raises(ClientAuthenticationError) as ex:
         credential.get_token("scope")
 
+    assert expected_message in ex.value.message
     assert policy.on_request.called
-
-
-@patch("azure.identity._credentials.browser.webbrowser.open", lambda _: True)
-def test_user_agent():
-    client_id = "client-id"
-    transport = validating_transport(
-        requests=[Request(), Request(required_headers={"User-Agent": USER_AGENT})],
-        responses=[
-            get_discovery_response(),
-            mock_response(json_payload=build_aad_response(access_token="**", id_token=build_id_token(aud=client_id))),
-        ],
-    )
-
-    # mock local server fakes successful authentication by immediately returning a well-formed response
-    oauth_state = "oauth-state"
-    auth_code_response = {"code": "authorization-code", "state": [oauth_state]}
-    server_class = Mock(return_value=Mock(wait_for_redirect=lambda: auth_code_response))
-
-    credential = InteractiveBrowserCredential(
-        client_id=client_id, transport=transport, _server_class=server_class, _cache=TokenCache()
-    )
-
-    with patch("azure.identity._credentials.browser.uuid.uuid4", lambda: oauth_state):
-        credential.get_token("scope")
-
-
-@patch("azure.identity._credentials.browser.webbrowser.open")
-@pytest.mark.parametrize("redirect_url", ("https://localhost:8042", None))
-def test_interactive_credential(mock_open, redirect_url):
-    mock_open.side_effect = _validate_auth_request_url
-    oauth_state = "state"
-    client_id = "client-id"
-    expected_refresh_token = "refresh-token"
-    expected_token = "access-token"
-    expires_in = 3600
-    authority = "authority"
-    tenant_id = "tenant-id"
-    endpoint = "https://{}/{}".format(authority, tenant_id)
-
-    transport = msal_validating_transport(
-        endpoint="https://{}/{}".format(authority, tenant_id),
-        requests=[Request(url_substring=endpoint)]
-        + [
-            Request(
-                authority=authority, url_substring=endpoint, required_data={"refresh_token": expected_refresh_token}
-            )
-        ],
-        responses=[
-            mock_response(
-                json_payload=build_aad_response(
-                    access_token=expected_token,
-                    expires_in=expires_in,
-                    refresh_token=expected_refresh_token,
-                    uid="uid",
-                    utid=tenant_id,
-                    id_token=build_id_token(aud=client_id, object_id="uid", tenant_id=tenant_id, iss=endpoint),
-                    token_type="Bearer",
-                )
-            ),
-            mock_response(
-                json_payload=build_aad_response(access_token=expected_token, expires_in=expires_in, token_type="Bearer")
-            ),
-        ],
-    )
-
-    # mock local server fakes successful authentication by immediately returning a well-formed response
-    auth_code_response = {"code": "authorization-code", "state": [oauth_state]}
-    server_class = Mock(return_value=Mock(wait_for_redirect=lambda: auth_code_response))
-
-    args = {
-        "authority": authority,
-        "tenant_id": tenant_id,
-        "client_id": client_id,
-        "transport": transport,
-        "_cache": TokenCache(),
-        "_server_class": server_class,
-    }
-    if redirect_url:  # avoid passing redirect_url=None
-        args["redirect_uri"] = redirect_url
-
-    credential = InteractiveBrowserCredential(**args)
-
-    # The credential's auth code request includes a uuid which must be included in the redirect. Patching to
-    # set the uuid requires less code here than a proper mock server.
-    with patch("azure.identity._credentials.browser.uuid.uuid4", lambda: oauth_state):
-        token = credential.get_token("scope")
-    assert token.token == expected_token
-    assert mock_open.call_count == 1
-    assert server_class.call_count == 1
-
-    if redirect_url:
-        parsed = urllib_parse.urlparse(redirect_url)
-        server_class.assert_called_once_with(parsed.hostname, parsed.port, timeout=ANY)
-
-    # token should be cached, get_token shouldn't prompt again
-    token = credential.get_token("scope")
-    assert token.token == expected_token
-    assert mock_open.call_count == 1
-    assert server_class.call_count == 1
-
-    # expired access token -> credential should use refresh token instead of prompting again
-    now = time.time()
-    with patch("time.time", lambda: now + expires_in):
-        token = credential.get_token("scope")
-    assert token.token == expected_token
-    assert mock_open.call_count == 1
-
-    # ensure all expected requests were sent
-    assert transport.send.call_count == 4
 
 
 def test_timeout():
@@ -313,17 +170,34 @@ def test_redirect_server():
     response = urllib.request.urlopen(url)  # nosec
 
     assert response.code == 200
-    assert server.query_params[expected_param] == [expected_value]
+    assert server.query_params[expected_param] == expected_value
 
 
-@patch("azure.identity._credentials.browser.webbrowser.open", lambda _: False)
 def test_no_browser():
     transport = validating_transport(requests=[Request()] * 2, responses=[get_discovery_response()] * 2)
     credential = InteractiveBrowserCredential(
         client_id="client-id", _server_class=Mock(), transport=transport, _cache=TokenCache()
     )
     with pytest.raises(ClientAuthenticationError, match=r".*browser.*"):
+        with patch(WEBBROWSER_OPEN, lambda _: False):
+            credential.get_token("scope")
+
+
+def test_redirect_uri():
+    """The credential should configure the redirect server to use a given redirect_uri"""
+
+    expected_hostname = "localhost"
+    expected_port = 42424
+    expected_message = "test_redirect_uri"
+    server = Mock(side_effect=Exception(expected_message))  # exception prevents this test actually authenticating
+    credential = InteractiveBrowserCredential(
+        redirect_uri="htps://{}:{}".format(expected_hostname, expected_port), _server_class=server
+    )
+    with pytest.raises(ClientAuthenticationError) as ex:
         credential.get_token("scope")
+
+    assert expected_message in ex.value.message
+    server.assert_called_once_with(expected_hostname, expected_port, timeout=ANY)
 
 
 @pytest.mark.parametrize("redirect_uri", ("http://localhost", "host", "host:42"))
@@ -354,16 +228,6 @@ def test_cannot_bind_redirect_uri():
     server.assert_called_once_with("localhost", 42, timeout=ANY)
 
 
-def _validate_auth_request_url(url):
-    parsed_url = urllib_parse.urlparse(url)
-    params = urllib_parse.parse_qs(parsed_url.query)
-    assert params.get("prompt") == ["select_account"], "Auth code request doesn't specify 'prompt=select_account'."
-
-    # when used as a Mock's side_effect, this method's return value is the Mock's return value
-    # (the real webbrowser.open returns a bool)
-    return True
-
-
 def test_claims_challenge():
     """get_token should pass any claims challenge to MSAL token acquisition APIs"""
 
@@ -382,14 +246,14 @@ def test_claims_challenge():
     credential = InteractiveBrowserCredential(_server_class=server_class, transport=transport)
     with patch.object(InteractiveBrowserCredential, "_get_app") as get_mock_app:
         msal_app = get_mock_app()
-        msal_app.acquire_token_by_authorization_code.return_value = msal_acquire_token_result
+        msal_app.initiate_auth_code_flow.return_value = {"auth_uri": "http://localhost"}
+        msal_app.acquire_token_by_auth_code_flow.return_value = msal_acquire_token_result
 
-        with patch(InteractiveBrowserCredential.__module__ + ".uuid.uuid4", lambda: oauth_state):
-            with patch(WEBBROWSER_OPEN, lambda _: True):
-                credential.get_token("scope", claims=expected_claims)
+        with patch(WEBBROWSER_OPEN, lambda _: True):
+            credential.get_token("scope", claims=expected_claims)
 
-        assert msal_app.acquire_token_by_authorization_code.call_count == 1
-        args, kwargs = msal_app.acquire_token_by_authorization_code.call_args
+        assert msal_app.acquire_token_by_auth_code_flow.call_count == 1
+        args, kwargs = msal_app.acquire_token_by_auth_code_flow.call_args
         assert kwargs["claims_challenge"] == expected_claims
 
         msal_app.get_accounts.return_value = [{"home_account_id": credential._auth_record.home_account_id}]

--- a/sdk/identity/azure-identity/tests/test_live.py
+++ b/sdk/identity/azure-identity/tests/test_live.py
@@ -76,9 +76,3 @@ def test_device_code():
 
     credential = DeviceCodeCredential(client_id=DEVELOPER_SIGN_ON_CLIENT_ID, prompt_callback=prompt, timeout=40)
     get_token(credential)
-
-
-@pytest.mark.manual
-def test_browser_auth():
-    credential = InteractiveBrowserCredential(client_id=DEVELOPER_SIGN_ON_CLIENT_ID, timeout=40)
-    get_token(credential)

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -103,7 +103,7 @@ futures
 mock
 typing
 typing-extensions
-msal<2.0.0,>=1.6.0
+msal<2.0.0,>=1.7.0
 msal-extensions~=0.3.0
 msrest>=0.5.0
 msrestazure<2.0.0,>=0.4.32


### PR DESCRIPTION
This closes #16429 by adopting msal 1.7.0's new authorization code API in InteractiveBrowserCredential. In addition to silencing deprecation warnings, this adds PKCE to the credential. One disadvantage is that the credential must now be tested manually because mock testing would require elaborate, fragile monkeypatching to work around security features of msal's implementation.