### PR TITLE
Add HTTP responses to authentication exceptions

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release History
 
 ## 1.6.0b3 (Unreleased)
+### Breaking Changes
+> These changes do not impact the API of stable versions such as 1.5.0.
+> Only code written against a beta version such as 1.6.0b1 may be affected.
+- Removed property `AuthenticationRequiredError.error_details` 
+
 ### Fixed
 - Credentials consistently retry token requests after connection failures, or
   when instructed to by a Retry-After header

--- a/sdk/identity/azure-identity/azure/identity/_credentials/device_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/device_code.py
@@ -93,11 +93,9 @@ class DeviceCodeCredential(InteractiveCredential):
             # MSAL will stop polling when the device code expires
             result = app.acquire_token_by_device_flow(flow, claims_challenge=kwargs.get("claims"))
 
-        if "access_token" not in result:
-            if result.get("error") == "authorization_pending":
-                message = "Timed out waiting for user to authenticate"
-            else:
-                message = "Authentication failed: {}".format(result.get("error_description") or result.get("error"))
-            raise ClientAuthenticationError(message=message)
+        # raise for a timeout here because the error is particular to this class
+        if "access_token" not in result and result.get("error") == "authorization_pending":
+            raise ClientAuthenticationError(message="Timed out waiting for user to authenticate")
 
+        # base class will raise for other errors
         return result

--- a/sdk/identity/azure-identity/azure/identity/_exceptions.py
+++ b/sdk/identity/azure-identity/azure/identity/_exceptions.py
@@ -23,11 +23,10 @@ class AuthenticationRequiredError(CredentialUnavailableError):
     method.
     """
 
-    def __init__(self, scopes, message=None, error_details=None, claims=None, **kwargs):
-        # type: (Iterable[str], Optional[str], Optional[str], Optional[str], **Any) -> None
+    def __init__(self, scopes, message=None, claims=None, **kwargs):
+        # type: (Iterable[str], Optional[str], Optional[str], **Any) -> None
         self._claims = claims
         self._scopes = scopes
-        self._error_details = error_details
         if not message:
             message = "Interactive authentication is required to get a token. Call 'authenticate' to begin."
         super(AuthenticationRequiredError, self).__init__(message=message, **kwargs)
@@ -37,12 +36,6 @@ class AuthenticationRequiredError(CredentialUnavailableError):
         # type: () -> Iterable[str]
         """Scopes requested during the failed authentication"""
         return self._scopes
-
-    @property
-    def error_details(self):
-        # type: () -> Optional[str]
-        """Additional authentication error details from Azure Active Directory"""
-        return self._error_details
 
     @property
     def claims(self):

--- a/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
@@ -129,7 +129,7 @@ class AadClientBase(ABC):
                     self._cache.update_rt(cache_entries[0], content["refresh_token"])
                     del content["refresh_token"]  # prevent caching a redundant entry
 
-        _raise_for_error(content)
+        _raise_for_error(response, content)
 
         if "expires_on" in content:
             expires_on = int(content["expires_on"])
@@ -248,14 +248,14 @@ def _scrub_secrets(response):
             response[secret] = "***"
 
 
-def _raise_for_error(response):
-    # type: (dict) -> None
-    if "error" not in response:
+def _raise_for_error(response, content):
+    # type: (PipelineResponse, dict) -> None
+    if "error" not in content:
         return
 
-    _scrub_secrets(response)
-    if "error_description" in response:
-        message = "Azure Active Directory error '({}) {}'".format(response["error"], response["error_description"])
+    _scrub_secrets(content)
+    if "error_description" in content:
+        message = "Azure Active Directory error '({}) {}'".format(content["error"], content["error_description"])
     else:
-        message = "Azure Active Directory error '{}'".format(response)
-    raise ClientAuthenticationError(message=message)
+        message = "Azure Active Directory error '{}'".format(content)
+    raise ClientAuthenticationError(message=message, response=response.http_response)

--- a/sdk/identity/azure-identity/azure/identity/_internal/interactive.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/interactive.py
@@ -140,7 +140,8 @@ class InteractiveCredential(MsalCredential):
             result = self._request_token(*scopes, **kwargs)
             if "access_token" not in result:
                 message = "Authentication failed: {}".format(result.get("error_description") or result.get("error"))
-                raise ClientAuthenticationError(message=message)
+                response = self._client.get_error_response(result)
+                raise ClientAuthenticationError(message=message, response=response)
 
             # this may be the first authentication, or the user may have authenticated a different identity
             self._auth_record = _build_auth_record(result)
@@ -198,8 +199,8 @@ class InteractiveCredential(MsalCredential):
 
         # if we get this far, result is either None or the content of an AAD error response
         if result:
-            details = result.get("error_description") or result.get("error")
-            raise AuthenticationRequiredError(scopes, error_details=details, claims=claims)
+            response = self._client.get_error_response(result)
+            raise AuthenticationRequiredError(scopes, claims=claims, response=response)
         raise AuthenticationRequiredError(scopes, claims=claims)
 
     def _get_app(self):

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_client.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import threading
+
 import six
 
 from azure.core.configuration import Configuration
@@ -30,7 +32,7 @@ if TYPE_CHECKING:
     from typing import Any, Dict, List, Optional, Union
     from azure.core.pipeline import PipelineResponse
     from azure.core.pipeline.policies import HTTPPolicy, SansIOHTTPPolicy
-    from azure.core.pipeline.transport import HttpTransport
+    from azure.core.pipeline.transport import HttpResponse, HttpTransport
 
     PolicyList = List[Union[HTTPPolicy, SansIOHTTPPolicy]]
     RequestData = Union[Dict[str, str], str]
@@ -80,6 +82,7 @@ class MsalClient(object):
 
     def __init__(self, **kwargs):  # pylint:disable=missing-client-constructor-parameter-credential
         # type: (**Any) -> None
+        self._local = threading.local()
         self._pipeline = _build_pipeline(**kwargs)
 
     def post(self, url, params=None, data=None, headers=None, **kwargs):  # pylint:disable=unused-argument
@@ -97,7 +100,8 @@ class MsalClient(object):
             else:
                 raise ValueError('expected "data" to be text or a dict')
 
-        response = self._pipeline.run(request, retry_on_methods=_POST)
+        response = self._pipeline.run(request, stream=False, retry_on_methods=_POST)
+        self._store_auth_error(response)
         return MsalResponse(response)
 
     def get(self, url, params=None, headers=None, **kwargs):  # pylint:disable=unused-argument
@@ -105,8 +109,26 @@ class MsalClient(object):
         request = HttpRequest("GET", url, headers=headers)
         if params:
             request.format_parameters(params)
-        response = self._pipeline.run(request)
+        response = self._pipeline.run(request, stream=False)
+        self._store_auth_error(response)
         return MsalResponse(response)
+
+    def get_error_response(self, msal_result):
+        # type: (dict) -> Optional[HttpResponse]
+        """Get the HTTP response associated with an MSAL error"""
+        error_code, response = getattr(self._local, "error", (None, None))
+        if response and error_code == msal_result.get("error"):
+            return response
+        return None
+
+    def _store_auth_error(self, response):
+        # type: (PipelineResponse) -> None
+        if response.http_response.status_code >= 400:
+            # if the body doesn't contain "error", this isn't an OAuth 2 error, i.e. this isn't a
+            # response to an auth request, so no credential will want to include it with an exception
+            content = response.context.get(ContentDecodePolicy.CONTEXT_NAME)
+            if content and "error" in content:
+                self._local.error = (content["error"], response.http_response)
 
 
 def _create_config(**kwargs):

--- a/sdk/identity/azure-identity/tests/test_interactive_credential.py
+++ b/sdk/identity/azure-identity/tests/test_interactive_credential.py
@@ -137,7 +137,6 @@ def test_disable_automatic_authentication():
 
     # the exception should carry the requested scopes and claims, and any error message from AAD
     assert ex.value.scopes == (scope,)
-    assert ex.value.error_details == expected_details
     assert ex.value.claims == expected_claims
 
 

--- a/sdk/identity/azure-identity/tests/test_msal_client.py
+++ b/sdk/identity/azure-identity/tests/test_msal_client.py
@@ -7,7 +7,7 @@ from azure.identity._internal.msal_client import MsalClient
 
 import pytest
 
-from helpers import mock
+from helpers import mock, mock_response, validating_transport, Request
 
 
 def test_retries_requests():
@@ -25,3 +25,28 @@ def test_retries_requests():
     with pytest.raises(ServiceRequestError, match=message):
         client.get("https://localhost")
     assert transport.send.call_count > 1
+
+
+def test_get_error_response():
+    first_result = {"error": "first"}
+    first_response = mock_response(401, json_payload=first_result)
+    second_result = {"error": "second"}
+    second_response = mock_response(401, json_payload=second_result)
+    transport = validating_transport(
+        requests=[Request(url="https://localhost")] * 2, responses=[first_response, second_response]
+    )
+
+    client = MsalClient(transport=transport)
+
+    for result in (first_result, second_result):
+        assert not client.get_error_response(result)
+
+    client.get("https://localhost")
+    response = client.get_error_response(first_result)
+    assert response is first_response
+
+    client.post("https://localhost")
+    response = client.get_error_response(second_result)
+    assert response is second_response
+
+    assert not client.get_error_response(first_result)


### PR DESCRIPTION
My goal here is to add Azure AD's response to each exception raised due to an Azure AD authentication error. That's easy where an exception is raised by code that already has the response. Less so for a credential implemented with MSAL, because MSAL returns only the response's deserialized body to the credential. So, this PR has MsalClient hang on to the last auth error response it saw, and adds a method credentials can call to get that response.

This closes #16906 by giving applications all the information AAD provided when authentication failed, for example:
```py
try:
    client.operation()
except AuthenticationRequiredError as ex:
    if ex.response:  # can be None, a response isn't always available
        content = json.loads(ex.response.text())
        ...
```

This PR removes the redundant `AuthenticationRequiredError.error_details`, whose value was simply `error_details` from AAD's response. That value is usually incorporated into an exception's message, and its raw value is available in the response.