### PR TITLE
[core] check request id in request headers

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.12.1 (Unreleased)
 
+### Bug Fixes
+
+- Do not override your `x-ms-client-request-id` if you have already explicitly set the value in your request headers  #17758
+
 
 ## 1.12.0 (2021-03-08)
 

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
@@ -157,7 +157,10 @@ class RequestIdPolicy(SansIOHTTPPolicy):
             request_id = self._request_id
         elif self._auto_request_id:
             request_id = str(uuid.uuid1())
-        if request_id is not unset:
+        if (
+            request_id is not unset and
+            "x-ms-client-request-id" not in request.http_request.headers
+        ):
             header = {"x-ms-client-request-id": request_id}
             request.http_request.headers.update(header)
 

--- a/sdk/core/azure-core/tests/test_request_id_policy.py
+++ b/sdk/core/azure-core/tests/test_request_id_policy.py
@@ -54,3 +54,11 @@ def test_request_id_policy(auto_request_id, request_id_init, request_id_set, req
         assert request.headers["x-ms-client-request-id"] == "VALUE"
     else:
         assert not "x-ms-client-request-id" in request.headers
+
+def test_request_id_policy_request_id_set_in_headers():
+    request = HttpRequest('GET', 'http://127.0.0.1/', headers={'x-ms-client-request-id': "should be me"})
+    request_id_policy = RequestIdPolicy()
+    pipeline_request = PipelineRequest(request, PipelineContext(None))
+    with mock.patch('uuid.uuid1', return_value="VALUE"):
+        request_id_policy.on_request(pipeline_request)
+    assert request.headers['x-ms-client-request-id'] == "should be me"


### PR DESCRIPTION
fixes #17757

NOTE: will not get in for this upcoming release since code complete has already passed