### PR TITLE
Fix Issue with "Remove-TestResources" in smoke-tests

### DIFF
--- a/eng/pipelines/templates/jobs/smoke-test.yml
+++ b/eng/pipelines/templates/jobs/smoke-test.yml
@@ -214,7 +214,7 @@ jobs:
 
       - template: /eng/common/TestResources/deploy-test-resources.yml
         parameters:
-          ServiceDirectory: '$(Build.SourcesDirectory)/common/smoketest/'
+          ServiceDirectory: 'smoke-test'
           SubscriptionConfiguration: $(SubscriptionConfiguration)
           Location: $(Location)
           ArmTemplateParameters: $(ArmTemplateParameters)
@@ -224,6 +224,6 @@ jobs:
 
       - template: /eng/common/TestResources/remove-test-resources.yml
         parameters:
-          ServiceDirectory: '$(Build.SourcesDirectory)/common/smoketest/'
+          ServiceDirectory: 'smoke-test'
           SubscriptionConfiguration: $(SubscriptionConfiguration)
 

--- a/eng/pipelines/templates/jobs/smoke-test.yml
+++ b/eng/pipelines/templates/jobs/smoke-test.yml
@@ -214,7 +214,7 @@ jobs:
 
       - template: /eng/common/TestResources/deploy-test-resources.yml
         parameters:
-          ServiceDirectory: 'smoke-test'
+          ServiceDirectory: 'template'
           SubscriptionConfiguration: $(SubscriptionConfiguration)
           Location: $(Location)
           ArmTemplateParameters: $(ArmTemplateParameters)
@@ -224,6 +224,6 @@ jobs:
 
       - template: /eng/common/TestResources/remove-test-resources.yml
         parameters:
-          ServiceDirectory: 'smoke-test'
+          ServiceDirectory: 'template'
           SubscriptionConfiguration: $(SubscriptionConfiguration)
 


### PR DESCRIPTION
@benbp when we default the basename we're looking for, the [logic has issues.](https://github.com/Azure/azure-sdk-for-python/blob/4d50ff1f7b589256c85860226409d2f52846d206/eng/common/TestResources/Remove-TestResources.ps1#L132).

The problem is that we pass in a bunch of folders with `/` in it. We don't actually NEED the full service directory, as it doesn't get used. Updating this so that we can have green cleanup.