### PR TITLE
adjust the filecount in integration stage so we don't attempt to push non-alpha packages 

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -286,7 +286,8 @@ stages:
               $packageDirectory = "${{artifact.name}}".Replace("_", "-")
               echo "##vso[task.setvariable variable=Package.Name]$packageDirectory"
           - pwsh: |
-              $fileCount = (Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}/$packageDirectory  | Measure-Object).Count
+              $fileCount = (Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}/$packageDirectory -Filter $packageDirectory-[0-9]*.[0-9]*.[0-9]*a[0-9]*  | Measure-Object).Count
+              
               if ($fileCount -eq 0) {
                 Write-Host "No alpha packages for ${{artifact.safeName}} to publish."
                 exit 0


### PR DESCRIPTION
I have verified with a local copy of an artifact set. Properly filters out non-alpha packages.

@seankane-msft  when you check it an approve, can you check-enforcer override? No checks will trigger for this boyo.