### PR TITLE
Adding azure-devtools to mr-auth dev_requirements

### DIFF
--- a/sdk/mixedreality/azure-mixedreality-authentication/dev_requirements.txt
+++ b/sdk/mixedreality/azure-mixedreality-authentication/dev_requirements.txt
@@ -2,3 +2,4 @@
 ../azure-mixedreality-nspkg
 ../../core/azure-core
 aiohttp>=3.0; python_version >= '3.5'
+-e ../../../tools/azure-devtools


### PR DESCRIPTION
  - This is the only difference I can spot with other libraries. I'm going to add it to see if it solves the problem with running the tests.