### PR TITLE
[Key Vault] Refactor secrets test causing CI errors

### DIFF
--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_secrets_async.py
@@ -181,8 +181,9 @@ class KeyVaultSecretTest(KeyVaultTestCase):
             self.assertIsNotNone(deleted_secret.deleted_date)
             self.assertIsNotNone(deleted_secret.scheduled_purge_date)
             self.assertIsNotNone(deleted_secret.recovery_id)
-            expected_secret = expected[deleted_secret.name]
-            self._assert_secret_attributes_equal(expected_secret.properties, deleted_secret.properties)
+            if deleted_secret.name in expected:
+                expected_secret = expected[deleted_secret.name]
+                self._assert_secret_attributes_equal(expected_secret.properties, deleted_secret.properties)
 
     @KeyVaultPreparer()
     async def test_list_versions(self, azure_keyvault_url, **kwargs):


### PR DESCRIPTION
This fixes a test that was causing [errors](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=742293&view=logs&j=ff845fa3-3112-58e3-ba23-75e7e191708f&t=ef27c25c-b018-5410-41d6-24c2e158ad58) in pipeline tests by not accounting for secrets deleted in other live tests.