### PR TITLE
Use `extend()` for `per_call_policies` and `per_retry_policies`

### DIFF
--- a/sdk/core/azure-core/azure/core/_pipeline_client.py
+++ b/sdk/core/azure-core/azure/core/_pipeline_client.py
@@ -123,24 +123,22 @@ class PipelineClient(PipelineClientBase):
                 ContentDecodePolicy(**kwargs)
             ]
             if isinstance(per_call_policies, Iterable):
-                for policy in per_call_policies:
-                    policies.append(policy)
+                policies.extend(per_call_policies)
             else:
                 policies.append(per_call_policies)
 
-            policies = policies + [config.redirect_policy,
-                               config.retry_policy,
-                               config.authentication_policy,
-                               config.custom_hook_policy]
+            policies.extend([config.redirect_policy,
+                             config.retry_policy,
+                             config.authentication_policy,
+                             config.custom_hook_policy])
             if isinstance(per_retry_policies, Iterable):
-                for policy in per_retry_policies:
-                    policies.append(policy)
+                policies.extend(per_retry_policies)
             else:
                 policies.append(per_retry_policies)
 
-            policies = policies + [config.logging_policy,
-                               DistributedTracingPolicy(**kwargs),
-                               config.http_logging_policy or HttpLoggingPolicy(**kwargs)]
+            policies.extend([config.logging_policy,
+                             DistributedTracingPolicy(**kwargs),
+                             config.http_logging_policy or HttpLoggingPolicy(**kwargs)])
 
         if not transport:
             transport = RequestsTransport(**kwargs)


### PR DESCRIPTION
Refine https://github.com/Azure/azure-sdk-for-python/pull/17340

For List Concatenation, using Add (`+`) is slower compared to INPLACE Add (`+=`) and `extend()`:

![](https://cdn.shortpixel.ai/client/to_avif,q_glossy,ret_img,w_640/https://blog.finxter.com/wp-content/uploads/2020/05/speed-Kopie.jpg)

Source: https://blog.finxter.com/python-list-concatenation-add-vs-inplace-add-vs-extend/

This PRs unifies the code for `per_call_policies` and `per_retry_policies` and only uses `extend()` for List Concatenation.
