### PR TITLE
Update Build Timeouts

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -86,6 +86,7 @@ parameters:
 
 jobs:
   - job: 'Build'
+    timeoutInMinutes: 90
     variables:
     - template: ../variables/globals.yml
 


### PR DESCRIPTION
`azure-mgmt-network` is [blowing out](https://dev.azure.com/azure-sdk/public/_build/results?buildId=745192&view=logs&jobId=b70e5e73-bbb6-5567-0939-8415943fadb9&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=651a14cc-88df-515d-1311-e0e8b23b578a) docs generation. It's not an issue of parallelization, it's just a gigantic project that sphinx takes forever to chew through. 
