### PR TITLE
Temporarily replace macOS CI tests with ubuntu CI tests

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -78,7 +78,12 @@ stages:
           - ${{ each config in parameters.AdditionalMatrixConfigs }}:
             -  ${{ config }}
         MatrixFilters: ${{ parameters.MatrixFilters }}
-        MatrixReplace: ${{ parameters.MatrixReplace }}
+        MatrixReplace:
+          # Temporarily replace macOS agents with ubuntu agents because of ongoing pool capacity issues
+          - Pool=Azure.Pipelines/azsdk-pool-mms-ubuntu-1804-general
+          - OsVmImage=macOS-10.15/MMSUbuntu18.04
+          - ${{ each replacement in parameters.MatrixReplace }}:
+            - ${{ replacement }}
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:


### PR DESCRIPTION
The Azure Pipelines hosted macOS pools are currently experiencing severe capacity issues, which is causing a lot of bottlenecks for our PR/CI and release pipelines. This PR overrides all CI/client/release tests that run on mac to run on our managed ubuntu pool instead. Live tests are unaffected and will still run on the mac pool.

See https://status.dev.azure.com/_event/233282345 for details on the underlying issue.