### PR TITLE
Track1 package is incorrectly set as track2

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -41,7 +41,7 @@ function Get-python-PackageInfoFromRepo  ($pkgPath, $serviceDirectory, $pkgName)
       {
         $pkgProp.SdkType = "client"
       }
-      $pkgProp.IsNewSdk = $setupProps[2]
+      $pkgProp.IsNewSdk = ($setupProps[2] -eq "True")
       $pkgProp.ArtifactName = $pkgName
       return $pkgProp
     }


### PR DESCRIPTION
Azure-common is incorrectly set as new SDK due to wrong bool type casting when property is set