### PR TITLE
[formrecognizer] temp disable sample tests until service bug fixed

### DIFF
--- a/scripts/devops_tasks/test_run_samples.py
+++ b/scripts/devops_tasks/test_run_samples.py
@@ -79,6 +79,10 @@ IGNORED_SAMPLES = {
         "receive_deferred_message_queue_async.py",
         "receive_iterator_queue_async.py",
         "session_pool_receive_async.py"
+    ],
+    "azure-ai-formrecognizer": [
+        "sample_recognize_receipts_from_url.py",
+        "sample_recognize_receipts_from_url_async.py"
     ]
 }
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_authentication_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_authentication_async.py
@@ -37,7 +37,7 @@ import asyncio
 
 class AuthenticationSampleAsync(object):
 
-    url = "https://raw.githubusercontent.com/Azure/azure-sdk-for-python/master/sdk/formrecognizer/azure-ai-formrecognizer/tests/sample_forms/receipt/contoso-receipt.png"
+    url = "https://raw.githubusercontent.com/Azure/azure-sdk-for-python/master/sdk/formrecognizer/azure-ai-formrecognizer/tests/sample_forms/forms/Form_1.jpg"
 
     async def authentication_with_api_key_credential_form_recognizer_client_async(self):
         # [START create_fr_client_with_key_async]
@@ -49,7 +49,7 @@ class AuthenticationSampleAsync(object):
         form_recognizer_client = FormRecognizerClient(endpoint, AzureKeyCredential(key))
         # [END create_fr_client_with_key_async]
         async with form_recognizer_client:
-            poller = await form_recognizer_client.begin_recognize_receipts_from_url(self.url)
+            poller = await form_recognizer_client.begin_recognize_content_from_url(self.url)
             result = await poller.result()
 
     async def authentication_with_azure_active_directory_form_recognizer_client_async(self):
@@ -66,7 +66,7 @@ class AuthenticationSampleAsync(object):
         form_recognizer_client = FormRecognizerClient(endpoint, credential)
         # [END create_fr_client_with_aad_async]
         async with form_recognizer_client:
-            poller = await form_recognizer_client.begin_recognize_receipts_from_url(self.url)
+            poller = await form_recognizer_client.begin_recognize_content_from_url(self.url)
             result = await poller.result()
 
     async def authentication_with_api_key_credential_form_training_client_async(self):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_authentication.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_authentication.py
@@ -36,7 +36,7 @@ import os
 
 class AuthenticationSample(object):
 
-    url = "https://raw.githubusercontent.com/Azure/azure-sdk-for-python/master/sdk/formrecognizer/azure-ai-formrecognizer/tests/sample_forms/receipt/contoso-receipt.png"
+    url = "https://raw.githubusercontent.com/Azure/azure-sdk-for-python/master/sdk/formrecognizer/azure-ai-formrecognizer/tests/sample_forms/forms/Form_1.jpg"
 
     def authentication_with_api_key_credential_form_recognizer_client(self):
         # [START create_fr_client_with_key]
@@ -47,7 +47,7 @@ class AuthenticationSample(object):
 
         form_recognizer_client = FormRecognizerClient(endpoint, AzureKeyCredential(key))
         # [END create_fr_client_with_key]
-        poller = form_recognizer_client.begin_recognize_receipts_from_url(self.url)
+        poller = form_recognizer_client.begin_recognize_content_from_url(self.url)
         receipt = poller.result()
 
     def authentication_with_azure_active_directory_form_recognizer_client(self):
@@ -63,7 +63,7 @@ class AuthenticationSample(object):
 
         form_recognizer_client = FormRecognizerClient(endpoint, credential)
         # [END create_fr_client_with_aad]
-        poller = form_recognizer_client.begin_recognize_receipts_from_url(self.url)
+        poller = form_recognizer_client.begin_recognize_content_from_url(self.url)
         receipt = poller.result()
 
     def authentication_with_api_key_credential_form_training_client(self):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_authentication.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_authentication.py
@@ -48,7 +48,7 @@ class AuthenticationSample(object):
         form_recognizer_client = FormRecognizerClient(endpoint, AzureKeyCredential(key))
         # [END create_fr_client_with_key]
         poller = form_recognizer_client.begin_recognize_content_from_url(self.url)
-        receipt = poller.result()
+        result = poller.result()
 
     def authentication_with_azure_active_directory_form_recognizer_client(self):
         # [START create_fr_client_with_aad]
@@ -64,7 +64,7 @@ class AuthenticationSample(object):
         form_recognizer_client = FormRecognizerClient(endpoint, credential)
         # [END create_fr_client_with_aad]
         poller = form_recognizer_client.begin_recognize_content_from_url(self.url)
-        receipt = poller.result()
+        result = poller.result()
 
     def authentication_with_api_key_credential_form_training_client(self):
         # [START create_ft_client_with_key]


### PR DESCRIPTION
Disabling URL samples so that we may get some green live tests. This change is being tracked in the overall issue for this service bug here: https://github.com/Azure/azure-sdk-for-python/issues/16535