### PR TITLE
[Storage] mgmt live tests

### DIFF
--- a/sdk/storage/azure-mgmt-storage/tests.yml
+++ b/sdk/storage/azure-mgmt-storage/tests.yml
@@ -3,7 +3,6 @@ trigger: none
 stages:
   - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
-      AllocateResourceGroup: 'false'
       ServiceDirectory: storage
       BuildTargetingString: azure-mgmt-storage
       EnvVars:

--- a/sdk/storage/azure-mgmt-storage/tests.yml
+++ b/sdk/storage/azure-mgmt-storage/tests.yml
@@ -1,0 +1,16 @@
+trigger: none
+
+stages:
+  - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
+    parameters:
+      AllocateResourceGroup: 'false'
+      ServiceDirectory: storage
+      BuildTargetingString: azure-mgmt-storage
+      EnvVars:
+        TEST_MODE: 'RunLiveNoRecord'
+        AZURE_SKIP_LIVE_RECORDING: 'True'
+        AZURE_TEST_RUN_LIVE: 'true'
+        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+        AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
+        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)


### PR DESCRIPTION
addressing: #17250

- created `azure-mgmt-storage/tests.yml` rather than `storage/tests-mgmt.yml`, as per a discussion with @benbp about KeyVault mgmt live tests. (Pipeline for KeyVault mgmt tests [here](https://dev.azure.com/azure-sdk/internal/_build?definitionId=2503).)