### PR TITLE
[EventHubs] remove unused packages in the dev_requirement

### DIFF
--- a/sdk/eventhub/azure-eventhub/dev_requirements.txt
+++ b/sdk/eventhub/azure-eventhub/dev_requirements.txt
@@ -4,7 +4,4 @@
 -e ../azure-mgmt-eventhub
 -e ../../resources/azure-mgmt-resource
 aiohttp>=3.0; python_version >= '3.5'
-docutils>=0.14
-pygments>=2.2.0
-behave==1.2.6
 -e ../../../tools/azure-devtools


### PR DESCRIPTION
The three packages specified in dev requirement are not used in azure-eventhub v5 anymore.
I believe those are carried over from the track1: https://github.com/Azure/azure-sdk-for-python/blob/release/eventhub-v1/sdk/eventhub/azure-eventhubs/dev_requirements.txt and could be removed from the dev requirements in v5.
```
docutils>=0.14
pygments>=2.2.0
behave==1.2.6
```