### PR TITLE
[Communication] - Phone Numbers - Removed PhoneNumberOperationStatus from public exposure

### DIFF
--- a/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/__init__.py
+++ b/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/__init__.py
@@ -15,7 +15,6 @@ from ._generated.models import (
     PhoneNumberAssignmentType,
     PhoneNumberCapabilityType,
     PhoneNumberType,
-    PhoneNumberOperationStatus
 )
 
 __all__ = [
@@ -27,6 +26,5 @@ __all__ = [
     'PhoneNumberAssignmentType',
     'PhoneNumberCapabilityType',
     'PhoneNumberType',
-    'PhoneNumberOperationStatus',
     'PhoneNumbersClient',
 ]

--- a/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_phone_numbers_client.py
+++ b/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_phone_numbers_client.py
@@ -171,7 +171,7 @@ class PhoneNumbersClient(object):
             calling=None, #type: str or PhoneNumberCapabilityType
             **kwargs # type: Any
     ):
-        # type: (...) -> LROPoller["_models.PurchasedPhoneNumber"]
+        # type: (...) -> LROPoller[PurchasedPhoneNumber]
         """Updates the capabilities of a phone number.
 
         :param phone_number: The phone number id in E.164 format. The leading plus can be either + or
@@ -187,7 +187,7 @@ class PhoneNumbersClient(object):
         :paramtype polling: bool or ~azure.core.polling.PollingMethod
         :keyword int polling_interval: Default waiting time between two polls
             for LRO operations if no Retry-After header is present.
-        :rtype: ~azure.core.polling.LROPoller[PurchasedPhoneNumber]
+        :rtype: ~azure.core.polling.LROPoller[~azure.communication.phonenumbers.models.PurchasedPhoneNumber]
         """
         return self._phone_number_client.phone_numbers.begin_update_capabilities(
             phone_number,

--- a/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/aio/_phone_numbers_client_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/aio/_phone_numbers_client_async.py
@@ -174,7 +174,7 @@ class PhoneNumbersClient(object):
             calling=None, # type: str
             **kwargs # type: Any
     ):
-        # type: (...) -> AsyncLROPoller["_models.PurchasedPhoneNumber"]
+        # type: (...) -> AsyncLROPoller[PurchasedPhoneNumber]
         """Updates the capabilities of a phone number.
 
         :param phone_number: The phone number id in E.164 format. The leading plus can be either + or
@@ -190,7 +190,7 @@ class PhoneNumbersClient(object):
         :paramtype polling: bool or ~azure.core.polling.PollingMethod
         :keyword int polling_interval: Default waiting time between two polls
             for LRO operations if no Retry-After header is present.
-        :rtype: ~azure.core.polling.AsyncLROPoller[PurchasedPhoneNumber]
+        :rtype: ~azure.core.polling.AsyncLROPoller[~azure.communication.phonenumbers.models.PurchasedPhoneNumber]
         """
         return await self._phone_number_client.phone_numbers.begin_update_capabilities(
             phone_number,

--- a/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client.py
@@ -8,8 +8,8 @@ from azure.communication.phonenumbers import (
     PhoneNumberCapabilities, 
     PhoneNumberCapabilityType, 
     PhoneNumberType,
-    PhoneNumberOperationStatus
 )
+from azure.communication.phonenumbers._generated.models import PhoneNumberOperationStatus
 from azure.communication.phonenumbers._shared.utils import parse_connection_str
 from phone_number_helper import PhoneNumberUriReplacer
 

--- a/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_phone_number_administration_client_async.py
@@ -9,8 +9,8 @@ from azure.communication.phonenumbers import (
     PhoneNumberCapabilities, 
     PhoneNumberCapabilityType, 
     PhoneNumberType, 
-    PhoneNumberOperationStatus
 )
+from azure.communication.phonenumbers._generated.models import PhoneNumberOperationStatus
 from azure.communication.phonenumbers._shared.utils import parse_connection_str
 from phone_number_helper import PhoneNumberUriReplacer
 


### PR DESCRIPTION
Follow up PR for removing the PhoneNumberOperationStatus enum from the public init file as @annatisch suggested.