### PR TITLE
[Identity] Fix `padding_needed` for base64-decoding claims

### DIFF
--- a/sdk/core/azure-mgmt-core/azure/mgmt/core/policies/_authentication.py
+++ b/sdk/core/azure-mgmt-core/azure/mgmt/core/policies/_authentication.py
@@ -74,7 +74,7 @@ def _parse_claims_challenge(challenge):
         return None
 
     encoded_claims = parsed_challenges[0].parameters["claims"]
-    padding_needed = 4 - len(encoded_claims) % 4
+    padding_needed = -len(encoded_claims) % 4
     try:
         return base64.urlsafe_b64decode(encoded_claims + "=" * padding_needed).decode()
     except Exception:  # pylint:disable=broad-except


### PR DESCRIPTION
When `len(encoded_claims)` is a multiple of 4, this line returns 4, thus appending extra `====` to the string.

This fix is copied from MSAL (+@rayluo for awareness)

https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/1.10.0/msal/oauth2cli/oidc.py#L23

```py
raw += '=' * (-len(raw) % 4)  # https://stackoverflow.com/a/32517907/728675
```