### PR TITLE
Replace isinstance call in Pipeline with structural checks

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/_base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/_base.py
@@ -141,6 +141,8 @@ class Pipeline(AbstractContextManager, Generic[HTTPRequestType, HTTPResponseType
             elif _implements_sansio_policy_protocol(policy):
                 policy = cast(SansIOHTTPPolicy, policy)
                 self._impl_policies.append(_SansIOHTTPPolicyRunner(policy))
+            elif policy is not None:
+                raise ValueError('A Pipeline policy must implement a "send" method or the SansIOHTTPPolicy protocol')
         for index in range(len(self._impl_policies) - 1):
             self._impl_policies[index].next = self._impl_policies[index + 1]
         if self._impl_policies:

--- a/sdk/core/azure-core/azure/core/pipeline/_base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/_base.py
@@ -33,6 +33,7 @@ from azure.core.pipeline import (
     PipelineContext,
 )
 from azure.core.pipeline.policies import HTTPPolicy, SansIOHTTPPolicy
+from .policies._base import _implements_sansio_policy_protocol
 from ._tools import await_result as _await_result
 
 HTTPResponseType = TypeVar("HTTPResponseType")
@@ -103,12 +104,6 @@ class _TransportRunner(HTTPPolicy):
             self._sender.send(request.http_request, **request.context.options),
             context=request.context,
         )
-
-
-def _implements_sansio_policy_protocol(obj):
-    # type: (Any) -> bool
-    """Returns a bool indicating whether an object implements SansIOHTTPPolicy's methods"""
-    return all(callable(getattr(obj, method, None)) for method in ("on_exception", "on_request", "on_response"))
 
 
 class Pipeline(AbstractContextManager, Generic[HTTPRequestType, HTTPResponseType]):

--- a/sdk/core/azure-core/azure/core/pipeline/_base_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/_base_async.py
@@ -150,6 +150,8 @@ class AsyncPipeline(
             elif _implements_sansio_policy_protocol(policy):
                 policy = cast(SansIOHTTPPolicy, policy)
                 self._impl_policies.append(_SansIOAsyncHTTPPolicyRunner(policy))
+            elif policy is not None:
+                raise ValueError('A Pipeline policy must implement a "send" method or the SansIOHTTPPolicy protocol')
         for index in range(len(self._impl_policies) - 1):
             self._impl_policies[index].next = self._impl_policies[index + 1]
         if self._impl_policies:

--- a/sdk/core/azure-core/azure/core/pipeline/_base_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/_base_async.py
@@ -29,7 +29,7 @@ from typing import Any, cast, Union, List, Generic, TypeVar, Dict
 
 from azure.core.pipeline import PipelineRequest, PipelineResponse, PipelineContext
 from azure.core.pipeline.policies import AsyncHTTPPolicy, SansIOHTTPPolicy
-from ._base import _implements_sansio_policy_protocol
+from .policies._base import _implements_sansio_policy_protocol
 from ._tools_async import await_result as _await_result
 
 AsyncHTTPResponseType = TypeVar("AsyncHTTPResponseType")

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_base.py
@@ -77,6 +77,12 @@ class HTTPPolicy(ABC, Generic[HTTPRequestType, HTTPResponseType]):
         """
 
 
+def _implements_sansio_policy_protocol(obj):
+    # type: (Any) -> bool
+    """Returns a bool indicating whether an object implements SansIOHTTPPolicy's methods"""
+    return all(callable(getattr(obj, method, None)) for method in ("on_exception", "on_request", "on_response"))
+
+
 class SansIOHTTPPolicy(Generic[HTTPRequestType, HTTPResponseType]):
     """Represents a sans I/O policy.
 

--- a/sdk/core/azure-core/tests/async_tests/test_pipeline_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_pipeline_async.py
@@ -59,6 +59,23 @@ import pytest
 
 
 @pytest.mark.asyncio
+async def test_ignores_none_policies():
+    """Pipeline shouldn't raise when a policy list includes None"""
+
+    completed_future = asyncio.Future()
+    completed_future.set_result(None)
+
+    transport = mock.Mock(send=mock.Mock(return_value=completed_future))
+    policy = mock.Mock(wraps=SansIOHTTPPolicy())
+    pipeline = AsyncPipeline(transport, policies=[None, policy, None])
+    await pipeline.run(HttpRequest("GET", "http://localhost"))
+
+    assert policy.on_request.called
+    assert policy.on_response.called
+    assert transport.send.called
+
+
+@pytest.mark.asyncio
 async def test_policy_wrapping():
     """AsyncPipeline should wrap only policies that implement the SansIOHTTPPolicy protocol and not send()"""
 

--- a/sdk/core/azure-core/tests/test_pipeline.py
+++ b/sdk/core/azure-core/tests/test_pipeline.py
@@ -66,6 +66,19 @@ from azure.core.pipeline.transport import (
 from azure.core.exceptions import AzureError
 
 
+def test_ignores_none_policies():
+    """Pipeline shouldn't raise when a policy list includes None"""
+
+    transport = mock.Mock()
+    policy = mock.Mock(wraps=SansIOHTTPPolicy())
+    pipeline = Pipeline(transport, policies=[None, policy, None])
+    pipeline.run(HttpRequest("GET", "http://localhost"))
+
+    assert policy.on_request.called
+    assert policy.on_response.called
+    assert transport.send.called
+
+
 def test_policy_wrapping():
     """Pipeline should wrap only policies that implement the SansIOHTTPPolicy protocol and not send()"""
 


### PR DESCRIPTION
Today, Pipeline calls `isinstance(policy, SansIOHTTPPolicy)` to decide whether to wrap a policy with a runner defining `send()`. Explicit type checking is contrary to our guidelines' preference for structural subtyping and it may also be useful to allow a SansIOHTTPPolicy to define its own `send()`. So, this PR replaces the `isinstance` call with structural checks: if a policy implements `send()`, Pipeline calls that method; otherwise, if a policy implements SansIOHTTPPolicy's methods, Pipeline wraps that policy with a runner. If an alleged policy doesn't define any of these methods, e.g. it's `None`, Pipeline ignores it.