### PR TITLE
search sdk: doc strings referencing incorrect parameter name

### DIFF
--- a/sdk/search/azure-search-documents/azure/search/documents/_internal/_paging.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_internal/_paging.py
@@ -78,7 +78,7 @@ class SearchItemPaged(ItemPaged[ReturnType]):
 
     def get_count(self):
         # type: () -> float
-        """Return the count of results if `include_total_result_count` was
+        """Return the count of results if `include_total_count` was
         set for the query.
 
         """

--- a/sdk/search/azure-search-documents/azure/search/documents/_internal/aio/_paging.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/_internal/aio/_paging.py
@@ -56,7 +56,7 @@ class AsyncSearchItemPaged(AsyncItemPaged[ReturnType]):
 
     async def get_count(self):
         # type: () -> float
-        """Return the count of results if `include_total_result_count` was
+        """Return the count of results if `include_total_count` was
         set for the query.
 
         """


### PR DESCRIPTION
Corrected parameter name in get_count() doc string: `include_total_result_count` ->  `include_total_count`