### PR TITLE
[Key Vault] Add local crypto support for AES-CBCPAD

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
@@ -232,7 +232,7 @@ class CryptographyClient(KeyVaultClientBase):
         if self._local_provider.supports(KeyOperation.encrypt, algorithm):
             raise_if_time_invalid(self._not_before, self._expires_on)
             try:
-                return self._local_provider.encrypt(algorithm, plaintext)
+                return self._local_provider.encrypt(algorithm, plaintext, iv=iv, aad=aad)
             except Exception as ex:  # pylint:disable=broad-except
                 _LOGGER.warning("Local encrypt operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
                 if self._jwk:
@@ -292,7 +292,7 @@ class CryptographyClient(KeyVaultClientBase):
 
         if self._local_provider.supports(KeyOperation.decrypt, algorithm):
             try:
-                return self._local_provider.decrypt(algorithm, ciphertext)
+                return self._local_provider.decrypt(algorithm, ciphertext, iv=iv, tag=tag, aad=aad)
             except Exception as ex:  # pylint:disable=broad-except
                 _LOGGER.warning("Local decrypt operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
                 if self._jwk:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
@@ -232,7 +232,7 @@ class CryptographyClient(KeyVaultClientBase):
         if self._local_provider.supports(KeyOperation.encrypt, algorithm):
             raise_if_time_invalid(self._not_before, self._expires_on)
             try:
-                return self._local_provider.encrypt(algorithm, plaintext, iv=iv, aad=aad)
+                return self._local_provider.encrypt(algorithm, plaintext, iv=iv)
             except Exception as ex:  # pylint:disable=broad-except
                 _LOGGER.warning("Local encrypt operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
                 if self._jwk:
@@ -292,7 +292,7 @@ class CryptographyClient(KeyVaultClientBase):
 
         if self._local_provider.supports(KeyOperation.decrypt, algorithm):
             try:
-                return self._local_provider.decrypt(algorithm, ciphertext, iv=iv, tag=tag, aad=aad)
+                return self._local_provider.decrypt(algorithm, ciphertext, iv=iv)
             except Exception as ex:  # pylint:disable=broad-except
                 _LOGGER.warning("Local decrypt operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
                 if self._jwk:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/algorithms/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/algorithms/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from .aes_cbc import Aes128Cbc, Aes192Cbc, Aes256Cbc
+from .aes_cbc import Aes128Cbc, Aes192Cbc, Aes256Cbc, Aes128CbcPad, Aes192CbcPad, Aes256CbcPad
 from .aes_cbc_hmac import Aes128CbcHmacSha256, Aes192CbcHmacSha384, Aes256CbcHmacSha512
 from .aes_kw import AesKw128, AesKw192, AesKw256
 from .ecdsa import Ecdsa256, Es256, Es384, Es512
@@ -13,6 +13,9 @@ __all__ = [
     "Aes128Cbc",
     "Aes192Cbc",
     "Aes256Cbc",
+    "Aes128CbcPad",
+    "Aes192CbcPad",
+    "Aes256CbcPad",
     "Aes128CbcHmacSha256",
     "Aes192CbcHmacSha384",
     "Aes256CbcHmacSha512",

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/algorithms/aes_cbc.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/algorithms/aes_cbc.py
@@ -10,6 +10,8 @@ from ..algorithm import SymmetricEncryptionAlgorithm
 from ..transform import BlockCryptoTransform
 
 
+# pylint: disable=W0223
+
 _CBC_BLOCK_SIZE = 128
 
 
@@ -20,16 +22,16 @@ class _AesCbcCryptoTransform(BlockCryptoTransform):
 
     def transform(self, data):
         return self.update(data) + self.finalize()
-    
+
     def block_size(self):
         return _CBC_BLOCK_SIZE
 
 
 class _AesCbcDecryptor(_AesCbcCryptoTransform):
-    def __init__(self, key, iv, padding):
+    def __init__(self, key, iv, padding_mode):
         super(_AesCbcDecryptor, self).__init__(key, iv)
         self._ctx = self._cipher.decryptor()
-        self._padder = padding.unpadder()
+        self._padder = padding_mode.unpadder()
 
     def update(self, data):
         decrypted = self._ctx.update(data) + self._ctx.finalize()
@@ -40,10 +42,10 @@ class _AesCbcDecryptor(_AesCbcCryptoTransform):
 
 
 class _AesCbcEncryptor(_AesCbcCryptoTransform):
-    def __init__(self, key, iv, padding):
+    def __init__(self, key, iv, padding_mode):
         super(_AesCbcEncryptor, self).__init__(key, iv)
         self._ctx = self._cipher.encryptor()
-        self._padder = padding.padder()
+        self._padder = padding_mode.padder()
 
     def update(self, data):
         padded = self._padder.update(data) + self._padder.finalize()

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/algorithms/aes_cbc.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/algorithms/aes_cbc.py
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from abc import abstractmethod
-
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import padding
@@ -12,60 +10,80 @@ from ..algorithm import SymmetricEncryptionAlgorithm
 from ..transform import BlockCryptoTransform
 
 
+_CBC_BLOCK_SIZE = 128
+
+
 class _AesCbcCryptoTransform(BlockCryptoTransform):
     def __init__(self, key, iv):
         super(_AesCbcCryptoTransform, self).__init__(key)
         self._cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
 
     def transform(self, data):
-        return self.update(data) + self.finalize(data)
-
-    @abstractmethod
+        return self.update(data) + self.finalize()
+    
     def block_size(self):
-        pass
+        return _CBC_BLOCK_SIZE
 
 
 class _AesCbcDecryptor(_AesCbcCryptoTransform):
     def __init__(self, key, iv):
         super(_AesCbcDecryptor, self).__init__(key, iv)
         self._ctx = self._cipher.decryptor()
-        self._padder = padding.PKCS7(self.block_size).unpadder()
+        self._padder = padding.ANSIX923(_CBC_BLOCK_SIZE).unpadder()  # TODO: Update this to zero-padding
 
     def update(self, data):
-        padded = self._ctx.update(data)
-        return self._padder.update(padded)
+        decrypted = self._ctx.update(data) + self._ctx.finalize()
+        return self._padder.update(decrypted)
 
-    def finalize(self, data):
-        padded = self._ctx.finalize()
-        return self._padder.update(padded) + self._padder.finalize()
+    def finalize(self):
+        return self._padder.finalize()
 
-    def block_size(self):
-        # return self._cipher.block_size
-        raise NotImplementedError()
+
+class _AesCbcPadDecryptor(_AesCbcCryptoTransform):
+    def __init__(self, key, iv):
+        super(_AesCbcPadDecryptor, self).__init__(key, iv)
+        self._ctx = self._cipher.decryptor()
+        self._padder = padding.PKCS7(_CBC_BLOCK_SIZE).unpadder()
+
+    def update(self, data):
+        decrypted = self._ctx.update(data) + self._ctx.finalize()
+        return self._padder.update(decrypted)
+
+    def finalize(self):
+        return self._padder.finalize()
 
 
 class _AesCbcEncryptor(_AesCbcCryptoTransform):
     def __init__(self, key, iv):
         super(_AesCbcEncryptor, self).__init__(key, iv)
         self._ctx = self._cipher.encryptor()
-        self._padder = padding.PKCS7(self.block_size).padder()
+        self._padder = padding.ANSIX923(_CBC_BLOCK_SIZE).padder()  # TODO: Update this to zero-padding
 
     def update(self, data):
-        padded = self._padder.update(data)
+        padded = self._padder.update(data) + self._padder.finalize()
         return self._ctx.update(padded)
 
-    def finalize(self, data):
-        padded = self._padder.finalize()
-        return self._ctx.update(padded) + self._ctx.finalize()
+    def finalize(self):
+        return self._ctx.finalize()
 
-    def block_size(self):
-        # return self._cipher.block_size
-        raise NotImplementedError()
+
+class _AesCbcPadEncryptor(_AesCbcCryptoTransform):
+    def __init__(self, key, iv):
+        super(_AesCbcPadEncryptor, self).__init__(key, iv)
+        self._ctx = self._cipher.encryptor()
+        self._padder = padding.PKCS7(_CBC_BLOCK_SIZE).padder()
+
+    def update(self, data):
+        padded = self._padder.update(data) + self._padder.finalize()
+        return self._ctx.update(padded)
+
+    def finalize(self):
+        return self._ctx.finalize()
 
 
 class _AesCbc(SymmetricEncryptionAlgorithm):
     _key_size = 256
-    _block_size = 128
+    _block_size = _CBC_BLOCK_SIZE
 
     def block_size(self):
         return self._block_size
@@ -91,20 +109,37 @@ class _AesCbc(SymmetricEncryptionAlgorithm):
 
     def _validate_input(self, key, iv):
         if not key:
-            raise ValueError("key")
+            raise ValueError("A key is required for AES-CBC and AES-CBCPAD encryption and decryption")
         if len(key) < self.key_size_in_bytes():
             raise ValueError("key must be at least %d bits" % self.key_size)
 
         if not iv:
-            raise ValueError("iv")
+            raise ValueError("A 16-byte iv is required for AES-CBC and AES-CBCPAD encryption and decryption")
         if not len(iv) == self.block_size_in_bytes():
             raise ValueError("iv must be %d bits" % self.block_size)
 
-        return key[: self.key_size_in_bytes], iv
+        return key[: self.key_size_in_bytes()], iv
+
+
+class _AesCbcPad(_AesCbc):
+    def create_encryptor(self, key, iv):
+        key, iv = self._validate_input(key, iv)
+
+        return _AesCbcPadEncryptor(key, iv)
+
+    def create_decryptor(self, key, iv):
+        key, iv = self._validate_input(key, iv)
+
+        return _AesCbcPadDecryptor(key, iv)
 
 
 class Aes128Cbc(_AesCbc):
     _name = "A128CBC"
+    _key_size = 128
+
+
+class Aes128CbcPad(_AesCbcPad):
+    _name = "A128CBCPAD"
     _key_size = 128
 
 
@@ -113,11 +148,24 @@ class Aes192Cbc(_AesCbc):
     _key_size = 192
 
 
+class Aes192CbcPad(_AesCbcPad):
+    _name = "A192CBCPAD"
+    _key_size = 192
+
+
 class Aes256Cbc(_AesCbc):
     _name = "A256CBC"
     _key_size = 256
 
 
+class Aes256CbcPad(_AesCbcPad):
+    _name = "A256CBCPAD"
+    _key_size = 256
+
+
 Aes128Cbc.register()
+Aes128CbcPad.register()
 Aes192Cbc.register()
+Aes192CbcPad.register()
 Aes256Cbc.register()
+Aes256CbcPad.register()

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/symmetric_key.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/symmetric_key.py
@@ -101,10 +101,10 @@ class SymmetricKey(Key):
     def default_key_wrap_algorithm(self):
         return _default_kw_alg_by_size[len(self._key)]
 
-    def encrypt(self, plain_text, **kwargs):  # pylint:disable=arguments-differ
+    def encrypt(self, plain_text, iv, **kwargs):  # pylint:disable=arguments-differ
         algorithm = self._get_algorithm("encrypt", **kwargs)
         raise_if_incorrect_key_size(algorithm, len(self._key))
-        encryptor = algorithm.create_encryptor(key=self._key, iv=kwargs.pop("iv", None))
+        encryptor = algorithm.create_encryptor(key=self._key, iv=iv)
         return encryptor.transform(plain_text)
 
     def decrypt(self, cipher_text, iv, **kwargs):  # pylint:disable=arguments-differ

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/symmetric_key.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/symmetric_key.py
@@ -4,8 +4,10 @@
 # ------------------------------------
 import uuid
 import os
+
+from azure.core.exceptions import AzureError
 from .key import Key
-from .algorithms.aes_cbc import Aes256Cbc, Aes192Cbc, Aes128Cbc
+from .algorithms.aes_cbc import Aes256CbcPad, Aes192CbcPad, Aes128CbcPad
 from .algorithms.aes_cbc_hmac import Aes256CbcHmacSha512, Aes192CbcHmacSha384, Aes128CbcHmacSha256
 from .algorithms.aes_kw import AesKw256, AesKw192, AesKw128
 
@@ -20,9 +22,9 @@ _default_key_size = key_size_256
 _supported_key_sizes = [key_size_128, key_size_192, key_size_256, key_size_384, key_size_512]
 
 _default_enc_alg_by_size = {
-    key_size_128: Aes128Cbc.name(),
-    key_size_192: Aes192Cbc.name(),
-    key_size_256: Aes128CbcHmacSha256.name(),
+    key_size_128: Aes128CbcPad.name(),
+    key_size_192: Aes192CbcPad.name(),
+    key_size_256: Aes256CbcPad.name(),
     key_size_384: Aes192CbcHmacSha384.name(),
     key_size_512: Aes256CbcHmacSha512.name(),
 }
@@ -34,6 +36,11 @@ _default_kw_alg_by_size = {
     key_size_384: AesKw256.name(),
     key_size_512: AesKw256.name(),
 }
+
+
+def raise_if_incorrect_key_size(algorithm, key_size):
+    if (algorithm._key_size >> 3 != key_size):
+        raise AzureError("Invalid AES encryption algorithm for key size. The algorithm must match the size of the key.")
 
 
 class SymmetricKey(Key):
@@ -59,13 +66,13 @@ class SymmetricKey(Key):
         supported_key_wrap_algorithms = []
         key_size = len(self._key)
         if key_size >= key_size_128:
-            supported_encryption_algorithms.append(Aes128Cbc.name())
+            supported_encryption_algorithms.append(Aes128CbcPad.name())
             supported_key_wrap_algorithms.append(AesKw128.name())
         if key_size >= key_size_192:
-            supported_encryption_algorithms.append(Aes192Cbc.name())
+            supported_encryption_algorithms.append(Aes192CbcPad.name())
             supported_key_wrap_algorithms.append(AesKw192.name())
         if key_size >= key_size_256:
-            supported_encryption_algorithms.append(Aes256Cbc.name())
+            supported_encryption_algorithms.append(Aes256CbcPad.name())
             supported_encryption_algorithms.append(Aes128CbcHmacSha256.name())
             supported_key_wrap_algorithms.append(AesKw256.name())
         if key_size >= key_size_384:
@@ -94,15 +101,17 @@ class SymmetricKey(Key):
     def default_key_wrap_algorithm(self):
         return _default_kw_alg_by_size[len(self._key)]
 
-    def encrypt(self, plain_text, iv, **kwargs):  # pylint:disable=arguments-differ
+    def encrypt(self, plain_text, **kwargs):  # pylint:disable=arguments-differ
         algorithm = self._get_algorithm("encrypt", **kwargs)
-        encryptor = algorithm.create_encryptor(key=self._key, iv=iv)
-        return encryptor.transform(plain_text, **kwargs)
+        raise_if_incorrect_key_size(algorithm, len(self._key))
+        encryptor = algorithm.create_encryptor(key=self._key, iv=kwargs.pop("iv", None))
+        return encryptor.transform(plain_text)
 
     def decrypt(self, cipher_text, iv, **kwargs):  # pylint:disable=arguments-differ
         algorithm = self._get_algorithm("decrypt", **kwargs)
+        raise_if_incorrect_key_size(algorithm, len(self._key))
         decryptor = algorithm.create_decryptor(key=self._key, iv=iv)
-        return decryptor.transform(cipher_text, **kwargs)
+        return decryptor.transform(cipher_text)
 
     def wrap_key(self, key, **kwargs):
         algorithm = self._get_algorithm("wrapKey", **kwargs)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/symmetric_key.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/symmetric_key.py
@@ -8,7 +8,7 @@ import os
 from azure.core.exceptions import AzureError
 from .key import Key
 from .algorithms.aes_cbc import Aes256CbcPad, Aes192CbcPad, Aes128CbcPad
-from .algorithms.aes_cbc_hmac import Aes256CbcHmacSha512, Aes192CbcHmacSha384, Aes128CbcHmacSha256
+from .algorithms.aes_cbc_hmac import Aes256CbcHmacSha512, Aes192CbcHmacSha384
 from .algorithms.aes_kw import AesKw256, AesKw192, AesKw128
 
 key_size_128 = 128 >> 3
@@ -73,12 +73,7 @@ class SymmetricKey(Key):
             supported_key_wrap_algorithms.append(AesKw192.name())
         if key_size >= key_size_256:
             supported_encryption_algorithms.append(Aes256CbcPad.name())
-            supported_encryption_algorithms.append(Aes128CbcHmacSha256.name())
             supported_key_wrap_algorithms.append(AesKw256.name())
-        if key_size >= key_size_384:
-            supported_encryption_algorithms.append(Aes192CbcHmacSha384.name())
-        if key_size >= key_size_512:
-            supported_encryption_algorithms.append(Aes256CbcHmacSha512.name())
         self._supported_encryption_algorithms = frozenset(supported_encryption_algorithms)
         self._supported_key_wrap_algorithms = frozenset(supported_key_wrap_algorithms)
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/symmetric_key.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/symmetric_key.py
@@ -39,7 +39,7 @@ _default_kw_alg_by_size = {
 
 
 def raise_if_incorrect_key_size(algorithm, key_size):
-    if (algorithm._key_size >> 3 != key_size):
+    if algorithm._key_size >> 3 != key_size:  # pylint:disable=protected-access
         raise AzureError("Invalid AES encryption algorithm for key size. The algorithm must match the size of the key.")
 
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/transform.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_internal/transform.py
@@ -32,7 +32,7 @@ class BlockCryptoTransform(CryptoTransform):
         raise NotImplementedError()
 
     @abstractmethod
-    def finalize(self, data):
+    def finalize(self):
         raise NotImplementedError()
 
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/local_provider.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/local_provider.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
 class LocalCryptographyProvider(ABC):
     def __init__(self, key):
-        # type: (JsonWebKey, **Any) -> None
+        # type: (JsonWebKey) -> None
         self._allowed_ops = frozenset(key.key_ops or [])
         self._internal_key = self._get_internal_key(key)
         self._key = key
@@ -60,16 +60,17 @@ class LocalCryptographyProvider(ABC):
         if operation not in self._allowed_ops:
             raise AzureError('This key does not allow the "{}" operation'.format(operation))
 
-    def encrypt(self, algorithm, plaintext):
-        # type: (EncryptionAlgorithm, bytes) -> EncryptResult
+    def encrypt(self, algorithm, plaintext, **kwargs):
+        # type: (EncryptionAlgorithm, bytes, **Any) -> EncryptResult
         self._raise_if_unsupported(KeyOperation.encrypt, algorithm)
-        ciphertext = self._internal_key.encrypt(plaintext, algorithm=algorithm.value)
-        return EncryptResult(key_id=self._key.kid, algorithm=algorithm, ciphertext=ciphertext)
+        iv = kwargs.pop("iv", None)
+        ciphertext = self._internal_key.encrypt(plaintext, algorithm=algorithm.value, iv=iv)
+        return EncryptResult(key_id=self._key.kid, algorithm=algorithm, ciphertext=ciphertext, iv=iv)
 
-    def decrypt(self, algorithm, ciphertext):
-        # type: (EncryptionAlgorithm, bytes) -> DecryptResult
+    def decrypt(self, algorithm, ciphertext, **kwargs):
+        # type: (EncryptionAlgorithm, bytes, **Any) -> DecryptResult
         self._raise_if_unsupported(KeyOperation.decrypt, algorithm)
-        plaintext = self._internal_key.decrypt(ciphertext, iv=None, algorithm=algorithm.value)
+        plaintext = self._internal_key.decrypt(ciphertext, iv=kwargs.pop("iv", None), algorithm=algorithm.value)
         return DecryptResult(key_id=self._key.kid, algorithm=algorithm, plaintext=plaintext)
 
     def wrap_key(self, algorithm, key):

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/local_provider.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/local_provider.py
@@ -60,17 +60,16 @@ class LocalCryptographyProvider(ABC):
         if operation not in self._allowed_ops:
             raise AzureError('This key does not allow the "{}" operation'.format(operation))
 
-    def encrypt(self, algorithm, plaintext, **kwargs):
+    def encrypt(self, algorithm, plaintext, iv=None, **kwargs):
         # type: (EncryptionAlgorithm, bytes, **Any) -> EncryptResult
         self._raise_if_unsupported(KeyOperation.encrypt, algorithm)
-        iv = kwargs.pop("iv", None)
         ciphertext = self._internal_key.encrypt(plaintext, algorithm=algorithm.value, iv=iv)
         return EncryptResult(key_id=self._key.kid, algorithm=algorithm, ciphertext=ciphertext, iv=iv)
 
-    def decrypt(self, algorithm, ciphertext, **kwargs):
+    def decrypt(self, algorithm, ciphertext, iv=None, **kwargs):
         # type: (EncryptionAlgorithm, bytes, **Any) -> DecryptResult
         self._raise_if_unsupported(KeyOperation.decrypt, algorithm)
-        plaintext = self._internal_key.decrypt(ciphertext, iv=kwargs.pop("iv", None), algorithm=algorithm.value)
+        plaintext = self._internal_key.decrypt(ciphertext, iv=iv, algorithm=algorithm.value)
         return DecryptResult(key_id=self._key.kid, algorithm=algorithm, plaintext=plaintext)
 
     def wrap_key(self, algorithm, key):

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/local_provider.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/local_provider.py
@@ -60,14 +60,14 @@ class LocalCryptographyProvider(ABC):
         if operation not in self._allowed_ops:
             raise AzureError('This key does not allow the "{}" operation'.format(operation))
 
-    def encrypt(self, algorithm, plaintext, iv=None, **kwargs):
-        # type: (EncryptionAlgorithm, bytes, **Any) -> EncryptResult
+    def encrypt(self, algorithm, plaintext, iv=None):
+        # type: (EncryptionAlgorithm, bytes, Optional[bytes]) -> EncryptResult
         self._raise_if_unsupported(KeyOperation.encrypt, algorithm)
         ciphertext = self._internal_key.encrypt(plaintext, algorithm=algorithm.value, iv=iv)
         return EncryptResult(key_id=self._key.kid, algorithm=algorithm, ciphertext=ciphertext, iv=iv)
 
-    def decrypt(self, algorithm, ciphertext, iv=None, **kwargs):
-        # type: (EncryptionAlgorithm, bytes, **Any) -> DecryptResult
+    def decrypt(self, algorithm, ciphertext, iv=None):
+        # type: (EncryptionAlgorithm, bytes, Optional[bytes]) -> DecryptResult
         self._raise_if_unsupported(KeyOperation.decrypt, algorithm)
         plaintext = self._internal_key.decrypt(ciphertext, iv=iv, algorithm=algorithm.value)
         return DecryptResult(key_id=self._key.kid, algorithm=algorithm, plaintext=plaintext)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/symmetric.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_providers/symmetric.py
@@ -24,7 +24,8 @@ class SymmetricCryptographyProvider(LocalCryptographyProvider):
 
     def supports(self, operation, algorithm):
         # type: (KeyOperation, Algorithm) -> bool
-        return (
-            operation in (KeyOperation.unwrap_key, KeyOperation.wrap_key)
-            and algorithm in self._internal_key.supported_key_wrap_algorithms
-        )
+        if operation in (KeyOperation.decrypt, KeyOperation.encrypt):
+            return algorithm in self._internal_key.supported_encryption_algorithms
+        if operation in (KeyOperation.unwrap_key, KeyOperation.wrap_key):
+            return algorithm in self._internal_key.supported_key_wrap_algorithms
+        return False

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
@@ -181,7 +181,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         if self._local_provider.supports(KeyOperation.encrypt, algorithm):
             raise_if_time_invalid(self._not_before, self._expires_on)
             try:
-                return self._local_provider.encrypt(algorithm, plaintext)
+                return self._local_provider.encrypt(algorithm, plaintext, iv=iv, aad=aad)
             except Exception as ex:  # pylint:disable=broad-except
                 _LOGGER.warning("Local encrypt operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
                 if self._jwk:
@@ -240,7 +240,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
 
         if self._local_provider.supports(KeyOperation.decrypt, algorithm):
             try:
-                return self._local_provider.decrypt(algorithm, ciphertext)
+                return self._local_provider.decrypt(algorithm, ciphertext, iv=iv, tag=tag, aad=aad)
             except Exception as ex:  # pylint:disable=broad-except
                 _LOGGER.warning("Local decrypt operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
                 if self._jwk:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
@@ -181,7 +181,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         if self._local_provider.supports(KeyOperation.encrypt, algorithm):
             raise_if_time_invalid(self._not_before, self._expires_on)
             try:
-                return self._local_provider.encrypt(algorithm, plaintext, iv=iv, aad=aad)
+                return self._local_provider.encrypt(algorithm, plaintext, iv=iv)
             except Exception as ex:  # pylint:disable=broad-except
                 _LOGGER.warning("Local encrypt operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
                 if self._jwk:
@@ -240,7 +240,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
 
         if self._local_provider.supports(KeyOperation.decrypt, algorithm):
             try:
-                return self._local_provider.decrypt(algorithm, ciphertext, iv=iv, tag=tag, aad=aad)
+                return self._local_provider.decrypt(algorithm, ciphertext, iv=iv)
             except Exception as ex:  # pylint:disable=broad-except
                 _LOGGER.warning("Local decrypt operation failed: %s", ex, exc_info=_LOGGER.isEnabledFor(logging.DEBUG))
                 if self._jwk:

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.test_symmetric_decrypt_local_mhsm.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.test_symmetric_decrypt_local_mhsm.yaml
@@ -1,0 +1,135 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.4.0b4 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: PUT
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encrypt3f0b15a1?api-version=7.2-preview
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://managedhsm.azure.net"
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-server-latency:
+      - '0'
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"key": {"key_ops": ["encrypt", "decrypt", "wrapKey", "unwrapKey"], "kty":
+      "oct-HSM", "k": "4n7QyEUSu9VbavQ00jfBH-ujEYcPgPLC4zZCYPMcgsg"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '138'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.4.0b4 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: PUT
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encrypt3f0b15a1?api-version=7.2-preview
+  response:
+    body:
+      string: '{"attributes":{"created":1617342845,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1617342845},"key":{"key_ops":["encrypt","decrypt","wrapKey","unwrapKey"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encrypt3f0b15a1/62fb9c7e70b90973056bef8610ed7796","kty":"oct-HSM"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '358'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-keyvault-network-info:
+      - addr=172.92.159.124
+      x-ms-keyvault-region:
+      - eastus2
+      x-ms-server-latency:
+      - '257'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"iv": "ibitv7BzReNZiTKgnFF0QQ", "value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ",
+      "alg": "A256CBCPAD", "aad": "dGVzdA"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '350'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.4.0b4 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encrypt3f0b15a1/62fb9c7e70b90973056bef8610ed7796/encrypt?api-version=7.2-preview
+  response:
+    body:
+      string: '{"alg":"A256CBCPAD","iv":"ibitv7BzReNZiTKgnFF0QQ","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encrypt3f0b15a1/62fb9c7e70b90973056bef8610ed7796","value":"LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCiqWw_oS3hdD48u_EhIUSvg"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '466'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-keyvault-network-info:
+      - addr=172.92.159.124
+      x-ms-keyvault-region:
+      - eastus2
+      x-ms-server-latency:
+      - '68'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.test_symmetric_encrypt_local_mhsm.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client.test_symmetric_encrypt_local_mhsm.yaml
@@ -1,0 +1,135 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.4.0b4 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: PUT
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encrypt3fb615ab?api-version=7.2-preview
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://managedhsm.azure.net"
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-server-latency:
+      - '1'
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"key": {"k": "4n7QyEUSu9VbavQ00jfBH-ujEYcPgPLC4zZCYPMcgsg", "kty": "oct-HSM",
+      "key_ops": ["encrypt", "decrypt", "wrapKey", "unwrapKey"]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '138'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.4.0b4 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: PUT
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encrypt3fb615ab?api-version=7.2-preview
+  response:
+    body:
+      string: '{"attributes":{"created":1617342836,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1617342836},"key":{"key_ops":["encrypt","decrypt","wrapKey","unwrapKey"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encrypt3fb615ab/0ef7121dedfd4f3c30dc8e393aed787f","kty":"oct-HSM"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '358'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-keyvault-network-info:
+      - addr=172.92.159.124
+      x-ms-keyvault-region:
+      - eastus2
+      x-ms-server-latency:
+      - '268'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"aad": "dGVzdA", "iv": "ibitv7BzReNZiTKgnFF0QQ", "value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCiqWw_oS3hdD48u_EhIUSvg",
+      "alg": "A256CBCPAD"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '361'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.4.0b4 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encrypt3fb615ab/0ef7121dedfd4f3c30dc8e393aed787f/decrypt?api-version=7.2-preview
+  response:
+    body:
+      string: '{"alg":"A256CBCPAD","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encrypt3fb615ab/0ef7121dedfd4f3c30dc8e393aed787f","value":"NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '425'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-keyvault-network-info:
+      - addr=172.92.159.124
+      x-ms-keyvault-region:
+      - eastus2
+      x-ms-server-latency:
+      - '78'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.test_symmetric_decrypt_local_mhsm.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.test_symmetric_decrypt_local_mhsm.yaml
@@ -1,0 +1,97 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.4.0b4 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: PUT
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encryptc9f4181e?api-version=7.2-preview
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control: no-cache
+      content-length: '0'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      www-authenticate: Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://managedhsm.azure.net"
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-server-latency: '0'
+    status:
+      code: 401
+      message: Unauthorized
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestsymmetric-encryptc9f4181e?api-version=7.2-preview
+- request:
+    body: '{"key": {"key_ops": ["encrypt", "decrypt", "wrapKey", "unwrapKey"], "kty":
+      "oct-HSM", "k": "4n7QyEUSu9VbavQ00jfBH-ujEYcPgPLC4zZCYPMcgsg"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '138'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.4.0b4 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: PUT
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encryptc9f4181e?api-version=7.2-preview
+  response:
+    body:
+      string: '{"attributes":{"created":1617351187,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1617351187},"key":{"key_ops":["encrypt","decrypt","unwrapKey","wrapKey"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encryptc9f4181e/39396ce49441436438d486354bf28188","kty":"oct-HSM"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '358'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-keyvault-network-info: addr=172.92.159.124
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '192'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestsymmetric-encryptc9f4181e?api-version=7.2-preview
+- request:
+    body: '{"value": "NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ",
+      "alg": "A256CBCPAD", "aad": "dGVzdA", "iv": "ibitv7BzReNZiTKgnFF0QQ"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '350'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.4.0b4 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encryptc9f4181e/39396ce49441436438d486354bf28188/encrypt?api-version=7.2-preview
+  response:
+    body:
+      string: '{"alg":"A256CBCPAD","iv":"ibitv7BzReNZiTKgnFF0QQ","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encryptc9f4181e/39396ce49441436438d486354bf28188","value":"LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCiqWw_oS3hdD48u_EhIUSvg"}'
+    headers:
+      cache-control: no-cache
+      content-length: '466'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-keyvault-network-info: addr=172.92.159.124
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '74'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestsymmetric-encryptc9f4181e/39396ce49441436438d486354bf28188/encrypt?api-version=7.2-preview
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.test_symmetric_encrypt_local_mhsm.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_crypto_client_async.test_symmetric_encrypt_local_mhsm.yaml
@@ -1,0 +1,97 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.4.0b4 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: PUT
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encryptca9f1828?api-version=7.2-preview
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control: no-cache
+      content-length: '0'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      www-authenticate: Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://managedhsm.azure.net"
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-server-latency: '0'
+    status:
+      code: 401
+      message: Unauthorized
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestsymmetric-encryptca9f1828?api-version=7.2-preview
+- request:
+    body: '{"key": {"key_ops": ["encrypt", "decrypt", "wrapKey", "unwrapKey"], "kty":
+      "oct-HSM", "k": "4n7QyEUSu9VbavQ00jfBH-ujEYcPgPLC4zZCYPMcgsg"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '138'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.4.0b4 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: PUT
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encryptca9f1828?api-version=7.2-preview
+  response:
+    body:
+      string: '{"attributes":{"created":1617351177,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1617351177},"key":{"key_ops":["encrypt","decrypt","unwrapKey","wrapKey"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encryptca9f1828/cc05679e9a464d08392de3c5192c0563","kty":"oct-HSM"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '358'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-keyvault-network-info: addr=172.92.159.124
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '233'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestsymmetric-encryptca9f1828?api-version=7.2-preview
+- request:
+    body: '{"value": "LMKuK63LOzPyZzk-GMl79Lciw-LNxXt5H9zA7ZTgfpIHvM5_XY9h8q0ils-y85LvB-Bj8jx7KmDAacxkXIXxrdhHz7c5URCoOh0HrwXW7QqBVnWarK4D04X_2KG2otO0DFTFfuVcs3flnFUF2bAEujPb3SA5FHlBLPhDge4elcbWn3XXtJVOzCian2Z3O04xyI_QAZp8Ds4K4XSHtU_P238YWRvcNc399qEYptrlWjHNxxFxxAC4Hc44pAGus3cCiqWw_oS3hdD48u_EhIUSvg",
+      "alg": "A256CBCPAD", "iv": "ibitv7BzReNZiTKgnFF0QQ", "aad": "dGVzdA"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '361'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.4.0b4 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encryptca9f1828/cc05679e9a464d08392de3c5192c0563/decrypt?api-version=7.2-preview
+  response:
+    body:
+      string: '{"alg":"A256CBCPAD","kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestsymmetric-encryptca9f1828/cc05679e9a464d08392de3c5192c0563","value":"NTA2M2U2YWFhODQ1ZjE1MDIwMDU0Nzk0NGZkMTk5Njc5Yzk4ZWQ2Zjk5ZGEwYTBiMmRhZmVhZjFmNDY4NDQ5NmZkNTMyYzFjMjI5OTY4Y2I5ZGVlNDQ5NTdmY2VmN2NjZWY1OWNlZGEwYjM2MmU1NmJjZDc4ZmQzZmFlZTU3ODFjNjIzYzBiYjIyYjM1YmVhYmRlMDY2NGZkMzBlMGU4MjRhYmEzZGQxYjBhZmZmYzRhM2Q5NTVlZGUyMGNmNmE4NTRkNTJjZmQ"}'
+    headers:
+      cache-control: no-cache
+      content-length: '425'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-keyvault-network-info: addr=172.92.159.124
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '78'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestsymmetric-encryptca9f1828/cc05679e9a464d08392de3c5192c0563/decrypt?api-version=7.2-preview
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -5,6 +5,7 @@
 import codecs
 from datetime import datetime
 import hashlib
+import os
 import time
 
 try:
@@ -17,6 +18,7 @@ from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.keyvault.keys import JsonWebKey, KeyCurveName, KeyOperation, KeyVaultKey
 from azure.keyvault.keys.crypto import CryptographyClient, EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
 from azure.keyvault.keys.crypto._key_validity import _UTC
+from azure.keyvault.keys.crypto._providers import NoLocalCryptography, get_local_cryptography_provider
 from azure.mgmt.keyvault.models import KeyPermissions, Permissions
 from parameterized import parameterized, param
 import pytest
@@ -123,13 +125,18 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
         return imported_key
 
     def _import_symmetric_test_key(self, client, name):
+        key_material = codecs.decode("e27ed0c84512bbd55b6af434d237c11feba311870f80f2c2e3364260f31c82c8", "hex_codec")
         key = JsonWebKey(
             kty="oct-HSM",
             key_ops=["encrypt", "decrypt", "wrapKey", "unwrapKey"],
-            k=codecs.decode("e27ed0c84512bbd55b6af434d237c11feba311870f80f2c2e3364260f31c82c8", "hex_codec"),
+            k=key_material,
         )
-        imported_key = client.import_key(name, key)
-        return imported_key
+        imported_key = client.import_key(name, key)  # the key material isn't returned by the service
+        key.kid = imported_key.id
+        key_vault_key = KeyVaultKey(key_id=imported_key.id, jwk=vars(key))  # create a key containing the material
+        assert key_vault_key.key.k == key_material
+        assert key_vault_key.key.kid == imported_key.id == key_vault_key.id
+        return key_vault_key
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
     def test_ec_key_id(self, **kwargs):
@@ -237,6 +244,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
         self.assertEqual(key_bytes, result.key)
 
     def test_symmetric_encrypt_and_decrypt_mhsm(self, **kwargs):
+        """Encrypt and decrypt with the service"""
         is_hsm = True
         self._skip_if_not_configured(is_hsm)
         endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
@@ -246,36 +254,43 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
 
         imported_key = self._import_symmetric_test_key(key_client, key_name)
         assert imported_key is not None
-        crypto_client = self.create_crypto_client(imported_key.id)
+        crypto_client = self.create_crypto_client(imported_key)
         # Use 256-bit AES algorithms for the 256-bit key
         symmetric_algorithms = [algo for algo in EncryptionAlgorithm if algo.startswith("A256")]
 
-        for algorithm in symmetric_algorithms:
-            if algorithm.endswith("GCM"):
-                result = crypto_client.encrypt(algorithm, self.plaintext, additional_authenticated_data=self.aad)
-                assert result.key_id == imported_key.id
-                result = crypto_client.decrypt(
-                    result.algorithm,
-                    result.ciphertext,
-                    iv=result.iv,
-                    authentication_tag=result.tag,
-                    additional_authenticated_data=self.aad
-                )
-            else:
-                result = crypto_client.encrypt(
-                    algorithm, self.plaintext, iv=self.iv, additional_authenticated_data=self.aad
-                )
-                assert result.key_id == imported_key.id
-                result = crypto_client.decrypt(
-                    result.algorithm, result.ciphertext, iv=self.iv, additional_authenticated_data=self.aad
-                )
+        supports_nothing = mock.Mock(supports=mock.Mock(return_value=False))
+        with mock.patch(crypto_client.__module__ + ".get_local_cryptography_provider", lambda *_: supports_nothing):
+            for algorithm in symmetric_algorithms:
+                if algorithm.endswith("GCM"):
+                    encrypt_result = crypto_client.encrypt(
+                        algorithm, self.plaintext, additional_authenticated_data=self.aad
+                    )
+                    assert encrypt_result.key_id == imported_key.id
+                    decrypt_result = crypto_client.decrypt(
+                        encrypt_result.algorithm,
+                        encrypt_result.ciphertext,
+                        iv=encrypt_result.iv,
+                        authentication_tag=encrypt_result.tag,
+                        additional_authenticated_data=self.aad
+                    )
+                else:
+                    encrypt_result = crypto_client.encrypt(
+                        algorithm, self.plaintext, iv=self.iv, additional_authenticated_data=self.aad
+                    )
+                    assert encrypt_result.key_id == imported_key.id
+                    decrypt_result = crypto_client.decrypt(
+                        encrypt_result.algorithm,
+                        encrypt_result.ciphertext,
+                        iv=encrypt_result.iv,
+                        additional_authenticated_data=self.aad
+                    )
 
-            assert result.key_id == imported_key.id
-            assert result.algorithm == algorithm
-            if algorithm.endswith("CBC"):
-                assert result.plaintext.startswith(self.plaintext)  # AES-CBC returns a zero-padded plaintext
-            else:
-                assert result.plaintext == self.plaintext
+                assert decrypt_result.key_id == imported_key.id
+                assert decrypt_result.algorithm == algorithm
+                if algorithm.endswith("CBC"):
+                    assert decrypt_result.plaintext.startswith(self.plaintext)  # AES-CBC returns a zero-padded plaintext
+                else:
+                    assert decrypt_result.plaintext == self.plaintext
 
     def test_symmetric_wrap_and_unwrap_mhsm(self, **kwargs):
         is_hsm = True
@@ -335,6 +350,71 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
 
             result = crypto_client.decrypt(result.algorithm, result.ciphertext)
             self.assertEqual(result.plaintext, self.plaintext)
+    
+    def test_symmetric_encrypt_local_mhsm(self, **kwargs):
+        """Encrypt locally, decrypt with the service"""
+        is_hsm = True
+        self._skip_if_not_configured(is_hsm)
+        endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
+
+        key_client = self.create_key_client(endpoint_url)
+        key_name = self.get_resource_name("symmetric-encrypt")
+
+        imported_key = self._import_symmetric_test_key(key_client, key_name)
+        assert imported_key is not None
+        crypto_client = self.create_crypto_client(imported_key)
+        # Use 256-bit AES-CBCPAD for the 256-bit key (only AES-CBCPAD is implemented locally)
+        algorithm = EncryptionAlgorithm.a256_cbcpad
+
+        crypto_client._local_provider = get_local_cryptography_provider(imported_key.key)
+        encrypt_result = crypto_client.encrypt(
+            algorithm, self.plaintext, iv=self.iv, additional_authenticated_data=self.aad
+        )
+        assert encrypt_result.key_id == imported_key.id
+        crypto_client._local_provider = NoLocalCryptography()
+        decrypt_result = crypto_client.decrypt(
+            encrypt_result.algorithm,
+            encrypt_result.ciphertext,
+            iv=encrypt_result.iv,
+            additional_authenticated_data=self.aad
+        )
+
+        assert decrypt_result.key_id == imported_key.id
+        assert decrypt_result.algorithm == algorithm
+        assert decrypt_result.plaintext == self.plaintext
+    
+    def test_symmetric_decrypt_local_mhsm(self, **kwargs):
+        """Encrypt with the service, decrypt locally"""
+        is_hsm = True
+        self._skip_if_not_configured(is_hsm)
+        endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
+
+        key_client = self.create_key_client(endpoint_url)
+        key_name = self.get_resource_name("symmetric-encrypt")
+
+        imported_key = self._import_symmetric_test_key(key_client, key_name)
+        assert imported_key is not None
+        crypto_client = self.create_crypto_client(imported_key)
+        # Use 256-bit AES-CBCPAD for the 256-bit key (only AES-CBCPAD is implemented locally)
+        algorithm = EncryptionAlgorithm.a256_cbcpad
+
+        crypto_client._initialized = True
+        crypto_client._local_provider = NoLocalCryptography()
+        encrypt_result = crypto_client.encrypt(
+            algorithm, self.plaintext, iv=self.iv, additional_authenticated_data=self.aad
+        )
+        assert encrypt_result.key_id == imported_key.id
+        crypto_client._local_provider = get_local_cryptography_provider(imported_key.key)
+        decrypt_result = crypto_client.decrypt(
+            encrypt_result.algorithm,
+            encrypt_result.ciphertext,
+            iv=encrypt_result.iv,
+            additional_authenticated_data=self.aad
+        )
+
+        assert decrypt_result.key_id == imported_key.id
+        assert decrypt_result.algorithm == algorithm
+        assert decrypt_result.plaintext == self.plaintext
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
     def test_wrap_local(self, **kwargs):
@@ -764,8 +844,36 @@ def test_prefers_local_provider():
     assert supports_everything.wrap_key.call_count == 1
 
 
+def test_aes_cbc_key_size_validation():
+    """The client should raise an error when the key is an inappropriate size for the specified algorithm"""
+
+    jwk = JsonWebKey(kty="oct-HSM", key_ops=["encrypt", "decrypt"], k=os.urandom(64))
+    iv = os.urandom(16)
+    client = CryptographyClient.from_jwk(jwk=jwk)
+    with pytest.raises(AzureError) as ex:
+        client.encrypt(EncryptionAlgorithm.a128_cbcpad, b"...", iv=iv)  # requires 16-byte key
+    assert "key size" in str(ex.value).lower()
+    with pytest.raises(AzureError) as ex:
+        client.encrypt(EncryptionAlgorithm.a192_cbcpad, b"...", iv=iv)  # requires 24-byte key
+    assert "key size" in str(ex.value).lower()
+    with pytest.raises(AzureError) as ex:
+        client.encrypt(EncryptionAlgorithm.a256_cbcpad, b"...", iv=iv)  # requires 32-byte key
+    assert "key size" in str(ex.value).lower()
+
+
+def test_aes_cbc_iv_validation():
+    """The client should raise an error when an iv is not provided"""
+
+    jwk = JsonWebKey(kty="oct-HSM", key_ops=["encrypt", "decrypt"], k=os.urandom(32))
+    client = CryptographyClient.from_jwk(jwk=jwk)
+    with pytest.raises(ValueError) as ex:
+        client.encrypt(EncryptionAlgorithm.a256_cbcpad, b"...")
+    assert "iv" in str(ex.value).lower()
+
+
 def test_encrypt_argument_validation():
     """The client should raise an error when arguments don't work with the specified algorithm"""
+
     mock_client = mock.Mock()
     key = mock.Mock(
         spec=KeyVaultKey,

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -245,9 +245,8 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
 
     def test_symmetric_encrypt_and_decrypt_mhsm(self, **kwargs):
         """Encrypt and decrypt with the service"""
-        is_hsm = True
-        self._skip_if_not_configured(is_hsm)
-        endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
+        self._skip_if_not_configured(True)
+        endpoint_url = self.managed_hsm_url
 
         key_client = self.create_key_client(endpoint_url)
         key_name = self.get_resource_name("symmetric-encrypt")
@@ -293,9 +292,8 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
                     assert decrypt_result.plaintext == self.plaintext
 
     def test_symmetric_wrap_and_unwrap_mhsm(self, **kwargs):
-        is_hsm = True
-        self._skip_if_not_configured(is_hsm)
-        endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
+        self._skip_if_not_configured(True)
+        endpoint_url = self.managed_hsm_url
 
         key_client = self.create_key_client(endpoint_url)
         key_name = self.get_resource_name("symmetric-kw")
@@ -353,9 +351,8 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
     
     def test_symmetric_encrypt_local_mhsm(self, **kwargs):
         """Encrypt locally, decrypt with the service"""
-        is_hsm = True
-        self._skip_if_not_configured(is_hsm)
-        endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
+        self._skip_if_not_configured(True)
+        endpoint_url = self.managed_hsm_url
 
         key_client = self.create_key_client(endpoint_url)
         key_name = self.get_resource_name("symmetric-encrypt")
@@ -385,9 +382,8 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
     
     def test_symmetric_decrypt_local_mhsm(self, **kwargs):
         """Encrypt with the service, decrypt locally"""
-        is_hsm = True
-        self._skip_if_not_configured(is_hsm)
-        endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
+        self._skip_if_not_configured(True)
+        endpoint_url = self.managed_hsm_url
 
         key_client = self.create_key_client(endpoint_url)
         key_name = self.get_resource_name("symmetric-encrypt")

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -16,6 +16,7 @@ from azure.keyvault.keys.crypto._key_validity import _UTC
 from azure.keyvault.keys.crypto._providers import NoLocalCryptography, get_local_cryptography_provider
 from azure.keyvault.keys.crypto.aio import CryptographyClient, EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
 from azure.mgmt.keyvault.models import KeyPermissions, Permissions
+from devtools_testutils import PowerShellPreparer
 from parameterized import parameterized, param
 import pytest
 
@@ -134,6 +135,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
         return key_vault_key
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_ec_key_id(self, **kwargs):
         """When initialized with a key ID, the client should retrieve the key and perform public operations locally"""
         is_hsm = kwargs.pop("is_hsm")
@@ -153,6 +155,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
         await crypto_client.verify(SignatureAlgorithm.es256, hashlib.sha256(self.plaintext).digest(), self.plaintext)
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_rsa_key_id(self, **kwargs):
         """When initialized with a key ID, the client should retrieve the key and perform public operations locally"""
         is_hsm = kwargs.pop("is_hsm")
@@ -174,6 +177,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
         await crypto_client.wrap_key(KeyWrapAlgorithm.rsa_oaep, self.plaintext)
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_encrypt_and_decrypt(self, **kwargs):
         is_hsm = kwargs.pop("is_hsm")
         self._skip_if_not_configured(is_hsm)
@@ -194,6 +198,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
         self.assertEqual(self.plaintext, result.plaintext)
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_sign_and_verify(self, **kwargs):
         is_hsm = kwargs.pop("is_hsm")
         self._skip_if_not_configured(is_hsm)
@@ -218,6 +223,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
         self.assertTrue(verified.is_valid)
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_wrap_and_unwrap(self, **kwargs):
         is_hsm = kwargs.pop("is_hsm")
         self._skip_if_not_configured(is_hsm)
@@ -238,6 +244,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
         result = await crypto_client.unwrap_key(result.algorithm, result.encrypted_key)
         self.assertEqual(key_bytes, result.key)
 
+    @PowerShellPreparer("keyvault")
     async def test_symmetric_encrypt_and_decrypt_mhsm(self, **kwargs):
         """Encrypt and decrypt with the service"""
         is_hsm = True
@@ -282,6 +289,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
                 else:
                     assert result.plaintext == self.plaintext
 
+    @PowerShellPreparer("keyvault")
     async def test_symmetric_wrap_and_unwrap_mhsm(self, **kwargs):
         is_hsm = True
         self._skip_if_not_configured(is_hsm)
@@ -301,6 +309,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
         assert result.key == self.plaintext
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_encrypt_local(self, **kwargs):
         """Encrypt locally, decrypt with Key Vault"""
         is_hsm = kwargs.pop("is_hsm")
@@ -321,6 +330,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
             self.assertEqual(result.plaintext, self.plaintext)
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_encrypt_local_from_jwk(self, **kwargs):
         """Encrypt locally, decrypt with Key Vault"""
         is_hsm = kwargs.pop("is_hsm")
@@ -341,6 +351,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
             result = await crypto_client.decrypt(result.algorithm, result.ciphertext)
             self.assertEqual(result.plaintext, self.plaintext)
 
+    @PowerShellPreparer("keyvault")
     async def test_symmetric_encrypt_local_mhsm(self, **kwargs):
         """Encrypt locally, decrypt with the service"""
         is_hsm = True
@@ -373,6 +384,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
         assert decrypt_result.algorithm == algorithm
         assert decrypt_result.plaintext == self.plaintext
 
+    @PowerShellPreparer("keyvault")
     async def test_symmetric_decrypt_local_mhsm(self, **kwargs):
         """Encrypt with the service, decrypt locally"""
         is_hsm = True
@@ -407,6 +419,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
         assert decrypt_result.plaintext == self.plaintext
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_wrap_local(self, **kwargs):
         """Wrap locally, unwrap with Key Vault"""
         is_hsm = kwargs.pop("is_hsm")
@@ -426,6 +439,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
             self.assertEqual(result.key, self.plaintext)
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_wrap_local_from_jwk(self, **kwargs):
         """Wrap locally, unwrap with Key Vault"""
         is_hsm = kwargs.pop("is_hsm")
@@ -446,6 +460,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
             self.assertEqual(result.key, self.plaintext)
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_rsa_verify_local(self, **kwargs):
         """Sign with Key Vault, verify locally"""
         is_hsm = kwargs.pop("is_hsm")
@@ -474,6 +489,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
                 self.assertTrue(result.is_valid)
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_rsa_verify_local_from_jwk(self, **kwargs):
         """Sign with Key Vault, verify locally"""
         is_hsm = kwargs.pop("is_hsm")
@@ -503,6 +519,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
                 self.assertTrue(result.is_valid)
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_ec_verify_local(self, **kwargs):
         """Sign with Key Vault, verify locally"""
         is_hsm = kwargs.pop("is_hsm")
@@ -531,6 +548,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
             self.assertTrue(result.is_valid)
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_ec_verify_local_from_jwk(self, **kwargs):
         """Sign with Key Vault, verify locally"""
         is_hsm = kwargs.pop("is_hsm")
@@ -560,6 +578,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
             self.assertTrue(result.is_valid)
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_local_validity_period_enforcement(self, **kwargs):
         """Local crypto operations should respect a key's nbf and exp properties"""
         is_hsm = kwargs.pop("is_hsm")

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -13,6 +13,7 @@ from azure.core.exceptions import AzureError, HttpResponseError
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.keyvault.keys import JsonWebKey, KeyCurveName, KeyOperation, KeyVaultKey
 from azure.keyvault.keys.crypto._key_validity import _UTC
+from azure.keyvault.keys.crypto._providers import NoLocalCryptography, get_local_cryptography_provider
 from azure.keyvault.keys.crypto.aio import CryptographyClient, EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
 from azure.mgmt.keyvault.models import KeyPermissions, Permissions
 from parameterized import parameterized, param
@@ -119,13 +120,18 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
         return imported_key
 
     async def _import_symmetric_test_key(self, client, name):
+        key_material = codecs.decode("e27ed0c84512bbd55b6af434d237c11feba311870f80f2c2e3364260f31c82c8", "hex_codec")
         key = JsonWebKey(
             kty="oct-HSM",
             key_ops=["encrypt", "decrypt", "wrapKey", "unwrapKey"],
-            k=codecs.decode("e27ed0c84512bbd55b6af434d237c11feba311870f80f2c2e3364260f31c82c8", "hex_codec"),
+            k=key_material,
         )
-        imported_key = await client.import_key(name, key)
-        return imported_key
+        imported_key = await client.import_key(name, key)  # the key material isn't returned by the service
+        key.kid = imported_key.id
+        key_vault_key = KeyVaultKey(key_id=imported_key.id, jwk=vars(key))  # create a key containing the material
+        assert key_vault_key.key.k == key_material
+        assert key_vault_key.key.kid == imported_key.id == key_vault_key.id
+        return key_vault_key
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
     async def test_ec_key_id(self, **kwargs):
@@ -233,6 +239,7 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
         self.assertEqual(key_bytes, result.key)
 
     async def test_symmetric_encrypt_and_decrypt_mhsm(self, **kwargs):
+        """Encrypt and decrypt with the service"""
         is_hsm = True
         self._skip_if_not_configured(is_hsm)
         endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
@@ -242,36 +249,38 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
 
         imported_key = await self._import_symmetric_test_key(key_client, key_name)
         assert imported_key is not None
-        crypto_client = self.create_crypto_client(imported_key.id, is_async=True)
+        crypto_client = self.create_crypto_client(imported_key, is_async=True)
         # Use 256-bit AES algorithms for the 256-bit key
         symmetric_algorithms = [algo for algo in EncryptionAlgorithm if algo.startswith("A256")]
 
-        for algorithm in symmetric_algorithms:
-            if algorithm.endswith("GCM"):
-                result = await crypto_client.encrypt(algorithm, self.plaintext, additional_authenticated_data=self.aad)
-                assert result.key_id == imported_key.id
-                result = await crypto_client.decrypt(
-                    result.algorithm,
-                    result.ciphertext,
-                    iv=result.iv,
-                    authentication_tag=result.tag,
-                    additional_authenticated_data=self.aad
-                )
-            else:
-                result = await crypto_client.encrypt(
-                    algorithm, self.plaintext, iv=self.iv, additional_authenticated_data=self.aad
-                )
-                self.assertEqual(result.key_id, imported_key.id)
-                result = await crypto_client.decrypt(
-                    result.algorithm, result.ciphertext, iv=self.iv, additional_authenticated_data=self.aad
-                )
+        supports_nothing = mock.Mock(supports=mock.Mock(return_value=False))
+        with mock.patch(crypto_client.__module__ + ".get_local_cryptography_provider", lambda *_: supports_nothing):
+            for algorithm in symmetric_algorithms:
+                if algorithm.endswith("GCM"):
+                    result = await crypto_client.encrypt(algorithm, self.plaintext, additional_authenticated_data=self.aad)
+                    assert result.key_id == imported_key.id
+                    result = await crypto_client.decrypt(
+                        result.algorithm,
+                        result.ciphertext,
+                        iv=result.iv,
+                        authentication_tag=result.tag,
+                        additional_authenticated_data=self.aad
+                    )
+                else:
+                    result = await crypto_client.encrypt(
+                        algorithm, self.plaintext, iv=self.iv, additional_authenticated_data=self.aad
+                    )
+                    self.assertEqual(result.key_id, imported_key.id)
+                    result = await crypto_client.decrypt(
+                        result.algorithm, result.ciphertext, iv=self.iv, additional_authenticated_data=self.aad
+                    )
 
-            assert result.key_id == imported_key.id
-            assert result.algorithm == algorithm
-            if algorithm.endswith("CBC"):
-                assert result.plaintext.startswith(self.plaintext)  # AES-CBC returns a zero-padded plaintext
-            else:
-                assert result.plaintext == self.plaintext
+                assert result.key_id == imported_key.id
+                assert result.algorithm == algorithm
+                if algorithm.endswith("CBC"):
+                    assert result.plaintext.startswith(self.plaintext)  # AES-CBC returns a zero-padded plaintext
+                else:
+                    assert result.plaintext == self.plaintext
 
     async def test_symmetric_wrap_and_unwrap_mhsm(self, **kwargs):
         is_hsm = True
@@ -331,6 +340,71 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
 
             result = await crypto_client.decrypt(result.algorithm, result.ciphertext)
             self.assertEqual(result.plaintext, self.plaintext)
+
+    async def test_symmetric_encrypt_local_mhsm(self, **kwargs):
+        """Encrypt locally, decrypt with the service"""
+        is_hsm = True
+        self._skip_if_not_configured(is_hsm)
+        endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
+
+        key_client = self.create_key_client(endpoint_url, is_async=True)
+        key_name = self.get_resource_name("symmetric-encrypt")
+
+        imported_key = await self._import_symmetric_test_key(key_client, key_name)
+        assert imported_key is not None
+        crypto_client = self.create_crypto_client(imported_key, is_async=True)
+        # Use 256-bit AES-CBCPAD for the 256-bit key (only AES-CBCPAD is implemented locally)
+        algorithm = EncryptionAlgorithm.a256_cbcpad
+
+        crypto_client._local_provider = get_local_cryptography_provider(imported_key.key)
+        encrypt_result = await crypto_client.encrypt(
+            algorithm, self.plaintext, iv=self.iv, additional_authenticated_data=self.aad
+        )
+        assert encrypt_result.key_id == imported_key.id
+        crypto_client._local_provider = NoLocalCryptography()
+        decrypt_result = await crypto_client.decrypt(
+            encrypt_result.algorithm,
+            encrypt_result.ciphertext,
+            iv=encrypt_result.iv,
+            additional_authenticated_data=self.aad
+        )
+
+        assert decrypt_result.key_id == imported_key.id
+        assert decrypt_result.algorithm == algorithm
+        assert decrypt_result.plaintext == self.plaintext
+
+    async def test_symmetric_decrypt_local_mhsm(self, **kwargs):
+        """Encrypt with the service, decrypt locally"""
+        is_hsm = True
+        self._skip_if_not_configured(is_hsm)
+        endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
+
+        key_client = self.create_key_client(endpoint_url, is_async=True)
+        key_name = self.get_resource_name("symmetric-encrypt")
+
+        imported_key = await self._import_symmetric_test_key(key_client, key_name)
+        assert imported_key is not None
+        crypto_client = self.create_crypto_client(imported_key, is_async=True)
+        # Use 256-bit AES-CBCPAD for the 256-bit key (only AES-CBCPAD is implemented locally)
+        algorithm = EncryptionAlgorithm.a256_cbcpad
+
+        crypto_client._initialized = True
+        crypto_client._local_provider = NoLocalCryptography()
+        encrypt_result = await crypto_client.encrypt(
+            algorithm, self.plaintext, iv=self.iv, additional_authenticated_data=self.aad
+        )
+        assert encrypt_result.key_id == imported_key.id
+        crypto_client._local_provider = get_local_cryptography_provider(imported_key.key)
+        decrypt_result = await crypto_client.decrypt(
+            encrypt_result.algorithm,
+            encrypt_result.ciphertext,
+            iv=encrypt_result.iv,
+            additional_authenticated_data=self.aad
+        )
+
+        assert decrypt_result.key_id == imported_key.id
+        assert decrypt_result.algorithm == algorithm
+        assert decrypt_result.plaintext == self.plaintext
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
     async def test_wrap_local(self, **kwargs):
@@ -793,8 +867,38 @@ async def test_prefers_local_provider():
 
 
 @pytest.mark.asyncio
+async def test_aes_cbc_key_size_validation():
+    """The client should raise an error when the key is an inappropriate size for the specified algorithm"""
+
+    jwk = JsonWebKey(kty="oct-HSM", key_ops=["encrypt", "decrypt"], k=os.urandom(64))
+    iv = os.urandom(16)
+    client = CryptographyClient.from_jwk(jwk=jwk)
+    with pytest.raises(AzureError) as ex:
+        await client.encrypt(EncryptionAlgorithm.a128_cbcpad, b"...", iv=iv)  # requires 16-byte key
+    assert "key size" in str(ex.value).lower()
+    with pytest.raises(AzureError) as ex:
+        await client.encrypt(EncryptionAlgorithm.a192_cbcpad, b"...", iv=iv)  # requires 24-byte key
+    assert "key size" in str(ex.value).lower()
+    with pytest.raises(AzureError) as ex:
+        await client.encrypt(EncryptionAlgorithm.a256_cbcpad, b"...", iv=iv)  # requires 32-byte key
+    assert "key size" in str(ex.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_aes_cbc_iv_validation():
+    """The client should raise an error when an iv is not provided"""
+
+    jwk = JsonWebKey(kty="oct-HSM", key_ops=["encrypt", "decrypt"], k=os.urandom(32))
+    client = CryptographyClient.from_jwk(jwk=jwk)
+    with pytest.raises(ValueError) as ex:
+        await client.encrypt(EncryptionAlgorithm.a256_cbcpad, b"...")
+    assert "iv" in str(ex.value).lower()
+
+
+@pytest.mark.asyncio
 async def test_encrypt_argument_validation():
     """The client should raise an error when arguments don't work with the specified algorithm"""
+    
     mock_client = mock.Mock()
     key = mock.Mock(
         spec=KeyVaultKey,

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -247,9 +247,8 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
     @PowerShellPreparer("keyvault")
     async def test_symmetric_encrypt_and_decrypt_mhsm(self, **kwargs):
         """Encrypt and decrypt with the service"""
-        is_hsm = True
-        self._skip_if_not_configured(is_hsm)
-        endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
+        self._skip_if_not_configured(True)
+        endpoint_url = self.managed_hsm_url
 
         key_client = self.create_key_client(endpoint_url, is_async=True)
         key_name = self.get_resource_name("symmetric-encrypt")
@@ -264,7 +263,9 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
         with mock.patch(crypto_client.__module__ + ".get_local_cryptography_provider", lambda *_: supports_nothing):
             for algorithm in symmetric_algorithms:
                 if algorithm.endswith("GCM"):
-                    result = await crypto_client.encrypt(algorithm, self.plaintext, additional_authenticated_data=self.aad)
+                    result = await crypto_client.encrypt(
+                        algorithm, self.plaintext, additional_authenticated_data=self.aad
+                    )
                     assert result.key_id == imported_key.id
                     result = await crypto_client.decrypt(
                         result.algorithm,
@@ -291,9 +292,8 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
 
     @PowerShellPreparer("keyvault")
     async def test_symmetric_wrap_and_unwrap_mhsm(self, **kwargs):
-        is_hsm = True
-        self._skip_if_not_configured(is_hsm)
-        endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
+        self._skip_if_not_configured(True)
+        endpoint_url = self.managed_hsm_url
 
         key_client = self.create_key_client(endpoint_url, is_async=True)
         key_name = self.get_resource_name("symmetric-kw")
@@ -354,9 +354,8 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
     @PowerShellPreparer("keyvault")
     async def test_symmetric_encrypt_local_mhsm(self, **kwargs):
         """Encrypt locally, decrypt with the service"""
-        is_hsm = True
-        self._skip_if_not_configured(is_hsm)
-        endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
+        self._skip_if_not_configured(True)
+        endpoint_url = self.managed_hsm_url
 
         key_client = self.create_key_client(endpoint_url, is_async=True)
         key_name = self.get_resource_name("symmetric-encrypt")
@@ -387,9 +386,8 @@ class CryptoClientTests(KeysTestCase, KeyVaultTestCase):
     @PowerShellPreparer("keyvault")
     async def test_symmetric_decrypt_local_mhsm(self, **kwargs):
         """Encrypt with the service, decrypt locally"""
-        is_hsm = True
-        self._skip_if_not_configured(is_hsm)
-        endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
+        self._skip_if_not_configured(True)
+        endpoint_url = self.managed_hsm_url
 
         key_client = self.create_key_client(endpoint_url, is_async=True)
         key_name = self.get_resource_name("symmetric-encrypt")

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -13,6 +13,7 @@ from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.keyvault.keys import JsonWebKey, KeyCurveName
 from azure.keyvault.keys.aio import KeyClient
+from devtools_testutils import PowerShellPreparer
 from parameterized import parameterized, param
 
 from _shared.test_case_async import KeyVaultTestCase
@@ -158,6 +159,7 @@ class KeyVaultKeyTest(KeysTestCase, KeyVaultTestCase):
         return imported_key
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_key_crud_operations(self, **kwargs):
         is_hsm = kwargs.pop("is_hsm")
         self._skip_if_not_configured(is_hsm)
@@ -227,6 +229,7 @@ class KeyVaultKeyTest(KeysTestCase, KeyVaultTestCase):
         self.assertEqual(rsa_key.id, deleted_key.id)
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_backup_restore(self, **kwargs):
         is_hsm = kwargs.pop("is_hsm")
         self._skip_if_not_configured(is_hsm)
@@ -256,6 +259,7 @@ class KeyVaultKeyTest(KeysTestCase, KeyVaultTestCase):
         self._assert_key_attributes_equal(created_bundle.properties, restored_key.properties)
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_key_list(self, **kwargs):
         is_hsm = kwargs.pop("is_hsm")
         self._skip_if_not_configured(is_hsm)
@@ -282,6 +286,7 @@ class KeyVaultKeyTest(KeysTestCase, KeyVaultTestCase):
         self.assertEqual(len(expected), 0)
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_list_versions(self, **kwargs):
         is_hsm = kwargs.pop("is_hsm")
         self._skip_if_not_configured(is_hsm)
@@ -311,6 +316,7 @@ class KeyVaultKeyTest(KeysTestCase, KeyVaultTestCase):
         self.assertEqual(0, len(expected))
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_list_deleted_keys(self, **kwargs):
         is_hsm = kwargs.pop("is_hsm")
         self._skip_if_not_configured(is_hsm)
@@ -345,6 +351,7 @@ class KeyVaultKeyTest(KeysTestCase, KeyVaultTestCase):
         self.assertEqual(len(expected), 0)
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_recover(self, **kwargs):
         is_hsm = kwargs.pop("is_hsm")
         self._skip_if_not_configured(is_hsm)
@@ -378,6 +385,7 @@ class KeyVaultKeyTest(KeysTestCase, KeyVaultTestCase):
         self.assertEqual(len(set(expected.keys()) & set(actual.keys())), len(expected))
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_purge(self, **kwargs):
         is_hsm = kwargs.pop("is_hsm")
         self._skip_if_not_configured(is_hsm)
@@ -408,6 +416,7 @@ class KeyVaultKeyTest(KeysTestCase, KeyVaultTestCase):
             assert deleted_key.name not in key_names
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_logging_enabled(self, **kwargs):
         is_hsm = kwargs.pop("is_hsm")
         self._skip_if_not_configured(is_hsm)
@@ -437,6 +446,7 @@ class KeyVaultKeyTest(KeysTestCase, KeyVaultTestCase):
         assert False, "Expected request body wasn't logged"
 
     @parameterized.expand([param(is_hsm=b) for b in [True, False]], name_func=suffixed_test_name)
+    @PowerShellPreparer("keyvault")
     async def test_logging_disabled(self, **kwargs):
         is_hsm = kwargs.pop("is_hsm")
         self._skip_if_not_configured(is_hsm)


### PR DESCRIPTION
Resolves #17425, at least to achieve parity with Javascript.

This adds local crypto support for encryption and decryption with AES-CBCPAD algorithms. AES-CBC support is on hold until we find a way to perform zero-padding -- the closest thing in `cryptography` is [ANSIX923](https://cryptography.io/en/latest/hazmat/primitives/padding.html#cryptography.hazmat.primitives.padding.ANSIX923) padding, but the final byte in that padding is nonzero.

This also fixes a bug that I had accidentally introduced in async tests by removing preparers: async test cases weren't being awaited due to the preparer's absence, and green test runs greatly exaggerated their success. This decorates affected tests with a dummy `PowerShellPreparer` that gets them noticed by the test runner without affecting execution otherwise.