### PR TITLE
[Key Vault] Update default MHSM location for tests

### DIFF
--- a/sdk/keyvault/test-resources.json
+++ b/sdk/keyvault/test-resources.json
@@ -32,15 +32,25 @@
         },
         "hsmLocation": {
             "type": "string",
-            "defaultValue": "eastus2",
+            "defaultValue": "westus",
             "allowedValues": [
+                "australiacentral",
+                "canadacentral",
+                "centralus",
+                "eastasia",
                 "eastus2",
-                "southcentralus",
+                "koreacentral",
                 "northeurope",
-                "westeurope"
+                "southafricanorth",
+                "southcentralus",
+                "southeastasia",
+                "switzerlandnorth",
+                "uksouth",
+                "westeurope",
+                "westus"
             ],
             "metadata": {
-                "description": "The location of the Managed HSM. By default, this is 'southcentralus'."
+                "description": "The location of the Managed HSM. By default, this is 'westus'."
             }
         },
         "enableHsm": {


### PR DESCRIPTION
Now that Managed HSM is supported in more locations, this makes `westus` the default location for HSM deployment via `test-resources.json` to avoid overlapping with JavaScript's test HSMs.