### PR TITLE
Fix date parsing in Azure Table entities

### DIFF
--- a/sdk/tables/azure-data-tables/azure/data/tables/_deserialize.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_deserialize.py
@@ -96,8 +96,12 @@ class Timezone(datetime.tzinfo):
 
 def _from_entity_datetime(value):
     # Cosmos returns this with a decimal point that throws an error on deserialization
-    if value[-9:] == ".0000000Z":
-        value = value[:-9] + "Z"
+    for suffix_len in (5, 9):
+        suffix = "." + ("0" * (suffix_len - 2)) + "Z"
+        if value[-suffix_len:] == suffix:
+            value = value[:-suffix_len] + "Z"
+            break
+
     return datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(
         tzinfo=Timezone()
     )


### PR DESCRIPTION
This fixes the following error:

ValueError: time data '2021-02-21T10:14:42.879Z' does not match format '%Y-%m-%dT%H:%M:%SZ'