### PR TITLE
Change test pipeline to run in eastus2

### DIFF
--- a/sdk/mixedreality/tests.yml
+++ b/sdk/mixedreality/tests.yml
@@ -6,6 +6,7 @@ stages:
       AllocateResourceGroup: false
       ServiceDirectory: mixedreality
       DeployArmTemplate: true
+      Location: eastus2
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)


### PR DESCRIPTION
  - The test resources rely on an ASA account, which isn't available in westus2, the default region.  So, i've adjusted the region to eastus2.