### PR TITLE
Rename CertificateCredential's certificate_bytes -> certificate_data

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Release History
 
 ## 1.6.0b2 (Unreleased)
-
+### Breaking Changes
+> These changes do not impact the API of stable versions such as 1.5.0.
+> Only code written against a beta version such as 1.6.0b1 may be affected.
+- Renamed `CertificateCredential` keyword argument `certificate_bytes` to
+  `certificate_data`
 
 ## 1.6.0b1 (2021-02-09)
 ### Changed

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/certificate.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/certificate.py
@@ -25,12 +25,12 @@ class CertificateCredential(AsyncContextManager):
     :param str tenant_id: ID of the service principal's tenant. Also called its 'directory' ID.
     :param str client_id: the service principal's client ID
     :param str certificate_path: path to a PEM-encoded certificate file including the private key. If not provided,
-          `certificate_bytes` is required.
+          `certificate_data` is required.
 
     :keyword str authority: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
           the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
           defines authorities for other clouds.
-    :keyword bytes certificate_bytes: the bytes of a certificate in PEM format, including the private key
+    :keyword bytes certificate_data: the bytes of a certificate in PEM format, including the private key
     :keyword password: The certificate's password. If a unicode string, it will be encoded as UTF-8. If the certificate
           requires a different encoding, pass appropriately encoded bytes instead.
     :paramtype password: str or bytes

--- a/sdk/identity/azure-identity/tests/test_certificate_credential.py
+++ b/sdk/identity/azure-identity/tests/test_certificate_credential.py
@@ -50,7 +50,7 @@ def test_non_rsa_key():
     with pytest.raises(ValueError, match=".*RS256.*"):
         CertificateCredential("tenant-id", "client-id", EC_CERT_PATH)
     with pytest.raises(ValueError, match=".*RS256.*"):
-        CertificateCredential("tenant-id", "client-id", certificate_bytes=open(EC_CERT_PATH, "rb").read())
+        CertificateCredential("tenant-id", "client-id", certificate_data=open(EC_CERT_PATH, "rb").read())
 
 
 def test_tenant_id_validation():
@@ -145,9 +145,9 @@ def test_requires_certificate():
     with pytest.raises(ValueError):
         CertificateCredential("tenant", "client-id", certificate_path="")
     with pytest.raises(ValueError):
-        CertificateCredential("tenant", "client-id", certificate_bytes=None)
+        CertificateCredential("tenant", "client-id", certificate_data=None)
     with pytest.raises(ValueError):
-        CertificateCredential("tenant", "client-id", certificate_path="", certificate_bytes=None)
+        CertificateCredential("tenant", "client-id", certificate_path="", certificate_data=None)
 
 
 @pytest.mark.parametrize("cert_path,cert_password", BOTH_CERTS)
@@ -190,7 +190,7 @@ def test_request_body(cert_path, cert_password, send_certificate_chain):
     cred = CertificateCredential(
         tenant_id,
         client_id,
-        certificate_bytes=cert_bytes,
+        certificate_data=cert_bytes,
         password=cert_password,
         transport=Mock(send=mock_send),
         authority=authority,

--- a/sdk/identity/azure-identity/tests/test_certificate_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_certificate_credential_async.py
@@ -23,7 +23,7 @@ def test_non_rsa_key():
     with pytest.raises(ValueError, match=".*RS256.*"):
         CertificateCredential("tenant-id", "client-id", EC_CERT_PATH)
     with pytest.raises(ValueError, match=".*RS256.*"):
-        CertificateCredential("tenant-id", "client-id", certificate_bytes=open(EC_CERT_PATH, "rb").read())
+        CertificateCredential("tenant-id", "client-id", certificate_data=open(EC_CERT_PATH, "rb").read())
 
 
 def test_tenant_id_validation():
@@ -141,9 +141,9 @@ def test_requires_certificate():
     with pytest.raises(ValueError):
         CertificateCredential("tenant", "client-id", certificate_path="")
     with pytest.raises(ValueError):
-        CertificateCredential("tenant", "client-id", certificate_bytes=None)
+        CertificateCredential("tenant", "client-id", certificate_data=None)
     with pytest.raises(ValueError):
-        CertificateCredential("tenant", "client-id", certificate_path="", certificate_bytes=None)
+        CertificateCredential("tenant", "client-id", certificate_path="", certificate_data=None)
 
 
 @pytest.mark.asyncio
@@ -177,7 +177,7 @@ async def test_request_body(cert_path, cert_password):
     cred = CertificateCredential(
         tenant_id,
         client_id,
-        certificate_bytes=cert_bytes,
+        certificate_data=cert_bytes,
         password=cert_password,
         transport=Mock(send=mock_send),
         authority=authority,

--- a/sdk/identity/azure-identity/tests/test_live.py
+++ b/sdk/identity/azure-identity/tests/test_live.py
@@ -36,13 +36,13 @@ def test_certificate_credential(live_certificate):
     )
     get_token(credential)
 
-    credential = CertificateCredential(tenant_id, client_id, certificate_bytes=live_certificate["cert_bytes"])
+    credential = CertificateCredential(tenant_id, client_id, certificate_data=live_certificate["cert_bytes"])
     get_token(credential)
 
     credential = CertificateCredential(
         tenant_id,
         client_id,
-        certificate_bytes=live_certificate["cert_with_password_bytes"],
+        certificate_data=live_certificate["cert_with_password_bytes"],
         password=live_certificate["password"],
     )
     get_token(credential)

--- a/sdk/identity/azure-identity/tests/test_live_async.py
+++ b/sdk/identity/azure-identity/tests/test_live_async.py
@@ -29,13 +29,13 @@ async def test_certificate_credential(live_certificate):
     )
     await get_token(credential)
 
-    credential = CertificateCredential(tenant_id, client_id, certificate_bytes=live_certificate["cert_bytes"])
+    credential = CertificateCredential(tenant_id, client_id, certificate_data=live_certificate["cert_bytes"])
     await get_token(credential)
 
     credential = CertificateCredential(
         tenant_id,
         client_id,
-        certificate_bytes=live_certificate["cert_with_password_bytes"],
+        certificate_data=live_certificate["cert_with_password_bytes"],
         password=live_certificate["password"],
     )
     await get_token(credential)


### PR DESCRIPTION
This renames "certificate_bytes" to "certificate_data" because the latter makes sense for file-like values as well as bytes. I don't expect to support file-like values in the next release, but I want to get the name change in ASAP.