### PR TITLE
[EventHubs] Doc warning on changing the value of the instance variable EventDataBatch.max_size_in_bytes

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
@@ -338,7 +338,9 @@ class EventDataBatch(object):
     **Please use the create_batch method of EventHubProducerClient
     to create an EventDataBatch object instead of instantiating an EventDataBatch object directly.**
 
-    **WARNING: Updating the value of the instance variable `max_size_in_bytes` on an instantiated EventDataBatch object is HIGHLY DISCOURAGED. The updated `max_size_in_bytes` value may conflict with the maximum size of events allowed by the Event Hubs service and result in a sending failure.**
+    **WARNING: Updating the value of the instance variable max_size_in_bytes on an instantiated EventDataBatch object
+    is HIGHLY DISCOURAGED. The updated max_size_in_bytes value may conflict with the maximum size of events allowed
+    by the Event Hubs service and result in a sending failure.**
 
     :param int max_size_in_bytes: The maximum size of bytes data that an EventDataBatch object can hold.
     :param str partition_id: The specific partition ID to send to.

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
@@ -338,9 +338,7 @@ class EventDataBatch(object):
     **Please use the create_batch method of EventHubProducerClient
     to create an EventDataBatch object instead of instantiating an EventDataBatch object directly.**
 
-    **It is highly recommended not to update the value of the instance variable `max_size_in_bytes` on an
-    instantiated EventDataBatch object which might lead to sending failure as the Event Hub service
-    has a fixed quota on the maximum allowed size of events.**
+    **WARNING: Updating the value of the instance variable `max_size_in_bytes` on an instantiated EventDataBatch object is HIGHLY DISCOURAGED. The updated `max_size_in_bytes` value may conflict with the maximum size of events allowed by the Event Hubs service and result in a sending failure.**
 
     :param int max_size_in_bytes: The maximum size of bytes data that an EventDataBatch object can hold.
     :param str partition_id: The specific partition ID to send to.

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
@@ -338,6 +338,10 @@ class EventDataBatch(object):
     **Please use the create_batch method of EventHubProducerClient
     to create an EventDataBatch object instead of instantiating an EventDataBatch object directly.**
 
+    **It is highly recommended not to update the value of the instance variable `max_size_in_bytes` on an
+    EventDataBatch object once instantiated which might lead to sending failure as the Event Hub service
+    has a fixed quota on the maximum allowed size of events.**
+
     :param int max_size_in_bytes: The maximum size of bytes data that an EventDataBatch object can hold.
     :param str partition_id: The specific partition ID to send to.
     :param str partition_key: With the given partition_key, event data will be sent to a particular partition of the

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py
@@ -339,7 +339,7 @@ class EventDataBatch(object):
     to create an EventDataBatch object instead of instantiating an EventDataBatch object directly.**
 
     **It is highly recommended not to update the value of the instance variable `max_size_in_bytes` on an
-    EventDataBatch object once instantiated which might lead to sending failure as the Event Hub service
+    instantiated EventDataBatch object which might lead to sending failure as the Event Hub service
     has a fixed quota on the maximum allowed size of events.**
 
     :param int max_size_in_bytes: The maximum size of bytes data that an EventDataBatch object can hold.


### PR DESCRIPTION
addressing issue: https://github.com/Azure/azure-sdk-for-python/issues/14752

concern: this is kina breaking change, should we do this?