### PR TITLE
allow filtering live test sets based on package name

### DIFF
--- a/sdk/communication/tests.yml
+++ b/sdk/communication/tests.yml
@@ -21,6 +21,7 @@ stages:
           BuildTargetingString: 'azure-mgmt-communication'
         JobName: ${{ package }}
         ServiceDirectory: communication
+        DeployArmTemplate: true
         EnvVars:
           AZURE_TEST_RUN_LIVE: 'true'
           AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/communication/tests.yml
+++ b/sdk/communication/tests.yml
@@ -1,17 +1,31 @@
 trigger: none
 
+parameters:
+  - name: TestPackagesEnabled 
+    type: object
+    default:
+      - identity
+      - chat
+      - phonenumbers
+      - sms
+      - mgmt
+
 stages:
-  - template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
-    parameters:
-      AllocateResourceGroup: 'false'
-      BuildTargetingString: $(BuildTargetingString)
-      ServiceDirectory: communication
-      DeployArmTemplate: true
-      EnvVars:
-        AZURE_TEST_RUN_LIVE: 'true'
-        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-        AZURE_SUBSCRIPTION_ID: $(acs-subscription-id)
-        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
-        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-        AZURE_COMMUNICATION_SERVICE_CONNECTION_STRING: $(communication-livetest-connection-string)
-        AZURE_COMMUNICATION_SERVICE_PHONE_NUMBER: $(communication-livetest-phone-number)
+  - ${{ each package in parameters.TestPackagesEnabled }}:
+    - template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
+      parameters:
+        AllocateResourceGroup: 'false'
+        ${{ if ne(package, 'mgmt') }}:
+          BuildTargetingString: ${{ format('azure-communication-{0}', package) }}
+        ${{ if eq(package, 'mgmt') }}:
+          BuildTargetingString: 'azure-mgmt-communication'
+        JobName: ${{ package }}
+        ServiceDirectory: communication
+        EnvVars:
+          AZURE_TEST_RUN_LIVE: 'true'
+          AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+          AZURE_SUBSCRIPTION_ID: $(acs-subscription-id)
+          AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+          AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
+          AZURE_COMMUNICATION_SERVICE_CONNECTION_STRING: $(communication-livetest-connection-string)
+          AZURE_COMMUNICATION_SERVICE_PHONE_NUMBER: $(communication-livetest-phone-number)


### PR DESCRIPTION
### Description: 
#### What
We want to have the ability to trigger live tests separately for different packages 
#### How
Set runtime parameters ```Services``` at the test YAML file.
Based on [recommendations ](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/keyvault/tests.yml)from sys engineering team, add in test filtering logic based on package name so that developers can override [ run parameters from the pipeline ](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/runtime-parameters?view=azure-devops&tabs=script). By default, all packages will be built and tested.
### Test: 
* Run [all packages](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=842788&view=results)
* Run [a selected package](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=842906&view=results)