### PR TITLE
[formrecognizer] unskip url samples

### DIFF
--- a/scripts/devops_tasks/test_run_samples.py
+++ b/scripts/devops_tasks/test_run_samples.py
@@ -100,10 +100,6 @@ IGNORED_SAMPLES = {
         "mgmt_topic_async.py",
         "proxy_async.py",
         "receive_deferred_message_queue_async.py"
-    ],
-    "azure-ai-formrecognizer": [
-        "sample_recognize_receipts_from_url.py",
-        "sample_recognize_receipts_from_url_async.py"
     ]
 }
 


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/16535

The service has fixed the issue of frequent "InvalidImageUrl" errors. Tests were unskipped when the feature branch was merged, but need to unskip these samples as well.