### PR TITLE
resolve issues with failing search documents on mindependency checks

### DIFF
--- a/eng/dependency_tools.txt
+++ b/eng/dependency_tools.txt
@@ -1,1 +1,2 @@
 ../../../tools/azure-sdk-tools
+aiohttp>=3.0; python_version >= '3.5'


### PR DESCRIPTION
This will ensure that it's always installed in our dependency checks.