### PR TITLE
Fix timing issue in caching test

### DIFF
--- a/sdk/identity/azure-identity/tests/test_managed_identity_client.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity_client.py
@@ -7,12 +7,13 @@ import time
 from azure.core.pipeline.transport import HttpRequest
 from azure.identity._internal.managed_identity_client import ManagedIdentityClient
 
-from helpers import mock_response, Request, validating_transport
+from helpers import mock, mock_response, Request, validating_transport
 
 
 def test_caching():
     scope = "scope"
-    expected_expires_on = int(time.time() + 3600)
+    now = int(time.time())
+    expected_expires_on = now + 3600
     expected_token = "*"
     transport = validating_transport(
         requests=[Request(url="http://localhost")],
@@ -35,7 +36,8 @@ def test_caching():
     token = client.get_cached_token(scope)
     assert not token
 
-    token = client.request_token(scope)
+    with mock.patch(ManagedIdentityClient.__module__ + ".time.time", lambda: now):
+        token = client.request_token(scope)
     assert token.expires_on == expected_expires_on
     assert token.token == expected_token
 


### PR DESCRIPTION
MSAL calculates the cached expires_on value of a token by adding its expires_in value to a timestamp, optionally provided at the time of caching. Async/ManagedIdentityClient does provide a timestamp, acquired before it requests a token. The cached expires_on value in these tests would therefore be later than expected if the system time rolls over to the next second before MSAL caches the token. That happened this morning, so here I am fixing it by ensuring the client gets a timestamp such that expires_in + timestamp = the expected expires_on. I almost fixed this by instead writing `assert token.expires_on - expected_expires_on < 2`  but felt it would then be necessary to add an explanatory paragraph like the one you're reading to the tests 😒 