### PR TITLE
Fix RetryPolicy setting extremely long connection timeout

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -12,6 +12,7 @@ Azure core requires Python 2.7 or Python 3.6+ since this release.
 ### Bug fixes
 
 - Make NetworkTraceLoggingPolicy show the auth token in plain text. #14191
+- Fixed RetryPolicy overriding default connection timeout with an extreme value #17481
 
 ## 1.12.0 (2021-03-08)
 

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py
@@ -303,11 +303,15 @@ class RetryPolicyBase(object):
             request.context.options["connection_timeout"] = min(connection_timeout, absolute_timeout)
 
         # otherwise, try to ensure the transport's configured connection_timeout doesn't exceed absolute_timeout
-        # ("connection_config" isn't defined on HttpTransport but all implementations in this library have it)
+        # ("connection_config" isn't defined on Async/HttpTransport but all implementations in this library have it)
         elif hasattr(request.context.transport, "connection_config"):
             default_timeout = getattr(request.context.transport.connection_config, "timeout", absolute_timeout)
-            if absolute_timeout < default_timeout:
-                request.context.options["connection_timeout"] = absolute_timeout
+            try:
+                if absolute_timeout < default_timeout:
+                    request.context.options["connection_timeout"] = absolute_timeout
+            except TypeError:
+                # transport.connection_config.timeout is something unexpected (not a number)
+                pass
 
     def _configure_positions(self, request, retry_settings):
         body_position = None

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py
@@ -296,12 +296,18 @@ class RetryPolicyBase(object):
             if is_response_error:
                 raise ServiceResponseTimeoutError('Response timeout')
             raise ServiceRequestTimeoutError('Request timeout')
+
+        # if connection_timeout is already set, ensure it doesn't exceed absolute_timeout
         connection_timeout = request.context.options.get('connection_timeout')
         if connection_timeout:
-            req_timeout = min(connection_timeout, absolute_timeout)
-        else:
-            req_timeout = absolute_timeout
-        request.context.options['connection_timeout'] = req_timeout
+            request.context.options["connection_timeout"] = min(connection_timeout, absolute_timeout)
+
+        # otherwise, try to ensure the transport's configured connection_timeout doesn't exceed absolute_timeout
+        # ("connection_config" isn't defined on HttpTransport but all implementations in this library have it)
+        elif hasattr(request.context.transport, "connection_config"):
+            default_timeout = getattr(request.context.transport.connection_config, "timeout", absolute_timeout)
+            if absolute_timeout < default_timeout:
+                request.context.options["connection_timeout"] = absolute_timeout
 
     def _configure_positions(self, request, retry_settings):
         body_position = None

--- a/sdk/core/azure-core/dev_requirements.txt
+++ b/sdk/core/azure-core/dev_requirements.txt
@@ -4,6 +4,6 @@ typing_extensions>=3.7.2
 opencensus>=0.6.0
 opencensus-ext-azure>=0.3.1
 opencensus-ext-threading
-mock
+mock; python_version < '3.3'
 -e ../../../tools/azure-sdk-tools
 -e ../../../tools/azure-devtools

--- a/sdk/core/azure-core/tests/async_tests/test_retry_policy_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_retry_policy_async.py
@@ -223,7 +223,7 @@ async def test_retry_timeout():
     timeout = 1
 
     def send(request, **kwargs):
-        assert kwargs["connection_timeout"] == timeout, "policy should set connection_timeout not to exceed timeout"
+        assert kwargs["connection_timeout"] <= timeout, "policy should set connection_timeout not to exceed timeout"
         raise ServiceResponseError("oops")
 
     transport = Mock(

--- a/sdk/core/azure-core/tests/async_tests/test_retry_policy_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_retry_policy_async.py
@@ -8,8 +8,9 @@ try:
 except ImportError:
     from cStringIO import StringIO as BytesIO
 import sys
-import mock
+from unittest.mock import Mock
 import pytest
+from azure.core.configuration import ConnectionConfiguration
 from azure.core.exceptions import AzureError, ServiceResponseError, ServiceResponseTimeoutError
 from azure.core.pipeline.policies import (
     AsyncRetryPolicy,
@@ -216,31 +217,44 @@ async def test_retry_seekable_file():
         await pipeline.run(http_request)
     os.unlink(f.name)
 
+
 @pytest.mark.asyncio
 async def test_retry_timeout():
-    class MockTransport(AsyncHttpTransport):
-        def __init__(self):
-            self.count = 0
+    timeout = 1
 
-        async def __aexit__(self, exc_type, exc_val, exc_tb):
-            pass
-        async def close(self):
-            pass
-        async def open(self):
-            pass
+    def send(request, **kwargs):
+        assert kwargs["connection_timeout"] == timeout, "policy should set connection_timeout not to exceed timeout"
+        raise ServiceResponseError("oops")
 
-        async def send(self, request, **kwargs):  # type: (PipelineRequest, Any) -> PipelineResponse
-            self.count += 1
-            if self.count > 2:
-                assert self.count <= 2
-            time.sleep(0.5)
-            raise ServiceResponseError('timeout')
+    transport = Mock(
+        spec=AsyncHttpTransport,
+        send=Mock(wraps=send),
+        connection_config=ConnectionConfiguration(connection_timeout=timeout * 2),
+        sleep=asyncio.sleep,
+    )
+    pipeline = AsyncPipeline(transport, [AsyncRetryPolicy(timeout=timeout)])
 
-    http_request = HttpRequest('GET', 'http://127.0.0.1/')
-    headers = {'Content-Type': "multipart/form-data"}
-    http_request.headers = headers
-    http_retry = AsyncRetryPolicy(retry_total=10, timeout=1)
-    pipeline = AsyncPipeline(MockTransport(), [http_retry])
     with pytest.raises(ServiceResponseTimeoutError):
-        await pipeline.run(http_request)
+        await pipeline.run(HttpRequest("GET", "http://127.0.0.1/"))
 
+
+@pytest.mark.asyncio
+async def test_timeout_defaults():
+    """When "timeout" is not set, the policy should not override the transport's timeout configuration"""
+
+    async def send(request, **kwargs):
+        for arg in ("connection_timeout", "read_timeout"):
+            assert arg not in kwargs, "policy should defer to transport configuration when not given a timeout"
+        response = HttpResponse(request, None)
+        response.status_code = 200
+        return response
+
+    transport = Mock(
+        spec_set=AsyncHttpTransport,
+        send=Mock(wraps=send),
+        sleep=Mock(side_effect=Exception("policy should not sleep: its first send succeeded")),
+    )
+    pipeline = AsyncPipeline(transport, [AsyncRetryPolicy()])
+
+    await pipeline.run(HttpRequest("GET", "http://127.0.0.1/"))
+    assert transport.send.call_count == 1, "policy should not retry: its first send succeeded"

--- a/sdk/core/azure-core/tests/test_retry_policy.py
+++ b/sdk/core/azure-core/tests/test_retry_policy.py
@@ -221,7 +221,7 @@ def test_retry_timeout():
     timeout = 1
 
     def send(request, **kwargs):
-        assert kwargs["connection_timeout"] == timeout, "policy should set connection_timeout not to exceed timeout"
+        assert kwargs["connection_timeout"] <= timeout, "policy should set connection_timeout not to exceed timeout"
         raise ServiceResponseError("oops")
 
     transport = Mock(

--- a/sdk/core/azure-core/tests/test_retry_policy.py
+++ b/sdk/core/azure-core/tests/test_retry_policy.py
@@ -8,6 +8,7 @@ try:
 except ImportError:
     from cStringIO import StringIO as BytesIO
 import pytest
+from azure.core.configuration import ConnectionConfiguration
 from azure.core.exceptions import AzureError, ServiceResponseError, ServiceResponseTimeoutError
 from azure.core.pipeline.policies import (
     RetryPolicy,
@@ -22,6 +23,12 @@ from azure.core.pipeline.transport import (
 import tempfile
 import os
 import time
+
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
+
 
 def test_retry_code_class_variables():
     retry_policy = RetryPolicy()
@@ -209,30 +216,42 @@ def test_retry_seekable_file():
         pipeline.run(http_request)
     os.unlink(f.name)
 
+
 def test_retry_timeout():
-    class MockTransport(HttpTransport):
-        def __init__(self):
-            self.count = 0
+    timeout = 1
 
-        def __exit__(self, exc_type, exc_val, exc_tb):
-            pass
-        def close(self):
-            pass
-        def open(self):
-            pass
+    def send(request, **kwargs):
+        assert kwargs["connection_timeout"] == timeout, "policy should set connection_timeout not to exceed timeout"
+        raise ServiceResponseError("oops")
 
-        def send(self, request, **kwargs):  # type: (PipelineRequest, Any) -> PipelineResponse
-            self.count += 1
-            if self.count > 2:
-                assert self.count <= 2
-            time.sleep(0.5)
-            raise ServiceResponseError('timeout')
+    transport = Mock(
+        spec=HttpTransport,
+        send=Mock(wraps=send),
+        connection_config=ConnectionConfiguration(connection_timeout=timeout * 2),
+        sleep=time.sleep,
+    )
+    pipeline = Pipeline(transport, [RetryPolicy(timeout=timeout)])
 
-    http_request = HttpRequest('GET', 'http://127.0.0.1/')
-    headers = {'Content-Type': "multipart/form-data"}
-    http_request.headers = headers
-    http_retry = RetryPolicy(retry_total=10, timeout=1)
-    pipeline = Pipeline(MockTransport(), [http_retry])
     with pytest.raises(ServiceResponseTimeoutError):
-        pipeline.run(http_request)
+        response = pipeline.run(HttpRequest("GET", "http://127.0.0.1/"))
 
+
+def test_timeout_defaults():
+    """When "timeout" is not set, the policy should not override the transport's timeout configuration"""
+
+    def send(request, **kwargs):
+        for arg in ("connection_timeout", "read_timeout"):
+            assert arg not in kwargs, "policy should defer to transport configuration when not given a timeout"
+        response = HttpResponse(request, None)
+        response.status_code = 200
+        return response
+
+    transport = Mock(
+        spec_set=HttpTransport,
+        send=Mock(wraps=send),
+        sleep=Mock(side_effect=Exception("policy should not sleep: its first send succeeded")),
+    )
+    pipeline = Pipeline(transport, [RetryPolicy()])
+
+    pipeline.run(HttpRequest("GET", "http://127.0.0.1/"))
+    assert transport.send.call_count == 1, "policy should not retry: its first send succeeded"


### PR DESCRIPTION
This fixes #17481 by ensuring RetryPolicy sets `connection_timeout` on a request only when it determines doing so will prevent a connection timeout from exceeding the policy's overall timeout.