### PR TITLE
Setuptools is no longer present in the default python install

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -18,7 +18,7 @@ function Get-AllPackageInfoFromRepo ($serviceDirectory)
   try
   {
     Push-Location $RepoRoot
-    pip install packaging==20.4 -q -I
+    pip install packaging==20.4 setuptools==44.1.1 -q -I
     $allPkgPropLines = python (Join-path eng scripts get_package_properties.py) -s $searchPath
   }
   catch


### PR DESCRIPTION
This PR is quite similar to #17720 

[Example Failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=815176&view=logs&j=b6f7b02f-4c06-5d94-ea42-ae5d966a2c2f&t=e1a5ddc8-f799-5d0b-74cd-349aec78d3e2)

This should have been caught in #17720, but I did not actually trigger the release, as the issue I was resolving was in the `build` stage. Dumb, to say the least.

