### PR TITLE
Fix documentation for TaskExecutionInformation

### DIFF
--- a/sdk/batch/azure-batch/azure/batch/models/_models.py
+++ b/sdk/batch/azure-batch/azure/batch/models/_models.py
@@ -9892,7 +9892,7 @@ class TaskExecutionInformation(Model):
      requeued by the Batch service as the result of a user request. This
      property is set only if the requeueCount is nonzero.
     :type last_requeue_time: datetime
-    :param result: The result of the Task execution. If the value is 'failed',
+    :param result: The result of the Task execution. If the value is 'failure',
      then the details of the failure can be found in the failureInfo property.
      Possible values include: 'success', 'failure'
     :type result: str or ~azure.batch.models.TaskExecutionResult


### PR DESCRIPTION
The docstring for TaskExecutionResult states that if the value of `result` references a value of 'failed', but the possible values are listed are 'success' and 'failure'