### PR TITLE
[Key Vault] Add EncryptParameters analog in Python

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/__init__.py
@@ -2,7 +2,16 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from ._models import DecryptionAlgorithmConfiguration, DecryptResult, EncryptionAlgorithmConfiguration, EncryptResult, SignResult, WrapResult, VerifyResult, UnwrapResult
+from ._models import (
+    DecryptionAlgorithmConfiguration,
+    DecryptResult,
+    EncryptionAlgorithmConfiguration,
+    EncryptResult,
+    SignResult,
+    WrapResult,
+    VerifyResult,
+    UnwrapResult,
+)
 from ._enums import EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
 from ._client import CryptographyClient
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/__init__.py
@@ -2,15 +2,17 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from ._models import DecryptResult, EncryptResult, SignResult, WrapResult, VerifyResult, UnwrapResult
+from ._models import DecryptionAlgorithmConfiguration, DecryptResult, EncryptionAlgorithmConfiguration, EncryptResult, SignResult, WrapResult, VerifyResult, UnwrapResult
 from ._enums import EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
 from ._client import CryptographyClient
 
 
 __all__ = [
     "CryptographyClient",
+    "DecryptionAlgorithmConfiguration",
     "DecryptResult",
     "EncryptionAlgorithm",
+    "EncryptionAlgorithmConfiguration",
     "EncryptResult",
     "KeyWrapAlgorithm",
     "SignatureAlgorithm",

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
@@ -9,7 +9,16 @@ import six
 from azure.core.exceptions import HttpResponseError
 from azure.core.tracing.decorator import distributed_trace
 
-from . import DecryptionAlgorithmConfiguration, DecryptResult, EncryptionAlgorithmConfiguration, EncryptResult, SignResult, VerifyResult, UnwrapResult, WrapResult
+from . import (
+    DecryptionAlgorithmConfiguration,
+    DecryptResult,
+    EncryptionAlgorithmConfiguration,
+    EncryptResult,
+    SignResult,
+    VerifyResult,
+    UnwrapResult,
+    WrapResult,
+)
 from ._key_validity import raise_if_time_invalid
 from ._providers import get_local_cryptography_provider, NoLocalCryptography
 from .. import KeyOperation

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
@@ -4,8 +4,10 @@
 # ------------------------------------
 from typing import TYPE_CHECKING
 
+from ._enums import EncryptionAlgorithm
+
 if TYPE_CHECKING:
-    from . import EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
+    from . import KeyWrapAlgorithm, SignatureAlgorithm
 
 
 class EncryptionAlgorithmConfiguration():

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
@@ -8,6 +8,7 @@ from ._enums import EncryptionAlgorithm
 
 if TYPE_CHECKING:
     from . import KeyWrapAlgorithm, SignatureAlgorithm
+    from typing import Any
 
 
 class EncryptionAlgorithmConfiguration():

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
@@ -6,7 +6,141 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from . import EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
-    from typing import Any
+
+
+class EncryptionAlgorithmConfiguration():
+    """An encryption algorithm, including parameters applicable to using it for encryption.
+    """
+
+    def __init__(self, algorithm, **kwargs):
+        self.algorithm = algorithm
+        self.iv = kwargs.pop("iv", None)
+        self.additional_authenticated_data = kwargs.pop("additional_authenticated_data", None)
+
+    @classmethod
+    def rsa_oaep(cls):
+        return cls(EncryptionAlgorithm.rsa_oaep)
+
+    @classmethod
+    def rsa_oaep_256(cls):
+        return cls(EncryptionAlgorithm.rsa_oaep_256)
+
+    @classmethod
+    def rsa1_5(cls):
+        return cls(EncryptionAlgorithm.rsa1_5)
+
+    @classmethod
+    def a128_gcm(cls, additional_authenticated_data=None):
+        return cls(
+            EncryptionAlgorithm.a128_gcm, additional_authenticated_data=additional_authenticated_data
+        )
+
+    @classmethod
+    def a192_gcm(cls, additional_authenticated_data=None):
+        return cls(
+            EncryptionAlgorithm.a192_gcm, additional_authenticated_data=additional_authenticated_data
+        )
+
+    @classmethod
+    def a256_gcm(cls, additional_authenticated_data=None):
+        return cls(
+            EncryptionAlgorithm.a256_gcm, additional_authenticated_data=additional_authenticated_data
+        )
+
+    @classmethod
+    def a128_cbc(cls, iv=None):
+        return cls(EncryptionAlgorithm.a128_cbc, iv=iv)
+
+    @classmethod
+    def a192_cbc(cls, iv=None):
+        return cls(EncryptionAlgorithm.a192_cbc, iv=iv)
+
+    @classmethod
+    def a256_cbc(cls, iv=None):
+        return cls(EncryptionAlgorithm.a256_cbc, iv=iv)
+
+    @classmethod
+    def a128_cbcpad(cls, iv=None):
+        return cls(EncryptionAlgorithm.a128_cbcpad, iv=iv)
+
+    @classmethod
+    def a192_cbcpad(cls, iv=None):
+        return cls(EncryptionAlgorithm.a192_cbcpad, iv=iv)
+
+    @classmethod
+    def a256_cbcpad(cls, iv=None):
+        return cls(EncryptionAlgorithm.a256_cbcpad, iv=iv)
+
+
+class DecryptionAlgorithmConfiguration():
+    """An encryption algorithm, including parameters applicable to using it for decryption.
+    """
+
+    def __init__(self, algorithm, **kwargs):
+        self.algorithm = algorithm
+        self.iv = kwargs.pop("iv", None)
+        self.authentication_tag = kwargs.pop("authentication_tag", None)
+        self.additional_authenticated_data = kwargs.pop("additional_authenticated_data", None)
+
+    @classmethod
+    def rsa_oaep(cls):
+        return cls(EncryptionAlgorithm.rsa_oaep)
+
+    @classmethod
+    def rsa_oaep_256(cls):
+        return cls(EncryptionAlgorithm.rsa_oaep_256)
+
+    @classmethod
+    def rsa1_5(cls):
+        return cls(EncryptionAlgorithm.rsa1_5)
+
+    @classmethod
+    def a128_gcm(cls, authentication_tag=None, additional_authenticated_data=None):
+        return cls(
+            EncryptionAlgorithm.a128_gcm,
+            authentication_tag=authentication_tag,
+            additional_authenticated_data=additional_authenticated_data
+        )
+
+    @classmethod
+    def a192_gcm(cls, authentication_tag=None, additional_authenticated_data=None):
+        return cls(
+            EncryptionAlgorithm.a192_gcm,
+            authentication_tag=authentication_tag,
+            additional_authenticated_data=additional_authenticated_data
+        )
+
+    @classmethod
+    def a256_gcm(cls, authentication_tag=None, additional_authenticated_data=None):
+        return cls(
+            EncryptionAlgorithm.a256_gcm,
+            authentication_tag=authentication_tag,
+            additional_authenticated_data=additional_authenticated_data
+        )
+
+    @classmethod
+    def a128_cbc(cls, iv=None):
+        return cls(EncryptionAlgorithm.a128_cbc, iv=iv)
+
+    @classmethod
+    def a192_cbc(cls, iv=None):
+        return cls(EncryptionAlgorithm.a192_cbc, iv=iv)
+
+    @classmethod
+    def a256_cbc(cls, iv=None):
+        return cls(EncryptionAlgorithm.a256_cbc, iv=iv)
+
+    @classmethod
+    def a128_cbcpad(cls, iv=None):
+        return cls(EncryptionAlgorithm.a128_cbcpad, iv=iv)
+
+    @classmethod
+    def a192_cbcpad(cls, iv=None):
+        return cls(EncryptionAlgorithm.a192_cbcpad, iv=iv)
+
+    @classmethod
+    def a256_cbcpad(cls, iv=None):
+        return cls(EncryptionAlgorithm.a256_cbcpad, iv=iv)
 
 
 class DecryptResult:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
@@ -20,7 +20,13 @@ if TYPE_CHECKING:
     # pylint:disable=unused-import
     from typing import Any, Optional, Union
     from azure.core.credentials_async import AsyncTokenCredential
-    from .. import EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
+    from .. import (
+        DecryptionAlgorithmConfiguration,
+        EncryptionAlgorithm,
+        EncryptionAlgorithmConfiguration,
+        KeyWrapAlgorithm,
+        SignatureAlgorithm,
+    )
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -106,13 +112,18 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             self._initialized = self._keys_get_forbidden
 
     @distributed_trace_async
-    async def encrypt(self, algorithm: "EncryptionAlgorithm", plaintext: bytes, **kwargs: "Any") -> EncryptResult:
+    async def encrypt(
+        self,
+        algorithm: "Union[EncryptionAlgorithm, EncryptionAlgorithmConfiguration]",
+        plaintext: bytes,
+        **kwargs: "Any"
+    ) -> EncryptResult:
         """Encrypt bytes using the client's key. Requires the keys/encrypt permission.
 
         This method encrypts only a single block of data, whose size depends on the key and encryption algorithm.
 
         :param algorithm: encryption algorithm to use
-        :type algorithm: :class:`~azure.keyvault.keys.crypto.EncryptionAlgorithm`
+        :type algorithm: EncryptionAlgorithm or EncryptionAlgorithmConfiguration
         :param bytes plaintext: bytes to encrypt
         :keyword bytes iv: optional initialization vector. For use with AES-CBC encryption.
         :keyword bytes additional_authenticated_data: optional data that is authenticated but not encrypted. For use
@@ -157,13 +168,18 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def decrypt(self, algorithm: "EncryptionAlgorithm", ciphertext: bytes, **kwargs: "Any") -> DecryptResult:
+    async def decrypt(
+        self,
+        algorithm: "Union[EncryptionAlgorithm, DecryptionAlgorithmConfiguration]",
+        ciphertext: bytes,
+        **kwargs: "Any"
+    ) -> DecryptResult:
         """Decrypt a single block of encrypted data using the client's key. Requires the keys/decrypt permission.
 
         This method decrypts only a single block of data, whose size depends on the key and encryption algorithm.
 
         :param algorithm: encryption algorithm to use
-        :type algorithm: :class:`~azure.keyvault.keys.crypto.EncryptionAlgorithm`
+        :type algorithm: EncryptionAlgorithm or DecryptionAlgorithmConfiguration
         :param bytes ciphertext: encrypted bytes to decrypt
         :keyword bytes iv: the initialization vector used during encryption. For use with AES encryption.
         :keyword bytes authentication_tag: the authentication tag generated during encryption. For use with AES-GCM


### PR DESCRIPTION
Adds `EncryptionAlgorithmConfiguration` and `DecryptionAlgorithmConfiguration` classes, which are accepted as an `algorithm` argument in `encrypt` and `decrypt`, respectively, to lead users to provide appropriate arguments to encryption algorithms.