### PR TITLE
[Key Vault] Bump six dependency for keys

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -5,7 +5,7 @@
 - `CryptographyClient` will perform all operations locally if initialized with
   the `.from_jwk` factory method
   ([#16565](https://github.com/Azure/azure-sdk-for-python/pull/16565))
-- Added requirement for six>=1.11.0
+- Added requirement for six>=1.12.0
 
 ## 4.4.0b2 (2021-2-10)
 ### Fixed

--- a/sdk/keyvault/azure-keyvault-keys/setup.py
+++ b/sdk/keyvault/azure-keyvault-keys/setup.py
@@ -85,7 +85,7 @@ setup(
         "cryptography>=2.1.4",
         "msrest>=0.6.21",
         "azure-common~=1.1",
-        "six>=1.11.0"
+        "six>=1.12.0"
     ],
     extras_require={
         ":python_version<'3.0'": ["azure-keyvault-nspkg"],

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -197,5 +197,6 @@ opentelemetry-sdk==0.17b0
 #override azure-monitor-opentelemetry-exporter opentelemetry-sdk==1.0.0rc1
 #override azure-core-tracing-opentelemetry opentelemetry-api==0.17b0
 #override azure-identity six>=1.12.0
+#override azure-keyvault-keys six>=1.12.0
 #override azure-mixedreality-authentication azure-core<2.0.0,>=1.4.0
 #override azure-iot-deviceupdate azure-core<2.0.0,>=1.6.0


### PR DESCRIPTION
CryptographyClient tests fail with six 1.11.0 because six.ensure_str was introduced in 1.12.0 (example failure [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=775819&view=logs&j=c0bd11c2-64dc-53bf-362f-abc8d8c4c701&t=46ae9f82-63b9-5395-aba9-09f3664ed8ab&l=12814)). This bumps the dependency to six>=1.12.0.