### PR TITLE
Revert Management Document Changes

### DIFF
--- a/doc/sphinx/package_service_mapping.json
+++ b/doc/sphinx/package_service_mapping.json
@@ -1,0 +1,1084 @@
+{
+  "azure-applicationinsights": {
+		"service_name": "Application Insights",
+		"category": "Client",
+    "namespaces": [
+      "azure.applicationinsights"
+    ]
+	},
+  "azure-batch": {
+    "category": "Client",
+    "namespaces": [
+      "azure.batch"
+    ],
+    "service_name": "Batch"
+  },
+  "azure-cognitiveservices-anomalydetector": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.anomalydetector"
+    ],
+    "service_name": "Cognitive Services Anomaly Detector"
+  },
+  "azure-cognitiveservices-formrecognizer": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.formrecognizer"
+    ],
+    "service_name": "Cognitive Services Recognizer"
+  },
+  "azure-cognitiveservices-personalizer": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.personalizer"
+    ],
+    "service_name": "Cognitive Services Personalizer"
+  },
+  "azure-cognitiveservices-knowledge-qnamaker": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.knowledge.qnamaker"
+    ],
+    "service_name": "Cognitive Services Knowledge QnA Maker"
+  },
+  "azure-cognitiveservices-language-luis": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.language.luis.authoring",
+      "azure.cognitiveservices.language.luis.runtime"
+    ],
+    "service_name": "Cognitive Services Language LUIS"
+  },
+  "azure-cognitiveservices-language-spellcheck": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.language.spellcheck"
+    ],
+    "service_name": "Cognitive Services Language Spellcheck"
+  },
+  "azure-cognitiveservices-language-textanalytics": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.language.textanalytics"
+    ],
+    "service_name": "Cognitive Services Language TextAnalytics"
+  },
+  "azure-cognitiveservices-search-autosuggest": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.search.autosuggest"
+    ],
+    "service_name": "Cognitive Services Search Autosuggest"
+  },
+  "azure-cognitiveservices-search-customimagesearch": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.search.customimagesearch"
+    ],
+    "service_name": "Cognitive Services Search CustomImageSearch"
+  },
+  "azure-cognitiveservices-search-customsearch": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.search.customsearch"
+    ],
+    "service_name": "Cognitive Services Search CustomSearch"
+  },
+  "azure-cognitiveservices-search-entitysearch": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.search.entitysearch"
+    ],
+    "service_name": "Cognitive Services Search EntitySearch"
+  },
+  "azure-cognitiveservices-search-imagesearch": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.search.imagesearch"
+    ],
+    "service_name": "Cognitive Services Search ImageSearch"
+  },
+  "azure-cognitiveservices-search-newssearch": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.search.newssearch"
+    ],
+    "service_name": "Cognitive Services Search NewsSearch"
+  },
+  "azure-cognitiveservices-search-videosearch": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.search.videosearch"
+    ],
+    "service_name": "Cognitive Services Search VideoSearch"
+  },
+  "azure-cognitiveservices-search-visualsearch": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.search.visualsearch"
+    ],
+    "service_name": "Cognitive Services Search VisualSearch"
+  },
+  "azure-cognitiveservices-search-websearch": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.search.websearch"
+    ],
+    "service_name": "Cognitive Services Search WebSearch"
+  },
+  "azure-cognitiveservices-vision-computervision": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.vision.computervision"
+    ],
+    "service_name": "Cognitive Services Vision ComputerVision"
+  },
+  "azure-cognitiveservices-vision-contentmoderator": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.vision.contentmoderator"
+    ],
+    "service_name": "Cognitive Services Vision ContentModerator"
+  },
+  "azure-cognitiveservices-vision-customvision": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.vision.customvision.prediction",
+      "azure.cognitiveservices.vision.customvision.training"
+    ],
+    "service_name": "Cognitive Services Vision CustomVision"
+  },
+  "azure-cognitiveservices-vision-face": {
+    "category": "Client",
+    "namespaces": [
+      "azure.cognitiveservices.vision.face"
+    ],
+    "service_name": "Cognitive Services Vision Face"
+  },
+  "azure-common": {
+    "category": "Other",
+    "service_name": "Other"
+  },
+  "azure-communication-administration": {
+    "category": "Client",
+    "service_name": "Communication",
+    "manually_generated": true
+  },
+  "azure-communication-chat": {
+    "category": "Client",
+    "service_name": "Communication",
+    "manually_generated": true
+  },
+  "azure-communication-sms": {
+    "category": "Client",
+    "service_name": "Communication",
+    "manually_generated": true
+  },
+  "azure-mgmt-communication": {
+    "category": "Management",
+    "service_name": "Communication",
+    "manually_generated": true
+  },
+  "azure-eventgrid": {
+    "category": "Client",
+    "namespaces": [
+      "azure.eventgrid"
+    ],
+    "service_name": "Event Grid"
+  },
+  "azure-graphrbac": {
+    "category": "Client",
+    "namespaces": [
+      "azure.graphrbac"
+    ],
+    "service_name": "Active Directory"
+  },
+  "azure-loganalytics": {
+		"service_name": "Log Analytics",
+		"category": "Client",
+    "namespaces": [
+      "azure.loganalytics"
+    ]
+	},
+  "azure-mgmt-advisor": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.advisor"
+    ],
+    "service_name": "Advisor"
+  },
+  "azure-mgmt-alertsmanagement": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.alertsmanagement"
+    ],
+    "service_name": "Alerts Management"
+  },
+  "azure-mgmt-apimanagement": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.apimanagement"
+    ],
+    "service_name": "API Management"
+  },
+  "azure-mgmt-applicationinsights": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.applicationinsights"
+    ],
+    "service_name": "Application Insights"
+  },
+  "azure-mgmt-authorization": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.authorization"
+    ],
+    "service_name": "Authorization"
+  },
+  "azure-mgmt-automation": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.automation"
+    ],
+    "service_name": "Automation"
+  },
+  "azure-mgmt-batch": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.batch"
+    ],
+    "service_name": "Batch"
+  },
+  "azure-mgmt-batchai": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.batchai"
+    ],
+    "service_name": "Batch AI"
+  },
+  "azure-mgmt-billing": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.billing"
+    ],
+    "service_name": "Billing"
+  },
+  "azure-mgmt-cdn": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.cdn"
+    ],
+    "service_name": "CDN"
+  },
+  "azure-mgmt-cognitiveservices": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.cognitiveservices"
+    ],
+    "service_name": "Cognitive Services"
+  },
+  "azure-mgmt-commerce": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.commerce"
+    ],
+    "service_name": "Commerce"
+  },
+  "azure-mgmt-compute/azure.mgmt.compute": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.compute.v2015_06_15",
+      "azure.mgmt.compute.v2016_03_30",
+      "azure.mgmt.compute.v2016_04_30_preview",
+      "azure.mgmt.compute.v2017_03_30",
+      "azure.mgmt.compute.v2017_09_01",
+      "azure.mgmt.compute.v2017_12_01",
+      "azure.mgmt.compute.v2018_04_01",
+      "azure.mgmt.compute.v2018_06_01",
+      "azure.mgmt.compute.v2018_09_30",
+      "azure.mgmt.compute.v2018_10_01",
+      "azure.mgmt.compute.v2019_03_01",
+      "azure.mgmt.compute.v2019_04_01"
+    ],
+    "service_name": "Virtual Machines"
+  },
+  "azure-mgmt-compute": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.compute.v2015_06_15",
+      "azure.mgmt.compute.v2016_03_30",
+      "azure.mgmt.compute.v2016_04_30_preview",
+      "azure.mgmt.compute.v2017_03_30",
+      "azure.mgmt.compute.v2017_09_01",
+      "azure.mgmt.compute.v2017_12_01",
+      "azure.mgmt.compute.v2018_04_01",
+      "azure.mgmt.compute.v2018_06_01",
+      "azure.mgmt.compute.v2018_09_30",
+      "azure.mgmt.compute.v2018_10_01",
+      "azure.mgmt.compute.v2019_03_01",
+      "azure.mgmt.compute.v2019_04_01"
+    ],
+    "service_name": "Virtual Machines"
+  },
+  "azure-mgmt-consumption": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.consumption"
+    ],
+    "service_name": "Consumption"
+  },
+  "azure-mgmt-containerinstance": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.containerinstance"
+    ],
+    "service_name": "Container Instance"
+  },
+  "azure-mgmt-containerregistry": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.containerregistry.v2017_03_01",
+      "azure.mgmt.containerregistry.v2017_10_01",
+      "azure.mgmt.containerregistry.v2018_02_01_preview",
+      "azure.mgmt.containerregistry.v2018_09_01",
+      "azure.mgmt.containerregistry.v2019_04_01"
+    ],
+    "service_name": "Container Registry"
+  },
+  "azure-mgmt-containerservice": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.containerservice.v2017_07_01",
+      "azure.mgmt.containerservice.v2018_03_01",
+      "azure.mgmt.containerservice.v2018_08_01_preview",
+      "azure.mgmt.containerservice.v2018_09_30_preview",
+      "azure.mgmt.containerservice.v2019_02_01",
+      "azure.mgmt.containerservice.v2019_04_30"
+    ],
+    "service_name": "Container Service"
+  },
+  "azure-mgmt-cosmosdb": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.cosmosdb"
+    ],
+    "service_name": "Cosmos DB"
+  },
+  "azure-mgmt-databricks": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.databricks"
+    ],
+    "service_name": "Data Bricks"
+  },
+  "azure-mgmt-datafactory": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.datafactory"
+    ],
+    "service_name": "Data Factory"
+  },
+  "azure-mgmt-datalake-analytics": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.datalake.analytics.account",
+      "azure.mgmt.datalake.analytics.catalog",
+      "azure.mgmt.datalake.analytics.job"
+    ],
+    "service_name": "Data Lake Analytics"
+  },
+  "azure-mgmt-datalake-store": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.datalake.store"
+    ],
+    "service_name": "Data Lake Store"
+  },
+  "azure-mgmt-datamigration": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.datamigration"
+    ],
+    "service_name": "Data migration"
+  },
+  "azure-mgmt-devspaces": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.devspaces"
+    ],
+    "service_name": "DevSpaces"
+  },
+  "azure-mgmt-devtestlabs": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.devtestlabs"
+    ],
+    "service_name": "Dev Test Labs"
+  },
+  "azure-mgmt-dns": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.dns.v2016_04_01",
+      "azure.mgmt.dns.v2018_03_01_preview",
+      "azure.mgmt.dns.v2018_05_01"
+    ],
+    "service_name": "DNS"
+  },
+  "azure-mgmt-eventgrid": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.eventgrid"
+    ],
+    "service_name": "Event Grid"
+  },
+  "azure-mgmt-eventhub": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.eventhub.v2015_08_01",
+      "azure.mgmt.eventhub.v2017_04_01",
+      "azure.mgmt.eventhub.v2018_01_01_preview"
+    ],
+    "service_name": "Event Hub"
+  },
+  "azure-mgmt-hanaonazure": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.hanaonazure"
+    ],
+    "service_name": "SAP Hana on Azure"
+  },
+  "azure-mgmt-hdinsight": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.hdinsight"
+    ],
+    "service_name": "HDInsight"
+  },
+  "azure-mgmt-imagebuilder": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.imagebuilder"
+    ],
+    "service_name": "ImageBuilder"
+  },
+  "azure-mgmt-iotcentral": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.iotcentral"
+    ],
+    "service_name": "IoT Central"
+  },
+  "azure-mgmt-iothub": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.iothub"
+    ],
+    "service_name": "IoT"
+  },
+  "azure-mgmt-iothubprovisioningservices": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.iothubprovisioningservices"
+    ],
+    "service_name": "IoT"
+  },
+  "azure-mgmt-keyvault": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.keyvault"
+    ],
+    "service_name": "Keyvault"
+  },
+  "azure-mgmt-kusto": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.kusto"
+    ],
+    "service_name": "Kusto"
+  },
+  "azure-mgmt-labservices": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.labservices"
+    ],
+    "service_name": "LabServices"
+  },
+  "azure-mgmt-loganalytics": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.loganalytics"
+    ],
+    "service_name": "Log Analytics"
+  },
+  "azure-mgmt-logic": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.logic"
+    ],
+    "service_name": "Logic Apps"
+  },
+  "azure-mgmt-machinelearningcompute": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.machinelearningcompute"
+    ],
+    "service_name": "Machine Learning Compute"
+  },
+  "azure-mgmt-machinelearningservices": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.machinelearningservices"
+    ],
+    "service_name": "Machine Learning Compute"
+  },
+  "azure-mgmt-managedservices": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.managedservices"
+    ],
+    "service_name": "Managed Services"
+  },
+  "azure-mgmt-managementgroups": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.managementgroups"
+    ],
+    "service_name": "Management Groups"
+  },
+  "azure-mgmt-managementpartner": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.managementpartner"
+    ],
+    "service_name": "Management Partner"
+  },
+  "azure-mgmt-maps": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.maps"
+    ],
+    "service_name": "Maps"
+  },
+  "azure-mgmt-marketplaceordering": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.marketplaceordering"
+    ],
+    "service_name": "Market Place Ordering"
+  },
+  "azure-mgmt-media": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.media"
+    ],
+    "service_name": "Media Services"
+  },
+  "azure-mgmt-mixedreality": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.mixedreality"
+    ],
+    "service_name": "Mixed Reality"
+  },
+  "azure-mgmt-monitor": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.monitor"
+    ],
+    "service_name": "Monitoring"
+  },
+  "azure-mgmt-msi": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.msi"
+    ],
+    "service_name": "MSI"
+  },
+  "azure-mgmt-netapp": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.netapp"
+    ],
+    "service_name": "NetApp"
+  },
+  "azure-mgmt-network": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.network.v2015_06_15",
+      "azure.mgmt.network.v2016_09_01",
+      "azure.mgmt.network.v2016_12_01",
+      "azure.mgmt.network.v2017_03_01",
+      "azure.mgmt.network.v2017_06_01",
+      "azure.mgmt.network.v2017_08_01",
+      "azure.mgmt.network.v2017_09_01",
+      "azure.mgmt.network.v2017_10_01",
+      "azure.mgmt.network.v2017_11_01",
+      "azure.mgmt.network.v2018_01_01",
+      "azure.mgmt.network.v2018_02_01",
+      "azure.mgmt.network.v2018_04_01",
+      "azure.mgmt.network.v2018_06_01",
+      "azure.mgmt.network.v2018_07_01",
+      "azure.mgmt.network.v2018_08_01",
+      "azure.mgmt.network.v2018_10_01",
+      "azure.mgmt.network.v2018_11_01",
+      "azure.mgmt.network.v2018_12_01",
+      "azure.mgmt.network.v2019_02_01"
+    ],
+    "service_name": "Network"
+  },
+  "azure-mgmt-notificationhubs": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.notificationhubs"
+    ],
+    "service_name": "Notification Hubs"
+  },
+  "azure-mgmt-policyinsights": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.policyinsights"
+    ],
+    "service_name": "Policy Insights"
+  },
+  "azure-mgmt-powerbiembedded": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.powerbiembedded"
+    ],
+    "service_name": "Power BI Embedded"
+  },
+  "azure-mgmt-rdbms/azure.mgmt.rdbms.mariadb": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.rdbms.mariadb"
+    ],
+    "service_name": "MariaDB"
+  },
+  "azure-mgmt-rdbms/azure.mgmt.rdbms.mysql": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.rdbms.mysql"
+    ],
+    "service_name": "MySQL"
+  },
+  "azure-mgmt-rdbms/azure.mgmt.rdbms.postgresql": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.rdbms.postgresql"
+    ],
+    "service_name": "PostgreSQL"
+  },
+  "azure-mgmt-rdbms": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.rdbms"
+    ],
+    "service_name": "OSS RDBMS"
+  },
+  "azure-mgmt-reservations": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.reservations"
+    ],
+    "service_name": "Reservations"
+  },
+  "azure-mgmt-recoveryservices": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.recoveryservices"
+    ],
+    "service_name": "Recovery Services"
+  },
+  "azure-mgmt-recoveryservicesbackup": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.recoveryservicesbackup"
+    ],
+    "service_name": "Recovery Services Backup"
+  },
+  "azure-mgmt-redis": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.redis"
+    ],
+    "service_name": "Redis Cache"
+  },
+  "azure-mgmt-relay": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.relay"
+    ],
+    "service_name": "Relay"
+  },
+  "azure-mgmt-resource": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.resource.managedapplications",
+      "azure.mgmt.resource.features.v2015_12_01",
+      "azure.mgmt.resource.subscriptions.v2016_06_01",
+      "azure.mgmt.resource.locks.v2015_01_01",
+      "azure.mgmt.resource.locks.v2016_09_01",
+      "azure.mgmt.resource.resources.v2016_02_01",
+      "azure.mgmt.resource.resources.v2016_09_01",
+      "azure.mgmt.resource.resources.v2017_05_10",
+      "azure.mgmt.resource.resources.v2018_02_01",
+      "azure.mgmt.resource.resources.v2018_05_01",
+      "azure.mgmt.resource.policy.v2015_10_01_preview",
+      "azure.mgmt.resource.policy.v2016_04_01",
+      "azure.mgmt.resource.policy.v2016_12_01",
+      "azure.mgmt.resource.links.v2016_09_01"
+    ],
+    "service_name": "Resource Management"
+  },
+  "azure-mgmt-resourcegraph": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.resourcegraph"
+    ],
+    "service_name": "Resource Graph"
+  },
+  "azure-mgmt-scheduler": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.scheduler"
+    ],
+    "service_name": "Scheduler"
+  },
+  "azure-mgmt-search": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.search"
+    ],
+    "service_name": "Search Management"
+  },
+  "azure-mgmt-security": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.security"
+    ],
+    "service_name": "Security Management"
+  },
+  "azure-mgmt-servermanager": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.servermanager"
+    ],
+    "service_name": "Server Management"
+  },
+  "azure-mgmt-servicebus": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.servicebus"
+    ],
+    "service_name": "Service Bus"
+  },
+  "azure-mgmt-servicefabric": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.servicefabric"
+    ],
+    "service_name": "Service Fabric"
+  },
+  "azure-mgmt-signalr": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.signalr"
+    ],
+    "service_name": "SignalR Management"
+  },
+  "azure-mgmt-sql": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.sql"
+    ],
+    "service_name": "SQL"
+  },
+  "azure-mgmt-sqlvirtualmachine": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.sqlvirtualmachine"
+    ],
+    "service_name": "SQL Virtual Machine"
+  },
+  "azure-mgmt-storage": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.storage.v2015_06_15",
+      "azure.mgmt.storage.v2016_01_01",
+      "azure.mgmt.storage.v2016_12_01",
+      "azure.mgmt.storage.v2017_06_01",
+      "azure.mgmt.storage.v2017_10_01",
+      "azure.mgmt.storage.v2018_02_01",
+      "azure.mgmt.storage.v2018_07_01",
+      "azure.mgmt.storage.v2019_04_01"
+    ],
+    "service_name": "Storage"
+  },
+  "azure-mgmt-subscription": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.subscription"
+    ],
+    "service_name": "Subscription"
+  },
+  "azure-mgmt-trafficmanager": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.trafficmanager"
+    ],
+    "service_name": "Traffic Manager"
+  },
+  "azure-mgmt-web": {
+    "category": "Management",
+    "namespaces": [
+      "azure.mgmt.web.v2015_04_01",
+      "azure.mgmt.web.v2015_08_01",
+      "azure.mgmt.web.v2016_03_01",
+      "azure.mgmt.web.v2016_08_01",
+      "azure.mgmt.web.v2016_09_01",
+      "azure.mgmt.web.v2018_02_01",
+      "azure.mgmt.web.v2018_11_01"
+    ],
+    "service_name": "Web Apps"
+  },
+  "azure-servicebus": {
+    "category": "Client",
+    "service_name": "Service Bus",
+    "manually_generated": true
+  },
+  "azure-eventhub": {
+    "category": "Client",
+    "service_name": "Event Hub",
+    "manually_generated": true
+  },
+  "azure-eventhub-checkpointstoreblob-aio": {
+    "category": "Client",
+    "service_name": "Event Hub",
+    "manually_generated": true
+  },
+  "azure-core": {
+    "category": "Client",
+    "service_name": "Core",
+    "manually_generated": true
+  },
+  "azure-core-tracing-opencensus": {
+    "category": "Client",
+    "service_name": "Core",
+    "manually_generated": true
+  },
+  "azure-core-tracing-opentelemetry": {
+    "category": "Client",
+    "service_name": "Core",
+    "manually_generated": true
+  },
+  "azure-identity": {
+    "category": "Client",
+    "service_name": "Identity",
+    "manually_generated": true
+  },
+  "azure-cosmos": {
+    "category": "Client",
+    "service_name": "Cosmos",
+    "manually_generated": true
+  },
+  "azure-search-documents": {
+    "category": "Client",
+    "service_name": "Search",
+    "manually_generated": true
+  },
+  "azure-search": {
+    "category": "Client",
+    "service_name": "Search",
+    "manually_generated": true
+  },
+  "azure-keyvault-keys": {
+    "category": "Client",
+    "service_name": "Keyvault",
+    "manually_generated": true
+  },
+  "azure-keyvault-secrets": {
+    "category": "Client",
+    "service_name": "Keyvault",
+    "manually_generated": true
+  },
+  "azure-keyvault-certificates": {
+    "category": "Client",
+    "service_name": "Keyvault",
+    "manually_generated": true
+  },
+  "azure-ai-textanalytics": {
+    "category": "Client",
+    "service_name": "Text Analytics",
+    "manually_generated": true
+  },
+    "azure-ai-formrecognizer": {
+    "category": "Client",
+    "service_name": "Form Recognizer",
+    "manually_generated": true
+  },
+  "azure-ai-metricsadvisor": {
+    "category": "Client",
+    "service_name": "Metrics Advisor",
+    "manually_generated": true
+  },
+  "azure-storage-blob": {
+    "category": "Client",
+    "service_name": "Storage",
+    "manually_generated": true
+  },
+  "azure-storage-blob-changefeed": {
+    "category": "Client",
+    "service_name": "Storage",
+    "manually_generated": true
+  },
+  "azure-storage-file-share": {
+    "category": "Client",
+    "service_name": "Storage",
+    "manually_generated": true
+  },
+  "azure-storage-file-datalake": {
+    "category": "Client",
+    "service_name": "Storage",
+    "manually_generated": true
+  },
+  "azure-storage-queue": {
+    "category": "Client",
+    "service_name": "Storage",
+    "manually_generated": true
+  },
+  "azure-appconfiguration": {
+    "category": "Client",
+    "service_name": "App Configuration",
+    "manually_generated": true
+  },
+  "azure-mgmt-appconfiguration": {
+    "category": "Management",
+    "service_name": "App Configuration",
+    "namespaces": [
+      "azure.mgmt.appconfiguration"
+    ]
+  },
+  "azure-mgmt-privatedns": {
+    "category": "Management",
+    "service_name": "Private DNS",
+    "namespaces": [
+      "azure.mgmt.privatedns"
+    ]
+  },
+  "azure-mgmt-frontdoor": {
+    "category": "Management",
+    "service_name": "Front Door",
+    "namespaces": [
+      "azure.mgmt.frontdoor"
+    ]
+  },
+  "azure-mgmt-hybridcompute": {
+    "category": "Management",
+    "service_name": "Hybrid Cloud",
+    "namespaces": [
+      "azure.mgmt.hybridcompute"
+    ]
+  },
+  "azure-mgmt-healthcareapis": {
+    "category": "Management",
+    "service_name": "Healthcare APIs",
+    "namespaces": [
+      "azure.mgmt.healthcareapis"
+    ]
+  },
+  "azure-mgmt-edgegateway": {
+    "category": "Management",
+    "service_name": "Edge Gateway",
+    "namespaces": [
+      "azure.mgmt.edgegateway"
+    ]
+  },
+  "azure-mgmt-deploymentmanager": {
+    "category": "Management",
+    "service_name": "Deployment Manager",
+    "namespaces": [
+      "azure.mgmt.deploymentmanager"
+    ]
+  },
+  "azure-mgmt-peering": {
+    "category": "Management",
+    "service_name": "Peering",
+    "namespaces": [
+      "azure.mgmt.peering"
+    ]
+  },
+  "azure-mgmt-appplatform": {
+    "category": "Management",
+    "service_name": "App Service",
+    "namespaces": [
+      "azure.mgmt.appplatform"
+    ]
+  },
+  "azure-mgmt-botservice": {
+    "category": "Management",
+    "service_name": "Bot Service",
+    "namespaces": [
+      "azure.mgmt.botservice"
+    ]
+  },
+  "azure-mgmt-costmanagement": {
+    "category": "Management",
+    "service_name": "Cost Management",
+    "namespaces": [
+      "azure.mgmt.costmanagement"
+    ]
+  },
+  "azure-mgmt-attestation": {
+    "category": "Management",
+    "service_name": "Attestation",
+    "namespaces": [
+      "azure.mgmt.attestation"
+    ]
+  },
+  "azure-mgmt-datashare": {
+    "category": "Management",
+    "service_name": "Data Share",
+    "namespaces": [
+      "azure.mgmt.datashare"
+    ]
+  },
+  "azure-mgmt-serialconsole": {
+    "category": "Management",
+    "service_name": "Serial Console",
+    "namespaces": [
+      "azure.mgmt.serialconsole"
+    ]
+  },
+  "azure-mgmt-storagesync": {
+    "category": "Management",
+    "service_name": "Storage Sync",
+    "namespaces": [
+      "azure.mgmt.storagesync"
+    ]
+  },
+  "azure-mgmt-storagecache": {
+    "category": "Management",
+    "service_name": "Storage",
+    "namespaces": [
+      "azure.mgmt.storagecache"
+    ]
+  },
+  "azure-mgmt-vmwarecloudsimple": {
+    "category": "Management",
+    "service_name": "VMWare by CloudSimple",
+    "namespaces": [
+      "azure.mgmt.vmwarecloudsimple"
+    ]
+  },
+  "azure-servicefabric": {
+    "category": "Client",
+    "namespaces": [
+      "azure.servicefabric"
+    ],
+    "service_name": "Service Fabric"
+  },
+  "azure-servicemanagement-legacy": {
+    "category": "Client",
+    "service_name": "Other"
+  }
+}

--- a/eng/tox/run_sphinx_apidoc.py
+++ b/eng/tox/run_sphinx_apidoc.py
@@ -20,6 +20,10 @@ import shutil
 logging.getLogger().setLevel(logging.INFO)
 
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", ".."))
+generate_mgmt_script = os.path.join(root_dir, "doc/sphinx/generate_doc.py")
+
+def is_mgmt_package(package_dir):
+    return "mgmt"  in pkg_name or "cognitiveservices" in pkg_name
 
 def copy_existing_docs(source, target):
     for file in os.listdir(source):
@@ -61,6 +65,31 @@ def sphinx_apidoc(working_directory):
         )
         exit(1)
 
+def mgmt_apidoc(working_directory, namespace):
+    command_array = [
+        sys.executable,
+        generate_mgmt_script,
+        "-p",
+        namespace,
+        "-o",
+        working_directory,
+        "--verbose"
+        ]
+
+    try:
+        logging.info("Command to generate management sphinx sources: {}".format(command_array))
+
+        check_call(
+            command_array
+        )
+    except CalledProcessError as e:
+        logging.error(
+            "script failed for path {} exited with error {}".format(
+                args.working_directory, e.returncode
+            )
+        )
+        exit(1)
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Run sphinx-apidoc against target folder. Handles management generation if necessary."
@@ -91,6 +120,9 @@ if __name__ == "__main__":
     pkg_name, namespace, pkg_version = get_package_details(os.path.join(package_dir, 'setup.py'))
 
     if should_build_docs(pkg_name):
-        sphinx_apidoc(args.working_directory)
+        if is_mgmt_package(pkg_name):
+            mgmt_apidoc(output_directory, namespace)
+        else:
+            sphinx_apidoc(args.working_directory)
     else:
         logging.info("Skipping sphinx source generation for {}".format(pkg_name))


### PR DESCRIPTION
To unblock release of `azure-mgmt-network`

While we dig into #17247 

While this will unblock release I have a very strong suspicion that the documentation that is being generated is omitting a lot of code. 

Need to compare the two generated sphinx sources prior to running `sphinx-build` and see what documents are being omitted from azure-mgmt-network.

