### PR TITLE
[Key Vault] Fix backup/restore samples

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/samples/backup_restore_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/backup_restore_operations_async.py
@@ -15,7 +15,7 @@ from azure.core.exceptions import HttpResponseError
 #
 # 2. azure-keyvault-certificates and azure-identity packages (pip install these)
 #
-# 3. Set Environment variables AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET, vault_url
+# 3. Set Environment variables AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET, VAULT_URL
 #    (See https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-keys#authenticate-the-client)
 #
 # ----------------------------------------------------------------------------------------------------------
@@ -27,7 +27,9 @@ from azure.core.exceptions import HttpResponseError
 #
 # 3. Delete a certificate (delete_certificate)
 #
-# 4. Restore a certificate (restore_certificate_backup)
+# 4. Purge a certificate (purge_deleted_certificate)
+#
+# 5. Restore a certificate (restore_certificate_backup)
 # ----------------------------------------------------------------------------------------------------------
 
 
@@ -62,12 +64,19 @@ async def run_sample():
         # The storage account certificate is no longer in use, so you can delete it.
         print("\n.. Delete the certificate")
         await client.delete_certificate(cert_name)
-        print("Deleted Certificate with name '{0}'".format(cert_name))
+        print("Deleted certificate with name '{0}'".format(cert_name))
 
-        # In future, if the certificate is required again, we can use the backup value to restore it in the Key Vault.
+        # Purge the deleted certificate.
+        # The purge will take some time, so wait before restoring the backup to avoid a conflict.
+        print("\n.. Purge the certificate")
+        await client.purge_deleted_certificate(cert_name)
+        await asyncio.sleep(60)
+        print("Purged certificate with name '{0}'".format(cert_name))
+
+        # In the future, if the certificate is required again, we can use the backup value to restore it in the Key Vault.
         print("\n.. Restore the certificate using the backed up certificate bytes")
         certificate = await client.restore_certificate_backup(certificate_backup)
-        print("Restored Certificate with name '{0}'".format(certificate.name))
+        print("Restored certificate with name '{0}'".format(certificate.name))
 
     except HttpResponseError as e:
         print("\nrun_sample has caught an error. {0}".format(e.message))

--- a/sdk/keyvault/azure-keyvault-keys/samples/backup_restore_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/backup_restore_operations_async.py
@@ -26,7 +26,9 @@ from azure.core.exceptions import HttpResponseError
 #
 # 3. Delete a key (delete_key)
 #
-# 4. Restore a key (restore_key_backup)
+# 4. Purge a key (purge_deleted_key)
+#
+# 5. Restore a key (restore_key_backup)
 # ----------------------------------------------------------------------------------------------------------
 async def run_sample():
     # Instantiate a key client that will be used to call the service.
@@ -51,12 +53,19 @@ async def run_sample():
 
         # The rsa key is no longer in use, so you delete it.
         deleted_key = await client.delete_key(key.name)
-        print("Deleted Key with name '{0}'".format(deleted_key.name))
+        print("Deleted key with name '{0}'".format(deleted_key.name))
 
-        # In future, if the key is required again, we can use the backup value to restore it in the Key Vault.
+        # Purge the deleted key.
+        # The purge will take some time, so wait before restoring the backup to avoid a conflict.
+        print("\n.. Purge the key")
+        await client.purge_deleted_key(key.name)
+        await asyncio.sleep(60)
+        print("Purged key with name '{0}'".format(deleted_key.name))
+
+        # In the future, if the key is required again, we can use the backup value to restore it in the Key Vault.
         print("\n.. Restore the key using the backed up key bytes")
         key = await client.restore_key_backup(key_backup)
-        print("Restored Key with name '{0}'".format(key.name))
+        print("Restored key with name '{0}'".format(key.name))
 
     except HttpResponseError as e:
         print("\nrun_sample has caught an error. {0}".format(e.message))

--- a/sdk/keyvault/azure-keyvault-secrets/samples/backup_restore_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/backup_restore_operations_async.py
@@ -27,7 +27,9 @@ from azure.core.exceptions import HttpResponseError
 #
 # 3. Delete a secret (delete_secret)
 #
-# 4. Restore a secret (restore_secret_backup)
+# 4. Purge a secret (purge_deleted_secret)
+#
+# 5. Restore a secret (restore_secret_backup)
 # ----------------------------------------------------------------------------------------------------------
 async def run_sample():
     # Instantiate a secret client that will be used to call the service.
@@ -53,12 +55,19 @@ async def run_sample():
         # The storage account secret is no longer in use, so you delete it.
         print("\n.. Deleting secret...")
         await client.delete_secret(secret.name)
-        print("Deleted Secret with name '{0}'".format(secret.name))
+        print("Deleted secret with name '{0}'".format(secret.name))
 
-        # In future, if the secret is required again, we can use the backup value to restore it in the Key Vault.
+        # Purge the deleted secret.
+        # The purge will take some time, so wait before restoring the backup to avoid a conflict.
+        print("\n.. Purge the secret")
+        await client.purge_deleted_secret(secret.name)
+        await asyncio.sleep(60)
+        print("Purged secret with name '{0}'".format(secret.name))
+
+        # In the future, if the secret is required again, we can use the backup value to restore it in the Key Vault.
         print("\n.. Restore the secret using the backed up secret bytes")
         secret = await client.restore_secret_backup(secret_backup)
-        print("Restored Secret with name '{0}'".format(secret.name))
+        print("Restored secret with name '{0}'".format(secret.name))
 
     except HttpResponseError as e:
         print("\nrun_sample has caught an error. {0}".format(e.message))


### PR DESCRIPTION
Resolves #17630.

Backup/restore samples in each package assumed that vaults had soft-delete disabled, so conflicts arise in soft-delete enabled vaults. This adds purges in those samples to relieve conflicts, and makes small tweaks for consistency/grammar.

Thank you @v-xuto for the find!