### PR TITLE
set-test-pipeline-version.yml failing due to lack of setuptools

### DIFF
--- a/eng/versioning/requirements.txt
+++ b/eng/versioning/requirements.txt
@@ -1,3 +1,4 @@
 packaging==19.2
 pyparsing==2.4.5
 six==1.13.0
+setuptools==44.1.1


### PR DESCRIPTION
What I cannot understand is why this has been succeeding up till now. Agent change maybe?
