### PR TITLE
Adjust Injected Requirement Generation

### DIFF
--- a/eng/tox/sanitize_setup.py
+++ b/eng/tox/sanitize_setup.py
@@ -92,7 +92,7 @@ def process_requires(setup_py_path):
 
         if not is_required_version_on_pypi(pkg_name, spec):
             old_req = str(req)
-            version = get_version(pkg_name)
+            version = get_version(pkg_name).base_version
             logging.info("Updating version {0} in requirement {1} to dev build version".format(version, old_req))
             new_req = old_req.replace(version, "{}{}".format(version, DEV_BUILD_IDENTIFIER))
             logging.info("New requirement for package {0}: {1}".format(pkg_name, new_req))

--- a/eng/tox/sanitize_setup.py
+++ b/eng/tox/sanitize_setup.py
@@ -72,9 +72,23 @@ def get_version(pkg_name):
 
         return version
     else:
-        logging.error("setyp.py is not found for package {} to identify current version".format(pkg_name))
+        logging.error("setup.py is not found for package {} to identify current version".format(pkg_name))
         exit(1)
-   
+
+
+def get_base_version(pkg_name):
+    # find version for the package from source. This logic should be revisited to find version from devops feed
+    glob_path = os.path.join(root_dir, "sdk", "*", pkg_name, "setup.py")
+    paths = glob.glob(glob_path)
+    if paths:
+        setup_py_path = paths[0]
+        _, version, _ = parse_setup(setup_py_path)
+        version_obj = Version(version)
+        return version_obj.base_version
+    else:
+        logging.error("setup.py is not found for package {} to identify current version".format(pkg_name))
+        exit(1)
+
 
 def process_requires(setup_py_path):
     # This method process package requirement to verify if all required packages are available on PyPI
@@ -92,9 +106,10 @@ def process_requires(setup_py_path):
 
         if not is_required_version_on_pypi(pkg_name, spec):
             old_req = str(req)
-            version = get_version(pkg_name).base_version
+            version = get_version(pkg_name)
+            base_version = get_base_version(pkg_name)
             logging.info("Updating version {0} in requirement {1} to dev build version".format(version, old_req))
-            new_req = old_req.replace(version, "{}{}".format(version, DEV_BUILD_IDENTIFIER))
+            new_req = old_req.replace(version, "{}{}".format(base_version, DEV_BUILD_IDENTIFIER))
             logging.info("New requirement for package {0}: {1}".format(pkg_name, new_req))
             requirement_to_update[old_req] = new_req
 


### PR DESCRIPTION
We produce builds that are equivalent to <base_version>aYYYYMMDDN, actually require that when we take a dep on an unpublished package

Example. azure-storage-file-datalake (in a PR) is taking a dep on a new version of azure-storage-blob. `azure-storage-blob>=12.8.0b1`

The issue is that when we produce daily packages, we publish artifacts with versioning that looks like `12.8.0a20210210003` and the like.

Our dynamic `req` replacer that resolves this for the test environments that _don't_ install dev_requirements had a minor bug! Before this change, we would be replacing the requirement for the `alpha` package with something like the following `azure-storage-blob<13.0.0,>=12.8.0b1a`

Notice the fact that `a` is just added on? Yep. Bad. Needs to _replace_ the `pre` titling before that.


