### PR TITLE
Use 1es hosted pools for smoke tests

### DIFF
--- a/common/smoketest/smoke-test.yml
+++ b/common/smoketest/smoke-test.yml
@@ -1,4 +1,4 @@
 jobs:
-  - template: /eng/pipelines/templates/jobs/smoke-test.yml
+  - template: /eng/pipelines/templates/jobs/smoke.tests.yml
     parameters:
       Daily: true

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -12,6 +12,9 @@ jobs:
   - ${{ if eq(parameters.Daily, false) }}:
     - job: smoke_test_eligibility
       displayName: Check Smoke Test Eligibility
+      pool:
+        name: "azsdk-pool-mms-ubuntu-1804-general"
+        vmImage: "MMSUbuntu18.04"
       steps:
         - ${{ each artifact in parameters.Artifacts }}:
           - ${{ if and(ne(variables['Skip.Release'], 'true'), ne(artifact.skipPublishPackage, 'true')) }}:
@@ -40,39 +43,39 @@ jobs:
         Python_27_Linux (AzureCloud):
           PythonVersion: '2.7'
           SkipAsyncInstall: true
-          Pool: Azure Pipelines
-          OSVmImage: ubuntu-18.04
+          Pool: "azsdk-pool-mms-ubuntu-1804-general"
+          OSVmImage: "MMSUbuntu18.04"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
         Python_37_Linux (AzureCloud):
           PythonVersion: '3.7'
-          Pool: Azure Pipelines
-          OSVmImage: ubuntu-18.04
+          Pool: "azsdk-pool-mms-ubuntu-1804-general"
+          OSVmImage: "MMSUbuntu18.04"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
         Python_38_Linux (AzureCloud):
           PythonVersion: '3.8'
-          Pool: Azure Pipelines
-          OSVmImage: ubuntu-18.04
+          Pool: "azsdk-pool-mms-ubuntu-1804-general"
+          OSVmImage: "MMSUbuntu18.04"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
         Python_38_Linux (AzureCloud Canary):
           PythonVersion: '3.8'
-          Pool: Azure Pipelines
-          OSVmImage: ubuntu-18.04
+          Pool: "azsdk-pool-mms-ubuntu-1804-general"
+          OSVmImage: "MMSUbuntu18.04"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
           ArmTemplateParameters: $(azureCloudArmParameters)
           Location: 'eastus2euap'
         Python_37_Windows (AzureCloud):
           PythonVersion: '3.7'
-          Pool: Azure Pipelines
-          OSVmImage: windows-2019
+          Pool: "azsdk-pool-mms-win-2019-general"
+          OSVmImage: "MMS2019"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
         Python_38_Windows (AzureCloud):
           PythonVersion: '3.8'
-          Pool: Azure Pipelines
-          OSVmImage: windows-2019
+          Pool: "azsdk-pool-mms-ubuntu-1804-general"
+          OSVmImage: "MMSUbuntu18.04"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
         Python_37_Mac (AzureCloud):
@@ -89,27 +92,27 @@ jobs:
           ArmTemplateParameters: $(azureCloudArmParameters)
         Python_38_Linux (AzureUSGovernment):
           PythonVersion: '3.8'
-          Pool: Azure Pipelines
-          OSVmImage: ubuntu-18.04
+          Pool: "azsdk-pool-mms-ubuntu-1804-general"
+          OSVmImage: "MMSUbuntu18.04"
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
           ArmTemplateParameters: $(azureUSGovernmentArmParameters)
         Python_37_Windows (AzureUSGovernment):
           PythonVersion: '3.7'
-          Pool: Azure Pipelines
-          OSVmImage: windows-2019
+          Pool: "azsdk-pool-mms-ubuntu-1804-general"
+          OSVmImage: "MMSUbuntu18.04"
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
           ArmTemplateParameters: $(azureUSGovernmentArmParameters)
         Python_38_Linux (AzureChinaCloud):
           PythonVersion: '3.8'
-          Pool: Azure Pipelines
-          OSVmImage: ubuntu-18.04
+          Pool: "azsdk-pool-mms-ubuntu-1804-general"
+          OSVmImage: "MMSUbuntu18.04"
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
           Location: 'chinanorth'
           ArmTemplateParameters: $(azureChinaCloudArmParameters)
         Python_37_Windows (AzureChinaCloud):
           PythonVersion: '3.7'
-          Pool: Azure Pipelines
-          OSVmImage: windows-2019
+          Pool: "azsdk-pool-mms-ubuntu-1804-general"
+          OSVmImage: "MMSUbuntu18.04"
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
           Location: 'chinanorth'
           ArmTemplateParameters: $(azureChinaCloudArmParameters)

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -56,7 +56,7 @@ stages:
                         ReleaseSha: $(Build.SourceVersion)
                         RepoId: Azure/azure-sdk-for-python
                         WorkingDirectory: $(System.DefaultWorkingDirectory)
-                    
+
           - ${{if ne(artifact.skipPublishPackage, 'true')}}:
             - deployment: PublishPackage
               displayName: "Publish to PyPI"
@@ -161,7 +161,7 @@ stages:
                   deploy:
                     steps:
                       - checkout: self
-                      
+
                       - pwsh: |
                           Get-ChildItem -Recurse $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
                         workingDirectory: $(Pipeline.Workspace)
@@ -228,7 +228,7 @@ stages:
     - stage: SmokeTest_Release_Packages
       displayName: Smoke Test Release Packages
       jobs:
-        - template: /eng/pipelines/templates/jobs/smoke-test.yml
+        - template: /eng/pipelines/templates/jobs/smoke.tests.yml
           parameters:
             Daily: false
             ArtifactName: ${{ parameters.ArtifactName }}


### PR DESCRIPTION
This PR switches the smoke test jobs and utility jobs to use the 1es hosted agents for windows and ubuntu runs.