### PR TITLE
Skip dumping package proprties to file in test phase

### DIFF
--- a/eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
+++ b/eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
@@ -2,8 +2,10 @@
 # is used when this pipeline is going to be generating and publishing daily dev builds.
 parameters:
   ServiceDirectory: ''
+  DumpPackageProperties: true
+
 steps:
-- ${{if ne(parameters.ServiceDirectory, '')}}:
+- ${{if and(ne(parameters.ServiceDirectory, ''), eq(parameters.DumpPackageProperties, true)) }}:
   - task: Powershell@2
     inputs:
       filePath: $(Build.SourcesDirectory)/eng/common/scripts/Save-Package-Properties.ps1

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -221,6 +221,7 @@ jobs:
             parameters:
               ServiceDirectory: ${{ parameters.ServiceDirectory }}
               BuildTargetingString: ${{ parameters.BuildTargetingString }}
+              DumpPackageProperties: false
 
   - job: 'RunRegression'
     condition: and(succeededOrFailed(), or(eq(variables['Run.Regression'], 'true'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['System.TeamProject'],'internal'))))

--- a/eng/pipelines/templates/steps/set-dev-build.yml
+++ b/eng/pipelines/templates/steps/set-dev-build.yml
@@ -1,11 +1,13 @@
 parameters:
   BuildTargetingString: 'azure-*'
   ServiceDirectory: ''
+  DumpPackageProperties: true
 
 steps:
   - template: /eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
     parameters:
       ServiceDirectory: ${{ parameters.ServiceDirectory }}
+      DumpPackageProperties: ${{ parameters.DumpPackageProperties }}
 
   - task: PythonScript@0
     condition: and(succeededOrFailed(), eq(variables['SetDevVersion'],'true'))


### PR DESCRIPTION
Common script  to extract package properties and dump it into file is failing on pypy3 for azure communication pipeline. This PR is to unblock release by skipping this step from test phase. Common change will be submitted to azure-sdk-tools repo in another PR after unblocking python release.