### PR TITLE
Fixing credentials to use AAD

### DIFF
--- a/sdk/appconfiguration/azure-appconfiguration/tests/async_wrapper.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/async_wrapper.py
@@ -14,7 +14,6 @@ from azure.appconfiguration.aio import AzureAppConfigurationClient
 from azure.core.exceptions import (
     AzureError,
 )
-from azure.identity.aio import DefaultAzureCredential
 from consts import (
     KEY,
     LABEL,
@@ -79,6 +78,7 @@ def app_config_decorator(func, **kwargs):
 
         kwargs['client'] = client
         kwargs['appconfiguration_connection_string'] = appconfiguration_connection_string
+
         # Do setUp on client
         test_config_setting = _add_for_test(
             client,

--- a/sdk/appconfiguration/azure-appconfiguration/tests/async_wrapper.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/async_wrapper.py
@@ -6,14 +6,9 @@
 # --------------------------------------------------------------------------
 from devtools_testutils import PowerShellPreparer
 
-from azure.appconfiguration import (
-    ResourceReadOnlyError,
-    ConfigurationSetting,
-)
+from azure.appconfiguration import ConfigurationSetting
 from azure.appconfiguration.aio import AzureAppConfigurationClient
-from azure.core.exceptions import (
-    AzureError,
-)
+from azure.core.exceptions import AzureError
 from consts import (
     KEY,
     LABEL,
@@ -66,7 +61,6 @@ def trim_kwargs_from_test_function(fn, kwargs):
             args = set(args)
             for key in [k for k in kwargs if k not in args]:
                 del kwargs[key]
-
 
 def app_config_decorator(func, **kwargs):
 

--- a/sdk/appconfiguration/azure-appconfiguration/tests/async_wrapper.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/async_wrapper.py
@@ -14,6 +14,7 @@ from azure.appconfiguration.aio import AzureAppConfigurationClient
 from azure.core.exceptions import (
     AzureError,
 )
+from azure.identity.aio import DefaultAzureCredential
 from consts import (
     KEY,
     LABEL,
@@ -78,7 +79,6 @@ def app_config_decorator(func, **kwargs):
 
         kwargs['client'] = client
         kwargs['appconfiguration_connection_string'] = appconfiguration_connection_string
-
         # Do setUp on client
         test_config_setting = _add_for_test(
             client,

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_configuration_client.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_configuration_client.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 from azure.core import MatchConditions
-from devtools_testutils import AzureMgmtTestCase, PowerShellPreparer
+from devtools_testutils import AzureTestCase, PowerShellPreparer
 from azure.core.exceptions import (
     ResourceModifiedError,
     ResourceNotFoundError,
@@ -35,7 +35,7 @@ import logging
 import re
 import functools
 
-class AppConfigurationClientTest(AzureMgmtTestCase):
+class AppConfigurationClientTest(AzureTestCase):
     def __init__(self, method_name):
         super(AppConfigurationClientTest, self).__init__(method_name)
         self.vcr.match_on = ["path", "method", "query"]

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_configuration_client_aad.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_configuration_client_aad.py
@@ -47,6 +47,12 @@ from azure.core.credentials import AccessToken
 
 from wrapper import app_config_decorator
 
+
+class FakeCredential(object):
+    def get_token(self, *scopes, **kwargs):
+        return AccessToken("fake_token", 2527537086)
+
+
 class AppConfigurationClientTest(AzureTestCase):
     def __init__(self, method_name):
         super(AppConfigurationClientTest, self).__init__(method_name)
@@ -57,9 +63,15 @@ class AppConfigurationClientTest(AzureTestCase):
             key=item.key, label=item.label
         )
 
+    def create_aad_client(self, base_url):
+        cred = self.get_credential(AzureAppConfigurationClient)
+        return AzureAppConfigurationClient(base_url, cred)
+
     # method: add_configuration_setting
     @app_config_decorator
-    def test_add_configuration_setting(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_add_configuration_setting(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
+
         kv = ConfigurationSetting(
             key=KEY + "_ADD",
             label=LABEL,
@@ -82,7 +94,8 @@ class AppConfigurationClientTest(AzureTestCase):
         )
 
     @app_config_decorator
-    def test_add_existing_configuration_setting(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_add_existing_configuration_setting(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         with pytest.raises(ResourceExistsError):
             client.add_configuration_setting(
                 ConfigurationSetting(
@@ -93,7 +106,8 @@ class AppConfigurationClientTest(AzureTestCase):
 
     # method: set_configuration_setting
     @app_config_decorator
-    def test_set_existing_configuration_setting_label_etag(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_set_existing_configuration_setting_label_etag(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         to_set_kv = test_config_setting
         to_set_kv.value = to_set_kv.value + "a"
         to_set_kv.tags = {"a": "b", "c": "d"}
@@ -108,7 +122,8 @@ class AppConfigurationClientTest(AzureTestCase):
         )
 
     @app_config_decorator
-    def test_set_existing_configuration_setting_label_wrong_etag(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_set_existing_configuration_setting_label_wrong_etag(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         to_set_kv = test_config_setting
         to_set_kv.value = to_set_kv.value + "a"
         to_set_kv.tags = {"a": "b", "c": "d"}
@@ -117,7 +132,8 @@ class AppConfigurationClientTest(AzureTestCase):
             client.set_configuration_setting(to_set_kv, match_condition=MatchConditions.IfNotModified)
 
     @app_config_decorator
-    def test_set_configuration_setting_etag(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_set_configuration_setting_etag(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         kv = ConfigurationSetting(
             key=KEY + "_SET",
             label=LABEL,
@@ -130,7 +146,8 @@ class AppConfigurationClientTest(AzureTestCase):
             client.set_configuration_setting(kv, match_condition=MatchConditions.IfNotModified)
 
     @app_config_decorator
-    def test_set_configuration_setting_no_etag(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_set_configuration_setting_no_etag(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         to_set_kv = ConfigurationSetting(
             key=KEY + "_SET",
             label=LABEL,
@@ -151,7 +168,8 @@ class AppConfigurationClientTest(AzureTestCase):
 
     # method: get_configuration_setting
     @app_config_decorator
-    def test_get_configuration_setting_no_label(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_get_configuration_setting_no_label(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         compare_kv = test_config_setting_no_label
         fetched_kv = client.get_configuration_setting(compare_kv.key)
         assert (
@@ -163,7 +181,8 @@ class AppConfigurationClientTest(AzureTestCase):
         assert fetched_kv.label is None
 
     @app_config_decorator
-    def test_get_configuration_setting_label(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_get_configuration_setting_label(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         compare_kv = test_config_setting
         fetched_kv = client.get_configuration_setting(
             compare_kv.key, compare_kv.label
@@ -177,7 +196,8 @@ class AppConfigurationClientTest(AzureTestCase):
         assert fetched_kv.label is not None
 
     @app_config_decorator
-    def test_get_non_existing_configuration_setting(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_get_non_existing_configuration_setting(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         compare_kv = test_config_setting
         with pytest.raises(ResourceNotFoundError):
             client.get_configuration_setting(
@@ -186,7 +206,8 @@ class AppConfigurationClientTest(AzureTestCase):
 
     # method: delete_configuration_setting
     @app_config_decorator
-    def test_delete_with_key_no_label(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_delete_with_key_no_label(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         to_delete_kv = test_config_setting_no_label
         client.delete_configuration_setting(to_delete_kv.key)
         self._delete_setting(client, to_delete_kv)
@@ -194,7 +215,8 @@ class AppConfigurationClientTest(AzureTestCase):
             client.get_configuration_setting(to_delete_kv.key)
 
     @app_config_decorator
-    def test_delete_with_key_label(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_delete_with_key_label(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         to_delete_kv = test_config_setting
         client.delete_configuration_setting(
             to_delete_kv.key, label=to_delete_kv.label
@@ -206,14 +228,16 @@ class AppConfigurationClientTest(AzureTestCase):
             )
 
     @app_config_decorator
-    def test_delete_non_existing(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_delete_non_existing(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         deleted_kv = client.delete_configuration_setting(
             "not_exist_" + KEY
         )
         assert deleted_kv is None
 
     @app_config_decorator
-    def test_delete_correct_etag(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_delete_correct_etag(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         to_delete_kv = test_config_setting_no_label
         deleted_kv = client.delete_configuration_setting(
             to_delete_kv.key, etag=to_delete_kv.etag
@@ -224,7 +248,8 @@ class AppConfigurationClientTest(AzureTestCase):
             client.get_configuration_setting(to_delete_kv.key)
 
     @app_config_decorator
-    def test_delete_wrong_etag(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_delete_wrong_etag(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         to_delete_kv = test_config_setting_no_label
         with pytest.raises(ResourceModifiedError):
             client.delete_configuration_setting(
@@ -233,7 +258,8 @@ class AppConfigurationClientTest(AzureTestCase):
 
     # method: list_configuration_settings
     @app_config_decorator
-    def test_list_configuration_settings_key_label(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_list_configuration_settings_key_label(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         items = list(client.list_configuration_settings(
             label_filter=LABEL, key_filter=KEY
         ))
@@ -241,20 +267,23 @@ class AppConfigurationClientTest(AzureTestCase):
         assert all(x.key == KEY and x.label == LABEL for x in items)
 
     @app_config_decorator
-    def test_list_configuration_settings_only_label(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_list_configuration_settings_only_label(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         items = list(client.list_configuration_settings(label_filter=LABEL))
         assert len(items) == 1
         assert all(x.label == LABEL for x in items)
 
     @pytest.mark.skip("3 != 2, three items are returned")
     @app_config_decorator
-    def test_list_configuration_settings_only_key(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_list_configuration_settings_only_key(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         items = list(client.list_configuration_settings(key_filter=KEY))
         assert len(items) == 2
         assert all(x.key == KEY for x in items)
 
     @app_config_decorator
-    def test_list_configuration_settings_fields(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_list_configuration_settings_fields(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         items = list(client.list_configuration_settings(
             key_filter="*", label_filter=LABEL, fields=["key", "content_type"]
         ))
@@ -263,7 +292,8 @@ class AppConfigurationClientTest(AzureTestCase):
 
     @pytest.mark.skip("ResourceExistsError: Operation returned an invalid status 'Precondition Failed'")
     @app_config_decorator
-    def test_list_configuration_settings_reserved_chars(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_list_configuration_settings_reserved_chars(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         resered_char_kv = ConfigurationSetting(
             key=KEY, label=LABEL_RESERVED_CHARS, value=TEST_VALUE
         )
@@ -280,7 +310,8 @@ class AppConfigurationClientTest(AzureTestCase):
 
     @pytest.mark.skip("Bad Request")
     @app_config_decorator
-    def test_list_configuration_settings_contains(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_list_configuration_settings_contains(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         items = list(client.list_configuration_settings(
             label_filter="*" + LABEL + "*"
         ))
@@ -288,7 +319,8 @@ class AppConfigurationClientTest(AzureTestCase):
         assert all(x.label == LABEL for x in items)
 
     @app_config_decorator
-    def test_list_configuration_settings_correct_etag(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_list_configuration_settings_correct_etag(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         to_list_kv = test_config_setting
         custom_headers = {"If-Match": to_list_kv.etag}
         items = list(client.list_configuration_settings(
@@ -298,7 +330,8 @@ class AppConfigurationClientTest(AzureTestCase):
         assert all(x.key == to_list_kv.key and x.label == to_list_kv.label for x in items)
 
     @app_config_decorator
-    def test_list_configuration_settings_multi_pages(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_list_configuration_settings_multi_pages(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         # create PAGE_SIZE+1 configuration settings to have at least two pages
         try:
             delete_me = [
@@ -328,12 +361,14 @@ class AppConfigurationClientTest(AzureTestCase):
             pass
 
     @app_config_decorator
-    def test_list_configuration_settings_null_label(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_list_configuration_settings_null_label(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         items = client.list_configuration_settings(label_filter="\0")
         assert len(list(items)) > 0
 
     @app_config_decorator
-    def test_list_configuration_settings_only_accepttime(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_list_configuration_settings_only_accepttime(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         exclude_today = client.list_configuration_settings(
             accept_datetime=datetime.datetime.today() + datetime.timedelta(days=-1)
         )
@@ -342,7 +377,8 @@ class AppConfigurationClientTest(AzureTestCase):
 
     # method: list_revisions
     @app_config_decorator
-    def test_list_revisions_key_label(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_list_revisions_key_label(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         to_list1 = test_config_setting
         items = list(client.list_revisions(
             label_filter=to_list1.label, key_filter=to_list1.key
@@ -351,27 +387,31 @@ class AppConfigurationClientTest(AzureTestCase):
         assert all(x.key == to_list1.key and x.label == to_list1.label for x in items)
 
     @app_config_decorator
-    def test_list_revisions_only_label(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_list_revisions_only_label(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         items = list(client.list_revisions(label_filter=LABEL))
         assert len(items) >= 1
         assert all(x.label == LABEL for x in items)
 
     @app_config_decorator
-    def test_list_revisions_key_no_label(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_list_revisions_key_no_label(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         items = list(client.list_revisions(key_filter=KEY))
         assert len(items) >= 1
         assert all(x.key == KEY for x in items)
 
     @pytest.mark.skip("Operation returned an invalid status 'Internal Server Error'")
     @app_config_decorator
-    def test_list_revisions_fields(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_list_revisions_fields(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         items = list(client.list_revisions(
             key_filter="*", label_filter=LABEL, fields=["key", "content_type"]
         ))
         assert all(x.key and not x.label and x.content_type and not x.tags and not x.etag for x in items)
 
     @app_config_decorator
-    def test_list_revisions_correct_etag(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_list_revisions_correct_etag(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         to_list_kv = test_config_setting
         custom_headers = {"If-Match": to_list_kv.etag}
         items = list(client.list_revisions(
@@ -381,7 +421,8 @@ class AppConfigurationClientTest(AzureTestCase):
         assert all(x.key == to_list_kv.key and x.label == to_list_kv.label for x in items)
 
     @app_config_decorator
-    def test_read_only(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_read_only(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         kv = test_config_setting_no_label
         read_only_kv = client.set_read_only(kv)
         assert read_only_kv.read_only
@@ -389,7 +430,8 @@ class AppConfigurationClientTest(AzureTestCase):
         assert not readable_kv.read_only
 
     @app_config_decorator
-    def test_delete_read_only(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_delete_read_only(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         to_delete_kv = test_config_setting_no_label
         read_only_kv = client.set_read_only(to_delete_kv)
         with pytest.raises(ResourceReadOnlyError):
@@ -401,7 +443,8 @@ class AppConfigurationClientTest(AzureTestCase):
             client.get_configuration_setting(to_delete_kv.key)
 
     @app_config_decorator
-    def test_set_read_only(self, client, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+    def test_set_read_only(self, appconfiguration_endpoint_string, test_config_setting, test_config_setting_no_label):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
         to_set_kv = test_config_setting
         to_set_kv.value = to_set_kv.value + "a"
         to_set_kv.tags = {"a": "b", "c": "d"}

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_configuration_client_aad.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_configuration_client_aad.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 from azure.core import MatchConditions
-from devtools_testutils import AzureTestCase, PowerShellPreparer
+from devtools_testutils import AzureTestCase
 from azure.core.exceptions import (
     ResourceModifiedError,
     ResourceNotFoundError,
@@ -16,7 +16,6 @@ from azure.appconfiguration import (
     AzureAppConfigurationClient,
     ConfigurationSetting,
 )
-from azure.identity import DefaultAzureCredential
 from consts import (
     KEY,
     LABEL,
@@ -33,24 +32,7 @@ import logging
 import re
 import functools
 
-AppConfigPreparer = functools.partial(
-    PowerShellPreparer,
-    'appconfiguration',
-    appconfiguration_connection_string="Endpoint=https://fake_app_config.azconfig-test.io;Id=0-l4-s0:h5htBaY5Z1LwFz50bIQv;Secret=lamefakesecretlamefakesecretlamefakesecrett=",
-    appconfiguration_endpoint_string="https://fake_app_config.azconfig-test.io")
-
-try:
-    from unittest.mock import Mock
-except ImportError:  # python < 3.3
-    from mock import Mock
-from azure.core.credentials import AccessToken
-
 from wrapper import app_config_decorator
-
-
-class FakeCredential(object):
-    def get_token(self, *scopes, **kwargs):
-        return AccessToken("fake_token", 2527537086)
 
 
 class AppConfigurationClientTest(AzureTestCase):

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_configuration_client_aad_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_configuration_client_aad_async.py
@@ -4,14 +4,13 @@
 # license information.
 # --------------------------------------------------------------------------
 from azure.core import MatchConditions
-from devtools_testutils import AzureMgmtTestCase, PowerShellPreparer
+from devtools_testutils import AzureTestCase
 from azure.core.exceptions import (
     ResourceModifiedError,
     ResourceNotFoundError,
     ResourceExistsError,
     AzureError,
 )
-from azure.identity.aio import DefaultAzureCredential
 from azure.appconfiguration import (
     ResourceReadOnlyError,
     ConfigurationSetting,
@@ -37,7 +36,7 @@ from async_wrapper import app_config_decorator
 from async_proxy import AzureAppConfigurationClientProxy
 
 
-class AppConfigurationClientTest(AzureMgmtTestCase):
+class AppConfigurationClientTest(AzureTestCase):
     def __init__(self, method_name):
         super(AppConfigurationClientTest, self).__init__(method_name)
         self.vcr.match_on = ["path", "method", "query"]

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_configuration_client_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_configuration_client_async.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 from azure.core import MatchConditions
-from devtools_testutils import AzureMgmtTestCase, PowerShellPreparer
+from devtools_testutils import AzureTestCase, PowerShellPreparer
 from azure.core.exceptions import (
     ResourceModifiedError,
     ResourceNotFoundError,
@@ -35,7 +35,7 @@ import functools
 
 from async_wrapper import app_config_decorator
 
-class AppConfigurationClientTest(AzureMgmtTestCase):
+class AppConfigurationClientTest(AzureTestCase):
     def __init__(self, method_name):
         super(AppConfigurationClientTest, self).__init__(method_name)
         self.vcr.match_on = ["path", "method", "query"]

--- a/sdk/appconfiguration/azure-appconfiguration/tests/wrapper.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/wrapper.py
@@ -9,9 +9,7 @@ from azure.appconfiguration import (
     AzureAppConfigurationClient,
     ConfigurationSetting,
 )
-from azure.core.exceptions import (
-    AzureError,
-)
+from azure.core.exceptions import AzureError
 from consts import (
     KEY,
     LABEL,
@@ -21,7 +19,6 @@ from consts import (
     PAGE_SIZE,
     KEY_UUID,
 )
-import os
 import functools
 import inspect
 
@@ -64,7 +61,6 @@ def trim_kwargs_from_test_function(fn, kwargs):
             args = set(args)
             for key in [k for k in kwargs if k not in args]:
                 del kwargs[key]
-
 
 def app_config_decorator(func, **kwargs):
 

--- a/sdk/appconfiguration/azure-appconfiguration/tests/wrapper.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/wrapper.py
@@ -12,7 +12,6 @@ from azure.appconfiguration import (
 from azure.core.exceptions import (
     AzureError,
 )
-from azure.identity import DefaultAzureCredential
 from consts import (
     KEY,
     LABEL,

--- a/sdk/appconfiguration/azure-appconfiguration/tests/wrapper.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/wrapper.py
@@ -12,6 +12,7 @@ from azure.appconfiguration import (
 from azure.core.exceptions import (
     AzureError,
 )
+from azure.identity import DefaultAzureCredential
 from consts import (
     KEY,
     LABEL,
@@ -107,55 +108,6 @@ def app_config_decorator(func, **kwargs):
 
         func(*args, **trimmed_kwargs)
 
-        for item in to_delete:
-            client.delete_configuration_setting(
-                key=item.key, label=item.label
-            )
-
-    return wrapper
-
-def async_app_config_decorator(func, **kwargs):
-
-    @AppConfigPreparer()
-    def wrapper(*args, **kwargs):
-        appconfiguration_connection_string = kwargs.pop("appconfiguration_connection_string")
-        client = AzureAppConfigurationClient.from_connection_string(appconfiguration_connection_string)
-
-        kwargs['client'] = client
-        kwargs['appconfiguration_connection_string'] = appconfiguration_connection_string
-
-        # Do setUp on client
-        test_config_setting = _add_for_test(
-            client,
-            ConfigurationSetting(
-                key=KEY,
-                label=LABEL,
-                value=TEST_VALUE,
-                content_type=TEST_CONTENT_TYPE,
-                tags={"tag1": "tag1", "tag2": "tag2"},
-            )
-        )
-        test_config_setting_no_label = _add_for_test(
-            client,
-            ConfigurationSetting(
-                key=KEY,
-                label=None,
-                value=TEST_VALUE,
-                content_type=TEST_CONTENT_TYPE,
-                tags={"tag1": "tag1", "tag2": "tag2"},
-            )
-        )
-        to_delete = [test_config_setting, test_config_setting_no_label]
-
-        kwargs['test_config_setting'] = test_config_setting
-        kwargs['test_config_setting_no_label'] = test_config_setting_no_label
-
-        trimmed_kwargs = {k:v for k, v in kwargs.items()}
-        trim_kwargs_from_test_function(func, trimmed_kwargs)
-
-        func(*args, **trimmed_kwargs)
-
-        # do tearDown on client
         for item in to_delete:
             client.delete_configuration_setting(
                 key=item.key, label=item.label


### PR DESCRIPTION
Noticed the `test_*_aad(_async).py` didn't use AAD, instead authenticating with a connection string, this PR fixes that situation.