### PR TITLE
Change `conn.conn_kw`'s content instead of replacing it

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/transport/_bigger_block_size_http_adapters.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_bigger_block_size_http_adapters.py
@@ -42,6 +42,6 @@ class BiggerBlockSizeHTTPAdapter(HTTPAdapter):
         system_version = tuple(sys.version_info)[:3]
         if system_version[:2] >= (3, 7):
             if not conn.conn_kw:
-                conne.conn_kw = {}
+                conn.conn_kw = {}
             conn.conn_kw['blocksize'] = 32768
         return conn

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_bigger_block_size_http_adapters.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_bigger_block_size_http_adapters.py
@@ -41,5 +41,5 @@ class BiggerBlockSizeHTTPAdapter(HTTPAdapter):
         conn = super(BiggerBlockSizeHTTPAdapter, self).get_connection(url, proxies)
         system_version = tuple(sys.version_info)[:3]
         if system_version[:2] >= (3, 7):
-            conn.conn_kw = {"blocksize": 32768}
+            conn.conn_kw['blocksize'] = 32768
         return conn

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_bigger_block_size_http_adapters.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_bigger_block_size_http_adapters.py
@@ -41,5 +41,7 @@ class BiggerBlockSizeHTTPAdapter(HTTPAdapter):
         conn = super(BiggerBlockSizeHTTPAdapter, self).get_connection(url, proxies)
         system_version = tuple(sys.version_info)[:3]
         if system_version[:2] >= (3, 7):
+            if not conn.conn_kw:
+                conne.conn_kw = {}
             conn.conn_kw['blocksize'] = 32768
         return conn


### PR DESCRIPTION
## Symptom

Python SDK fails when an HTTPS proxy is used:

```py
from azure.mgmt.compute import ComputeManagementClient
from azure.identity import AzureCliCredential

subscription_id = 'xxx'
proxies = {'https': 'https://127.0.0.1:8888'}

compute_client = ComputeManagementClient(subscription_id=subscription_id, credential=AzureCliCredential(),
                                         proxies=proxies)
compute_client.virtual_machine_scale_sets.get(resource_group_name='xxx', vm_scale_set_name='xxx')
```

```
Traceback (most recent call last):
  File "D:/cli/testproj/demo.py", line 12, in <module>
    compute_client.virtual_machine_scale_sets.get(resource_group_name='xxx',
  File "D:\cli\env38\lib\site-packages\azure\mgmt\compute\v2020_06_01\operations\_virtual_machine_scale_sets_operations.py", line 458, in get
    pipeline_response = self._client._pipeline.run(request, stream=False, **kwargs)
  File "D:\cli\env38\lib\site-packages\azure\core\pipeline\_base.py", line 211, in run
    return first_node.send(pipeline_request)  # type: ignore
  File "D:\cli\env38\lib\site-packages\azure\core\pipeline\_base.py", line 71, in send
    response = self.next.send(request)
  File "D:\cli\env38\lib\site-packages\azure\mgmt\core\policies\_base.py", line 47, in send
    response = self.next.send(request)
  File "D:\cli\env38\lib\site-packages\azure\core\pipeline\_base.py", line 71, in send
    response = self.next.send(request)
  File "D:\cli\env38\lib\site-packages\azure\core\pipeline\_base.py", line 71, in send
    response = self.next.send(request)
  File "D:\cli\env38\lib\site-packages\azure\core\pipeline\_base.py", line 71, in send
    response = self.next.send(request)
  [Previous line repeated 1 more time]
  File "D:\cli\env38\lib\site-packages\azure\core\pipeline\policies\_redirect.py", line 158, in send
    response = self.next.send(request)
  File "D:\cli\env38\lib\site-packages\azure\core\pipeline\policies\_retry.py", line 435, in send
    response = self.next.send(request)
  File "D:\cli\env38\lib\site-packages\azure\core\pipeline\_base.py", line 71, in send
    response = self.next.send(request)
  File "D:\cli\env38\lib\site-packages\azure\core\pipeline\_base.py", line 71, in send
    response = self.next.send(request)
  File "D:\cli\env38\lib\site-packages\azure\core\pipeline\_base.py", line 71, in send
    response = self.next.send(request)
  [Previous line repeated 2 more times]
  File "D:\cli\env38\lib\site-packages\azure\core\pipeline\_base.py", line 103, in send
    self._sender.send(request.http_request, **request.context.options),
  File "D:\cli\env38\lib\site-packages\azure\core\pipeline\transport\_requests_basic.py", line 260, in send
    response = self.session.request(  # type: ignore
  File "D:\cli\env38\lib\site-packages\requests\sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "D:\cli\env38\lib\site-packages\requests\sessions.py", line 655, in send
    r = adapter.send(request, **kwargs)
  File "D:\cli\env38\lib\site-packages\requests\adapters.py", line 439, in send
    resp = conn.urlopen(
  File "D:\cli\env38\lib\site-packages\urllib3\connectionpool.py", line 696, in urlopen
    self._prepare_proxy(conn)
  File "D:\cli\env38\lib\site-packages\urllib3\connectionpool.py", line 964, in _prepare_proxy
    conn.connect()
  File "D:\cli\env38\lib\site-packages\urllib3\connection.py", line 359, in connect
    conn = self._connect_tls_proxy(hostname, conn)
  File "D:\cli\env38\lib\site-packages\urllib3\connection.py", line 476, in _connect_tls_proxy
    ssl_context = proxy_config.ssl_context
AttributeError: 'NoneType' object has no attribute 'ssl_context'
```

## Root cause

https://github.com/Azure/azure-sdk-for-python/pull/14442 replaces `conn.conn_kw` with a new `dict`.

It corrupts the internal logic of `urllib3`, as `conn.conn_kw` is not empty. Replacing it causes existing key-values to be discarded.

Example `conn.conn_kw` when proxy is used:

```py
{
  'socket_options': [], 
  'proxy': Url(scheme='https', auth=None, host='127.0.0.1', port=8888, path=None, query=None, fragment=None), 
  'proxy_config': ProxyConfig(ssl_context=None, use_forwarding_for_https=False)
}
```

The above error happens because `proxy_config` from `conn.conn_kw` is discarded.

## Change

This PR changes `conn.conn_kw`'s content instead of replacing it, so that existing values are preserved.
