### PR TITLE
Add ubuntu 18.04 agent VM DNS workaround to CI tests

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -67,6 +67,8 @@ jobs:
       parameters:
         AgentImage: $(OSVmImage)
 
+    - template: /eng/common/pipelines/templates/steps/bypass-local-dns.yml
+
     - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
       parameters:
         PackageName: "azure-template"


### PR DESCRIPTION
This adds a workaround to our CI tests for this issue: https://github.com/actions/virtual-environments/issues/798. We already run this in live tests, but not in CI.