### PR TITLE
[Key Vault] Add public_exponent option to create_key

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -119,7 +119,7 @@ jobs:
             Location: ${{ coalesce(parameters.Location, parameters.CloudConfig.Location) }}
             ServiceDirectory: '${{ parameters.ServiceDirectory }}'
             SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
-            ArmTemplateParameters: ${{ coalesce(parameters.CloudConfig.ArmTemplateParameters, '@{}') }}
+            ArmTemplateParameters: $(ArmTemplateParameters)
 
       - template: ../steps/build-test.yml
         parameters:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -116,6 +116,7 @@ class KeyClient(KeyVaultClientBase):
 
         :param str name: The name for the new key.
         :keyword int size: Key size in bits, for example 2048, 3072, or 4096.
+        :keyword int public_exponent: The RSA public exponent to use. Applies only to RSA keys created in a Managed HSM.
         :keyword bool hardware_protected: Whether the key should be created in a hardware security module.
          Defaults to ``False``.
         :keyword key_operations: Allowed key operations

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -60,6 +60,7 @@ class KeyClient(KeyVaultClientBase):
         :keyword curve: Elliptic curve name. Applies only to elliptic curve keys. Defaults to the NIST P-256
          elliptic curve. To create an elliptic curve key, consider using :func:`create_ec_key` instead.
         :paramtype curve: ~azure.keyvault.keys.KeyCurveName or str
+        :keyword int public_exponent: The RSA public exponent to use. Applies only to RSA keys created in a Managed HSM.
         :keyword key_operations: Allowed key operations
         :paramtype key_operations: list[~azure.keyvault.keys.KeyOperation or str]
         :keyword bool enabled: Whether the key is enabled for use.
@@ -93,7 +94,8 @@ class KeyClient(KeyVaultClientBase):
             key_attributes=attributes,
             key_ops=kwargs.pop("key_operations", None),
             tags=kwargs.pop("tags", None),
-            curve=kwargs.pop("curve", None)
+            curve=kwargs.pop("curve", None),
+            public_exponent=kwargs.pop("public_exponent", None)
         )
 
         bundle = self._client.create_key(

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -58,6 +58,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :keyword curve: Elliptic curve name. Applies only to elliptic curve keys. Defaults to the NIST P-256
          elliptic curve. To create an elliptic curve key, consider using :func:`create_ec_key` instead.
         :paramtype curve: ~azure.keyvault.keys.KeyCurveName or str
+        :keyword int public_exponent: The RSA public exponent to use. Applies only to RSA keys created in a Managed HSM.
         :keyword key_operations: Allowed key operations
         :paramtype key_operations: list[~azure.keyvault.keys.KeyOperation or str]
         :keyword bool enabled: Whether the key is enabled for use.
@@ -92,7 +93,8 @@ class KeyClient(AsyncKeyVaultClientBase):
             key_attributes=attributes,
             key_ops=kwargs.pop("key_operations", None),
             tags=kwargs.pop("tags", None),
-            curve=kwargs.pop("curve", None)
+            curve=kwargs.pop("curve", None),
+            public_exponent=kwargs.pop("public_exponent", None)
         )
 
         bundle = await self._client.create_key(

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -114,6 +114,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :param str name: The name for the new key.
         :keyword int size: Key size in bits, for example 2048, 3072, or 4096.
+        :keyword int public_exponent: The RSA public exponent to use. Applies only to RSA keys created in a Managed HSM.
         :keyword bool hardware_protected: Whether the key should be created in a hardware security module.
          Defaults to ``False``.
         :keyword key_operations: Allowed key operations

--- a/sdk/keyvault/azure-keyvault-keys/platform-matrix.json
+++ b/sdk/keyvault/azure-keyvault-keys/platform-matrix.json
@@ -2,11 +2,11 @@
   "include": [
     {
       "Agent": {
-          "ubuntu-18.04": {
-            "OSVmImage": "MMSUbuntu18.04",
-            "Pool": "azsdk-pool-mms-ubuntu-1804-general",
-            "ArmTemplateParameters": "@{ enableHsm = $true }"
-          }
+        "ubuntu-18.04_ManagedHSM": {
+          "OSVmImage": "MMSUbuntu18.04",
+          "Pool": "azsdk-pool-mms-ubuntu-1804-general",
+          "ArmTemplateParameters": "@{ enableHsm = $true }"
+        }
       },
       "PythonVersion": "3.9",
       "CoverageArg": ""

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_rsa_public_exponent_mhsm.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_key_client.test_rsa_public_exponent_mhsm.yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestrsa-keyaa84129c/create?api-version=7.2-preview
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://managedhsm.azure.net"
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-server-latency:
+      - '1'
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"public_exponent": 17, "kty": "RSA-HSM"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestrsa-keyaa84129c/create?api-version=7.2-preview
+  response:
+    body:
+      string: '{"attributes":{"created":1618353119,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1618353119},"key":{"e":"EQ","key_ops":["wrapKey","decrypt","encrypt","unwrapKey","sign","verify"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestrsa-keyaa84129c/a63a1a240ff003079a3a50fb3116302b","kty":"RSA-HSM","n":"nO6rF2ru8HUAHbf2VyzVge6ic77k_Ju2VGuMKhNaX4nac8S2jMfHOYfkCmNi_NuZ_RUSYEkjtwwwh5LkAKwGP6AjKkEESbZiOyeBPi5bJB5A9g0-JKDT1Yudpnl4nBoXZinhvj0Dgr0LS38r-vu6wJjt_w_37Ofiun_sFCJcLGUfqN6KSGBbAE4XscLOY3GRUl1E3Mcq232R4yRxWsEhGmMDOVEM5VocRUiZOD-LRc0QclHQYX1lwto93UX272VVx5BrRTAtf9XZdTnWajk7xM-JXlYkkhon5KmdTavFL0pMGv23mnSjIMFT5sUPXanEYkwM1RqSJWnIRt2YoyVCzQ"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '722'
+      content-security-policy:
+      - default-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region:
+      - eastus2
+      x-ms-server-latency:
+      - '1041'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_rsa_public_exponent_mhsm.yaml
+++ b/sdk/keyvault/azure-keyvault-keys/tests/recordings/test_keys_async.test_rsa_public_exponent_mhsm.yaml
@@ -1,0 +1,64 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestrsa-keyad3012ae/create?api-version=7.2-preview
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control: no-cache
+      content-length: '0'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      www-authenticate: Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://managedhsm.azure.net"
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-server-latency: '1'
+    status:
+      code: 401
+      message: Unauthorized
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestrsa-keyad3012ae/create?api-version=7.2-preview
+- request:
+    body: '{"public_exponent": 17, "kty": "RSA-HSM"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-keys/4.4.0b5 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://managedhsmname.managedhsm.azure.net/keys/livekvtestrsa-keyad3012ae/create?api-version=7.2-preview
+  response:
+    body:
+      string: '{"attributes":{"created":1618353643,"enabled":true,"exportable":false,"recoverableDays":90,"recoveryLevel":"Recoverable+Purgeable","updated":1618353643},"key":{"e":"EQ","key_ops":["wrapKey","decrypt","encrypt","unwrapKey","sign","verify"],"kid":"https://managedhsmname.managedhsm.azure.net/keys/livekvtestrsa-keyad3012ae/d0b837d03f9c069780c5d37fd8bce435","kty":"RSA-HSM","n":"nIkUlKQZuvk31cPRCAzYoHZ-lHpSBUHLfSPQsPpyy5LpUrJPHFozMNUAZ2VUKR_-9S17Znn5CVwbAKXfXPx-5dsq6_hqjvfMtwoWJDU4tPa5vqS-SxZQ-CTYj8N4N1rx2qyF5Z18OSwZGQ3up7vl8RsPSeI1SEIhHWPIg6A4VLe0VhByiYXyOIZeDm7MVnpeisQMgaQoiObgYYzN5xBpbGSFd2_7H-AivK58BgRGoAzfd_FXVS1a9244hHH3gFy7oSo3ccPZyI_kKjXlB4kTmvvZBdQeVbWOeaNDemxsH8TsJy1yR9V1lwkZ08M19iYYbYtomeLpAcws46kPWc-wjQ"}}'
+    headers:
+      cache-control: no-cache
+      content-length: '722'
+      content-security-policy: default-src 'self'
+      content-type: application/json; charset=utf-8
+      strict-transport-security: max-age=31536000; includeSubDomains
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-ms-keyvault-network-info: conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=Ipv4;
+      x-ms-keyvault-region: eastus2
+      x-ms-server-latency: '812'
+    status:
+      code: 200
+      message: OK
+    url: https://mcpatinotesthsm.managedhsm.azure.net/keys/livekvtestrsa-keyad3012ae/create?api-version=7.2-preview
+version: 1

--- a/sdk/keyvault/test-resources-post.ps1
+++ b/sdk/keyvault/test-resources-post.ps1
@@ -108,10 +108,10 @@ az keyvault security-domain download --hsm-name $hsmName --security-domain-file 
 Log "Security domain downloaded to '$sdPath'; Managed HSM is now active at '$hsmUrl'"
 
 # Force a sleep to wait for Managed HSM activation to propagate through Cosmos replication. Issue tracked in AzDo.
-Log "Sleeping for 30 seconds to allow activation to propagate..."
-Start-Sleep -Seconds 30
+Log "Sleeping for 120 seconds to allow activation to propagate..."
+Start-Sleep -Seconds 120
 
 Log "Creating additional required role assignments for resource access."
-New-AzKeyVaultRoleAssignment -HsmName $hsmName -RoleDefinitionName "Managed HSM Crypto Officer" -ObjectID $DeploymentOutputs["CLIENT_OBJECT_ID"]
-New-AzKeyVaultRoleAssignment -HsmName $hsmName -RoleDefinitionName "Managed HSM Crypto User" -ObjectID $DeploymentOutputs["CLIENT_OBJECT_ID"]
+New-AzKeyVaultRoleAssignment -HsmName $hsmName -RoleDefinitionName "Managed HSM Crypto Officer" -ObjectID $DeploymentOutputs["CLIENT_OBJECTID"]
+New-AzKeyVaultRoleAssignment -HsmName $hsmName -RoleDefinitionName "Managed HSM Crypto User" -ObjectID $DeploymentOutputs["CLIENT_OBJECTID"]
 Log "Done."


### PR DESCRIPTION
Resolves #18016.

This also tweaks pipeline test configuration, since local testing has shown that we need a longer delay before assigning crypto roles (otherwise we get an error). `platform-matrix.json` has been changed to more closely resemble [JS's](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-keys/platform-matrix.json) because HSMs aren't being properly deployed for pipeline tests (see example [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=839819&view=logs&j=d2931fad-161b-5770-82cb-ab9682370e2d&t=f8caccc0-eeff-5bcd-6c2a-15a3d1a89be2&l=1812)).