### PR TITLE
Reorder Python versions in matrix

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -5,7 +5,7 @@
       "windows-2019": { "OSVmImage": "MMS2019", "Pool": "azsdk-pool-mms-win-2019-general" },
       "macOS-10.15": { "OSVmImage": "macOS-10.15", "Pool": "Azure Pipelines" }
     },
-    "PythonVersion": [ "3.5", "3.7", "2.7", "pypy3" ],
+    "PythonVersion": [ "pypy3", "3.5", "3.7", "2.7" ],
     "CoverageArg": [ "--disablecov" ]
   },
   "include": [


### PR DESCRIPTION
Context: azure-keyvault-keys tests are consistently failing on Windows with Python 3.7 (example [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=776772&view=results)). Live tests with 3.7 on Windows pass locally, so this is an attempt to see if the failures are particular to how Windows and/or 3.7 tests are run in the pipeline.