### PR TITLE
[Key Vault] Label unreleased certificates and secrets versions as beta

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.2.2 (Unreleased)
+## 4.2.2b1 (Unreleased)
 ### Added
 - Added method `parse_key_vault_certificate_id` that parses out a full ID returned by Key Vault, so users can easily
 access the certificate's `name`, `vault_url`, and `version`.

--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.2.2b1 (Unreleased)
+## 4.3.0b1 (Unreleased)
 ### Added
 - Added method `parse_key_vault_certificate_id` that parses out a full ID returned by Key Vault, so users can easily
 access the certificate's `name`, `vault_url`, and `version`.

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_version.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "4.2.2b1"
+VERSION = "4.3.0b1"

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_version.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "4.2.2"
+VERSION = "4.2.2b1"

--- a/sdk/keyvault/azure-keyvault-certificates/setup.py
+++ b/sdk/keyvault/azure-keyvault-certificates/setup.py
@@ -58,7 +58,7 @@ setup(
     author_email="azurekeyvault@microsoft.com",
     url="https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-certificates",
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 4 - Beta",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
@@ -66,7 +66,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
-        'Programming Language :: Python :: 3.8',
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: MIT License",
     ],
     zip_safe=False,

--- a/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.2.1 (Unreleased)
+## 4.2.1b1 (Unreleased)
 ### Fixed
 - Correct typing for async paging methods
 

--- a/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.2.1b1 (Unreleased)
+## 4.3.0b1 (Unreleased)
 ### Fixed
 - Correct typing for async paging methods
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_version.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "4.2.1"
+VERSION = "4.2.1b1"

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_version.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "4.2.1b1"
+VERSION = "4.3.0b1"

--- a/sdk/keyvault/azure-keyvault-secrets/setup.py
+++ b/sdk/keyvault/azure-keyvault-secrets/setup.py
@@ -58,7 +58,7 @@ setup(
     author_email="azurekeyvault@microsoft.com",
     url="https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-secrets",
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 4 - Beta",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
@@ -66,7 +66,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
-        'Programming Language :: Python :: 3.8',
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: MIT License",
     ],
     zip_safe=False,


### PR DESCRIPTION
This will (theoretically) resolve nightly build failures (see [example](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=773462&view=results)) caused by a lack of APIView approvals on unreleased packages. These checks shouldn't fail the pipeline if the package version checked into master is a beta version.