### PR TITLE
[Communication] Removing an incorrect version from Changelog

### DIFF
--- a/sdk/communication/azure-communication-sms/CHANGELOG.md
+++ b/sdk/communication/azure-communication-sms/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0b6 (2021-03-09)
 ### Added
+- Added support for Azure Active Directory authentication.
 - Added support for 1:N SMS messaging.
 - Added support for SMS idempotency.
 - Send method series in SmsClient are idempotent under retry policy.
@@ -12,12 +13,9 @@
 - Send method takes in strings for phone numbers instead of `PhoneNumberIdentifier`.
 - Send method returns a list of `SmsSendResult`s instead of a `SendSmsResponse`.
 
-## 1.0.0b5 (2021-02-09)
-### Added
-- Added support for Azure Active Directory authentication.
-
 ## 1.0.0b4 (2020-11-16)
 - Updated `azure-communication-sms` version.
+
 ### Breaking Changes
 - Replaced CommunicationUser with CommunicationUserIdentifier.
 - Replaced PhoneNumber with PhoneNumberIdentifier.


### PR DESCRIPTION
* b5 was never released, but now we have release b6 so we will simply skip b5.