### PR TITLE
Increase gen doc task timeout.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -86,7 +86,7 @@ parameters:
 
 jobs:
   - job: 'Build'
-    timeoutInMinutes: 90
+    timeoutInMinutes: 240
     variables:
     - template: ../variables/globals.yml
 

--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -74,6 +74,7 @@ steps:
   - task: PythonScript@0
     displayName: 'Generate Docs'
     condition: and(succeededOrFailed(), ${{parameters.BuildDocs}})
+    timeoutInMinutes: 180
     inputs:
       scriptPath: 'scripts/devops_tasks/setup_execute_tests.py'
       arguments: >-


### PR DESCRIPTION
This PR increases the build job to 3 hours, and the generate docs job to 2 hours. This is just an experiment to get a measure of how long the generate docs step is now taking for the network management APIs.