### PR TITLE
Update try_import to be aware of what package it's running against

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -88,7 +88,7 @@ deps =
 commands =
     - {envbindir}/python -m pip uninstall aiohttp --yes
     {envbindir}/python {toxinidir}/../../../eng/tox/create_package_and_install.py -d {envtmpdir} -p {toxinidir} -w {envtmpdir}
-    {envbindir}/python {toxinidir}/../../../eng/tox/try_import.py aiohttp
+    {envbindir}/python {toxinidir}/../../../eng/tox/try_import.py aiohttp -p {toxinidir}
     {envbindir}/python -m pip freeze
     pytest \
       {[testenv]default_pytest_params} \

--- a/eng/tox/try_import.py
+++ b/eng/tox/try_import.py
@@ -5,8 +5,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-# This script is used to verify that packages are not importable. This is especially useful when 
-# running checks without the presence of "optional" packages like aiohttp. 
+# This script is used to verify that packages are not importable. This is especially useful when
+# running checks without the presence of "optional" packages like aiohttp.
 
 
 import argparse
@@ -33,7 +33,6 @@ if __name__ == "__main__":
         nargs="+",
         help="The set of packages that we shouldn't be able to import.",
     )
-
 
     parser.add_argument(
         "-p",

--- a/eng/tox/try_import.py
+++ b/eng/tox/try_import.py
@@ -11,6 +11,13 @@
 
 import argparse
 import logging
+import os
+import sys
+
+root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", ".."))
+common_task_path = os.path.abspath(os.path.join(root_dir, "scripts", "devops_tasks"))
+sys.path.append(common_task_path)
+from common_tasks import parse_setup, get_name_from_specifier
 
 logging.getLogger().setLevel(logging.INFO)
 
@@ -27,13 +34,24 @@ if __name__ == "__main__":
         help="The set of packages that we shouldn't be able to import.",
     )
 
+
+    parser.add_argument(
+        "-p",
+        "--path-to-setup",
+        dest="target_setup",
+        help="The path to the setup.py (not including the file) for the package that we are running try_import alongside. The key here is that if a package on our 'check' list actually requires something, we will not fail the check.",
+    )
+
     args = parser.parse_args()
 
-    print(args.imports)
+    acceptable_to_import = []
+    if args.target_setup:
+        _, _, _, reqs = parse_setup(args.target_setup)
+        acceptable_to_import = [get_name_from_specifier(req).strip() for req in reqs]
 
     importable_packages = []
 
-    for ns in list(args.imports):
+    for ns in [ns for ns in list(args.imports) if ns not in acceptable_to_import]:
         try:
             logging.info("Ensuring that namespace {} is not importable.".format(ns))
             exec("import {}".format(ns))

--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -193,6 +193,10 @@ def parse_setup_requires(setup_path):
     return python_requires
 
 
+def get_name_from_specifier(version):
+    return re.split(r'[><=]', version)[0]
+
+
 def filter_for_compatibility(package_set):
     collected_packages = []
     v = sys.version_info


### PR DESCRIPTION
If a package _requires_ `aiohttp` we shouldn't be mandating that it's _not present_.
