### PR TITLE
Bump msrest

### DIFF
--- a/sdk/tables/azure-data-tables/CHANGELOG.md
+++ b/sdk/tables/azure-data-tables/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 12.0.0b5 (Unreleased)
 
-* Bumped minimum requirement of msrest from `0.6.10` to `0.6.11`.
+* Bumped minimum requirement of msrest from `0.6.10` to `0.6.19`.
+
 ## 12.0.0b4 (2020-01-12)
 * Fixes an [issue](https://github.com/Azure/azure-sdk-for-python/issues/15554) where `query_entities` kwarg `parameters` would not work with multiple parameters or with non-string parameters. This now works with multiple parameters and numeric, string, boolean, UUID, and datetime objects.
 * Fixes an [issue](https://github.com/Azure/azure-sdk-for-python/issues/15653) where `delete_entity` will return an `ClientAuthenticationError` when the '@' symbol is included in the entity.

--- a/sdk/tables/azure-data-tables/setup.py
+++ b/sdk/tables/azure-data-tables/setup.py
@@ -80,7 +80,7 @@ setup(
     ]),
     install_requires=[
         "azure-core<2.0.0,>=1.6.0",
-        "msrest>=0.6.11"
+        "msrest>=0.6.19"
     ],
     extras_require={
         ":python_version<'3.0'": ['futures', 'azure-data-nspkg<2.0.0,>=1.0.0'],

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -151,7 +151,7 @@ avro<2.0.0,>=1.10.0
 #override azure-storage-file-datalake azure-storage-blob<13.0.0,>=12.7.0
 #override azure-security-attestation msrest>=0.6.0
 #override azure-security-attestation azure-core<2.0.0,>=1.8.2
-#override azure-data-tables msrest>=0.6.11
+#override azure-data-tables msrest>=0.6.19
 opencensus>=0.6.0
 opencensus-ext-threading
 opencensus-ext-azure>=0.3.1


### PR DESCRIPTION
previous bump didn't work for python 2.7, this takes care of that.