### PR TITLE
Update OT to 1.0.0

### DIFF
--- a/sdk/core/azure-core-tracing-opencensus/azure/core/tracing/ext/opencensus_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opencensus/azure/core/tracing/ext/opencensus_span/__init__.py
@@ -46,8 +46,8 @@ _config_integration.trace_integrations(['threading'])
 class OpenCensusSpan(HttpSpanMixin, object):
     """Wraps a given OpenCensus Span so that it implements azure.core.tracing.AbstractSpan"""
 
-    def __init__(self, span=None, name="span"):
-        # type: (Optional[Span], Optional[str]) -> None
+    def __init__(self, span=None, name="span", **kwargs):
+        # type: (Optional[Span], Optional[str], Any) -> None
         """
         If a span is not passed in, creates a new tracer. If the instrumentation key for Azure Exporter is given, will
         configure the azure exporter else will just create a new tracer.
@@ -58,7 +58,7 @@ class OpenCensusSpan(HttpSpanMixin, object):
         :type name: str
         """
         tracer = self.get_current_tracer()
-        self._span_instance = span or tracer.start_span(name=name)
+        self._span_instance = span or tracer.start_span(name=name, **kwargs)
 
     @property
     def span_instance(self):

--- a/sdk/core/azure-core-tracing-opencensus/azure/core/tracing/ext/opencensus_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opencensus/azure/core/tracing/ext/opencensus_span/__init__.py
@@ -56,6 +56,9 @@ class OpenCensusSpan(HttpSpanMixin, object):
         :type span: :class: opencensus.trace.Span
         :param name: The name of the OpenCensus span to create if a new span is needed
         :type name: str
+        :keyword SpanKind kind: The span kind of this span.
+        :keyword links: The list of links to be added to the span.
+        :paramtype links: list[~azure.core.tracing.Link]
         """
         tracer = self.get_current_tracer()
         self._span_instance = span or tracer.start_span(name=name, **kwargs)
@@ -74,6 +77,9 @@ class OpenCensusSpan(HttpSpanMixin, object):
         Create a child span for the current span and append it to the child spans list in the span instance.
         :param name: Name of the child span
         :type name: str
+        :keyword SpanKind kind: The span kind of this span.
+        :keyword links: The list of links to be added to the span.
+        :paramtype links: list[~azure.core.tracing.Link]
         :return: The OpenCensusSpan that is wrapping the child span instance
         """
         return self.__class__(name=name, **kwargs)

--- a/sdk/core/azure-core-tracing-opencensus/azure/core/tracing/ext/opencensus_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opencensus/azure/core/tracing/ext/opencensus_span/__init__.py
@@ -68,15 +68,15 @@ class OpenCensusSpan(HttpSpanMixin, object):
         """
         return self._span_instance
 
-    def span(self, name="span"):
-        # type: (Optional[str]) -> OpenCensusSpan
+    def span(self, name="span", **kwargs):
+        # type: (Optional[str], Any) -> OpenCensusSpan
         """
         Create a child span for the current span and append it to the child spans list in the span instance.
         :param name: Name of the child span
         :type name: str
         :return: The OpenCensusSpan that is wrapping the child span instance
         """
-        return self.__class__(name=name)
+        return self.__class__(name=name, **kwargs)
 
     @property
     def kind(self):

--- a/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
+++ b/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0b9 (Unreleased)
 
+- Pinned opentelemetry-api to version 1.0.0rc1
 
 ## 1.0.0b8 (2021-02-08)
 

--- a/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
+++ b/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0b9 (Unreleased)
 
 - Pinned opentelemetry-api to version 1.0.0
+- `Link` and `SpanKind` can now be added while creating the span instance.
 
 ## 1.0.0b8 (2021-02-08)
 

--- a/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
+++ b/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.0b9 (Unreleased)
 
-- Pinned opentelemetry-api to version 1.0.0rc1
+- Pinned opentelemetry-api to version 1.0.0
 
 ## 1.0.0b8 (2021-02-08)
 

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -120,7 +120,7 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         )
         if kind is None:
             raise ValueError("Kind {} is not supported in OpenTelemetry".format(value))
-        self.span_instance.kind = kind
+        self.span_instance.set_attribute("kind", kind)
 
     def __enter__(self):
         """Start a span."""

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -206,7 +206,7 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         ctx = extract(DictGetter(), headers)
         span_ctx = get_span_from_context(ctx).get_span_context()
         current_span = cls.get_current_span()
-        updated_links = current_span.links + [Link(span_ctx, attributes)]
+        updated_links = current_span.links + (Link(span_ctx, attributes),)
         current_span.set_attribute("links", updated_links)
         #current_span.links.append(Link(span_ctx, attributes))
 

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -93,7 +93,7 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         return self._span_instance
 
     def span(self, name="span", **kwargs):
-        # type: (Optional[str]) -> OpenTelemetrySpan
+        # type: (Optional[str], Any) -> OpenTelemetrySpan
         """
         Create a child span for the current span and append it to the child spans list in the span instance.
         :param name: Name of the child span

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -77,7 +77,7 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
                     ctx = extract(link.headers)
                     span_ctx = get_span_from_context(ctx).get_span_context()
                     ot_links.append(OpenTelemetryLink(span_ctx, link.attributes))
-                    kwargs.setdefault('links', ot_links)
+                kwargs.setdefault('links', ot_links)
             except AttributeError:
                 # we will just send the links as is if it's not ~azure.core.tracing.Link without any validation
                 # assuming user knows what they are doing.

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 """Implements azure.core.tracing.AbstractSpan to wrap OpenTelemetry spans."""
 
+import warnings
 from opentelemetry import trace
 from opentelemetry.trace import Span, Link, Tracer, SpanKind as OpenTelemetrySpanKind
 from opentelemetry.context import attach, detach, get_current
@@ -120,6 +121,11 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
     def kind(self, value):
         # type: (SpanKind) -> None
         """Set the span kind of this span."""
+        warnings.warn(
+            """Kind must be set while creating the span for Opentelemetry. It might be possible
+            that one of the packages you are using doesn't follow the latest Opentelemtry Spec.
+            Try updating the azure pacakges to the latest versions."""
+        )
         kind = (
             OpenTelemetrySpanKind.CLIENT if value == SpanKind.CLIENT else
             OpenTelemetrySpanKind.PRODUCER if value == SpanKind.PRODUCER else
@@ -214,6 +220,11 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         :param headers: A key value pair dictionary
         :type headers: dict
         """
+        warnings.warn(
+            """Link must be added while creating the span for Opentelemetry. It might be possible
+            that one of the packages you are using doesn't follow the latest Opentelemtry Spec.
+            Try updating the azure pacakges to the latest versions."""
+        )
         ctx = extract(DictGetter(), headers)
         span_ctx = get_span_from_context(ctx).get_span_context()
         current_span = cls.get_current_span()

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -145,7 +145,7 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
 
     def __enter__(self):
         """Start a span."""
-        self._current_ctxt_manager = self.get_current_tracer().use_span(self._span_instance, end_on_exit=True)
+        self._current_ctxt_manager = trace.use_span(self._span_instance, end_on_exit=True)
         self._current_ctxt_manager.__enter__()
         return self
 
@@ -171,7 +171,7 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         :return: A key value pair dictionary
         """
         temp_headers = {} # type: Dict[str, str]
-        inject(_set_headers_from_http_request_headers, temp_headers)
+        inject(temp_headers)
         return temp_headers
 
     def add_attribute(self, key, value):
@@ -235,7 +235,7 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
             that one of the packages you are using doesn't follow the latest Opentelemtry Spec.
             Try updating the azure pacakges to the latest versions."""
         )
-        ctx = extract(DictGetter(), headers)
+        ctx = extract(headers)
         span_ctx = get_span_from_context(ctx).get_span_context()
         current_span = cls.get_current_span()
         current_span._links.append(Link(span_ctx, attributes)) # pylint: disable=protected-access
@@ -261,7 +261,7 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         # type: (Span) -> ContextManager
         """Change the context for the life of this context manager.
         """
-        return cls.get_current_tracer().use_span(span, end_on_exit=False)
+        return trace.use_span(span, end_on_exit=False)
 
     @classmethod
     def set_current_span(cls, span):

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -21,7 +21,7 @@ except ImportError:
     TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    from typing import Any, Mapping, MutableMapping, Dict, Optional, Union, Callable, Sequence
+    from typing import Any, Mapping, Dict, Optional, Union, Callable, Sequence
 
     from azure.core.pipeline.transport import HttpRequest, HttpResponse
     AttributeValue = Union[
@@ -37,24 +37,6 @@ if TYPE_CHECKING:
     Attributes = Optional[Dict[str, AttributeValue]]
 
 __version__ = VERSION
-
-
-def _get_headers_from_http_request_headers(headers: "Mapping[str, Any]", key: str):
-    """Return headers that matches this key.
-
-    Must comply to opentelemetry.context.propagation.httptextformat.Getter:
-    Getter = typing.Callable[[_T, str], typing.List[str]]
-    """
-    return [headers.get(key, "")]
-
-
-def _set_headers_from_http_request_headers(headers: "MutableMapping[str, Any]", key: str, value: str):
-    """Set headers in the given headers dict.
-
-    Must comply to opentelemetry.context.propagation.httptextformat.Setter:
-    Setter = typing.Callable[[_T, str, str], None]
-    """
-    headers[key] = value
 
 
 class OpenTelemetrySpan(HttpSpanMixin, object):

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -66,10 +66,10 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
     :type name: str
     """
 
-    def __init__(self, span=None, name="span"):
-        # type: (Optional[Span], Optional[str]) -> None
+    def __init__(self, span=None, name="span", **kwargs):
+        # type: (Optional[Span], Optional[str], Any) -> None
         current_tracer = self.get_current_tracer()
-        self._span_instance = span or current_tracer.start_span(name=name)
+        self._span_instance = span or current_tracer.start_span(name=name, **kwargs)
         self._current_ctxt_manager = None
 
     @property
@@ -80,7 +80,7 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         """
         return self._span_instance
 
-    def span(self, name="span"):
+    def span(self, name="span", **kwargs):
         # type: (Optional[str]) -> OpenTelemetrySpan
         """
         Create a child span for the current span and append it to the child spans list in the span instance.
@@ -88,7 +88,7 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         :type name: str
         :return: The OpenTelemetrySpan that is wrapping the child span instance
         """
-        return self.__class__(name=name)
+        return self.__class__(name=name, **kwargs)
 
     @property
     def kind(self):
@@ -206,7 +206,7 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         ctx = extract(DictGetter(), headers)
         span_ctx = get_span_from_context(ctx).get_span_context()
         current_span = cls.get_current_span()
-        current_span._links.append(Link(span_ctx, attributes))        
+        current_span._links.append(Link(span_ctx, attributes))
 
     @classmethod
     def get_current_span(cls):

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -120,7 +120,7 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         )
         if kind is None:
             raise ValueError("Kind {} is not supported in OpenTelemetry".format(value))
-        self.span_instance.set_attribute("kind", kind)
+        self._span_instance._kind = kind
 
     def __enter__(self):
         """Start a span."""
@@ -206,9 +206,7 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         ctx = extract(DictGetter(), headers)
         span_ctx = get_span_from_context(ctx).get_span_context()
         current_span = cls.get_current_span()
-        updated_links = current_span.links + (Link(span_ctx, attributes),)
-        current_span.set_attribute("links", updated_links)
-        #current_span.links.append(Link(span_ctx, attributes))
+        current_span._links.append(Link(span_ctx, attributes))        
 
     @classmethod
     def get_current_span(cls):

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -47,6 +47,8 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
     :param name: The name of the OpenTelemetry span to create if a new span is needed
     :type name: str
     :keyword SpanKind kind: The span kind of this span.
+    :keyword links: The list of links to be added to the span.
+    :paramtype links: list[Link]
     """
 
     def __init__(self, span=None, name="span", **kwargs):
@@ -84,6 +86,9 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         Create a child span for the current span and append it to the child spans list in the span instance.
         :param name: Name of the child span
         :type name: str
+        :keyword SpanKind kind: The span kind of this span.
+        :keyword links: The list of links to be added to the span.
+        :paramtype links: list[Link]
         :return: The OpenTelemetrySpan that is wrapping the child span instance
         """
         return self.__class__(name=name, **kwargs)

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -128,13 +128,13 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
     def __enter__(self):
         """Start a span."""
         self._current_ctxt_manager = trace.use_span(self._span_instance, end_on_exit=True)
-        self._current_ctxt_manager.__enter__()
+        self._current_ctxt_manager.__enter__() # pylint: disable=no-member
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
         """Finish a span."""
         if self._current_ctxt_manager:
-            self._current_ctxt_manager.__exit__(exception_type, exception_value, traceback)
+            self._current_ctxt_manager.__exit__(exception_type, exception_value, traceback) # pylint: disable=no-member
             self._current_ctxt_manager = None
 
     def start(self):

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -199,6 +199,15 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
 
     @staticmethod
     def create_link_from_headers(headers, attributes=None):
+        # type: (Dict[str, str], Attributes) -> Link
+        """
+        Given a dictionary, extracts the context and creates a link that can be added to spans.
+
+        :param headers: A dictionary of the request header as key value pairs.
+        :type headers: dict
+        :param attributes: Any additional attributes that should be added to link
+        :type attributes: dict
+        """
         ctx = extract(headers)
         span_ctx = get_span_from_context(ctx).get_span_context()
         return Link(span_ctx, attributes)

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -198,7 +198,7 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         }, attributes)
 
     @staticmethod
-    def create_link_from_headers(cls, headers, attributes=None):
+    def create_link_from_headers(headers, attributes=None):
         ctx = extract(headers)
         span_ctx = get_span_from_context(ctx).get_span_context()
         return Link(span_ctx, attributes)

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -206,7 +206,9 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         ctx = extract(DictGetter(), headers)
         span_ctx = get_span_from_context(ctx).get_span_context()
         current_span = cls.get_current_span()
-        current_span.links.append(Link(span_ctx, attributes))
+        updated_links = current_span.links + [Link(span_ctx, attributes)]
+        current_span.set_attribute("links", updated_links)
+        #current_span.links.append(Link(span_ctx, attributes))
 
     @classmethod
     def get_current_span(cls):

--- a/sdk/core/azure-core-tracing-opentelemetry/dev_requirements.txt
+++ b/sdk/core/azure-core-tracing-opentelemetry/dev_requirements.txt
@@ -1,4 +1,4 @@
 -e ../../../tools/azure-sdk-tools
 ../azure-core
 -e ../../../tools/azure-devtools
-opentelemetry-sdk==1.0.0
+opentelemetry-sdk<2.0.0,>=1.0.0

--- a/sdk/core/azure-core-tracing-opentelemetry/dev_requirements.txt
+++ b/sdk/core/azure-core-tracing-opentelemetry/dev_requirements.txt
@@ -1,4 +1,4 @@
 -e ../../../tools/azure-sdk-tools
 ../azure-core
 -e ../../../tools/azure-devtools
-opentelemetry-sdk==0.17b0
+opentelemetry-sdk==1.0.0rc1

--- a/sdk/core/azure-core-tracing-opentelemetry/dev_requirements.txt
+++ b/sdk/core/azure-core-tracing-opentelemetry/dev_requirements.txt
@@ -1,4 +1,4 @@
 -e ../../../tools/azure-sdk-tools
 ../azure-core
 -e ../../../tools/azure-devtools
-opentelemetry-sdk==1.0.0rc1
+opentelemetry-sdk==1.0.0

--- a/sdk/core/azure-core-tracing-opentelemetry/samples/sample_eventgrid.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/samples/sample_eventgrid.py
@@ -28,7 +28,7 @@ settings.tracing_implementation = OpenTelemetrySpan
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import ConsoleSpanExporter
-from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
 # Simple console exporter
 exporter = ConsoleSpanExporter()
@@ -36,7 +36,7 @@ exporter = ConsoleSpanExporter()
 trace.set_tracer_provider(TracerProvider())
 tracer = trace.get_tracer(__name__)
 trace.get_tracer_provider().add_span_processor(
-    SimpleExportSpanProcessor(exporter)
+    SimpleSpanProcessor(exporter)
 )
 
 # Example with Eventgrid SDKs

--- a/sdk/core/azure-core-tracing-opentelemetry/samples/sample_receive_sb.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/samples/sample_receive_sb.py
@@ -1,0 +1,55 @@
+"""
+Examples to show usage of the azure-core-tracing-opentelemetry
+with the servicebus SDK and exporting to Azure monitor backend.
+
+This example traces calls for receiving messages from the servicebus queue.
+
+The telemetry will be collected automatically and sent to Application
+Insights via the AzureMonitorTraceExporter
+"""
+
+import os
+
+# Declare OpenTelemetry as enabled tracing plugin for Azure SDKs
+from azure.core.settings import settings
+from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
+
+settings.tracing_implementation = OpenTelemetrySpan
+
+# Regular open telemetry usage from here, see https://github.com/open-telemetry/opentelemetry-python
+# for details
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+
+trace.set_tracer_provider(TracerProvider())
+tracer = trace.get_tracer(__name__)
+
+# azure monitor trace exporter to send telemetry to appinsights
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+# Simple console exporter
+exporter = ConsoleSpanExporter()
+span_processor = SimpleSpanProcessor(
+    exporter
+)
+trace.get_tracer_provider().add_span_processor(span_processor)
+
+# Example with Servicebus SDKs
+from azure.servicebus import ServiceBusClient, ServiceBusMessage
+
+connstr = os.environ['SERVICE_BUS_CONN_STR']
+queue_name = os.environ['SERVICE_BUS_QUEUE_NAME']
+
+with tracer.start_as_current_span(name="MyApplication2"):
+    with ServiceBusClient.from_connection_string(connstr) as client:
+        with client.get_queue_sender("new_queue") as sender:
+            #Sending a single message
+            single_message = ServiceBusMessage("Single message")
+            sender.send_messages(single_message)
+        # continually receives new messages until it doesn't receive any new messages for 5 (max_wait_time) seconds.
+        with client.get_queue_receiver(queue_name="new_queue", max_wait_time=5) as receiver:
+            # Receive all messages
+            for msg in receiver:
+                print("Received: " + str(msg))
+                receiver.complete_message(msg)

--- a/sdk/core/azure-core-tracing-opentelemetry/samples/sample_servicebus.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/samples/sample_servicebus.py
@@ -50,9 +50,9 @@ queue_name = os.environ['SERVICE_BUS_QUEUE_NAME']
 with tracer.start_as_current_span(name="MyApplication"):
     with ServiceBusClient.from_connection_string(connstr) as client:
         with client.get_queue_sender(queue_name) as sender:
-            # # Sending a single message
-            # single_message = ServiceBusMessage("Single message")
-            # sender.send_messages(single_message)
+            # Sending a single message
+            single_message = ServiceBusMessage("Single message")
+            sender.send_messages(single_message)
 
             # Sending a list of messages
             messages = [ServiceBusMessage("First message"), ServiceBusMessage("Second message")]

--- a/sdk/core/azure-core-tracing-opentelemetry/samples/sample_servicebus.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/samples/sample_servicebus.py
@@ -27,7 +27,7 @@ settings.tracing_implementation = OpenTelemetrySpan
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import ConsoleSpanExporter
-from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
 # Simple console exporter
 exporter = ConsoleSpanExporter()
@@ -35,7 +35,7 @@ exporter = ConsoleSpanExporter()
 trace.set_tracer_provider(TracerProvider())
 tracer = trace.get_tracer(__name__)
 trace.get_tracer_provider().add_span_processor(
-    SimpleExportSpanProcessor(exporter)
+    SimpleSpanProcessor(exporter)
 )
 
 # Example with Servicebus SDKs
@@ -50,9 +50,9 @@ queue_name = os.environ['SERVICE_BUS_QUEUE_NAME']
 with tracer.start_as_current_span(name="MyApplication"):
     with ServiceBusClient.from_connection_string(connstr) as client:
         with client.get_queue_sender(queue_name) as sender:
-            # Sending a single message
-            single_message = ServiceBusMessage("Single message")
-            sender.send_messages(single_message)
+            # # Sending a single message
+            # single_message = ServiceBusMessage("Single message")
+            # sender.send_messages(single_message)
 
             # Sending a list of messages
             messages = [ServiceBusMessage("First message"), ServiceBusMessage("Second message")]

--- a/sdk/core/azure-core-tracing-opentelemetry/samples/sample_storage.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/samples/sample_storage.py
@@ -28,7 +28,7 @@ settings.tracing_implementation = OpenTelemetrySpan
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import ConsoleSpanExporter
-from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
 # Simple console exporter
 exporter = ConsoleSpanExporter()
@@ -36,7 +36,7 @@ exporter = ConsoleSpanExporter()
 trace.set_tracer_provider(TracerProvider())
 tracer = trace.get_tracer(__name__)
 trace.get_tracer_provider().add_span_processor(
-    SimpleExportSpanProcessor(exporter)
+    SimpleSpanProcessor(exporter)
 )
 
 # Example with Storage SDKs

--- a/sdk/core/azure-core-tracing-opentelemetry/setup.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/setup.py
@@ -56,8 +56,8 @@ setup(
     ],
     python_requires=">=3.6.0",
     install_requires=[
-        'opentelemetry-api==1.0.0',
-        'azure-core<2.0.0,>=1.0.0',
+        'opentelemetry-api<2.0.0,>=1.0.0',
+        'azure-core<2.0.0,>=1.13.0',
     ],
     extras_require={
         ":python_version<'3.5'": ['typing'],

--- a/sdk/core/azure-core-tracing-opentelemetry/setup.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/setup.py
@@ -59,7 +59,7 @@ setup(
     ],
     python_requires=">=3.5.0",
     install_requires=[
-        'opentelemetry-api==0.17b0',
+        'opentelemetry-api==1.0.0rc1',
         'azure-core<2.0.0,>=1.0.0',
     ],
     extras_require={

--- a/sdk/core/azure-core-tracing-opentelemetry/setup.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/setup.py
@@ -59,7 +59,7 @@ setup(
     ],
     python_requires=">=3.5.0",
     install_requires=[
-        'opentelemetry-api==1.0.0rc1',
+        'opentelemetry-api==1.0.0',
         'azure-core<2.0.0,>=1.0.0',
     ],
     extras_require={

--- a/sdk/core/azure-core-tracing-opentelemetry/setup.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/setup.py
@@ -46,7 +46,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -57,7 +56,7 @@ setup(
     packages=[
         'azure.core.tracing.ext.opentelemetry_span',
     ],
-    python_requires=">=3.5.0",
+    python_requires=">=3.6.0",
     install_requires=[
         'opentelemetry-api==1.0.0',
         'azure-core<2.0.0,>=1.0.0',

--- a/sdk/core/azure-core-tracing-opentelemetry/setup.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/setup.py
@@ -43,8 +43,6 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,6 +8,8 @@ Azure core requires Python 2.7 or Python 3.6+ since this release.
 
 - Added `azure.core.utils.parse_connection_string` function to parse connection strings across SDKs, with common validation and support for case insensitive keys.
 - Supported adding custom policies  #16519
+- Added `~azure.core.tracing.Link` that should be used while passing `Links` to  `AbstractSpan`.
+- `AbstractSpan` constructor can now take in additional keyword only args.
 
 ### Bug fixes
 

--- a/sdk/core/azure-core/azure/core/tracing/__init__.py
+++ b/sdk/core/azure-core/azure/core/tracing/__init__.py
@@ -2,8 +2,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from azure.core.tracing._abstract_span import AbstractSpan, SpanKind, HttpSpanMixin
+from azure.core.tracing._abstract_span import AbstractSpan, SpanKind, HttpSpanMixin, Link
 
 __all__ = [
-    "AbstractSpan", "SpanKind", "HttpSpanMixin"
+    "AbstractSpan", "SpanKind", "HttpSpanMixin", "Link"
 ]

--- a/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
+++ b/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
@@ -52,8 +52,8 @@ class AbstractSpan(Protocol):
         The optional arguement name is given to the new span.
         """
 
-    def span(self, name="child_span"):
-        # type: (Optional[str]) -> AbstractSpan
+    def span(self, name="child_span", **kwargs):
+        # type: (Optional[str], Any) -> AbstractSpan
         """
         Create a child span for the current span and append it to the child spans list.
         The child span must be wrapped by an implementation of AbstractSpan

--- a/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
+++ b/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
@@ -45,8 +45,8 @@ class SpanKind(Enum):
 class AbstractSpan(Protocol):
     """Wraps a span from a distributed tracing implementation."""
 
-    def __init__(self, span=None, name=None):  # pylint: disable=super-init-not-called
-        # type: (Optional[Any], Optional[str]) -> None
+    def __init__(self, span=None, name=None, **kwargs):  # pylint: disable=super-init-not-called
+        # type: (Optional[Any], Optional[str], Any) -> None
         """
         If a span is given wraps the span. Else a new span is created.
         The optional arguement name is given to the new span.

--- a/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
+++ b/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
@@ -129,6 +129,18 @@ class AbstractSpan(Protocol):
         Returns the span the class is wrapping.
         """
 
+    @staticmethod
+    def create_link_from_headers(headers, attributes=None):
+        # type: (Dict[str, str], Attributes) -> Any
+        """
+        Given a dictionary, extracts the context and creates a link that can be added to spans.
+
+        :param headers: A dictionary of the request header as key value pairs.
+        :type headers: dict
+        :param attributes: Any additional attributes that should be added to link
+        :type attributes: dict
+        """
+
     @classmethod
     def link(cls, traceparent, attributes=None):
         # type: (str, Attributes) -> None

--- a/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
+++ b/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
@@ -129,18 +129,6 @@ class AbstractSpan(Protocol):
         Returns the span the class is wrapping.
         """
 
-    @staticmethod
-    def create_link_from_headers(headers, attributes=None):
-        # type: (Dict[str, str], Attributes) -> Any
-        """
-        Given a dictionary, extracts the context and creates a link that can be added to spans.
-
-        :param headers: A dictionary of the request header as key value pairs.
-        :type headers: dict
-        :param attributes: Any additional attributes that should be added to link
-        :type attributes: dict
-        """
-
     @classmethod
     def link(cls, traceparent, attributes=None):
         # type: (str, Attributes) -> None
@@ -244,3 +232,16 @@ class HttpSpanMixin(_MIXIN_BASE):
             self.add_attribute(self._HTTP_STATUS_CODE, response.status_code)
         else:
             self.add_attribute(self._HTTP_STATUS_CODE, 504)
+
+class Link(object):
+    """
+    This is a wrapper link the context to the current tracer.
+    :param headers: A dictionary of the request header as key value pairs.
+    :type headers: dict
+    :param attributes: Any additional attributes that should be added to link
+    :type attributes: dict
+    """
+    def __init__(self, headers, attributes=None):
+        # type: (Dict[str, str], Attributes) -> None
+        self.headers = headers
+        self.attributes = attributes

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -158,8 +158,8 @@ avro<2.0.0,>=1.10.0
 opencensus>=0.6.0
 opencensus-ext-threading
 opencensus-ext-azure>=0.3.1
-opentelemetry-api==1.0.0rc1
-opentelemetry-sdk==1.0.0rc1
+opentelemetry-api==1.0.0
+opentelemetry-sdk==1.0.0
 #override azure-eventhub-checkpointstoreblob msrest>=0.6.18
 #override azure-eventhub-checkpointstoreblob-aio msrest>=0.6.18
 #override azure-eventhub-checkpointstoreblob azure-core<2.0.0,>=1.10.0
@@ -196,7 +196,7 @@ opentelemetry-sdk==1.0.0rc1
 #override azure-monitor-opentelemetry-exporter msrest>=0.6.10
 #override azure-monitor-opentelemetry-exporter opentelemetry-api==1.0.0rc1
 #override azure-monitor-opentelemetry-exporter opentelemetry-sdk==1.0.0rc1
-#override azure-core-tracing-opentelemetry opentelemetry-api==1.0.0rc1
+#override azure-core-tracing-opentelemetry opentelemetry-api==1.0.0
 #override azure-identity six>=1.12.0
 #override azure-keyvault-keys six>=1.12.0
 #override azure-mixedreality-authentication azure-core<2.0.0,>=1.4.0

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -124,7 +124,7 @@ avro<2.0.0,>=1.10.0
 #override azure-mgmt-core azure-core<2.0.0,>=1.9.0
 #override azure-containerregistry azure-core>=1.4.0,<2.0.0
 #override azure-core-tracing-opencensus azure-core<2.0.0,>=1.0.0
-#override azure-core-tracing-opentelemetry azure-core<2.0.0,>=1.0.0
+#override azure-core-tracing-opentelemetry azure-core<2.0.0,>=1.13.0
 #override azure-cosmos azure-core<2.0.0,>=1.0.0
 #override azure-data-tables azure-core<2.0.0,>=1.10.0
 #override azure-eventhub azure-core<2.0.0,>=1.5.0
@@ -158,8 +158,8 @@ avro<2.0.0,>=1.10.0
 opencensus>=0.6.0
 opencensus-ext-threading
 opencensus-ext-azure>=0.3.1
-opentelemetry-api==1.0.0
-opentelemetry-sdk==1.0.0
+opentelemetry-api<2.0.0,>=1.0.0
+opentelemetry-sdk<2.0.0,>=1.0.0
 #override azure-eventhub-checkpointstoreblob msrest>=0.6.18
 #override azure-eventhub-checkpointstoreblob-aio msrest>=0.6.18
 #override azure-eventhub-checkpointstoreblob azure-core<2.0.0,>=1.10.0
@@ -196,7 +196,7 @@ opentelemetry-sdk==1.0.0
 #override azure-monitor-opentelemetry-exporter msrest>=0.6.10
 #override azure-monitor-opentelemetry-exporter opentelemetry-api==1.0.0rc1
 #override azure-monitor-opentelemetry-exporter opentelemetry-sdk==1.0.0rc1
-#override azure-core-tracing-opentelemetry opentelemetry-api==1.0.0
+#override azure-core-tracing-opentelemetry opentelemetry-api<2.0.0,>=1.0.0
 #override azure-identity six>=1.12.0
 #override azure-keyvault-keys six>=1.12.0
 #override azure-mixedreality-authentication azure-core<2.0.0,>=1.4.0

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -158,8 +158,8 @@ avro<2.0.0,>=1.10.0
 opencensus>=0.6.0
 opencensus-ext-threading
 opencensus-ext-azure>=0.3.1
-opentelemetry-api==0.17b0
-opentelemetry-sdk==0.17b0
+opentelemetry-api==1.0.0rc1
+opentelemetry-sdk==1.0.0rc1
 #override azure-eventhub-checkpointstoreblob msrest>=0.6.18
 #override azure-eventhub-checkpointstoreblob-aio msrest>=0.6.18
 #override azure-eventhub-checkpointstoreblob azure-core<2.0.0,>=1.10.0
@@ -196,7 +196,7 @@ opentelemetry-sdk==0.17b0
 #override azure-monitor-opentelemetry-exporter msrest>=0.6.10
 #override azure-monitor-opentelemetry-exporter opentelemetry-api==1.0.0rc1
 #override azure-monitor-opentelemetry-exporter opentelemetry-sdk==1.0.0rc1
-#override azure-core-tracing-opentelemetry opentelemetry-api==0.17b0
+#override azure-core-tracing-opentelemetry opentelemetry-api==1.0.0rc1
 #override azure-identity six>=1.12.0
 #override azure-keyvault-keys six>=1.12.0
 #override azure-mixedreality-authentication azure-core<2.0.0,>=1.4.0


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-python/issues/17539



usage would be like this:
```
from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
from azure.core.settings import settings
from azure.core.tracing import Link
settings.tracing_implementation = OpenTelemetrySpan
span_impl = settings.tracing_implementation()

links = Link({'traceparent': '2346782uehdcfhvj'})

span = span_impl(name="example", kind=SpanKind.CLIENT,  links=[links])
```