### PR TITLE
Fixed an issue when missing padding in base64 decode

### DIFF
--- a/sdk/mixedreality/azure-mixedreality-authentication/azure/mixedreality/authentication/_utils.py
+++ b/sdk/mixedreality/azure-mixedreality-authentication/azure/mixedreality/authentication/_utils.py
@@ -42,7 +42,11 @@ def retrieve_jwt_expiration_timestamp(jwt_value):
         raise ValueError("Invalid JWT structure. Expected a JWS Compact Serialization formatted value.")
 
     try:
-        padded_base64_payload = base64.b64decode(parts[1]).decode('utf-8')
+        # JWT prefers no padding (see https://tools.ietf.org/id/draft-jones-json-web-token-02.html#base64urlnotes).
+        # We pad the value with the max padding of === to keep our logic simple and allow the base64 decoder to handle
+        # the value properly. b64decode will properly trim the padding appropriately, but apparently doesn't want to
+        # handle the addition of padding.
+        padded_base64_payload = base64.b64decode(parts[1] + "===").decode('utf-8')
         payload = json.loads(padded_base64_payload)
     except ValueError:
         raise ValueError("Unable to decode the JWT.")

--- a/sdk/mixedreality/azure-mixedreality-authentication/tests/test_utils.py
+++ b/sdk/mixedreality/azure-mixedreality-authentication/tests/test_utils.py
@@ -24,9 +24,20 @@ class TestUtils:
         assert cv2 is not None
         assert cv1 != cv2
 
-    def test_retrieve_jwt_expiration_timestamp(self):
+    def test_retrieve_jwt_expiration_timestamp_with_padding(self):
         # Note: The trailing "." on the end indicates an empty signature indicating that this JWT is not signed.
         jwt_value = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJlbWFpbCI6IkJvYkBjb250b3NvLmNvbSIsImdpdmVuX25hbWUiOiJCb2IiLCJpc3MiOiJodHRwOi8vRGVmYXVsdC5Jc3N1ZXIuY29tIiwiYXVkIjoiaHR0cDovL0RlZmF1bHQuQXVkaWVuY2UuY29tIiwiaWF0IjoiMTYxMDgxMjI1MCIsIm5iZiI6IjE2MTA4MTI1NTAiLCJleHAiOiIxNjEwODk4NjUwIn0=."
+        expected_expiration_timestamp = 1610898650 # 1/17/2021 3:50:50 PM UTC
+
+        actual = retrieve_jwt_expiration_timestamp(jwt_value)
+
+        assert actual is not None
+        assert actual == expected_expiration_timestamp
+
+    def test_retrieve_jwt_expiration_timestamp_no_padding(self):
+        # Note: The trailing "." on the end indicates an empty signature indicating that this JWT is not signed.
+        #       The trailing "=" has been removed to test without base64 padding, which is apparently expected for JWT.
+        jwt_value = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJlbWFpbCI6IkJvYkBjb250b3NvLmNvbSIsImdpdmVuX25hbWUiOiJCb2IiLCJpc3MiOiJodHRwOi8vRGVmYXVsdC5Jc3N1ZXIuY29tIiwiYXVkIjoiaHR0cDovL0RlZmF1bHQuQXVkaWVuY2UuY29tIiwiaWF0IjoiMTYxMDgxMjI1MCIsIm5iZiI6IjE2MTA4MTI1NTAiLCJleHAiOiIxNjEwODk4NjUwIn0."
         expected_expiration_timestamp = 1610898650 # 1/17/2021 3:50:50 PM UTC
 
         actual = retrieve_jwt_expiration_timestamp(jwt_value)


### PR DESCRIPTION
  - Apparently JWT doesn't use base64 padding and the Python base64 decoder requires it. So, we add the max padding and the decoder trims it properly.