### PR TITLE
[EventHubs] no-op instead of raising error when sending out empty event data batch

### DIFF
--- a/sdk/eventhub/azure-eventhub/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 5.3.1 (Unreleased)
 
+**Bug fixes**
+
+- Sending emtpy `event_data_batch` will be a no-op now instead of raising error.
 
 ## 5.3.0 (2021-02-08)
 

--- a/sdk/eventhub/azure-eventhub/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Bug fixes**
 
-- Sending emtpy `event_data_batch` will be a no-op now instead of raising error.
+- Sending empty `event_data_batch` will be a no-op now instead of raising error.
 
 ## 5.3.0 (2021-02-08)
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
@@ -9,7 +9,7 @@ from typing import Any, Union, TYPE_CHECKING, Dict, List, Optional, cast
 
 from uamqp import constants
 
-from .exceptions import ConnectError, EventHubError
+from .exceptions import ConnectError, EventHubError, EventDataSendError
 from ._client_base import ClientBase
 from ._producer import EventHubProducer
 from ._constants import ALL_PARTITIONS
@@ -242,6 +242,7 @@ class EventHubProducerClient(ClientBase):
                 :caption: Sends event data
 
         """
+
         partition_id = kwargs.get("partition_id")
         partition_key = kwargs.get("partition_key")
         if isinstance(event_data_batch, EventDataBatch):
@@ -255,6 +256,10 @@ class EventHubProducerClient(ClientBase):
         partition_id = (
             to_send_batch._partition_id or ALL_PARTITIONS  # pylint:disable=protected-access
         )
+
+        if len(to_send_batch) == 0:
+            raise EventDataSendError("The event_data_batch object must not be empty.")
+
         send_timeout = kwargs.pop("timeout", None)
         try:
             cast(EventHubProducer, self._producers[partition_id]).send(

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
@@ -242,7 +242,6 @@ class EventHubProducerClient(ClientBase):
                 :caption: Sends event data
 
         """
-
         partition_id = kwargs.get("partition_id")
         partition_key = kwargs.get("partition_key")
         if isinstance(event_data_batch, EventDataBatch):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
@@ -257,7 +257,7 @@ class EventHubProducerClient(ClientBase):
         )
 
         if len(to_send_batch) == 0:
-            raise EventDataSendError("The event_data_batch object must not be empty.")
+            return
 
         send_timeout = kwargs.pop("timeout", None)
         try:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
@@ -9,7 +9,7 @@ from typing import Any, Union, TYPE_CHECKING, Dict, List, Optional, cast
 
 from uamqp import constants
 
-from .exceptions import ConnectError, EventHubError, EventDataSendError
+from .exceptions import ConnectError, EventHubError
 from ._client_base import ClientBase
 from ._producer import EventHubProducer
 from ._constants import ALL_PARTITIONS

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_client_async.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any, Union, TYPE_CHECKING, List, Optional, Dict, cast
 from uamqp import constants
 
-from ..exceptions import ConnectError, EventHubError
+from ..exceptions import ConnectError, EventHubError, EventDataSendError
 from ._client_base_async import ClientBaseAsync
 from ._producer_async import EventHubProducer
 from .._constants import ALL_PARTITIONS
@@ -283,6 +283,9 @@ class EventHubProducerClient(ClientBaseAsync):
         else:
             to_send_batch = await self.create_batch(partition_id=partition_id, partition_key=partition_key)
             to_send_batch._load_events(event_data_batch)  # pylint:disable=protected-access
+
+        if len(to_send_batch) == 0:
+            raise EventDataSendError("The event_data_batch object must not be empty.")
 
         partition_id = (
             to_send_batch._partition_id or ALL_PARTITIONS  # pylint:disable=protected-access

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_client_async.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any, Union, TYPE_CHECKING, List, Optional, Dict, cast
 from uamqp import constants
 
-from ..exceptions import ConnectError, EventHubError, EventDataSendError
+from ..exceptions import ConnectError, EventHubError
 from ._client_base_async import ClientBaseAsync
 from ._producer_async import EventHubProducer
 from .._constants import ALL_PARTITIONS

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_client_async.py
@@ -285,7 +285,7 @@ class EventHubProducerClient(ClientBaseAsync):
             to_send_batch._load_events(event_data_batch)  # pylint:disable=protected-access
 
         if len(to_send_batch) == 0:
-            raise EventDataSendError("The event_data_batch object must not be empty.")
+            return
 
         partition_id = (
             to_send_batch._partition_id or ALL_PARTITIONS  # pylint:disable=protected-access

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -30,6 +30,9 @@ async def test_send_with_partition_key_async(connstr_receivers):
                 data_val += 1
                 await client.send_batch(batch)
 
+        with pytest.raises(EventDataSendError):
+            await client.send_batch(await client.create_batch())
+
     found_partition_keys = {}
     for index, partition in enumerate(receivers):
         received = partition.receive_message_batch(timeout=5000)

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -30,8 +30,7 @@ async def test_send_with_partition_key_async(connstr_receivers):
                 data_val += 1
                 await client.send_batch(batch)
 
-        with pytest.raises(EventDataSendError):
-            await client.send_batch(await client.create_batch())
+        await client.send_batch(await client.create_batch())
 
     found_partition_keys = {}
     for index, partition in enumerate(receivers):

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -204,8 +204,7 @@ async def test_send_list_partition_async(connstr_receivers):
 
 
 @pytest.mark.parametrize("to_send, exception_type",
-                         [([], EventDataSendError),
-                          ([EventData("A"*1024)]*1100, ValueError),
+                         [([EventData("A"*1024)]*1100, ValueError),
                           ("any str", AttributeError)
                           ])
 @pytest.mark.liveTest

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -211,8 +211,7 @@ def test_send_list_partition(connstr_receivers):
 
 
 @pytest.mark.parametrize("to_send, exception_type",
-                         [([], EventDataSendError),
-                          ([EventData("A"*1024)]*1100, ValueError),
+                         [([EventData("A"*1024)]*1100, ValueError),
                           ("any str", AttributeError)
                           ])
 @pytest.mark.liveTest

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -28,8 +28,7 @@ def test_send_with_partition_key(connstr_receivers):
                 data_val += 1
                 client.send_batch(batch)
 
-        with pytest.raises(EventDataSendError):
-            client.send_batch(client.create_batch())
+        client.send_batch(client.create_batch())
 
     found_partition_keys = {}
     for index, partition in enumerate(receivers):

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -28,6 +28,9 @@ def test_send_with_partition_key(connstr_receivers):
                 data_val += 1
                 client.send_batch(batch)
 
+        with pytest.raises(EventDataSendError):
+            client.send_batch(client.create_batch())
+
     found_partition_keys = {}
     for index, partition in enumerate(receivers):
         received = partition.receive_message_batch(timeout=5000)


### PR DESCRIPTION
addressing: https://github.com/Azure/azure-sdk-for-python/issues/14841

- doing no-op instead of raising error when sending empty event batch
  - this aligns with event hubs in other languages and service bus in python
- This should be a non-breaking change.

references:

JS EH:
https://github.com/Azure/azure-sdk-for-js/blob/fc443f9b35c1cce112f9862685c07bed2bbae854/sdk/eventhub/event-hubs/src/eventHubSender.ts#L304-L316

.NET EH:
https://github.com/Azure/azure-sdk-for-net/blob/b493f7ad5487fd0d01f004e9f7ebdf50bfec0b96/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs#L573-L576

JAVA EH: can not find the code :(