### PR TITLE
[core] remove requests import

### DIFF
--- a/sdk/core/azure-core/azure/core/_utils.py
+++ b/sdk/core/azure-core/azure/core/_utils.py
@@ -68,3 +68,28 @@ def _convert_to_isoformat(date_time):
 
     deserialized = deserialized.replace(tzinfo=tzinfo)
     return deserialized
+
+def _case_insensitive_dict(*args, **kwargs):
+    """Return a case-insensitive dict from a structure that a dict would have accepted.
+
+    Rational is I don't want to re-implement this, but I don't want
+    to assume "requests" or "aiohttp" are installed either.
+    So I use the one from "requests" or the one from "aiohttp" ("multidict")
+    If one day this library is used in an HTTP context without "requests" nor "aiohttp" installed,
+    we can add "multidict" as a dependency or re-implement our own.
+    """
+    try:
+        from requests.structures import CaseInsensitiveDict
+
+        return CaseInsensitiveDict(*args, **kwargs)
+    except ImportError:
+        pass
+    try:
+        # multidict is installed by aiohttp
+        from multidict import CIMultiDict
+
+        return CIMultiDict(*args, **kwargs)
+    except ImportError:
+        raise ValueError(
+            "Neither 'requests' or 'multidict' are installed and no case-insensitive dict impl have been found"
+        )

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_utils.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_utils.py
@@ -25,8 +25,7 @@
 # --------------------------------------------------------------------------
 import datetime
 import email.utils
-from requests.structures import CaseInsensitiveDict
-from ..._utils import _FixedOffset
+from ..._utils import _FixedOffset, _case_insensitive_dict
 
 def _parse_http_date(text):
     """Parse a HTTP date format into datetime."""
@@ -58,7 +57,7 @@ def get_retry_after(response):
     :return: Value of Retry-After in seconds.
     :rtype: float or None
     """
-    headers = CaseInsensitiveDict(response.http_response.headers)
+    headers = _case_insensitive_dict(**response.http_response.headers)
     retry_after = headers.get("retry-after")
     if retry_after:
         return parse_retry_after(retry_after)

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
@@ -74,6 +74,7 @@ from azure.core.pipeline import (
     PipelineContext,
 )
 from .._tools import await_result as _await_result
+from ..._utils import _case_insensitive_dict
 
 
 if TYPE_CHECKING:
@@ -85,32 +86,6 @@ HTTPRequestType = TypeVar("HTTPRequestType")
 PipelineType = TypeVar("PipelineType")
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _case_insensitive_dict(*args, **kwargs):
-    """Return a case-insensitive dict from a structure that a dict would have accepted.
-
-    Rational is I don't want to re-implement this, but I don't want
-    to assume "requests" or "aiohttp" are installed either.
-    So I use the one from "requests" or the one from "aiohttp" ("multidict")
-    If one day this library is used in an HTTP context without "requests" nor "aiohttp" installed,
-    we can add "multidict" as a dependency or re-implement our own.
-    """
-    try:
-        from requests.structures import CaseInsensitiveDict
-
-        return CaseInsensitiveDict(*args, **kwargs)
-    except ImportError:
-        pass
-    try:
-        # multidict is installed by aiohttp
-        from multidict import CIMultiDict
-
-        return CIMultiDict(*args, **kwargs)
-    except ImportError:
-        raise ValueError(
-            "Neither 'requests' or 'multidict' are installed and no case-insensitive dict impl have been found"
-        )
 
 
 def _format_url_section(template, **kwargs):


### PR DESCRIPTION
Currently, there is a `from requests.structures import CaseInsensitiveDict` statement in `azure-core/azure/core/pipeline/transport/_base.py`. Two problems with this:
* This file should not be directly importing from `requests`. It should be calling the previously implemented `_case_insensitive_dict` method, for consistency. 
*  Trying to do a relative import of `_case_insensitive_dict` from where it is currently results in an `ImportError` for `'AioHttpTransportResponse`. Moving it to `azure/core/_utils` resolves the problem. 
* The `_case_insensitive_dict` method will also be used by the `_connection_string_parser.py` method in `azure.core.utils` -- another reason to move it to a more common place.