### PR TITLE
[translation] remove convenience input for translation glossary

### DIFF
--- a/sdk/documenttranslation/azure-ai-documenttranslation/azure/ai/documenttranslation/_models.py
+++ b/sdk/documenttranslation/azure-ai-documenttranslation/azure/ai/documenttranslation/_models.py
@@ -23,7 +23,7 @@ class TranslationGlossary(object):  # pylint: disable=useless-object-inheritance
      supplied.
      If the translation language pair is not present in the glossary, it will not be applied.
     :type glossary_url: str
-    :keyword str format: Format.
+    :param str format: Format.
     :keyword str format_version: Format version.
     :keyword storage_source: Storage Source. Default value: "AzureBlob".
     :paramtype storage_source: str
@@ -32,11 +32,12 @@ class TranslationGlossary(object):  # pylint: disable=useless-object-inheritance
     def __init__(
             self,
             glossary_url,
+            format,
             **kwargs
     ):
-        # type: (str, **Any) -> None
+        # type: (str, str, **Any) -> None
         self.glossary_url = glossary_url
-        self.format = kwargs.get("format", None)
+        self.format = format
         self.format_version = kwargs.get("format_version", None)
         self.storage_source = kwargs.get("storage_source", None)
 
@@ -49,18 +50,8 @@ class TranslationGlossary(object):  # pylint: disable=useless-object-inheritance
             )
 
     @staticmethod
-    def _to_generated_unknown_type(glossary):
-        if isinstance(glossary, TranslationGlossary):
-            return glossary._to_generated()  # pylint: disable=protected-access
-        if isinstance(glossary, six.string_types):
-            return _Glossary(
-                    glossary_url=glossary,
-                )
-        return None
-
-    @staticmethod
     def _to_generated_list(glossaries):
-        return [TranslationGlossary._to_generated_unknown_type(glossary) for glossary in glossaries]
+        return [glossary._to_generated() for glossary in glossaries]
 
 
 class TranslationTarget(object):  # pylint: disable=useless-object-inheritance
@@ -72,7 +63,7 @@ class TranslationTarget(object):  # pylint: disable=useless-object-inheritance
     :type language_code: str
     :keyword str category_id: Category / custom system for translation request.
     :keyword glossaries: List of TranslationGlossary.
-    :paramtype glossaries: Union[list[str], list[~azure.ai.documenttranslation.TranslationGlossary]]
+    :paramtype glossaries: list[~azure.ai.documenttranslation.TranslationGlossary]
     :keyword storage_source: Storage Source. Default value: "AzureBlob".
     :paramtype storage_source: str
     """

--- a/sdk/documenttranslation/azure-ai-documenttranslation/azure/ai/documenttranslation/_models.py
+++ b/sdk/documenttranslation/azure-ai-documenttranslation/azure/ai/documenttranslation/_models.py
@@ -23,7 +23,7 @@ class TranslationGlossary(object):  # pylint: disable=useless-object-inheritance
      supplied.
      If the translation language pair is not present in the glossary, it will not be applied.
     :type glossary_url: str
-    :param str format: Format.
+    :param str file_format: Format.
     :keyword str format_version: Format version.
     :keyword storage_source: Storage Source. Default value: "AzureBlob".
     :paramtype storage_source: str
@@ -32,26 +32,26 @@ class TranslationGlossary(object):  # pylint: disable=useless-object-inheritance
     def __init__(
             self,
             glossary_url,
-            format,
+            file_format,
             **kwargs
     ):
         # type: (str, str, **Any) -> None
         self.glossary_url = glossary_url
-        self.format = format
+        self.file_format = file_format
         self.format_version = kwargs.get("format_version", None)
         self.storage_source = kwargs.get("storage_source", None)
 
     def _to_generated(self):
         return _Glossary(
                 glossary_url=self.glossary_url,
-                format=self.format,
+                format=self.file_format,
                 version=self.format_version,
                 storage_source=self.storage_source
             )
 
     @staticmethod
     def _to_generated_list(glossaries):
-        return [glossary._to_generated() for glossary in glossaries]
+        return [glossary._to_generated() for glossary in glossaries]  # pylint: disable=protected-access
 
 
 class TranslationTarget(object):  # pylint: disable=useless-object-inheritance
@@ -320,8 +320,8 @@ class DocumentTranslationError(object):  # pylint: disable=useless-object-inheri
 class FileFormat(object):  # pylint: disable=useless-object-inheritance, R0903
     """FileFormat.
 
-    :ivar format: Name of the format.
-    :vartype format: str
+    :ivar file_format: Name of the format.
+    :vartype file_format: str
     :ivar file_extensions: Supported file extension for this format.
     :vartype file_extensions: list[str]
     :ivar content_types: Supported Content-Types for this format.
@@ -335,7 +335,7 @@ class FileFormat(object):  # pylint: disable=useless-object-inheritance, R0903
         **kwargs
     ):
         # type: (**Any) -> None
-        self.format = kwargs.get('format', None)
+        self.file_format = kwargs.get('file_format', None)
         self.file_extensions = kwargs.get('file_extensions', None)
         self.content_types = kwargs.get('content_types', None)
         self.format_versions = kwargs.get('format_versions', None)
@@ -343,7 +343,7 @@ class FileFormat(object):  # pylint: disable=useless-object-inheritance, R0903
     @classmethod
     def _from_generated(cls, file_format):
         return cls(
-            format=file_format.format,
+            file_format=file_format.format,
             file_extensions=file_format.file_extensions,
             content_types=file_format.content_types,
             format_versions=file_format.versions


### PR DESCRIPTION
Turns out the `format` parameter is required for `TranslationGlossary`  (corrected in [latest swagger](https://github.com/Azure/azure-rest-api-specs/pull/13618/files#diff-9e5b67a75cb0befd46a7d2ab04b76e9163170c2e326a079c19cce5285e78c32fR944)) and so we can't have the convenience input as a `list[str]` anymore. :(

Listed other changes in swagger in this issue: #17550

Also...
Pylint correctly pointed out that we shouldn't be using the name `format` for any attribute. What my commit tries to say is "rename all instances of "format" to "file_format" since we shouldn't redefine built-in types in python"