### PR TITLE
[azure-core] Remove unnecessary attribute access

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
@@ -337,7 +337,7 @@ class NetworkTraceLoggingPolicy(SansIOHTTPPolicy):
                     if response.context.options.get('stream', False):
                         _LOGGER.debug("Body is streamable")
                     else:
-                        _LOGGER.debug(response.http_response.text())
+                        _LOGGER.debug(http_response.text())
         except Exception as err:  # pylint: disable=broad-except
             _LOGGER.debug("Failed to log response: %s", repr(err))
 


### PR DESCRIPTION
`http_response` already exists in the context. No need to get it from `response` again.