### PR TITLE
Support matrix config import, and non sparse parameter arguments

### DIFF
--- a/eng/scripts/job-matrix/Create-JobMatrix.ps1
+++ b/eng/scripts/job-matrix/Create-JobMatrix.ps1
@@ -20,7 +20,7 @@ param (
 
 $config = GetMatrixConfigFromJson (Get-Content $ConfigPath)
 # Strip empty string filters in order to be able to use azure pipelines yaml join()
-$Filters = $Filters | Where-Object { $_ -ne "" }
+$Filters = $Filters | Where-Object { $_ }
 
 [array]$matrix = GenerateMatrix `
     -config $config `

--- a/eng/scripts/job-matrix/Create-JobMatrix.ps1
+++ b/eng/scripts/job-matrix/Create-JobMatrix.ps1
@@ -12,14 +12,23 @@ param (
     [Parameter(Mandatory=$True)][string] $ConfigPath,
     [Parameter(Mandatory=$True)][string] $Selection,
     [Parameter(Mandatory=$False)][string] $DisplayNameFilter,
-    [Parameter(Mandatory=$False)][array] $Filters
+    [Parameter(Mandatory=$False)][array] $Filters,
+    [Parameter(Mandatory=$False)][array] $NonSparseParameters
 )
 
 . $PSScriptRoot/job-matrix-functions.ps1
 
 $config = GetMatrixConfigFromJson (Get-Content $ConfigPath)
+# Strip empty string filters in order to be able to use azure pipelines yaml join()
+$Filters = $Filters | Where-Object { $_ -ne "" }
 
-[array]$matrix = GenerateMatrix $config $Selection $DisplayNameFilter $Filters
+[array]$matrix = GenerateMatrix `
+    -config $config `
+    -selectFromMatrixType $Selection `
+    -displayNameFilter $DisplayNameFilter `
+    -filters $Filters `
+    -nonSparseParameters $NonSparseParameters
+
 $serialized = SerializePipelineMatrix $matrix
 
 Write-Output $serialized.pretty

--- a/eng/scripts/job-matrix/README.md
+++ b/eng/scripts/job-matrix/README.md
@@ -163,7 +163,13 @@ To import a matrix, add a parameter with the key `$IMPORT`:
 Importing can be useful, for example, in cases where there is a shared base matrix, but there is a need to run it
 once for each instance of a language version.
 
-Includes and excludes for the importing matrix will still get processed after the imported matrix is combined with the base matrix.
+The processing order is as follows:
+
+1. The base matrix is generated
+1. The imported base matrix is generated
+1. Includes/excludes from the imported matrix get applied to the imported matrix
+1. The base matrix is multipled by the imported matrix
+1. Includes/excludes from the top-level matrix get applied to the multiplied matrix
 
 ## Matrix Generation behavior
 

--- a/eng/scripts/job-matrix/README.md
+++ b/eng/scripts/job-matrix/README.md
@@ -3,19 +3,19 @@
 * [Usage in a pipeline](#usage-in-a-pipeline)
 * [Matrix config file syntax](#matrix-config-file-syntax)
  * [Fields](#fields)
-	* [matrix](#matrix)
-	* [include](#include)
-	* [exclude](#exclude)
-	* [displayNames](#displaynames)
-	* [$IMPORT](#import)
+    * [matrix](#matrix)
+    * [include](#include)
+    * [exclude](#exclude)
+    * [displayNames](#displaynames)
+    * [$IMPORT](#import)
 * [Matrix Generation behavior](#matrix-generation-behavior)
-	* [all](#all)
-	* [sparse](#sparse)
-	* [include/exclude](#includeexclude)
-	* [displayNames](#displaynames-1)
-	* [Filters](#filters)
-	* [NonSparseParameters](#nonsparseparameters)
-	* [Under the hood](#under-the-hood)
+    * [all](#all)
+    * [sparse](#sparse)
+    * [include/exclude](#includeexclude)
+    * [displayNames](#displaynames-1)
+    * [Filters](#filters)
+    * [NonSparseParameters](#nonsparseparameters)
+    * [Under the hood](#under-the-hood)
 * [Testing](#testing)
 
 
@@ -40,14 +40,14 @@ jobs:
       - Name: base_product_matrix
         Path: /eng/pipelines/matrix.json
         Selection: sparse
-		NonSparseParameters: <csv of parameter names for which all combinations should be included>
-		GenerateVMJobs: true
+        NonSparseParameters: <csv of parameter names for which all combinations should be included>
+        GenerateVMJobs: true
       - Name: sdk_specific_matrix
         Path: /sdk/foobar/matrix.json
         Selection: all
-		GenerateContainerJobs: true
-	steps:
-	  - pwsh:
+        GenerateContainerJobs: true
+    steps:
+      - pwsh:
           ...
 ```
 
@@ -61,14 +61,14 @@ type is useful for when 2 or more parameters need to be grouped together, but wi
   "<parameter1 name>": [ <values...> ],
   "<parameter2 name>": [ <values...> ],
   "<parameter set>": {
-	"<parameter set 1 name>": {
-		"<parameter set 1 value 1": "value",
-		"<parameter set 1 value 2": "<value>",
-	},
-	"<parameter set 2 name>": {
-		"<parameter set 2 value 1": "value",
-		"<parameter set 2 value 2": "<value>",
-	}
+    "<parameter set 1 name>": {
+        "<parameter set 1 value 1": "value",
+        "<parameter set 1 value 2": "<value>",
+    },
+    "<parameter set 2 name>": {
+        "<parameter set 2 value 1": "value",
+        "<parameter set 2 value 2": "<value>",
+    }
   }
 }
 "include": [ <matrix>, <matrix>, ... ],
@@ -165,11 +165,131 @@ once for each instance of a language version.
 
 The processing order is as follows:
 
-1. The base matrix is generated
-1. The imported base matrix is generated
+Given a matrix and import matrix like below:
+```
+{
+    "matrix": {
+        "$IMPORT": "example-matrix.json",
+        "endpointType": [ "storage", "cosmos" ],
+        "JavaVersion": [ "1.8", "1.11" ]
+    },
+    "include": [
+        {
+            "operatingSystem": "windows",
+            "mode": "TestFromSource",
+            "JavaVersion": "1.8"
+        }
+    ]
+}
+
+### example-matrix.json to import
+{
+    "matrix": {
+      "operatingSystem": [ "windows", "linux" ],
+      "client": [ "netty", "okhttp" ]
+    },
+    "include": [
+        {
+          "operatingSystem": "mac",
+          "client": "netty"
+        }
+    ]
+}
+```
+
+1. The base matrix is generated (sparse in this example):
+    ```
+    {
+      "storage_18": {
+        "endpointType": "storage",
+        "JavaVersion": "1.8"
+      },
+      "cosmos_111": {
+        "endpointType": "cosmos",
+        "JavaVersion": "1.11"
+      }
+    }
+    ```
+1. The imported base matrix is generated (sparse in this example):
+    ```
+    {
+      "windows_netty": {
+        "operatingSystem": "windows",
+        "client": "netty"
+      },
+      "linux_okhttp": {
+        "operatingSystem": "linux",
+        "client": "okhttp"
+      }
+    }
+    ```
 1. Includes/excludes from the imported matrix get applied to the imported matrix
-1. The base matrix is multipled by the imported matrix
-1. Includes/excludes from the top-level matrix get applied to the multiplied matrix
+    ```
+    {
+      "windows_netty": {
+        "operatingSystem": "windows",
+        "client": "netty"
+      },
+      "linux_okhttp": {
+        "operatingSystem": "linux",
+        "client": "okhttp"
+      },
+      "mac_netty": {
+        "operatingSystem": "mac",
+        "client": "netty"
+      }
+    }
+    ```
+1. The base matrix is multipled by the imported matrix (in this case, the base matrix has 2 elements, and the imported
+   matrix has 3 elements, so the product is a matrix with 6 elements:
+    ```
+      "storage_18_windows_netty": {
+        "endpointType": "storage",
+        "JavaVersion": "1.8",
+        "operatingSystem": "windows",
+        "client": "netty"
+      },
+      "storage_18_linux_okhttp": {
+        "endpointType": "storage",
+        "JavaVersion": "1.8",
+        "operatingSystem": "linux",
+        "client": "okhttp"
+      },
+      "storage_18_mac_netty": {
+        "endpointType": "storage",
+        "JavaVersion": "1.8",
+        "operatingSystem": "mac",
+        "client": "netty"
+      },
+      "cosmos_111_windows_netty": {
+        "endpointType": "cosmos",
+        "JavaVersion": "1.11",
+        "operatingSystem": "windows",
+        "client": "netty"
+      },
+      "cosmos_111_linux_okhttp": {
+        "endpointType": "cosmos",
+        "JavaVersion": "1.11",
+        "operatingSystem": "linux",
+        "client": "okhttp"
+      },
+      "cosmos_111_mac_netty": {
+        "endpointType": "cosmos",
+        "JavaVersion": "1.11",
+        "operatingSystem": "mac",
+        "client": "netty"
+      }
+    }
+    ```
+1. Includes/excludes from the top-level matrix get applied to the multiplied matrix, so the below element will be added
+   to the above matrix, for an output matrix with 7 elements:
+    ```
+    "windows_TestFromSource_18": {
+      "operatingSystem": "windows",
+      "mode": "TestFromSource",
+      "JavaVersion": "1.8"
+    }
+    ```
 
 ## Matrix Generation behavior
 
@@ -247,7 +367,7 @@ The logic for generating display names works like this:
 - Join parameter values by "_"
     a. If the parameter value exists as a key in `displayNames` in the matrix config, replace it with that value.
     b. For each name value, strip all non-alphanumeric characters (excluding "_").
-	c. If the name is greater than 100 characters, truncate it.
+    c. If the name is greater than 100 characters, truncate it.
 
 #### Filters
 

--- a/eng/scripts/job-matrix/job-matrix-functions.modification.tests.ps1
+++ b/eng/scripts/job-matrix/job-matrix-functions.modification.tests.ps1
@@ -1,0 +1,151 @@
+Import-Module Pester
+
+BeforeAll {
+    . ./job-matrix-functions.ps1
+}
+
+Describe "Platform Matrix nonSparse" -Tag "nonsparse" {
+    BeforeEach {
+        $matrixJson = @'
+{
+    "matrix": {
+        "testField1": [ 1, 2 ],
+        "testField2": [ 1, 2, 3 ],
+        "testField3": [ 1, 2, 3, 4 ],
+    }
+}
+'@
+        $config = GetMatrixConfigFromJson $matrixJson
+    }
+
+    It "Should process nonSparse parameters" {
+        $parameters, $nonSparse = ProcessNonSparseParameters $config.orderedMatrix "testField1","testField3"
+        $parameters.Count | Should -Be 1
+        $parameters["testField2"] | Should -Be 1,2,3
+        $nonSparse.Count | Should -Be 2
+        $nonSparse["testField1"] | Should -Be 1,2
+        $nonSparse["testField3"] | Should -Be 1,2,3,4
+
+        $parameters, $nonSparse = ProcessNonSparseParameters $config.orderedMatrix "testField3"
+        $parameters.Count | Should -Be 2
+        $parameters.Contains("testField3") | Should -Be $false
+        $nonSparse.Count | Should -Be 1
+        $nonSparse["testField3"] | Should -Be 1,2,3,4
+    }
+
+    It "Should ignore nonSparse with all selection" {
+        $matrix = GenerateMatrix $config "all" -nonSparseParameters "testField3"
+        $matrix.Length | Should -Be 24
+    }
+
+    It "Should combine sparse matrix with nonSparse parameters" {
+        $matrix = GenerateMatrix $config "sparse" -nonSparseParameters "testField3"
+        $matrix.Length | Should -Be 12
+    }
+
+    It "Should combine with multiple nonSparse fields" {
+        $matrixJson = @'
+{
+    "matrix": {
+        "testField1": [ 1, 2 ],
+        "testField2": [ 1, 2 ],
+        "testField3": [ 31, 32 ],
+        "testField4": [ 41, 42 ]
+    }
+}
+'@
+        $config = GetMatrixConfigFromJson $matrixJson
+
+        $matrix = GenerateMatrix $config "all" -nonSparseParameters "testField3","testField4"
+        $matrix.Length | Should -Be 16
+
+        $matrix = GenerateMatrix $config "sparse" -nonSparseParameters "testField3","testField4"
+        $matrix.Length | Should -Be 8
+    }
+}
+
+Describe "Platform Matrix Import" -Tag "import" {
+    It "Should generate a matrix with nonSparseParameters and an imported sparse matrix" {
+        $matrixJson = @'
+{
+    "matrix": {
+        "$IMPORT": "./test-import-matrix.json",
+        "testField": [ "test1", "test2" ]
+    }
+}
+'@
+        $importConfig = GetMatrixConfigFromJson $matrixJson
+        $matrix = GenerateMatrix $importConfig "sparse" -nonSparseParameters "testField"
+
+        $matrix.Length | Should -Be 6
+
+        $matrix[0].name | Should -Be test1_foo1_bar1
+        $matrix[0].parameters.testField | Should -Be "test1"
+        $matrix[0].parameters.Foo | Should -Be "foo1"
+        $matrix[2].name | Should -Be test1_importedBaz
+        $matrix[2].parameters.testField | Should -Be "test1"
+        $matrix[2].parameters.Baz | Should -Be "importedBaz"
+        $matrix[4].name | Should -Be test2_foo2_bar2
+        $matrix[4].parameters.testField | Should -Be "test2"
+        $matrix[4].parameters.Foo | Should -Be "foo2"
+    }
+
+    It "Should generate a sparse matrix with an imported a sparse matrix" {
+        $matrixJson = @'
+{
+    "matrix": {
+        "$IMPORT": "./test-import-matrix.json",
+        "testField1": [ "test11", "test12" ],
+        "testField2": [ "test21", "test22" ]
+    }
+}
+'@
+        $importConfig = GetMatrixConfigFromJson $matrixJson
+        $matrix = GenerateMatrix $importConfig "sparse"
+
+        $matrix.Length | Should -Be 6
+
+        $matrix[0].name | Should -Be test11_test21_foo1_bar1
+        $matrix[0].parameters.testField1 | Should -Be "test11"
+        $matrix[0].parameters.testField2 | Should -Be "test21"
+        $matrix[0].parameters.Foo | Should -Be "foo1"
+        $matrix[2].name | Should -Be test11_test21_importedBaz
+        $matrix[2].parameters.testField1 | Should -Be "test11"
+        $matrix[2].parameters.testField2 | Should -Be "test21"
+        $matrix[2].parameters.Baz | Should -Be "importedBaz"
+        $matrix[4].name | Should -Be test12_test22_foo2_bar2
+        $matrix[4].parameters.testField1 | Should -Be "test12"
+        $matrix[4].parameters.testField2 | Should -Be "test22"
+        $matrix[4].parameters.Foo | Should -Be "foo2"
+    }
+
+    It "Should import a sparse matrix with import, include, and exclude" {
+        $matrixJson = @'
+{
+    "matrix": {
+        "$IMPORT": "./test-import-matrix.json",
+        "testField": [ "test1", "test2", "test3" ],
+    },
+    "include": [
+      {
+        "testImportIncludeName": [ "testInclude1", "testInclude2" ]
+      }
+    ],
+    "exclude": [
+      {
+        "testField": "test1"
+      },
+      {
+        "testField": "test3",
+        "Baz": "importedBaz"
+      }
+    ]
+}
+'@
+
+        $importConfig = GetMatrixConfigFromJson $matrixJson
+        $matrix = GenerateMatrix $importConfig "sparse"
+
+        $matrix.Length | Should -Be 7
+    }
+}

--- a/eng/scripts/job-matrix/job-matrix-functions.ps1
+++ b/eng/scripts/job-matrix/job-matrix-functions.ps1
@@ -63,7 +63,7 @@ function ProcessNonSparseParameters(
     [System.Collections.Specialized.OrderedDictionary]$parameters,
     [Array]$nonSparseParameters
 ) {
-    if (-not $nonSparseParameters) {
+    if (!$nonSparseParameters) {
         return $parameters, $null
     }
 
@@ -198,7 +198,7 @@ function ProcessIncludes([MatrixConfig]$config, [Array]$matrix)
 
 function ProcessImport([System.Collections.Specialized.OrderedDictionary]$matrix, [String]$selection)
 {
-    if (-not $matrix -or -not $matrix.Contains($IMPORT_KEYWORD)) {
+    if (!$matrix -or !$matrix.Contains($IMPORT_KEYWORD)) {
         return $matrix
     }
 
@@ -214,10 +214,10 @@ function ProcessImport([System.Collections.Specialized.OrderedDictionary]$matrix
 function CombineMatrices([Array]$matrix1, [Array]$matrix2)
 {
     $combined = @()
-    if (-not $matrix1) {
+    if (!$matrix1) {
         return $matrix2
     }
-    if (-not $matrix2) {
+    if (!$matrix2) {
         return $matrix1
     }
 
@@ -228,7 +228,7 @@ function CombineMatrices([Array]$matrix1, [Array]$matrix2)
                 parameters = CloneOrderedDictionary $entry1.parameters
             }
             foreach($param in $entry2.parameters.GetEnumerator()) {
-                if (-not $newEntry.Contains($param.Name)) {
+                if (!$newEntry.Contains($param.Name)) {
                     $newEntry.parameters[$param.Name] = $param.Value
                 } else {
                     Write-Warning "Skipping duplicate parameter `"$($param.Name)`" when combining matrix."
@@ -256,7 +256,7 @@ function MatrixElementMatch([System.Collections.Specialized.OrderedDictionary]$s
     }
 
     foreach ($key in $target.Keys) {
-        if (-not $source.Contains($key) -or $source[$key] -ne $target[$key]) {
+        if (!$source.Contains($key) -or $source[$key] -ne $target[$key]) {
             return $false
         }
     }
@@ -401,7 +401,7 @@ function InitializeMatrix
     )
     $head, $tail = $parameters
 
-    if (-not $head) {
+    if (!$head) {
         $entry = CreateMatrixEntry $permutation $displayNamesLookup
         $permutations.Add($entry) | Out-Null
         return

--- a/eng/scripts/job-matrix/job-matrix-functions.ps1
+++ b/eng/scripts/job-matrix/job-matrix-functions.ps1
@@ -9,6 +9,8 @@ class MatrixConfig {
     [Array]$exclude
 }
 
+$IMPORT_KEYWORD = '$IMPORT'
+
 function CreateDisplayName([string]$parameter, [Hashtable]$displayNamesLookup)
 {
     $name = $parameter.ToString()
@@ -25,28 +27,58 @@ function CreateDisplayName([string]$parameter, [Hashtable]$displayNamesLookup)
 
 function GenerateMatrix(
     [MatrixConfig]$config,
-    [string]$selectFromMatrixType,
-    [string]$displayNameFilter = ".*",
-    [array]$filters = @()
+    [String]$selectFromMatrixType,
+    [String]$displayNameFilter = ".*",
+    [Array]$filters = @(),
+    [Array]$nonSparseParameters = @()
 ) {
+    $orderedMatrix, $importedMatrix = ProcessImport $config.orderedMatrix $selectFromMatrixType
     if ($selectFromMatrixType -eq "sparse") {
-        [Array]$matrix = GenerateSparseMatrix $config.orderedMatrix $config.displayNamesLookup
+        [Array]$matrix = GenerateSparseMatrix $orderedMatrix $config.displayNamesLookup $nonSparseParameters
     } elseif ($selectFromMatrixType -eq "all") {
-        [Array]$matrix = GenerateFullMatrix $config.orderedMatrix $config.displayNamesLookup
+        [Array]$matrix = GenerateFullMatrix $orderedMatrix $config.displayNamesLookup
     } else {
         throw "Matrix generator not implemented for selectFromMatrixType: $($platform.selectFromMatrixType)"
+    }
+
+    # Combine with imported after matrix generation, since a sparse selection should result in a full combination of the
+    # top level and imported sparse matrices (as opposed to a sparse selection of both matrices).
+    if ($importedMatrix) {
+        [Array]$matrix = CombineMatrices $matrix $importedMatrix
     }
 
     if ($config.exclude) {
         [Array]$matrix = ProcessExcludes $matrix $config.exclude
     }
     if ($config.include) {
-        [Array]$matrix = ProcessIncludes $matrix $config.include $config.displayNamesLookup
+        [Array]$matrix = ProcessIncludes $config $matrix $selectFromMatrixType
     }
 
     [Array]$matrix = FilterMatrixDisplayName $matrix $displayNameFilter
     [Array]$matrix = FilterMatrix $matrix $filters
     return $matrix
+}
+
+function ProcessNonSparseParameters(
+    [System.Collections.Specialized.OrderedDictionary]$parameters,
+    [Array]$nonSparseParameters
+) {
+    if (-not $nonSparseParameters) {
+        return $parameters, $null
+    }
+
+    $sparse = [ordered]@{}
+    $nonSparse = [ordered]@{}
+
+    foreach ($param in $parameters.GetEnumerator()) {
+        if ($param.Name -in $nonSparseParameters) {
+            $nonSparse[$param.Name] = $param.Value
+        } else {
+            $sparse[$param.Name] = $param.Value
+        }
+    }
+
+    return $sparse, $nonSparse
 }
 
 function FilterMatrixDisplayName([array]$matrix, [string]$filter) {
@@ -97,7 +129,7 @@ function ParseFilter([string]$filter) {
 
 # Importing the JSON as PSCustomObject preserves key ordering,
 # whereas ConvertFrom-Json -AsHashtable does not
-function GetMatrixConfigFromJson($jsonConfig)
+function GetMatrixConfigFromJson([String]$jsonConfig)
 {
     [MatrixConfig]$config = $jsonConfig | ConvertFrom-Json
     $config.orderedMatrix = [ordered]@{}
@@ -137,8 +169,7 @@ function ProcessExcludes([Array]$matrix, [Array]$excludes)
     $exclusionMatrix = @()
 
     foreach ($exclusion in $excludes) {
-        $converted = ConvertToMatrixArrayFormat $exclusion
-        $full = GenerateFullMatrix $converted
+        $full = GenerateFullMatrix $exclusion
         $exclusionMatrix += $full
     }
 
@@ -154,15 +185,68 @@ function ProcessExcludes([Array]$matrix, [Array]$excludes)
     return $matrix | Where-Object { !$_.parameters.Contains($deleteKey) }
 }
 
-function ProcessIncludes([Array]$matrix, [Array]$includes, [Hashtable]$displayNamesLookup)
+function ProcessIncludes([MatrixConfig]$config, [Array]$matrix)
 {
-    foreach ($inclusion in $includes) {
-        $converted = ConvertToMatrixArrayFormat $inclusion
-        $full = GenerateFullMatrix $converted $displayNamesLookup
-        $matrix += $full
+    $inclusionMatrix = @()
+    foreach ($inclusion in $config.include) {
+        $full = GenerateFullMatrix $inclusion $config.displayNamesLookup
+        $inclusionMatrix += $full
     }
 
-    return $matrix
+    return $matrix + $inclusionMatrix
+}
+
+function ProcessImport([System.Collections.Specialized.OrderedDictionary]$matrix, [String]$selection)
+{
+    if (-not $matrix -or -not $matrix.Contains($IMPORT_KEYWORD)) {
+        return $matrix
+    }
+
+    $importPath = $matrix[$IMPORT_KEYWORD]
+    $matrix.Remove($IMPORT_KEYWORD)
+
+    $matrixConfig = GetMatrixConfigFromJson (Get-Content $importPath)
+    $importedMatrix = GenerateMatrix $matrixConfig $selection
+
+    return $matrix, $importedMatrix
+}
+
+function CombineMatrices([Array]$matrix1, [Array]$matrix2)
+{
+    $combined = @()
+    if (-not $matrix1) {
+        return $matrix2
+    }
+    if (-not $matrix2) {
+        return $matrix1
+    }
+
+    foreach ($entry1 in $matrix1) {
+        foreach ($entry2 in $matrix2) {
+            $newEntry = @{
+                name = $entry1.name
+                parameters = CloneOrderedDictionary $entry1.parameters
+            }
+            foreach($param in $entry2.parameters.GetEnumerator()) {
+                if (-not $newEntry.Contains($param.Name)) {
+                    $newEntry.parameters[$param.Name] = $param.Value
+                } else {
+                    Write-Warning "Skipping duplicate parameter `"$($param.Name)`" when combining matrix."
+                }
+            }
+
+            # The maximum allowed matrix name length is 100 characters
+            $entry2.name = $entry2.name.TrimStart("job_")
+            $newEntry.name = $newEntry.name, $entry2.name -join "_"
+            if ($newEntry.name.Length -gt 100) {
+                $newEntry.name = $newEntry.name[0..99] -join ""
+            }
+
+            $combined += $newEntry
+        }
+    }
+
+    return $combined
 }
 
 function MatrixElementMatch([System.Collections.Specialized.OrderedDictionary]$source, [System.Collections.Specialized.OrderedDictionary]$target)
@@ -178,21 +262,6 @@ function MatrixElementMatch([System.Collections.Specialized.OrderedDictionary]$s
     }
 
     return $true
-}
-
-function ConvertToMatrixArrayFormat([System.Collections.Specialized.OrderedDictionary]$matrix)
-{
-    $converted = [Ordered]@{}
-
-    foreach ($key in $matrix.Keys) {
-        if ($matrix[$key] -isnot [Array]) {
-            $converted[$key] = ,$matrix[$key]
-        } else {
-            $converted[$key] = $matrix[$key]
-        }
-    }
-
-    return $converted
 }
 
 function CloneOrderedDictionary([System.Collections.Specialized.OrderedDictionary]$dictionary) {
@@ -219,13 +288,33 @@ function SerializePipelineMatrix([Array]$matrix)
     }
 }
 
-function GenerateSparseMatrix([System.Collections.Specialized.OrderedDictionary]$parameters, [Hashtable]$displayNamesLookup)
-{
+function GenerateSparseMatrix(
+    [System.Collections.Specialized.OrderedDictionary]$parameters,
+    [Hashtable]$displayNamesLookup,
+    [Array]$nonSparseParameters = @()
+) {
+    $parameters, $nonSparse = ProcessNonSparseParameters $parameters $nonSparseParameters
     [Array]$dimensions = GetMatrixDimensions $parameters
-    $size = ($dimensions | Measure-Object -Maximum).Maximum
-
     [Array]$matrix = GenerateFullMatrix $parameters $displayNamesLookup
+
     $sparseMatrix = @()
+    $indexes = GetSparseMatrixIndexes $dimensions
+    foreach ($idx in $indexes) {
+        $sparseMatrix += GetNdMatrixElement $idx $matrix $dimensions
+    }
+
+    if ($nonSparse) {
+        [Array]$allOfMatrix = GenerateFullMatrix $nonSparse $displayNamesLookup
+        return CombineMatrices $allOfMatrix $sparseMatrix
+    }
+
+    return $sparseMatrix
+}
+
+function GetSparseMatrixIndexes([Array]$dimensions)
+{
+    $size = ($dimensions | Measure-Object -Maximum).Maximum
+    $indexes = @()
 
     # With full matrix, retrieve items by doing diagonal lookups across the matrix N times.
     # For example, given a matrix with dimensions 3, 2, 2:
@@ -238,14 +327,16 @@ function GenerateSparseMatrix([System.Collections.Specialized.OrderedDictionary]
         for ($j = 0; $j -lt $dimensions.Length; $j++) {
             $idx += $i % $dimensions[$j]
         }
-        $sparseMatrix += GetNdMatrixElement $idx $matrix $dimensions
+        $indexes += ,$idx
     }
 
-    return $sparseMatrix
+    return $indexes
 }
 
-function GenerateFullMatrix([System.Collections.Specialized.OrderedDictionary] $parameters, [Hashtable]$displayNamesLookup = @{})
-{
+function GenerateFullMatrix(
+    [System.Collections.Specialized.OrderedDictionary] $parameters,
+    [Hashtable]$displayNamesLookup = @{}
+) {
     # Handle when the config does not have a matrix specified (e.g. only the include field is specified)
     if ($parameters.Count -eq 0) {
         return @()
@@ -256,7 +347,7 @@ function GenerateFullMatrix([System.Collections.Specialized.OrderedDictionary] $
     $matrix = [System.Collections.ArrayList]::new()
     InitializeMatrix $parameterArray $displayNamesLookup $matrix
 
-    return $matrix.ToArray()
+    return $matrix
 }
 
 function CreateMatrixEntry([System.Collections.Specialized.OrderedDictionary]$permutation, [Hashtable]$displayNamesLookup = @{})
@@ -308,19 +399,20 @@ function InitializeMatrix
         [System.Collections.ArrayList]$permutations,
         $permutation = [Ordered]@{}
     )
+    $head, $tail = $parameters
 
-    if (-not $parameters) {
+    if (-not $head) {
         $entry = CreateMatrixEntry $permutation $displayNamesLookup
         $permutations.Add($entry) | Out-Null
         return
     }
 
-    $head, $tail = $parameters
-    foreach ($value in $head.value) {
-        $newPermutation = CloneOrderedDictionary($permutation)
+    # This behavior implicitly treats non-array values as single elements
+    foreach ($value in $head.Value) {
+        $newPermutation = CloneOrderedDictionary $permutation
         if ($value -is [PSCustomObject]) {
             foreach ($nestedParameter in $value.PSObject.Properties) {
-                $nestedPermutation = CloneOrderedDictionary($newPermutation)
+                $nestedPermutation = CloneOrderedDictionary $newPermutation
                 $nestedPermutation[$nestedParameter.Name] = $nestedParameter.Value
                 InitializeMatrix $tail $displayNamesLookup $permutations $nestedPermutation
             }
@@ -334,11 +426,11 @@ function InitializeMatrix
 function GetMatrixDimensions([System.Collections.Specialized.OrderedDictionary]$parameters)
 {
     $dimensions = @()
-    foreach ($val in $parameters.Values) {
-        if ($val -is [PSCustomObject]) {
-            $dimensions += ($val.PSObject.Properties | Measure-Object).Count
-        } elseif ($val -is [Array]) {
-            $dimensions += $val.Length
+    foreach ($param in $parameters.GetEnumerator()) {
+        if ($param.Value -is [PSCustomObject]) {
+            $dimensions += ($param.Value.PSObject.Properties | Measure-Object).Count
+        } elseif ($param.Value -is [Array]) {
+            $dimensions += $param.Value.Length
         } else {
             $dimensions += 1
         }

--- a/eng/scripts/job-matrix/test-import-matrix.json
+++ b/eng/scripts/job-matrix/test-import-matrix.json
@@ -1,0 +1,11 @@
+{
+  "matrix": {
+    "Foo": [ "foo1", "foo2" ],
+    "Bar": [ "bar1", "bar2" ]
+  },
+  "include": [
+    {
+      "Baz": "importedBaz"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds support for config import and non-sparse parameters to job matrix generation. These features will enable a couple scenarios I have found while trying to convert Python live test configurations to use the job matrix generation scripts.

The import feature allows a matrix configuration to depend on another matrix configuration, for example if a live test wanted to run our base platform matrix, but add a set of additional test arguments to it. There are multiple places in the python sdk tests.yml files where we duplicate the platform matrix in order to make some minor modifications to it.

The non-sparse parameter feature allows us to generate sparse matrices while making sure that we still include all combinations of one or more parameters. This is also useful in conjunction with the import feature in order to enable some platform configurations that need to add multiple parameters to the base, but only need the full set of one parameter, otherwise the test matrix would be very large.

See the README changes for more in-depth details.

Example that will import a common sparse matrix and combine it with another sparse matrix, and then combine that with all values of `testFieldC`:
```
{
    "matrix": {
        "$IMPORT": "./test-import-matrix.json",
        "testFieldA": [ "test1A", "test2A" ],
        "testFieldB": [ "test1B", "test2B" ],
        "testFieldC": [ "test1C", "test2C", "test3C" ]
    }
}

Create-JobMatrix ./matrix.json -selection sparse -nonSparseParameters testFieldC
```