### PR TITLE
Check schema of the object to determine the type [preview4]

### DIFF
--- a/sdk/communication/azure-communication-chat/azure/communication/chat/_shared/models.py
+++ b/sdk/communication/azure-communication-chat/azure/communication/chat/_shared/models.py
@@ -108,13 +108,13 @@ class UnknownIdentifier(object):
     Represents an identifier of an unknown type.
     It will be encountered in communications with endpoints that are not
     identifiable by this version of the SDK.
-    :ivar identifier: Unknown communication identifier.
-    :vartype identifier: str
+    :ivar rawId: Unknown communication identifier.
+    :vartype rawId: str
     :param identifier: Value to initialize UnknownIdentifier.
     :type identifier: str
     """
     def __init__(self, identifier):
-        self.identifier = identifier
+        self.rawId = rawId
 
 class _CaseInsensitiveEnumMeta(EnumMeta):
     def __getitem__(self, name):

--- a/sdk/communication/azure-communication-chat/azure/communication/chat/_shared/models.py
+++ b/sdk/communication/azure-communication-chat/azure/communication/chat/_shared/models.py
@@ -108,13 +108,13 @@ class UnknownIdentifier(object):
     Represents an identifier of an unknown type.
     It will be encountered in communications with endpoints that are not
     identifiable by this version of the SDK.
-    :ivar rawId: Unknown communication identifier.
-    :vartype rawId: str
+    :ivar raw_id: Unknown communication identifier.
+    :vartype raw_id: str
     :param identifier: Value to initialize UnknownIdentifier.
     :type identifier: str
     """
     def __init__(self, identifier):
-        self.rawId = rawId
+        self.raw_id = identifier
 
 class _CaseInsensitiveEnumMeta(EnumMeta):
     def __getitem__(self, name):
@@ -148,7 +148,7 @@ class MicrosoftTeamsUserIdentifier(object):
     :vartype user_id: str
     :param user_id: Value to initialize MicrosoftTeamsUserIdentifier.
     :type user_id: str
-    :ivar rawId: Raw id of the Microsoft Teams user.
+    :ivar raw_id: Raw id of the Microsoft Teams user.
     :vartype raw_id: str
     :ivar cloud: Cloud environment that this identifier belongs to
     :vartype cloud: CommunicationCloudEnvironment

--- a/sdk/communication/azure-communication-chat/azure/communication/chat/communication_identifier_serializer.py
+++ b/sdk/communication/azure-communication-chat/azure/communication/chat/communication_identifier_serializer.py
@@ -5,15 +5,17 @@
 # --------------------------------------------------------------------------
 from enum import Enum
 
-from .models import (
+from ._generated.models import (
     CommunicationIdentifierModel,
+    CommunicationUserIdentifierModel,
+    PhoneNumberIdentifierModel,
+    MicrosoftTeamsUserIdentifierModel
+)
+from ._shared.models import (
     CommunicationUserIdentifier,
     PhoneNumberIdentifier,
     MicrosoftTeamsUserIdentifier,
     UnknownIdentifier,
-    CommunicationUserIdentifierModel,
-    PhoneNumberIdentifierModel,
-    MicrosoftTeamsUserIdentifierModel
 )
 
 class _IdentifierType(Enum):

--- a/sdk/communication/azure-communication-chat/azure/communication/chat/communication_identifier_serializer.py
+++ b/sdk/communication/azure-communication-chat/azure/communication/chat/communication_identifier_serializer.py
@@ -34,7 +34,7 @@ class CommunicationUserIdentifierSerializer(object):
         :rtype: ~azure.communication.chat.CommunicationIdentifierModel
         :raises Union[TypeError, ValueError]
         """
-        identifierType = CommunicationUserIdentifierSerializer._getIdnetifierType(communicationIdentifier)
+        identifierType = CommunicationUserIdentifierSerializer._getIdentifierType(communicationIdentifier)
 
         if identifierType == _IdentifierType.COMMUNICATION_USER_IDENTIFIER:
             return CommunicationIdentifierModel(

--- a/sdk/communication/azure-communication-chat/azure/communication/chat/communication_identifier_serializer.py
+++ b/sdk/communication/azure-communication-chat/azure/communication/chat/communication_identifier_serializer.py
@@ -57,7 +57,7 @@ class CommunicationUserIdentifierSerializer(object):
 
         if identifierType == _IdentifierType.UNKNOWN_IDENTIFIER:
             return CommunicationIdentifierModel(
-                raw_id=communicationIdentifier.unknownIdentifier
+                raw_id=communicationIdentifier.raw_id
             )
 
         raise TypeError("Unsupported identifier type " + communicationIdentifier.__class__.__name__)
@@ -128,6 +128,6 @@ class CommunicationUserIdentifierSerializer(object):
         if has_attributes(communicationIdentifier, ["raw_id", "user_id", "is_anonymous", "cloud"]):
             return _IdentifierType.MICROSOFT_TEAMS_IDENTIFIER
 
-        if has_attributes(communicationIdentifier, ["unknownIdentifier"]):
+        if has_attributes(communicationIdentifier, ["raw_id"]):
             return _IdentifierType.UNKNOWN_IDENTIFIER
 

--- a/sdk/communication/azure-communication-chat/azure/communication/chat/communication_identifier_serializer.py
+++ b/sdk/communication/azure-communication-chat/azure/communication/chat/communication_identifier_serializer.py
@@ -130,4 +130,3 @@ class CommunicationUserIdentifierSerializer(object):
 
         if has_attributes(communicationIdentifier, ["raw_id"]):
             return _IdentifierType.UNKNOWN_IDENTIFIER
-

--- a/sdk/communication/azure-communication-chat/tests/_shared/test_communication_identifier_serializer.py
+++ b/sdk/communication/azure-communication-chat/tests/_shared/test_communication_identifier_serializer.py
@@ -94,7 +94,7 @@ class CommunicationUserIdentifierSerializerTest(unittest.TestCase):
         unknown_identifier_expected = UnknownIdentifier("an id")
 
         assert isinstance(unknown_identifier_actual, UnknownIdentifier)
-        assert unknown_identifier_actual.identifier == unknown_identifier_expected.identifier
+        assert unknown_identifier_actual.rawId == unknown_identifier_expected.rawId
 
     def test_serialize_phone_number(self):
         phone_number_identifier_model = CommunicationUserIdentifierSerializer.serialize(

--- a/sdk/communication/azure-communication-chat/tests/_shared/test_communication_identifier_serializer.py
+++ b/sdk/communication/azure-communication-chat/tests/_shared/test_communication_identifier_serializer.py
@@ -94,7 +94,7 @@ class CommunicationUserIdentifierSerializerTest(unittest.TestCase):
         unknown_identifier_expected = UnknownIdentifier("an id")
 
         assert isinstance(unknown_identifier_actual, UnknownIdentifier)
-        assert unknown_identifier_actual.rawId == unknown_identifier_expected.rawId
+        assert unknown_identifier_actual.raw_id == unknown_identifier_expected.raw_id
 
     def test_serialize_phone_number(self):
         phone_number_identifier_model = CommunicationUserIdentifierSerializer.serialize(

--- a/sdk/communication/azure-communication-identity/azure/communication/identity/_shared/models.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/_shared/models.py
@@ -37,13 +37,13 @@ class UnknownIdentifier(object):
     Represents an identifier of an unknown type.
     It will be encountered in communications with endpoints that are not
     identifiable by this version of the SDK.
-    :ivar identifier: Unknown communication identifier.
-    :vartype identifier: str
+    :ivar rawId: Unknown communication identifier.
+    :vartype rawId: str
     :param identifier: Value to initialize UnknownIdentifier.
     :type identifier: str
     """
     def __init__(self, identifier):
-        self.identifier = identifier
+        self.rawId = rawId
 
 class _CaseInsensitiveEnumMeta(EnumMeta):
     def __getitem__(cls, name):

--- a/sdk/communication/azure-communication-identity/azure/communication/identity/_shared/models.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/_shared/models.py
@@ -37,13 +37,13 @@ class UnknownIdentifier(object):
     Represents an identifier of an unknown type.
     It will be encountered in communications with endpoints that are not
     identifiable by this version of the SDK.
-    :ivar rawId: Unknown communication identifier.
-    :vartype rawId: str
+    :ivar raw_id: Unknown communication identifier.
+    :vartype raw_id: str
     :param identifier: Value to initialize UnknownIdentifier.
     :type identifier: str
     """
     def __init__(self, identifier):
-        self.rawId = rawId
+        self.raw_id = identifier
 
 class _CaseInsensitiveEnumMeta(EnumMeta):
     def __getitem__(cls, name):

--- a/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_shared/models.py
+++ b/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_shared/models.py
@@ -37,13 +37,13 @@ class UnknownIdentifier(object):
     Represents an identifier of an unknown type.
     It will be encountered in communications with endpoints that are not
     identifiable by this version of the SDK.
-    :ivar identifier: Unknown communication identifier.
-    :vartype identifier: str
+    :ivar rawId: Unknown communication identifier.
+    :vartype rawId: str
     :param identifier: Value to initialize UnknownIdentifier.
     :type identifier: str
     """
     def __init__(self, identifier):
-        self.identifier = identifier
+        self.rawId = rawId
 
 class _CaseInsensitiveEnumMeta(EnumMeta):
     def __getitem__(cls, name):

--- a/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_shared/models.py
+++ b/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_shared/models.py
@@ -37,13 +37,13 @@ class UnknownIdentifier(object):
     Represents an identifier of an unknown type.
     It will be encountered in communications with endpoints that are not
     identifiable by this version of the SDK.
-    :ivar rawId: Unknown communication identifier.
-    :vartype rawId: str
+    :ivar raw_id: Unknown communication identifier.
+    :vartype raw_id: str
     :param identifier: Value to initialize UnknownIdentifier.
     :type identifier: str
     """
     def __init__(self, identifier):
-        self.rawId = rawId
+        self.raw_id = identifier
 
 class _CaseInsensitiveEnumMeta(EnumMeta):
     def __getitem__(cls, name):

--- a/sdk/communication/azure-communication-sms/azure/communication/sms/_shared/models.py
+++ b/sdk/communication/azure-communication-sms/azure/communication/sms/_shared/models.py
@@ -37,13 +37,13 @@ class UnknownIdentifier(object):
     Represents an identifier of an unknown type.
     It will be encountered in communications with endpoints that are not
     identifiable by this version of the SDK.
-    :ivar identifier: Unknown communication identifier.
-    :vartype identifier: str
+    :ivar rawId: Unknown communication identifier.
+    :vartype rawId: str
     :param identifier: Value to initialize UnknownIdentifier.
     :type identifier: str
     """
     def __init__(self, identifier):
-        self.identifier = identifier
+        self.rawId = rawId
 
 class CommunicationIdentifierModel(msrest.serialization.Model):
     """Communication Identifier Model.

--- a/sdk/communication/azure-communication-sms/azure/communication/sms/_shared/models.py
+++ b/sdk/communication/azure-communication-sms/azure/communication/sms/_shared/models.py
@@ -37,13 +37,13 @@ class UnknownIdentifier(object):
     Represents an identifier of an unknown type.
     It will be encountered in communications with endpoints that are not
     identifiable by this version of the SDK.
-    :ivar rawId: Unknown communication identifier.
-    :vartype rawId: str
+    :ivar raw_id: Unknown communication identifier.
+    :vartype raw_id: str
     :param identifier: Value to initialize UnknownIdentifier.
     :type identifier: str
     """
     def __init__(self, identifier):
-        self.rawId = rawId
+        self.raw_id = identifier
 
 class CommunicationIdentifierModel(msrest.serialization.Model):
     """Communication Identifier Model.


### PR DESCRIPTION
This PR checks the schema of the communicationIdentifierObject to determine the type during serialization. 
It also changes the schema of the `UnknownIdentifier` model class as it has the exact same schema as `CommunicationUserIdentifier`