### PR TITLE
Scrub batch shared keys

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-blob/tests/_shared/testcase.py
@@ -104,6 +104,10 @@ class GlobalStorageAccountPreparer(AzureMgmtPreparer):
                 storage_account.name,
                 "storagename"
             )
+            self.test_class_instance.scrubber.register_name_pair(
+                "SharedKey",
+                "FakeSharedKey"
+            )
         else:
             name = "storagename"
             storage_account.name = name

--- a/sdk/storage/azure-storage-blob/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-blob/tests/_shared/testcase.py
@@ -105,8 +105,8 @@ class GlobalStorageAccountPreparer(AzureMgmtPreparer):
                 "storagename"
             )
             self.test_class_instance.scrubber.register_name_pair(
-                "SharedKey",
-                "FakeSharedKey"
+                ":.{43}=\r",
+                ":fake_shared_key=\r"
             )
         else:
             name = "storagename"

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_batch_set_standard_blob_tier_for_version.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_batch_set_standard_blob_tier_for_version.yaml
@@ -11,148 +11,29 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:24 GMT
+      - Wed, 03 Mar 2021 01:01:56 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9?restype=container
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
-        specified container already exists.\nRequestId:3f4ed601-301e-006f-2c5e-ef4753000000\nTime:2021-01-20T18:58:24.6983762Z</Message></Error>"
-    headers:
-      content-length:
-      - '230'
-      content-type:
-      - application/xml
-      date:
-      - Wed, 20 Jan 2021 18:58:24 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-error-code:
-      - ContainerAlreadyExists
-      x-ms-version:
-      - '2020-04-08'
-    status:
-      code: 409
-      message: The specified container already exists.
-- request:
-    body: "--===============1554708815==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
-      binary\r\nContent-ID: 0\r\n\r\nDELETE /containered9318a9/blob1? HTTP/1.1\r\nx-ms-date:
-      Wed, 20 Jan 2021 18:58:24 GMT\r\nx-ms-client-request-id: 791f02e6-5b51-11eb-8539-c8348e5fffbc\r\nAuthorization:
-      SharedKey tamerdevtest:Cup88f/G5wpCKmdb1hk/BXnPBAMhICQyXqhFUd+kMD0=\r\n\r\n\r\n--===============1554708815==\r\nContent-Type:
-      application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /containered9318a9/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 18:58:24 GMT\r\nx-ms-client-request-id:
-      791f02e7-5b51-11eb-8aa2-c8348e5fffbc\r\nAuthorization: SharedKey tamerdevtest:9jQkskOQfZWjs0/gF9FNjTXVnJTr5ThWmkurCu8JucA=\r\n\r\n\r\n--===============1554708815==\r\nContent-Type:
-      application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /containered9318a9/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 18:58:24 GMT\r\nx-ms-client-request-id:
-      791f02e8-5b51-11eb-865b-c8348e5fffbc\r\nAuthorization: SharedKey tamerdevtest:dqQcWb2fyv5nToHTYdBnn6owlzgza6q0YNsP8TeBb3M=\r\n\r\n\r\n--===============1554708815==--\r\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1083'
-      Content-Type:
-      - multipart/mixed; boundary================1554708815==
-      User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-date:
-      - Wed, 20 Jan 2021 18:58:24 GMT
-      x-ms-version:
-      - '2020-04-08'
-    method: POST
-    uri: https://storagename.blob.core.windows.net/containered9318a9?restype=container&comp=batch
-  response:
-    body:
-      string: "--batchresponse_19fa9f7b-04c6-484d-8db5-39948fe4e568\r\nContent-Type:
-        application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 404 The specified blob does
-        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: 3f4ed621-301e-006f-455e-ef47531e9788\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 791f02e6-5b51-11eb-8539-c8348e5fffbc\r\nContent-Length:
-        216\r\nContent-Type: application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml
-        version=\"1.0\" encoding=\"utf-8\"?>\n<Error><Code>BlobNotFound</Code><Message>The
-        specified blob does not exist.\nRequestId:3f4ed621-301e-006f-455e-ef47531e9788\nTime:2021-01-20T18:58:25.4358914Z</Message></Error>\r\n--batchresponse_19fa9f7b-04c6-484d-8db5-39948fe4e568\r\nContent-Type:
-        application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 404 The specified blob does
-        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: 3f4ed621-301e-006f-455e-ef47531e978b\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 791f02e7-5b51-11eb-8aa2-c8348e5fffbc\r\nContent-Length:
-        216\r\nContent-Type: application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml
-        version=\"1.0\" encoding=\"utf-8\"?>\n<Error><Code>BlobNotFound</Code><Message>The
-        specified blob does not exist.\nRequestId:3f4ed621-301e-006f-455e-ef47531e978b\nTime:2021-01-20T18:58:25.4348912Z</Message></Error>\r\n--batchresponse_19fa9f7b-04c6-484d-8db5-39948fe4e568\r\nContent-Type:
-        application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 409 This operation is not
-        permitted because the blob has snapshots.\r\nx-ms-error-code: SnapshotsPresent\r\nx-ms-request-id:
-        3f4ed621-301e-006f-455e-ef47531e978c\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        791f02e8-5b51-11eb-865b-c8348e5fffbc\r\nContent-Length: 249\r\nContent-Type:
-        application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml version=\"1.0\"
-        encoding=\"utf-8\"?>\n<Error><Code>SnapshotsPresent</Code><Message>This operation
-        is not permitted because the blob has snapshots.\nRequestId:3f4ed621-301e-006f-455e-ef47531e978c\nTime:2021-01-20T18:58:25.4348912Z</Message></Error>\r\n--batchresponse_19fa9f7b-04c6-484d-8db5-39948fe4e568--"
-    headers:
-      content-type:
-      - multipart/mixed; boundary=batchresponse_19fa9f7b-04c6-484d-8db5-39948fe4e568
-      date:
-      - Wed, 20 Jan 2021 18:58:24 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding:
-      - chunked
-      x-ms-version:
-      - '2020-04-08'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: hello world
-    headers:
-      Accept:
-      - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '11'
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-date:
-      - Wed, 20 Jan 2021 18:58:25 GMT
-      x-ms-encryption-algorithm:
-      - AES256
-      x-ms-version:
-      - '2020-04-08'
-    method: PUT
-    uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
-  response:
-    body:
       string: ''
     headers:
       content-length:
       - '0'
-      content-md5:
-      - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 18:58:25 GMT
+      - Wed, 03 Mar 2021 01:01:56 GMT
       etag:
-      - '"0x8D8BD755DD1160E"'
+      - '"0x8D8DDDFF1001BF7"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:25 GMT
+      - Wed, 03 Mar 2021 01:01:56 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-content-crc64:
-      - vo7q9sPVKY0=
-      x-ms-request-server-encrypted:
-      - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:25.5732238Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -169,16 +50,70 @@ interactions:
       - '11'
       Content-Type:
       - application/octet-stream
+      If-None-Match:
+      - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:25 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - XrY7u+Ae7tCTyyK7j1rNww==
+      date:
+      - Wed, 03 Mar 2021 01:01:56 GMT
+      etag:
+      - '"0x8D8DDDFF10BCFB3"'
+      last-modified:
+      - Wed, 03 Mar 2021 01:01:56 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - vo7q9sPVKY0=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: hello world
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '11'
+      Content-Type:
+      - application/octet-stream
+      If-None-Match:
+      - '*'
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Wed, 03 Mar 2021 01:01:57 GMT
+      x-ms-encryption-algorithm:
+      - AES256
+      x-ms-version:
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob2
   response:
@@ -190,11 +125,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 18:58:25 GMT
+      - Wed, 03 Mar 2021 01:01:56 GMT
       etag:
-      - '"0x8D8BD755E1A889E"'
+      - '"0x8D8DDDFF1165995"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:26 GMT
+      - Wed, 03 Mar 2021 01:01:56 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -202,9 +137,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:26.0545694Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -221,16 +154,18 @@ interactions:
       - '11'
       Content-Type:
       - application/octet-stream
+      If-None-Match:
+      - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:26 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob3
   response:
@@ -242,11 +177,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 18:58:25 GMT
+      - Wed, 03 Mar 2021 01:01:56 GMT
       etag:
-      - '"0x8D8BD755E312205"'
+      - '"0x8D8DDDFF11FD1C9"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:26 GMT
+      - Wed, 03 Mar 2021 01:01:56 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -254,410 +189,21 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:26.2046764Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-date:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      x-ms-encryption-algorithm:
-      - AES256
-      x-ms-version:
-      - '2020-04-08'
-    method: PUT
-    uri: https://storagename.blob.core.windows.net/containered9318a9/blob3?comp=snapshot
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      date:
-      - Wed, 20 Jan 2021 18:58:25 GMT
-      etag:
-      - '"0x8D8BD755E312205"'
-      last-modified:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-request-server-encrypted:
-      - 'false'
-      x-ms-snapshot:
-      - '2021-01-20T18:58:26.3537827Z'
-      x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:26.3547827Z'
-    status:
-      code: 201
-      message: Created
-- request:
-    body: abc
-    headers:
-      Accept:
-      - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3'
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-date:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      x-ms-encryption-algorithm:
-      - AES256
-      x-ms-version:
-      - '2020-04-08'
-    method: PUT
-    uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      content-md5:
-      - kAFQmDzST7DWlj99KOF/cg==
-      date:
-      - Wed, 20 Jan 2021 18:58:25 GMT
-      etag:
-      - '"0x8D8BD755E5F184C"'
-      last-modified:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-content-crc64:
-      - 6/rBP7vK5QU=
-      x-ms-request-server-encrypted:
-      - 'true'
-      x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:26.5048924Z'
-    status:
-      code: 201
-      message: Created
-- request:
-    body: abc
-    headers:
-      Accept:
-      - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3'
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-date:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      x-ms-encryption-algorithm:
-      - AES256
-      x-ms-version:
-      - '2020-04-08'
-    method: PUT
-    uri: https://storagename.blob.core.windows.net/containered9318a9/blob2
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      content-md5:
-      - kAFQmDzST7DWlj99KOF/cg==
-      date:
-      - Wed, 20 Jan 2021 18:58:25 GMT
-      etag:
-      - '"0x8D8BD755E742ACD"'
-      last-modified:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-content-crc64:
-      - 6/rBP7vK5QU=
-      x-ms-request-server-encrypted:
-      - 'true'
-      x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:26.6429917Z'
-    status:
-      code: 201
-      message: Created
-- request:
-    body: abc
-    headers:
-      Accept:
-      - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3'
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-date:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      x-ms-encryption-algorithm:
-      - AES256
-      x-ms-version:
-      - '2020-04-08'
-    method: PUT
-    uri: https://storagename.blob.core.windows.net/containered9318a9/blob3
-  response:
-    body:
-      string: ''
-    headers:
-      content-length:
-      - '0'
-      content-md5:
-      - kAFQmDzST7DWlj99KOF/cg==
-      date:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      etag:
-      - '"0x8D8BD755E8AC43A"'
-      last-modified:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-content-crc64:
-      - 6/rBP7vK5QU=
-      x-ms-request-server-encrypted:
-      - 'true'
-      x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:26.7920993Z'
-    status:
-      code: 201
-      message: Created
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-date:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      x-ms-encryption-algorithm:
-      - AES256
-      x-ms-version:
-      - '2020-04-08'
-    method: HEAD
-    uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
-  response:
-    body:
-      string: ''
-    headers:
-      accept-ranges:
-      - bytes
-      content-length:
-      - '3'
-      content-md5:
-      - kAFQmDzST7DWlj99KOF/cg==
-      content-type:
-      - application/octet-stream
-      date:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      etag:
-      - '"0x8D8BD755E5F184C"'
-      last-modified:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-access-tier:
-      - Hot
-      x-ms-access-tier-change-time:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-creation-time:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      x-ms-is-current-version:
-      - 'true'
-      x-ms-lease-state:
-      - available
-      x-ms-lease-status:
-      - unlocked
-      x-ms-server-encrypted:
-      - 'true'
-      x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:26.5048924Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "--===============1234946365==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
-      binary\r\nContent-ID: 0\r\n\r\nPUT /containered9318a9/blob1?versionid=2021-01-20T18%3A58%3A26.5048924Z&comp=tier
-      HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier: Archive\r\nx-ms-date: Wed,
-      20 Jan 2021 18:58:26 GMT\r\nx-ms-client-request-id: 7a7243bc-5b51-11eb-8bc0-c8348e5fffbc\r\nAuthorization:
-      SharedKey tamerdevtest:t22k94quXAHPji8KUAD7HZiYrxh5cnfXKGF7LkPGVQ0=\r\n\r\n\r\n--===============1234946365==\r\nContent-Type:
-      application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nPUT
-      /containered9318a9/blob2?versionid=2021-01-20T18%3A58%3A26.0545694Z&comp=tier
-      HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier: Archive\r\nx-ms-date: Wed,
-      20 Jan 2021 18:58:26 GMT\r\nx-ms-client-request-id: 7a7243bd-5b51-11eb-9868-c8348e5fffbc\r\nAuthorization:
-      SharedKey tamerdevtest:igLq6BNnel50redFIiX7jlzOcaCBEn/t7aPfWlN1890=\r\n\r\n\r\n--===============1234946365==\r\nContent-Type:
-      application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nPUT
-      /containered9318a9/blob3?snapshot=2021-01-20T18%3A58%3A26.3537827Z&comp=tier
-      HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier: Archive\r\nx-ms-date: Wed,
-      20 Jan 2021 18:58:26 GMT\r\nx-ms-client-request-id: 7a726ab8-5b51-11eb-9d17-c8348e5fffbc\r\nAuthorization:
-      SharedKey tamerdevtest:MrTXPvYBf49cUwrkQgTIUef+FBXTM66SNYL26/J0xPo=\r\n\r\n\r\n--===============1234946365==--\r\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1367'
-      Content-Type:
-      - multipart/mixed; boundary================1234946365==
-      User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-date:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      x-ms-version:
-      - '2020-04-08'
-    method: POST
-    uri: https://storagename.blob.core.windows.net/containered9318a9?restype=container&comp=batch
-  response:
-    body:
-      string: "--batchresponse_5bd790f4-a10b-4079-95b9-e3a98154a4bc\r\nContent-Type:
-        application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        3f4ed749-301e-006f-385e-ef47531e97a8\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7a7243bc-5b51-11eb-8bc0-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_5bd790f4-a10b-4079-95b9-e3a98154a4bc\r\nContent-Type:
-        application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        3f4ed749-301e-006f-385e-ef47531e97aa\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7a7243bd-5b51-11eb-9868-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_5bd790f4-a10b-4079-95b9-e3a98154a4bc\r\nContent-Type:
-        application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        3f4ed749-301e-006f-385e-ef47531e97ab\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7a726ab8-5b51-11eb-9d17-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_5bd790f4-a10b-4079-95b9-e3a98154a4bc--"
-    headers:
-      content-type:
-      - multipart/mixed; boundary=batchresponse_5bd790f4-a10b-4079-95b9-e3a98154a4bc
-      date:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      transfer-encoding:
-      - chunked
-      x-ms-version:
-      - '2020-04-08'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-      x-ms-date:
-      - Wed, 20 Jan 2021 18:58:27 GMT
-      x-ms-encryption-algorithm:
-      - AES256
-      x-ms-version:
-      - '2020-04-08'
-    method: HEAD
-    uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
-  response:
-    body:
-      string: ''
-    headers:
-      accept-ranges:
-      - bytes
-      content-length:
-      - '3'
-      content-md5:
-      - kAFQmDzST7DWlj99KOF/cg==
-      content-type:
-      - application/octet-stream
-      date:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      etag:
-      - '"0x8D8BD755E5F184C"'
-      last-modified:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-access-tier:
-      - Archive
-      x-ms-access-tier-change-time:
-      - Wed, 20 Jan 2021 18:58:27 GMT
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-creation-time:
-      - Wed, 20 Jan 2021 18:58:26 GMT
-      x-ms-is-current-version:
-      - 'true'
-      x-ms-lease-state:
-      - available
-      x-ms-lease-status:
-      - unlocked
-      x-ms-server-encrypted:
-      - 'true'
-      x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:26.5048924Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "--===============0781981862==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============2112334733==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /containered9318a9/blob1? HTTP/1.1\r\nx-ms-date:
-      Wed, 20 Jan 2021 18:58:27 GMT\r\nx-ms-client-request-id: 7acdc052-5b51-11eb-bfd3-c8348e5fffbc\r\nAuthorization:
-      SharedKey tamerdevtest:9mugQAle4R8WsXNiAhLZSk1ovwx3VyePQaOBsQBASek=\r\n\r\n\r\n--===============0781981862==\r\nContent-Type:
+      Wed, 03 Mar 2021 01:01:57 GMT\r\nx-ms-client-request-id: 0d4f0d39-7bbc-11eb-b9d7-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2112334733==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /containered9318a9/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 18:58:27 GMT\r\nx-ms-client-request-id:
-      7acdc053-5b51-11eb-83a7-c8348e5fffbc\r\nAuthorization: SharedKey tamerdevtest:tvy/2BcL8bAr0Z1IIRS4Y5YZjkiM8TIX3wqScKnQVjc=\r\n\r\n\r\n--===============0781981862==\r\nContent-Type:
+      /containered9318a9/blob2? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:01:57 GMT\r\nx-ms-client-request-id:
+      0d4f0d3a-7bbc-11eb-adb5-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2112334733==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /containered9318a9/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 18:58:27 GMT\r\nx-ms-client-request-id:
-      7acdc054-5b51-11eb-854d-c8348e5fffbc\r\nAuthorization: SharedKey tamerdevtest:MJ00mikDHnKmT9j4jFJoF15Fiv0SwtjmV+0DDA89NPs=\r\n\r\n\r\n--===============0781981862==--\r\n"
+      /containered9318a9/blob3? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:01:57 GMT\r\nx-ms-client-request-id:
+      0d4f3638-7bbc-11eb-a02d-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2112334733==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -668,44 +214,41 @@ interactions:
       Content-Length:
       - '1083'
       Content-Type:
-      - multipart/mixed; boundary================0781981862==
+      - multipart/mixed; boundary================2112334733==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:27 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/containered9318a9?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_944b5b67-2bd1-41df-b01d-47cf3100b304\r\nContent-Type:
+      string: "--batchresponse_efab03b0-dbb8-4994-9cc6-d35807c729ac\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 3f4ed799-301e-006f-7f5e-ef47531e97b2\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 7acdc052-5b51-11eb-bfd3-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_944b5b67-2bd1-41df-b01d-47cf3100b304\r\nContent-Type:
+        true\r\nx-ms-request-id: fa20d664-501e-0058-51c8-0f8bab1e30b8\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 0d4f0d39-7bbc-11eb-b9d7-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_efab03b0-dbb8-4994-9cc6-d35807c729ac\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 3f4ed799-301e-006f-7f5e-ef47531e97b3\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 7acdc053-5b51-11eb-83a7-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_944b5b67-2bd1-41df-b01d-47cf3100b304\r\nContent-Type:
-        application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 409 This operation is not
-        permitted because the blob has snapshots.\r\nx-ms-error-code: SnapshotsPresent\r\nx-ms-request-id:
-        3f4ed799-301e-006f-7f5e-ef47531e97b4\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7acdc054-5b51-11eb-854d-c8348e5fffbc\r\nContent-Length: 249\r\nContent-Type:
-        application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml version=\"1.0\"
-        encoding=\"utf-8\"?>\n<Error><Code>SnapshotsPresent</Code><Message>This operation
-        is not permitted because the blob has snapshots.\nRequestId:3f4ed799-301e-006f-7f5e-ef47531e97b4\nTime:2021-01-20T18:58:27.6764715Z</Message></Error>\r\n--batchresponse_944b5b67-2bd1-41df-b01d-47cf3100b304--"
+        true\r\nx-ms-request-id: fa20d664-501e-0058-51c8-0f8bab1e30ba\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 0d4f0d3a-7bbc-11eb-adb5-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_efab03b0-dbb8-4994-9cc6-d35807c729ac\r\nContent-Type:
+        application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
+        true\r\nx-ms-request-id: fa20d664-501e-0058-51c8-0f8bab1e30bb\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 0d4f3638-7bbc-11eb-a02d-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_efab03b0-dbb8-4994-9cc6-d35807c729ac--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_944b5b67-2bd1-41df-b01d-47cf3100b304
+      - multipart/mixed; boundary=batchresponse_efab03b0-dbb8-4994-9cc6-d35807c729ac
       date:
-      - Wed, 20 Jan 2021 18:58:27 GMT
+      - Wed, 03 Mar 2021 01:01:56 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -723,15 +266,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:27 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
   response:
@@ -743,11 +286,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 18:58:27 GMT
+      - Wed, 03 Mar 2021 01:01:56 GMT
       etag:
-      - '"0x8D8BD755F3B4920"'
+      - '"0x8D8DDDFF14E6736"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:27 GMT
+      - Wed, 03 Mar 2021 01:01:56 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -755,9 +298,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:27.9469344Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -775,15 +316,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:27 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob2
   response:
@@ -795,11 +336,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 18:58:27 GMT
+      - Wed, 03 Mar 2021 01:01:56 GMT
       etag:
-      - '"0x8D8BD755F519459"'
+      - '"0x8D8DDDFF157DF66"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:56 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -807,9 +348,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:28.0930393Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -827,15 +366,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob3
   response:
@@ -847,11 +386,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 18:58:27 GMT
+      - Wed, 03 Mar 2021 01:01:56 GMT
       etag:
-      - '"0x8D8BD755F667FC1"'
+      - '"0x8D8DDDFF1615795"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -859,9 +398,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:28.2311377Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -877,13 +414,13 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob3?comp=snapshot
   response:
@@ -893,21 +430,19 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 20 Jan 2021 18:58:27 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       etag:
-      - '"0x8D8BD755F667FC1"'
+      - '"0x8D8DDDFF1615795"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'false'
       x-ms-snapshot:
-      - '2021-01-20T18:58:28.3742402Z'
+      - '2021-03-03T01:01:57.0799863Z'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:28.3752402Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -925,15 +460,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
   response:
@@ -945,11 +480,11 @@ interactions:
       content-md5:
       - kAFQmDzST7DWlj99KOF/cg==
       date:
-      - Wed, 20 Jan 2021 18:58:27 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       etag:
-      - '"0x8D8BD755F920491"'
+      - '"0x8D8DDDFF17755EF"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -957,9 +492,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:28.5163425Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -977,15 +510,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob2
   response:
@@ -997,11 +530,11 @@ interactions:
       content-md5:
       - kAFQmDzST7DWlj99KOF/cg==
       date:
-      - Wed, 20 Jan 2021 18:58:27 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       etag:
-      - '"0x8D8BD755FA67AAF"'
+      - '"0x8D8DDDFF1816A85"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -1009,9 +542,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:28.6514399Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -1029,15 +560,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob3
   response:
@@ -1049,11 +580,11 @@ interactions:
       content-md5:
       - kAFQmDzST7DWlj99KOF/cg==
       date:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       etag:
-      - '"0x8D8BD755FBC2994"'
+      - '"0x8D8DDDFF18B09CE"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -1061,9 +592,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:28.7925412Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -1077,13 +606,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
   response:
@@ -1099,13 +628,15 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       etag:
-      - '"0x8D8BD755F920491"'
+      - '"0x8D8DDDFF17755EF"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary:
+      - Origin
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-inferred:
@@ -1113,9 +644,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 20 Jan 2021 18:58:28 GMT
-      x-ms-is-current-version:
-      - 'true'
+      - Wed, 03 Mar 2021 01:01:56 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -1123,28 +652,24 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:28.5163425Z'
+      - '2020-06-12'
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============1932183161==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
-      binary\r\nContent-ID: 0\r\n\r\nPUT /containered9318a9/blob1?versionid=2021-01-20T18%3A58%3A28.5163425Z&comp=tier
-      HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier: Cool\r\nx-ms-date: Wed, 20
-      Jan 2021 18:58:28 GMT\r\nx-ms-client-request-id: 7ba24cec-5b51-11eb-93b4-c8348e5fffbc\r\nAuthorization:
-      SharedKey tamerdevtest:m/1WBgYWbw/RwMlTk+4Fr/JGqPIx1cLs0aEJR7Use0M=\r\n\r\n\r\n--===============1932183161==\r\nContent-Type:
+    body: "--===============1251718867==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+      binary\r\nContent-ID: 0\r\n\r\nPUT /containered9318a9/blob1?comp=tier HTTP/1.1\r\nContent-Length:
+      0\r\nx-ms-access-tier: Archive\r\nx-ms-date: Wed, 03 Mar 2021 01:01:57 GMT\r\nx-ms-client-request-id:
+      0dc44175-7bbc-11eb-b43a-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1251718867==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nPUT
-      /containered9318a9/blob2?versionid=2021-01-20T18%3A58%3A28.0930393Z&comp=tier
-      HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier: Cool\r\nx-ms-date: Wed, 20
-      Jan 2021 18:58:28 GMT\r\nx-ms-client-request-id: 7ba24ced-5b51-11eb-b7f7-c8348e5fffbc\r\nAuthorization:
-      SharedKey tamerdevtest:sfLuKbCKuQ65S0Ch8jQefnZBsJMe8tjqN2HABUqNcTw=\r\n\r\n\r\n--===============1932183161==\r\nContent-Type:
+      /containered9318a9/blob2?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
+      Archive\r\nx-ms-date: Wed, 03 Mar 2021 01:01:57 GMT\r\nx-ms-client-request-id:
+      0dc46887-7bbc-11eb-88f7-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1251718867==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nPUT
-      /containered9318a9/blob3?snapshot=2021-01-20T18%3A58%3A28.3742402Z&comp=tier
-      HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier: Cool\r\nx-ms-date: Wed, 20
-      Jan 2021 18:58:28 GMT\r\nx-ms-client-request-id: 7ba24cee-5b51-11eb-8f25-c8348e5fffbc\r\nAuthorization:
-      SharedKey tamerdevtest:NZPpgvRHx2EMUeCiBaBINtxJNGavE9HZ1QNWVOkDxQs=\r\n\r\n\r\n--===============1932183161==--\r\n"
+      /containered9318a9/blob3?snapshot=2021-03-03T01%3A01%3A57.0799863Z&comp=tier
+      HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier: Archive\r\nx-ms-date: Wed,
+      03 Mar 2021 01:01:57 GMT\r\nx-ms-client-request-id: 0dc46888-7bbc-11eb-932d-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1251718867==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -1153,40 +678,40 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1358'
+      - '1281'
       Content-Type:
-      - multipart/mixed; boundary================1932183161==
+      - multipart/mixed; boundary================1251718867==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/containered9318a9?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_7389f2a1-e8ad-4f61-a136-058e9f69d290\r\nContent-Type:
+      string: "--batchresponse_f7ca3f4d-c413-444d-9f81-e30aefd2604d\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        3f4ed86f-301e-006f-365e-ef47531e97cb\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7ba24cec-5b51-11eb-93b4-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_7389f2a1-e8ad-4f61-a136-058e9f69d290\r\nContent-Type:
+        fa20d7e7-501e-0058-2ac8-0f8bab1e30c8\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        0dc44175-7bbc-11eb-b43a-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_f7ca3f4d-c413-444d-9f81-e30aefd2604d\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        3f4ed86f-301e-006f-365e-ef47531e97cc\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7ba24ced-5b51-11eb-b7f7-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_7389f2a1-e8ad-4f61-a136-058e9f69d290\r\nContent-Type:
+        fa20d7e7-501e-0058-2ac8-0f8bab1e30cb\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        0dc46887-7bbc-11eb-88f7-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_f7ca3f4d-c413-444d-9f81-e30aefd2604d\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        3f4ed86f-301e-006f-365e-ef47531e97cd\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7ba24cee-5b51-11eb-8f25-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_7389f2a1-e8ad-4f61-a136-058e9f69d290--"
+        fa20d7e7-501e-0058-2ac8-0f8bab1e30cc\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        0dc46888-7bbc-11eb-932d-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_f7ca3f4d-c413-444d-9f81-e30aefd2604d--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_7389f2a1-e8ad-4f61-a136-058e9f69d290
+      - multipart/mixed; boundary=batchresponse_f7ca3f4d-c413-444d-9f81-e30aefd2604d
       date:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -1200,13 +725,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
   response:
@@ -1222,23 +747,23 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       etag:
-      - '"0x8D8BD755F920491"'
+      - '"0x8D8DDDFF17755EF"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary:
+      - Origin
       x-ms-access-tier:
-      - Cool
+      - Archive
       x-ms-access-tier-change-time:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 20 Jan 2021 18:58:28 GMT
-      x-ms-is-current-version:
-      - 'true'
+      - Wed, 03 Mar 2021 01:01:56 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -1246,23 +771,21 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:28.5163425Z'
+      - '2020-06-12'
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============0107807186==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============1386896762==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /containered9318a9/blob1? HTTP/1.1\r\nx-ms-date:
-      Wed, 20 Jan 2021 18:58:29 GMT\r\nx-ms-client-request-id: 7bcf6332-5b51-11eb-85e7-c8348e5fffbc\r\nAuthorization:
-      SharedKey tamerdevtest:6pONAUFW/Rn4r7OWRd05+oHe2wDZlkixWsA65XFCmqI=\r\n\r\n\r\n--===============0107807186==\r\nContent-Type:
+      Wed, 03 Mar 2021 01:01:58 GMT\r\nx-ms-client-request-id: 0de349fa-7bbc-11eb-ae62-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1386896762==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /containered9318a9/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 18:58:29 GMT\r\nx-ms-client-request-id:
-      7bcf8a4f-5b51-11eb-9451-c8348e5fffbc\r\nAuthorization: SharedKey tamerdevtest:4Kg8djDvSkvDvJwQRKcUMRmDJNidCbE7C9oK0E7Symk=\r\n\r\n\r\n--===============0107807186==\r\nContent-Type:
+      /containered9318a9/blob2? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:01:58 GMT\r\nx-ms-client-request-id:
+      0de3724e-7bbc-11eb-97e9-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1386896762==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /containered9318a9/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 18:58:29 GMT\r\nx-ms-client-request-id:
-      7bcf8a50-5b51-11eb-8f3d-c8348e5fffbc\r\nAuthorization: SharedKey tamerdevtest:CVSFbi0F9x7LctmacngxeNlfinXpibwmcT2nnidiUtg=\r\n\r\n\r\n--===============0107807186==--\r\n"
+      /containered9318a9/blob3? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:01:58 GMT\r\nx-ms-client-request-id:
+      0de3724f-7bbc-11eb-bd0c-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1386896762==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -1273,44 +796,44 @@ interactions:
       Content-Length:
       - '1083'
       Content-Type:
-      - multipart/mixed; boundary================0107807186==
+      - multipart/mixed; boundary================1386896762==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/containered9318a9?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_d528dedf-45b4-4ca8-b67e-d3f141384277\r\nContent-Type:
+      string: "--batchresponse_9205896d-c6e4-4a71-a75e-499426a96410\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 3f4ed894-301e-006f-575e-ef47531e97d0\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 7bcf6332-5b51-11eb-85e7-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_d528dedf-45b4-4ca8-b67e-d3f141384277\r\nContent-Type:
+        true\r\nx-ms-request-id: fa20d835-501e-0058-6ac8-0f8bab1e30cd\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 0de349fa-7bbc-11eb-ae62-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_9205896d-c6e4-4a71-a75e-499426a96410\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 3f4ed894-301e-006f-575e-ef47531e97d1\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 7bcf8a4f-5b51-11eb-9451-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_d528dedf-45b4-4ca8-b67e-d3f141384277\r\nContent-Type:
+        true\r\nx-ms-request-id: fa20d835-501e-0058-6ac8-0f8bab1e30ce\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 0de3724e-7bbc-11eb-97e9-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_9205896d-c6e4-4a71-a75e-499426a96410\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 409 This operation is not
         permitted because the blob has snapshots.\r\nx-ms-error-code: SnapshotsPresent\r\nx-ms-request-id:
-        3f4ed894-301e-006f-575e-ef47531e97d2\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7bcf8a50-5b51-11eb-8f3d-c8348e5fffbc\r\nContent-Length: 249\r\nContent-Type:
+        fa20d835-501e-0058-6ac8-0f8bab1e30cf\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        0de3724f-7bbc-11eb-bd0c-c8348e5fffbf\r\nContent-Length: 249\r\nContent-Type:
         application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml version=\"1.0\"
         encoding=\"utf-8\"?>\n<Error><Code>SnapshotsPresent</Code><Message>This operation
-        is not permitted because the blob has snapshots.\nRequestId:3f4ed894-301e-006f-575e-ef47531e97d2\nTime:2021-01-20T18:58:29.3686603Z</Message></Error>\r\n--batchresponse_d528dedf-45b4-4ca8-b67e-d3f141384277--"
+        is not permitted because the blob has snapshots.\nRequestId:fa20d835-501e-0058-6ac8-0f8bab1e30cf\nTime:2021-03-03T01:01:57.6226030Z</Message></Error>\r\n--batchresponse_9205896d-c6e4-4a71-a75e-499426a96410--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_d528dedf-45b4-4ca8-b67e-d3f141384277
+      - multipart/mixed; boundary=batchresponse_9205896d-c6e4-4a71-a75e-499426a96410
       date:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -1328,15 +851,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
   response:
@@ -1348,11 +871,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 18:58:28 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       etag:
-      - '"0x8D8BD75602D4FB0"'
+      - '"0x8D8DDDFF1C981A0"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -1360,9 +883,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:29.5330736Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -1380,15 +901,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob2
   response:
@@ -1400,11 +921,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       etag:
-      - '"0x8D8BD7560441033"'
+      - '"0x8D8DDDFF1D39631"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -1412,9 +933,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:29.6821811Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -1432,15 +951,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob3
   response:
@@ -1452,11 +971,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       etag:
-      - '"0x8D8BD75605BBB42"'
+      - '"0x8D8DDDFF1DD0E65"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -1464,9 +983,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:29.8382930Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -1482,13 +999,13 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob3?comp=snapshot
   response:
@@ -1498,21 +1015,19 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       etag:
-      - '"0x8D8BD75605BBB42"'
+      - '"0x8D8DDDFF1DD0E65"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'false'
       x-ms-snapshot:
-      - '2021-01-20T18:58:29.9853993Z'
+      - '2021-03-03T01:01:57.8847534Z'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:29.9863993Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -1530,15 +1045,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
   response:
@@ -1550,11 +1065,11 @@ interactions:
       content-md5:
       - kAFQmDzST7DWlj99KOF/cg==
       date:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       etag:
-      - '"0x8D8BD7560889FFA"'
+      - '"0x8D8DDDFF1F185C3"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -1562,9 +1077,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:30.1325066Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -1582,15 +1095,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob2
   response:
@@ -1602,11 +1115,11 @@ interactions:
       content-md5:
       - kAFQmDzST7DWlj99KOF/cg==
       date:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       etag:
-      - '"0x8D8BD75609F124F"'
+      - '"0x8D8DDDFF1FBE88C"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -1614,9 +1127,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:30.2796127Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -1634,15 +1145,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob3
   response:
@@ -1654,11 +1165,11 @@ interactions:
       content-md5:
       - kAFQmDzST7DWlj99KOF/cg==
       date:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       etag:
-      - '"0x8D8BD7560B584A9"'
+      - '"0x8D8DDDFF206E7BF"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -1666,9 +1177,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:30.4267193Z'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -1682,13 +1191,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
   response:
@@ -1704,23 +1213,23 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 20 Jan 2021 18:58:29 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       etag:
-      - '"0x8D8BD7560889FFA"'
+      - '"0x8D8DDDFF1F185C3"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary:
+      - Origin
       x-ms-access-tier:
-      - Cool
-      x-ms-access-tier-change-time:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Hot
+      x-ms-access-tier-inferred:
+      - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 20 Jan 2021 18:58:30 GMT
-      x-ms-is-current-version:
-      - 'true'
+      - Wed, 03 Mar 2021 01:01:57 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -1728,28 +1237,24 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:30.1325066Z'
+      - '2020-06-12'
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============1472408348==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
-      binary\r\nContent-ID: 0\r\n\r\nPUT /containered9318a9/blob1?versionid=2021-01-20T18%3A58%3A30.1325066Z&comp=tier
-      HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier: Hot\r\nx-ms-date: Wed, 20
-      Jan 2021 18:58:30 GMT\r\nx-ms-client-request-id: 7c9d6e76-5b51-11eb-a2df-c8348e5fffbc\r\nAuthorization:
-      SharedKey tamerdevtest:LXxIavUTL9zsI9uMpHLYHC6pWRTwy3qmX/k7ux35wCc=\r\n\r\n\r\n--===============1472408348==\r\nContent-Type:
+    body: "--===============1936042099==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+      binary\r\nContent-ID: 0\r\n\r\nPUT /containered9318a9/blob1?comp=tier HTTP/1.1\r\nContent-Length:
+      0\r\nx-ms-access-tier: Cool\r\nx-ms-date: Wed, 03 Mar 2021 01:01:58 GMT\r\nx-ms-client-request-id:
+      0e3f077b-7bbc-11eb-ad75-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1936042099==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nPUT
-      /containered9318a9/blob2?versionid=2021-01-20T18%3A58%3A29.6821811Z&comp=tier
-      HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier: Hot\r\nx-ms-date: Wed, 20
-      Jan 2021 18:58:30 GMT\r\nx-ms-client-request-id: 7c9d6e77-5b51-11eb-86ec-c8348e5fffbc\r\nAuthorization:
-      SharedKey tamerdevtest:z5VPHot86YForxZgExg9tavy6VfhdlT29y5OeJDj1mg=\r\n\r\n\r\n--===============1472408348==\r\nContent-Type:
+      /containered9318a9/blob2?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
+      Cool\r\nx-ms-date: Wed, 03 Mar 2021 01:01:58 GMT\r\nx-ms-client-request-id:
+      0e3f2e40-7bbc-11eb-8611-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1936042099==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nPUT
-      /containered9318a9/blob3?snapshot=2021-01-20T18%3A58%3A29.9853993Z&comp=tier
-      HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier: Hot\r\nx-ms-date: Wed, 20
-      Jan 2021 18:58:30 GMT\r\nx-ms-client-request-id: 7c9d6e78-5b51-11eb-a6a0-c8348e5fffbc\r\nAuthorization:
-      SharedKey tamerdevtest:zxxs5+Xu63RpFsoHx4F1bCyHr73cE/iauzexHK9MP64=\r\n\r\n\r\n--===============1472408348==--\r\n"
+      /containered9318a9/blob3?snapshot=2021-03-03T01%3A01%3A57.8847534Z&comp=tier
+      HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier: Cool\r\nx-ms-date: Wed, 03
+      Mar 2021 01:01:58 GMT\r\nx-ms-client-request-id: 0e3f2e41-7bbc-11eb-9fd1-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1936042099==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -1758,40 +1263,40 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1355'
+      - '1272'
       Content-Type:
-      - multipart/mixed; boundary================1472408348==
+      - multipart/mixed; boundary================1936042099==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/containered9318a9?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_638b9b0a-91c1-4408-9ffb-daf8b4c677d3\r\nContent-Type:
+      string: "--batchresponse_48aedb4e-dd8f-40dc-ba64-db688f23c5eb\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        3f4ed962-301e-006f-6a5e-ef47531e97eb\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7c9d6e76-5b51-11eb-a2df-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_638b9b0a-91c1-4408-9ffb-daf8b4c677d3\r\nContent-Type:
+        fa20d96a-501e-0058-72c8-0f8bab1e30e5\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        0e3f077b-7bbc-11eb-ad75-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_48aedb4e-dd8f-40dc-ba64-db688f23c5eb\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        3f4ed962-301e-006f-6a5e-ef47531e97ec\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7c9d6e77-5b51-11eb-86ec-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_638b9b0a-91c1-4408-9ffb-daf8b4c677d3\r\nContent-Type:
+        fa20d96a-501e-0058-72c8-0f8bab1e30e6\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        0e3f2e40-7bbc-11eb-8611-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_48aedb4e-dd8f-40dc-ba64-db688f23c5eb\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        3f4ed962-301e-006f-6a5e-ef47531e97ed\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7c9d6e78-5b51-11eb-a6a0-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_638b9b0a-91c1-4408-9ffb-daf8b4c677d3--"
+        fa20d96a-501e-0058-72c8-0f8bab1e30e7\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        0e3f2e41-7bbc-11eb-9fd1-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_48aedb4e-dd8f-40dc-ba64-db688f23c5eb--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_638b9b0a-91c1-4408-9ffb-daf8b4c677d3
+      - multipart/mixed; boundary=batchresponse_48aedb4e-dd8f-40dc-ba64-db688f23c5eb
       date:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -1805,13 +1310,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
   response:
@@ -1827,23 +1332,23 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       etag:
-      - '"0x8D8BD7560889FFA"'
+      - '"0x8D8DDDFF1F185C3"'
       last-modified:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Wed, 03 Mar 2021 01:01:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary:
+      - Origin
       x-ms-access-tier:
-      - Hot
+      - Cool
       x-ms-access-tier-change-time:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 20 Jan 2021 18:58:30 GMT
-      x-ms-is-current-version:
-      - 'true'
+      - Wed, 03 Mar 2021 01:01:57 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -1851,23 +1356,21 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
-      x-ms-version-id:
-      - '2021-01-20T18:58:30.1325066Z'
+      - '2020-06-12'
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============1453433141==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============0220075200==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /containered9318a9/blob1? HTTP/1.1\r\nx-ms-date:
-      Wed, 20 Jan 2021 18:58:30 GMT\r\nx-ms-client-request-id: 7cc8fdf7-5b51-11eb-81d8-c8348e5fffbc\r\nAuthorization:
-      SharedKey tamerdevtest:9GlM0X0qTzqs8OTyeLCMx4fmUjctu+fHzuQm/RKt0fY=\r\n\r\n\r\n--===============1453433141==\r\nContent-Type:
+      Wed, 03 Mar 2021 01:01:58 GMT\r\nx-ms-client-request-id: 0e543051-7bbc-11eb-b8e7-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0220075200==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /containered9318a9/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 18:58:30 GMT\r\nx-ms-client-request-id:
-      7cc8fdf8-5b51-11eb-9d03-c8348e5fffbc\r\nAuthorization: SharedKey tamerdevtest:olIWGOYhTEQ71HkYUTL8ywpr9tqIYF2nTAeoO3nR1pM=\r\n\r\n\r\n--===============1453433141==\r\nContent-Type:
+      /containered9318a9/blob2? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:01:58 GMT\r\nx-ms-client-request-id:
+      0e5457a2-7bbc-11eb-a83d-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0220075200==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /containered9318a9/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 18:58:30 GMT\r\nx-ms-client-request-id:
-      7cc8fdf9-5b51-11eb-8a25-c8348e5fffbc\r\nAuthorization: SharedKey tamerdevtest:wHti3zmCYbswExPCHqyBZ30BKxXDSp1ISJzv0iL0PVE=\r\n\r\n\r\n--===============1453433141==--\r\n"
+      /containered9318a9/blob3? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:01:58 GMT\r\nx-ms-client-request-id:
+      0e5457a3-7bbc-11eb-b4e6-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0220075200==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -1878,44 +1381,629 @@ interactions:
       Content-Length:
       - '1083'
       Content-Type:
-      - multipart/mixed; boundary================1453433141==
+      - multipart/mixed; boundary================0220075200==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/containered9318a9?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_31658250-d35b-4748-87ac-71af60767e39\r\nContent-Type:
+      string: "--batchresponse_91af34f7-5c19-49a8-9274-5c7ad7938d8e\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 3f4ed999-301e-006f-155e-ef47531e97f1\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 7cc8fdf7-5b51-11eb-81d8-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_31658250-d35b-4748-87ac-71af60767e39\r\nContent-Type:
+        true\r\nx-ms-request-id: fa20d9af-501e-0058-28c8-0f8bab1e30ed\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 0e543051-7bbc-11eb-b8e7-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_91af34f7-5c19-49a8-9274-5c7ad7938d8e\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 3f4ed999-301e-006f-155e-ef47531e97f2\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 7cc8fdf8-5b51-11eb-9d03-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_31658250-d35b-4748-87ac-71af60767e39\r\nContent-Type:
+        true\r\nx-ms-request-id: fa20d9af-501e-0058-28c8-0f8bab1e30ee\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 0e5457a2-7bbc-11eb-a83d-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_91af34f7-5c19-49a8-9274-5c7ad7938d8e\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 409 This operation is not
         permitted because the blob has snapshots.\r\nx-ms-error-code: SnapshotsPresent\r\nx-ms-request-id:
-        3f4ed999-301e-006f-155e-ef47531e97f3\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7cc8fdf9-5b51-11eb-8a25-c8348e5fffbc\r\nContent-Length: 249\r\nContent-Type:
+        fa20d9af-501e-0058-28c8-0f8bab1e30ef\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        0e5457a3-7bbc-11eb-b4e6-c8348e5fffbf\r\nContent-Length: 249\r\nContent-Type:
         application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml version=\"1.0\"
         encoding=\"utf-8\"?>\n<Error><Code>SnapshotsPresent</Code><Message>This operation
-        is not permitted because the blob has snapshots.\nRequestId:3f4ed999-301e-006f-155e-ef47531e97f3\nTime:2021-01-20T18:58:31.0068148Z</Message></Error>\r\n--batchresponse_31658250-d35b-4748-87ac-71af60767e39--"
+        is not permitted because the blob has snapshots.\nRequestId:fa20d9af-501e-0058-28c8-0f8bab1e30ef\nTime:2021-03-03T01:01:58.3541356Z</Message></Error>\r\n--batchresponse_91af34f7-5c19-49a8-9274-5c7ad7938d8e--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_31658250-d35b-4748-87ac-71af60767e39
+      - multipart/mixed; boundary=batchresponse_91af34f7-5c19-49a8-9274-5c7ad7938d8e
       date:
-      - Wed, 20 Jan 2021 18:58:30 GMT
+      - Wed, 03 Mar 2021 01:01:58 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: hello world
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '11'
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Wed, 03 Mar 2021 01:01:59 GMT
+      x-ms-encryption-algorithm:
+      - AES256
+      x-ms-version:
+      - '2020-06-12'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - XrY7u+Ae7tCTyyK7j1rNww==
+      date:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      etag:
+      - '"0x8D8DDDFF23BE74E"'
+      last-modified:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - vo7q9sPVKY0=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: hello world
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '11'
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Wed, 03 Mar 2021 01:01:59 GMT
+      x-ms-encryption-algorithm:
+      - AES256
+      x-ms-version:
+      - '2020-06-12'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/containered9318a9/blob2
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - XrY7u+Ae7tCTyyK7j1rNww==
+      date:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      etag:
+      - '"0x8D8DDDFF247A9F8"'
+      last-modified:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - vo7q9sPVKY0=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: hello world
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '11'
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Wed, 03 Mar 2021 01:01:59 GMT
+      x-ms-encryption-algorithm:
+      - AES256
+      x-ms-version:
+      - '2020-06-12'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/containered9318a9/blob3
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - XrY7u+Ae7tCTyyK7j1rNww==
+      date:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      etag:
+      - '"0x8D8DDDFF251493D"'
+      last-modified:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - vo7q9sPVKY0=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 03 Mar 2021 01:01:59 GMT
+      x-ms-encryption-algorithm:
+      - AES256
+      x-ms-version:
+      - '2020-06-12'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/containered9318a9/blob3?comp=snapshot
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      etag:
+      - '"0x8D8DDDFF251493D"'
+      last-modified:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted:
+      - 'false'
+      x-ms-snapshot:
+      - '2021-03-03T01:01:58.6444754Z'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: abc
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3'
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Wed, 03 Mar 2021 01:01:59 GMT
+      x-ms-encryption-algorithm:
+      - AES256
+      x-ms-version:
+      - '2020-06-12'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - kAFQmDzST7DWlj99KOF/cg==
+      date:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      etag:
+      - '"0x8D8DDDFF2654B42"'
+      last-modified:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - 6/rBP7vK5QU=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: abc
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3'
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Wed, 03 Mar 2021 01:01:59 GMT
+      x-ms-encryption-algorithm:
+      - AES256
+      x-ms-version:
+      - '2020-06-12'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/containered9318a9/blob2
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - kAFQmDzST7DWlj99KOF/cg==
+      date:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      etag:
+      - '"0x8D8DDDFF26F5FD8"'
+      last-modified:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - 6/rBP7vK5QU=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: abc
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3'
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-date:
+      - Wed, 03 Mar 2021 01:01:59 GMT
+      x-ms-encryption-algorithm:
+      - AES256
+      x-ms-version:
+      - '2020-06-12'
+    method: PUT
+    uri: https://storagename.blob.core.windows.net/containered9318a9/blob3
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-md5:
+      - kAFQmDzST7DWlj99KOF/cg==
+      date:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      etag:
+      - '"0x8D8DDDFF279C29C"'
+      last-modified:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-content-crc64:
+      - 6/rBP7vK5QU=
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 03 Mar 2021 01:01:59 GMT
+      x-ms-encryption-algorithm:
+      - AES256
+      x-ms-version:
+      - '2020-06-12'
+    method: HEAD
+    uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
+  response:
+    body:
+      string: ''
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '3'
+      content-md5:
+      - kAFQmDzST7DWlj99KOF/cg==
+      content-type:
+      - application/octet-stream
+      date:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      etag:
+      - '"0x8D8DDDFF2654B42"'
+      last-modified:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary:
+      - Origin
+      x-ms-access-tier:
+      - Hot
+      x-ms-access-tier-inferred:
+      - 'true'
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "--===============0326860610==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+      binary\r\nContent-ID: 0\r\n\r\nPUT /containered9318a9/blob1?comp=tier HTTP/1.1\r\nContent-Length:
+      0\r\nx-ms-access-tier: Hot\r\nx-ms-date: Wed, 03 Mar 2021 01:01:59 GMT\r\nx-ms-client-request-id:
+      0eb22772-7bbc-11eb-86a2-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0326860610==\r\nContent-Type:
+      application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nPUT
+      /containered9318a9/blob2?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
+      Hot\r\nx-ms-date: Wed, 03 Mar 2021 01:01:59 GMT\r\nx-ms-client-request-id: 0eb24e7b-7bbc-11eb-a339-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0326860610==\r\nContent-Type:
+      application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nPUT
+      /containered9318a9/blob3?snapshot=2021-03-03T01%3A01%3A58.6444754Z&comp=tier
+      HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier: Hot\r\nx-ms-date: Wed, 03
+      Mar 2021 01:01:59 GMT\r\nx-ms-client-request-id: 0eb24e7c-7bbc-11eb-b6d7-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0326860610==--\r\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1269'
+      Content-Type:
+      - multipart/mixed; boundary================0326860610==
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 03 Mar 2021 01:01:59 GMT
+      x-ms-version:
+      - '2020-06-12'
+    method: POST
+    uri: https://storagename.blob.core.windows.net/containered9318a9?restype=container&comp=batch
+  response:
+    body:
+      string: "--batchresponse_71927dc0-128b-4c06-9770-44faf0898810\r\nContent-Type:
+        application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
+        fa20daa0-501e-0058-79c8-0f8bab1e30fd\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        0eb22772-7bbc-11eb-86a2-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_71927dc0-128b-4c06-9770-44faf0898810\r\nContent-Type:
+        application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
+        fa20daa0-501e-0058-79c8-0f8bab1e30fe\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        0eb24e7b-7bbc-11eb-a339-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_71927dc0-128b-4c06-9770-44faf0898810\r\nContent-Type:
+        application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
+        fa20daa0-501e-0058-79c8-0f8bab1e30ff\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        0eb24e7c-7bbc-11eb-b6d7-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_71927dc0-128b-4c06-9770-44faf0898810--"
+    headers:
+      content-type:
+      - multipart/mixed; boundary=batchresponse_71927dc0-128b-4c06-9770-44faf0898810
+      date:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 03 Mar 2021 01:01:59 GMT
+      x-ms-encryption-algorithm:
+      - AES256
+      x-ms-version:
+      - '2020-06-12'
+    method: HEAD
+    uri: https://storagename.blob.core.windows.net/containered9318a9/blob1
+  response:
+    body:
+      string: ''
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '3'
+      content-md5:
+      - kAFQmDzST7DWlj99KOF/cg==
+      content-type:
+      - application/octet-stream
+      date:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      etag:
+      - '"0x8D8DDDFF2654B42"'
+      last-modified:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      vary:
+      - Origin
+      x-ms-access-tier:
+      - Hot
+      x-ms-access-tier-change-time:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Wed, 03 Mar 2021 01:01:58 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-06-12'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "--===============0134211683==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+      binary\r\nContent-ID: 0\r\n\r\nDELETE /containered9318a9/blob1? HTTP/1.1\r\nx-ms-date:
+      Wed, 03 Mar 2021 01:01:59 GMT\r\nx-ms-client-request-id: 0ec6da8c-7bbc-11eb-a8da-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0134211683==\r\nContent-Type:
+      application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
+      /containered9318a9/blob2? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:01:59 GMT\r\nx-ms-client-request-id:
+      0ec702b1-7bbc-11eb-b2b4-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0134211683==\r\nContent-Type:
+      application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
+      /containered9318a9/blob3? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:01:59 GMT\r\nx-ms-client-request-id:
+      0ec702b2-7bbc-11eb-b3c7-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0134211683==--\r\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1083'
+      Content-Type:
+      - multipart/mixed; boundary================0134211683==
+      User-Agent:
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 03 Mar 2021 01:01:59 GMT
+      x-ms-version:
+      - '2020-06-12'
+    method: POST
+    uri: https://storagename.blob.core.windows.net/containered9318a9?restype=container&comp=batch
+  response:
+    body:
+      string: "--batchresponse_a6edfe6f-0901-465f-8ab5-a5299ee11d06\r\nContent-Type:
+        application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
+        true\r\nx-ms-request-id: fa20db1e-501e-0058-68c8-0f8bab1e3109\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 0ec6da8c-7bbc-11eb-a8da-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_a6edfe6f-0901-465f-8ab5-a5299ee11d06\r\nContent-Type:
+        application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
+        true\r\nx-ms-request-id: fa20db1e-501e-0058-68c8-0f8bab1e310a\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 0ec702b1-7bbc-11eb-b2b4-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_a6edfe6f-0901-465f-8ab5-a5299ee11d06\r\nContent-Type:
+        application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 409 This operation is not
+        permitted because the blob has snapshots.\r\nx-ms-error-code: SnapshotsPresent\r\nx-ms-request-id:
+        fa20db1e-501e-0058-68c8-0f8bab1e310b\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        0ec702b2-7bbc-11eb-b3c7-c8348e5fffbf\r\nContent-Length: 249\r\nContent-Type:
+        application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml version=\"1.0\"
+        encoding=\"utf-8\"?>\n<Error><Code>SnapshotsPresent</Code><Message>This operation
+        is not permitted because the blob has snapshots.\nRequestId:fa20db1e-501e-0058-68c8-0f8bab1e310b\nTime:2021-03-03T01:01:59.1126907Z</Message></Error>\r\n--batchresponse_a6edfe6f-0901-465f-8ab5-a5299ee11d06--"
+    headers:
+      content-type:
+      - multipart/mixed; boundary=batchresponse_a6edfe6f-0901-465f-8ab5-a5299ee11d06
+      date:
+      - Wed, 03 Mar 2021 01:01:59 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2020-06-12'
     status:
       code: 202
       message: Accepted

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_delete_blobs_simple.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_delete_blobs_simple.yaml
@@ -11,33 +11,32 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:16:22 GMT
+      - Wed, 03 Mar 2021 01:07:12 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/container40320ffd?restype=container
   response:
     body:
-      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
-        specified container already exists.\nRequestId:ce1ea384-101e-0066-4671-ef1cd4000000\nTime:2021-01-20T21:16:22.9697338Z</Message></Error>"
+      string: ''
     headers:
       content-length:
-      - '230'
-      content-type:
-      - application/xml
+      - '0'
       date:
-      - Wed, 20 Jan 2021 21:16:22 GMT
+      - Wed, 03 Mar 2021 01:07:11 GMT
+      etag:
+      - '"0x8D8DDE0AD071490"'
+      last-modified:
+      - Wed, 03 Mar 2021 01:07:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-error-code:
-      - ContainerAlreadyExists
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
-      code: 409
-      message: The specified container already exists.
+      code: 201
+      message: Created
 - request:
     body: hello world
     headers:
@@ -54,15 +53,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:16:22 GMT
+      - Wed, 03 Mar 2021 01:07:12 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/container40320ffd/blob1
   response:
@@ -74,11 +73,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 21:16:23 GMT
+      - Wed, 03 Mar 2021 01:07:11 GMT
       etag:
-      - '"0x8D8BD88A391E737"'
+      - '"0x8D8DDE0AD146176"'
       last-modified:
-      - Wed, 20 Jan 2021 21:16:23 GMT
+      - Wed, 03 Mar 2021 01:07:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -86,7 +85,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -106,15 +105,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:16:22 GMT
+      - Wed, 03 Mar 2021 01:07:12 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/container40320ffd/blob2
   response:
@@ -126,11 +125,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 21:16:23 GMT
+      - Wed, 03 Mar 2021 01:07:11 GMT
       etag:
-      - '"0x8D8BD88A39C22E5"'
+      - '"0x8D8DDE0AD23CE8A"'
       last-modified:
-      - Wed, 20 Jan 2021 21:16:23 GMT
+      - Wed, 03 Mar 2021 01:07:12 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -138,7 +137,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -158,15 +157,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:16:22 GMT
+      - Wed, 03 Mar 2021 01:07:12 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/container40320ffd/blob3
   response:
@@ -178,11 +177,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 21:16:23 GMT
+      - Wed, 03 Mar 2021 01:07:11 GMT
       etag:
-      - '"0x8D8BD88A3A65E8F"'
+      - '"0x8D8DDE0AD2EF4D7"'
       last-modified:
-      - Wed, 20 Jan 2021 21:16:23 GMT
+      - Wed, 03 Mar 2021 01:07:12 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -190,7 +189,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -204,13 +203,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:16:22 GMT
+      - Wed, 03 Mar 2021 01:07:12 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/container40320ffd/blob1
   response:
@@ -226,11 +225,11 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 20 Jan 2021 21:16:23 GMT
+      - Wed, 03 Mar 2021 01:07:11 GMT
       etag:
-      - '"0x8D8BD88A391E737"'
+      - '"0x8D8DDE0AD146176"'
       last-modified:
-      - Wed, 20 Jan 2021 21:16:23 GMT
+      - Wed, 03 Mar 2021 01:07:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       vary:
@@ -242,7 +241,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 20 Jan 2021 21:16:23 GMT
+      - Wed, 03 Mar 2021 01:07:11 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -250,21 +249,21 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============1216683920==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============0557771650==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /container40320ffd/blob1? HTTP/1.1\r\nIf-Match:
-      \"0x8D8BD88A391E737\"\r\nx-ms-date: Wed, 20 Jan 2021 21:16:22 GMT\r\nx-ms-client-request-id:
-      bf40f64b-5b64-11eb-87a7-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:6wfTuhqimw/gXnTdMa6a4/V5ZNv2GyuWx6xH4WDcY6g=\r\n\r\n\r\n--===============1216683920==\r\nContent-Type:
+      \"0x8D8DDE0AD146176\"\r\nx-ms-date: Wed, 03 Mar 2021 01:07:12 GMT\r\nx-ms-client-request-id:
+      c968b661-7bbc-11eb-880e-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0557771650==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /container40320ffd/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 21:16:22 GMT\r\nx-ms-client-request-id:
-      bf411d52-5b64-11eb-8730-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:z8U0YHpqobg5WwidHdcWKLwEYPbakut1/BOQ4Va0l0Q=\r\n\r\n\r\n--===============1216683920==\r\nContent-Type:
+      /container40320ffd/blob2? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:07:12 GMT\r\nx-ms-client-request-id:
+      c968b662-7bbc-11eb-85cb-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0557771650==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /container40320ffd/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 21:16:22 GMT\r\nx-ms-client-request-id:
-      bf411d53-5b64-11eb-9db3-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:YYc6L0x5vv3/GWf2lJHXrgo62+BxFHtWVhQryaOWCeQ=\r\n\r\n\r\n--===============1216683920==--\r\n"
+      /container40320ffd/blob3? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:07:12 GMT\r\nx-ms-client-request-id:
+      c968dd73-7bbc-11eb-8eac-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0557771650==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -275,41 +274,41 @@ interactions:
       Content-Length:
       - '1114'
       Content-Type:
-      - multipart/mixed; boundary================1216683920==
+      - multipart/mixed; boundary================0557771650==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:16:22 GMT
+      - Wed, 03 Mar 2021 01:07:12 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/container40320ffd?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_caba0e34-3e72-43cf-a8b2-92942b3737d5\r\nContent-Type:
+      string: "--batchresponse_182ded06-cc0d-4220-aad0-d741e39ccc7e\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: ce1ea4ba-101e-0066-6571-ef1cd41e4b63\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: bf40f64b-5b64-11eb-87a7-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_caba0e34-3e72-43cf-a8b2-92942b3737d5\r\nContent-Type:
+        true\r\nx-ms-request-id: 8592c0db-f01e-006e-20c9-0f06db1e8012\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: c968b661-7bbc-11eb-880e-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_182ded06-cc0d-4220-aad0-d741e39ccc7e\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: ce1ea4ba-101e-0066-6571-ef1cd41e4b65\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: bf411d52-5b64-11eb-8730-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_caba0e34-3e72-43cf-a8b2-92942b3737d5\r\nContent-Type:
+        true\r\nx-ms-request-id: 8592c0db-f01e-006e-20c9-0f06db1e8014\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: c968b662-7bbc-11eb-85cb-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_182ded06-cc0d-4220-aad0-d741e39ccc7e\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: ce1ea4ba-101e-0066-6571-ef1cd41e4b66\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: bf411d53-5b64-11eb-9db3-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_caba0e34-3e72-43cf-a8b2-92942b3737d5--"
+        true\r\nx-ms-request-id: 8592c0db-f01e-006e-20c9-0f06db1e8015\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: c968dd73-7bbc-11eb-8eac-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_182ded06-cc0d-4220-aad0-d741e39ccc7e--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_caba0e34-3e72-43cf-a8b2-92942b3737d5
+      - multipart/mixed; boundary=batchresponse_182ded06-cc0d-4220-aad0-d741e39ccc7e
       date:
-      - Wed, 20 Jan 2021 21:16:23 GMT
+      - Wed, 03 Mar 2021 01:07:12 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 202
       message: Accepted

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_delete_blobs_simple_no_raise.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_delete_blobs_simple_no_raise.yaml
@@ -11,32 +11,33 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:17:25 GMT
+      - Wed, 03 Mar 2021 01:10:39 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containere26513ac?restype=container
   response:
     body:
-      string: ''
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
+        specified container already exists.\nRequestId:62030904-301e-0013-18ca-0f77f8000000\nTime:2021-03-03T01:10:39.4752887Z</Message></Error>"
     headers:
       content-length:
-      - '0'
+      - '230'
+      content-type:
+      - application/xml
       date:
-      - Wed, 20 Jan 2021 21:17:24 GMT
-      etag:
-      - '"0x8D8BD88C8FE4FE5"'
-      last-modified:
-      - Wed, 20 Jan 2021 21:17:25 GMT
+      - Wed, 03 Mar 2021 01:10:38 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-error-code:
+      - ContainerAlreadyExists
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
-      code: 201
-      message: Created
+      code: 409
+      message: The specified container already exists.
 - request:
     body: hello world
     headers:
@@ -53,15 +54,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:17:25 GMT
+      - Wed, 03 Mar 2021 01:10:40 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containere26513ac/blob1
   response:
@@ -73,11 +74,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 21:17:24 GMT
+      - Wed, 03 Mar 2021 01:10:38 GMT
       etag:
-      - '"0x8D8BD88C9090FA6"'
+      - '"0x8D8DDE128D58214"'
       last-modified:
-      - Wed, 20 Jan 2021 21:17:25 GMT
+      - Wed, 03 Mar 2021 01:10:39 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -85,7 +86,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -105,15 +106,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:17:25 GMT
+      - Wed, 03 Mar 2021 01:10:40 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containere26513ac/blob2
   response:
@@ -125,11 +126,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 21:17:25 GMT
+      - Wed, 03 Mar 2021 01:10:38 GMT
       etag:
-      - '"0x8D8BD88C9132437"'
+      - '"0x8D8DDE128E0330B"'
       last-modified:
-      - Wed, 20 Jan 2021 21:17:25 GMT
+      - Wed, 03 Mar 2021 01:10:39 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -137,7 +138,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -157,15 +158,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:17:25 GMT
+      - Wed, 03 Mar 2021 01:10:40 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containere26513ac/blob3
   response:
@@ -177,11 +178,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 21:17:25 GMT
+      - Wed, 03 Mar 2021 01:10:38 GMT
       etag:
-      - '"0x8D8BD88C91DAE10"'
+      - '"0x8D8DDE128EB8068"'
       last-modified:
-      - Wed, 20 Jan 2021 21:17:26 GMT
+      - Wed, 03 Mar 2021 01:10:39 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -189,21 +190,21 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
 - request:
-    body: "--===============0650979416==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============2061818319==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /containere26513ac/blob1? HTTP/1.1\r\nx-ms-date:
-      Wed, 20 Jan 2021 21:17:25 GMT\r\nx-ms-client-request-id: e4ae3803-5b64-11eb-ba9f-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:uYFirWzLo3UWDPxagom9VCiSHYZYVaZkv0Rnipp8b+8=\r\n\r\n\r\n--===============0650979416==\r\nContent-Type:
+      Wed, 03 Mar 2021 01:10:40 GMT\r\nx-ms-client-request-id: 451a3992-7bbd-11eb-b77d-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2061818319==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /containere26513ac/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 21:17:25 GMT\r\nx-ms-client-request-id:
-      e4ae3804-5b64-11eb-94f5-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:b9UUMulUqLLu7oIFdpqCyv7O1ie5m5Dd2XggrNcsKUo=\r\n\r\n\r\n--===============0650979416==\r\nContent-Type:
+      /containere26513ac/blob2? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:10:40 GMT\r\nx-ms-client-request-id:
+      451a6354-7bbd-11eb-83e6-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2061818319==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /containere26513ac/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 21:17:25 GMT\r\nx-ms-client-request-id:
-      e4ae3805-5b64-11eb-a147-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:rngd4SGoTvlbhPeDbeJu1u8/tR4+u3D1r0LuHukCB6E=\r\n\r\n\r\n--===============0650979416==--\r\n"
+      /containere26513ac/blob3? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:10:40 GMT\r\nx-ms-client-request-id:
+      451a6355-7bbd-11eb-b29a-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2061818319==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -214,41 +215,41 @@ interactions:
       Content-Length:
       - '1083'
       Content-Type:
-      - multipart/mixed; boundary================0650979416==
+      - multipart/mixed; boundary================2061818319==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:17:25 GMT
+      - Wed, 03 Mar 2021 01:10:40 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/containere26513ac?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_7697ce19-e080-48c3-aa69-83ca6bbb2504\r\nContent-Type:
+      string: "--batchresponse_0bc103cf-ede7-4339-ab8b-0d341969c75d\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: d1e6a91a-a01e-0011-7e71-efc9401e78fe\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: e4ae3803-5b64-11eb-ba9f-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_7697ce19-e080-48c3-aa69-83ca6bbb2504\r\nContent-Type:
+        true\r\nx-ms-request-id: 62030a14-301e-0013-14ca-0f77f81e0c8b\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 451a3992-7bbd-11eb-b77d-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_0bc103cf-ede7-4339-ab8b-0d341969c75d\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: d1e6a91a-a01e-0011-7e71-efc9401e7900\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: e4ae3804-5b64-11eb-94f5-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_7697ce19-e080-48c3-aa69-83ca6bbb2504\r\nContent-Type:
+        true\r\nx-ms-request-id: 62030a14-301e-0013-14ca-0f77f81e0c8e\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 451a6354-7bbd-11eb-83e6-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_0bc103cf-ede7-4339-ab8b-0d341969c75d\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: d1e6a91a-a01e-0011-7e71-efc9401e7901\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: e4ae3805-5b64-11eb-a147-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_7697ce19-e080-48c3-aa69-83ca6bbb2504--"
+        true\r\nx-ms-request-id: 62030a14-301e-0013-14ca-0f77f81e0c8f\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 451a6355-7bbd-11eb-b29a-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_0bc103cf-ede7-4339-ab8b-0d341969c75d--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_7697ce19-e080-48c3-aa69-83ca6bbb2504
+      - multipart/mixed; boundary=batchresponse_0bc103cf-ede7-4339-ab8b-0d341969c75d
       date:
-      - Wed, 20 Jan 2021 21:17:25 GMT
+      - Wed, 03 Mar 2021 01:10:40 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 202
       message: Accepted

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_delete_blobs_snapshot.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_delete_blobs_snapshot.yaml
@@ -11,11 +11,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:33:32 GMT
+      - Wed, 03 Mar 2021 01:14:45 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/test617e10e3?restype=container
   response:
@@ -25,15 +25,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 20 Jan 2021 20:33:32 GMT
+      - Wed, 03 Mar 2021 01:14:45 GMT
       etag:
-      - '"0x8D8BD82A7E69FE6"'
+      - '"0x8D8DDE1BBD8E0AF"'
       last-modified:
-      - Wed, 20 Jan 2021 20:33:33 GMT
+      - Wed, 03 Mar 2021 01:14:46 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -53,15 +53,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 20:33:32 GMT
+      - Wed, 03 Mar 2021 01:14:46 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/test617e10e3/blob1
   response:
@@ -73,11 +73,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 20:33:32 GMT
+      - Wed, 03 Mar 2021 01:14:45 GMT
       etag:
-      - '"0x8D8BD82A7F3183F"'
+      - '"0x8D8DDE1BBEF686B"'
       last-modified:
-      - Wed, 20 Jan 2021 20:33:33 GMT
+      - Wed, 03 Mar 2021 01:14:46 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -85,7 +85,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -101,13 +101,13 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:33:33 GMT
+      - Wed, 03 Mar 2021 01:14:46 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/test617e10e3/blob1?comp=snapshot
   response:
@@ -117,19 +117,19 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 20 Jan 2021 20:33:32 GMT
+      - Wed, 03 Mar 2021 01:14:45 GMT
       etag:
-      - '"0x8D8BD82A7F3183F"'
+      - '"0x8D8DDE1BBEF686B"'
       last-modified:
-      - Wed, 20 Jan 2021 20:33:33 GMT
+      - Wed, 03 Mar 2021 01:14:46 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'false'
       x-ms-snapshot:
-      - '2021-01-20T20:33:33.5070816Z'
+      - '2021-03-03T01:14:46.4385506Z'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -149,15 +149,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 20:33:33 GMT
+      - Wed, 03 Mar 2021 01:14:47 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/test617e10e3/blob2
   response:
@@ -169,11 +169,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 20:33:32 GMT
+      - Wed, 03 Mar 2021 01:14:45 GMT
       etag:
-      - '"0x8D8BD82A80E6F09"'
+      - '"0x8D8DDE1BC1325B4"'
       last-modified:
-      - Wed, 20 Jan 2021 20:33:33 GMT
+      - Wed, 03 Mar 2021 01:14:46 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -181,7 +181,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -201,15 +201,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 20:33:33 GMT
+      - Wed, 03 Mar 2021 01:14:47 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/test617e10e3/blob3
   response:
@@ -221,11 +221,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 20:33:32 GMT
+      - Wed, 03 Mar 2021 01:14:46 GMT
       etag:
-      - '"0x8D8BD82A8194719"'
+      - '"0x8D8DDE1BC2AAB07"'
       last-modified:
-      - Wed, 20 Jan 2021 20:33:33 GMT
+      - Wed, 03 Mar 2021 01:14:46 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -233,7 +233,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -247,31 +247,31 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:33:33 GMT
+      - Wed, 03 Mar 2021 01:14:47 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: GET
     uri: https://storagename.blob.core.windows.net/test617e10e3?restype=container&comp=list&include=snapshots
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"test617e10e3\"><Blobs><Blob><Name>blob1</Name><Snapshot>2021-01-20T20:33:33.5070816Z</Snapshot><Properties><Creation-Time>Wed,
-        20 Jan 2021 20:33:33 GMT</Creation-Time><Last-Modified>Wed, 20 Jan 2021 20:33:33
-        GMT</Last-Modified><Etag>0x8D8BD82A7F3183F</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"test617e10e3\"><Blobs><Blob><Name>blob1</Name><Snapshot>2021-03-03T01:14:46.4385506Z</Snapshot><Properties><Creation-Time>Wed,
+        03 Mar 2021 01:14:46 GMT</Creation-Time><Last-Modified>Wed, 03 Mar 2021 01:14:46
+        GMT</Last-Modified><Etag>0x8D8DDE1BBEF686B</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>blob1</Name><Properties><Creation-Time>Wed, 20 Jan 2021
-        20:33:33 GMT</Creation-Time><Last-Modified>Wed, 20 Jan 2021 20:33:33 GMT</Last-Modified><Etag>0x8D8BD82A7F3183F</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>blob1</Name><Properties><Creation-Time>Wed, 03 Mar 2021
+        01:14:46 GMT</Creation-Time><Last-Modified>Wed, 03 Mar 2021 01:14:46 GMT</Last-Modified><Etag>0x8D8DDE1BBEF686B</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>blob2</Name><Properties><Creation-Time>Wed, 20 Jan 2021
-        20:33:33 GMT</Creation-Time><Last-Modified>Wed, 20 Jan 2021 20:33:33 GMT</Last-Modified><Etag>0x8D8BD82A80E6F09</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>blob2</Name><Properties><Creation-Time>Wed, 03 Mar 2021
+        01:14:46 GMT</Creation-Time><Last-Modified>Wed, 03 Mar 2021 01:14:46 GMT</Last-Modified><Etag>0x8D8DDE1BC1325B4</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>blob3</Name><Properties><Creation-Time>Wed, 20 Jan 2021
-        20:33:33 GMT</Creation-Time><Last-Modified>Wed, 20 Jan 2021 20:33:33 GMT</Last-Modified><Etag>0x8D8BD82A8194719</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>blob3</Name><Properties><Creation-Time>Wed, 03 Mar 2021
+        01:14:46 GMT</Creation-Time><Last-Modified>Wed, 03 Mar 2021 01:14:46 GMT</Last-Modified><Etag>0x8D8DDE1BC2AAB07</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
@@ -279,7 +279,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Wed, 20 Jan 2021 20:33:32 GMT
+      - Wed, 03 Mar 2021 01:14:46 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -287,23 +287,23 @@ interactions:
       vary:
       - Origin
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============1049724224==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============1114621032==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /test617e10e3/blob1? HTTP/1.1\r\nx-ms-delete-snapshots:
-      only\r\nx-ms-date: Wed, 20 Jan 2021 20:33:33 GMT\r\nx-ms-client-request-id:
-      c3b7449e-5b5e-11eb-81ea-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:NMhu/QoBLMsZXHRT3wvz+0juGwFyOdhCdkGWpTJAhX0=\r\n\r\n\r\n--===============1049724224==\r\nContent-Type:
+      only\r\nx-ms-date: Wed, 03 Mar 2021 01:14:47 GMT\r\nx-ms-client-request-id:
+      d870b204-7bbd-11eb-9713-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1114621032==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
       /test617e10e3/blob2? HTTP/1.1\r\nx-ms-delete-snapshots: only\r\nx-ms-date: Wed,
-      20 Jan 2021 20:33:33 GMT\r\nx-ms-client-request-id: c3b76ba3-5b5e-11eb-9110-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:KC2Es/SaD/Im/3JzmHoSSZnxtGGlfxeJO9OMpr9adM8=\r\n\r\n\r\n--===============1049724224==\r\nContent-Type:
+      03 Mar 2021 01:14:47 GMT\r\nx-ms-client-request-id: d870b205-7bbd-11eb-b5ee-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1114621032==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
       /test617e10e3/blob3? HTTP/1.1\r\nx-ms-delete-snapshots: only\r\nx-ms-date: Wed,
-      20 Jan 2021 20:33:33 GMT\r\nx-ms-client-request-id: c3b76ba4-5b5e-11eb-87f5-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:mqusfa8do8OtbXVdRXAxJYK0KCz5QuDHw4/0/MaMylY=\r\n\r\n\r\n--===============1049724224==--\r\n"
+      03 Mar 2021 01:14:47 GMT\r\nx-ms-client-request-id: d870b206-7bbd-11eb-8aec-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1114621032==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -314,45 +314,45 @@ interactions:
       Content-Length:
       - '1155'
       Content-Type:
-      - multipart/mixed; boundary================1049724224==
+      - multipart/mixed; boundary================1114621032==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:33:33 GMT
+      - Wed, 03 Mar 2021 01:14:47 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/test617e10e3?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_1095d3e1-abcd-475f-9e6a-197220582478\r\nContent-Type:
+      string: "--batchresponse_ae1de5f8-abc7-496e-a22d-a98f571c2953\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: b4ab4bd2-f01e-009a-406b-efcd2d1ed6f5\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: c3b7449e-5b5e-11eb-81ea-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_1095d3e1-abcd-475f-9e6a-197220582478\r\nContent-Type:
+        true\r\nx-ms-request-id: da136612-101e-0092-11ca-0fd7221e2d48\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: d870b204-7bbd-11eb-9713-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_ae1de5f8-abc7-496e-a22d-a98f571c2953\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 404 The specified blob does
-        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: b4ab4bd2-f01e-009a-406b-efcd2d1ed6f7\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: c3b76ba3-5b5e-11eb-9110-c8348e5fffbc\r\nContent-Length:
+        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: da136612-101e-0092-11ca-0fd7221e2d4c\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: d870b205-7bbd-11eb-b5ee-c8348e5fffbf\r\nContent-Length:
         216\r\nContent-Type: application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml
         version=\"1.0\" encoding=\"utf-8\"?>\n<Error><Code>BlobNotFound</Code><Message>The
-        specified blob does not exist.\nRequestId:b4ab4bd2-f01e-009a-406b-efcd2d1ed6f7\nTime:2021-01-20T20:33:33.8726390Z</Message></Error>\r\n--batchresponse_1095d3e1-abcd-475f-9e6a-197220582478\r\nContent-Type:
+        specified blob does not exist.\nRequestId:da136612-101e-0092-11ca-0fd7221e2d4c\nTime:2021-03-03T01:14:47.6188163Z</Message></Error>\r\n--batchresponse_ae1de5f8-abc7-496e-a22d-a98f571c2953\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 404 The specified blob does
-        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: b4ab4bd2-f01e-009a-406b-efcd2d1ed6f8\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: c3b76ba4-5b5e-11eb-87f5-c8348e5fffbc\r\nContent-Length:
+        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: da136612-101e-0092-11ca-0fd7221e2d4d\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: d870b206-7bbd-11eb-8aec-c8348e5fffbf\r\nContent-Length:
         216\r\nContent-Type: application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml
         version=\"1.0\" encoding=\"utf-8\"?>\n<Error><Code>BlobNotFound</Code><Message>The
-        specified blob does not exist.\nRequestId:b4ab4bd2-f01e-009a-406b-efcd2d1ed6f8\nTime:2021-01-20T20:33:33.8716910Z</Message></Error>\r\n--batchresponse_1095d3e1-abcd-475f-9e6a-197220582478--"
+        specified blob does not exist.\nRequestId:da136612-101e-0092-11ca-0fd7221e2d4d\nTime:2021-03-03T01:14:47.6188163Z</Message></Error>\r\n--batchresponse_ae1de5f8-abc7-496e-a22d-a98f571c2953--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_1095d3e1-abcd-475f-9e6a-197220582478
+      - multipart/mixed; boundary=batchresponse_ae1de5f8-abc7-496e-a22d-a98f571c2953
       date:
-      - Wed, 20 Jan 2021 20:33:33 GMT
+      - Wed, 03 Mar 2021 01:14:47 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -366,27 +366,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:33:33 GMT
+      - Wed, 03 Mar 2021 01:14:48 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: GET
     uri: https://storagename.blob.core.windows.net/test617e10e3?restype=container&comp=list&include=snapshots
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
         ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"test617e10e3\"><Blobs><Blob><Name>blob1</Name><Properties><Creation-Time>Wed,
-        20 Jan 2021 20:33:33 GMT</Creation-Time><Last-Modified>Wed, 20 Jan 2021 20:33:33
-        GMT</Last-Modified><Etag>0x8D8BD82A7F3183F</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        03 Mar 2021 01:14:46 GMT</Creation-Time><Last-Modified>Wed, 03 Mar 2021 01:14:46
+        GMT</Last-Modified><Etag>0x8D8DDE1BBEF686B</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>blob2</Name><Properties><Creation-Time>Wed, 20 Jan 2021
-        20:33:33 GMT</Creation-Time><Last-Modified>Wed, 20 Jan 2021 20:33:33 GMT</Last-Modified><Etag>0x8D8BD82A80E6F09</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>blob2</Name><Properties><Creation-Time>Wed, 03 Mar 2021
+        01:14:46 GMT</Creation-Time><Last-Modified>Wed, 03 Mar 2021 01:14:46 GMT</Last-Modified><Etag>0x8D8DDE1BC1325B4</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>blob3</Name><Properties><Creation-Time>Wed, 20 Jan 2021
-        20:33:33 GMT</Creation-Time><Last-Modified>Wed, 20 Jan 2021 20:33:33 GMT</Last-Modified><Etag>0x8D8BD82A8194719</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>blob3</Name><Properties><Creation-Time>Wed, 03 Mar 2021
+        01:14:46 GMT</Creation-Time><Last-Modified>Wed, 03 Mar 2021 01:14:46 GMT</Last-Modified><Etag>0x8D8DDE1BC2AAB07</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
@@ -394,7 +394,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Wed, 20 Jan 2021 20:33:33 GMT
+      - Wed, 03 Mar 2021 01:14:47 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -402,7 +402,7 @@ interactions:
       vary:
       - Origin
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 200
       message: OK

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_delete_blobs_with_if_tags.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_delete_blobs_with_if_tags.yaml
@@ -198,15 +198,15 @@ interactions:
     body: "--===============1251307753==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /containera875126b/blob1? HTTP/1.1\r\nx-ms-if-tags:
       \"tag1\"='firsttag WRONG'\r\nx-ms-date: Wed, 20 Jan 2021 21:14:11 GMT\r\nx-ms-client-request-id:
-      70af588e-5b64-11eb-a244-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:mOEvzGZJu42VuKyB1bYn8uiMJzgug4VSJnG8DcKbdS4=\r\n\r\n\r\n--===============1251307753==\r\nContent-Type:
+      70af588e-5b64-11eb-a244-c8348e5fffbc\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1251307753==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
       /containera875126b/blob2? HTTP/1.1\r\nx-ms-if-tags: \"tag1\"='firsttag WRONG'\r\nx-ms-date:
       Wed, 20 Jan 2021 21:14:11 GMT\r\nx-ms-client-request-id: 70af7fbb-5b64-11eb-afe5-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:iP4VwZro+1xrvKbdqIRyA/aojJkki0xSErLwNVSyw5o=\r\n\r\n\r\n--===============1251307753==\r\nContent-Type:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1251307753==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
       /containera875126b/blob3? HTTP/1.1\r\nx-ms-if-tags: \"tag1\"='firsttag WRONG'\r\nx-ms-date:
       Wed, 20 Jan 2021 21:14:11 GMT\r\nx-ms-client-request-id: 70af7fbc-5b64-11eb-abb4-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:Pq8A1UzXGkb6O+3rB0skzNfUZyKuXTDvxLjoHdP11fs=\r\n\r\n\r\n--===============1251307753==--\r\n"
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1251307753==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -268,15 +268,15 @@ interactions:
     body: "--===============0227128804==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /containera875126b/blob1? HTTP/1.1\r\nx-ms-if-tags:
       \"tag1\"='firsttag'\r\nx-ms-date: Wed, 20 Jan 2021 21:14:13 GMT\r\nx-ms-client-request-id:
-      71dde62c-5b64-11eb-8cfa-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:n4ToE/loDwwFtlRcRrvRIrukX+Wexok0dLHNCWhLvdI=\r\n\r\n\r\n--===============0227128804==\r\nContent-Type:
+      71dde62c-5b64-11eb-8cfa-c8348e5fffbc\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0227128804==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
       /containera875126b/blob2? HTTP/1.1\r\nx-ms-if-tags: \"tag1\"='firsttag'\r\nx-ms-date:
       Wed, 20 Jan 2021 21:14:13 GMT\r\nx-ms-client-request-id: 71de0ea8-5b64-11eb-a85c-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:36Y0RHqNx8Aq27N2tv9+f39qow2FC8l1h8mOETlbWRI=\r\n\r\n\r\n--===============0227128804==\r\nContent-Type:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0227128804==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
       /containera875126b/blob3? HTTP/1.1\r\nx-ms-if-tags: \"tag1\"='firsttag'\r\nx-ms-date:
       Wed, 20 Jan 2021 21:14:13 GMT\r\nx-ms-client-request-id: 71de0ea9-5b64-11eb-bc48-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:HFNslBZzI/G4gPztKkbN4m7QS0d/rTUPue2OJCuu5wo=\r\n\r\n\r\n--===============0227128804==--\r\n"
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0227128804==--\r\n"
     headers:
       Accept:
       - '*/*'

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_standard_blob_tier_set_tier_api_batch.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_standard_blob_tier_set_tier_api_batch.yaml
@@ -11,11 +11,11 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:02 GMT
+      - Wed, 03 Mar 2021 01:21:09 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containera687174a?restype=container
   response:
@@ -25,29 +25,29 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 20 Jan 2021 20:14:02 GMT
+      - Wed, 03 Mar 2021 01:21:08 GMT
       etag:
-      - '"0x8D8BD7FEE34F6FB"'
+      - '"0x8D8DDE2A0338D92"'
       last-modified:
-      - Wed, 20 Jan 2021 20:14:02 GMT
+      - Wed, 03 Mar 2021 01:21:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
 - request:
-    body: "--===============1061106535==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============0991914385==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /containera687174a/blob1? HTTP/1.1\r\nx-ms-date:
-      Wed, 20 Jan 2021 20:14:02 GMT\r\nx-ms-client-request-id: 09c733b9-5b5c-11eb-a314-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:6hRLb3ceni6/gMkhl86ynvqIGWA3IrjWhFsiDwwg2yU=\r\n\r\n\r\n--===============1061106535==\r\nContent-Type:
+      Wed, 03 Mar 2021 01:21:09 GMT\r\nx-ms-client-request-id: bc62900d-7bbe-11eb-a577-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0991914385==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /containera687174a/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 20:14:02 GMT\r\nx-ms-client-request-id:
-      09c75acb-5b5c-11eb-8ed6-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:eki+OO+vEmlP92AeZBLYiyG/zcZPgkBlCmY2w/U0SpE=\r\n\r\n\r\n--===============1061106535==\r\nContent-Type:
+      /containera687174a/blob2? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:21:09 GMT\r\nx-ms-client-request-id:
+      bc62b722-7bbe-11eb-933e-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0991914385==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /containera687174a/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 20:14:02 GMT\r\nx-ms-client-request-id:
-      09c75acc-5b5c-11eb-94f0-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:v4peK6W9BnQ2BN671qneltfDdswzRqYeGJ28fH7hbyY=\r\n\r\n\r\n--===============1061106535==--\r\n"
+      /containera687174a/blob3? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:21:09 GMT\r\nx-ms-client-request-id:
+      bc630541-7bbe-11eb-919f-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0991914385==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -58,47 +58,47 @@ interactions:
       Content-Length:
       - '1083'
       Content-Type:
-      - multipart/mixed; boundary================1061106535==
+      - multipart/mixed; boundary================0991914385==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:02 GMT
+      - Wed, 03 Mar 2021 01:21:09 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/containera687174a?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_ddb0be6e-ed37-4787-98c1-e3e07f9a5a49\r\nContent-Type:
+      string: "--batchresponse_a0b6996a-099b-4599-8fea-8870f7cc9a6a\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 404 The specified blob does
-        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: 712d50ac-401e-0019-6f68-efd34f1e98a2\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 09c733b9-5b5c-11eb-a314-c8348e5fffbc\r\nContent-Length:
+        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: 859a0ef6-f01e-006e-60cb-0f06db1ecddb\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: bc62900d-7bbe-11eb-a577-c8348e5fffbf\r\nContent-Length:
         216\r\nContent-Type: application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml
         version=\"1.0\" encoding=\"utf-8\"?>\n<Error><Code>BlobNotFound</Code><Message>The
-        specified blob does not exist.\nRequestId:712d50ac-401e-0019-6f68-efd34f1e98a2\nTime:2021-01-20T20:14:05.3007498Z</Message></Error>\r\n--batchresponse_ddb0be6e-ed37-4787-98c1-e3e07f9a5a49\r\nContent-Type:
+        specified blob does not exist.\nRequestId:859a0ef6-f01e-006e-60cb-0f06db1ecddb\nTime:2021-03-03T01:21:09.4236573Z</Message></Error>\r\n--batchresponse_a0b6996a-099b-4599-8fea-8870f7cc9a6a\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 404 The specified blob does
-        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: 712d50ac-401e-0019-6f68-efd34f1e98a4\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 09c75acb-5b5c-11eb-8ed6-c8348e5fffbc\r\nContent-Length:
+        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: 859a0ef6-f01e-006e-60cb-0f06db1ecddd\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: bc62b722-7bbe-11eb-933e-c8348e5fffbf\r\nContent-Length:
         216\r\nContent-Type: application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml
         version=\"1.0\" encoding=\"utf-8\"?>\n<Error><Code>BlobNotFound</Code><Message>The
-        specified blob does not exist.\nRequestId:712d50ac-401e-0019-6f68-efd34f1e98a4\nTime:2021-01-20T20:14:05.3007498Z</Message></Error>\r\n--batchresponse_ddb0be6e-ed37-4787-98c1-e3e07f9a5a49\r\nContent-Type:
+        specified blob does not exist.\nRequestId:859a0ef6-f01e-006e-60cb-0f06db1ecddd\nTime:2021-03-03T01:21:09.4236573Z</Message></Error>\r\n--batchresponse_a0b6996a-099b-4599-8fea-8870f7cc9a6a\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 404 The specified blob does
-        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: 712d50ac-401e-0019-6f68-efd34f1e98a5\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 09c75acc-5b5c-11eb-94f0-c8348e5fffbc\r\nContent-Length:
+        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: 859a0ef6-f01e-006e-60cb-0f06db1ecdde\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: bc630541-7bbe-11eb-919f-c8348e5fffbf\r\nContent-Length:
         216\r\nContent-Type: application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml
         version=\"1.0\" encoding=\"utf-8\"?>\n<Error><Code>BlobNotFound</Code><Message>The
-        specified blob does not exist.\nRequestId:712d50ac-401e-0019-6f68-efd34f1e98a5\nTime:2021-01-20T20:14:05.3007498Z</Message></Error>\r\n--batchresponse_ddb0be6e-ed37-4787-98c1-e3e07f9a5a49--"
+        specified blob does not exist.\nRequestId:859a0ef6-f01e-006e-60cb-0f06db1ecdde\nTime:2021-03-03T01:21:09.4186538Z</Message></Error>\r\n--batchresponse_a0b6996a-099b-4599-8fea-8870f7cc9a6a--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_ddb0be6e-ed37-4787-98c1-e3e07f9a5a49
+      - multipart/mixed; boundary=batchresponse_a0b6996a-099b-4599-8fea-8870f7cc9a6a
       date:
-      - Wed, 20 Jan 2021 20:14:04 GMT
+      - Wed, 03 Mar 2021 01:21:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -118,15 +118,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:05 GMT
+      - Wed, 03 Mar 2021 01:21:10 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containera687174a/blob1
   response:
@@ -138,11 +138,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 20:14:04 GMT
+      - Wed, 03 Mar 2021 01:21:09 GMT
       etag:
-      - '"0x8D8BD7FEFCFA55B"'
+      - '"0x8D8DDE2A05B1E21"'
       last-modified:
-      - Wed, 20 Jan 2021 20:14:05 GMT
+      - Wed, 03 Mar 2021 01:21:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -150,7 +150,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -170,15 +170,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:05 GMT
+      - Wed, 03 Mar 2021 01:21:10 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containera687174a/blob2
   response:
@@ -190,11 +190,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 20:14:04 GMT
+      - Wed, 03 Mar 2021 01:21:09 GMT
       etag:
-      - '"0x8D8BD7FEFDCA0D9"'
+      - '"0x8D8DDE2A069797B"'
       last-modified:
-      - Wed, 20 Jan 2021 20:14:05 GMT
+      - Wed, 03 Mar 2021 01:21:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -202,7 +202,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -222,15 +222,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:05 GMT
+      - Wed, 03 Mar 2021 01:21:10 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containera687174a/blob3
   response:
@@ -242,11 +242,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 20:14:05 GMT
+      - Wed, 03 Mar 2021 01:21:09 GMT
       etag:
-      - '"0x8D8BD7FEFE8B1BA"'
+      - '"0x8D8DDE2A077D4D6"'
       last-modified:
-      - Wed, 20 Jan 2021 20:14:05 GMT
+      - Wed, 03 Mar 2021 01:21:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -254,7 +254,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -268,13 +268,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:05 GMT
+      - Wed, 03 Mar 2021 01:21:10 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/containera687174a/blob1
   response:
@@ -290,11 +290,11 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 20 Jan 2021 20:14:05 GMT
+      - Wed, 03 Mar 2021 01:21:09 GMT
       etag:
-      - '"0x8D8BD7FEFCFA55B"'
+      - '"0x8D8DDE2A05B1E21"'
       last-modified:
-      - Wed, 20 Jan 2021 20:14:05 GMT
+      - Wed, 03 Mar 2021 01:21:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       vary:
@@ -306,7 +306,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 20 Jan 2021 20:14:05 GMT
+      - Wed, 03 Mar 2021 01:21:09 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -314,23 +314,23 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============0222699796==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============2102783098==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nPUT /containera687174a/blob1?comp=tier HTTP/1.1\r\nContent-Length:
-      0\r\nx-ms-access-tier: Archive\r\nx-ms-date: Wed, 20 Jan 2021 20:14:05 GMT\r\nx-ms-client-request-id:
-      0b85ba0a-5b5c-11eb-be5f-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:e971+RC19RLBRuU64wySoSlXCO0kGx9r0GojPmqRd9I=\r\n\r\n\r\n--===============0222699796==\r\nContent-Type:
+      0\r\nx-ms-access-tier: Archive\r\nx-ms-date: Wed, 03 Mar 2021 01:21:10 GMT\r\nx-ms-client-request-id:
+      bcb20e13-7bbe-11eb-9ec5-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2102783098==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nPUT
       /containera687174a/blob2?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
-      Archive\r\nx-ms-date: Wed, 20 Jan 2021 20:14:05 GMT\r\nx-ms-client-request-id:
-      0b85ba0b-5b5c-11eb-bb9a-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:7gq5iQ3DL+d+BCZ0vCnlwFjDnpeGCevbniAksYYUZsw=\r\n\r\n\r\n--===============0222699796==\r\nContent-Type:
+      Archive\r\nx-ms-date: Wed, 03 Mar 2021 01:21:10 GMT\r\nx-ms-client-request-id:
+      bcb20e14-7bbe-11eb-971a-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2102783098==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nPUT
       /containera687174a/blob3?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
-      Archive\r\nx-ms-date: Wed, 20 Jan 2021 20:14:05 GMT\r\nx-ms-client-request-id:
-      0b85e129-5b5c-11eb-9fc6-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:uEOxn4Espm3KT/wkIGTVVDbeFKPKReumEKWtu4zkhaE=\r\n\r\n\r\n--===============0222699796==--\r\n"
+      Archive\r\nx-ms-date: Wed, 03 Mar 2021 01:21:10 GMT\r\nx-ms-client-request-id:
+      bcb20e15-7bbe-11eb-b693-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2102783098==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -341,38 +341,38 @@ interactions:
       Content-Length:
       - '1239'
       Content-Type:
-      - multipart/mixed; boundary================0222699796==
+      - multipart/mixed; boundary================2102783098==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:05 GMT
+      - Wed, 03 Mar 2021 01:21:10 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/containera687174a?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_fca30c16-ebbc-44b0-aeca-b99dbae8228f\r\nContent-Type:
+      string: "--batchresponse_3d06f4bf-a644-4b7a-b809-0bae8d16654d\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        712d5993-401e-0019-7c68-efd34f1e995c\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        0b85ba0a-5b5c-11eb-be5f-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_fca30c16-ebbc-44b0-aeca-b99dbae8228f\r\nContent-Type:
+        859a0fe2-f01e-006e-2ccb-0f06db1ecdec\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        bcb20e13-7bbe-11eb-9ec5-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_3d06f4bf-a644-4b7a-b809-0bae8d16654d\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        712d5993-401e-0019-7c68-efd34f1e9c73\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        0b85ba0b-5b5c-11eb-bb9a-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_fca30c16-ebbc-44b0-aeca-b99dbae8228f\r\nContent-Type:
+        859a0fe2-f01e-006e-2ccb-0f06db1ece0d\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        bcb20e14-7bbe-11eb-971a-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_3d06f4bf-a644-4b7a-b809-0bae8d16654d\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        712d5993-401e-0019-7c68-efd34f1e9c74\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        0b85e129-5b5c-11eb-9fc6-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_fca30c16-ebbc-44b0-aeca-b99dbae8228f--"
+        859a0fe2-f01e-006e-2ccb-0f06db1ece0e\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        bcb20e15-7bbe-11eb-b693-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_3d06f4bf-a644-4b7a-b809-0bae8d16654d--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_fca30c16-ebbc-44b0-aeca-b99dbae8228f
+      - multipart/mixed; boundary=batchresponse_3d06f4bf-a644-4b7a-b809-0bae8d16654d
       date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:10 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -386,13 +386,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/containera687174a/blob1
   response:
@@ -408,11 +408,11 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:10 GMT
       etag:
-      - '"0x8D8BD7FEFCFA55B"'
+      - '"0x8D8DDE2A05B1E21"'
       last-modified:
-      - Wed, 20 Jan 2021 20:14:05 GMT
+      - Wed, 03 Mar 2021 01:21:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       vary:
@@ -420,11 +420,11 @@ interactions:
       x-ms-access-tier:
       - Archive
       x-ms-access-tier-change-time:
-      - Wed, 20 Jan 2021 20:14:21 GMT
+      - Wed, 03 Mar 2021 01:21:10 GMT
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 20 Jan 2021 20:14:05 GMT
+      - Wed, 03 Mar 2021 01:21:09 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -432,21 +432,21 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============0033426702==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============0112412341==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /containera687174a/blob1? HTTP/1.1\r\nx-ms-date:
-      Wed, 20 Jan 2021 20:14:25 GMT\r\nx-ms-client-request-id: 1781c804-5b5c-11eb-a91f-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:+jilfWBiSGuyW0AyFfT5zFz4HC6SQ3VW1ryfZq0zQJ4=\r\n\r\n\r\n--===============0033426702==\r\nContent-Type:
+      Wed, 03 Mar 2021 01:21:11 GMT\r\nx-ms-client-request-id: bd5f0c51-7bbe-11eb-8a34-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0112412341==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /containera687174a/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 20:14:25 GMT\r\nx-ms-client-request-id:
-      1781ef1a-5b5c-11eb-92db-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:dikkvh76VNlu7krNiAw7TadNcaP1T1HLRG9ggkjRsaQ=\r\n\r\n\r\n--===============0033426702==\r\nContent-Type:
+      /containera687174a/blob2? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:21:11 GMT\r\nx-ms-client-request-id:
+      bd5f212d-7bbe-11eb-8578-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0112412341==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /containera687174a/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 20:14:25 GMT\r\nx-ms-client-request-id:
-      1781ef1b-5b5c-11eb-b1e3-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:DjI8fVL7LBQpxySMBR8ybT8w54WRlTwEDcOmCYn4Ems=\r\n\r\n\r\n--===============0033426702==--\r\n"
+      /containera687174a/blob3? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:21:11 GMT\r\nx-ms-client-request-id:
+      bd5f212e-7bbe-11eb-9958-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0112412341==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -457,41 +457,41 @@ interactions:
       Content-Length:
       - '1083'
       Content-Type:
-      - multipart/mixed; boundary================0033426702==
+      - multipart/mixed; boundary================0112412341==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/containera687174a?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_376bd023-9823-401a-8284-3b67fcb9d552\r\nContent-Type:
+      string: "--batchresponse_8c08f709-201b-4b67-823f-014556bbe482\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 712d99e4-401e-0019-3368-efd34f1e9d37\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 1781c804-5b5c-11eb-a91f-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_376bd023-9823-401a-8284-3b67fcb9d552\r\nContent-Type:
+        true\r\nx-ms-request-id: 859a1238-f01e-006e-2fcb-0f06db1ece16\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: bd5f0c51-7bbe-11eb-8a34-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_8c08f709-201b-4b67-823f-014556bbe482\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 712d99e4-401e-0019-3368-efd34f1e9d39\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 1781ef1a-5b5c-11eb-92db-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_376bd023-9823-401a-8284-3b67fcb9d552\r\nContent-Type:
+        true\r\nx-ms-request-id: 859a1238-f01e-006e-2fcb-0f06db1ece17\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: bd5f212d-7bbe-11eb-8578-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_8c08f709-201b-4b67-823f-014556bbe482\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 712d99e4-401e-0019-3368-efd34f1e9d3a\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 1781ef1b-5b5c-11eb-b1e3-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_376bd023-9823-401a-8284-3b67fcb9d552--"
+        true\r\nx-ms-request-id: 859a1238-f01e-006e-2fcb-0f06db1ece18\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: bd5f212e-7bbe-11eb-9958-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_8c08f709-201b-4b67-823f-014556bbe482--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_376bd023-9823-401a-8284-3b67fcb9d552
+      - multipart/mixed; boundary=batchresponse_8c08f709-201b-4b67-823f-014556bbe482
       date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:10 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -511,15 +511,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containera687174a/blob1
   response:
@@ -531,11 +531,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:10 GMT
       etag:
-      - '"0x8D8BD7FFC0A0E68"'
+      - '"0x8D8DDE2A1493A4A"'
       last-modified:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -543,7 +543,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -563,15 +563,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containera687174a/blob2
   response:
@@ -583,11 +583,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:10 GMT
       etag:
-      - '"0x8D8BD7FFC1709E0"'
+      - '"0x8D8DDE2A15635BB"'
       last-modified:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -595,7 +595,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -615,15 +615,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containera687174a/blob3
   response:
@@ -635,11 +635,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:10 GMT
       etag:
-      - '"0x8D8BD7FFC22090A"'
+      - '"0x8D8DDE2A163CD97"'
       last-modified:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -647,7 +647,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -661,13 +661,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/containera687174a/blob1
   response:
@@ -683,11 +683,11 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       etag:
-      - '"0x8D8BD7FFC0A0E68"'
+      - '"0x8D8DDE2A1493A4A"'
       last-modified:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       vary:
@@ -699,7 +699,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -707,23 +707,23 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============0025169746==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============0200280524==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nPUT /containera687174a/blob1?comp=tier HTTP/1.1\r\nContent-Length:
-      0\r\nx-ms-access-tier: Cool\r\nx-ms-date: Wed, 20 Jan 2021 20:14:25 GMT\r\nx-ms-client-request-id:
-      17be03ce-5b5c-11eb-9827-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:u3tizz9Sk4hGuj48mM71Jb/poHqWMJP6vArPrqcp5F8=\r\n\r\n\r\n--===============0025169746==\r\nContent-Type:
+      0\r\nx-ms-access-tier: Cool\r\nx-ms-date: Wed, 03 Mar 2021 01:21:12 GMT\r\nx-ms-client-request-id:
+      bda93479-7bbe-11eb-b618-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0200280524==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nPUT
       /containera687174a/blob2?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
-      Cool\r\nx-ms-date: Wed, 20 Jan 2021 20:14:25 GMT\r\nx-ms-client-request-id:
-      17be2acd-5b5c-11eb-9e9f-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:UvbhoMLX1JfakrcXJOm4E2vjYy/M08Wep8KsEqGtJKY=\r\n\r\n\r\n--===============0025169746==\r\nContent-Type:
+      Cool\r\nx-ms-date: Wed, 03 Mar 2021 01:21:12 GMT\r\nx-ms-client-request-id:
+      bda95b8a-7bbe-11eb-9c93-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0200280524==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nPUT
       /containera687174a/blob3?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
-      Cool\r\nx-ms-date: Wed, 20 Jan 2021 20:14:25 GMT\r\nx-ms-client-request-id:
-      17be2ace-5b5c-11eb-b90e-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:q2yXDLNRa5S28WO7YM3qc7TXrHfDjK9B9B3ZiFlH5A4=\r\n\r\n\r\n--===============0025169746==--\r\n"
+      Cool\r\nx-ms-date: Wed, 03 Mar 2021 01:21:12 GMT\r\nx-ms-client-request-id:
+      bda95b8b-7bbe-11eb-b4fa-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0200280524==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -734,38 +734,38 @@ interactions:
       Content-Length:
       - '1230'
       Content-Type:
-      - multipart/mixed; boundary================0025169746==
+      - multipart/mixed; boundary================0200280524==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:12 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/containera687174a?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_c2698bdb-c8f3-495a-9151-d120a7ed0654\r\nContent-Type:
+      string: "--batchresponse_a017765f-658f-4a9d-ae7a-a773322e757c\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        712d9b38-401e-0019-7068-efd34f1e9daa\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        17be03ce-5b5c-11eb-9827-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_c2698bdb-c8f3-495a-9151-d120a7ed0654\r\nContent-Type:
+        859a1357-f01e-006e-2ecb-0f06db1ece27\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        bda93479-7bbe-11eb-b618-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_a017765f-658f-4a9d-ae7a-a773322e757c\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        712d9b38-401e-0019-7068-efd34f1e9dab\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        17be2acd-5b5c-11eb-9e9f-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_c2698bdb-c8f3-495a-9151-d120a7ed0654\r\nContent-Type:
+        859a1357-f01e-006e-2ecb-0f06db1ece28\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        bda95b8a-7bbe-11eb-9c93-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_a017765f-658f-4a9d-ae7a-a773322e757c\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        712d9b38-401e-0019-7068-efd34f1e9dac\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        17be2ace-5b5c-11eb-b90e-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_c2698bdb-c8f3-495a-9151-d120a7ed0654--"
+        859a1357-f01e-006e-2ecb-0f06db1ece29\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        bda95b8b-7bbe-11eb-b4fa-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_a017765f-658f-4a9d-ae7a-a773322e757c--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_c2698bdb-c8f3-495a-9151-d120a7ed0654
+      - multipart/mixed; boundary=batchresponse_a017765f-658f-4a9d-ae7a-a773322e757c
       date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -779,13 +779,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:12 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/containera687174a/blob1
   response:
@@ -801,11 +801,11 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       etag:
-      - '"0x8D8BD7FFC0A0E68"'
+      - '"0x8D8DDE2A1493A4A"'
       last-modified:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       vary:
@@ -813,11 +813,11 @@ interactions:
       x-ms-access-tier:
       - Cool
       x-ms-access-tier-change-time:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -825,21 +825,21 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============0415382344==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============0337533341==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /containera687174a/blob1? HTTP/1.1\r\nx-ms-date:
-      Wed, 20 Jan 2021 20:14:26 GMT\r\nx-ms-client-request-id: 17db3d5d-5b5c-11eb-b40b-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:v6T/Ie3LqqFWGUQVfG4MUG+Uz1wWvNbP1e0xeKjiDZw=\r\n\r\n\r\n--===============0415382344==\r\nContent-Type:
+      Wed, 03 Mar 2021 01:21:12 GMT\r\nx-ms-client-request-id: bdc1b315-7bbe-11eb-93d0-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0337533341==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /containera687174a/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 20:14:26 GMT\r\nx-ms-client-request-id:
-      17db3d5e-5b5c-11eb-a37f-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:avIlER4xTuN8wb7KqbOA1i3GkVU2gI9zBhxoLvcFby0=\r\n\r\n\r\n--===============0415382344==\r\nContent-Type:
+      /containera687174a/blob2? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:21:12 GMT\r\nx-ms-client-request-id:
+      bdc1b316-7bbe-11eb-b530-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0337533341==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /containera687174a/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 20:14:26 GMT\r\nx-ms-client-request-id:
-      17db6472-5b5c-11eb-83bb-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:et+BvABaQb7JHX4usmRPUn694CdHqptX/TzawP3OSWg=\r\n\r\n\r\n--===============0415382344==--\r\n"
+      /containera687174a/blob3? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:21:12 GMT\r\nx-ms-client-request-id:
+      bdc1b317-7bbe-11eb-a58d-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0337533341==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -850,41 +850,41 @@ interactions:
       Content-Length:
       - '1083'
       Content-Type:
-      - multipart/mixed; boundary================0415382344==
+      - multipart/mixed; boundary================0337533341==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:12 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/containera687174a?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_995d89de-dfdc-4ff2-8f66-ae6f1db9233f\r\nContent-Type:
+      string: "--batchresponse_6a89988a-fa79-4abf-8a02-993483e8cf9c\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 712d9bf1-401e-0019-1f68-efd34f1e9db1\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 17db3d5d-5b5c-11eb-b40b-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_995d89de-dfdc-4ff2-8f66-ae6f1db9233f\r\nContent-Type:
+        true\r\nx-ms-request-id: 859a13a7-f01e-006e-76cb-0f06db1ece2f\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: bdc1b315-7bbe-11eb-93d0-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_6a89988a-fa79-4abf-8a02-993483e8cf9c\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 712d9bf1-401e-0019-1f68-efd34f1e9db2\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 17db3d5e-5b5c-11eb-a37f-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_995d89de-dfdc-4ff2-8f66-ae6f1db9233f\r\nContent-Type:
+        true\r\nx-ms-request-id: 859a13a7-f01e-006e-76cb-0f06db1ece30\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: bdc1b316-7bbe-11eb-b530-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_6a89988a-fa79-4abf-8a02-993483e8cf9c\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 712d9bf1-401e-0019-1f68-efd34f1e9db3\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 17db6472-5b5c-11eb-83bb-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_995d89de-dfdc-4ff2-8f66-ae6f1db9233f--"
+        true\r\nx-ms-request-id: 859a13a7-f01e-006e-76cb-0f06db1ece31\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: bdc1b317-7bbe-11eb-a58d-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_6a89988a-fa79-4abf-8a02-993483e8cf9c--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_995d89de-dfdc-4ff2-8f66-ae6f1db9233f
+      - multipart/mixed; boundary=batchresponse_6a89988a-fa79-4abf-8a02-993483e8cf9c
       date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -904,15 +904,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:12 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containera687174a/blob1
   response:
@@ -924,11 +924,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 20:14:25 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       etag:
-      - '"0x8D8BD7FFC6B0A91"'
+      - '"0x8D8DDE2A1AB482E"'
       last-modified:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -936,7 +936,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -956,15 +956,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:12 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containera687174a/blob2
   response:
@@ -976,11 +976,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       etag:
-      - '"0x8D8BD7FFC80E1CA"'
+      - '"0x8D8DDE2A1B50E88"'
       last-modified:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -988,7 +988,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -1008,15 +1008,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:12 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/containera687174a/blob3
   response:
@@ -1028,11 +1028,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       etag:
-      - '"0x8D8BD7FFC8F6441"'
+      - '"0x8D8DDE2A1BED4E6"'
       last-modified:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -1040,7 +1040,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 201
       message: Created
@@ -1054,13 +1054,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:12 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/containera687174a/blob1
   response:
@@ -1076,11 +1076,11 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       etag:
-      - '"0x8D8BD7FFC6B0A91"'
+      - '"0x8D8DDE2A1AB482E"'
       last-modified:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       vary:
@@ -1092,7 +1092,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -1100,23 +1100,23 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============1461488493==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============2111109274==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nPUT /containera687174a/blob1?comp=tier HTTP/1.1\r\nContent-Length:
-      0\r\nx-ms-access-tier: Hot\r\nx-ms-date: Wed, 20 Jan 2021 20:14:26 GMT\r\nx-ms-client-request-id:
-      18322334-5b5c-11eb-a60a-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:a2cdGbp6xeD6+0fUrgpL+BJrffnFuJ3A1mlhj5f5fA0=\r\n\r\n\r\n--===============1461488493==\r\nContent-Type:
+      0\r\nx-ms-access-tier: Hot\r\nx-ms-date: Wed, 03 Mar 2021 01:21:12 GMT\r\nx-ms-client-request-id:
+      bdf92139-7bbe-11eb-9c2c-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2111109274==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nPUT
       /containera687174a/blob2?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
-      Hot\r\nx-ms-date: Wed, 20 Jan 2021 20:14:26 GMT\r\nx-ms-client-request-id: 18324b9c-5b5c-11eb-9bcc-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:a4fg+V3vjFbgdMo0Ig+5stajZ9sOXCfslYF/qBFcl0E=\r\n\r\n\r\n--===============1461488493==\r\nContent-Type:
+      Hot\r\nx-ms-date: Wed, 03 Mar 2021 01:21:12 GMT\r\nx-ms-client-request-id: bdf94843-7bbe-11eb-850b-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2111109274==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nPUT
       /containera687174a/blob3?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
-      Hot\r\nx-ms-date: Wed, 20 Jan 2021 20:14:26 GMT\r\nx-ms-client-request-id: 18329859-5b5c-11eb-9db5-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:8QQq6m7CA21ZbLCxsB90Euv+NYp4RbQlIJK39V/7Kvw=\r\n\r\n\r\n--===============1461488493==--\r\n"
+      Hot\r\nx-ms-date: Wed, 03 Mar 2021 01:21:12 GMT\r\nx-ms-client-request-id: bdf94844-7bbe-11eb-9d50-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2111109274==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -1127,38 +1127,38 @@ interactions:
       Content-Length:
       - '1227'
       Content-Type:
-      - multipart/mixed; boundary================1461488493==
+      - multipart/mixed; boundary================2111109274==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:12 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/containera687174a?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_8be5ff63-6254-415e-9123-547c428b4c87\r\nContent-Type:
+      string: "--batchresponse_84fcdc32-00c5-46d0-a81d-7d7e91a53bc7\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        712d9dad-401e-0019-2568-efd34f1e9dc1\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        18322334-5b5c-11eb-a60a-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_8be5ff63-6254-415e-9123-547c428b4c87\r\nContent-Type:
+        859a1487-f01e-006e-43cb-0f06db1ece3a\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        bdf92139-7bbe-11eb-9c2c-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_84fcdc32-00c5-46d0-a81d-7d7e91a53bc7\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        712d9dad-401e-0019-2568-efd34f1e9dc2\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        18324b9c-5b5c-11eb-9bcc-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_8be5ff63-6254-415e-9123-547c428b4c87\r\nContent-Type:
+        859a1487-f01e-006e-43cb-0f06db1ece3b\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        bdf94843-7bbe-11eb-850b-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_84fcdc32-00c5-46d0-a81d-7d7e91a53bc7\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        712d9dad-401e-0019-2568-efd34f1e9dc3\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        18329859-5b5c-11eb-9db5-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_8be5ff63-6254-415e-9123-547c428b4c87--"
+        859a1487-f01e-006e-43cb-0f06db1ece3c\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        bdf94844-7bbe-11eb-9d50-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_84fcdc32-00c5-46d0-a81d-7d7e91a53bc7--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_8be5ff63-6254-415e-9123-547c428b4c87
+      - multipart/mixed; boundary=batchresponse_84fcdc32-00c5-46d0-a81d-7d7e91a53bc7
       date:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -1172,13 +1172,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:12 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/containera687174a/blob1
   response:
@@ -1194,11 +1194,11 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       etag:
-      - '"0x8D8BD7FFC6B0A91"'
+      - '"0x8D8DDE2A1AB482E"'
       last-modified:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       vary:
@@ -1206,11 +1206,11 @@ interactions:
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Wed, 20 Jan 2021 20:14:27 GMT
+      - Wed, 03 Mar 2021 01:21:12 GMT
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -1218,21 +1218,21 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============0474761090==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============0917688996==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /containera687174a/blob1? HTTP/1.1\r\nx-ms-date:
-      Wed, 20 Jan 2021 20:14:26 GMT\r\nx-ms-client-request-id: 1852f557-5b5c-11eb-8726-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:Teqr1tTUrFxRmE1wqX9j9JWLsV+0bpCCx7DTIZ3p4mE=\r\n\r\n\r\n--===============0474761090==\r\nContent-Type:
+      Wed, 03 Mar 2021 01:21:12 GMT\r\nx-ms-client-request-id: be0cceaa-7bbe-11eb-844d-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0917688996==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /containera687174a/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 20:14:26 GMT\r\nx-ms-client-request-id:
-      18531c48-5b5c-11eb-a665-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:HcbY0nrCBLREWz25jxbpHWRGYZsGfJ64k8f9z9dEb5Y=\r\n\r\n\r\n--===============0474761090==\r\nContent-Type:
+      /containera687174a/blob2? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:21:12 GMT\r\nx-ms-client-request-id:
+      be0cceab-7bbe-11eb-9608-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0917688996==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /containera687174a/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 20:14:26 GMT\r\nx-ms-client-request-id:
-      18531c49-5b5c-11eb-a82d-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:Ymi1dOJctUHqd5mqqTN8rg5HaD7BpTImAycfjmw708E=\r\n\r\n\r\n--===============0474761090==--\r\n"
+      /containera687174a/blob3? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:21:12 GMT\r\nx-ms-client-request-id:
+      be0cceac-7bbe-11eb-8869-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0917688996==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -1243,41 +1243,41 @@ interactions:
       Content-Length:
       - '1083'
       Content-Type:
-      - multipart/mixed; boundary================0474761090==
+      - multipart/mixed; boundary================0917688996==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:12 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/containera687174a?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_5b613b6e-e346-48a0-b66e-fcc130d22b53\r\nContent-Type:
+      string: "--batchresponse_e53c59cd-b70b-4e83-873c-13f7628ce97b\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 712d9e3d-401e-0019-1a68-efd34f1e9dc9\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 1852f557-5b5c-11eb-8726-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_5b613b6e-e346-48a0-b66e-fcc130d22b53\r\nContent-Type:
+        true\r\nx-ms-request-id: 859a14e4-f01e-006e-17cb-0f06db1ece43\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: be0cceaa-7bbe-11eb-844d-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_e53c59cd-b70b-4e83-873c-13f7628ce97b\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 712d9e3d-401e-0019-1a68-efd34f1e9dca\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 18531c48-5b5c-11eb-a665-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_5b613b6e-e346-48a0-b66e-fcc130d22b53\r\nContent-Type:
+        true\r\nx-ms-request-id: 859a14e4-f01e-006e-17cb-0f06db1ece44\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: be0cceab-7bbe-11eb-9608-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_e53c59cd-b70b-4e83-873c-13f7628ce97b\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 712d9e3d-401e-0019-1a68-efd34f1e9dcb\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 18531c49-5b5c-11eb-a82d-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_5b613b6e-e346-48a0-b66e-fcc130d22b53--"
+        true\r\nx-ms-request-id: 859a14e4-f01e-006e-17cb-0f06db1ece45\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: be0cceac-7bbe-11eb-8869-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_e53c59cd-b70b-4e83-873c-13f7628ce97b--"
     headers:
       content-type:
-      - multipart/mixed; boundary=batchresponse_5b613b6e-e346-48a0-b66e-fcc130d22b53
+      - multipart/mixed; boundary=batchresponse_e53c59cd-b70b-4e83-873c-13f7628ce97b
       date:
-      - Wed, 20 Jan 2021 20:14:26 GMT
+      - Wed, 03 Mar 2021 01:21:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
       - chunked
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     status:
       code: 202
       message: Accepted

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_standard_blob_tier_with_if_tags.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container.test_standard_blob_tier_with_if_tags.yaml
@@ -260,17 +260,17 @@ interactions:
       binary\r\nContent-ID: 0\r\n\r\nPUT /container20d714e9/blob1?comp=tier HTTP/1.1\r\nContent-Length:
       0\r\nx-ms-access-tier: Cool\r\nx-ms-if-tags: \"tag1\"='firsttag WRONG'\r\nx-ms-date:
       Wed, 20 Jan 2021 20:24:47 GMT\r\nx-ms-client-request-id: 8a07a80b-5b5d-11eb-8f44-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:1dCvZPiK0UwbamE/gKfwiDgAavOSlXxLKAX1pEyUY/w=\r\n\r\n\r\n--===============2091308276==\r\nContent-Type:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2091308276==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nPUT
       /container20d714e9/blob2?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
       Cool\r\nx-ms-if-tags: \"tag1\"='firsttag WRONG'\r\nx-ms-date: Wed, 20 Jan 2021
       20:24:47 GMT\r\nx-ms-client-request-id: 8a07a80c-5b5d-11eb-b14d-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:h8ZiHqMO9n/JRGv+Ek7zKZHkbKmiAghXAu5C5FJ9DUA=\r\n\r\n\r\n--===============2091308276==\r\nContent-Type:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2091308276==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nPUT
       /container20d714e9/blob3?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
       Cool\r\nx-ms-if-tags: \"tag1\"='firsttag WRONG'\r\nx-ms-date: Wed, 20 Jan 2021
       20:24:47 GMT\r\nx-ms-client-request-id: 8a07a80d-5b5d-11eb-9d90-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:c/gHLC8RwyZ6q1aAfEkw0JP1gV/ORbnJOtxeVbQjxzY=\r\n\r\n\r\n--===============2091308276==--\r\n"
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2091308276==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -333,17 +333,17 @@ interactions:
       binary\r\nContent-ID: 0\r\n\r\nPUT /container20d714e9/blob1?comp=tier HTTP/1.1\r\nContent-Length:
       0\r\nx-ms-access-tier: Cool\r\nx-ms-if-tags: \"tag1\"='firsttag'\r\nx-ms-date:
       Wed, 20 Jan 2021 20:25:05 GMT\r\nx-ms-client-request-id: 94bd6c5c-5b5d-11eb-baa1-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:irPTULbMxzE3OQvLxpjloA+GQlhB1OdT+pg8wtABqmQ=\r\n\r\n\r\n--===============2000693648==\r\nContent-Type:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2000693648==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nPUT
       /container20d714e9/blob2?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
       Cool\r\nx-ms-if-tags: \"tag1\"='firsttag'\r\nx-ms-date: Wed, 20 Jan 2021 20:25:05
       GMT\r\nx-ms-client-request-id: 94bd9364-5b5d-11eb-aba0-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:N5j2S5tB4eWXCHHswQPtdQT6bfilfWbpgwTPSzwhj7c=\r\n\r\n\r\n--===============2000693648==\r\nContent-Type:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2000693648==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nPUT
       /container20d714e9/blob3?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
       Cool\r\nx-ms-if-tags: \"tag1\"='firsttag'\r\nx-ms-date: Wed, 20 Jan 2021 20:25:05
       GMT\r\nx-ms-client-request-id: 94bd9365-5b5d-11eb-841c-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:zf6BXEn0G9GoNskRh26644jLBYbZyYw0LJEj1hzpcNE=\r\n\r\n\r\n--===============2000693648==--\r\n"
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2000693648==--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -455,13 +455,13 @@ interactions:
     body: "--===============1494746912==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /container20d714e9/blob1? HTTP/1.1\r\nx-ms-date:
       Wed, 20 Jan 2021 20:25:05 GMT\r\nx-ms-client-request-id: 94da5772-5b5d-11eb-8bc8-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:X1mhPk3vfq/OKapBcc43Rq+wHvm6deZG9XMwk83R2S4=\r\n\r\n\r\n--===============1494746912==\r\nContent-Type:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1494746912==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
       /container20d714e9/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 20:25:05 GMT\r\nx-ms-client-request-id:
-      94da7e82-5b5d-11eb-a538-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:E5PxAl1Wtyxmnjq2wqb4pZyCdLnM0ViOjkgC2ujB7W8=\r\n\r\n\r\n--===============1494746912==\r\nContent-Type:
+      94da7e82-5b5d-11eb-a538-c8348e5fffbc\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1494746912==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
       /container20d714e9/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 20:25:05 GMT\r\nx-ms-client-request-id:
-      94da7e83-5b5d-11eb-a1d1-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:LJ+3kYSwX0MViQ//i3Ht71PNzANASkpZMmxg4vHSRl4=\r\n\r\n\r\n--===============1494746912==--\r\n"
+      94da7e83-5b5d-11eb-a1d1-c8348e5fffbc\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1494746912==--\r\n"
     headers:
       Accept:
       - '*/*'

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.test_delete_blobs_simple.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.test_delete_blobs_simple.yaml
@@ -5,11 +5,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:16:56 GMT
+      - Wed, 03 Mar 2021 01:09:02 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontaineraa4e127a?restype=container
   response:
@@ -17,11 +17,11 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 20 Jan 2021 21:16:56 GMT
-      etag: '"0x8D8BD88B7C56D2F"'
-      last-modified: Wed, 20 Jan 2021 21:16:56 GMT
+      date: Wed, 03 Mar 2021 01:09:02 GMT
+      etag: '"0x8D8DDE0EEEEACA1"'
+      last-modified: Wed, 03 Mar 2021 01:09:02 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -38,15 +38,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:16:56 GMT
+      - Wed, 03 Mar 2021 01:09:03 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontaineraa4e127a/blob1
   response:
@@ -55,13 +55,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:16:56 GMT
-      etag: '"0x8D8BD88B7CAEEB9"'
-      last-modified: Wed, 20 Jan 2021 21:16:56 GMT
+      date: Wed, 03 Mar 2021 01:09:02 GMT
+      etag: '"0x8D8DDE0EEF183C1"'
+      last-modified: Wed, 03 Mar 2021 01:09:02 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -78,15 +78,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:16:56 GMT
+      - Wed, 03 Mar 2021 01:09:03 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontaineraa4e127a/blob2
   response:
@@ -95,13 +95,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:16:56 GMT
-      etag: '"0x8D8BD88B7CDD59D"'
-      last-modified: Wed, 20 Jan 2021 21:16:56 GMT
+      date: Wed, 03 Mar 2021 01:09:02 GMT
+      etag: '"0x8D8DDE0EEF4438D"'
+      last-modified: Wed, 03 Mar 2021 01:09:02 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -118,15 +118,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:16:56 GMT
+      - Wed, 03 Mar 2021 01:09:03 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontaineraa4e127a/blob3
   response:
@@ -135,13 +135,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:16:56 GMT
-      etag: '"0x8D8BD88B7D131CD"'
-      last-modified: Wed, 20 Jan 2021 21:16:57 GMT
+      date: Wed, 03 Mar 2021 01:09:02 GMT
+      etag: '"0x8D8DDE0EEF72A72"'
+      last-modified: Wed, 03 Mar 2021 01:09:02 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -152,13 +152,13 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:16:56 GMT
+      - Wed, 03 Mar 2021 01:09:03 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/acontaineraa4e127a/blob1
   response:
@@ -169,70 +169,70 @@ interactions:
       content-length: '11'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
       content-type: application/octet-stream
-      date: Wed, 20 Jan 2021 21:16:57 GMT
-      etag: '"0x8D8BD88B7CAEEB9"'
-      last-modified: Wed, 20 Jan 2021 21:16:56 GMT
+      date: Wed, 03 Mar 2021 01:09:02 GMT
+      etag: '"0x8D8DDE0EEF183C1"'
+      last-modified: Wed, 03 Mar 2021 01:09:02 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       vary: Origin
       x-ms-access-tier: Hot
       x-ms-access-tier-inferred: 'true'
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Wed, 20 Jan 2021 21:16:56 GMT
+      x-ms-creation-time: Wed, 03 Mar 2021 01:09:02 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 200
       message: OK
     url: https://emilydevtest.blob.core.windows.net/acontaineraa4e127a/blob1
 - request:
-    body: "--===============1931584078==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============1054211227==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /acontaineraa4e127a/blob1? HTTP/1.1\r\nIf-Match:
-      \"0x8D8BD88B7CAEEB9\"\r\nx-ms-date: Wed, 20 Jan 2021 21:16:56 GMT\r\nx-ms-client-request-id:
-      d3647881-5b64-11eb-b997-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:BaYSS0MkWnmPHQMckfwWsPtRyI+GbKWiNZp6eH/IkBo=\r\n\r\n\r\n--===============1931584078==\r\nContent-Type:
+      \"0x8D8DDE0EEF183C1\"\r\nx-ms-date: Wed, 03 Mar 2021 01:09:03 GMT\r\nx-ms-client-request-id:
+      0b285409-7bbd-11eb-9df0-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1054211227==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /acontaineraa4e127a/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 21:16:56
-      GMT\r\nx-ms-client-request-id: d3647882-5b64-11eb-b558-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:EjwlFCZohYKu85xHiZ+ovrsMhdvnWdUidXi4gBkxWiw=\r\n\r\n\r\n--===============1931584078==\r\nContent-Type:
+      /acontaineraa4e127a/blob2? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:09:03
+      GMT\r\nx-ms-client-request-id: 0b28540a-7bbd-11eb-9ac0-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1054211227==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /acontaineraa4e127a/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 21:16:56
-      GMT\r\nx-ms-client-request-id: d3647883-5b64-11eb-9500-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:ht4Y8IgIk8lYOWstAYNPINR3Og15AEa/ZUlQHBy22MY=\r\n\r\n\r\n--===============1931584078==--\r\n"
+      /acontaineraa4e127a/blob3? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:09:03
+      GMT\r\nx-ms-client-request-id: 0b287b27-7bbd-11eb-aabe-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1054211227==--\r\n"
     headers:
       Content-Length:
       - '1117'
       Content-Type:
-      - multipart/mixed; boundary================1931584078==
+      - multipart/mixed; boundary================1054211227==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:16:56 GMT
+      - Wed, 03 Mar 2021 01:09:03 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/acontaineraa4e127a?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_d6588365-b178-42f3-870e-41a17658e986\r\nContent-Type:
+      string: "--batchresponse_fcbd3c88-3936-4670-b692-1b0818b90a35\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: d6c0283f-201e-00c4-6e71-ef26cd1eed5b\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: d3647881-5b64-11eb-b997-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_d6588365-b178-42f3-870e-41a17658e986\r\nContent-Type:
+        true\r\nx-ms-request-id: c21196ce-d01e-0056-4cc9-0fa21b1e5892\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 0b285409-7bbd-11eb-9df0-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_fcbd3c88-3936-4670-b692-1b0818b90a35\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: d6c0283f-201e-00c4-6e71-ef26cd1eed5d\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: d3647882-5b64-11eb-b558-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_d6588365-b178-42f3-870e-41a17658e986\r\nContent-Type:
+        true\r\nx-ms-request-id: c21196ce-d01e-0056-4cc9-0fa21b1e5894\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 0b28540a-7bbd-11eb-9ac0-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_fcbd3c88-3936-4670-b692-1b0818b90a35\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: d6c0283f-201e-00c4-6e71-ef26cd1eed5e\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: d3647883-5b64-11eb-9500-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_d6588365-b178-42f3-870e-41a17658e986--"
+        true\r\nx-ms-request-id: c21196ce-d01e-0056-4cc9-0fa21b1e5895\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 0b287b27-7bbd-11eb-aabe-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_fcbd3c88-3936-4670-b692-1b0818b90a35--"
     headers:
-      content-type: multipart/mixed; boundary=batchresponse_d6588365-b178-42f3-870e-41a17658e986
-      date: Wed, 20 Jan 2021 21:16:56 GMT
+      content-type: multipart/mixed; boundary=batchresponse_fcbd3c88-3936-4670-b692-1b0818b90a35
+      date: Wed, 03 Mar 2021 01:09:02 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 202
       message: Accepted

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.test_delete_blobs_simple_no_raise.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.test_delete_blobs_simple_no_raise.yaml
@@ -5,11 +5,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:18:12 GMT
+      - Wed, 03 Mar 2021 01:12:50 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainer62f51629?restype=container
   response:
@@ -17,11 +17,11 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 20 Jan 2021 21:18:13 GMT
-      etag: '"0x8D8BD88E5313788"'
-      last-modified: Wed, 20 Jan 2021 21:18:13 GMT
+      date: Wed, 03 Mar 2021 01:12:49 GMT
+      etag: '"0x8D8DDE1769E7EB0"'
+      last-modified: Wed, 03 Mar 2021 01:12:50 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -38,15 +38,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:18:12 GMT
+      - Wed, 03 Mar 2021 01:12:50 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainer62f51629/blob1
   response:
@@ -55,13 +55,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:18:13 GMT
-      etag: '"0x8D8BD88E534CBBF"'
-      last-modified: Wed, 20 Jan 2021 21:18:13 GMT
+      date: Wed, 03 Mar 2021 01:12:49 GMT
+      etag: '"0x8D8DDE176A3FCE8"'
+      last-modified: Wed, 03 Mar 2021 01:12:50 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -78,15 +78,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:18:12 GMT
+      - Wed, 03 Mar 2021 01:12:50 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainer62f51629/blob2
   response:
@@ -95,13 +95,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:18:13 GMT
-      etag: '"0x8D8BD88E53827F0"'
-      last-modified: Wed, 20 Jan 2021 21:18:13 GMT
+      date: Wed, 03 Mar 2021 01:12:49 GMT
+      etag: '"0x8D8DDE176A6959E"'
+      last-modified: Wed, 03 Mar 2021 01:12:50 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -118,15 +118,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:18:12 GMT
+      - Wed, 03 Mar 2021 01:12:50 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainer62f51629/blob3
   response:
@@ -135,64 +135,64 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:18:13 GMT
-      etag: '"0x8D8BD88E53BAB39"'
-      last-modified: Wed, 20 Jan 2021 21:18:13 GMT
+      date: Wed, 03 Mar 2021 01:12:49 GMT
+      etag: '"0x8D8DDE176A97C7D"'
+      last-modified: Wed, 03 Mar 2021 01:12:50 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
     url: https://emilydevtest.blob.core.windows.net/acontainer62f51629/blob3
 - request:
-    body: "--===============1457182830==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============0141392682==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /acontainer62f51629/blob1? HTTP/1.1\r\nx-ms-date:
-      Wed, 20 Jan 2021 21:18:12 GMT\r\nx-ms-client-request-id: 00cbda36-5b65-11eb-929a-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:irJjBzqBF1KkJi9yF7rJvrUBtKlD8/q6Z3Re24Gjp1c=\r\n\r\n\r\n--===============1457182830==\r\nContent-Type:
+      Wed, 03 Mar 2021 01:12:50 GMT\r\nx-ms-client-request-id: 92d7f161-7bbd-11eb-8ce4-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0141392682==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /acontainer62f51629/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 21:18:12
-      GMT\r\nx-ms-client-request-id: 00cbda37-5b65-11eb-87cf-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:2bSZyy3Hsf6C2lVgKNKc91J/wIXnBlOL3o5iyGAH6Vw=\r\n\r\n\r\n--===============1457182830==\r\nContent-Type:
+      /acontainer62f51629/blob2? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:12:50
+      GMT\r\nx-ms-client-request-id: 92d7f162-7bbd-11eb-bd28-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0141392682==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /acontainer62f51629/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 21:18:12
-      GMT\r\nx-ms-client-request-id: 00cbda38-5b65-11eb-b8d8-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:QsHtN6duHnQqxcQjJ5wRBZ+B9wQL1U0MDa5zHVzZ7vs=\r\n\r\n\r\n--===============1457182830==--\r\n"
+      /acontainer62f51629/blob3? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:12:50
+      GMT\r\nx-ms-client-request-id: 92d7f163-7bbd-11eb-a25e-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0141392682==--\r\n"
     headers:
       Content-Length:
       - '1086'
       Content-Type:
-      - multipart/mixed; boundary================1457182830==
+      - multipart/mixed; boundary================0141392682==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:18:12 GMT
+      - Wed, 03 Mar 2021 01:12:50 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/acontainer62f51629?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_e522a9a1-0258-49fa-a2a6-bb2b524bbd65\r\nContent-Type:
+      string: "--batchresponse_07a943f5-b1ba-44bb-ad57-01001f133c33\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 55e90a69-801e-0080-2871-efacf21e513c\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 00cbda36-5b65-11eb-929a-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_e522a9a1-0258-49fa-a2a6-bb2b524bbd65\r\nContent-Type:
+        true\r\nx-ms-request-id: b25caec3-701e-0070-15ca-0fea031e0cbc\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 92d7f161-7bbd-11eb-8ce4-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_07a943f5-b1ba-44bb-ad57-01001f133c33\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 55e90a69-801e-0080-2871-efacf21e513e\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 00cbda37-5b65-11eb-87cf-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_e522a9a1-0258-49fa-a2a6-bb2b524bbd65\r\nContent-Type:
+        true\r\nx-ms-request-id: b25caec3-701e-0070-15ca-0fea031e0cbe\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 92d7f162-7bbd-11eb-bd28-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_07a943f5-b1ba-44bb-ad57-01001f133c33\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 55e90a69-801e-0080-2871-efacf21e513f\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 00cbda38-5b65-11eb-b8d8-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_e522a9a1-0258-49fa-a2a6-bb2b524bbd65--"
+        true\r\nx-ms-request-id: b25caec3-701e-0070-15ca-0fea031e0cbf\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: 92d7f163-7bbd-11eb-a25e-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_07a943f5-b1ba-44bb-ad57-01001f133c33--"
     headers:
-      content-type: multipart/mixed; boundary=batchresponse_e522a9a1-0258-49fa-a2a6-bb2b524bbd65
-      date: Wed, 20 Jan 2021 21:18:13 GMT
+      content-type: multipart/mixed; boundary=batchresponse_07a943f5-b1ba-44bb-ad57-01001f133c33
+      date: Wed, 03 Mar 2021 01:12:49 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 202
       message: Accepted

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.test_delete_blobs_snapshot.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.test_delete_blobs_snapshot.yaml
@@ -5,11 +5,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:10:12 GMT
+      - Wed, 03 Mar 2021 01:15:35 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainerd0941360?restype=container
   response:
@@ -17,11 +17,11 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 20 Jan 2021 21:10:12 GMT
-      etag: '"0x8D8BD87C6EC3BAA"'
-      last-modified: Wed, 20 Jan 2021 21:10:12 GMT
+      date: Wed, 03 Mar 2021 01:15:34 GMT
+      etag: '"0x8D8DDE1D8EBBFA2"'
+      last-modified: Wed, 03 Mar 2021 01:15:34 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -38,15 +38,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:10:12 GMT
+      - Wed, 03 Mar 2021 01:15:35 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainerd0941360/blob1
   response:
@@ -55,13 +55,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:10:12 GMT
-      etag: '"0x8D8BD87C6EF4EDC"'
-      last-modified: Wed, 20 Jan 2021 21:10:12 GMT
+      date: Wed, 03 Mar 2021 01:15:34 GMT
+      etag: '"0x8D8DDE1D8EEFE6D"'
+      last-modified: Wed, 03 Mar 2021 01:15:34 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -72,13 +72,13 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:10:12 GMT
+      - Wed, 03 Mar 2021 01:15:35 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainerd0941360/blob1?comp=snapshot
   response:
@@ -86,13 +86,13 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 20 Jan 2021 21:10:12 GMT
-      etag: '"0x8D8BD87C6EF4EDC"'
-      last-modified: Wed, 20 Jan 2021 21:10:12 GMT
+      date: Wed, 03 Mar 2021 01:15:34 GMT
+      etag: '"0x8D8DDE1D8EEFE6D"'
+      last-modified: Wed, 03 Mar 2021 01:15:34 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted: 'false'
-      x-ms-snapshot: '2021-01-20T21:10:12.9052171Z'
-      x-ms-version: '2020-04-08'
+      x-ms-snapshot: '2021-03-03T01:15:35.0006784Z'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -109,15 +109,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:10:12 GMT
+      - Wed, 03 Mar 2021 01:15:35 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainerd0941360/blob2
   response:
@@ -126,13 +126,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:10:12 GMT
-      etag: '"0x8D8BD87C6F76726"'
-      last-modified: Wed, 20 Jan 2021 21:10:12 GMT
+      date: Wed, 03 Mar 2021 01:15:34 GMT
+      etag: '"0x8D8DDE1D8F51A5F"'
+      last-modified: Wed, 03 Mar 2021 01:15:35 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -149,15 +149,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:10:12 GMT
+      - Wed, 03 Mar 2021 01:15:35 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainerd0941360/blob3
   response:
@@ -166,13 +166,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:10:12 GMT
-      etag: '"0x8D8BD87C6FA9C3C"'
-      last-modified: Wed, 20 Jan 2021 21:10:12 GMT
+      date: Wed, 03 Mar 2021 01:15:34 GMT
+      etag: '"0x8D8DDE1D8F7DA32"'
+      last-modified: Wed, 03 Mar 2021 01:15:35 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -183,96 +183,96 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:10:12 GMT
+      - Wed, 03 Mar 2021 01:15:35 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: GET
     uri: https://storagename.blob.core.windows.net/acontainerd0941360?restype=container&comp=list&include=snapshots
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"acontainerd0941360\"><Blobs><Blob><Name>blob1</Name><Snapshot>2021-01-20T21:10:12.9052171Z</Snapshot><Properties><Creation-Time>Wed,
-        20 Jan 2021 21:10:12 GMT</Creation-Time><Last-Modified>Wed, 20 Jan 2021 21:10:12
-        GMT</Last-Modified><Etag>0x8D8BD87C6EF4EDC</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"acontainerd0941360\"><Blobs><Blob><Name>blob1</Name><Snapshot>2021-03-03T01:15:35.0006784Z</Snapshot><Properties><Creation-Time>Wed,
+        03 Mar 2021 01:15:34 GMT</Creation-Time><Last-Modified>Wed, 03 Mar 2021 01:15:34
+        GMT</Last-Modified><Etag>0x8D8DDE1D8EEFE6D</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>blob1</Name><Properties><Creation-Time>Wed, 20 Jan 2021
-        21:10:12 GMT</Creation-Time><Last-Modified>Wed, 20 Jan 2021 21:10:12 GMT</Last-Modified><Etag>0x8D8BD87C6EF4EDC</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>blob1</Name><Properties><Creation-Time>Wed, 03 Mar 2021
+        01:15:34 GMT</Creation-Time><Last-Modified>Wed, 03 Mar 2021 01:15:34 GMT</Last-Modified><Etag>0x8D8DDE1D8EEFE6D</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>blob2</Name><Properties><Creation-Time>Wed, 20 Jan 2021
-        21:10:12 GMT</Creation-Time><Last-Modified>Wed, 20 Jan 2021 21:10:12 GMT</Last-Modified><Etag>0x8D8BD87C6F76726</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>blob2</Name><Properties><Creation-Time>Wed, 03 Mar 2021
+        01:15:35 GMT</Creation-Time><Last-Modified>Wed, 03 Mar 2021 01:15:35 GMT</Last-Modified><Etag>0x8D8DDE1D8F51A5F</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>blob3</Name><Properties><Creation-Time>Wed, 20 Jan 2021
-        21:10:12 GMT</Creation-Time><Last-Modified>Wed, 20 Jan 2021 21:10:12 GMT</Last-Modified><Etag>0x8D8BD87C6FA9C3C</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>blob3</Name><Properties><Creation-Time>Wed, 03 Mar 2021
+        01:15:35 GMT</Creation-Time><Last-Modified>Wed, 03 Mar 2021 01:15:35 GMT</Last-Modified><Etag>0x8D8DDE1D8F7DA32</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
     headers:
       content-type: application/xml
-      date: Wed, 20 Jan 2021 21:10:12 GMT
+      date: Wed, 03 Mar 2021 01:15:34 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       vary: Origin
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 200
       message: OK
     url: https://emilydevtest.blob.core.windows.net/acontainerd0941360?restype=container&comp=list&include=snapshots
 - request:
-    body: "--===============0712464537==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============0849767484==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /acontainerd0941360/blob1? HTTP/1.1\r\nx-ms-delete-snapshots:
-      only\r\nx-ms-date: Wed, 20 Jan 2021 21:10:12 GMT\r\nx-ms-client-request-id:
-      e2985216-5b63-11eb-9b67-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:blxBoTOD5T5PLEgCZP8ViVRtSxfkOmOudOdW6kum1TY=\r\n\r\n\r\n--===============0712464537==\r\nContent-Type:
+      only\r\nx-ms-date: Wed, 03 Mar 2021 01:15:35 GMT\r\nx-ms-client-request-id:
+      f52a1c06-7bbd-11eb-980f-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0849767484==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
       /acontainerd0941360/blob2? HTTP/1.1\r\nx-ms-delete-snapshots: only\r\nx-ms-date:
-      Wed, 20 Jan 2021 21:10:12 GMT\r\nx-ms-client-request-id: e2985217-5b63-11eb-b3fd-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:WRQ8kR2wxlZx6ZNn1PzLmNwx9LKITslvhphP1GRazC8=\r\n\r\n\r\n--===============0712464537==\r\nContent-Type:
+      Wed, 03 Mar 2021 01:15:35 GMT\r\nx-ms-client-request-id: f52a1c07-7bbd-11eb-8c6e-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0849767484==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
       /acontainerd0941360/blob3? HTTP/1.1\r\nx-ms-delete-snapshots: only\r\nx-ms-date:
-      Wed, 20 Jan 2021 21:10:12 GMT\r\nx-ms-client-request-id: e2985218-5b63-11eb-adb2-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:qAxLY+hGuHF2sn5BEVQqZoEM69ivpNFP8ZU3FrymMhw=\r\n\r\n\r\n--===============0712464537==--\r\n"
+      Wed, 03 Mar 2021 01:15:35 GMT\r\nx-ms-client-request-id: f52a430a-7bbd-11eb-8d14-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0849767484==--\r\n"
     headers:
       Content-Length:
       - '1173'
       Content-Type:
-      - multipart/mixed; boundary================0712464537==
+      - multipart/mixed; boundary================0849767484==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:10:12 GMT
+      - Wed, 03 Mar 2021 01:15:35 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/acontainerd0941360?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_8d8e78a9-55b3-41d2-b945-c86e38ec9e2a\r\nContent-Type:
+      string: "--batchresponse_bcd177d2-680c-4e01-8e6d-27880489f868\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: b2c3c0ce-c01e-00e3-4070-ef31091e35d0\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: e2985216-5b63-11eb-9b67-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_8d8e78a9-55b3-41d2-b945-c86e38ec9e2a\r\nContent-Type:
+        true\r\nx-ms-request-id: 648650d6-d01e-0069-06ca-0f6ab81e7b59\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: f52a1c06-7bbd-11eb-980f-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_bcd177d2-680c-4e01-8e6d-27880489f868\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 404 The specified blob does
-        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: b2c3c0ce-c01e-00e3-4070-ef31091e35d2\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: e2985217-5b63-11eb-b3fd-c8348e5fffbc\r\nContent-Length:
+        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: 648650d6-d01e-0069-06ca-0f6ab81e7b78\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: f52a1c07-7bbd-11eb-8c6e-c8348e5fffbf\r\nContent-Length:
         216\r\nContent-Type: application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml
         version=\"1.0\" encoding=\"utf-8\"?>\n<Error><Code>BlobNotFound</Code><Message>The
-        specified blob does not exist.\nRequestId:b2c3c0ce-c01e-00e3-4070-ef31091e35d2\nTime:2021-01-20T21:10:13.0831979Z</Message></Error>\r\n--batchresponse_8d8e78a9-55b3-41d2-b945-c86e38ec9e2a\r\nContent-Type:
+        specified blob does not exist.\nRequestId:648650d6-d01e-0069-06ca-0f6ab81e7b78\nTime:2021-03-03T01:15:36.5625654Z</Message></Error>\r\n--batchresponse_bcd177d2-680c-4e01-8e6d-27880489f868\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 404 The specified blob does
-        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: b2c3c0ce-c01e-00e3-4070-ef31091e35d3\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: e2985218-5b63-11eb-adb2-c8348e5fffbc\r\nContent-Length:
+        not exist.\r\nx-ms-error-code: BlobNotFound\r\nx-ms-request-id: 648650d6-d01e-0069-06ca-0f6ab81e7b79\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: f52a430a-7bbd-11eb-8d14-c8348e5fffbf\r\nContent-Length:
         216\r\nContent-Type: application/xml\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n\uFEFF<?xml
         version=\"1.0\" encoding=\"utf-8\"?>\n<Error><Code>BlobNotFound</Code><Message>The
-        specified blob does not exist.\nRequestId:b2c3c0ce-c01e-00e3-4070-ef31091e35d3\nTime:2021-01-20T21:10:13.0831979Z</Message></Error>\r\n--batchresponse_8d8e78a9-55b3-41d2-b945-c86e38ec9e2a--"
+        specified blob does not exist.\nRequestId:648650d6-d01e-0069-06ca-0f6ab81e7b79\nTime:2021-03-03T01:15:36.5625654Z</Message></Error>\r\n--batchresponse_bcd177d2-680c-4e01-8e6d-27880489f868--"
     headers:
-      content-type: multipart/mixed; boundary=batchresponse_8d8e78a9-55b3-41d2-b945-c86e38ec9e2a
-      date: Wed, 20 Jan 2021 21:10:13 GMT
+      content-type: multipart/mixed; boundary=batchresponse_bcd177d2-680c-4e01-8e6d-27880489f868
+      date: Wed, 03 Mar 2021 01:15:36 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -283,37 +283,37 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:10:12 GMT
+      - Wed, 03 Mar 2021 01:15:37 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: GET
     uri: https://storagename.blob.core.windows.net/acontainerd0941360?restype=container&comp=list&include=snapshots
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
         ServiceEndpoint=\"https://storagename.blob.core.windows.net/\" ContainerName=\"acontainerd0941360\"><Blobs><Blob><Name>blob1</Name><Properties><Creation-Time>Wed,
-        20 Jan 2021 21:10:12 GMT</Creation-Time><Last-Modified>Wed, 20 Jan 2021 21:10:12
-        GMT</Last-Modified><Etag>0x8D8BD87C6EF4EDC</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        03 Mar 2021 01:15:34 GMT</Creation-Time><Last-Modified>Wed, 03 Mar 2021 01:15:34
+        GMT</Last-Modified><Etag>0x8D8DDE1D8EEFE6D</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>blob2</Name><Properties><Creation-Time>Wed, 20 Jan 2021
-        21:10:12 GMT</Creation-Time><Last-Modified>Wed, 20 Jan 2021 21:10:12 GMT</Last-Modified><Etag>0x8D8BD87C6F76726</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>blob2</Name><Properties><Creation-Time>Wed, 03 Mar 2021
+        01:15:35 GMT</Creation-Time><Last-Modified>Wed, 03 Mar 2021 01:15:35 GMT</Last-Modified><Etag>0x8D8DDE1D8F51A5F</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>blob3</Name><Properties><Creation-Time>Wed, 20 Jan 2021
-        21:10:12 GMT</Creation-Time><Last-Modified>Wed, 20 Jan 2021 21:10:12 GMT</Last-Modified><Etag>0x8D8BD87C6FA9C3C</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>blob3</Name><Properties><Creation-Time>Wed, 03 Mar 2021
+        01:15:35 GMT</Creation-Time><Last-Modified>Wed, 03 Mar 2021 01:15:35 GMT</Last-Modified><Etag>0x8D8DDE1D8F7DA32</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
     headers:
       content-type: application/xml
-      date: Wed, 20 Jan 2021 21:10:13 GMT
+      date: Wed, 03 Mar 2021 01:15:36 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
       vary: Origin
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 200
       message: OK

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.test_delete_blobs_with_if_tags.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.test_delete_blobs_with_if_tags.yaml
@@ -150,15 +150,15 @@ interactions:
     body: "--===============1813932577==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /acontainer218e14e8/blob1? HTTP/1.1\r\nx-ms-if-tags:
       \"tag1\"='firsttag WRONG'\r\nx-ms-date: Wed, 20 Jan 2021 21:11:16 GMT\r\nx-ms-client-request-id:
-      08ee57af-5b64-11eb-9f38-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:PZ5ASZ3doobqza4oEMxN375J78C641HDV/Xm1+38c/w=\r\n\r\n\r\n--===============1813932577==\r\nContent-Type:
+      08ee57af-5b64-11eb-9f38-c8348e5fffbc\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1813932577==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
       /acontainer218e14e8/blob2? HTTP/1.1\r\nx-ms-if-tags: \"tag1\"='firsttag WRONG'\r\nx-ms-date:
       Wed, 20 Jan 2021 21:11:16 GMT\r\nx-ms-client-request-id: 08ee57b0-5b64-11eb-b0c0-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:+rjbwFXGRz9RNWvCBzty7f6gFd8mzTxHG0zlFJMzXEg=\r\n\r\n\r\n--===============1813932577==\r\nContent-Type:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1813932577==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
       /acontainer218e14e8/blob3? HTTP/1.1\r\nx-ms-if-tags: \"tag1\"='firsttag WRONG'\r\nx-ms-date:
       Wed, 20 Jan 2021 21:11:16 GMT\r\nx-ms-client-request-id: 08ee57b1-5b64-11eb-bd94-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:0dpHp77TYSL2jTfBO2HQaVH/AOS7uWrj9b2fj9ZZJsc=\r\n\r\n\r\n--===============1813932577==--\r\n"
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1813932577==--\r\n"
     headers:
       Content-Length:
       - '1203'
@@ -210,15 +210,15 @@ interactions:
     body: "--===============1593829889==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /acontainer218e14e8/blob1? HTTP/1.1\r\nx-ms-if-tags:
       \"tag1\"='firsttag'\r\nx-ms-date: Wed, 20 Jan 2021 21:11:17 GMT\r\nx-ms-client-request-id:
-      0934eb01-5b64-11eb-9347-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:7mtnhryU2cNltXTa+xIACQaq6lU14Rnq9TlmqHHNiko=\r\n\r\n\r\n--===============1593829889==\r\nContent-Type:
+      0934eb01-5b64-11eb-9347-c8348e5fffbc\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1593829889==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
       /acontainer218e14e8/blob2? HTTP/1.1\r\nx-ms-if-tags: \"tag1\"='firsttag'\r\nx-ms-date:
       Wed, 20 Jan 2021 21:11:17 GMT\r\nx-ms-client-request-id: 0934eb02-5b64-11eb-9fe4-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:pCL46h/tPcA8RlGF/rrWDu7gZ4TeX6WgamIXCAVNibo=\r\n\r\n\r\n--===============1593829889==\r\nContent-Type:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1593829889==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
       /acontainer218e14e8/blob3? HTTP/1.1\r\nx-ms-if-tags: \"tag1\"='firsttag'\r\nx-ms-date:
       Wed, 20 Jan 2021 21:11:17 GMT\r\nx-ms-client-request-id: 0934eb03-5b64-11eb-9093-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:rUTCgvtxmoh7bWRbW/6l+k9zFmIzVZul1Ij9Ho0MPSg=\r\n\r\n\r\n--===============1593829889==--\r\n"
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1593829889==--\r\n"
     headers:
       Content-Length:
       - '1185'

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.test_standard_blob_tier_set_tier_api_batch.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.test_standard_blob_tier_set_tier_api_batch.yaml
@@ -5,11 +5,11 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:38 GMT
+      - Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7?restype=container
   response:
@@ -17,11 +17,11 @@ interactions:
       string: ''
     headers:
       content-length: '0'
-      date: Wed, 20 Jan 2021 21:21:38 GMT
-      etag: '"0x8D8BD895FE54F5B"'
-      last-modified: Wed, 20 Jan 2021 21:21:38 GMT
+      date: Wed, 03 Mar 2021 01:21:21 GMT
+      etag: '"0x8D8DDE2A8536218"'
+      last-modified: Wed, 03 Mar 2021 01:21:22 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -38,15 +38,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:38 GMT
+      - Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7/blob1
   response:
@@ -55,13 +55,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:21:38 GMT
-      etag: '"0x8D8BD895FEAC258"'
-      last-modified: Wed, 20 Jan 2021 21:21:39 GMT
+      date: Wed, 03 Mar 2021 01:21:21 GMT
+      etag: '"0x8D8DDE2A8574A0D"'
+      last-modified: Wed, 03 Mar 2021 01:21:22 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -78,15 +78,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:38 GMT
+      - Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7/blob2
   response:
@@ -95,13 +95,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:21:38 GMT
-      etag: '"0x8D8BD895FEE6CBD"'
-      last-modified: Wed, 20 Jan 2021 21:21:39 GMT
+      date: Wed, 03 Mar 2021 01:21:22 GMT
+      etag: '"0x8D8DDE2A85A09D8"'
+      last-modified: Wed, 03 Mar 2021 01:21:22 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -118,15 +118,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:38 GMT
+      - Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7/blob3
   response:
@@ -135,13 +135,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:21:38 GMT
-      etag: '"0x8D8BD895FF1C8EF"'
-      last-modified: Wed, 20 Jan 2021 21:21:39 GMT
+      date: Wed, 03 Mar 2021 01:21:22 GMT
+      etag: '"0x8D8DDE2A85CC9A7"'
+      last-modified: Wed, 03 Mar 2021 01:21:22 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -152,13 +152,13 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:38 GMT
+      - Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7/blob1
   response:
@@ -169,67 +169,67 @@ interactions:
       content-length: '11'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
       content-type: application/octet-stream
-      date: Wed, 20 Jan 2021 21:21:38 GMT
-      etag: '"0x8D8BD895FEAC258"'
-      last-modified: Wed, 20 Jan 2021 21:21:39 GMT
+      date: Wed, 03 Mar 2021 01:21:22 GMT
+      etag: '"0x8D8DDE2A8574A0D"'
+      last-modified: Wed, 03 Mar 2021 01:21:22 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       vary: Origin
       x-ms-access-tier: Hot
       x-ms-access-tier-inferred: 'true'
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Wed, 20 Jan 2021 21:21:39 GMT
+      x-ms-creation-time: Wed, 03 Mar 2021 01:21:22 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 200
       message: OK
     url: https://emilydevtest.blob.core.windows.net/acontainer3d7c19c7/blob1
 - request:
-    body: "--===============0119952415==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============0894961032==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nPUT /acontainer3d7c19c7/blob1?comp=tier HTTP/1.1\r\nContent-Length:
-      0\r\nx-ms-access-tier: Archive\r\nx-ms-date: Wed, 20 Jan 2021 21:21:38 GMT\r\nx-ms-client-request-id:
-      7b854184-5b65-11eb-b111-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:WPPWE7SYe2K2Pr2h3PN9Kv/JzUOAdxrnDJapDbJsvKQ=\r\n\r\n\r\n--===============0119952415==\r\nContent-Type:
+      0\r\nx-ms-access-tier: Archive\r\nx-ms-date: Wed, 03 Mar 2021 01:21:23 GMT\r\nx-ms-client-request-id:
+      c48d3454-7bbe-11eb-b2e8-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0894961032==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nPUT
       /acontainer3d7c19c7/blob2?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
-      Archive\r\nx-ms-date: Wed, 20 Jan 2021 21:21:38 GMT\r\nx-ms-client-request-id:
-      7b85687c-5b65-11eb-ae70-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:BNfHzEovWgnayLnM4+TPWmJYNtKk8LdVllj6WGvwi3k=\r\n\r\n\r\n--===============0119952415==\r\nContent-Type:
+      Archive\r\nx-ms-date: Wed, 03 Mar 2021 01:21:23 GMT\r\nx-ms-client-request-id:
+      c48d5c4c-7bbe-11eb-b0f0-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0894961032==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nPUT
       /acontainer3d7c19c7/blob3?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
-      Archive\r\nx-ms-date: Wed, 20 Jan 2021 21:21:38 GMT\r\nx-ms-client-request-id:
-      7b85687d-5b65-11eb-8d99-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:w5p1VAeIKvaWLGOIuANp63DGYxkvD36oT1ThhPlzAUk=\r\n\r\n\r\n--===============0119952415==--\r\n"
+      Archive\r\nx-ms-date: Wed, 03 Mar 2021 01:21:23 GMT\r\nx-ms-client-request-id:
+      c48d5c4d-7bbe-11eb-ae2b-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0894961032==--\r\n"
     headers:
       Content-Length:
       - '1242'
       Content-Type:
-      - multipart/mixed; boundary================0119952415==
+      - multipart/mixed; boundary================0894961032==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:38 GMT
+      - Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_a4feea92-3bf6-4c7c-9eeb-4e258bb16778\r\nContent-Type:
+      string: "--batchresponse_f76ed9da-d64b-4f77-9ad6-dfcb1c545c1b\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        100bcbcf-001e-0027-6e72-ef44301e768a\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7b854184-5b65-11eb-b111-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_a4feea92-3bf6-4c7c-9eeb-4e258bb16778\r\nContent-Type:
+        648ae617-d01e-0069-1ecb-0f6ab81e9fff\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        c48d3454-7bbe-11eb-b2e8-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_f76ed9da-d64b-4f77-9ad6-dfcb1c545c1b\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        100bcbcf-001e-0027-6e72-ef44301e7695\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7b85687c-5b65-11eb-ae70-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_a4feea92-3bf6-4c7c-9eeb-4e258bb16778\r\nContent-Type:
+        648ae617-d01e-0069-1ecb-0f6ab81ea001\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        c48d5c4c-7bbe-11eb-b0f0-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_f76ed9da-d64b-4f77-9ad6-dfcb1c545c1b\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        100bcbcf-001e-0027-6e72-ef44301e7696\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7b85687d-5b65-11eb-8d99-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_a4feea92-3bf6-4c7c-9eeb-4e258bb16778--"
+        648ae617-d01e-0069-1ecb-0f6ab81ea002\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        c48d5c4d-7bbe-11eb-ae2b-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_f76ed9da-d64b-4f77-9ad6-dfcb1c545c1b--"
     headers:
-      content-type: multipart/mixed; boundary=batchresponse_a4feea92-3bf6-4c7c-9eeb-4e258bb16778
-      date: Wed, 20 Jan 2021 21:21:40 GMT
+      content-type: multipart/mixed; boundary=batchresponse_f76ed9da-d64b-4f77-9ad6-dfcb1c545c1b
+      date: Wed, 03 Mar 2021 01:21:22 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -240,13 +240,13 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:41 GMT
+      - Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7/blob1
   response:
@@ -257,70 +257,70 @@ interactions:
       content-length: '11'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
       content-type: application/octet-stream
-      date: Wed, 20 Jan 2021 21:21:40 GMT
-      etag: '"0x8D8BD895FEAC258"'
-      last-modified: Wed, 20 Jan 2021 21:21:39 GMT
+      date: Wed, 03 Mar 2021 01:21:22 GMT
+      etag: '"0x8D8DDE2A8574A0D"'
+      last-modified: Wed, 03 Mar 2021 01:21:22 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       vary: Origin
       x-ms-access-tier: Archive
-      x-ms-access-tier-change-time: Wed, 20 Jan 2021 21:21:41 GMT
+      x-ms-access-tier-change-time: Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Wed, 20 Jan 2021 21:21:39 GMT
+      x-ms-creation-time: Wed, 03 Mar 2021 01:21:22 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 200
       message: OK
     url: https://emilydevtest.blob.core.windows.net/acontainer3d7c19c7/blob1
 - request:
-    body: "--===============1747488249==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============1032558992==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /acontainer3d7c19c7/blob1? HTTP/1.1\r\nx-ms-date:
-      Wed, 20 Jan 2021 21:21:41 GMT\r\nx-ms-client-request-id: 7d270fb5-5b65-11eb-a811-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:VAFq48c0ZKfcJst73KkqBImaxPC9xSLqIBHHfmCZO7c=\r\n\r\n\r\n--===============1747488249==\r\nContent-Type:
+      Wed, 03 Mar 2021 01:21:23 GMT\r\nx-ms-client-request-id: c499aa30-7bbe-11eb-898d-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1032558992==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /acontainer3d7c19c7/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 21:21:41
-      GMT\r\nx-ms-client-request-id: 7d270fb6-5b65-11eb-add3-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:Z0UlhrBhA8l87802y4A7VRMf1ik4MTRaHYz/7SMHE/s=\r\n\r\n\r\n--===============1747488249==\r\nContent-Type:
+      /acontainer3d7c19c7/blob2? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:21:23
+      GMT\r\nx-ms-client-request-id: c499aa31-7bbe-11eb-bde7-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1032558992==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /acontainer3d7c19c7/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 21:21:41
-      GMT\r\nx-ms-client-request-id: 7d270fb7-5b65-11eb-978d-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:vu2k/3UZaj/cgb1X0r+4lzLlTvWUpxTWj4PN7UJin/s=\r\n\r\n\r\n--===============1747488249==--\r\n"
+      /acontainer3d7c19c7/blob3? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:21:23
+      GMT\r\nx-ms-client-request-id: c499aa32-7bbe-11eb-9116-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1032558992==--\r\n"
     headers:
       Content-Length:
       - '1086'
       Content-Type:
-      - multipart/mixed; boundary================1747488249==
+      - multipart/mixed; boundary================1032558992==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:41 GMT
+      - Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_80ad3f55-4597-4f9e-acda-6a2ed78d6bc7\r\nContent-Type:
+      string: "--batchresponse_7103ffaa-b3ba-47db-a8a6-df6992c6b50a\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 6a0850aa-301e-0003-5972-efb2901e0041\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 7d270fb5-5b65-11eb-a811-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_80ad3f55-4597-4f9e-acda-6a2ed78d6bc7\r\nContent-Type:
+        true\r\nx-ms-request-id: 51fe8cd3-f01e-0023-0ccb-0fc9371ec22c\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: c499aa30-7bbe-11eb-898d-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_7103ffaa-b3ba-47db-a8a6-df6992c6b50a\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 6a0850aa-301e-0003-5972-efb2901e0043\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 7d270fb6-5b65-11eb-add3-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_80ad3f55-4597-4f9e-acda-6a2ed78d6bc7\r\nContent-Type:
+        true\r\nx-ms-request-id: 51fe8cd3-f01e-0023-0ccb-0fc9371ec22e\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: c499aa31-7bbe-11eb-bde7-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_7103ffaa-b3ba-47db-a8a6-df6992c6b50a\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 6a0850aa-301e-0003-5972-efb2901e0044\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 7d270fb7-5b65-11eb-978d-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_80ad3f55-4597-4f9e-acda-6a2ed78d6bc7--"
+        true\r\nx-ms-request-id: 51fe8cd3-f01e-0023-0ccb-0fc9371ec22f\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: c499aa32-7bbe-11eb-9116-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_7103ffaa-b3ba-47db-a8a6-df6992c6b50a--"
     headers:
-      content-type: multipart/mixed; boundary=batchresponse_80ad3f55-4597-4f9e-acda-6a2ed78d6bc7
-      date: Wed, 20 Jan 2021 21:21:41 GMT
+      content-type: multipart/mixed; boundary=batchresponse_7103ffaa-b3ba-47db-a8a6-df6992c6b50a
+      date: Wed, 03 Mar 2021 01:21:22 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -337,15 +337,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:41 GMT
+      - Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7/blob1
   response:
@@ -354,13 +354,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:21:41 GMT
-      etag: '"0x8D8BD8961A78438"'
-      last-modified: Wed, 20 Jan 2021 21:21:41 GMT
+      date: Wed, 03 Mar 2021 01:21:22 GMT
+      etag: '"0x8D8DDE2A87C4027"'
+      last-modified: Wed, 03 Mar 2021 01:21:23 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -377,15 +377,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:41 GMT
+      - Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7/blob2
   response:
@@ -394,13 +394,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:21:41 GMT
-      etag: '"0x8D8BD8961ADC753"'
-      last-modified: Wed, 20 Jan 2021 21:21:41 GMT
+      date: Wed, 03 Mar 2021 01:21:22 GMT
+      etag: '"0x8D8DDE2A87EB1BE"'
+      last-modified: Wed, 03 Mar 2021 01:21:23 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -417,15 +417,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:41 GMT
+      - Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7/blob3
   response:
@@ -434,13 +434,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:21:41 GMT
-      etag: '"0x8D8BD8961B171B3"'
-      last-modified: Wed, 20 Jan 2021 21:21:42 GMT
+      date: Wed, 03 Mar 2021 01:21:22 GMT
+      etag: '"0x8D8DDE2A8814A6B"'
+      last-modified: Wed, 03 Mar 2021 01:21:23 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -451,13 +451,13 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:41 GMT
+      - Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7/blob1
   response:
@@ -468,67 +468,67 @@ interactions:
       content-length: '11'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
       content-type: application/octet-stream
-      date: Wed, 20 Jan 2021 21:21:41 GMT
-      etag: '"0x8D8BD8961A78438"'
-      last-modified: Wed, 20 Jan 2021 21:21:41 GMT
+      date: Wed, 03 Mar 2021 01:21:22 GMT
+      etag: '"0x8D8DDE2A87C4027"'
+      last-modified: Wed, 03 Mar 2021 01:21:23 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       vary: Origin
       x-ms-access-tier: Hot
       x-ms-access-tier-inferred: 'true'
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Wed, 20 Jan 2021 21:21:41 GMT
+      x-ms-creation-time: Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 200
       message: OK
     url: https://emilydevtest.blob.core.windows.net/acontainer3d7c19c7/blob1
 - request:
-    body: "--===============0926475726==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============2112864625==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nPUT /acontainer3d7c19c7/blob1?comp=tier HTTP/1.1\r\nContent-Length:
-      0\r\nx-ms-access-tier: Cool\r\nx-ms-date: Wed, 20 Jan 2021 21:21:41 GMT\r\nx-ms-client-request-id:
-      7d44be4a-5b65-11eb-ad18-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:I86sJIbC+yGajkEyUTNRUr0xq+NFT46V0m9edB8bsjE=\r\n\r\n\r\n--===============0926475726==\r\nContent-Type:
+      0\r\nx-ms-access-tier: Cool\r\nx-ms-date: Wed, 03 Mar 2021 01:21:23 GMT\r\nx-ms-client-request-id:
+      c4b19309-7bbe-11eb-8c9d-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2112864625==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nPUT
       /acontainer3d7c19c7/blob2?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
-      Cool\r\nx-ms-date: Wed, 20 Jan 2021 21:21:41 GMT\r\nx-ms-client-request-id:
-      7d44be4b-5b65-11eb-b475-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:tuZKemBXmln1dRrKR685q16y+fB3d2r24iwxV0Mdjcw=\r\n\r\n\r\n--===============0926475726==\r\nContent-Type:
+      Cool\r\nx-ms-date: Wed, 03 Mar 2021 01:21:23 GMT\r\nx-ms-client-request-id:
+      c4b1930a-7bbe-11eb-a8c4-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2112864625==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nPUT
       /acontainer3d7c19c7/blob3?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
-      Cool\r\nx-ms-date: Wed, 20 Jan 2021 21:21:41 GMT\r\nx-ms-client-request-id:
-      7d44be4c-5b65-11eb-a95a-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:MYfkM0UrcHIef/eMlTbTZKWOgv22jqdjoBKCbZyZXXo=\r\n\r\n\r\n--===============0926475726==--\r\n"
+      Cool\r\nx-ms-date: Wed, 03 Mar 2021 01:21:23 GMT\r\nx-ms-client-request-id:
+      c4b1930b-7bbe-11eb-9b2b-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2112864625==--\r\n"
     headers:
       Content-Length:
       - '1233'
       Content-Type:
-      - multipart/mixed; boundary================0926475726==
+      - multipart/mixed; boundary================2112864625==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:41 GMT
+      - Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_22db90d8-65e0-4513-928f-2ba0825072f6\r\nContent-Type:
+      string: "--batchresponse_12d4b78a-e320-4ad5-aeb6-49fcf9bcd807\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        7162481e-401e-0019-2d72-efd34f1e4444\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7d44be4a-5b65-11eb-ad18-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_22db90d8-65e0-4513-928f-2ba0825072f6\r\nContent-Type:
+        09315bcf-c01e-0091-0ccb-0f36461e4045\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        c4b19309-7bbe-11eb-8c9d-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_12d4b78a-e320-4ad5-aeb6-49fcf9bcd807\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        7162481e-401e-0019-2d72-efd34f1e4446\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7d44be4b-5b65-11eb-b475-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_22db90d8-65e0-4513-928f-2ba0825072f6\r\nContent-Type:
+        09315bcf-c01e-0091-0ccb-0f36461e404c\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        c4b1930a-7bbe-11eb-a8c4-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_12d4b78a-e320-4ad5-aeb6-49fcf9bcd807\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        7162481e-401e-0019-2d72-efd34f1e4447\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7d44be4c-5b65-11eb-a95a-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_22db90d8-65e0-4513-928f-2ba0825072f6--"
+        09315bcf-c01e-0091-0ccb-0f36461e404d\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        c4b1930b-7bbe-11eb-9b2b-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_12d4b78a-e320-4ad5-aeb6-49fcf9bcd807--"
     headers:
-      content-type: multipart/mixed; boundary=batchresponse_22db90d8-65e0-4513-928f-2ba0825072f6
-      date: Wed, 20 Jan 2021 21:21:42 GMT
+      content-type: multipart/mixed; boundary=batchresponse_12d4b78a-e320-4ad5-aeb6-49fcf9bcd807
+      date: Wed, 03 Mar 2021 01:21:22 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -539,13 +539,13 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:41 GMT
+      - Wed, 03 Mar 2021 01:21:24 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7/blob1
   response:
@@ -556,70 +556,70 @@ interactions:
       content-length: '11'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
       content-type: application/octet-stream
-      date: Wed, 20 Jan 2021 21:21:42 GMT
-      etag: '"0x8D8BD8961A78438"'
-      last-modified: Wed, 20 Jan 2021 21:21:41 GMT
+      date: Wed, 03 Mar 2021 01:21:22 GMT
+      etag: '"0x8D8DDE2A87C4027"'
+      last-modified: Wed, 03 Mar 2021 01:21:23 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       vary: Origin
       x-ms-access-tier: Cool
-      x-ms-access-tier-change-time: Wed, 20 Jan 2021 21:21:42 GMT
+      x-ms-access-tier-change-time: Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Wed, 20 Jan 2021 21:21:41 GMT
+      x-ms-creation-time: Wed, 03 Mar 2021 01:21:23 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 200
       message: OK
     url: https://emilydevtest.blob.core.windows.net/acontainer3d7c19c7/blob1
 - request:
-    body: "--===============0377100579==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============1479626306==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /acontainer3d7c19c7/blob1? HTTP/1.1\r\nx-ms-date:
-      Wed, 20 Jan 2021 21:21:41 GMT\r\nx-ms-client-request-id: 7d52a0d8-5b65-11eb-84c8-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:mQLunmJg6cjiarVPg1OYH+JQpcbxdfNG96g6oyGuvkI=\r\n\r\n\r\n--===============0377100579==\r\nContent-Type:
+      Wed, 03 Mar 2021 01:21:24 GMT\r\nx-ms-client-request-id: c4d36609-7bbe-11eb-8987-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1479626306==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /acontainer3d7c19c7/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 21:21:41
-      GMT\r\nx-ms-client-request-id: 7d52a0d9-5b65-11eb-94b0-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:RrREIgv0BKO8MYp2dh/eZk8dGUOYAM1LgqauF7BHvF0=\r\n\r\n\r\n--===============0377100579==\r\nContent-Type:
+      /acontainer3d7c19c7/blob2? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:21:24
+      GMT\r\nx-ms-client-request-id: c4d38d17-7bbe-11eb-a3a2-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1479626306==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /acontainer3d7c19c7/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 21:21:41
-      GMT\r\nx-ms-client-request-id: 7d52a0da-5b65-11eb-851b-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:B65pGGgz6MqDSrGfNKYJFS+0Dpbtg9R2UqNigeiEOuw=\r\n\r\n\r\n--===============0377100579==--\r\n"
+      /acontainer3d7c19c7/blob3? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:21:24
+      GMT\r\nx-ms-client-request-id: c4d38d18-7bbe-11eb-86a8-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1479626306==--\r\n"
     headers:
       Content-Length:
       - '1086'
       Content-Type:
-      - multipart/mixed; boundary================0377100579==
+      - multipart/mixed; boundary================1479626306==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:41 GMT
+      - Wed, 03 Mar 2021 01:21:24 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_7920712d-fa74-4ea5-8b94-15d7c5954dbe\r\nContent-Type:
+      string: "--batchresponse_7724eb05-376d-4c94-8bf6-707085f52c46\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 52e7bc41-f01e-007e-1572-efc3b31ebf67\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 7d52a0d8-5b65-11eb-84c8-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_7920712d-fa74-4ea5-8b94-15d7c5954dbe\r\nContent-Type:
+        true\r\nx-ms-request-id: 45d9931f-701e-0060-5ecb-0f2f6b1effae\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: c4d36609-7bbe-11eb-8987-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_7724eb05-376d-4c94-8bf6-707085f52c46\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 52e7bc41-f01e-007e-1572-efc3b31ebf69\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 7d52a0d9-5b65-11eb-94b0-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_7920712d-fa74-4ea5-8b94-15d7c5954dbe\r\nContent-Type:
+        true\r\nx-ms-request-id: 45d9931f-701e-0060-5ecb-0f2f6b1effb2\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: c4d38d17-7bbe-11eb-a3a2-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_7724eb05-376d-4c94-8bf6-707085f52c46\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 52e7bc41-f01e-007e-1572-efc3b31ebf6a\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 7d52a0da-5b65-11eb-851b-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_7920712d-fa74-4ea5-8b94-15d7c5954dbe--"
+        true\r\nx-ms-request-id: 45d9931f-701e-0060-5ecb-0f2f6b1effb3\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: c4d38d18-7bbe-11eb-86a8-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_7724eb05-376d-4c94-8bf6-707085f52c46--"
     headers:
-      content-type: multipart/mixed; boundary=batchresponse_7920712d-fa74-4ea5-8b94-15d7c5954dbe
-      date: Wed, 20 Jan 2021 21:21:41 GMT
+      content-type: multipart/mixed; boundary=batchresponse_7724eb05-376d-4c94-8bf6-707085f52c46
+      date: Wed, 03 Mar 2021 01:21:23 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -636,15 +636,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:41 GMT
+      - Wed, 03 Mar 2021 01:21:24 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7/blob1
   response:
@@ -653,13 +653,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:21:41 GMT
-      etag: '"0x8D8BD8961D3A805"'
-      last-modified: Wed, 20 Jan 2021 21:21:42 GMT
+      date: Wed, 03 Mar 2021 01:21:23 GMT
+      etag: '"0x8D8DDE2A8FB7A08"'
+      last-modified: Wed, 03 Mar 2021 01:21:24 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -676,15 +676,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:41 GMT
+      - Wed, 03 Mar 2021 01:21:24 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7/blob2
   response:
@@ -693,13 +693,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:21:41 GMT
-      etag: '"0x8D8BD8961D6DD26"'
-      last-modified: Wed, 20 Jan 2021 21:21:42 GMT
+      date: Wed, 03 Mar 2021 01:21:24 GMT
+      etag: '"0x8D8DDE2A8FE39D7"'
+      last-modified: Wed, 03 Mar 2021 01:21:24 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -716,15 +716,15 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:41 GMT
+      - Wed, 03 Mar 2021 01:21:24 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: PUT
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7/blob3
   response:
@@ -733,13 +733,13 @@ interactions:
     headers:
       content-length: '0'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
-      date: Wed, 20 Jan 2021 21:21:41 GMT
-      etag: '"0x8D8BD8961DB23EC"'
-      last-modified: Wed, 20 Jan 2021 21:21:42 GMT
+      date: Wed, 03 Mar 2021 01:21:24 GMT
+      etag: '"0x8D8DDE2A90147D0"'
+      last-modified: Wed, 03 Mar 2021 01:21:24 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64: vo7q9sPVKY0=
       x-ms-request-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 201
       message: Created
@@ -750,13 +750,13 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:41 GMT
+      - Wed, 03 Mar 2021 01:21:24 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7/blob1
   response:
@@ -767,67 +767,67 @@ interactions:
       content-length: '11'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
       content-type: application/octet-stream
-      date: Wed, 20 Jan 2021 21:21:41 GMT
-      etag: '"0x8D8BD8961D3A805"'
-      last-modified: Wed, 20 Jan 2021 21:21:42 GMT
+      date: Wed, 03 Mar 2021 01:21:24 GMT
+      etag: '"0x8D8DDE2A8FB7A08"'
+      last-modified: Wed, 03 Mar 2021 01:21:24 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       vary: Origin
       x-ms-access-tier: Hot
       x-ms-access-tier-inferred: 'true'
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Wed, 20 Jan 2021 21:21:42 GMT
+      x-ms-creation-time: Wed, 03 Mar 2021 01:21:24 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 200
       message: OK
     url: https://emilydevtest.blob.core.windows.net/acontainer3d7c19c7/blob1
 - request:
-    body: "--===============1523997868==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============1419131099==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nPUT /acontainer3d7c19c7/blob1?comp=tier HTTP/1.1\r\nContent-Length:
-      0\r\nx-ms-access-tier: Hot\r\nx-ms-date: Wed, 20 Jan 2021 21:21:41 GMT\r\nx-ms-client-request-id:
-      7d6e1812-5b65-11eb-a749-c8348e5fffbc\r\nAuthorization: SharedKey emilydevtest:Ba8HL/44flJBGcbWcwVPJYKe1s7M9XH3Rrjc9PpTtEA=\r\n\r\n\r\n--===============1523997868==\r\nContent-Type:
+      0\r\nx-ms-access-tier: Hot\r\nx-ms-date: Wed, 03 Mar 2021 01:21:24 GMT\r\nx-ms-client-request-id:
+      c531ea60-7bbe-11eb-9e73-c8348e5fffbf\r\nAuthorization: SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1419131099==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nPUT
       /acontainer3d7c19c7/blob2?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
-      Hot\r\nx-ms-date: Wed, 20 Jan 2021 21:21:41 GMT\r\nx-ms-client-request-id: 7d6e1813-5b65-11eb-a277-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:71erTQgvGG9QDtOrNFUi1FrTFe/0VuIBKtDSmNuC1rk=\r\n\r\n\r\n--===============1523997868==\r\nContent-Type:
+      Hot\r\nx-ms-date: Wed, 03 Mar 2021 01:21:24 GMT\r\nx-ms-client-request-id: c531ea61-7bbe-11eb-b23c-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1419131099==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nPUT
       /acontainer3d7c19c7/blob3?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
-      Hot\r\nx-ms-date: Wed, 20 Jan 2021 21:21:41 GMT\r\nx-ms-client-request-id: 7d6e1814-5b65-11eb-b111-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:2vK3DMNTaxdJmj3sr/IEtgzO+MjTKQOEb3H5XmYmY9c=\r\n\r\n\r\n--===============1523997868==--\r\n"
+      Hot\r\nx-ms-date: Wed, 03 Mar 2021 01:21:24 GMT\r\nx-ms-client-request-id: c531ea62-7bbe-11eb-ab98-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============1419131099==--\r\n"
     headers:
       Content-Length:
       - '1230'
       Content-Type:
-      - multipart/mixed; boundary================1523997868==
+      - multipart/mixed; boundary================1419131099==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:41 GMT
+      - Wed, 03 Mar 2021 01:21:24 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_b89e7046-ca5b-4873-8f73-3516ea0b81bd\r\nContent-Type:
+      string: "--batchresponse_e83dd3e2-2cc9-404f-b260-6e831f789c30\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        a8983960-f01e-001c-3272-ef01941ea435\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7d6e1812-5b65-11eb-a749-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_b89e7046-ca5b-4873-8f73-3516ea0b81bd\r\nContent-Type:
+        8cd69314-901e-001a-75cb-0f322b1eb129\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        c531ea60-7bbe-11eb-9e73-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_e83dd3e2-2cc9-404f-b260-6e831f789c30\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        a8983960-f01e-001c-3272-ef01941ea43b\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7d6e1813-5b65-11eb-a277-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_b89e7046-ca5b-4873-8f73-3516ea0b81bd\r\nContent-Type:
+        8cd69314-901e-001a-75cb-0f322b1eb12e\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        c531ea61-7bbe-11eb-b23c-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_e83dd3e2-2cc9-404f-b260-6e831f789c30\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 200 OK\r\nx-ms-request-id:
-        a8983960-f01e-001c-3272-ef01941ea43c\r\nx-ms-version: 2020-04-08\r\nx-ms-client-request-id:
-        7d6e1814-5b65-11eb-b111-c8348e5fffbc\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_b89e7046-ca5b-4873-8f73-3516ea0b81bd--"
+        8cd69314-901e-001a-75cb-0f322b1eb12f\r\nx-ms-version: 2020-06-12\r\nx-ms-client-request-id:
+        c531ea62-7bbe-11eb-ab98-c8348e5fffbf\r\nServer: Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_e83dd3e2-2cc9-404f-b260-6e831f789c30--"
     headers:
-      content-type: multipart/mixed; boundary=batchresponse_b89e7046-ca5b-4873-8f73-3516ea0b81bd
-      date: Wed, 20 Jan 2021 21:21:42 GMT
+      content-type: multipart/mixed; boundary=batchresponse_e83dd3e2-2cc9-404f-b260-6e831f789c30
+      date: Wed, 03 Mar 2021 01:21:24 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 202
       message: Accepted
@@ -838,13 +838,13 @@ interactions:
       Accept:
       - application/xml
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:42 GMT
+      - Wed, 03 Mar 2021 01:21:24 GMT
       x-ms-encryption-algorithm:
       - AES256
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: HEAD
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7/blob1
   response:
@@ -855,70 +855,70 @@ interactions:
       content-length: '11'
       content-md5: XrY7u+Ae7tCTyyK7j1rNww==
       content-type: application/octet-stream
-      date: Wed, 20 Jan 2021 21:21:42 GMT
-      etag: '"0x8D8BD8961D3A805"'
-      last-modified: Wed, 20 Jan 2021 21:21:42 GMT
+      date: Wed, 03 Mar 2021 01:21:24 GMT
+      etag: '"0x8D8DDE2A8FB7A08"'
+      last-modified: Wed, 03 Mar 2021 01:21:24 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       vary: Origin
       x-ms-access-tier: Hot
-      x-ms-access-tier-change-time: Wed, 20 Jan 2021 21:21:42 GMT
+      x-ms-access-tier-change-time: Wed, 03 Mar 2021 01:21:24 GMT
       x-ms-blob-type: BlockBlob
-      x-ms-creation-time: Wed, 20 Jan 2021 21:21:42 GMT
+      x-ms-creation-time: Wed, 03 Mar 2021 01:21:24 GMT
       x-ms-lease-state: available
       x-ms-lease-status: unlocked
       x-ms-server-encrypted: 'true'
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 200
       message: OK
     url: https://emilydevtest.blob.core.windows.net/acontainer3d7c19c7/blob1
 - request:
-    body: "--===============0716953274==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
+    body: "--===============0126865615==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /acontainer3d7c19c7/blob1? HTTP/1.1\r\nx-ms-date:
-      Wed, 20 Jan 2021 21:21:42 GMT\r\nx-ms-client-request-id: 7d8b1616-5b65-11eb-92ad-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:fZ8gqPbbHeWK/WuAjqCNbzdTHNDq1CnARPu3dOPZies=\r\n\r\n\r\n--===============0716953274==\r\nContent-Type:
+      Wed, 03 Mar 2021 01:21:24 GMT\r\nx-ms-client-request-id: c558cf42-7bbe-11eb-8644-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0126865615==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
-      /acontainer3d7c19c7/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 21:21:42
-      GMT\r\nx-ms-client-request-id: 7d8b1617-5b65-11eb-a59a-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:u5oCWEF6k/85Oo8z7fhDJB3+W46X8zSyEHs8WrrNCM0=\r\n\r\n\r\n--===============0716953274==\r\nContent-Type:
+      /acontainer3d7c19c7/blob2? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:21:24
+      GMT\r\nx-ms-client-request-id: c558cf43-7bbe-11eb-b9ee-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0126865615==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
-      /acontainer3d7c19c7/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 21:21:42
-      GMT\r\nx-ms-client-request-id: 7d8b1618-5b65-11eb-8cad-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:X2zBRnKjkBcF4o/IBNmNK2H31O68bFDvKfSZctMDQ0k=\r\n\r\n\r\n--===============0716953274==--\r\n"
+      /acontainer3d7c19c7/blob3? HTTP/1.1\r\nx-ms-date: Wed, 03 Mar 2021 01:21:24
+      GMT\r\nx-ms-client-request-id: c558cf44-7bbe-11eb-a1f5-c8348e5fffbf\r\nAuthorization:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0126865615==--\r\n"
     headers:
       Content-Length:
       - '1086'
       Content-Type:
-      - multipart/mixed; boundary================0716953274==
+      - multipart/mixed; boundary================0126865615==
       User-Agent:
-      - azsdk-python-storage-blob/12.7.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-storage-blob/12.8.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Wed, 20 Jan 2021 21:21:42 GMT
+      - Wed, 03 Mar 2021 01:21:24 GMT
       x-ms-version:
-      - '2020-04-08'
+      - '2020-06-12'
     method: POST
     uri: https://storagename.blob.core.windows.net/acontainer3d7c19c7?restype=container&comp=batch
   response:
     body:
-      string: "--batchresponse_3c93aa5a-8ce1-4284-a06a-2c86bd9aef46\r\nContent-Type:
+      string: "--batchresponse_cd5f14d3-fb8d-44d7-886d-6f98c9032a58\r\nContent-Type:
         application/http\r\nContent-ID: 0\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 5a1fac22-401e-00c2-3d72-ef15721e9d66\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 7d8b1616-5b65-11eb-92ad-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_3c93aa5a-8ce1-4284-a06a-2c86bd9aef46\r\nContent-Type:
+        true\r\nx-ms-request-id: e117dd61-401e-00b0-17cb-0f123d1ec07c\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: c558cf42-7bbe-11eb-8644-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_cd5f14d3-fb8d-44d7-886d-6f98c9032a58\r\nContent-Type:
         application/http\r\nContent-ID: 1\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 5a1fac22-401e-00c2-3d72-ef15721e9d68\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 7d8b1617-5b65-11eb-a59a-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_3c93aa5a-8ce1-4284-a06a-2c86bd9aef46\r\nContent-Type:
+        true\r\nx-ms-request-id: e117dd61-401e-00b0-17cb-0f123d1ec07e\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: c558cf43-7bbe-11eb-b9ee-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_cd5f14d3-fb8d-44d7-886d-6f98c9032a58\r\nContent-Type:
         application/http\r\nContent-ID: 2\r\n\r\nHTTP/1.1 202 Accepted\r\nx-ms-delete-type-permanent:
-        true\r\nx-ms-request-id: 5a1fac22-401e-00c2-3d72-ef15721e9d69\r\nx-ms-version:
-        2020-04-08\r\nx-ms-client-request-id: 7d8b1618-5b65-11eb-8cad-c8348e5fffbc\r\nServer:
-        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_3c93aa5a-8ce1-4284-a06a-2c86bd9aef46--"
+        true\r\nx-ms-request-id: e117dd61-401e-00b0-17cb-0f123d1ec07f\r\nx-ms-version:
+        2020-06-12\r\nx-ms-client-request-id: c558cf44-7bbe-11eb-a1f5-c8348e5fffbf\r\nServer:
+        Windows-Azure-Blob/1.0\r\n\r\n--batchresponse_cd5f14d3-fb8d-44d7-886d-6f98c9032a58--"
     headers:
-      content-type: multipart/mixed; boundary=batchresponse_3c93aa5a-8ce1-4284-a06a-2c86bd9aef46
-      date: Wed, 20 Jan 2021 21:21:41 GMT
+      content-type: multipart/mixed; boundary=batchresponse_cd5f14d3-fb8d-44d7-886d-6f98c9032a58
+      date: Wed, 03 Mar 2021 01:21:24 GMT
       server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding: chunked
-      x-ms-version: '2020-04-08'
+      x-ms-version: '2020-06-12'
     status:
       code: 202
       message: Accepted

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.test_standard_blob_tier_with_if_tags.yaml
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_container_async.test_standard_blob_tier_with_if_tags.yaml
@@ -193,17 +193,17 @@ interactions:
       binary\r\nContent-ID: 0\r\n\r\nPUT /acontainera8cf1766/blob1?comp=tier HTTP/1.1\r\nContent-Length:
       0\r\nx-ms-access-tier: Cool\r\nx-ms-if-tags: \"tag1\"='firsttag WRONG'\r\nx-ms-date:
       Wed, 20 Jan 2021 21:09:12 GMT\r\nx-ms-client-request-id: be7865cb-5b63-11eb-924a-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:atE8/xJ4NIJjdTLvLk4n4GhqFBeySVb4PyZd1nyeT0A=\r\n\r\n\r\n--===============0483744744==\r\nContent-Type:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0483744744==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nPUT
       /acontainera8cf1766/blob2?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
       Cool\r\nx-ms-if-tags: \"tag1\"='firsttag WRONG'\r\nx-ms-date: Wed, 20 Jan 2021
       21:09:12 GMT\r\nx-ms-client-request-id: be788cd3-5b63-11eb-a5ac-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:ggduBK1wjRhh/7ZeASUqsproHg79GXFeqjhhLPH2hxo=\r\n\r\n\r\n--===============0483744744==\r\nContent-Type:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0483744744==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nPUT
       /acontainera8cf1766/blob3?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
       Cool\r\nx-ms-if-tags: \"tag1\"='firsttag WRONG'\r\nx-ms-date: Wed, 20 Jan 2021
       21:09:12 GMT\r\nx-ms-client-request-id: be788cd4-5b63-11eb-9f54-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:C9Ebxg41Uhs/SgFg48vy96Knv8In6IoXnwOb3LGK3Q8=\r\n\r\n\r\n--===============0483744744==--\r\n"
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============0483744744==--\r\n"
     headers:
       Content-Length:
       - '1350'
@@ -256,17 +256,17 @@ interactions:
       binary\r\nContent-ID: 0\r\n\r\nPUT /acontainera8cf1766/blob1?comp=tier HTTP/1.1\r\nContent-Length:
       0\r\nx-ms-access-tier: Cool\r\nx-ms-if-tags: \"tag1\"='firsttag'\r\nx-ms-date:
       Wed, 20 Jan 2021 21:09:12 GMT\r\nx-ms-client-request-id: bedb95a6-5b63-11eb-9cab-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:cYYCukOlJFKXN5JsWGo2q/vovlicUlS9wUDbIzGzM6k=\r\n\r\n\r\n--===============2092322008==\r\nContent-Type:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2092322008==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nPUT
       /acontainera8cf1766/blob2?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
       Cool\r\nx-ms-if-tags: \"tag1\"='firsttag'\r\nx-ms-date: Wed, 20 Jan 2021 21:09:12
       GMT\r\nx-ms-client-request-id: bedbbcca-5b63-11eb-ab1c-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:mpPGvEPhKGkg03WEYTEdMRMOmnosiiJkEpsH2nNutU0=\r\n\r\n\r\n--===============2092322008==\r\nContent-Type:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2092322008==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nPUT
       /acontainera8cf1766/blob3?comp=tier HTTP/1.1\r\nContent-Length: 0\r\nx-ms-access-tier:
       Cool\r\nx-ms-if-tags: \"tag1\"='firsttag'\r\nx-ms-date: Wed, 20 Jan 2021 21:09:12
       GMT\r\nx-ms-client-request-id: bedbbccb-5b63-11eb-a502-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:zzQN09cEQfa1f6ck6+mmG3x9onnY6sKGGjMkhu+9vYo=\r\n\r\n\r\n--===============2092322008==--\r\n"
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2092322008==--\r\n"
     headers:
       Content-Length:
       - '1332'
@@ -347,15 +347,15 @@ interactions:
     body: "--===============2097351685==\r\nContent-Type: application/http\r\nContent-Transfer-Encoding:
       binary\r\nContent-ID: 0\r\n\r\nDELETE /acontainera8cf1766/blob1? HTTP/1.1\r\nx-ms-date:
       Wed, 20 Jan 2021 21:09:12 GMT\r\nx-ms-client-request-id: bee48343-5b63-11eb-b9b4-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:mWHf8zGcTHBT5fBujBY+Z88rPUCHtcoP6ytS6b5XCzQ=\r\n\r\n\r\n--===============2097351685==\r\nContent-Type:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2097351685==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nDELETE
       /acontainera8cf1766/blob2? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 21:09:12
       GMT\r\nx-ms-client-request-id: bee48344-5b63-11eb-a7e1-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:nonl469LqnRMjMrAAtG1nSGxwsL+EaJgJsCiZ5eMJbs=\r\n\r\n\r\n--===============2097351685==\r\nContent-Type:
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2097351685==\r\nContent-Type:
       application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nDELETE
       /acontainera8cf1766/blob3? HTTP/1.1\r\nx-ms-date: Wed, 20 Jan 2021 21:09:12
       GMT\r\nx-ms-client-request-id: bee48345-5b63-11eb-a3dc-c8348e5fffbc\r\nAuthorization:
-      SharedKey emilydevtest:+4nlfAje8Xn4GQWvfjqcld8lYcRubB+uNy1egYMZS6g=\r\n\r\n\r\n--===============2097351685==--\r\n"
+      SharedKey storagename:fake_shared_key=\r\n\r\n\r\n--===============2097351685==--\r\n"
     headers:
       Content-Length:
       - '1086'

--- a/sdk/storage/azure-storage-blob/tests/test_container.py
+++ b/sdk/storage/azure-storage-blob/tests/test_container.py
@@ -1442,12 +1442,14 @@ class StorageContainerTest(StorageTestCase):
             raise_on_any_failure=False
         )
 
-    @pytest.mark.playback_test_only
     @pytest.mark.skipif(sys.version_info < (3, 0), reason="Batch not supported on Python 2.7")
     @GlobalStorageAccountPreparer()
     def test_batch_set_standard_blob_tier_for_version(self, resource_group, location, storage_account, storage_account_key):
         bsc = BlobServiceClient(self.account_url(storage_account, "blob"), storage_account_key)
         container = self._create_container(bsc)
+        container.upload_blob("blob1", "hello world")
+        container.upload_blob("blob2", "hello world")
+        container.upload_blob("blob3", "hello world")
         tiers = [StandardBlobTier.Archive, StandardBlobTier.Cool, StandardBlobTier.Hot]
 
         for tier in tiers:

--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/recording_processors.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 import six
 
-from .utilities import is_text_payload, is_json_payload
+from .utilities import is_text_payload, is_json_payload, is_batch_payload
 
 
 class RecordingProcessor(object):
@@ -195,6 +195,10 @@ class GeneralNameReplacer(RecordingProcessor):
                 if old in body:
                     request.body = body.replace(old, new)
 
+            if request.body and request.uri and is_batch_payload(request):
+                body = six.ensure_str(request.body)
+                if old in body:
+                    request.body = body.replace(old, new)
         return request
 
     def process_response(self, response):

--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/recording_processors.py
@@ -196,9 +196,12 @@ class GeneralNameReplacer(RecordingProcessor):
                     request.body = body.replace(old, new)
 
             if request.body and request.uri and is_batch_payload(request):
+                import re
                 body = six.ensure_str(request.body)
-                if old in body:
-                    request.body = body.replace(old, new)
+                matched_objects = set(re.findall(old, body))
+                for matched_object in matched_objects:
+                    request.body = body.replace(matched_object, new)
+                    body = body.replace(matched_object, new)
         return request
 
     def process_response(self, response):

--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/utilities.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/utilities.py
@@ -62,6 +62,12 @@ def is_text_payload(entity):
     return True
 
 
+def is_batch_payload(entity):
+    if _get_content_type(entity) == "multipart/mixed" and "&comp=batch" in entity.uri:
+        return True
+    return False
+
+
 def is_json_payload(entity):
     return _get_content_type(entity) == 'application/json'
 


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/17054. Currently shared keys are leaking in batch operations since we have no way of replacing these values. This PR adds a new method to detect a batch operation and filter out the storage account name and shared keys from its payload using a passed regex expression.