### PR TITLE
Update azure-core minimum version

### DIFF
--- a/sdk/mixedreality/azure-mixedreality-authentication/setup.py
+++ b/sdk/mixedreality/azure-mixedreality-authentication/setup.py
@@ -66,7 +66,7 @@ setup(
         'azure.mixedreality'
     ]),
     install_requires=[
-        'azure-core<2.0.0,>=1.2.2',
+        'azure-core<2.0.0,>=1.4.0',
         'msrest>=0.5.0'
     ],
     extras_require={

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -197,3 +197,4 @@ opentelemetry-sdk==0.17b0
 #override azure-identity six>=1.12.0
 #override azure-ai-formrecognizer
 #override azure-ai-metricsadvisor
+#override azure-mixedreality-authentication azure-core<2.0.0,>=1.4.0

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -195,6 +195,4 @@ opentelemetry-sdk==0.17b0
 #override azure-monitor-opentelemetry-exporter opentelemetry-sdk==1.0.0rc1
 #override azure-core-tracing-opentelemetry opentelemetry-api==0.17b0
 #override azure-identity six>=1.12.0
-#override azure-ai-formrecognizer
-#override azure-ai-metricsadvisor
 #override azure-mixedreality-authentication azure-core<2.0.0,>=1.4.0


### PR DESCRIPTION
  - This change updates the minimum version of Azure Core to 1.4.0 to make sure we get a package version that includes AzureKeyCredential to fix the nightly release builds.