### PR TITLE
Remove implicit dependency on successful completion of verify-links

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -83,6 +83,15 @@ jobs:
       vmImage: MMSUbuntu18.04
 
     steps:
+    - template: /eng/common/pipelines/templates/steps/verify-links.yml
+      parameters:
+        ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+          Directory: ''
+          Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
+        ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+          Directory: sdk/${{ parameters.ServiceDirectory }}
+        CheckLinkGuidance: $true
+        
     - template: ../steps/analyze.yml
       parameters:
         ServiceDirectory: ${{ parameters.ServiceDirectory }}

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -83,15 +83,6 @@ jobs:
       vmImage: MMSUbuntu18.04
 
     steps:
-    - template: /eng/common/pipelines/templates/steps/verify-links.yml
-      parameters:
-        ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-          Directory: ''
-          Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
-        ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-          Directory: sdk/${{ parameters.ServiceDirectory }}
-        CheckLinkGuidance: $true
-
     - template: ../steps/analyze.yml
       parameters:
         ServiceDirectory: ${{ parameters.ServiceDirectory }}

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -91,7 +91,7 @@ jobs:
         ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
           Directory: sdk/${{ parameters.ServiceDirectory }}
         CheckLinkGuidance: $true
-        
+
     - template: ../steps/analyze.yml
       parameters:
         ServiceDirectory: ${{ parameters.ServiceDirectory }}

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -9,6 +9,16 @@ parameters:
 steps:
   - template: /eng/pipelines/templates/steps/analyze_dependency.yml
 
+  - template: /eng/common/pipelines/templates/steps/verify-links.yml
+    parameters:
+      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+        Directory: ''
+        Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
+      ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+        Directory: sdk/${{ parameters.ServiceDirectory }}
+      CheckLinkGuidance: $true
+      Condition: succeededOrFailed()
+
   - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
     parameters:
       PackageName: "azure-template"

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -34,6 +34,18 @@ steps:
 
 
   - pwsh: |
+     pip install -r eng/ci_tools.txt $(if($IsWindows) {"--user" })
+    displayName: 'Install Necessary Dependencies'
+    condition: succeededOrFailed()
+
+  - script: |
+      cd eng/versioning
+      pip install -r requirements.txt
+      python find_invalid_versions.py --always-succeed --service=${{parameters.ServiceDirectory}}
+    displayName: Find Invalid Versions
+    condition: succeededOrFailed()
+
+  - pwsh: |
       Get-ChildItem $(Build.SourcesDirectory) -Filter "*.py" |
       Foreach-Object {
         if ((Get-Content $_ -Raw) -match "\r\n") {
@@ -58,12 +70,6 @@ steps:
     # builds should be sufficient.
     condition: and(succeededOrFailed(), ne(variables['Build.Reason'],'PullRequest'))
     displayName: 'Component Detection'
-
-  - pwsh: |
-     pip install -r eng/ci_tools.txt $(if($IsWindows) {"--user" })
-     ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/eng/.docsettings.yml
-    displayName: 'Install Necessary Dependencies'
-    condition: succeededOrFailed()
 
   - task: PythonScript@0
     displayName: 'Verify sdist'

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -9,16 +9,6 @@ parameters:
 steps:
   - template: /eng/pipelines/templates/steps/analyze_dependency.yml
 
-  - template: /eng/common/pipelines/templates/steps/verify-links.yml
-    parameters:
-      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-        Directory: ''
-        Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
-      ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-        Directory: sdk/${{ parameters.ServiceDirectory }}
-      CheckLinkGuidance: $true
-      Condition: succeededOrFailed()
-
   - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
     parameters:
       PackageName: "azure-template"
@@ -41,11 +31,7 @@ steps:
     # target is based on data available per-package the --always-succeed should
     # be removed so this script can help enforce correct practices
     # (https://github.com/Azure/azure-sdk-for-python/issues/8697)
-  - script: |
-      cd eng/versioning
-      pip install -r requirements.txt
-      python find_invalid_versions.py --always-succeed --service=${{parameters.ServiceDirectory}}
-    displayName: Find Invalid Versions
+
 
   - pwsh: |
       Get-ChildItem $(Build.SourcesDirectory) -Filter "*.py" |
@@ -72,6 +58,12 @@ steps:
     # builds should be sufficient.
     condition: and(succeededOrFailed(), ne(variables['Build.Reason'],'PullRequest'))
     displayName: 'Component Detection'
+
+  - pwsh: |
+     pip install -r eng/ci_tools.txt $(if($IsWindows) {"--user" })
+     ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/eng/.docsettings.yml
+    displayName: 'Install Necessary Dependencies'
+    condition: succeededOrFailed()
 
   - task: PythonScript@0
     displayName: 'Verify sdist'

--- a/eng/pipelines/templates/steps/analyze_dependency.yml
+++ b/eng/pipelines/templates/steps/analyze_dependency.yml
@@ -1,6 +1,7 @@
 steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python $(PythonVersion)'
+    condition: succeededOrFailed()
     inputs:
      versionSpec: '$(PythonVersion)'
 
@@ -8,14 +9,17 @@ steps:
      pip install -r eng/ci_tools.txt $(if($IsWindows) {"--user" })
      ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/eng/.docsettings.yml
     displayName: 'Verify Readmes'
+    condition: succeededOrFailed()
 
   - pwsh: |
       mkdir "$(Build.ArtifactStagingDirectory)/reports"
       Copy-Item -Path "$(Build.SourcesDirectory)/eng/common/InterdependencyGraph.html" -Destination "$(Build.ArtifactStagingDirectory)/reports/InterdependencyGraph.html"
     displayName: 'Populate Reports Staging Folder'
+    condition: succeededOrFailed()
 
   - task: PythonScript@0
     displayName: 'Analyze dependencies'
+    condition: succeededOrFailed()
     inputs:
      scriptPath: 'scripts/analyze_deps.py'
      arguments: '--verbose --out "$(Build.ArtifactStagingDirectory)/reports/dependencies.html" --dump "$(Build.ArtifactStagingDirectory)/reports/data.js"'


### PR DESCRIPTION
It's an eng/common/scripts which uses a specific function from within `LanguageSettings.ps1`.

That specific function actually needs `packaging` to be installed. This happens in `analyze_deps.py`, so we simply move this below it without burning any more time on installation.