### PR TITLE
Support multiple subscription configuration options

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -114,11 +114,16 @@ jobs:
 
         # figure out what's up with the create resource group above
       - ${{ if eq(parameters['DeployArmTemplate'], true) }}:
+        - template: /eng/common/TestResources/build-test-resource-config.yml
+          parameters:
+            SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
+            SubscriptionConfigurations: ${{ parameters.CloudConfig.SubscriptionConfigurations }}
+
         - template: ../../../common/TestResources/deploy-test-resources.yml
           parameters:
             Location: ${{ coalesce(parameters.Location, parameters.CloudConfig.Location) }}
             ServiceDirectory: '${{ parameters.ServiceDirectory }}'
-            SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
+            SubscriptionConfiguration: $(SubscriptionConfiguration)
             ArmTemplateParameters: $(ArmTemplateParameters)
 
       - template: ../steps/build-test.yml
@@ -150,4 +155,4 @@ jobs:
         - template: /eng/common/TestResources/remove-test-resources.yml
           parameters:
             ServiceDirectory: '${{ parameters.ServiceDirectory }}'
-            SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
+            SubscriptionConfiguration: $(SubscriptionConfiguration)

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -139,6 +139,7 @@ stages:
               - ${{ parameters.MatrixFilters }}
             CloudConfig:
               SubscriptionConfiguration: ${{ cloud.value.SubscriptionConfiguration }}
+              SubscriptionConfigurations: ${{ cloud.value.SubscriptionConfigurations }}
               Location: ${{ coalesce(parameters.Location, cloud.value.Location) }}
               Cloud: ${{ cloud.key }}
 


### PR DESCRIPTION
This PR enables live tests to use multiple subscription configurations per cloud instead of one. Currently there are some services that need to manage their own cloud-specific values in a keyvault they control (e.g. acs, storage), but also need to use some shared values that only Azure SDK engineering systems can have access to, like service principal credentials.

This change takes advantage of a [recent update](https://github.com/Azure/azure-sdk-tools/pull/1560) to enable merging multiple subscription configurations together before passing the value to the ARM template deployment job.