### PR TITLE
Fix Get-AllPackageInfoFromRepo for Linux Machine runs

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -33,9 +33,9 @@ function Get-AllPackageInfoFromRepo ($serviceDirectory)
 
   foreach ($line in $allPkgPropLines)
   {
-    $pkgInfo = ($line -Split ",").Trim("()' ")
+    $pkgInfo = ($line -Split " ")
     $packageName = $pkgInfo[0]
-    $packageVersion = $pkgInfo[1].Trim("'u")
+    $packageVersion = $pkgInfo[1]
     $isNewSdk = ($pkgInfo[2] -eq "True")
     $setupPyDir = $pkgInfo[3]
     $pkgDirectoryPath = Resolve-Path (Join-Path -Path $RepoRoot $setupPyDir)

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -35,7 +35,7 @@ function Get-AllPackageInfoFromRepo ($serviceDirectory)
   {
     $pkgInfo = ($line -Split ",").Trim("()' ")
     $packageName = $pkgInfo[0]
-    $packageVersion = $pkgInfo[1]
+    $packageVersion = $pkgInfo[1].Trim("'u")
     $isNewSdk = ($pkgInfo[2] -eq "True")
     $setupPyDir = $pkgInfo[3]
     $pkgDirectoryPath = Resolve-Path (Join-Path -Path $RepoRoot $setupPyDir)

--- a/eng/scripts/get_package_properties.py
+++ b/eng/scripts/get_package_properties.py
@@ -15,4 +15,5 @@ if __name__ == '__main__':
         for filename in files:
             if os.path.basename(filename) == "setup.py":
                 if os.path.basename(root) != 'azure-mgmt' and os.path.basename(root) != 'azure' and os.path.basename(root) != 'azure-storage' and os.path.basename(root) != 'tests':
-                    print(get_package_properties(root))
+                    pkgName, version, is_new_sdk, setup_py_path = get_package_properties(root)
+                    print("{0} {1} {2} {3}".format(pkgName, version, is_new_sdk, setup_py_path))


### PR DESCRIPTION
For some reason `eng\scripts\get_package_properties.py` result includes a `u` for the version when run on Linux [Example](https://dev.azure.com/azure-sdk/playground/_build/results?buildId=772101&view=logs&j=a4f1cc8a-0ccb-5e90-36f4-f06f41d0ce59&t=648c9d12-90a9-5fb6-d4d2-15f97230c638&l=12)
This fixes this case so we have the same result as from windows machines.