### PR TITLE
Fix format string to be compatible with python version <3.6

### DIFF
--- a/eng/versioning/version_shared.py
+++ b/eng/versioning/version_shared.py
@@ -144,8 +144,8 @@ def update_change_log(setup_py_location, version, service, package, is_unrelease
         service,
         "--PackageName",
         package,
-        f"--Unreleased:${is_unreleased}",
-        f"--ReplaceLatestEntryTitle:${replace_latest_entry_title}",
+        "--Unreleased:${}".format(is_unreleased),
+        "--ReplaceLatestEntryTitle:${}".format(replace_latest_entry_title),
     ]
     if release_date is not None:
         commands.append("--ReleaseDate")


### PR DESCRIPTION
This is to accommodate places where a python version older than 3.6 is being used.
Unblocks https://dev.azure.com/azure-sdk/internal/_build/results?buildId=732638&view=logs&j=be2373b3-6b66-526b-20b8-841c5ec5eb4b&t=b70d2dda-49b9-5248-c844-52bce8972e6b