### PR TITLE
[ServiceBus] Add body_as_str helper method on ServicBusMessage

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **New Features**
 
-* Added a `body_as_str` method on `ServiceBusMessage` which returns the content of the message as a string.
+* Added a `body_as_str` method on `ServiceBusMessage` and `ServiceBusReceivedMessage` which returns the content of the message as a string.
 
 ## 7.0.1 (2021-01-12)
 

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 7.0.2 (Unreleased)
 
+**New Features**
+
+* Added a `body_as_str` method on `ServiceBusMessage` which returns the content of the message as a string.
 
 ## 7.0.1 (2021-01-12)
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/message.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/message.py
@@ -9,7 +9,7 @@ import datetime
 import uuid
 import logging
 import copy
-from typing import Optional, List, Union, Iterable, TYPE_CHECKING, Any
+from typing import Optional, List, Union, Iterable, TYPE_CHECKING, Any, cast
 
 import six
 
@@ -320,6 +320,29 @@ class ServiceBusMessage(
         :rtype: bytes or Iterable[bytes]
         """
         return self.message.get_data()
+
+    @property
+    def body_as_str(self, encoding="UTF-8"):
+        # type: (str) -> str
+        """The content of the message as a string, if the data is of a compatible type.
+
+        :param encoding: The encoding to use for decoding message.
+         Default is 'UTF-8'
+        :rtype: str
+        """
+        data = self.body
+        try:
+            return "".join(b.decode(encoding) for b in cast(Iterable[bytes], data))
+        except TypeError:
+            return six.text_type(data)
+        except:  # pylint: disable=bare-except
+            pass
+        try:
+            return cast(bytes, data).decode(encoding)
+        except Exception as e:
+            raise TypeError(
+                "Message data is not compatible with string type: {}".format(e)
+            )
 
     @property
     def content_type(self):

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/message.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/message.py
@@ -321,7 +321,6 @@ class ServiceBusMessage(
         """
         return self.message.get_data()
 
-    @property
     def body_as_str(self, encoding="UTF-8"):
         # type: (str) -> str
         """The content of the message as a string, if the data is of a compatible type.

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -1913,8 +1913,8 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
                 message = ServiceBusMessage("ServiceBusMessage")
                 message2 = ServiceBusMessage("Message2")
-                assert message.body_as_str == "ServiceBusMessage"
-                assert message2.body_as_str == "Message2"
+                assert message.body_as_str() == "ServiceBusMessage"
+                assert message2.body_as_str() == "Message2"
                 # first test batch message resending.
                 batch_message = sender.create_message_batch()
                 batch_message._from_list([message, message2])  # pylint: disable=protected-access
@@ -1932,7 +1932,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
                     for message in receiver:
                         messages.append(message)
-                        assert message.body_as_str in ["ServiceBusMessage", "Message2"]
+                        assert message.body_as_str() in ["ServiceBusMessage", "Message2"]
                 assert len(messages) == 2
 
 

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -1913,6 +1913,8 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
                 message = ServiceBusMessage("ServiceBusMessage")
                 message2 = ServiceBusMessage("Message2")
+                assert message.body_as_str == "ServiceBusMessage"
+                assert message2.body_as_str == "Message2"
                 # first test batch message resending.
                 batch_message = sender.create_message_batch()
                 batch_message._from_list([message, message2])  # pylint: disable=protected-access
@@ -1930,6 +1932,7 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
                     for message in receiver:
                         messages.append(message)
+                        assert message.body_as_str in ["ServiceBusMessage", "Message2"]
                 assert len(messages) == 2
 
 


### PR DESCRIPTION
addressing issue: https://github.com/Azure/azure-sdk-for-python/issues/16453

also align with the EventData method in EventHub SDK (code copied): https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/eventhub/azure-eventhub/azure/eventhub/_common.py#L289-L309

question for @annatisch : should we bump the version to v7.1.0 as this is a new feature?
