### PR TITLE
[Communication] Prep release for admin, chat, sms

### DIFF
--- a/sdk/communication/azure-communication-administration/CHANGELOG.md
+++ b/sdk/communication/azure-communication-administration/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b4 (Unreleased)
+## 1.0.0b4 (2020-20-09)
 
 ### Breaking Changes
 - CommunicationIdentityClient is moved to a new package: "azure.communication.identity"

--- a/sdk/communication/azure-communication-administration/CHANGELOG.md
+++ b/sdk/communication/azure-communication-administration/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.0.0b4 (2020-20-09)
 
 ### Breaking Changes
-- CommunicationIdentityClient is moved to a new package: "azure.communication.identity"
+- CommunicationIdentityClient is moved to a new package: "azure.communication.identity".
 - Replaced CommunicationUser with CommunicationUserIdentifier.
 - Renamed CommunicationUserCredential to CommunicationTokenCredential.
 

--- a/sdk/communication/azure-communication-chat/CHANGELOG.md
+++ b/sdk/communication/azure-communication-chat/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b4 (2021-02-08)
+## 1.0.0b4 (2021-02-09)
 ### Breaking Changes
 - Replaced CommunicationUser with CommunicationUserIdentifier.
 - Replaced PhoneNumber with PhoneNumberIdentifier

--- a/sdk/communication/azure-communication-chat/CHANGELOG.md
+++ b/sdk/communication/azure-communication-chat/CHANGELOG.md
@@ -2,17 +2,16 @@
 
 ## 1.0.0b4 (2021-02-09)
 ### Breaking Changes
-- Replaced CommunicationUser with CommunicationUserIdentifier.
-- Replaced PhoneNumber with PhoneNumberIdentifier
+- Updated to Azure.Communication.Common version 1.0.0-beta.4. Now uses `CommunicationUserIdentifier` and `CommunicationIdentifier` in place of `CommunicationUser`, and `CommunicationTokenCredential` instead of `CommunicationUserCredential`.
+- Removed priority field (ChatMessage.Priority)
+- Renamed PhoneNumber to PhoneNumberIdentifier
+
+### Added
 - Support for CreateChatThreadResult and AddChatParticipantsResult to handle partial errors in batch calls.
 - Added idempotency identifier parameter for chat creation calls.
 - Added support for readreceipts and getparticipants pagination.
 - Added new model for messages anc ontent types : Text, Html, ParticipantAdded, ParticipantRemoved, TopicUpdated 
-- Removed priority field (ChatMessage.Priority)
 - Added new model for errors (CommunicationError)
-
-### Added
-
 - Added `MicrosoftTeamsUserIdentifier`
 
 ## 1.0.0b3 (2020-11-16)

--- a/sdk/communication/azure-communication-chat/CHANGELOG.md
+++ b/sdk/communication/azure-communication-chat/CHANGELOG.md
@@ -2,17 +2,17 @@
 
 ## 1.0.0b4 (2021-02-09)
 ### Breaking Changes
-- Updated to Azure.Communication.Common version 1.0.0-beta.4. Now uses `CommunicationUserIdentifier` and `CommunicationIdentifier` in place of `CommunicationUser`, and `CommunicationTokenCredential` instead of `CommunicationUserCredential`.
-- Removed priority field (ChatMessage.Priority)
-- Renamed PhoneNumber to PhoneNumberIdentifier
+- Uses `CommunicationUserIdentifier` and `CommunicationIdentifier` in place of `CommunicationUser`, and `CommunicationTokenCredential` instead of `CommunicationUserCredential`.
+- Removed priority field (ChatMessage.Priority).
+- Renamed PhoneNumber to PhoneNumberIdentifier.
 
 ### Added
 - Support for CreateChatThreadResult and AddChatParticipantsResult to handle partial errors in batch calls.
 - Added idempotency identifier parameter for chat creation calls.
 - Added support for readreceipts and getparticipants pagination.
-- Added new model for messages anc ontent types : Text, Html, ParticipantAdded, ParticipantRemoved, TopicUpdated 
-- Added new model for errors (CommunicationError)
-- Added `MicrosoftTeamsUserIdentifier`
+- Added new model for messages anc ontent types : Text, Html, ParticipantAdded, ParticipantRemoved, TopicUpdated.
+- Added new model for errors (CommunicationError).
+- Added `MicrosoftTeamsUserIdentifier`.
 
 ## 1.0.0b3 (2020-11-16)
 - Updated `azure-communication-chat` version.

--- a/sdk/communication/azure-communication-sms/CHANGELOG.md
+++ b/sdk/communication/azure-communication-sms/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b5 (Unreleased)
+## 1.0.0b5 (2021-02-09)
 ### Added
 
 - Added support for Azure Active Directory authentication

--- a/sdk/communication/azure-communication-sms/CHANGELOG.md
+++ b/sdk/communication/azure-communication-sms/CHANGELOG.md
@@ -2,14 +2,13 @@
 
 ## 1.0.0b5 (2021-02-09)
 ### Added
-
-- Added support for Azure Active Directory authentication
+- Added support for Azure Active Directory authentication.
 
 ## 1.0.0b4 (2020-11-16)
 - Updated `azure-communication-sms` version.
 ### Breaking Changes
 - Replaced CommunicationUser with CommunicationUserIdentifier.
-- Replaced PhoneNumber with PhoneNumberIdentifier
+- Replaced PhoneNumber with PhoneNumberIdentifier.
 
 ## 1.0.0b3 (2020-10-07)
 - Add dependency to `azure-communication-nspkg` package, to support py2


### PR DESCRIPTION
Update CHANGELOG.md for 2021-02-09 release for 
* admin
* chat
CHANGELOG.md for identity is already update to '2021-02-09'

https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/communication/azure-communication-identity/CHANGELOG.md
