### PR TITLE
[Communication]: Use type TokenCredential and AsyncTokenCredential for SMS and Identity

### DIFF
--- a/sdk/communication/azure-communication-identity/CHANGELOG.md
+++ b/sdk/communication/azure-communication-identity/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking
 - CommunicationIdentityClient's (synchronous and asynchronous) `issue_token` function is now renamed to `get_token`.
+- The CommunicationIdentityClient constructor uses type `TokenCredential` and `AsyncTokenCredential` for the credential parameter.
 
 ## 1.0.0b4 (2021-02-09)
 

--- a/sdk/communication/azure-communication-identity/azure/communication/identity/_communication_identity_client.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/_communication_identity_client.py
@@ -18,9 +18,8 @@ class CommunicationIdentityClient(object):
 
     :param str endpoint:
         The endpoint url for Azure Communication Service resource.
-    :param credential:
-        The credentials with which to authenticate. The value is an account
-        shared access key
+    :param TokenCredential credential:
+        The TokenCredential we use to authenticate against the service.
 
     .. admonition:: Example:
 
@@ -31,7 +30,7 @@ class CommunicationIdentityClient(object):
     def __init__(
             self,
             endpoint, # type: str
-            credential, # type: str
+            credential, # type: TokenCredential
             **kwargs # type: Any
         ):
         # type: (...) -> None

--- a/sdk/communication/azure-communication-identity/azure/communication/identity/aio/_communication_identity_client_async.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/aio/_communication_identity_client_async.py
@@ -19,9 +19,8 @@ class CommunicationIdentityClient:
 
     :param str endpoint:
         The endpoint url for Azure Communication Service resource.
-    :param credential:
-        The credentials with which to authenticate. The value is an account
-        shared access key
+    :param AsyncTokenCredential credential:
+        The AsyncTokenCredential we use to authenticate against the service.
 
     .. admonition:: Example:
 
@@ -32,7 +31,7 @@ class CommunicationIdentityClient:
     def __init__(
             self,
             endpoint, # type: str
-            credential, # type: str
+            credential, # type: AsyncTokenCredential
             **kwargs # type: Any
         ):
         # type: (...) -> None

--- a/sdk/communication/azure-communication-sms/CHANGELOG.md
+++ b/sdk/communication/azure-communication-sms/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added support for SMS idempotency.
 - Send method series in SmsClient are idempotent under retry policy.
 - Added support for tagging SMS messages.
+- The SmsClient constructor uses type `TokenCredential` and `AsyncTokenCredential` for the credential parameter.
 
 ### Breaking
 - Send method takes in strings for phone numbers instead of `PhoneNumberIdentifier`.

--- a/sdk/communication/azure-communication-sms/azure/communication/sms/_sms_client.py
+++ b/sdk/communication/azure-communication-sms/azure/communication/sms/_sms_client.py
@@ -25,13 +25,12 @@ class SmsClient(object):
 
     :param str endpoint:
         The endpoint url for Azure Communication Service resource.
-    :param str credential:
-        The credentials with which to authenticate. The value is an account
-        shared access key
+    :param TokenCredential credential:
+        The TokenCredential we use to authenticate against the service.
     """
     def __init__(
             self, endpoint, # type: str
-            credential, # type: str
+            credential, # type: TokenCredential
             **kwargs # type: Any
         ):
         # type: (...) -> None

--- a/sdk/communication/azure-communication-sms/azure/communication/sms/aio/_sms_client_async.py
+++ b/sdk/communication/azure-communication-sms/azure/communication/sms/aio/_sms_client_async.py
@@ -25,13 +25,12 @@ class SmsClient(object):
 
    :param str endpoint:
         The endpoint url for Azure Communication Service resource.
-    :param str credential:
-        The credentials with which to authenticate. The value is an account
-        shared access key
+    :param AsyncTokenCredential credential:
+        The AsyncTokenCredential we use to authenticate against the service.
     """
     def __init__(
             self, endpoint,  # type: str
-            credential,  # type: str
+            credential,  # type: AsyncTokenCredential
             **kwargs  # type: Any
         ):
         # type: (...) -> None


### PR DESCRIPTION
Updated SMS and identity clients to use type TokenCredential and AsyncTokenCredential for the credential parameter.

SMS: https://apiview.dev/Assemblies/Review/f5d7cd8246734532ac59a09de84660a9
Identity: https://apiview.dev/Assemblies/Review/cf5b3c767f8340cab539691975abf54e