### PR TITLE
skipping test if running against python 2.7

### DIFF
--- a/sdk/tables/azure-data-tables/tests/test_table_client_cosmos.py
+++ b/sdk/tables/azure-data-tables/tests/test_table_client_cosmos.py
@@ -94,6 +94,7 @@ class TestTableClient(AzureTestCase, TableTestCase):
         if self.is_live:
             sleep(SLEEP_DELAY)
 
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     @CosmosPreparer()
     def test_user_agent_append(self, tables_cosmos_account_name, tables_primary_cosmos_account_key):
         service = self.create_client_from_credential(


### PR DESCRIPTION
Removed this accidentally on the test refactor