### PR TITLE
[formrecognizer] regenerate for ID doc fixes 

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
@@ -5,6 +5,7 @@
 **New features**
 
 - New methods `begin_recognize_id_documents` and `begin_recognize_id_documents_from_url` introduced to the SDK. Use these methods to recognize data from identity documents.
+- New field value types "gender" and "country" described in the `FieldValueType` enum.
 - Content-type `image/bmp` now supported by custom forms and training methods.
 - Added keyword argument `pages` for business cards, receipts, custom forms, and invoices 
 to specify which page to process of the document.

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_generated/v2_1_preview_3/models/__init__.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_generated/v2_1_preview_3/models/__init__.py
@@ -79,6 +79,7 @@ except (SyntaxError, ImportError):
 
 from ._form_recognizer_client_enums import (
     ContentType,
+    FieldValueGender,
     FieldValueSelectionMark,
     FieldValueType,
     KeyValueType,
@@ -129,6 +130,7 @@ __all__ = [
     'TrainSourceFilter',
     'TrainingDocumentInfo',
     'ContentType',
+    'FieldValueGender',
     'FieldValueSelectionMark',
     'FieldValueType',
     'KeyValueType',

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_generated/v2_1_preview_3/models/_form_recognizer_client_enums.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_generated/v2_1_preview_3/models/_form_recognizer_client_enums.py
@@ -41,6 +41,14 @@ class ContentType(with_metaclass(_CaseInsensitiveEnumMeta, str, Enum)):
     #: Content Type 'image/tiff'.
     IMAGE_TIFF = "image/tiff"
 
+class FieldValueGender(with_metaclass(_CaseInsensitiveEnumMeta, str, Enum)):
+    """Gender value: M, F, or X.
+    """
+
+    M = "M"
+    F = "F"
+    X = "X"
+
 class FieldValueSelectionMark(with_metaclass(_CaseInsensitiveEnumMeta, str, Enum)):
     """Selection mark value.
     """
@@ -61,6 +69,8 @@ class FieldValueType(with_metaclass(_CaseInsensitiveEnumMeta, str, Enum)):
     ARRAY = "array"
     OBJECT = "object"
     SELECTION_MARK = "selectionMark"
+    GENDER = "gender"
+    COUNTRY = "country"
 
 class KeyValueType(with_metaclass(_CaseInsensitiveEnumMeta, str, Enum)):
     """Semantic data type of the key value element.

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_generated/v2_1_preview_3/models/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_generated/v2_1_preview_3/models/_models.py
@@ -522,7 +522,7 @@ class FieldValue(msrest.serialization.Model):
     All required parameters must be populated in order to send to Azure.
 
     :param type: Required. Type of field value. Possible values include: "string", "date", "time",
-     "phoneNumber", "number", "integer", "array", "object", "selectionMark".
+     "phoneNumber", "number", "integer", "array", "object", "selectionMark", "gender", "country".
     :type type: str or ~azure.ai.formrecognizer.v2_1_preview_3.models.FieldValueType
     :param value_string: String value.
     :type value_string: str
@@ -544,6 +544,10 @@ class FieldValue(msrest.serialization.Model):
      "unselected".
     :type value_selection_mark: str or
      ~azure.ai.formrecognizer.v2_1_preview_3.models.FieldValueSelectionMark
+    :param value_gender: Gender value: M, F, or X. Possible values include: "M", "F", "X".
+    :type value_gender: str or ~azure.ai.formrecognizer.v2_1_preview_3.models.FieldValueGender
+    :param value_country: 3-letter country code (ISO 3166-1 alpha-3).
+    :type value_country: str
     :param text: Text content of the extracted field.
     :type text: str
     :param bounding_box: Bounding box of the field value, if appropriate.
@@ -575,6 +579,8 @@ class FieldValue(msrest.serialization.Model):
         'value_array': {'key': 'valueArray', 'type': '[FieldValue]'},
         'value_object': {'key': 'valueObject', 'type': '{FieldValue}'},
         'value_selection_mark': {'key': 'valueSelectionMark', 'type': 'str'},
+        'value_gender': {'key': 'valueGender', 'type': 'str'},
+        'value_country': {'key': 'valueCountry', 'type': 'str'},
         'text': {'key': 'text', 'type': 'str'},
         'bounding_box': {'key': 'boundingBox', 'type': '[float]'},
         'confidence': {'key': 'confidence', 'type': 'float'},
@@ -597,6 +603,8 @@ class FieldValue(msrest.serialization.Model):
         self.value_array = kwargs.get('value_array', None)
         self.value_object = kwargs.get('value_object', None)
         self.value_selection_mark = kwargs.get('value_selection_mark', None)
+        self.value_gender = kwargs.get('value_gender', None)
+        self.value_country = kwargs.get('value_country', None)
         self.text = kwargs.get('text', None)
         self.bounding_box = kwargs.get('bounding_box', None)
         self.confidence = kwargs.get('confidence', None)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_generated/v2_1_preview_3/models/_models_py3.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_generated/v2_1_preview_3/models/_models_py3.py
@@ -588,7 +588,7 @@ class FieldValue(msrest.serialization.Model):
     All required parameters must be populated in order to send to Azure.
 
     :param type: Required. Type of field value. Possible values include: "string", "date", "time",
-     "phoneNumber", "number", "integer", "array", "object", "selectionMark".
+     "phoneNumber", "number", "integer", "array", "object", "selectionMark", "gender", "country".
     :type type: str or ~azure.ai.formrecognizer.v2_1_preview_3.models.FieldValueType
     :param value_string: String value.
     :type value_string: str
@@ -610,6 +610,10 @@ class FieldValue(msrest.serialization.Model):
      "unselected".
     :type value_selection_mark: str or
      ~azure.ai.formrecognizer.v2_1_preview_3.models.FieldValueSelectionMark
+    :param value_gender: Gender value: M, F, or X. Possible values include: "M", "F", "X".
+    :type value_gender: str or ~azure.ai.formrecognizer.v2_1_preview_3.models.FieldValueGender
+    :param value_country: 3-letter country code (ISO 3166-1 alpha-3).
+    :type value_country: str
     :param text: Text content of the extracted field.
     :type text: str
     :param bounding_box: Bounding box of the field value, if appropriate.
@@ -641,6 +645,8 @@ class FieldValue(msrest.serialization.Model):
         'value_array': {'key': 'valueArray', 'type': '[FieldValue]'},
         'value_object': {'key': 'valueObject', 'type': '{FieldValue}'},
         'value_selection_mark': {'key': 'valueSelectionMark', 'type': 'str'},
+        'value_gender': {'key': 'valueGender', 'type': 'str'},
+        'value_country': {'key': 'valueCountry', 'type': 'str'},
         'text': {'key': 'text', 'type': 'str'},
         'bounding_box': {'key': 'boundingBox', 'type': '[float]'},
         'confidence': {'key': 'confidence', 'type': 'float'},
@@ -661,6 +667,8 @@ class FieldValue(msrest.serialization.Model):
         value_array: Optional[List["FieldValue"]] = None,
         value_object: Optional[Dict[str, "FieldValue"]] = None,
         value_selection_mark: Optional[Union[str, "FieldValueSelectionMark"]] = None,
+        value_gender: Optional[Union[str, "FieldValueGender"]] = None,
+        value_country: Optional[str] = None,
         text: Optional[str] = None,
         bounding_box: Optional[List[float]] = None,
         confidence: Optional[float] = None,
@@ -679,6 +687,8 @@ class FieldValue(msrest.serialization.Model):
         self.value_array = value_array
         self.value_object = value_object
         self.value_selection_mark = value_selection_mark
+        self.value_gender = value_gender
+        self.value_country = value_country
         self.text = text
         self.bounding_box = bounding_box
         self.confidence = confidence

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_models.py
@@ -66,12 +66,19 @@ def get_field_value(
         return (
             value.text
         )  # FIXME https://github.com/Azure/azure-sdk-for-python/issues/15276
-
+    if value.type == "gender":
+        return value.value_gender
+    if value.type == "country":
+        return value.value_country
     return None
 
 
 class FieldValueType(str, Enum):
-    """Semantic data type of the field value."""
+    """Semantic data type of the field value.
+
+    .. versionadded:: v2.1-preview
+        The *gender* and *country* values
+    """
 
     STRING = "string"
     DATE = "date"
@@ -82,6 +89,8 @@ class FieldValueType(str, Enum):
     LIST = "list"
     DICTIONARY = "dictionary"
     SELECTION_MARK = "selectionMark"
+    GENDER = "gender"
+    COUNTRY = "country"
 
 
 class LengthUnit(str, Enum):
@@ -228,7 +237,8 @@ class FormField(object):
 
     :ivar str value_type: The type of `value` found on FormField. Described in
         :class:`~azure.ai.formrecognizer.FieldValueType`, possible types include: 'string',
-        'date', 'time', 'phoneNumber', 'float', 'integer', 'dictionary', 'list', or 'selectionMark'.
+        'date', 'time', 'phoneNumber', 'float', 'integer', 'dictionary', 'list', 'selectionMark',
+        'gender', or 'country'.
     :ivar ~azure.ai.formrecognizer.FieldData label_data:
         Contains the text, bounding box, and field elements for the field label.
         Note that this is not returned for forms analyzed by models trained with labels.

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_id_documents_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_id_documents_async.py
@@ -68,14 +68,13 @@ class RecognizeIdDocumentsSampleAsync(object):
                     print("Date of Expiration: {} has confidence: {}".format(doe.value, doe.confidence))
                 sex = id_document.fields.get("Sex")
                 if sex:
-                    print("Sex: {} has confidence: {}".format(sex.value_data.text, sex.confidence))
+                    print("Sex: {} has confidence: {}".format(sex.value, sex.confidence))
                 address = id_document.fields.get("Address")
                 if address:
                     print("Address: {} has confidence: {}".format(address.value, address.confidence))
-                # FIXME: uncomment this
-                # country = id_document.fields.get("Country")
-                # if country:
-                #     print("Country: {} has confidence: {}".format(country.value, country.confidence))
+                country = id_document.fields.get("Country")
+                if country:
+                    print("Country: {} has confidence: {}".format(country.value, country.confidence))
                 region = id_document.fields.get("Region")
                 if region:
                     print("Region: {} has confidence: {}".format(region.value, region.confidence))

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_id_documents.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_id_documents.py
@@ -65,14 +65,13 @@ class RecognizeIdDocumentsSample(object):
                 print("Date of Expiration: {} has confidence: {}".format(doe.value, doe.confidence))
             sex = id_document.fields.get("Sex")
             if sex:
-                print("Sex: {} has confidence: {}".format(sex.value_data.text, sex.confidence))
+                print("Sex: {} has confidence: {}".format(sex.value, sex.confidence))
             address = id_document.fields.get("Address")
             if address:
                 print("Address: {} has confidence: {}".format(address.value, address.confidence))
-            # FIXME: uncomment this
-            # country = id_document.fields.get("Country")
-            # if country:
-            #     print("Country: {} has confidence: {}".format(country.value, country.confidence))
+            country = id_document.fields.get("Country")
+            if country:
+                print("Country: {} has confidence: {}".format(country.value, country.confidence))
             region = id_document.fields.get("Region")
             if region:
                 print("Region: {} has confidence: {}".format(region.value, region.confidence))

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents.test_id_document_jpg.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents.test_id_document_jpg.yaml
@@ -14,7 +14,7 @@ interactions:
       Content-Type:
       - image/jpeg
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyze?includeTextDetails=false
   response:
@@ -22,19 +22,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 24c2fb17-cf3b-416a-ad0c-78cb0d8d0990
+      - c72bba2f-706e-4163-bf19-e590c8860f52
       content-length:
       - '0'
       date:
-      - Thu, 18 Mar 2021 21:25:03 GMT
+      - Fri, 26 Mar 2021 03:48:47 GMT
       operation-location:
-      - https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/24c2fb17-cf3b-416a-ad0c-78cb0d8d0990
+      - https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/c72bba2f-706e-4163-bf19-e590c8860f52
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '85'
+      - '363'
     status:
       code: 202
       message: Accepted
@@ -48,13 +48,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/24c2fb17-cf3b-416a-ad0c-78cb0d8d0990
+    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/c72bba2f-706e-4163-bf19-e590c8860f52
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2021-03-18T21:25:04Z",
-        "lastUpdatedDateTime": "2021-03-18T21:25:07Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2021-03-26T03:48:47Z",
+        "lastUpdatedDateTime": "2021-03-26T03:48:50Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": -0.2823, "width": 450, "height":
         294, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:idDocument:driverLicense",
         "docTypeConfidence": 0.995, "pageRange": [1, 1], "fields": {"Address": {"type":
@@ -78,19 +78,19 @@ interactions:
         "page": 1, "confidence": 0.99}}}]}}'
     headers:
       apim-request-id:
-      - 7723f250-9c3c-4160-bb18-6f8aab72df13
+      - 5217754b-22cf-405b-b879-cc9c73ff1b97
       content-length:
       - '1587'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 18 Mar 2021 21:25:09 GMT
+      - Fri, 26 Mar 2021 03:48:52 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '22'
+      - '88'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents.test_id_document_jpg_include_field_elements.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents.test_id_document_jpg_include_field_elements.yaml
@@ -14,7 +14,7 @@ interactions:
       Content-Type:
       - image/jpeg
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyze?includeTextDetails=true
   response:
@@ -22,19 +22,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - c9c4f21c-99bf-4276-b030-47488fbcda5e
+      - 5c59ad38-0e95-4594-9f3d-158976b6f91a
       content-length:
       - '0'
       date:
-      - Thu, 18 Mar 2021 21:25:09 GMT
+      - Fri, 26 Mar 2021 03:41:27 GMT
       operation-location:
-      - https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/c9c4f21c-99bf-4276-b030-47488fbcda5e
+      - https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/5c59ad38-0e95-4594-9f3d-158976b6f91a
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '84'
+      - '514'
     status:
       code: 202
       message: Accepted
@@ -48,13 +48,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/c9c4f21c-99bf-4276-b030-47488fbcda5e
+    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/5c59ad38-0e95-4594-9f3d-158976b6f91a
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2021-03-18T21:25:10Z",
-        "lastUpdatedDateTime": "2021-03-18T21:25:13Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2021-03-26T03:41:27Z",
+        "lastUpdatedDateTime": "2021-03-26T03:41:30Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": -0.2823, "width": 450, "height":
         294, "unit": "pixel", "lines": [{"text": "USA WASHINGTON", "boundingBox":
         [17, 25, 232, 22, 233, 47, 17, 49], "words": [{"text": "USA", "boundingBox":
@@ -204,19 +204,19 @@ interactions:
         ["#/readResults/0/lines/13/words/2"]}}}]}}'
     headers:
       apim-request-id:
-      - 7d6387d9-9508-4edd-9940-a56d8a043f3c
+      - f792d4c5-6125-443f-a25b-5dd996e1dc66
       content-length:
       - '10387'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 18 Mar 2021 21:25:15 GMT
+      - Fri, 26 Mar 2021 03:41:32 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '20'
+      - '116'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents_async.test_id_document_jpg.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents_async.test_id_document_jpg.yaml
@@ -8,20 +8,20 @@ interactions:
       Content-Type:
       - image/jpeg
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyze?includeTextDetails=false
   response:
     body:
       string: ''
     headers:
-      apim-request-id: db7a3e39-800b-49a0-aaa8-c64297c07849
+      apim-request-id: 7f18b604-bc96-428f-9787-1633a3e72f04
       content-length: '0'
-      date: Thu, 18 Mar 2021 19:52:15 GMT
-      operation-location: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/db7a3e39-800b-49a0-aaa8-c64297c07849
+      date: Fri, 26 Mar 2021 03:45:40 GMT
+      operation-location: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/7f18b604-bc96-428f-9787-1633a3e72f04
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '90'
+      x-envoy-upstream-service-time: '191'
     status:
       code: 202
       message: Accepted
@@ -30,13 +30,13 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/db7a3e39-800b-49a0-aaa8-c64297c07849
+    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/7f18b604-bc96-428f-9787-1633a3e72f04
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2021-03-18T19:52:15Z",
-        "lastUpdatedDateTime": "2021-03-18T19:52:19Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2021-03-26T03:45:40Z",
+        "lastUpdatedDateTime": "2021-03-26T03:45:42Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": -0.2823, "width": 450, "height":
         294, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:idDocument:driverLicense",
         "docTypeConfidence": 0.995, "pageRange": [1, 1], "fields": {"Address": {"type":
@@ -59,15 +59,15 @@ interactions:
         "M", "text": "M", "boundingBox": [226, 190, 232, 190, 233, 201, 226, 201],
         "page": 1, "confidence": 0.99}}}]}}'
     headers:
-      apim-request-id: fac5d868-10d5-44ea-8e4a-fbc319f74e42
+      apim-request-id: 1896353b-9122-4edf-95cd-e9e0dbab373f
       content-length: '1587'
       content-type: application/json; charset=utf-8
-      date: Thu, 18 Mar 2021 19:52:20 GMT
+      date: Fri, 26 Mar 2021 03:45:45 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '21'
+      x-envoy-upstream-service-time: '71'
     status:
       code: 200
       message: OK
-    url: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/db7a3e39-800b-49a0-aaa8-c64297c07849
+    url: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/7f18b604-bc96-428f-9787-1633a3e72f04
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents_async.test_id_document_jpg_include_field_elements.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents_async.test_id_document_jpg_include_field_elements.yaml
@@ -8,20 +8,20 @@ interactions:
       Content-Type:
       - image/jpeg
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyze?includeTextDetails=true
   response:
     body:
       string: ''
     headers:
-      apim-request-id: 1b1ec656-a9c3-4cf9-8b82-debff0b5b6e8
+      apim-request-id: aa35dcf3-0fbf-43c0-bd01-96a4c327c970
       content-length: '0'
-      date: Thu, 18 Mar 2021 19:52:21 GMT
-      operation-location: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/1b1ec656-a9c3-4cf9-8b82-debff0b5b6e8
+      date: Fri, 26 Mar 2021 03:45:28 GMT
+      operation-location: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/aa35dcf3-0fbf-43c0-bd01-96a4c327c970
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '411'
+      x-envoy-upstream-service-time: '90'
     status:
       code: 202
       message: Accepted
@@ -30,13 +30,13 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/1b1ec656-a9c3-4cf9-8b82-debff0b5b6e8
+    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/aa35dcf3-0fbf-43c0-bd01-96a4c327c970
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2021-03-18T19:52:21Z",
-        "lastUpdatedDateTime": "2021-03-18T19:52:25Z", "analyzeResult": {"version":
+      string: '{"status": "succeeded", "createdDateTime": "2021-03-26T03:45:29Z",
+        "lastUpdatedDateTime": "2021-03-26T03:45:32Z", "analyzeResult": {"version":
         "2.1.0", "readResults": [{"page": 1, "angle": -0.2823, "width": 450, "height":
         294, "unit": "pixel", "lines": [{"text": "USA WASHINGTON", "boundingBox":
         [17, 25, 232, 22, 233, 47, 17, 49], "words": [{"text": "USA", "boundingBox":
@@ -185,15 +185,15 @@ interactions:
         [226, 190, 232, 190, 233, 201, 226, 201], "page": 1, "confidence": 0.99, "elements":
         ["#/readResults/0/lines/13/words/2"]}}}]}}'
     headers:
-      apim-request-id: 3576bbba-a46a-4a1a-b3bc-4f8ff3e01e88
+      apim-request-id: db31d339-c1a1-4e33-8105-a462667aea3c
       content-length: '10387'
       content-type: application/json; charset=utf-8
-      date: Thu, 18 Mar 2021 19:52:25 GMT
+      date: Fri, 26 Mar 2021 03:45:34 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '18'
+      x-envoy-upstream-service-time: '32'
     status:
       code: 200
       message: OK
-    url: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/1b1ec656-a9c3-4cf9-8b82-debff0b5b6e8
+    url: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/aa35dcf3-0fbf-43c0-bd01-96a4c327c970
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents_from_url.test_id_document_jpg.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents_from_url.test_id_document_jpg.yaml
@@ -9,11 +9,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '216'
+      - '218'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyze?includeTextDetails=false
   response:
@@ -21,19 +21,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 2b7822e2-acd3-43c1-902b-c3ab6ebdff95
+      - 64a9220a-6d6b-4907-983e-c03fb2c092b3
       content-length:
       - '0'
       date:
-      - Fri, 05 Mar 2021 17:39:39 GMT
+      - Fri, 26 Mar 2021 03:51:00 GMT
       operation-location:
-      - https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/2b7822e2-acd3-43c1-902b-c3ab6ebdff95
+      - https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/64a9220a-6d6b-4907-983e-c03fb2c092b3
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '543'
+      - '797'
     status:
       code: 202
       message: Accepted
@@ -47,49 +47,49 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/2b7822e2-acd3-43c1-902b-c3ab6ebdff95
+    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/64a9220a-6d6b-4907-983e-c03fb2c092b3
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2021-03-05T17:39:39Z",
-        "lastUpdatedDateTime": "2021-03-05T17:39:41Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": -0.4021, "width": 506, "height":
-        319, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:idDocument:driverLicense",
+      string: '{"status": "succeeded", "createdDateTime": "2021-03-26T03:51:01Z",
+        "lastUpdatedDateTime": "2021-03-26T03:51:04Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": -0.2823, "width": 450, "height":
+        294, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:idDocument:driverLicense",
         "docTypeConfidence": 0.995, "pageRange": [1, 1], "fields": {"Address": {"type":
-        "string", "valueString": "123 MAIN STREET APT. 1 HARRISBURG, PA 17101-0000",
-        "text": "123 MAIN STREET APT. 1 HARRISBURG, PA 17101-0000", "boundingBox":
-        [178, 161, 357, 161, 357, 195, 178, 195], "page": 1, "confidence": 0.906},
-        "Country": {"type": "country", "valueCountry": "USA", "confidence": 0.99},
-        "DateOfBirth": {"type": "date", "valueDate": "1975-08-04", "text": "08/04/1975",
-        "boundingBox": [215, 93, 309, 92, 309, 109, 215, 108], "page": 1, "confidence":
-        0.995}, "DateOfExpiration": {"type": "date", "valueDate": "2023-08-05", "text":
-        "08/05/2023", "boundingBox": [215, 113, 307, 112, 307, 129, 215, 129], "page":
-        1, "confidence": 0.99}, "DocumentNumber": {"type": "string", "valueString":
-        "99 999 999", "text": "99 999 999", "boundingBox": [216, 74, 307, 74, 307,
-        91, 216, 91], "page": 1, "confidence": 0.991}, "FirstName": {"type": "string",
-        "valueString": "JANICE ANN", "text": "JANICE ANN", "boundingBox": [177, 147,
-        264, 147, 264, 161, 177, 161], "page": 1, "confidence": 0.987}, "LastName":
-        {"type": "string", "valueString": "SAMPLE", "text": "SAMPLE", "boundingBox":
-        [178, 135, 237, 134, 236, 147, 179, 147], "page": 1, "confidence": 0.986},
-        "Region": {"type": "string", "valueString": "Pennsylvania", "confidence":
-        0.99}, "Sex": {"type": "gender", "valueGender": "F", "text": "F", "boundingBox":
-        [210, 199, 216, 199, 217, 211, 210, 211], "page": 1, "confidence": 0.99}}}]}}'
+        "string", "valueString": "123 STREET ADDRESS YOUR CITY WA 99999-1234", "text":
+        "123 STREET ADDRESS YOUR CITY WA 99999-1234", "boundingBox": [158, 151, 326,
+        151, 326, 177, 158, 177], "page": 1, "confidence": 0.965}, "Country": {"type":
+        "country", "valueCountry": "USA", "confidence": 0.99}, "DateOfBirth": {"type":
+        "date", "valueDate": "1958-01-06", "text": "01/06/1958", "boundingBox": [187,
+        133, 272, 132, 272, 148, 187, 149], "page": 1, "confidence": 0.99}, "DateOfExpiration":
+        {"type": "date", "valueDate": "2020-08-12", "text": "08/12/2020", "boundingBox":
+        [332, 230, 414, 228, 414, 244, 332, 245], "page": 1, "confidence": 0.99},
+        "DocumentNumber": {"type": "string", "valueString": "LICWDLACD5DG", "text":
+        "LIC#WDLABCD456DG", "boundingBox": [162, 70, 307, 68, 307, 84, 163, 85], "page":
+        1, "confidence": 0.99}, "FirstName": {"type": "string", "valueString": "LIAM
+        R.", "text": "LIAM R.", "boundingBox": [158, 102, 216, 102, 216, 116, 158,
+        116], "page": 1, "confidence": 0.985}, "LastName": {"type": "string", "valueString":
+        "TALBOT", "text": "TALBOT", "boundingBox": [160, 86, 213, 85, 213, 99, 160,
+        100], "page": 1, "confidence": 0.987}, "Region": {"type": "string", "valueString":
+        "Washington", "confidence": 0.99}, "Sex": {"type": "gender", "valueGender":
+        "M", "text": "M", "boundingBox": [226, 190, 232, 190, 233, 201, 226, 201],
+        "page": 1, "confidence": 0.99}}}]}}'
     headers:
       apim-request-id:
-      - 839db9a4-6a6a-4b03-89e2-74d5aa47e4c9
+      - 9f2a93cf-cfbc-47a9-9786-18e3c7cda6ee
       content-length:
-      - '1602'
+      - '1587'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 05 Mar 2021 17:39:43 GMT
+      - Fri, 26 Mar 2021 03:51:06 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '18'
+      - '25'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents_from_url.test_id_document_jpg_include_field_elements.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents_from_url.test_id_document_jpg_include_field_elements.yaml
@@ -9,11 +9,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '216'
+      - '218'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyze?includeTextDetails=true
   response:
@@ -21,19 +21,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 3b71a732-87e5-4e09-838c-a3a76deb86fe
+      - 2be51958-f5c0-49cb-8139-32ff0431a6d9
       content-length:
       - '0'
       date:
-      - Fri, 05 Mar 2021 17:39:44 GMT
+      - Fri, 26 Mar 2021 03:51:11 GMT
       operation-location:
-      - https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/3b71a732-87e5-4e09-838c-a3a76deb86fe
+      - https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/2be51958-f5c0-49cb-8139-32ff0431a6d9
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '142'
+      - '659'
     status:
       code: 202
       message: Accepted
@@ -47,184 +47,175 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/3b71a732-87e5-4e09-838c-a3a76deb86fe
+    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/2be51958-f5c0-49cb-8139-32ff0431a6d9
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2021-03-05T17:39:45Z",
-        "lastUpdatedDateTime": "2021-03-05T17:39:47Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": -0.4021, "width": 506, "height":
-        319, "unit": "pixel", "lines": [{"text": "Pennsylvania", "boundingBox": [23,
-        20, 222, 23, 222, 69, 23, 67], "words": [{"text": "Pennsylvania", "boundingBox":
-        [26, 20, 220, 26, 221, 64, 23, 64], "confidence": 0.254}], "appearance": {"style":
-        {"name": "other", "confidence": 0.878}}}, {"text": "DRIVER''S LICENSE", "boundingBox":
-        [256, 16, 454, 16, 454, 33, 256, 34], "words": [{"text": "DRIVER''S", "boundingBox":
-        [257, 17, 351, 16, 352, 34, 257, 35], "confidence": 0.87}, {"text": "LICENSE",
-        "boundingBox": [360, 16, 448, 16, 447, 34, 360, 34], "confidence": 0.996}],
+      string: '{"status": "succeeded", "createdDateTime": "2021-03-26T03:51:12Z",
+        "lastUpdatedDateTime": "2021-03-26T03:51:14Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": -0.2823, "width": 450, "height":
+        294, "unit": "pixel", "lines": [{"text": "USA WASHINGTON", "boundingBox":
+        [17, 25, 232, 22, 233, 47, 17, 49], "words": [{"text": "USA", "boundingBox":
+        [18, 34, 42, 31, 41, 48, 18, 49], "confidence": 0.931}, {"text": "WASHINGTON",
+        "boundingBox": [45, 30, 218, 25, 218, 48, 44, 48], "confidence": 0.991}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "USA", "boundingBox": [202, 59, 227, 58, 227, 69, 202, 70], "words": [{"text":
-        "USA", "boundingBox": [202, 59, 224, 58, 224, 69, 202, 70], "confidence":
-        0.994}], "appearance": {"style": {"name": "other", "confidence": 0.878}}},
-        {"text": "4d DLN: 99 999 999", "boundingBox": [166, 75, 313, 73, 314, 90,
-        167, 92], "words": [{"text": "4d", "boundingBox": [168, 78, 180, 77, 181,
-        91, 169, 91], "confidence": 0.996}, {"text": "DLN:", "boundingBox": [183,
-        77, 213, 76, 213, 91, 183, 91], "confidence": 0.959}, {"text": "99", "boundingBox":
-        [216, 75, 235, 75, 235, 91, 216, 91], "confidence": 0.994}, {"text": "999",
-        "boundingBox": [242, 74, 271, 74, 271, 90, 242, 91], "confidence": 0.994},
-        {"text": "999", "boundingBox": [279, 74, 307, 74, 307, 90, 279, 90], "confidence":
-        0.999}], "appearance": {"style": {"name": "other", "confidence": 0.878}}},
-        {"text": "3 DOB: 08/04/1975", "boundingBox": [170, 92, 312, 91, 313, 108,
-        170, 109], "words": [{"text": "3", "boundingBox": [170, 95, 178, 95, 179,
-        109, 170, 109], "confidence": 0.994}, {"text": "DOB:", "boundingBox": [181,
-        95, 212, 93, 213, 108, 182, 109], "confidence": 0.993}, {"text": "08/04/1975",
-        "boundingBox": [215, 93, 309, 92, 309, 109, 215, 108], "confidence": 0.994}],
+        "WA", "boundingBox": [17, 24, 39, 25, 39, 37, 18, 36], "words": [{"text":
+        "WA", "boundingBox": [18, 24, 37, 25, 36, 37, 17, 36], "confidence": 0.997}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "DUPS: 00", "boundingBox": [358, 76, 416, 74, 417, 89, 358, 91], "words":
-        [{"text": "DUPS:", "boundingBox": [358, 77, 390, 76, 390, 91, 359, 91], "confidence":
-        0.991}, {"text": "00", "boundingBox": [392, 76, 412, 74, 412, 90, 393, 91],
-        "confidence": 0.994}], "appearance": {"style": {"name": "other", "confidence":
-        0.878}}}, {"text": "123", "boundingBox": [21, 94, 21, 79, 30, 79, 31, 94],
-        "words": [{"text": "123", "boundingBox": [22, 94, 21, 79, 31, 79, 31, 93],
-        "confidence": 0.952}], "appearance": {"style": {"name": "other", "confidence":
-        0.878}}}, {"text": "4b EXP: 08/05/2023", "boundingBox": [168, 112, 313, 111,
-        313, 128, 168, 129], "words": [{"text": "4b", "boundingBox": [168, 116, 179,
-        115, 179, 128, 169, 128], "confidence": 0.967}, {"text": "EXP:", "boundingBox":
-        [181, 115, 210, 113, 210, 129, 182, 128], "confidence": 0.979}, {"text": "08/05/2023",
-        "boundingBox": [215, 113, 307, 112, 307, 129, 215, 129], "confidence": 0.994}],
+        "DRIVER LICENSE", "boundingBox": [274, 27, 401, 27, 401, 42, 274, 43], "words":
+        [{"text": "DRIVER", "boundingBox": [275, 27, 329, 28, 328, 43, 275, 43], "confidence":
+        0.994}, {"text": "LICENSE", "boundingBox": [333, 28, 398, 28, 397, 43, 333,
+        43], "confidence": 0.996}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "FEDERAL LIMITS APPLY", "boundingBox": [258, 49, 414, 49,
+        414, 62, 259, 63], "words": [{"text": "FEDERAL", "boundingBox": [259, 50,
+        319, 50, 319, 64, 259, 63], "confidence": 0.994}, {"text": "LIMITS", "boundingBox":
+        [321, 50, 364, 50, 364, 63, 322, 64], "confidence": 0.996}, {"text": "APPLY",
+        "boundingBox": [367, 50, 411, 49, 411, 63, 367, 63], "confidence": 0.996}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "da ISS: 03/01/2019", "boundingBox": [340, 112, 479, 111, 479, 128, 340, 130],
-        "words": [{"text": "da", "boundingBox": [343, 114, 354, 114, 355, 129, 344,
-        130], "confidence": 0.18}, {"text": "ISS:", "boundingBox": [357, 114, 378,
-        113, 379, 129, 358, 129], "confidence": 0.527}, {"text": "03/01/2019", "boundingBox":
-        [381, 113, 476, 112, 475, 129, 382, 129], "confidence": 0.994}], "appearance":
-        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "1 SAMPLE", "boundingBox":
-        [168, 134, 242, 133, 242, 146, 168, 147], "words": [{"text": "1", "boundingBox":
-        [169, 135, 176, 135, 176, 147, 169, 147], "confidence": 0.934}, {"text": "SAMPLE",
-        "boundingBox": [178, 135, 237, 134, 236, 147, 179, 147], "confidence": 0.996}],
+        "4d LIC#WDLABCD456DG 9CLASS", "boundingBox": [150, 67, 366, 67, 365, 84, 150,
+        84], "words": [{"text": "4d", "boundingBox": [151, 70, 159, 70, 160, 85, 152,
+        85], "confidence": 0.474}, {"text": "LIC#WDLABCD456DG", "boundingBox": [162,
+        70, 307, 68, 307, 84, 163, 85], "confidence": 0.968}, {"text": "9CLASS", "boundingBox":
+        [318, 69, 364, 71, 364, 84, 318, 84], "confidence": 0.716}], "appearance":
+        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "DONORS", "boundingBox":
+        [376, 69, 431, 69, 431, 83, 377, 84], "words": [{"text": "DONORS", "boundingBox":
+        [380, 70, 431, 69, 432, 83, 381, 84], "confidence": 0.179}], "appearance":
+        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "1 TALBOT", "boundingBox":
+        [149, 85, 212, 85, 213, 99, 149, 99], "words": [{"text": "1", "boundingBox":
+        [150, 86, 157, 86, 157, 100, 150, 100], "confidence": 0.965}, {"text": "TALBOT",
+        "boundingBox": [160, 86, 213, 85, 213, 99, 160, 100], "confidence": 0.996}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "2 JANICE ANN", "boundingBox": [169, 147, 271, 146, 271, 159, 169, 160], "words":
-        [{"text": "2", "boundingBox": [169, 148, 174, 148, 175, 161, 170, 161], "confidence":
-        0.994}, {"text": "JANICE", "boundingBox": [177, 148, 229, 147, 230, 160, 177,
-        161], "confidence": 0.996}, {"text": "ANN", "boundingBox": [235, 147, 264,
-        147, 264, 160, 235, 160], "confidence": 0.997}], "appearance": {"style": {"name":
-        "other", "confidence": 0.878}}}, {"text": "8 123 MAIN STREET", "boundingBox":
-        [168, 160, 289, 161, 289, 173, 168, 173], "words": [{"text": "8", "boundingBox":
-        [169, 161, 176, 161, 175, 172, 169, 172], "confidence": 0.996}, {"text": "123",
-        "boundingBox": [179, 161, 199, 161, 199, 173, 179, 172], "confidence": 0.999},
-        {"text": "MAIN", "boundingBox": [202, 161, 232, 161, 232, 174, 202, 173],
-        "confidence": 0.994}, {"text": "STREET", "boundingBox": [238, 161, 287, 161,
-        287, 173, 238, 174], "confidence": 0.996}], "appearance": {"style": {"name":
-        "other", "confidence": 0.878}}}, {"text": "APT. 1", "boundingBox": [175, 172,
-        222, 171, 222, 184, 175, 185], "words": [{"text": "APT.", "boundingBox": [179,
-        173, 208, 172, 208, 185, 178, 185], "confidence": 0.985}, {"text": "1", "boundingBox":
-        [210, 172, 218, 172, 217, 184, 210, 184], "confidence": 0.996}], "appearance":
-        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "HARRISBURG,
-        PA 17101-0000", "boundingBox": [178, 181, 359, 181, 359, 195, 178, 195], "words":
-        [{"text": "HARRISBURG,", "boundingBox": [179, 182, 267, 181, 267, 195, 179,
-        195], "confidence": 0.989}, {"text": "PA", "boundingBox": [269, 181, 286,
-        181, 286, 195, 269, 195], "confidence": 0.997}, {"text": "17101-0000", "boundingBox":
-        [290, 181, 357, 182, 357, 195, 290, 195], "confidence": 0.994}], "appearance":
-        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "15 SEX: F 18
-        EYES: BRO", "boundingBox": [170, 198, 308, 198, 308, 211, 170, 211], "words":
-        [{"text": "15", "boundingBox": [170, 199, 180, 199, 180, 211, 170, 211], "confidence":
-        0.994}, {"text": "SEX:", "boundingBox": [182, 199, 208, 199, 208, 211, 182,
-        211], "confidence": 0.988}, {"text": "F", "boundingBox": [210, 199, 216, 199,
-        217, 211, 210, 211], "confidence": 0.996}, {"text": "18", "boundingBox": [230,
-        199, 241, 199, 241, 211, 230, 211], "confidence": 0.996}, {"text": "EYES:",
-        "boundingBox": [243, 199, 274, 198, 275, 211, 243, 211], "confidence": 0.995},
-        {"text": "BRO", "boundingBox": [277, 198, 302, 198, 303, 211, 277, 211], "confidence":
-        0.997}], "appearance": {"style": {"name": "other", "confidence": 0.878}}},
-        {"text": "16 HGT: 5''-06\"", "boundingBox": [170, 210, 247, 209, 247, 221,
-        170, 222], "words": [{"text": "16", "boundingBox": [171, 211, 180, 211, 180,
-        222, 171, 222], "confidence": 0.962}, {"text": "HGT:", "boundingBox": [182,
-        211, 210, 211, 210, 222, 182, 222], "confidence": 0.987}, {"text": "5''-06\"",
-        "boundingBox": [212, 211, 247, 209, 247, 222, 212, 222], "confidence": 0.945}],
+        "2 LIAM R.", "boundingBox": [150, 101, 215, 101, 215, 116, 150, 116], "words":
+        [{"text": "2", "boundingBox": [151, 102, 155, 102, 155, 116, 151, 116], "confidence":
+        0.994}, {"text": "LIAM", "boundingBox": [158, 102, 190, 102, 190, 116, 158,
+        116], "confidence": 0.991}, {"text": "R.", "boundingBox": [197, 102, 215,
+        102, 216, 116, 197, 116], "confidence": 0.996}], "appearance": {"style": {"name":
+        "other", "confidence": 0.878}}}, {"text": "3 DOB 01/06/1958", "boundingBox":
+        [151, 133, 274, 131, 274, 147, 151, 149], "words": [{"text": "3", "boundingBox":
+        [151, 135, 156, 135, 156, 149, 152, 149], "confidence": 0.994}, {"text": "DOB",
+        "boundingBox": [159, 134, 184, 133, 184, 149, 159, 149], "confidence": 0.998},
+        {"text": "01/06/1958", "boundingBox": [187, 133, 272, 132, 272, 148, 187,
+        149], "confidence": 0.994}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "4a ISS 01/06/2015", "boundingBox": [313, 133, 435, 131,
+        435, 147, 313, 149], "words": [{"text": "4a", "boundingBox": [314, 135, 324,
+        135, 325, 149, 314, 149], "confidence": 0.994}, {"text": "ISS", "boundingBox":
+        [327, 134, 345, 134, 345, 149, 328, 149], "confidence": 0.481}, {"text": "01/06/2015",
+        "boundingBox": [348, 133, 431, 132, 431, 148, 348, 149], "confidence": 0.994}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "IBERTY", "boundingBox": [357, 205, 393, 210, 391, 223, 355, 217], "words":
-        [{"text": "IBERTY", "boundingBox": [357, 206, 393, 211, 391, 223, 356, 218],
-        "confidence": 0.21}], "appearance": {"style": {"name": "other", "confidence":
-        0.878}}}, {"text": "9 CLASS: C", "boundingBox": [169, 226, 242, 225, 243,
-        237, 169, 238], "words": [{"text": "9", "boundingBox": [170, 227, 177, 227,
-        177, 238, 170, 238], "confidence": 0.994}, {"text": "CLASS:", "boundingBox":
-        [182, 227, 223, 226, 223, 238, 182, 237], "confidence": 0.995}, {"text": "C",
-        "boundingBox": [225, 226, 231, 226, 231, 238, 225, 238], "confidence": 0.996}],
+        "8 123 STREET ADDRESS", "boundingBox": [151, 151, 303, 150, 303, 164, 151,
+        164], "words": [{"text": "8", "boundingBox": [151, 151, 156, 151, 156, 165,
+        152, 165], "confidence": 0.588}, {"text": "123", "boundingBox": [158, 151,
+        180, 151, 181, 165, 159, 165], "confidence": 0.997}, {"text": "STREET", "boundingBox":
+        [183, 151, 234, 151, 235, 164, 184, 165], "confidence": 0.996}, {"text": "ADDRESS",
+        "boundingBox": [237, 151, 301, 151, 301, 165, 237, 164], "confidence": 0.995}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "9a END: NONE", "boundingBox": [168, 238, 251, 237, 251, 248, 168, 249], "words":
-        [{"text": "9a", "boundingBox": [169, 238, 180, 238, 180, 249, 169, 249], "confidence":
-        0.994}, {"text": "END:", "boundingBox": [183, 238, 210, 238, 209, 249, 182,
-        249], "confidence": 0.987}, {"text": "NONE", "boundingBox": [212, 238, 246,
-        237, 246, 249, 211, 249], "confidence": 0.994}], "appearance": {"style": {"name":
-        "other", "confidence": 0.878}}}, {"text": "12 RESTR: NONE", "boundingBox":
-        [169, 248, 264, 247, 264, 260, 169, 261], "words": [{"text": "12", "boundingBox":
-        [170, 249, 180, 249, 180, 261, 170, 261], "confidence": 0.994}, {"text": "RESTR:",
-        "boundingBox": [182, 249, 221, 249, 221, 261, 182, 261], "confidence": 0.995},
-        {"text": "NONE", "boundingBox": [223, 249, 260, 248, 260, 260, 224, 261],
-        "confidence": 0.994}], "appearance": {"style": {"name": "other", "confidence":
-        0.878}}}, {"text": "SAMPLE", "boundingBox": [27, 255, 26, 185, 41, 185, 42,
-        255], "words": [{"text": "SAMPLE", "boundingBox": [28, 254, 27, 191, 42, 192,
-        42, 254], "confidence": 0.996}], "appearance": {"style": {"name": "other",
-        "confidence": 0.878}}}, {"text": "damice famale BE 5 DD:1234567890123", "boundingBox":
-        [23, 263, 324, 265, 324, 293, 23, 292], "words": [{"text": "damice", "boundingBox":
-        [23, 265, 97, 264, 98, 292, 25, 293], "confidence": 0.742}, {"text": "famale",
-        "boundingBox": [103, 264, 184, 266, 184, 289, 104, 291], "confidence": 0.184},
-        {"text": "BE", "boundingBox": [189, 266, 213, 267, 213, 288, 190, 289], "confidence":
-        0.178}, {"text": "5", "boundingBox": [219, 268, 222, 268, 222, 288, 219, 288],
-        "confidence": 0.93}, {"text": "DD:1234567890123", "boundingBox": [228, 268,
-        325, 278, 324, 284, 228, 288], "confidence": 0.798}], "appearance": {"style":
-        {"name": "other", "confidence": 0.821}}}, {"text": "DL", "boundingBox": [347,
-        248, 387, 249, 385, 273, 346, 271], "words": [{"text": "DL", "boundingBox":
-        [346, 248, 379, 249, 378, 273, 346, 271], "confidence": 0.994}], "appearance":
-        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "456789012345",
-        "boundingBox": [246, 283, 320, 283, 320, 293, 246, 294], "words": [{"text":
-        "456789012345", "boundingBox": [247, 285, 316, 283, 316, 294, 247, 293], "confidence":
-        0.968}], "appearance": {"style": {"name": "other", "confidence": 0.878}}},
-        {"text": "ORGAN DONOR", "boundingBox": [371, 285, 472, 285, 472, 299, 371,
-        299], "words": [{"text": "ORGAN", "boundingBox": [372, 287, 415, 287, 415,
-        299, 372, 299], "confidence": 0.994}, {"text": "DONOR", "boundingBox": [420,
-        287, 465, 286, 466, 299, 420, 299], "confidence": 0.996}], "appearance": {"style":
-        {"name": "other", "confidence": 0.878}}}]}], "documentResults": [{"docType":
-        "prebuilt:idDocument:driverLicense", "docTypeConfidence": 0.995, "pageRange":
-        [1, 1], "fields": {"Address": {"type": "string", "valueString": "123 MAIN
-        STREET APT. 1 HARRISBURG, PA 17101-0000", "text": "123 MAIN STREET APT. 1
-        HARRISBURG, PA 17101-0000", "boundingBox": [178, 161, 357, 161, 357, 195,
-        178, 195], "page": 1, "confidence": 0.906, "elements": ["#/readResults/0/lines/11/words/1",
-        "#/readResults/0/lines/11/words/2", "#/readResults/0/lines/11/words/3", "#/readResults/0/lines/12/words/0",
-        "#/readResults/0/lines/12/words/1", "#/readResults/0/lines/13/words/0", "#/readResults/0/lines/13/words/1",
-        "#/readResults/0/lines/13/words/2"]}, "Country": {"type": "country", "valueCountry":
-        "USA", "confidence": 0.99}, "DateOfBirth": {"type": "date", "valueDate": "1975-08-04",
-        "text": "08/04/1975", "boundingBox": [215, 93, 309, 92, 309, 109, 215, 108],
-        "page": 1, "confidence": 0.995, "elements": ["#/readResults/0/lines/4/words/2"]},
-        "DateOfExpiration": {"type": "date", "valueDate": "2023-08-05", "text": "08/05/2023",
-        "boundingBox": [215, 113, 307, 112, 307, 129, 215, 129], "page": 1, "confidence":
-        0.99, "elements": ["#/readResults/0/lines/7/words/2"]}, "DocumentNumber":
-        {"type": "string", "valueString": "99 999 999", "text": "99 999 999", "boundingBox":
-        [216, 74, 307, 74, 307, 91, 216, 91], "page": 1, "confidence": 0.991, "elements":
-        ["#/readResults/0/lines/3/words/2", "#/readResults/0/lines/3/words/3", "#/readResults/0/lines/3/words/4"]},
-        "FirstName": {"type": "string", "valueString": "JANICE ANN", "text": "JANICE
-        ANN", "boundingBox": [177, 147, 264, 147, 264, 161, 177, 161], "page": 1,
-        "confidence": 0.987, "elements": ["#/readResults/0/lines/10/words/1", "#/readResults/0/lines/10/words/2"]},
-        "LastName": {"type": "string", "valueString": "SAMPLE", "text": "SAMPLE",
-        "boundingBox": [178, 135, 237, 134, 236, 147, 179, 147], "page": 1, "confidence":
-        0.986, "elements": ["#/readResults/0/lines/9/words/1"]}, "Region": {"type":
-        "string", "valueString": "Pennsylvania", "confidence": 0.99}, "Sex": {"type":
-        "gender", "valueGender": "F", "text": "F", "boundingBox": [210, 199, 216,
-        199, 217, 211, 210, 211], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/14/words/2"]}}}]}}'
+        "YOUR CITY WA 99999-1234", "boundingBox": [157, 163, 327, 163, 327, 176, 157,
+        176], "words": [{"text": "YOUR", "boundingBox": [158, 164, 193, 164, 194,
+        177, 159, 177], "confidence": 0.869}, {"text": "CITY", "boundingBox": [198,
+        164, 229, 164, 229, 177, 198, 177], "confidence": 0.98}, {"text": "WA", "boundingBox":
+        [232, 164, 251, 164, 252, 177, 232, 177], "confidence": 0.997}, {"text": "99999-1234",
+        "boundingBox": [256, 164, 326, 163, 326, 177, 256, 177], "confidence": 0.994}],
+        "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
+        "20 1234567XX1101", "boundingBox": [10, 173, 10, 81, 21, 81, 21, 173], "words":
+        [{"text": "20", "boundingBox": [10, 173, 10, 162, 21, 162, 21, 173], "confidence":
+        0.999}, {"text": "1234567XX1101", "boundingBox": [10, 154, 10, 82, 21, 82,
+        21, 154], "confidence": 0.922}], "appearance": {"style": {"name": "other",
+        "confidence": 0.878}}}, {"text": "15 SEX M", "boundingBox": [185, 190, 240,
+        189, 240, 201, 185, 202], "words": [{"text": "15", "boundingBox": [186, 191,
+        196, 191, 196, 202, 186, 202], "confidence": 0.994}, {"text": "SEX", "boundingBox":
+        [199, 191, 220, 190, 220, 201, 199, 202], "confidence": 0.998}, {"text": "M",
+        "boundingBox": [226, 190, 232, 190, 233, 201, 226, 201], "confidence": 0.996}],
+        "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
+        "16 HGT 5''-08\"", "boundingBox": [185, 202, 265, 199, 266, 212, 185, 215],
+        "words": [{"text": "16", "boundingBox": [186, 203, 196, 203, 196, 214, 185,
+        214], "confidence": 0.994}, {"text": "HGT", "boundingBox": [198, 203, 222,
+        202, 222, 214, 198, 214], "confidence": 0.998}, {"text": "5''-08\"", "boundingBox":
+        [226, 202, 263, 200, 263, 213, 226, 214], "confidence": 0.986}], "appearance":
+        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "18 EYES BLU",
+        "boundingBox": [293, 189, 368, 188, 368, 200, 293, 202], "words": [{"text":
+        "18", "boundingBox": [294, 190, 304, 190, 305, 202, 294, 202], "confidence":
+        0.994}, {"text": "EYES", "boundingBox": [307, 190, 336, 189, 336, 202, 307,
+        202], "confidence": 0.993}, {"text": "BLU", "boundingBox": [339, 189, 362,
+        188, 362, 201, 339, 202], "confidence": 0.994}], "appearance": {"style": {"name":
+        "other", "confidence": 0.878}}}, {"text": "17 WGT 165 lb", "boundingBox":
+        [293, 202, 374, 200, 375, 213, 294, 215], "words": [{"text": "17", "boundingBox":
+        [294, 203, 305, 203, 305, 215, 294, 215], "confidence": 0.994}, {"text": "WGT",
+        "boundingBox": [307, 203, 334, 202, 334, 214, 307, 215], "confidence": 0.998},
+        {"text": "165", "boundingBox": [336, 202, 357, 201, 357, 214, 336, 214], "confidence":
+        0.998}, {"text": "lb", "boundingBox": [360, 201, 372, 201, 372, 214, 360,
+        214], "confidence": 0.408}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "12 RESTRICTIONS 9a END L", "boundingBox": [185, 216, 345,
+        214, 346, 227, 185, 229], "words": [{"text": "12", "boundingBox": [186, 217,
+        195, 217, 195, 229, 186, 229], "confidence": 0.994}, {"text": "RESTRICTIONS",
+        "boundingBox": [198, 217, 281, 216, 281, 228, 198, 229], "confidence": 0.994},
+        {"text": "9a", "boundingBox": [292, 216, 305, 216, 305, 228, 292, 228], "confidence":
+        0.994}, {"text": "END", "boundingBox": [307, 216, 330, 215, 330, 228, 307,
+        228], "confidence": 0.998}, {"text": "L", "boundingBox": [335, 215, 341, 215,
+        341, 228, 335, 228], "confidence": 0.996}], "appearance": {"style": {"name":
+        "other", "confidence": 0.878}}}, {"text": "B", "boundingBox": [231, 229, 241,
+        229, 241, 241, 231, 240], "words": [{"text": "B", "boundingBox": [231, 229,
+        239, 229, 238, 241, 231, 240], "confidence": 0.994}], "appearance": {"style":
+        {"name": "other", "confidence": 0.878}}}, {"text": "4b EXP 08/12/2020", "boundingBox":
+        [293, 230, 417, 228, 418, 243, 293, 245], "words": [{"text": "4b", "boundingBox":
+        [294, 232, 305, 231, 305, 245, 294, 245], "confidence": 0.932}, {"text": "EXP",
+        "boundingBox": [308, 231, 329, 230, 329, 245, 308, 245], "confidence": 0.991},
+        {"text": "08/12/2020", "boundingBox": [332, 230, 414, 228, 414, 244, 332,
+        245], "confidence": 0.986}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "5 DDWDLABCD456DG1234567XX1101", "boundingBox": [152, 261,
+        355, 260, 355, 273, 152, 274], "words": [{"text": "5", "boundingBox": [153,
+        262, 158, 262, 158, 274, 153, 274], "confidence": 0.986}, {"text": "DDWDLABCD456DG1234567XX1101",
+        "boundingBox": [161, 262, 355, 261, 356, 274, 161, 274], "confidence": 0.947}],
+        "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
+        "Veteran", "boundingBox": [389, 258, 437, 259, 436, 271, 389, 270], "words":
+        [{"text": "Veteran", "boundingBox": [390, 259, 434, 260, 434, 271, 390, 271],
+        "confidence": 0.996}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "REV 07/01/2018", "boundingBox": [366, 274, 436, 274, 436,
+        284, 366, 285], "words": [{"text": "REV", "boundingBox": [366, 275, 384, 275,
+        384, 285, 366, 285], "confidence": 0.994}, {"text": "07/01/2018", "boundingBox":
+        [386, 275, 435, 275, 434, 285, 386, 285], "confidence": 0.991}], "appearance":
+        {"style": {"name": "other", "confidence": 0.878}}}]}], "documentResults":
+        [{"docType": "prebuilt:idDocument:driverLicense", "docTypeConfidence": 0.995,
+        "pageRange": [1, 1], "fields": {"Address": {"type": "string", "valueString":
+        "123 STREET ADDRESS YOUR CITY WA 99999-1234", "text": "123 STREET ADDRESS
+        YOUR CITY WA 99999-1234", "boundingBox": [158, 151, 326, 151, 326, 177, 158,
+        177], "page": 1, "confidence": 0.965, "elements": ["#/readResults/0/lines/10/words/1",
+        "#/readResults/0/lines/10/words/2", "#/readResults/0/lines/10/words/3", "#/readResults/0/lines/11/words/0",
+        "#/readResults/0/lines/11/words/1", "#/readResults/0/lines/11/words/2", "#/readResults/0/lines/11/words/3"]},
+        "Country": {"type": "country", "valueCountry": "USA", "confidence": 0.99},
+        "DateOfBirth": {"type": "date", "valueDate": "1958-01-06", "text": "01/06/1958",
+        "boundingBox": [187, 133, 272, 132, 272, 148, 187, 149], "page": 1, "confidence":
+        0.99, "elements": ["#/readResults/0/lines/8/words/2"]}, "DateOfExpiration":
+        {"type": "date", "valueDate": "2020-08-12", "text": "08/12/2020", "boundingBox":
+        [332, 230, 414, 228, 414, 244, 332, 245], "page": 1, "confidence": 0.99, "elements":
+        ["#/readResults/0/lines/19/words/2"]}, "DocumentNumber": {"type": "string",
+        "valueString": "LICWDLACD5DG", "text": "LIC#WDLABCD456DG", "boundingBox":
+        [162, 70, 307, 68, 307, 84, 163, 85], "page": 1, "confidence": 0.99, "elements":
+        ["#/readResults/0/lines/4/words/1"]}, "FirstName": {"type": "string", "valueString":
+        "LIAM R.", "text": "LIAM R.", "boundingBox": [158, 102, 216, 102, 216, 116,
+        158, 116], "page": 1, "confidence": 0.985, "elements": ["#/readResults/0/lines/7/words/1",
+        "#/readResults/0/lines/7/words/2"]}, "LastName": {"type": "string", "valueString":
+        "TALBOT", "text": "TALBOT", "boundingBox": [160, 86, 213, 85, 213, 99, 160,
+        100], "page": 1, "confidence": 0.987, "elements": ["#/readResults/0/lines/6/words/1"]},
+        "Region": {"type": "string", "valueString": "Washington", "confidence": 0.99},
+        "Sex": {"type": "gender", "valueGender": "M", "text": "M", "boundingBox":
+        [226, 190, 232, 190, 233, 201, 226, 201], "page": 1, "confidence": 0.99, "elements":
+        ["#/readResults/0/lines/13/words/2"]}}}]}}'
     headers:
       apim-request-id:
-      - fc1ea92d-146e-4f6a-8762-1ea5079a8f12
+      - 0d9a071e-456f-4e69-8433-597797140b2c
       content-length:
-      - '11076'
+      - '10387'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 05 Mar 2021 17:39:49 GMT
+      - Fri, 26 Mar 2021 03:51:16 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '16'
+      - '25'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents_from_url.test_id_document_url_transform_jpg.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents_from_url.test_id_document_url_transform_jpg.yaml
@@ -9,11 +9,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '216'
+      - '218'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyze?includeTextDetails=true
   response:
@@ -21,19 +21,19 @@ interactions:
       string: ''
     headers:
       apim-request-id:
-      - 339cb21b-3fae-41d8-b946-7de05d244a0e
+      - 5ed3459d-0fd5-498d-a384-d44e31270e45
       content-length:
       - '0'
       date:
-      - Fri, 05 Mar 2021 17:39:50 GMT
+      - Fri, 26 Mar 2021 03:51:36 GMT
       operation-location:
-      - https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/339cb21b-3fae-41d8-b946-7de05d244a0e
+      - https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/5ed3459d-0fd5-498d-a384-d44e31270e45
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '394'
+      - '915'
     status:
       code: 202
       message: Accepted
@@ -47,184 +47,175 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/339cb21b-3fae-41d8-b946-7de05d244a0e
+    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/5ed3459d-0fd5-498d-a384-d44e31270e45
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2021-03-05T17:39:51Z",
-        "lastUpdatedDateTime": "2021-03-05T17:39:54Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": -0.4021, "width": 506, "height":
-        319, "unit": "pixel", "lines": [{"text": "Pennsylvania", "boundingBox": [23,
-        20, 222, 23, 222, 69, 23, 67], "words": [{"text": "Pennsylvania", "boundingBox":
-        [26, 20, 220, 26, 221, 64, 23, 64], "confidence": 0.254}], "appearance": {"style":
-        {"name": "other", "confidence": 0.878}}}, {"text": "DRIVER''S LICENSE", "boundingBox":
-        [256, 16, 454, 16, 454, 33, 256, 34], "words": [{"text": "DRIVER''S", "boundingBox":
-        [257, 17, 351, 16, 352, 34, 257, 35], "confidence": 0.87}, {"text": "LICENSE",
-        "boundingBox": [360, 16, 448, 16, 447, 34, 360, 34], "confidence": 0.996}],
+      string: '{"status": "succeeded", "createdDateTime": "2021-03-26T03:51:36Z",
+        "lastUpdatedDateTime": "2021-03-26T03:51:39Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": -0.2823, "width": 450, "height":
+        294, "unit": "pixel", "lines": [{"text": "USA WASHINGTON", "boundingBox":
+        [17, 25, 232, 22, 233, 47, 17, 49], "words": [{"text": "USA", "boundingBox":
+        [18, 34, 42, 31, 41, 48, 18, 49], "confidence": 0.931}, {"text": "WASHINGTON",
+        "boundingBox": [45, 30, 218, 25, 218, 48, 44, 48], "confidence": 0.991}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "USA", "boundingBox": [202, 59, 227, 58, 227, 69, 202, 70], "words": [{"text":
-        "USA", "boundingBox": [202, 59, 224, 58, 224, 69, 202, 70], "confidence":
-        0.994}], "appearance": {"style": {"name": "other", "confidence": 0.878}}},
-        {"text": "4d DLN: 99 999 999", "boundingBox": [166, 75, 313, 73, 314, 90,
-        167, 92], "words": [{"text": "4d", "boundingBox": [168, 78, 180, 77, 181,
-        91, 169, 91], "confidence": 0.996}, {"text": "DLN:", "boundingBox": [183,
-        77, 213, 76, 213, 91, 183, 91], "confidence": 0.959}, {"text": "99", "boundingBox":
-        [216, 75, 235, 75, 235, 91, 216, 91], "confidence": 0.994}, {"text": "999",
-        "boundingBox": [242, 74, 271, 74, 271, 90, 242, 91], "confidence": 0.994},
-        {"text": "999", "boundingBox": [279, 74, 307, 74, 307, 90, 279, 90], "confidence":
-        0.999}], "appearance": {"style": {"name": "other", "confidence": 0.878}}},
-        {"text": "3 DOB: 08/04/1975", "boundingBox": [170, 92, 312, 91, 313, 108,
-        170, 109], "words": [{"text": "3", "boundingBox": [170, 95, 178, 95, 179,
-        109, 170, 109], "confidence": 0.994}, {"text": "DOB:", "boundingBox": [181,
-        95, 212, 93, 213, 108, 182, 109], "confidence": 0.993}, {"text": "08/04/1975",
-        "boundingBox": [215, 93, 309, 92, 309, 109, 215, 108], "confidence": 0.994}],
+        "WA", "boundingBox": [17, 24, 39, 25, 39, 37, 18, 36], "words": [{"text":
+        "WA", "boundingBox": [18, 24, 37, 25, 36, 37, 17, 36], "confidence": 0.997}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "DUPS: 00", "boundingBox": [358, 76, 416, 74, 417, 89, 358, 91], "words":
-        [{"text": "DUPS:", "boundingBox": [358, 77, 390, 76, 390, 91, 359, 91], "confidence":
-        0.991}, {"text": "00", "boundingBox": [392, 76, 412, 74, 412, 90, 393, 91],
-        "confidence": 0.994}], "appearance": {"style": {"name": "other", "confidence":
-        0.878}}}, {"text": "123", "boundingBox": [21, 94, 21, 79, 30, 79, 31, 94],
-        "words": [{"text": "123", "boundingBox": [22, 94, 21, 79, 31, 79, 31, 93],
-        "confidence": 0.952}], "appearance": {"style": {"name": "other", "confidence":
-        0.878}}}, {"text": "4b EXP: 08/05/2023", "boundingBox": [168, 112, 313, 111,
-        313, 128, 168, 129], "words": [{"text": "4b", "boundingBox": [168, 116, 179,
-        115, 179, 128, 169, 128], "confidence": 0.967}, {"text": "EXP:", "boundingBox":
-        [181, 115, 210, 113, 210, 129, 182, 128], "confidence": 0.979}, {"text": "08/05/2023",
-        "boundingBox": [215, 113, 307, 112, 307, 129, 215, 129], "confidence": 0.994}],
+        "DRIVER LICENSE", "boundingBox": [274, 27, 401, 27, 401, 42, 274, 43], "words":
+        [{"text": "DRIVER", "boundingBox": [275, 27, 329, 28, 328, 43, 275, 43], "confidence":
+        0.994}, {"text": "LICENSE", "boundingBox": [333, 28, 398, 28, 397, 43, 333,
+        43], "confidence": 0.996}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "FEDERAL LIMITS APPLY", "boundingBox": [258, 49, 414, 49,
+        414, 62, 259, 63], "words": [{"text": "FEDERAL", "boundingBox": [259, 50,
+        319, 50, 319, 64, 259, 63], "confidence": 0.994}, {"text": "LIMITS", "boundingBox":
+        [321, 50, 364, 50, 364, 63, 322, 64], "confidence": 0.996}, {"text": "APPLY",
+        "boundingBox": [367, 50, 411, 49, 411, 63, 367, 63], "confidence": 0.996}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "da ISS: 03/01/2019", "boundingBox": [340, 112, 479, 111, 479, 128, 340, 130],
-        "words": [{"text": "da", "boundingBox": [343, 114, 354, 114, 355, 129, 344,
-        130], "confidence": 0.18}, {"text": "ISS:", "boundingBox": [357, 114, 378,
-        113, 379, 129, 358, 129], "confidence": 0.527}, {"text": "03/01/2019", "boundingBox":
-        [381, 113, 476, 112, 475, 129, 382, 129], "confidence": 0.994}], "appearance":
-        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "1 SAMPLE", "boundingBox":
-        [168, 134, 242, 133, 242, 146, 168, 147], "words": [{"text": "1", "boundingBox":
-        [169, 135, 176, 135, 176, 147, 169, 147], "confidence": 0.934}, {"text": "SAMPLE",
-        "boundingBox": [178, 135, 237, 134, 236, 147, 179, 147], "confidence": 0.996}],
+        "4d LIC#WDLABCD456DG 9CLASS", "boundingBox": [150, 67, 366, 67, 365, 84, 150,
+        84], "words": [{"text": "4d", "boundingBox": [151, 70, 159, 70, 160, 85, 152,
+        85], "confidence": 0.474}, {"text": "LIC#WDLABCD456DG", "boundingBox": [162,
+        70, 307, 68, 307, 84, 163, 85], "confidence": 0.968}, {"text": "9CLASS", "boundingBox":
+        [318, 69, 364, 71, 364, 84, 318, 84], "confidence": 0.716}], "appearance":
+        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "DONORS", "boundingBox":
+        [376, 69, 431, 69, 431, 83, 377, 84], "words": [{"text": "DONORS", "boundingBox":
+        [380, 70, 431, 69, 432, 83, 381, 84], "confidence": 0.179}], "appearance":
+        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "1 TALBOT", "boundingBox":
+        [149, 85, 212, 85, 213, 99, 149, 99], "words": [{"text": "1", "boundingBox":
+        [150, 86, 157, 86, 157, 100, 150, 100], "confidence": 0.965}, {"text": "TALBOT",
+        "boundingBox": [160, 86, 213, 85, 213, 99, 160, 100], "confidence": 0.996}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "2 JANICE ANN", "boundingBox": [169, 147, 271, 146, 271, 159, 169, 160], "words":
-        [{"text": "2", "boundingBox": [169, 148, 174, 148, 175, 161, 170, 161], "confidence":
-        0.994}, {"text": "JANICE", "boundingBox": [177, 148, 229, 147, 230, 160, 177,
-        161], "confidence": 0.996}, {"text": "ANN", "boundingBox": [235, 147, 264,
-        147, 264, 160, 235, 160], "confidence": 0.997}], "appearance": {"style": {"name":
-        "other", "confidence": 0.878}}}, {"text": "8 123 MAIN STREET", "boundingBox":
-        [168, 160, 289, 161, 289, 173, 168, 173], "words": [{"text": "8", "boundingBox":
-        [169, 161, 176, 161, 175, 172, 169, 172], "confidence": 0.996}, {"text": "123",
-        "boundingBox": [179, 161, 199, 161, 199, 173, 179, 172], "confidence": 0.999},
-        {"text": "MAIN", "boundingBox": [202, 161, 232, 161, 232, 174, 202, 173],
-        "confidence": 0.994}, {"text": "STREET", "boundingBox": [238, 161, 287, 161,
-        287, 173, 238, 174], "confidence": 0.996}], "appearance": {"style": {"name":
-        "other", "confidence": 0.878}}}, {"text": "APT. 1", "boundingBox": [175, 172,
-        222, 171, 222, 184, 175, 185], "words": [{"text": "APT.", "boundingBox": [179,
-        173, 208, 172, 208, 185, 178, 185], "confidence": 0.985}, {"text": "1", "boundingBox":
-        [210, 172, 218, 172, 217, 184, 210, 184], "confidence": 0.996}], "appearance":
-        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "HARRISBURG,
-        PA 17101-0000", "boundingBox": [178, 181, 359, 181, 359, 195, 178, 195], "words":
-        [{"text": "HARRISBURG,", "boundingBox": [179, 182, 267, 181, 267, 195, 179,
-        195], "confidence": 0.989}, {"text": "PA", "boundingBox": [269, 181, 286,
-        181, 286, 195, 269, 195], "confidence": 0.997}, {"text": "17101-0000", "boundingBox":
-        [290, 181, 357, 182, 357, 195, 290, 195], "confidence": 0.994}], "appearance":
-        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "15 SEX: F 18
-        EYES: BRO", "boundingBox": [170, 198, 308, 198, 308, 211, 170, 211], "words":
-        [{"text": "15", "boundingBox": [170, 199, 180, 199, 180, 211, 170, 211], "confidence":
-        0.994}, {"text": "SEX:", "boundingBox": [182, 199, 208, 199, 208, 211, 182,
-        211], "confidence": 0.988}, {"text": "F", "boundingBox": [210, 199, 216, 199,
-        217, 211, 210, 211], "confidence": 0.996}, {"text": "18", "boundingBox": [230,
-        199, 241, 199, 241, 211, 230, 211], "confidence": 0.996}, {"text": "EYES:",
-        "boundingBox": [243, 199, 274, 198, 275, 211, 243, 211], "confidence": 0.995},
-        {"text": "BRO", "boundingBox": [277, 198, 302, 198, 303, 211, 277, 211], "confidence":
-        0.997}], "appearance": {"style": {"name": "other", "confidence": 0.878}}},
-        {"text": "16 HGT: 5''-06\"", "boundingBox": [170, 210, 247, 209, 247, 221,
-        170, 222], "words": [{"text": "16", "boundingBox": [171, 211, 180, 211, 180,
-        222, 171, 222], "confidence": 0.962}, {"text": "HGT:", "boundingBox": [182,
-        211, 210, 211, 210, 222, 182, 222], "confidence": 0.987}, {"text": "5''-06\"",
-        "boundingBox": [212, 211, 247, 209, 247, 222, 212, 222], "confidence": 0.945}],
+        "2 LIAM R.", "boundingBox": [150, 101, 215, 101, 215, 116, 150, 116], "words":
+        [{"text": "2", "boundingBox": [151, 102, 155, 102, 155, 116, 151, 116], "confidence":
+        0.994}, {"text": "LIAM", "boundingBox": [158, 102, 190, 102, 190, 116, 158,
+        116], "confidence": 0.991}, {"text": "R.", "boundingBox": [197, 102, 215,
+        102, 216, 116, 197, 116], "confidence": 0.996}], "appearance": {"style": {"name":
+        "other", "confidence": 0.878}}}, {"text": "3 DOB 01/06/1958", "boundingBox":
+        [151, 133, 274, 131, 274, 147, 151, 149], "words": [{"text": "3", "boundingBox":
+        [151, 135, 156, 135, 156, 149, 152, 149], "confidence": 0.994}, {"text": "DOB",
+        "boundingBox": [159, 134, 184, 133, 184, 149, 159, 149], "confidence": 0.998},
+        {"text": "01/06/1958", "boundingBox": [187, 133, 272, 132, 272, 148, 187,
+        149], "confidence": 0.994}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "4a ISS 01/06/2015", "boundingBox": [313, 133, 435, 131,
+        435, 147, 313, 149], "words": [{"text": "4a", "boundingBox": [314, 135, 324,
+        135, 325, 149, 314, 149], "confidence": 0.994}, {"text": "ISS", "boundingBox":
+        [327, 134, 345, 134, 345, 149, 328, 149], "confidence": 0.481}, {"text": "01/06/2015",
+        "boundingBox": [348, 133, 431, 132, 431, 148, 348, 149], "confidence": 0.994}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "IBERTY", "boundingBox": [357, 205, 393, 210, 391, 223, 355, 217], "words":
-        [{"text": "IBERTY", "boundingBox": [357, 206, 393, 211, 391, 223, 356, 218],
-        "confidence": 0.21}], "appearance": {"style": {"name": "other", "confidence":
-        0.878}}}, {"text": "9 CLASS: C", "boundingBox": [169, 226, 242, 225, 243,
-        237, 169, 238], "words": [{"text": "9", "boundingBox": [170, 227, 177, 227,
-        177, 238, 170, 238], "confidence": 0.994}, {"text": "CLASS:", "boundingBox":
-        [182, 227, 223, 226, 223, 238, 182, 237], "confidence": 0.995}, {"text": "C",
-        "boundingBox": [225, 226, 231, 226, 231, 238, 225, 238], "confidence": 0.996}],
+        "8 123 STREET ADDRESS", "boundingBox": [151, 151, 303, 150, 303, 164, 151,
+        164], "words": [{"text": "8", "boundingBox": [151, 151, 156, 151, 156, 165,
+        152, 165], "confidence": 0.588}, {"text": "123", "boundingBox": [158, 151,
+        180, 151, 181, 165, 159, 165], "confidence": 0.997}, {"text": "STREET", "boundingBox":
+        [183, 151, 234, 151, 235, 164, 184, 165], "confidence": 0.996}, {"text": "ADDRESS",
+        "boundingBox": [237, 151, 301, 151, 301, 165, 237, 164], "confidence": 0.995}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "9a END: NONE", "boundingBox": [168, 238, 251, 237, 251, 248, 168, 249], "words":
-        [{"text": "9a", "boundingBox": [169, 238, 180, 238, 180, 249, 169, 249], "confidence":
-        0.994}, {"text": "END:", "boundingBox": [183, 238, 210, 238, 209, 249, 182,
-        249], "confidence": 0.987}, {"text": "NONE", "boundingBox": [212, 238, 246,
-        237, 246, 249, 211, 249], "confidence": 0.994}], "appearance": {"style": {"name":
-        "other", "confidence": 0.878}}}, {"text": "12 RESTR: NONE", "boundingBox":
-        [169, 248, 264, 247, 264, 260, 169, 261], "words": [{"text": "12", "boundingBox":
-        [170, 249, 180, 249, 180, 261, 170, 261], "confidence": 0.994}, {"text": "RESTR:",
-        "boundingBox": [182, 249, 221, 249, 221, 261, 182, 261], "confidence": 0.995},
-        {"text": "NONE", "boundingBox": [223, 249, 260, 248, 260, 260, 224, 261],
-        "confidence": 0.994}], "appearance": {"style": {"name": "other", "confidence":
-        0.878}}}, {"text": "SAMPLE", "boundingBox": [27, 255, 26, 185, 41, 185, 42,
-        255], "words": [{"text": "SAMPLE", "boundingBox": [28, 254, 27, 191, 42, 192,
-        42, 254], "confidence": 0.996}], "appearance": {"style": {"name": "other",
-        "confidence": 0.878}}}, {"text": "damice famale BE 5 DD:1234567890123", "boundingBox":
-        [23, 263, 324, 265, 324, 293, 23, 292], "words": [{"text": "damice", "boundingBox":
-        [23, 265, 97, 264, 98, 292, 25, 293], "confidence": 0.742}, {"text": "famale",
-        "boundingBox": [103, 264, 184, 266, 184, 289, 104, 291], "confidence": 0.184},
-        {"text": "BE", "boundingBox": [189, 266, 213, 267, 213, 288, 190, 289], "confidence":
-        0.178}, {"text": "5", "boundingBox": [219, 268, 222, 268, 222, 288, 219, 288],
-        "confidence": 0.93}, {"text": "DD:1234567890123", "boundingBox": [228, 268,
-        325, 278, 324, 284, 228, 288], "confidence": 0.798}], "appearance": {"style":
-        {"name": "other", "confidence": 0.821}}}, {"text": "DL", "boundingBox": [347,
-        248, 387, 249, 385, 273, 346, 271], "words": [{"text": "DL", "boundingBox":
-        [346, 248, 379, 249, 378, 273, 346, 271], "confidence": 0.994}], "appearance":
-        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "456789012345",
-        "boundingBox": [246, 283, 320, 283, 320, 293, 246, 294], "words": [{"text":
-        "456789012345", "boundingBox": [247, 285, 316, 283, 316, 294, 247, 293], "confidence":
-        0.968}], "appearance": {"style": {"name": "other", "confidence": 0.878}}},
-        {"text": "ORGAN DONOR", "boundingBox": [371, 285, 472, 285, 472, 299, 371,
-        299], "words": [{"text": "ORGAN", "boundingBox": [372, 287, 415, 287, 415,
-        299, 372, 299], "confidence": 0.994}, {"text": "DONOR", "boundingBox": [420,
-        287, 465, 286, 466, 299, 420, 299], "confidence": 0.996}], "appearance": {"style":
-        {"name": "other", "confidence": 0.878}}}]}], "documentResults": [{"docType":
-        "prebuilt:idDocument:driverLicense", "docTypeConfidence": 0.995, "pageRange":
-        [1, 1], "fields": {"Address": {"type": "string", "valueString": "123 MAIN
-        STREET APT. 1 HARRISBURG, PA 17101-0000", "text": "123 MAIN STREET APT. 1
-        HARRISBURG, PA 17101-0000", "boundingBox": [178, 161, 357, 161, 357, 195,
-        178, 195], "page": 1, "confidence": 0.906, "elements": ["#/readResults/0/lines/11/words/1",
-        "#/readResults/0/lines/11/words/2", "#/readResults/0/lines/11/words/3", "#/readResults/0/lines/12/words/0",
-        "#/readResults/0/lines/12/words/1", "#/readResults/0/lines/13/words/0", "#/readResults/0/lines/13/words/1",
-        "#/readResults/0/lines/13/words/2"]}, "Country": {"type": "country", "valueCountry":
-        "USA", "confidence": 0.99}, "DateOfBirth": {"type": "date", "valueDate": "1975-08-04",
-        "text": "08/04/1975", "boundingBox": [215, 93, 309, 92, 309, 109, 215, 108],
-        "page": 1, "confidence": 0.995, "elements": ["#/readResults/0/lines/4/words/2"]},
-        "DateOfExpiration": {"type": "date", "valueDate": "2023-08-05", "text": "08/05/2023",
-        "boundingBox": [215, 113, 307, 112, 307, 129, 215, 129], "page": 1, "confidence":
-        0.99, "elements": ["#/readResults/0/lines/7/words/2"]}, "DocumentNumber":
-        {"type": "string", "valueString": "99 999 999", "text": "99 999 999", "boundingBox":
-        [216, 74, 307, 74, 307, 91, 216, 91], "page": 1, "confidence": 0.991, "elements":
-        ["#/readResults/0/lines/3/words/2", "#/readResults/0/lines/3/words/3", "#/readResults/0/lines/3/words/4"]},
-        "FirstName": {"type": "string", "valueString": "JANICE ANN", "text": "JANICE
-        ANN", "boundingBox": [177, 147, 264, 147, 264, 161, 177, 161], "page": 1,
-        "confidence": 0.987, "elements": ["#/readResults/0/lines/10/words/1", "#/readResults/0/lines/10/words/2"]},
-        "LastName": {"type": "string", "valueString": "SAMPLE", "text": "SAMPLE",
-        "boundingBox": [178, 135, 237, 134, 236, 147, 179, 147], "page": 1, "confidence":
-        0.986, "elements": ["#/readResults/0/lines/9/words/1"]}, "Region": {"type":
-        "string", "valueString": "Pennsylvania", "confidence": 0.99}, "Sex": {"type":
-        "gender", "valueGender": "F", "text": "F", "boundingBox": [210, 199, 216,
-        199, 217, 211, 210, 211], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/14/words/2"]}}}]}}'
+        "YOUR CITY WA 99999-1234", "boundingBox": [157, 163, 327, 163, 327, 176, 157,
+        176], "words": [{"text": "YOUR", "boundingBox": [158, 164, 193, 164, 194,
+        177, 159, 177], "confidence": 0.869}, {"text": "CITY", "boundingBox": [198,
+        164, 229, 164, 229, 177, 198, 177], "confidence": 0.98}, {"text": "WA", "boundingBox":
+        [232, 164, 251, 164, 252, 177, 232, 177], "confidence": 0.997}, {"text": "99999-1234",
+        "boundingBox": [256, 164, 326, 163, 326, 177, 256, 177], "confidence": 0.994}],
+        "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
+        "20 1234567XX1101", "boundingBox": [10, 173, 10, 81, 21, 81, 21, 173], "words":
+        [{"text": "20", "boundingBox": [10, 173, 10, 162, 21, 162, 21, 173], "confidence":
+        0.999}, {"text": "1234567XX1101", "boundingBox": [10, 154, 10, 82, 21, 82,
+        21, 154], "confidence": 0.922}], "appearance": {"style": {"name": "other",
+        "confidence": 0.878}}}, {"text": "15 SEX M", "boundingBox": [185, 190, 240,
+        189, 240, 201, 185, 202], "words": [{"text": "15", "boundingBox": [186, 191,
+        196, 191, 196, 202, 186, 202], "confidence": 0.994}, {"text": "SEX", "boundingBox":
+        [199, 191, 220, 190, 220, 201, 199, 202], "confidence": 0.998}, {"text": "M",
+        "boundingBox": [226, 190, 232, 190, 233, 201, 226, 201], "confidence": 0.996}],
+        "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
+        "16 HGT 5''-08\"", "boundingBox": [185, 202, 265, 199, 266, 212, 185, 215],
+        "words": [{"text": "16", "boundingBox": [186, 203, 196, 203, 196, 214, 185,
+        214], "confidence": 0.994}, {"text": "HGT", "boundingBox": [198, 203, 222,
+        202, 222, 214, 198, 214], "confidence": 0.998}, {"text": "5''-08\"", "boundingBox":
+        [226, 202, 263, 200, 263, 213, 226, 214], "confidence": 0.986}], "appearance":
+        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "18 EYES BLU",
+        "boundingBox": [293, 189, 368, 188, 368, 200, 293, 202], "words": [{"text":
+        "18", "boundingBox": [294, 190, 304, 190, 305, 202, 294, 202], "confidence":
+        0.994}, {"text": "EYES", "boundingBox": [307, 190, 336, 189, 336, 202, 307,
+        202], "confidence": 0.993}, {"text": "BLU", "boundingBox": [339, 189, 362,
+        188, 362, 201, 339, 202], "confidence": 0.994}], "appearance": {"style": {"name":
+        "other", "confidence": 0.878}}}, {"text": "17 WGT 165 lb", "boundingBox":
+        [293, 202, 374, 200, 375, 213, 294, 215], "words": [{"text": "17", "boundingBox":
+        [294, 203, 305, 203, 305, 215, 294, 215], "confidence": 0.994}, {"text": "WGT",
+        "boundingBox": [307, 203, 334, 202, 334, 214, 307, 215], "confidence": 0.998},
+        {"text": "165", "boundingBox": [336, 202, 357, 201, 357, 214, 336, 214], "confidence":
+        0.998}, {"text": "lb", "boundingBox": [360, 201, 372, 201, 372, 214, 360,
+        214], "confidence": 0.408}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "12 RESTRICTIONS 9a END L", "boundingBox": [185, 216, 345,
+        214, 346, 227, 185, 229], "words": [{"text": "12", "boundingBox": [186, 217,
+        195, 217, 195, 229, 186, 229], "confidence": 0.994}, {"text": "RESTRICTIONS",
+        "boundingBox": [198, 217, 281, 216, 281, 228, 198, 229], "confidence": 0.994},
+        {"text": "9a", "boundingBox": [292, 216, 305, 216, 305, 228, 292, 228], "confidence":
+        0.994}, {"text": "END", "boundingBox": [307, 216, 330, 215, 330, 228, 307,
+        228], "confidence": 0.998}, {"text": "L", "boundingBox": [335, 215, 341, 215,
+        341, 228, 335, 228], "confidence": 0.996}], "appearance": {"style": {"name":
+        "other", "confidence": 0.878}}}, {"text": "B", "boundingBox": [231, 229, 241,
+        229, 241, 241, 231, 240], "words": [{"text": "B", "boundingBox": [231, 229,
+        239, 229, 238, 241, 231, 240], "confidence": 0.994}], "appearance": {"style":
+        {"name": "other", "confidence": 0.878}}}, {"text": "4b EXP 08/12/2020", "boundingBox":
+        [293, 230, 417, 228, 418, 243, 293, 245], "words": [{"text": "4b", "boundingBox":
+        [294, 232, 305, 231, 305, 245, 294, 245], "confidence": 0.932}, {"text": "EXP",
+        "boundingBox": [308, 231, 329, 230, 329, 245, 308, 245], "confidence": 0.991},
+        {"text": "08/12/2020", "boundingBox": [332, 230, 414, 228, 414, 244, 332,
+        245], "confidence": 0.986}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "5 DDWDLABCD456DG1234567XX1101", "boundingBox": [152, 261,
+        355, 260, 355, 273, 152, 274], "words": [{"text": "5", "boundingBox": [153,
+        262, 158, 262, 158, 274, 153, 274], "confidence": 0.986}, {"text": "DDWDLABCD456DG1234567XX1101",
+        "boundingBox": [161, 262, 355, 261, 356, 274, 161, 274], "confidence": 0.947}],
+        "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
+        "Veteran", "boundingBox": [389, 258, 437, 259, 436, 271, 389, 270], "words":
+        [{"text": "Veteran", "boundingBox": [390, 259, 434, 260, 434, 271, 390, 271],
+        "confidence": 0.996}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "REV 07/01/2018", "boundingBox": [366, 274, 436, 274, 436,
+        284, 366, 285], "words": [{"text": "REV", "boundingBox": [366, 275, 384, 275,
+        384, 285, 366, 285], "confidence": 0.994}, {"text": "07/01/2018", "boundingBox":
+        [386, 275, 435, 275, 434, 285, 386, 285], "confidence": 0.991}], "appearance":
+        {"style": {"name": "other", "confidence": 0.878}}}]}], "documentResults":
+        [{"docType": "prebuilt:idDocument:driverLicense", "docTypeConfidence": 0.995,
+        "pageRange": [1, 1], "fields": {"Address": {"type": "string", "valueString":
+        "123 STREET ADDRESS YOUR CITY WA 99999-1234", "text": "123 STREET ADDRESS
+        YOUR CITY WA 99999-1234", "boundingBox": [158, 151, 326, 151, 326, 177, 158,
+        177], "page": 1, "confidence": 0.965, "elements": ["#/readResults/0/lines/10/words/1",
+        "#/readResults/0/lines/10/words/2", "#/readResults/0/lines/10/words/3", "#/readResults/0/lines/11/words/0",
+        "#/readResults/0/lines/11/words/1", "#/readResults/0/lines/11/words/2", "#/readResults/0/lines/11/words/3"]},
+        "Country": {"type": "country", "valueCountry": "USA", "confidence": 0.99},
+        "DateOfBirth": {"type": "date", "valueDate": "1958-01-06", "text": "01/06/1958",
+        "boundingBox": [187, 133, 272, 132, 272, 148, 187, 149], "page": 1, "confidence":
+        0.99, "elements": ["#/readResults/0/lines/8/words/2"]}, "DateOfExpiration":
+        {"type": "date", "valueDate": "2020-08-12", "text": "08/12/2020", "boundingBox":
+        [332, 230, 414, 228, 414, 244, 332, 245], "page": 1, "confidence": 0.99, "elements":
+        ["#/readResults/0/lines/19/words/2"]}, "DocumentNumber": {"type": "string",
+        "valueString": "LICWDLACD5DG", "text": "LIC#WDLABCD456DG", "boundingBox":
+        [162, 70, 307, 68, 307, 84, 163, 85], "page": 1, "confidence": 0.99, "elements":
+        ["#/readResults/0/lines/4/words/1"]}, "FirstName": {"type": "string", "valueString":
+        "LIAM R.", "text": "LIAM R.", "boundingBox": [158, 102, 216, 102, 216, 116,
+        158, 116], "page": 1, "confidence": 0.985, "elements": ["#/readResults/0/lines/7/words/1",
+        "#/readResults/0/lines/7/words/2"]}, "LastName": {"type": "string", "valueString":
+        "TALBOT", "text": "TALBOT", "boundingBox": [160, 86, 213, 85, 213, 99, 160,
+        100], "page": 1, "confidence": 0.987, "elements": ["#/readResults/0/lines/6/words/1"]},
+        "Region": {"type": "string", "valueString": "Washington", "confidence": 0.99},
+        "Sex": {"type": "gender", "valueGender": "M", "text": "M", "boundingBox":
+        [226, 190, 232, 190, 233, 201, 226, 201], "page": 1, "confidence": 0.99, "elements":
+        ["#/readResults/0/lines/13/words/2"]}}}]}}'
     headers:
       apim-request-id:
-      - 8aee81d6-cd6a-4dec-99ac-3c65300bee68
+      - ee9eed25-c21b-4204-b633-bb1fab15c069
       content-length:
-      - '11076'
+      - '10387'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 05 Mar 2021 17:39:55 GMT
+      - Fri, 26 Mar 2021 03:51:41 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '18'
+      - '28'
     status:
       code: 200
       message: OK

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents_from_url_async.test_id_document_jpg.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents_from_url_async.test_id_document_jpg.yaml
@@ -5,24 +5,24 @@ interactions:
       Accept:
       - application/json
       Content-Length:
-      - '216'
+      - '218'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyze?includeTextDetails=false
   response:
     body:
       string: ''
     headers:
-      apim-request-id: 5e9c5bf5-5a1b-415e-b67b-838a24bb0862
+      apim-request-id: 40c2e2eb-44b9-41e2-b2bb-383c84907b34
       content-length: '0'
-      date: Fri, 05 Mar 2021 17:42:18 GMT
-      operation-location: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/5e9c5bf5-5a1b-415e-b67b-838a24bb0862
+      date: Fri, 26 Mar 2021 03:52:26 GMT
+      operation-location: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/40c2e2eb-44b9-41e2-b2bb-383c84907b34
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '429'
+      x-envoy-upstream-service-time: '869'
     status:
       code: 202
       message: Accepted
@@ -31,44 +31,44 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/5e9c5bf5-5a1b-415e-b67b-838a24bb0862
+    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/40c2e2eb-44b9-41e2-b2bb-383c84907b34
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2021-03-05T17:42:18Z",
-        "lastUpdatedDateTime": "2021-03-05T17:42:22Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": -0.4021, "width": 506, "height":
-        319, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:idDocument:driverLicense",
+      string: '{"status": "succeeded", "createdDateTime": "2021-03-26T03:52:27Z",
+        "lastUpdatedDateTime": "2021-03-26T03:52:29Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": -0.2823, "width": 450, "height":
+        294, "unit": "pixel"}], "documentResults": [{"docType": "prebuilt:idDocument:driverLicense",
         "docTypeConfidence": 0.995, "pageRange": [1, 1], "fields": {"Address": {"type":
-        "string", "valueString": "123 MAIN STREET APT. 1 HARRISBURG, PA 17101-0000",
-        "text": "123 MAIN STREET APT. 1 HARRISBURG, PA 17101-0000", "boundingBox":
-        [178, 161, 357, 161, 357, 195, 178, 195], "page": 1, "confidence": 0.906},
-        "Country": {"type": "country", "valueCountry": "USA", "confidence": 0.99},
-        "DateOfBirth": {"type": "date", "valueDate": "1975-08-04", "text": "08/04/1975",
-        "boundingBox": [215, 93, 309, 92, 309, 109, 215, 108], "page": 1, "confidence":
-        0.995}, "DateOfExpiration": {"type": "date", "valueDate": "2023-08-05", "text":
-        "08/05/2023", "boundingBox": [215, 113, 307, 112, 307, 129, 215, 129], "page":
-        1, "confidence": 0.99}, "DocumentNumber": {"type": "string", "valueString":
-        "99 999 999", "text": "99 999 999", "boundingBox": [216, 74, 307, 74, 307,
-        91, 216, 91], "page": 1, "confidence": 0.991}, "FirstName": {"type": "string",
-        "valueString": "JANICE ANN", "text": "JANICE ANN", "boundingBox": [177, 147,
-        264, 147, 264, 161, 177, 161], "page": 1, "confidence": 0.987}, "LastName":
-        {"type": "string", "valueString": "SAMPLE", "text": "SAMPLE", "boundingBox":
-        [178, 135, 237, 134, 236, 147, 179, 147], "page": 1, "confidence": 0.986},
-        "Region": {"type": "string", "valueString": "Pennsylvania", "confidence":
-        0.99}, "Sex": {"type": "gender", "valueGender": "F", "text": "F", "boundingBox":
-        [210, 199, 216, 199, 217, 211, 210, 211], "page": 1, "confidence": 0.99}}}]}}'
+        "string", "valueString": "123 STREET ADDRESS YOUR CITY WA 99999-1234", "text":
+        "123 STREET ADDRESS YOUR CITY WA 99999-1234", "boundingBox": [158, 151, 326,
+        151, 326, 177, 158, 177], "page": 1, "confidence": 0.965}, "Country": {"type":
+        "country", "valueCountry": "USA", "confidence": 0.99}, "DateOfBirth": {"type":
+        "date", "valueDate": "1958-01-06", "text": "01/06/1958", "boundingBox": [187,
+        133, 272, 132, 272, 148, 187, 149], "page": 1, "confidence": 0.99}, "DateOfExpiration":
+        {"type": "date", "valueDate": "2020-08-12", "text": "08/12/2020", "boundingBox":
+        [332, 230, 414, 228, 414, 244, 332, 245], "page": 1, "confidence": 0.99},
+        "DocumentNumber": {"type": "string", "valueString": "LICWDLACD5DG", "text":
+        "LIC#WDLABCD456DG", "boundingBox": [162, 70, 307, 68, 307, 84, 163, 85], "page":
+        1, "confidence": 0.99}, "FirstName": {"type": "string", "valueString": "LIAM
+        R.", "text": "LIAM R.", "boundingBox": [158, 102, 216, 102, 216, 116, 158,
+        116], "page": 1, "confidence": 0.985}, "LastName": {"type": "string", "valueString":
+        "TALBOT", "text": "TALBOT", "boundingBox": [160, 86, 213, 85, 213, 99, 160,
+        100], "page": 1, "confidence": 0.987}, "Region": {"type": "string", "valueString":
+        "Washington", "confidence": 0.99}, "Sex": {"type": "gender", "valueGender":
+        "M", "text": "M", "boundingBox": [226, 190, 232, 190, 233, 201, 226, 201],
+        "page": 1, "confidence": 0.99}}}]}}'
     headers:
-      apim-request-id: 3f5c07c0-4d7a-4bf1-a29c-0d6441557f75
-      content-length: '1602'
+      apim-request-id: 8e15cd43-5fcb-42ed-9aac-4a15b8e6753e
+      content-length: '1587'
       content-type: application/json; charset=utf-8
-      date: Fri, 05 Mar 2021 17:42:23 GMT
+      date: Fri, 26 Mar 2021 03:52:32 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '18'
+      x-envoy-upstream-service-time: '24'
     status:
       code: 200
       message: OK
-    url: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/5e9c5bf5-5a1b-415e-b67b-838a24bb0862
+    url: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/40c2e2eb-44b9-41e2-b2bb-383c84907b34
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents_from_url_async.test_id_document_jpg_include_field_elements.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents_from_url_async.test_id_document_jpg_include_field_elements.yaml
@@ -5,24 +5,24 @@ interactions:
       Accept:
       - application/json
       Content-Length:
-      - '216'
+      - '218'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyze?includeTextDetails=true
   response:
     body:
       string: ''
     headers:
-      apim-request-id: 8c22b9e0-64b1-4621-b4f2-9adccef6ad03
+      apim-request-id: fb4f9a98-9950-45f8-9734-6fa72c1b6a3c
       content-length: '0'
-      date: Fri, 05 Mar 2021 17:42:24 GMT
-      operation-location: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/8c22b9e0-64b1-4621-b4f2-9adccef6ad03
+      date: Fri, 26 Mar 2021 03:52:39 GMT
+      operation-location: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/fb4f9a98-9950-45f8-9734-6fa72c1b6a3c
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '431'
+      x-envoy-upstream-service-time: '245'
     status:
       code: 202
       message: Accepted
@@ -31,179 +31,170 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/8c22b9e0-64b1-4621-b4f2-9adccef6ad03
+    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/fb4f9a98-9950-45f8-9734-6fa72c1b6a3c
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2021-03-05T17:42:24Z",
-        "lastUpdatedDateTime": "2021-03-05T17:42:27Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": -0.4021, "width": 506, "height":
-        319, "unit": "pixel", "lines": [{"text": "Pennsylvania", "boundingBox": [23,
-        20, 222, 23, 222, 69, 23, 67], "words": [{"text": "Pennsylvania", "boundingBox":
-        [26, 20, 220, 26, 221, 64, 23, 64], "confidence": 0.254}], "appearance": {"style":
-        {"name": "other", "confidence": 0.878}}}, {"text": "DRIVER''S LICENSE", "boundingBox":
-        [256, 16, 454, 16, 454, 33, 256, 34], "words": [{"text": "DRIVER''S", "boundingBox":
-        [257, 17, 351, 16, 352, 34, 257, 35], "confidence": 0.87}, {"text": "LICENSE",
-        "boundingBox": [360, 16, 448, 16, 447, 34, 360, 34], "confidence": 0.996}],
+      string: '{"status": "succeeded", "createdDateTime": "2021-03-26T03:52:39Z",
+        "lastUpdatedDateTime": "2021-03-26T03:52:41Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": -0.2823, "width": 450, "height":
+        294, "unit": "pixel", "lines": [{"text": "USA WASHINGTON", "boundingBox":
+        [17, 25, 232, 22, 233, 47, 17, 49], "words": [{"text": "USA", "boundingBox":
+        [18, 34, 42, 31, 41, 48, 18, 49], "confidence": 0.931}, {"text": "WASHINGTON",
+        "boundingBox": [45, 30, 218, 25, 218, 48, 44, 48], "confidence": 0.991}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "USA", "boundingBox": [202, 59, 227, 58, 227, 69, 202, 70], "words": [{"text":
-        "USA", "boundingBox": [202, 59, 224, 58, 224, 69, 202, 70], "confidence":
-        0.994}], "appearance": {"style": {"name": "other", "confidence": 0.878}}},
-        {"text": "4d DLN: 99 999 999", "boundingBox": [166, 75, 313, 73, 314, 90,
-        167, 92], "words": [{"text": "4d", "boundingBox": [168, 78, 180, 77, 181,
-        91, 169, 91], "confidence": 0.996}, {"text": "DLN:", "boundingBox": [183,
-        77, 213, 76, 213, 91, 183, 91], "confidence": 0.959}, {"text": "99", "boundingBox":
-        [216, 75, 235, 75, 235, 91, 216, 91], "confidence": 0.994}, {"text": "999",
-        "boundingBox": [242, 74, 271, 74, 271, 90, 242, 91], "confidence": 0.994},
-        {"text": "999", "boundingBox": [279, 74, 307, 74, 307, 90, 279, 90], "confidence":
-        0.999}], "appearance": {"style": {"name": "other", "confidence": 0.878}}},
-        {"text": "3 DOB: 08/04/1975", "boundingBox": [170, 92, 312, 91, 313, 108,
-        170, 109], "words": [{"text": "3", "boundingBox": [170, 95, 178, 95, 179,
-        109, 170, 109], "confidence": 0.994}, {"text": "DOB:", "boundingBox": [181,
-        95, 212, 93, 213, 108, 182, 109], "confidence": 0.993}, {"text": "08/04/1975",
-        "boundingBox": [215, 93, 309, 92, 309, 109, 215, 108], "confidence": 0.994}],
+        "WA", "boundingBox": [17, 24, 39, 25, 39, 37, 18, 36], "words": [{"text":
+        "WA", "boundingBox": [18, 24, 37, 25, 36, 37, 17, 36], "confidence": 0.997}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "DUPS: 00", "boundingBox": [358, 76, 416, 74, 417, 89, 358, 91], "words":
-        [{"text": "DUPS:", "boundingBox": [358, 77, 390, 76, 390, 91, 359, 91], "confidence":
-        0.991}, {"text": "00", "boundingBox": [392, 76, 412, 74, 412, 90, 393, 91],
-        "confidence": 0.994}], "appearance": {"style": {"name": "other", "confidence":
-        0.878}}}, {"text": "123", "boundingBox": [21, 94, 21, 79, 30, 79, 31, 94],
-        "words": [{"text": "123", "boundingBox": [22, 94, 21, 79, 31, 79, 31, 93],
-        "confidence": 0.952}], "appearance": {"style": {"name": "other", "confidence":
-        0.878}}}, {"text": "4b EXP: 08/05/2023", "boundingBox": [168, 112, 313, 111,
-        313, 128, 168, 129], "words": [{"text": "4b", "boundingBox": [168, 116, 179,
-        115, 179, 128, 169, 128], "confidence": 0.967}, {"text": "EXP:", "boundingBox":
-        [181, 115, 210, 113, 210, 129, 182, 128], "confidence": 0.979}, {"text": "08/05/2023",
-        "boundingBox": [215, 113, 307, 112, 307, 129, 215, 129], "confidence": 0.994}],
+        "DRIVER LICENSE", "boundingBox": [274, 27, 401, 27, 401, 42, 274, 43], "words":
+        [{"text": "DRIVER", "boundingBox": [275, 27, 329, 28, 328, 43, 275, 43], "confidence":
+        0.994}, {"text": "LICENSE", "boundingBox": [333, 28, 398, 28, 397, 43, 333,
+        43], "confidence": 0.996}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "FEDERAL LIMITS APPLY", "boundingBox": [258, 49, 414, 49,
+        414, 62, 259, 63], "words": [{"text": "FEDERAL", "boundingBox": [259, 50,
+        319, 50, 319, 64, 259, 63], "confidence": 0.994}, {"text": "LIMITS", "boundingBox":
+        [321, 50, 364, 50, 364, 63, 322, 64], "confidence": 0.996}, {"text": "APPLY",
+        "boundingBox": [367, 50, 411, 49, 411, 63, 367, 63], "confidence": 0.996}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "da ISS: 03/01/2019", "boundingBox": [340, 112, 479, 111, 479, 128, 340, 130],
-        "words": [{"text": "da", "boundingBox": [343, 114, 354, 114, 355, 129, 344,
-        130], "confidence": 0.18}, {"text": "ISS:", "boundingBox": [357, 114, 378,
-        113, 379, 129, 358, 129], "confidence": 0.527}, {"text": "03/01/2019", "boundingBox":
-        [381, 113, 476, 112, 475, 129, 382, 129], "confidence": 0.994}], "appearance":
-        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "1 SAMPLE", "boundingBox":
-        [168, 134, 242, 133, 242, 146, 168, 147], "words": [{"text": "1", "boundingBox":
-        [169, 135, 176, 135, 176, 147, 169, 147], "confidence": 0.934}, {"text": "SAMPLE",
-        "boundingBox": [178, 135, 237, 134, 236, 147, 179, 147], "confidence": 0.996}],
+        "4d LIC#WDLABCD456DG 9CLASS", "boundingBox": [150, 67, 366, 67, 365, 84, 150,
+        84], "words": [{"text": "4d", "boundingBox": [151, 70, 159, 70, 160, 85, 152,
+        85], "confidence": 0.474}, {"text": "LIC#WDLABCD456DG", "boundingBox": [162,
+        70, 307, 68, 307, 84, 163, 85], "confidence": 0.968}, {"text": "9CLASS", "boundingBox":
+        [318, 69, 364, 71, 364, 84, 318, 84], "confidence": 0.716}], "appearance":
+        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "DONORS", "boundingBox":
+        [376, 69, 431, 69, 431, 83, 377, 84], "words": [{"text": "DONORS", "boundingBox":
+        [380, 70, 431, 69, 432, 83, 381, 84], "confidence": 0.179}], "appearance":
+        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "1 TALBOT", "boundingBox":
+        [149, 85, 212, 85, 213, 99, 149, 99], "words": [{"text": "1", "boundingBox":
+        [150, 86, 157, 86, 157, 100, 150, 100], "confidence": 0.965}, {"text": "TALBOT",
+        "boundingBox": [160, 86, 213, 85, 213, 99, 160, 100], "confidence": 0.996}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "2 JANICE ANN", "boundingBox": [169, 147, 271, 146, 271, 159, 169, 160], "words":
-        [{"text": "2", "boundingBox": [169, 148, 174, 148, 175, 161, 170, 161], "confidence":
-        0.994}, {"text": "JANICE", "boundingBox": [177, 148, 229, 147, 230, 160, 177,
-        161], "confidence": 0.996}, {"text": "ANN", "boundingBox": [235, 147, 264,
-        147, 264, 160, 235, 160], "confidence": 0.997}], "appearance": {"style": {"name":
-        "other", "confidence": 0.878}}}, {"text": "8 123 MAIN STREET", "boundingBox":
-        [168, 160, 289, 161, 289, 173, 168, 173], "words": [{"text": "8", "boundingBox":
-        [169, 161, 176, 161, 175, 172, 169, 172], "confidence": 0.996}, {"text": "123",
-        "boundingBox": [179, 161, 199, 161, 199, 173, 179, 172], "confidence": 0.999},
-        {"text": "MAIN", "boundingBox": [202, 161, 232, 161, 232, 174, 202, 173],
-        "confidence": 0.994}, {"text": "STREET", "boundingBox": [238, 161, 287, 161,
-        287, 173, 238, 174], "confidence": 0.996}], "appearance": {"style": {"name":
-        "other", "confidence": 0.878}}}, {"text": "APT. 1", "boundingBox": [175, 172,
-        222, 171, 222, 184, 175, 185], "words": [{"text": "APT.", "boundingBox": [179,
-        173, 208, 172, 208, 185, 178, 185], "confidence": 0.985}, {"text": "1", "boundingBox":
-        [210, 172, 218, 172, 217, 184, 210, 184], "confidence": 0.996}], "appearance":
-        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "HARRISBURG,
-        PA 17101-0000", "boundingBox": [178, 181, 359, 181, 359, 195, 178, 195], "words":
-        [{"text": "HARRISBURG,", "boundingBox": [179, 182, 267, 181, 267, 195, 179,
-        195], "confidence": 0.989}, {"text": "PA", "boundingBox": [269, 181, 286,
-        181, 286, 195, 269, 195], "confidence": 0.997}, {"text": "17101-0000", "boundingBox":
-        [290, 181, 357, 182, 357, 195, 290, 195], "confidence": 0.994}], "appearance":
-        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "15 SEX: F 18
-        EYES: BRO", "boundingBox": [170, 198, 308, 198, 308, 211, 170, 211], "words":
-        [{"text": "15", "boundingBox": [170, 199, 180, 199, 180, 211, 170, 211], "confidence":
-        0.994}, {"text": "SEX:", "boundingBox": [182, 199, 208, 199, 208, 211, 182,
-        211], "confidence": 0.988}, {"text": "F", "boundingBox": [210, 199, 216, 199,
-        217, 211, 210, 211], "confidence": 0.996}, {"text": "18", "boundingBox": [230,
-        199, 241, 199, 241, 211, 230, 211], "confidence": 0.996}, {"text": "EYES:",
-        "boundingBox": [243, 199, 274, 198, 275, 211, 243, 211], "confidence": 0.995},
-        {"text": "BRO", "boundingBox": [277, 198, 302, 198, 303, 211, 277, 211], "confidence":
-        0.997}], "appearance": {"style": {"name": "other", "confidence": 0.878}}},
-        {"text": "16 HGT: 5''-06\"", "boundingBox": [170, 210, 247, 209, 247, 221,
-        170, 222], "words": [{"text": "16", "boundingBox": [171, 211, 180, 211, 180,
-        222, 171, 222], "confidence": 0.962}, {"text": "HGT:", "boundingBox": [182,
-        211, 210, 211, 210, 222, 182, 222], "confidence": 0.987}, {"text": "5''-06\"",
-        "boundingBox": [212, 211, 247, 209, 247, 222, 212, 222], "confidence": 0.945}],
+        "2 LIAM R.", "boundingBox": [150, 101, 215, 101, 215, 116, 150, 116], "words":
+        [{"text": "2", "boundingBox": [151, 102, 155, 102, 155, 116, 151, 116], "confidence":
+        0.994}, {"text": "LIAM", "boundingBox": [158, 102, 190, 102, 190, 116, 158,
+        116], "confidence": 0.991}, {"text": "R.", "boundingBox": [197, 102, 215,
+        102, 216, 116, 197, 116], "confidence": 0.996}], "appearance": {"style": {"name":
+        "other", "confidence": 0.878}}}, {"text": "3 DOB 01/06/1958", "boundingBox":
+        [151, 133, 274, 131, 274, 147, 151, 149], "words": [{"text": "3", "boundingBox":
+        [151, 135, 156, 135, 156, 149, 152, 149], "confidence": 0.994}, {"text": "DOB",
+        "boundingBox": [159, 134, 184, 133, 184, 149, 159, 149], "confidence": 0.998},
+        {"text": "01/06/1958", "boundingBox": [187, 133, 272, 132, 272, 148, 187,
+        149], "confidence": 0.994}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "4a ISS 01/06/2015", "boundingBox": [313, 133, 435, 131,
+        435, 147, 313, 149], "words": [{"text": "4a", "boundingBox": [314, 135, 324,
+        135, 325, 149, 314, 149], "confidence": 0.994}, {"text": "ISS", "boundingBox":
+        [327, 134, 345, 134, 345, 149, 328, 149], "confidence": 0.481}, {"text": "01/06/2015",
+        "boundingBox": [348, 133, 431, 132, 431, 148, 348, 149], "confidence": 0.994}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "IBERTY", "boundingBox": [357, 205, 393, 210, 391, 223, 355, 217], "words":
-        [{"text": "IBERTY", "boundingBox": [357, 206, 393, 211, 391, 223, 356, 218],
-        "confidence": 0.21}], "appearance": {"style": {"name": "other", "confidence":
-        0.878}}}, {"text": "9 CLASS: C", "boundingBox": [169, 226, 242, 225, 243,
-        237, 169, 238], "words": [{"text": "9", "boundingBox": [170, 227, 177, 227,
-        177, 238, 170, 238], "confidence": 0.994}, {"text": "CLASS:", "boundingBox":
-        [182, 227, 223, 226, 223, 238, 182, 237], "confidence": 0.995}, {"text": "C",
-        "boundingBox": [225, 226, 231, 226, 231, 238, 225, 238], "confidence": 0.996}],
+        "8 123 STREET ADDRESS", "boundingBox": [151, 151, 303, 150, 303, 164, 151,
+        164], "words": [{"text": "8", "boundingBox": [151, 151, 156, 151, 156, 165,
+        152, 165], "confidence": 0.588}, {"text": "123", "boundingBox": [158, 151,
+        180, 151, 181, 165, 159, 165], "confidence": 0.997}, {"text": "STREET", "boundingBox":
+        [183, 151, 234, 151, 235, 164, 184, 165], "confidence": 0.996}, {"text": "ADDRESS",
+        "boundingBox": [237, 151, 301, 151, 301, 165, 237, 164], "confidence": 0.995}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "9a END: NONE", "boundingBox": [168, 238, 251, 237, 251, 248, 168, 249], "words":
-        [{"text": "9a", "boundingBox": [169, 238, 180, 238, 180, 249, 169, 249], "confidence":
-        0.994}, {"text": "END:", "boundingBox": [183, 238, 210, 238, 209, 249, 182,
-        249], "confidence": 0.987}, {"text": "NONE", "boundingBox": [212, 238, 246,
-        237, 246, 249, 211, 249], "confidence": 0.994}], "appearance": {"style": {"name":
-        "other", "confidence": 0.878}}}, {"text": "12 RESTR: NONE", "boundingBox":
-        [169, 248, 264, 247, 264, 260, 169, 261], "words": [{"text": "12", "boundingBox":
-        [170, 249, 180, 249, 180, 261, 170, 261], "confidence": 0.994}, {"text": "RESTR:",
-        "boundingBox": [182, 249, 221, 249, 221, 261, 182, 261], "confidence": 0.995},
-        {"text": "NONE", "boundingBox": [223, 249, 260, 248, 260, 260, 224, 261],
-        "confidence": 0.994}], "appearance": {"style": {"name": "other", "confidence":
-        0.878}}}, {"text": "SAMPLE", "boundingBox": [27, 255, 26, 185, 41, 185, 42,
-        255], "words": [{"text": "SAMPLE", "boundingBox": [28, 254, 27, 191, 42, 192,
-        42, 254], "confidence": 0.996}], "appearance": {"style": {"name": "other",
-        "confidence": 0.878}}}, {"text": "damice famale BE 5 DD:1234567890123", "boundingBox":
-        [23, 263, 324, 265, 324, 293, 23, 292], "words": [{"text": "damice", "boundingBox":
-        [23, 265, 97, 264, 98, 292, 25, 293], "confidence": 0.742}, {"text": "famale",
-        "boundingBox": [103, 264, 184, 266, 184, 289, 104, 291], "confidence": 0.184},
-        {"text": "BE", "boundingBox": [189, 266, 213, 267, 213, 288, 190, 289], "confidence":
-        0.178}, {"text": "5", "boundingBox": [219, 268, 222, 268, 222, 288, 219, 288],
-        "confidence": 0.93}, {"text": "DD:1234567890123", "boundingBox": [228, 268,
-        325, 278, 324, 284, 228, 288], "confidence": 0.798}], "appearance": {"style":
-        {"name": "other", "confidence": 0.821}}}, {"text": "DL", "boundingBox": [347,
-        248, 387, 249, 385, 273, 346, 271], "words": [{"text": "DL", "boundingBox":
-        [346, 248, 379, 249, 378, 273, 346, 271], "confidence": 0.994}], "appearance":
-        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "456789012345",
-        "boundingBox": [246, 283, 320, 283, 320, 293, 246, 294], "words": [{"text":
-        "456789012345", "boundingBox": [247, 285, 316, 283, 316, 294, 247, 293], "confidence":
-        0.968}], "appearance": {"style": {"name": "other", "confidence": 0.878}}},
-        {"text": "ORGAN DONOR", "boundingBox": [371, 285, 472, 285, 472, 299, 371,
-        299], "words": [{"text": "ORGAN", "boundingBox": [372, 287, 415, 287, 415,
-        299, 372, 299], "confidence": 0.994}, {"text": "DONOR", "boundingBox": [420,
-        287, 465, 286, 466, 299, 420, 299], "confidence": 0.996}], "appearance": {"style":
-        {"name": "other", "confidence": 0.878}}}]}], "documentResults": [{"docType":
-        "prebuilt:idDocument:driverLicense", "docTypeConfidence": 0.995, "pageRange":
-        [1, 1], "fields": {"Address": {"type": "string", "valueString": "123 MAIN
-        STREET APT. 1 HARRISBURG, PA 17101-0000", "text": "123 MAIN STREET APT. 1
-        HARRISBURG, PA 17101-0000", "boundingBox": [178, 161, 357, 161, 357, 195,
-        178, 195], "page": 1, "confidence": 0.906, "elements": ["#/readResults/0/lines/11/words/1",
-        "#/readResults/0/lines/11/words/2", "#/readResults/0/lines/11/words/3", "#/readResults/0/lines/12/words/0",
-        "#/readResults/0/lines/12/words/1", "#/readResults/0/lines/13/words/0", "#/readResults/0/lines/13/words/1",
-        "#/readResults/0/lines/13/words/2"]}, "Country": {"type": "country", "valueCountry":
-        "USA", "confidence": 0.99}, "DateOfBirth": {"type": "date", "valueDate": "1975-08-04",
-        "text": "08/04/1975", "boundingBox": [215, 93, 309, 92, 309, 109, 215, 108],
-        "page": 1, "confidence": 0.995, "elements": ["#/readResults/0/lines/4/words/2"]},
-        "DateOfExpiration": {"type": "date", "valueDate": "2023-08-05", "text": "08/05/2023",
-        "boundingBox": [215, 113, 307, 112, 307, 129, 215, 129], "page": 1, "confidence":
-        0.99, "elements": ["#/readResults/0/lines/7/words/2"]}, "DocumentNumber":
-        {"type": "string", "valueString": "99 999 999", "text": "99 999 999", "boundingBox":
-        [216, 74, 307, 74, 307, 91, 216, 91], "page": 1, "confidence": 0.991, "elements":
-        ["#/readResults/0/lines/3/words/2", "#/readResults/0/lines/3/words/3", "#/readResults/0/lines/3/words/4"]},
-        "FirstName": {"type": "string", "valueString": "JANICE ANN", "text": "JANICE
-        ANN", "boundingBox": [177, 147, 264, 147, 264, 161, 177, 161], "page": 1,
-        "confidence": 0.987, "elements": ["#/readResults/0/lines/10/words/1", "#/readResults/0/lines/10/words/2"]},
-        "LastName": {"type": "string", "valueString": "SAMPLE", "text": "SAMPLE",
-        "boundingBox": [178, 135, 237, 134, 236, 147, 179, 147], "page": 1, "confidence":
-        0.986, "elements": ["#/readResults/0/lines/9/words/1"]}, "Region": {"type":
-        "string", "valueString": "Pennsylvania", "confidence": 0.99}, "Sex": {"type":
-        "gender", "valueGender": "F", "text": "F", "boundingBox": [210, 199, 216,
-        199, 217, 211, 210, 211], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/14/words/2"]}}}]}}'
+        "YOUR CITY WA 99999-1234", "boundingBox": [157, 163, 327, 163, 327, 176, 157,
+        176], "words": [{"text": "YOUR", "boundingBox": [158, 164, 193, 164, 194,
+        177, 159, 177], "confidence": 0.869}, {"text": "CITY", "boundingBox": [198,
+        164, 229, 164, 229, 177, 198, 177], "confidence": 0.98}, {"text": "WA", "boundingBox":
+        [232, 164, 251, 164, 252, 177, 232, 177], "confidence": 0.997}, {"text": "99999-1234",
+        "boundingBox": [256, 164, 326, 163, 326, 177, 256, 177], "confidence": 0.994}],
+        "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
+        "20 1234567XX1101", "boundingBox": [10, 173, 10, 81, 21, 81, 21, 173], "words":
+        [{"text": "20", "boundingBox": [10, 173, 10, 162, 21, 162, 21, 173], "confidence":
+        0.999}, {"text": "1234567XX1101", "boundingBox": [10, 154, 10, 82, 21, 82,
+        21, 154], "confidence": 0.922}], "appearance": {"style": {"name": "other",
+        "confidence": 0.878}}}, {"text": "15 SEX M", "boundingBox": [185, 190, 240,
+        189, 240, 201, 185, 202], "words": [{"text": "15", "boundingBox": [186, 191,
+        196, 191, 196, 202, 186, 202], "confidence": 0.994}, {"text": "SEX", "boundingBox":
+        [199, 191, 220, 190, 220, 201, 199, 202], "confidence": 0.998}, {"text": "M",
+        "boundingBox": [226, 190, 232, 190, 233, 201, 226, 201], "confidence": 0.996}],
+        "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
+        "16 HGT 5''-08\"", "boundingBox": [185, 202, 265, 199, 266, 212, 185, 215],
+        "words": [{"text": "16", "boundingBox": [186, 203, 196, 203, 196, 214, 185,
+        214], "confidence": 0.994}, {"text": "HGT", "boundingBox": [198, 203, 222,
+        202, 222, 214, 198, 214], "confidence": 0.998}, {"text": "5''-08\"", "boundingBox":
+        [226, 202, 263, 200, 263, 213, 226, 214], "confidence": 0.986}], "appearance":
+        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "18 EYES BLU",
+        "boundingBox": [293, 189, 368, 188, 368, 200, 293, 202], "words": [{"text":
+        "18", "boundingBox": [294, 190, 304, 190, 305, 202, 294, 202], "confidence":
+        0.994}, {"text": "EYES", "boundingBox": [307, 190, 336, 189, 336, 202, 307,
+        202], "confidence": 0.993}, {"text": "BLU", "boundingBox": [339, 189, 362,
+        188, 362, 201, 339, 202], "confidence": 0.994}], "appearance": {"style": {"name":
+        "other", "confidence": 0.878}}}, {"text": "17 WGT 165 lb", "boundingBox":
+        [293, 202, 374, 200, 375, 213, 294, 215], "words": [{"text": "17", "boundingBox":
+        [294, 203, 305, 203, 305, 215, 294, 215], "confidence": 0.994}, {"text": "WGT",
+        "boundingBox": [307, 203, 334, 202, 334, 214, 307, 215], "confidence": 0.998},
+        {"text": "165", "boundingBox": [336, 202, 357, 201, 357, 214, 336, 214], "confidence":
+        0.998}, {"text": "lb", "boundingBox": [360, 201, 372, 201, 372, 214, 360,
+        214], "confidence": 0.408}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "12 RESTRICTIONS 9a END L", "boundingBox": [185, 216, 345,
+        214, 346, 227, 185, 229], "words": [{"text": "12", "boundingBox": [186, 217,
+        195, 217, 195, 229, 186, 229], "confidence": 0.994}, {"text": "RESTRICTIONS",
+        "boundingBox": [198, 217, 281, 216, 281, 228, 198, 229], "confidence": 0.994},
+        {"text": "9a", "boundingBox": [292, 216, 305, 216, 305, 228, 292, 228], "confidence":
+        0.994}, {"text": "END", "boundingBox": [307, 216, 330, 215, 330, 228, 307,
+        228], "confidence": 0.998}, {"text": "L", "boundingBox": [335, 215, 341, 215,
+        341, 228, 335, 228], "confidence": 0.996}], "appearance": {"style": {"name":
+        "other", "confidence": 0.878}}}, {"text": "B", "boundingBox": [231, 229, 241,
+        229, 241, 241, 231, 240], "words": [{"text": "B", "boundingBox": [231, 229,
+        239, 229, 238, 241, 231, 240], "confidence": 0.994}], "appearance": {"style":
+        {"name": "other", "confidence": 0.878}}}, {"text": "4b EXP 08/12/2020", "boundingBox":
+        [293, 230, 417, 228, 418, 243, 293, 245], "words": [{"text": "4b", "boundingBox":
+        [294, 232, 305, 231, 305, 245, 294, 245], "confidence": 0.932}, {"text": "EXP",
+        "boundingBox": [308, 231, 329, 230, 329, 245, 308, 245], "confidence": 0.991},
+        {"text": "08/12/2020", "boundingBox": [332, 230, 414, 228, 414, 244, 332,
+        245], "confidence": 0.986}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "5 DDWDLABCD456DG1234567XX1101", "boundingBox": [152, 261,
+        355, 260, 355, 273, 152, 274], "words": [{"text": "5", "boundingBox": [153,
+        262, 158, 262, 158, 274, 153, 274], "confidence": 0.986}, {"text": "DDWDLABCD456DG1234567XX1101",
+        "boundingBox": [161, 262, 355, 261, 356, 274, 161, 274], "confidence": 0.947}],
+        "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
+        "Veteran", "boundingBox": [389, 258, 437, 259, 436, 271, 389, 270], "words":
+        [{"text": "Veteran", "boundingBox": [390, 259, 434, 260, 434, 271, 390, 271],
+        "confidence": 0.996}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "REV 07/01/2018", "boundingBox": [366, 274, 436, 274, 436,
+        284, 366, 285], "words": [{"text": "REV", "boundingBox": [366, 275, 384, 275,
+        384, 285, 366, 285], "confidence": 0.994}, {"text": "07/01/2018", "boundingBox":
+        [386, 275, 435, 275, 434, 285, 386, 285], "confidence": 0.991}], "appearance":
+        {"style": {"name": "other", "confidence": 0.878}}}]}], "documentResults":
+        [{"docType": "prebuilt:idDocument:driverLicense", "docTypeConfidence": 0.995,
+        "pageRange": [1, 1], "fields": {"Address": {"type": "string", "valueString":
+        "123 STREET ADDRESS YOUR CITY WA 99999-1234", "text": "123 STREET ADDRESS
+        YOUR CITY WA 99999-1234", "boundingBox": [158, 151, 326, 151, 326, 177, 158,
+        177], "page": 1, "confidence": 0.965, "elements": ["#/readResults/0/lines/10/words/1",
+        "#/readResults/0/lines/10/words/2", "#/readResults/0/lines/10/words/3", "#/readResults/0/lines/11/words/0",
+        "#/readResults/0/lines/11/words/1", "#/readResults/0/lines/11/words/2", "#/readResults/0/lines/11/words/3"]},
+        "Country": {"type": "country", "valueCountry": "USA", "confidence": 0.99},
+        "DateOfBirth": {"type": "date", "valueDate": "1958-01-06", "text": "01/06/1958",
+        "boundingBox": [187, 133, 272, 132, 272, 148, 187, 149], "page": 1, "confidence":
+        0.99, "elements": ["#/readResults/0/lines/8/words/2"]}, "DateOfExpiration":
+        {"type": "date", "valueDate": "2020-08-12", "text": "08/12/2020", "boundingBox":
+        [332, 230, 414, 228, 414, 244, 332, 245], "page": 1, "confidence": 0.99, "elements":
+        ["#/readResults/0/lines/19/words/2"]}, "DocumentNumber": {"type": "string",
+        "valueString": "LICWDLACD5DG", "text": "LIC#WDLABCD456DG", "boundingBox":
+        [162, 70, 307, 68, 307, 84, 163, 85], "page": 1, "confidence": 0.99, "elements":
+        ["#/readResults/0/lines/4/words/1"]}, "FirstName": {"type": "string", "valueString":
+        "LIAM R.", "text": "LIAM R.", "boundingBox": [158, 102, 216, 102, 216, 116,
+        158, 116], "page": 1, "confidence": 0.985, "elements": ["#/readResults/0/lines/7/words/1",
+        "#/readResults/0/lines/7/words/2"]}, "LastName": {"type": "string", "valueString":
+        "TALBOT", "text": "TALBOT", "boundingBox": [160, 86, 213, 85, 213, 99, 160,
+        100], "page": 1, "confidence": 0.987, "elements": ["#/readResults/0/lines/6/words/1"]},
+        "Region": {"type": "string", "valueString": "Washington", "confidence": 0.99},
+        "Sex": {"type": "gender", "valueGender": "M", "text": "M", "boundingBox":
+        [226, 190, 232, 190, 233, 201, 226, 201], "page": 1, "confidence": 0.99, "elements":
+        ["#/readResults/0/lines/13/words/2"]}}}]}}'
     headers:
-      apim-request-id: ee3f02b9-a329-45bb-9dae-97afcf13352f
-      content-length: '11076'
+      apim-request-id: 19896590-4830-40b4-af87-23c20056e05c
+      content-length: '10387'
       content-type: application/json; charset=utf-8
-      date: Fri, 05 Mar 2021 17:42:29 GMT
+      date: Fri, 26 Mar 2021 03:52:43 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '18'
+      x-envoy-upstream-service-time: '32'
     status:
       code: 200
       message: OK
-    url: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/8c22b9e0-64b1-4621-b4f2-9adccef6ad03
+    url: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/fb4f9a98-9950-45f8-9734-6fa72c1b6a3c
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents_from_url_async.test_id_document_url_transform_jpg.yaml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/recordings/test_id_documents_from_url_async.test_id_document_url_transform_jpg.yaml
@@ -5,24 +5,24 @@ interactions:
       Accept:
       - application/json
       Content-Length:
-      - '216'
+      - '218'
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyze?includeTextDetails=true
   response:
     body:
       string: ''
     headers:
-      apim-request-id: e6ddf690-296a-43a4-8d59-ad8ee1b90a4b
+      apim-request-id: ac44fd3f-b8ae-4394-b352-4013d3b408eb
       content-length: '0'
-      date: Fri, 05 Mar 2021 17:42:29 GMT
-      operation-location: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/e6ddf690-296a-43a4-8d59-ad8ee1b90a4b
+      date: Fri, 26 Mar 2021 03:52:02 GMT
+      operation-location: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/ac44fd3f-b8ae-4394-b352-4013d3b408eb
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '128'
+      x-envoy-upstream-service-time: '800'
     status:
       code: 202
       message: Accepted
@@ -31,179 +31,170 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - azsdk-python-ai-formrecognizer/3.1.0b4 Python/3.9.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/e6ddf690-296a-43a4-8d59-ad8ee1b90a4b
+    uri: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/ac44fd3f-b8ae-4394-b352-4013d3b408eb
   response:
     body:
-      string: '{"status": "succeeded", "createdDateTime": "2021-03-05T17:42:30Z",
-        "lastUpdatedDateTime": "2021-03-05T17:42:33Z", "analyzeResult": {"version":
-        "2.1.0", "readResults": [{"page": 1, "angle": -0.4021, "width": 506, "height":
-        319, "unit": "pixel", "lines": [{"text": "Pennsylvania", "boundingBox": [23,
-        20, 222, 23, 222, 69, 23, 67], "words": [{"text": "Pennsylvania", "boundingBox":
-        [26, 20, 220, 26, 221, 64, 23, 64], "confidence": 0.254}], "appearance": {"style":
-        {"name": "other", "confidence": 0.878}}}, {"text": "DRIVER''S LICENSE", "boundingBox":
-        [256, 16, 454, 16, 454, 33, 256, 34], "words": [{"text": "DRIVER''S", "boundingBox":
-        [257, 17, 351, 16, 352, 34, 257, 35], "confidence": 0.87}, {"text": "LICENSE",
-        "boundingBox": [360, 16, 448, 16, 447, 34, 360, 34], "confidence": 0.996}],
+      string: '{"status": "succeeded", "createdDateTime": "2021-03-26T03:52:02Z",
+        "lastUpdatedDateTime": "2021-03-26T03:52:05Z", "analyzeResult": {"version":
+        "2.1.0", "readResults": [{"page": 1, "angle": -0.2823, "width": 450, "height":
+        294, "unit": "pixel", "lines": [{"text": "USA WASHINGTON", "boundingBox":
+        [17, 25, 232, 22, 233, 47, 17, 49], "words": [{"text": "USA", "boundingBox":
+        [18, 34, 42, 31, 41, 48, 18, 49], "confidence": 0.931}, {"text": "WASHINGTON",
+        "boundingBox": [45, 30, 218, 25, 218, 48, 44, 48], "confidence": 0.991}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "USA", "boundingBox": [202, 59, 227, 58, 227, 69, 202, 70], "words": [{"text":
-        "USA", "boundingBox": [202, 59, 224, 58, 224, 69, 202, 70], "confidence":
-        0.994}], "appearance": {"style": {"name": "other", "confidence": 0.878}}},
-        {"text": "4d DLN: 99 999 999", "boundingBox": [166, 75, 313, 73, 314, 90,
-        167, 92], "words": [{"text": "4d", "boundingBox": [168, 78, 180, 77, 181,
-        91, 169, 91], "confidence": 0.996}, {"text": "DLN:", "boundingBox": [183,
-        77, 213, 76, 213, 91, 183, 91], "confidence": 0.959}, {"text": "99", "boundingBox":
-        [216, 75, 235, 75, 235, 91, 216, 91], "confidence": 0.994}, {"text": "999",
-        "boundingBox": [242, 74, 271, 74, 271, 90, 242, 91], "confidence": 0.994},
-        {"text": "999", "boundingBox": [279, 74, 307, 74, 307, 90, 279, 90], "confidence":
-        0.999}], "appearance": {"style": {"name": "other", "confidence": 0.878}}},
-        {"text": "3 DOB: 08/04/1975", "boundingBox": [170, 92, 312, 91, 313, 108,
-        170, 109], "words": [{"text": "3", "boundingBox": [170, 95, 178, 95, 179,
-        109, 170, 109], "confidence": 0.994}, {"text": "DOB:", "boundingBox": [181,
-        95, 212, 93, 213, 108, 182, 109], "confidence": 0.993}, {"text": "08/04/1975",
-        "boundingBox": [215, 93, 309, 92, 309, 109, 215, 108], "confidence": 0.994}],
+        "WA", "boundingBox": [17, 24, 39, 25, 39, 37, 18, 36], "words": [{"text":
+        "WA", "boundingBox": [18, 24, 37, 25, 36, 37, 17, 36], "confidence": 0.997}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "DUPS: 00", "boundingBox": [358, 76, 416, 74, 417, 89, 358, 91], "words":
-        [{"text": "DUPS:", "boundingBox": [358, 77, 390, 76, 390, 91, 359, 91], "confidence":
-        0.991}, {"text": "00", "boundingBox": [392, 76, 412, 74, 412, 90, 393, 91],
-        "confidence": 0.994}], "appearance": {"style": {"name": "other", "confidence":
-        0.878}}}, {"text": "123", "boundingBox": [21, 94, 21, 79, 30, 79, 31, 94],
-        "words": [{"text": "123", "boundingBox": [22, 94, 21, 79, 31, 79, 31, 93],
-        "confidence": 0.952}], "appearance": {"style": {"name": "other", "confidence":
-        0.878}}}, {"text": "4b EXP: 08/05/2023", "boundingBox": [168, 112, 313, 111,
-        313, 128, 168, 129], "words": [{"text": "4b", "boundingBox": [168, 116, 179,
-        115, 179, 128, 169, 128], "confidence": 0.967}, {"text": "EXP:", "boundingBox":
-        [181, 115, 210, 113, 210, 129, 182, 128], "confidence": 0.979}, {"text": "08/05/2023",
-        "boundingBox": [215, 113, 307, 112, 307, 129, 215, 129], "confidence": 0.994}],
+        "DRIVER LICENSE", "boundingBox": [274, 27, 401, 27, 401, 42, 274, 43], "words":
+        [{"text": "DRIVER", "boundingBox": [275, 27, 329, 28, 328, 43, 275, 43], "confidence":
+        0.994}, {"text": "LICENSE", "boundingBox": [333, 28, 398, 28, 397, 43, 333,
+        43], "confidence": 0.996}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "FEDERAL LIMITS APPLY", "boundingBox": [258, 49, 414, 49,
+        414, 62, 259, 63], "words": [{"text": "FEDERAL", "boundingBox": [259, 50,
+        319, 50, 319, 64, 259, 63], "confidence": 0.994}, {"text": "LIMITS", "boundingBox":
+        [321, 50, 364, 50, 364, 63, 322, 64], "confidence": 0.996}, {"text": "APPLY",
+        "boundingBox": [367, 50, 411, 49, 411, 63, 367, 63], "confidence": 0.996}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "da ISS: 03/01/2019", "boundingBox": [340, 112, 479, 111, 479, 128, 340, 130],
-        "words": [{"text": "da", "boundingBox": [343, 114, 354, 114, 355, 129, 344,
-        130], "confidence": 0.18}, {"text": "ISS:", "boundingBox": [357, 114, 378,
-        113, 379, 129, 358, 129], "confidence": 0.527}, {"text": "03/01/2019", "boundingBox":
-        [381, 113, 476, 112, 475, 129, 382, 129], "confidence": 0.994}], "appearance":
-        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "1 SAMPLE", "boundingBox":
-        [168, 134, 242, 133, 242, 146, 168, 147], "words": [{"text": "1", "boundingBox":
-        [169, 135, 176, 135, 176, 147, 169, 147], "confidence": 0.934}, {"text": "SAMPLE",
-        "boundingBox": [178, 135, 237, 134, 236, 147, 179, 147], "confidence": 0.996}],
+        "4d LIC#WDLABCD456DG 9CLASS", "boundingBox": [150, 67, 366, 67, 365, 84, 150,
+        84], "words": [{"text": "4d", "boundingBox": [151, 70, 159, 70, 160, 85, 152,
+        85], "confidence": 0.474}, {"text": "LIC#WDLABCD456DG", "boundingBox": [162,
+        70, 307, 68, 307, 84, 163, 85], "confidence": 0.968}, {"text": "9CLASS", "boundingBox":
+        [318, 69, 364, 71, 364, 84, 318, 84], "confidence": 0.716}], "appearance":
+        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "DONORS", "boundingBox":
+        [376, 69, 431, 69, 431, 83, 377, 84], "words": [{"text": "DONORS", "boundingBox":
+        [380, 70, 431, 69, 432, 83, 381, 84], "confidence": 0.179}], "appearance":
+        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "1 TALBOT", "boundingBox":
+        [149, 85, 212, 85, 213, 99, 149, 99], "words": [{"text": "1", "boundingBox":
+        [150, 86, 157, 86, 157, 100, 150, 100], "confidence": 0.965}, {"text": "TALBOT",
+        "boundingBox": [160, 86, 213, 85, 213, 99, 160, 100], "confidence": 0.996}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "2 JANICE ANN", "boundingBox": [169, 147, 271, 146, 271, 159, 169, 160], "words":
-        [{"text": "2", "boundingBox": [169, 148, 174, 148, 175, 161, 170, 161], "confidence":
-        0.994}, {"text": "JANICE", "boundingBox": [177, 148, 229, 147, 230, 160, 177,
-        161], "confidence": 0.996}, {"text": "ANN", "boundingBox": [235, 147, 264,
-        147, 264, 160, 235, 160], "confidence": 0.997}], "appearance": {"style": {"name":
-        "other", "confidence": 0.878}}}, {"text": "8 123 MAIN STREET", "boundingBox":
-        [168, 160, 289, 161, 289, 173, 168, 173], "words": [{"text": "8", "boundingBox":
-        [169, 161, 176, 161, 175, 172, 169, 172], "confidence": 0.996}, {"text": "123",
-        "boundingBox": [179, 161, 199, 161, 199, 173, 179, 172], "confidence": 0.999},
-        {"text": "MAIN", "boundingBox": [202, 161, 232, 161, 232, 174, 202, 173],
-        "confidence": 0.994}, {"text": "STREET", "boundingBox": [238, 161, 287, 161,
-        287, 173, 238, 174], "confidence": 0.996}], "appearance": {"style": {"name":
-        "other", "confidence": 0.878}}}, {"text": "APT. 1", "boundingBox": [175, 172,
-        222, 171, 222, 184, 175, 185], "words": [{"text": "APT.", "boundingBox": [179,
-        173, 208, 172, 208, 185, 178, 185], "confidence": 0.985}, {"text": "1", "boundingBox":
-        [210, 172, 218, 172, 217, 184, 210, 184], "confidence": 0.996}], "appearance":
-        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "HARRISBURG,
-        PA 17101-0000", "boundingBox": [178, 181, 359, 181, 359, 195, 178, 195], "words":
-        [{"text": "HARRISBURG,", "boundingBox": [179, 182, 267, 181, 267, 195, 179,
-        195], "confidence": 0.989}, {"text": "PA", "boundingBox": [269, 181, 286,
-        181, 286, 195, 269, 195], "confidence": 0.997}, {"text": "17101-0000", "boundingBox":
-        [290, 181, 357, 182, 357, 195, 290, 195], "confidence": 0.994}], "appearance":
-        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "15 SEX: F 18
-        EYES: BRO", "boundingBox": [170, 198, 308, 198, 308, 211, 170, 211], "words":
-        [{"text": "15", "boundingBox": [170, 199, 180, 199, 180, 211, 170, 211], "confidence":
-        0.994}, {"text": "SEX:", "boundingBox": [182, 199, 208, 199, 208, 211, 182,
-        211], "confidence": 0.988}, {"text": "F", "boundingBox": [210, 199, 216, 199,
-        217, 211, 210, 211], "confidence": 0.996}, {"text": "18", "boundingBox": [230,
-        199, 241, 199, 241, 211, 230, 211], "confidence": 0.996}, {"text": "EYES:",
-        "boundingBox": [243, 199, 274, 198, 275, 211, 243, 211], "confidence": 0.995},
-        {"text": "BRO", "boundingBox": [277, 198, 302, 198, 303, 211, 277, 211], "confidence":
-        0.997}], "appearance": {"style": {"name": "other", "confidence": 0.878}}},
-        {"text": "16 HGT: 5''-06\"", "boundingBox": [170, 210, 247, 209, 247, 221,
-        170, 222], "words": [{"text": "16", "boundingBox": [171, 211, 180, 211, 180,
-        222, 171, 222], "confidence": 0.962}, {"text": "HGT:", "boundingBox": [182,
-        211, 210, 211, 210, 222, 182, 222], "confidence": 0.987}, {"text": "5''-06\"",
-        "boundingBox": [212, 211, 247, 209, 247, 222, 212, 222], "confidence": 0.945}],
+        "2 LIAM R.", "boundingBox": [150, 101, 215, 101, 215, 116, 150, 116], "words":
+        [{"text": "2", "boundingBox": [151, 102, 155, 102, 155, 116, 151, 116], "confidence":
+        0.994}, {"text": "LIAM", "boundingBox": [158, 102, 190, 102, 190, 116, 158,
+        116], "confidence": 0.991}, {"text": "R.", "boundingBox": [197, 102, 215,
+        102, 216, 116, 197, 116], "confidence": 0.996}], "appearance": {"style": {"name":
+        "other", "confidence": 0.878}}}, {"text": "3 DOB 01/06/1958", "boundingBox":
+        [151, 133, 274, 131, 274, 147, 151, 149], "words": [{"text": "3", "boundingBox":
+        [151, 135, 156, 135, 156, 149, 152, 149], "confidence": 0.994}, {"text": "DOB",
+        "boundingBox": [159, 134, 184, 133, 184, 149, 159, 149], "confidence": 0.998},
+        {"text": "01/06/1958", "boundingBox": [187, 133, 272, 132, 272, 148, 187,
+        149], "confidence": 0.994}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "4a ISS 01/06/2015", "boundingBox": [313, 133, 435, 131,
+        435, 147, 313, 149], "words": [{"text": "4a", "boundingBox": [314, 135, 324,
+        135, 325, 149, 314, 149], "confidence": 0.994}, {"text": "ISS", "boundingBox":
+        [327, 134, 345, 134, 345, 149, 328, 149], "confidence": 0.481}, {"text": "01/06/2015",
+        "boundingBox": [348, 133, 431, 132, 431, 148, 348, 149], "confidence": 0.994}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "IBERTY", "boundingBox": [357, 205, 393, 210, 391, 223, 355, 217], "words":
-        [{"text": "IBERTY", "boundingBox": [357, 206, 393, 211, 391, 223, 356, 218],
-        "confidence": 0.21}], "appearance": {"style": {"name": "other", "confidence":
-        0.878}}}, {"text": "9 CLASS: C", "boundingBox": [169, 226, 242, 225, 243,
-        237, 169, 238], "words": [{"text": "9", "boundingBox": [170, 227, 177, 227,
-        177, 238, 170, 238], "confidence": 0.994}, {"text": "CLASS:", "boundingBox":
-        [182, 227, 223, 226, 223, 238, 182, 237], "confidence": 0.995}, {"text": "C",
-        "boundingBox": [225, 226, 231, 226, 231, 238, 225, 238], "confidence": 0.996}],
+        "8 123 STREET ADDRESS", "boundingBox": [151, 151, 303, 150, 303, 164, 151,
+        164], "words": [{"text": "8", "boundingBox": [151, 151, 156, 151, 156, 165,
+        152, 165], "confidence": 0.588}, {"text": "123", "boundingBox": [158, 151,
+        180, 151, 181, 165, 159, 165], "confidence": 0.997}, {"text": "STREET", "boundingBox":
+        [183, 151, 234, 151, 235, 164, 184, 165], "confidence": 0.996}, {"text": "ADDRESS",
+        "boundingBox": [237, 151, 301, 151, 301, 165, 237, 164], "confidence": 0.995}],
         "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
-        "9a END: NONE", "boundingBox": [168, 238, 251, 237, 251, 248, 168, 249], "words":
-        [{"text": "9a", "boundingBox": [169, 238, 180, 238, 180, 249, 169, 249], "confidence":
-        0.994}, {"text": "END:", "boundingBox": [183, 238, 210, 238, 209, 249, 182,
-        249], "confidence": 0.987}, {"text": "NONE", "boundingBox": [212, 238, 246,
-        237, 246, 249, 211, 249], "confidence": 0.994}], "appearance": {"style": {"name":
-        "other", "confidence": 0.878}}}, {"text": "12 RESTR: NONE", "boundingBox":
-        [169, 248, 264, 247, 264, 260, 169, 261], "words": [{"text": "12", "boundingBox":
-        [170, 249, 180, 249, 180, 261, 170, 261], "confidence": 0.994}, {"text": "RESTR:",
-        "boundingBox": [182, 249, 221, 249, 221, 261, 182, 261], "confidence": 0.995},
-        {"text": "NONE", "boundingBox": [223, 249, 260, 248, 260, 260, 224, 261],
-        "confidence": 0.994}], "appearance": {"style": {"name": "other", "confidence":
-        0.878}}}, {"text": "SAMPLE", "boundingBox": [27, 255, 26, 185, 41, 185, 42,
-        255], "words": [{"text": "SAMPLE", "boundingBox": [28, 254, 27, 191, 42, 192,
-        42, 254], "confidence": 0.996}], "appearance": {"style": {"name": "other",
-        "confidence": 0.878}}}, {"text": "damice famale BE 5 DD:1234567890123", "boundingBox":
-        [23, 263, 324, 265, 324, 293, 23, 292], "words": [{"text": "damice", "boundingBox":
-        [23, 265, 97, 264, 98, 292, 25, 293], "confidence": 0.742}, {"text": "famale",
-        "boundingBox": [103, 264, 184, 266, 184, 289, 104, 291], "confidence": 0.184},
-        {"text": "BE", "boundingBox": [189, 266, 213, 267, 213, 288, 190, 289], "confidence":
-        0.178}, {"text": "5", "boundingBox": [219, 268, 222, 268, 222, 288, 219, 288],
-        "confidence": 0.93}, {"text": "DD:1234567890123", "boundingBox": [228, 268,
-        325, 278, 324, 284, 228, 288], "confidence": 0.798}], "appearance": {"style":
-        {"name": "other", "confidence": 0.821}}}, {"text": "DL", "boundingBox": [347,
-        248, 387, 249, 385, 273, 346, 271], "words": [{"text": "DL", "boundingBox":
-        [346, 248, 379, 249, 378, 273, 346, 271], "confidence": 0.994}], "appearance":
-        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "456789012345",
-        "boundingBox": [246, 283, 320, 283, 320, 293, 246, 294], "words": [{"text":
-        "456789012345", "boundingBox": [247, 285, 316, 283, 316, 294, 247, 293], "confidence":
-        0.968}], "appearance": {"style": {"name": "other", "confidence": 0.878}}},
-        {"text": "ORGAN DONOR", "boundingBox": [371, 285, 472, 285, 472, 299, 371,
-        299], "words": [{"text": "ORGAN", "boundingBox": [372, 287, 415, 287, 415,
-        299, 372, 299], "confidence": 0.994}, {"text": "DONOR", "boundingBox": [420,
-        287, 465, 286, 466, 299, 420, 299], "confidence": 0.996}], "appearance": {"style":
-        {"name": "other", "confidence": 0.878}}}]}], "documentResults": [{"docType":
-        "prebuilt:idDocument:driverLicense", "docTypeConfidence": 0.995, "pageRange":
-        [1, 1], "fields": {"Address": {"type": "string", "valueString": "123 MAIN
-        STREET APT. 1 HARRISBURG, PA 17101-0000", "text": "123 MAIN STREET APT. 1
-        HARRISBURG, PA 17101-0000", "boundingBox": [178, 161, 357, 161, 357, 195,
-        178, 195], "page": 1, "confidence": 0.906, "elements": ["#/readResults/0/lines/11/words/1",
-        "#/readResults/0/lines/11/words/2", "#/readResults/0/lines/11/words/3", "#/readResults/0/lines/12/words/0",
-        "#/readResults/0/lines/12/words/1", "#/readResults/0/lines/13/words/0", "#/readResults/0/lines/13/words/1",
-        "#/readResults/0/lines/13/words/2"]}, "Country": {"type": "country", "valueCountry":
-        "USA", "confidence": 0.99}, "DateOfBirth": {"type": "date", "valueDate": "1975-08-04",
-        "text": "08/04/1975", "boundingBox": [215, 93, 309, 92, 309, 109, 215, 108],
-        "page": 1, "confidence": 0.995, "elements": ["#/readResults/0/lines/4/words/2"]},
-        "DateOfExpiration": {"type": "date", "valueDate": "2023-08-05", "text": "08/05/2023",
-        "boundingBox": [215, 113, 307, 112, 307, 129, 215, 129], "page": 1, "confidence":
-        0.99, "elements": ["#/readResults/0/lines/7/words/2"]}, "DocumentNumber":
-        {"type": "string", "valueString": "99 999 999", "text": "99 999 999", "boundingBox":
-        [216, 74, 307, 74, 307, 91, 216, 91], "page": 1, "confidence": 0.991, "elements":
-        ["#/readResults/0/lines/3/words/2", "#/readResults/0/lines/3/words/3", "#/readResults/0/lines/3/words/4"]},
-        "FirstName": {"type": "string", "valueString": "JANICE ANN", "text": "JANICE
-        ANN", "boundingBox": [177, 147, 264, 147, 264, 161, 177, 161], "page": 1,
-        "confidence": 0.987, "elements": ["#/readResults/0/lines/10/words/1", "#/readResults/0/lines/10/words/2"]},
-        "LastName": {"type": "string", "valueString": "SAMPLE", "text": "SAMPLE",
-        "boundingBox": [178, 135, 237, 134, 236, 147, 179, 147], "page": 1, "confidence":
-        0.986, "elements": ["#/readResults/0/lines/9/words/1"]}, "Region": {"type":
-        "string", "valueString": "Pennsylvania", "confidence": 0.99}, "Sex": {"type":
-        "gender", "valueGender": "F", "text": "F", "boundingBox": [210, 199, 216,
-        199, 217, 211, 210, 211], "page": 1, "confidence": 0.99, "elements": ["#/readResults/0/lines/14/words/2"]}}}]}}'
+        "YOUR CITY WA 99999-1234", "boundingBox": [157, 163, 327, 163, 327, 176, 157,
+        176], "words": [{"text": "YOUR", "boundingBox": [158, 164, 193, 164, 194,
+        177, 159, 177], "confidence": 0.869}, {"text": "CITY", "boundingBox": [198,
+        164, 229, 164, 229, 177, 198, 177], "confidence": 0.98}, {"text": "WA", "boundingBox":
+        [232, 164, 251, 164, 252, 177, 232, 177], "confidence": 0.997}, {"text": "99999-1234",
+        "boundingBox": [256, 164, 326, 163, 326, 177, 256, 177], "confidence": 0.994}],
+        "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
+        "20 1234567XX1101", "boundingBox": [10, 173, 10, 81, 21, 81, 21, 173], "words":
+        [{"text": "20", "boundingBox": [10, 173, 10, 162, 21, 162, 21, 173], "confidence":
+        0.999}, {"text": "1234567XX1101", "boundingBox": [10, 154, 10, 82, 21, 82,
+        21, 154], "confidence": 0.922}], "appearance": {"style": {"name": "other",
+        "confidence": 0.878}}}, {"text": "15 SEX M", "boundingBox": [185, 190, 240,
+        189, 240, 201, 185, 202], "words": [{"text": "15", "boundingBox": [186, 191,
+        196, 191, 196, 202, 186, 202], "confidence": 0.994}, {"text": "SEX", "boundingBox":
+        [199, 191, 220, 190, 220, 201, 199, 202], "confidence": 0.998}, {"text": "M",
+        "boundingBox": [226, 190, 232, 190, 233, 201, 226, 201], "confidence": 0.996}],
+        "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
+        "16 HGT 5''-08\"", "boundingBox": [185, 202, 265, 199, 266, 212, 185, 215],
+        "words": [{"text": "16", "boundingBox": [186, 203, 196, 203, 196, 214, 185,
+        214], "confidence": 0.994}, {"text": "HGT", "boundingBox": [198, 203, 222,
+        202, 222, 214, 198, 214], "confidence": 0.998}, {"text": "5''-08\"", "boundingBox":
+        [226, 202, 263, 200, 263, 213, 226, 214], "confidence": 0.986}], "appearance":
+        {"style": {"name": "other", "confidence": 0.878}}}, {"text": "18 EYES BLU",
+        "boundingBox": [293, 189, 368, 188, 368, 200, 293, 202], "words": [{"text":
+        "18", "boundingBox": [294, 190, 304, 190, 305, 202, 294, 202], "confidence":
+        0.994}, {"text": "EYES", "boundingBox": [307, 190, 336, 189, 336, 202, 307,
+        202], "confidence": 0.993}, {"text": "BLU", "boundingBox": [339, 189, 362,
+        188, 362, 201, 339, 202], "confidence": 0.994}], "appearance": {"style": {"name":
+        "other", "confidence": 0.878}}}, {"text": "17 WGT 165 lb", "boundingBox":
+        [293, 202, 374, 200, 375, 213, 294, 215], "words": [{"text": "17", "boundingBox":
+        [294, 203, 305, 203, 305, 215, 294, 215], "confidence": 0.994}, {"text": "WGT",
+        "boundingBox": [307, 203, 334, 202, 334, 214, 307, 215], "confidence": 0.998},
+        {"text": "165", "boundingBox": [336, 202, 357, 201, 357, 214, 336, 214], "confidence":
+        0.998}, {"text": "lb", "boundingBox": [360, 201, 372, 201, 372, 214, 360,
+        214], "confidence": 0.408}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "12 RESTRICTIONS 9a END L", "boundingBox": [185, 216, 345,
+        214, 346, 227, 185, 229], "words": [{"text": "12", "boundingBox": [186, 217,
+        195, 217, 195, 229, 186, 229], "confidence": 0.994}, {"text": "RESTRICTIONS",
+        "boundingBox": [198, 217, 281, 216, 281, 228, 198, 229], "confidence": 0.994},
+        {"text": "9a", "boundingBox": [292, 216, 305, 216, 305, 228, 292, 228], "confidence":
+        0.994}, {"text": "END", "boundingBox": [307, 216, 330, 215, 330, 228, 307,
+        228], "confidence": 0.998}, {"text": "L", "boundingBox": [335, 215, 341, 215,
+        341, 228, 335, 228], "confidence": 0.996}], "appearance": {"style": {"name":
+        "other", "confidence": 0.878}}}, {"text": "B", "boundingBox": [231, 229, 241,
+        229, 241, 241, 231, 240], "words": [{"text": "B", "boundingBox": [231, 229,
+        239, 229, 238, 241, 231, 240], "confidence": 0.994}], "appearance": {"style":
+        {"name": "other", "confidence": 0.878}}}, {"text": "4b EXP 08/12/2020", "boundingBox":
+        [293, 230, 417, 228, 418, 243, 293, 245], "words": [{"text": "4b", "boundingBox":
+        [294, 232, 305, 231, 305, 245, 294, 245], "confidence": 0.932}, {"text": "EXP",
+        "boundingBox": [308, 231, 329, 230, 329, 245, 308, 245], "confidence": 0.991},
+        {"text": "08/12/2020", "boundingBox": [332, 230, 414, 228, 414, 244, 332,
+        245], "confidence": 0.986}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "5 DDWDLABCD456DG1234567XX1101", "boundingBox": [152, 261,
+        355, 260, 355, 273, 152, 274], "words": [{"text": "5", "boundingBox": [153,
+        262, 158, 262, 158, 274, 153, 274], "confidence": 0.986}, {"text": "DDWDLABCD456DG1234567XX1101",
+        "boundingBox": [161, 262, 355, 261, 356, 274, 161, 274], "confidence": 0.947}],
+        "appearance": {"style": {"name": "other", "confidence": 0.878}}}, {"text":
+        "Veteran", "boundingBox": [389, 258, 437, 259, 436, 271, 389, 270], "words":
+        [{"text": "Veteran", "boundingBox": [390, 259, 434, 260, 434, 271, 390, 271],
+        "confidence": 0.996}], "appearance": {"style": {"name": "other", "confidence":
+        0.878}}}, {"text": "REV 07/01/2018", "boundingBox": [366, 274, 436, 274, 436,
+        284, 366, 285], "words": [{"text": "REV", "boundingBox": [366, 275, 384, 275,
+        384, 285, 366, 285], "confidence": 0.994}, {"text": "07/01/2018", "boundingBox":
+        [386, 275, 435, 275, 434, 285, 386, 285], "confidence": 0.991}], "appearance":
+        {"style": {"name": "other", "confidence": 0.878}}}]}], "documentResults":
+        [{"docType": "prebuilt:idDocument:driverLicense", "docTypeConfidence": 0.995,
+        "pageRange": [1, 1], "fields": {"Address": {"type": "string", "valueString":
+        "123 STREET ADDRESS YOUR CITY WA 99999-1234", "text": "123 STREET ADDRESS
+        YOUR CITY WA 99999-1234", "boundingBox": [158, 151, 326, 151, 326, 177, 158,
+        177], "page": 1, "confidence": 0.965, "elements": ["#/readResults/0/lines/10/words/1",
+        "#/readResults/0/lines/10/words/2", "#/readResults/0/lines/10/words/3", "#/readResults/0/lines/11/words/0",
+        "#/readResults/0/lines/11/words/1", "#/readResults/0/lines/11/words/2", "#/readResults/0/lines/11/words/3"]},
+        "Country": {"type": "country", "valueCountry": "USA", "confidence": 0.99},
+        "DateOfBirth": {"type": "date", "valueDate": "1958-01-06", "text": "01/06/1958",
+        "boundingBox": [187, 133, 272, 132, 272, 148, 187, 149], "page": 1, "confidence":
+        0.99, "elements": ["#/readResults/0/lines/8/words/2"]}, "DateOfExpiration":
+        {"type": "date", "valueDate": "2020-08-12", "text": "08/12/2020", "boundingBox":
+        [332, 230, 414, 228, 414, 244, 332, 245], "page": 1, "confidence": 0.99, "elements":
+        ["#/readResults/0/lines/19/words/2"]}, "DocumentNumber": {"type": "string",
+        "valueString": "LICWDLACD5DG", "text": "LIC#WDLABCD456DG", "boundingBox":
+        [162, 70, 307, 68, 307, 84, 163, 85], "page": 1, "confidence": 0.99, "elements":
+        ["#/readResults/0/lines/4/words/1"]}, "FirstName": {"type": "string", "valueString":
+        "LIAM R.", "text": "LIAM R.", "boundingBox": [158, 102, 216, 102, 216, 116,
+        158, 116], "page": 1, "confidence": 0.985, "elements": ["#/readResults/0/lines/7/words/1",
+        "#/readResults/0/lines/7/words/2"]}, "LastName": {"type": "string", "valueString":
+        "TALBOT", "text": "TALBOT", "boundingBox": [160, 86, 213, 85, 213, 99, 160,
+        100], "page": 1, "confidence": 0.987, "elements": ["#/readResults/0/lines/6/words/1"]},
+        "Region": {"type": "string", "valueString": "Washington", "confidence": 0.99},
+        "Sex": {"type": "gender", "valueGender": "M", "text": "M", "boundingBox":
+        [226, 190, 232, 190, 233, 201, 226, 201], "page": 1, "confidence": 0.99, "elements":
+        ["#/readResults/0/lines/13/words/2"]}}}]}}'
     headers:
-      apim-request-id: 714d2583-7dc2-46fc-a569-d19a70e9b2aa
-      content-length: '11076'
+      apim-request-id: 76205f95-42db-4bfb-bb0c-74b5be445f38
+      content-length: '10387'
       content-type: application/json; charset=utf-8
-      date: Fri, 05 Mar 2021 17:42:35 GMT
+      date: Fri, 26 Mar 2021 03:52:07 GMT
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       x-content-type-options: nosniff
-      x-envoy-upstream-service-time: '18'
+      x-envoy-upstream-service-time: '25'
     status:
       code: 200
       message: OK
-    url: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/e6ddf690-296a-43a4-8d59-ad8ee1b90a4b
+    url: https://region.api.cognitive.microsoft.com/formrecognizer/v2.1-preview.3/prebuilt/idDocument/analyzeResults/ac44fd3f-b8ae-4394-b352-4013d3b408eb
 version: 1

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_id_documents.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_id_documents.py
@@ -175,14 +175,13 @@ class TestIdDocument(FormRecognizerTest):
         # check dict values
         self.assertEqual(id_document.fields.get("LastName").value, "TALBOT")
         self.assertEqual(id_document.fields.get("FirstName").value, "LIAM R.")
-        # self.assertEqual(id_document.fields.get("DocumentNumber").value, "WDLABCD456DG") # service error when reading the license number returns 'LICWDLACD5DG'
+        # FIXME service error when reading the license number returns 'LICWDLACD5DG'
+        # self.assertEqual(id_document.fields.get("DocumentNumber").value, "WDLABCD456DG")
         self.assertEqual(id_document.fields.get("DateOfBirth").value, date(1958,1,6))
         self.assertEqual(id_document.fields.get("DateOfExpiration").value, date(2020,8,12))
-        # FIXME: this is different than the other field values
-        self.assertEqual(id_document.fields.get("Sex").value_data.text, "M")
+        self.assertEqual(id_document.fields.get("Sex").value, "M")
         self.assertEqual(id_document.fields.get("Address").value, "123 STREET ADDRESS YOUR CITY WA 99999-1234")
-        # FIXME: country is not returning a value
-        # self.assertEqual(id_document.fields.get("Country").value_data.text, "United States")
+        self.assertEqual(id_document.fields.get("Country").value, "USA")
         self.assertEqual(id_document.fields.get("Region").value, "Washington")
 
     @FormRecognizerPreparer()
@@ -200,12 +199,11 @@ class TestIdDocument(FormRecognizerTest):
 
         for field in id_document.fields.values():
             if field.name == "Country":
-                # FIXME: this is different than the other field values
-                # self.assertEqual(field.value_data.text, "United States")
+                self.assertEqual(field.value, "USA")
                 continue
             elif field.name == "Region":
                 self.assertEqual(field.value, "Washington")
-            else: 
+            else:
                 self.assertFieldElementsHasValues(field.value_data.field_elements, id_document.page_range.first_page_number)
 
     @FormRecognizerPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_id_documents_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_id_documents_async.py
@@ -191,13 +191,13 @@ class TestIdDocumentsAsync(AsyncFormRecognizerTest):
 
         self.assertEqual(id_document.fields.get("LastName").value, "TALBOT")
         self.assertEqual(id_document.fields.get("FirstName").value, "LIAM R.")
-        # self.assertEqual(id_document.fields.get("DocumentNumber").value, "WDLABCD456DG") # service error when reading the license number returns 'LICWDLACD5DG'
+        # FIXME: service error when reading the license number returns 'LICWDLACD5DG'
+        # self.assertEqual(id_document.fields.get("DocumentNumber").value, "WDLABCD456DG")
         self.assertEqual(id_document.fields.get("DateOfBirth").value, date(1958,1,6))
         self.assertEqual(id_document.fields.get("DateOfExpiration").value, date(2020,8,12))
-        self.assertEqual(id_document.fields.get("Sex").value_data.text, "M")
+        self.assertEqual(id_document.fields.get("Sex").value, "M")
         self.assertEqual(id_document.fields.get("Address").value, "123 STREET ADDRESS YOUR CITY WA 99999-1234")
-        # FIXME: country is not returning a value
-        # self.assertEqual(id_document.fields.get("Country").value_data.text, "United States")
+        self.assertEqual(id_document.fields.get("Country").value, "USA")
         self.assertEqual(id_document.fields.get("Region").value, "Washington")
 
     @FormRecognizerPreparer()
@@ -216,12 +216,11 @@ class TestIdDocumentsAsync(AsyncFormRecognizerTest):
 
         for field in id_document.fields.values():
             if field.name == "Country":
-                # FIXME: this is different than the other field values
-                # self.assertEqual(field.value_data.text, "United States")
+                self.assertEqual(field.value, "USA")
                 continue
             elif field.name == "Region":
                 self.assertEqual(field.value, "Washington")
-            else: 
+            else:
                 self.assertFieldElementsHasValues(field.value_data.field_elements, id_document.page_range.first_page_number)
 
     @FormRecognizerPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_id_documents_from_url.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_id_documents_from_url.py
@@ -106,17 +106,16 @@ class TestIdDocumentsFromUrl(FormRecognizerTest):
         id_document = result[0]
 
         # check dict values
-        self.assertEqual(id_document.fields.get("LastName").value, "SAMPLE")
-        self.assertEqual(id_document.fields.get("FirstName").value, "JANICE ANN")
-        self.assertEqual(id_document.fields.get("DocumentNumber").value, "99 999 999")
-        self.assertEqual(id_document.fields.get("DateOfBirth").value, date(1975,8,4))
-        self.assertEqual(id_document.fields.get("DateOfExpiration").value, date(2023,8,5))
-        # FIXME: this is different than the other field values
-        self.assertEqual(id_document.fields.get("Sex").value_data.text, "F")
-        self.assertEqual(id_document.fields.get("Address").value, "123 MAIN STREET APT. 1 HARRISBURG, PA 17101-0000")
-        # FIXME: this is different than the other field values
-        # self.assertEqual(id_document.fields.get("Country").value_data.text, "United States")
-        self.assertEqual(id_document.fields.get("Region").value, "Pennsylvania")
+        self.assertEqual(id_document.fields.get("LastName").value, "TALBOT")
+        self.assertEqual(id_document.fields.get("FirstName").value, "LIAM R.")
+        # FIXME service error when reading the license number returns 'LICWDLACD5DG'
+        # self.assertEqual(id_document.fields.get("DocumentNumber").value, "WDLABCD456DG")
+        self.assertEqual(id_document.fields.get("DateOfBirth").value, date(1958,1,6))
+        self.assertEqual(id_document.fields.get("DateOfExpiration").value, date(2020,8,12))
+        self.assertEqual(id_document.fields.get("Sex").value, "M")
+        self.assertEqual(id_document.fields.get("Address").value, "123 STREET ADDRESS YOUR CITY WA 99999-1234")
+        self.assertEqual(id_document.fields.get("Country").value, "USA")
+        self.assertEqual(id_document.fields.get("Region").value, "Washington")
 
     @FormRecognizerPreparer()
     @GlobalClientPreparer()
@@ -131,12 +130,11 @@ class TestIdDocumentsFromUrl(FormRecognizerTest):
 
         for field in id_document.fields.values():
             if field.name == "Country":
-                # FIXME: this is different than the other field values
-                # self.assertEqual(field.value_data.text, "United States")
+                self.assertEqual(field.value, "USA")
                 continue
             elif field.name == "Region":
-                self.assertEqual(field.value, "Pennsylvania")
-            else: 
+                self.assertEqual(field.value, "Washington")
+            else:
                 self.assertFieldElementsHasValues(field.value_data.field_elements, id_document.page_range.first_page_number)
 
     @FormRecognizerPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_id_documents_from_url_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_id_documents_from_url_async.py
@@ -115,17 +115,17 @@ class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
         id_document = result[0]
 
         # check dict values
-        self.assertEqual(id_document.fields.get("LastName").value, "SAMPLE")
-        self.assertEqual(id_document.fields.get("FirstName").value, "JANICE ANN")
-        self.assertEqual(id_document.fields.get("DocumentNumber").value, "99 999 999")
-        self.assertEqual(id_document.fields.get("DateOfBirth").value, date(1975,8,4))
-        self.assertEqual(id_document.fields.get("DateOfExpiration").value, date(2023,8,5))
-        # FIXME: this is different than the other field values
-        self.assertEqual(id_document.fields.get("Sex").value_data.text, "F")
-        self.assertEqual(id_document.fields.get("Address").value, "123 MAIN STREET APT. 1 HARRISBURG, PA 17101-0000")
-        # FIXME: this is different than the other field values
-        # self.assertEqual(id_document.fields.get("Country").value_data.text, "United States")
-        self.assertEqual(id_document.fields.get("Region").value, "Pennsylvania")
+        self.assertEqual(id_document.fields.get("LastName").value, "TALBOT")
+        self.assertEqual(id_document.fields.get("FirstName").value, "LIAM R.")
+        # FIXME service error when reading the license number returns 'LICWDLACD5DG'
+        # self.assertEqual(id_document.fields.get("DocumentNumber").value, "WDLABCD456DG")
+        self.assertEqual(id_document.fields.get("DateOfBirth").value, date(1958,1,6))
+        self.assertEqual(id_document.fields.get("DateOfExpiration").value, date(2020,8,12))
+        self.assertEqual(id_document.fields.get("Sex").value, "M")
+        self.assertEqual(id_document.fields.get("Address").value, "123 STREET ADDRESS YOUR CITY WA 99999-1234")
+        self.assertEqual(id_document.fields.get("Country").value, "USA")
+        self.assertEqual(id_document.fields.get("Region").value, "Washington")
+
 
     @FormRecognizerPreparer()
     @GlobalClientPreparer()
@@ -141,12 +141,11 @@ class TestIdDocumentsFromUrlAsync(AsyncFormRecognizerTest):
 
         for field in id_document.fields.values():
             if field.name == "Country":
-                # FIXME: this is different than the other field values
-                # self.assertEqual(field.value_data.text, "United States")
+                self.assertEqual(field.value, "USA")
                 continue
             elif field.name == "Region":
-                self.assertEqual(field.value, "Pennsylvania")
-            else: 
+                self.assertEqual(field.value, "Washington")
+            else:
                 self.assertFieldElementsHasValues(field.value_data.field_elements, id_document.page_range.first_page_number)
 
     @FormRecognizerPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/testcase.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/testcase.py
@@ -143,7 +143,7 @@ class FormRecognizerTest(AzureTestCase):
         self.business_card_url_jpg = self.get_blob_url(testing_container_sas_url, "testingdata", "businessCard.jpg")
         self.business_card_url_png = self.get_blob_url(testing_container_sas_url, "testingdata", "businessCard.png")
         self.business_card_multipage_url_pdf = self.get_blob_url(testing_container_sas_url, "testingdata", "business-card-multipage.pdf")
-        self.id_document_url_jpg = self.get_blob_url(testing_container_sas_url, "testingdata", "license_2.jpg")
+        self.id_document_url_jpg = self.get_blob_url(testing_container_sas_url, "testingdata", "license.jpg")
         self.invoice_url_pdf = self.get_blob_url(testing_container_sas_url, "testingdata", "Invoice_1.pdf")
         self.invoice_url_tiff = self.get_blob_url(testing_container_sas_url, "testingdata", "Invoice_1.tiff")
         self.multipage_vendor_url_pdf = self.get_blob_url(testing_container_sas_url, "testingdata", "multi1.pdf")


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/17465 https://github.com/Azure/azure-sdk-for-python/issues/17432

- Regenerates on the latest swagger to get the valueGender and valueCountry updates for ID docs
- Updates samples and tests for this fix
- file stream/URL tests now targeting same sample license picture