### PR TITLE
[Key Vault] Add client creation decorator to certificates tests

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/_test_case.py
@@ -2,11 +2,40 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import functools
+
+from azure.keyvault.certificates import ApiVersion
 from azure.keyvault.certificates._shared import HttpChallengeCache
 from azure.keyvault.certificates._shared.client_base import DEFAULT_VERSION
-from devtools_testutils import AzureTestCase
-from parameterized import parameterized
+from devtools_testutils import AzureTestCase, PowerShellPreparer
+from parameterized import parameterized, param
 import pytest
+
+
+def client_setup(testcase_func):
+    """decorator that creates a client to be passed in to a test method"""
+    @PowerShellPreparer("keyvault", azure_keyvault_url="https://vaultname.vault.azure.net")
+    @functools.wraps(testcase_func)
+    def wrapper(test_class_instance, azure_keyvault_url, api_version, **kwargs):
+        test_class_instance._skip_if_not_configured(api_version)
+        client = test_class_instance.create_client(azure_keyvault_url, api_version=api_version, **kwargs)
+
+        if kwargs.get("is_async"):
+            import asyncio
+
+            coroutine = testcase_func(test_class_instance, client)
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(coroutine)
+        else:
+            testcase_func(test_class_instance, client)
+    return wrapper
+
+
+def get_decorator(**kwargs):
+    """returns a test decorator for test parameterization"""
+    versions = kwargs.pop("api_versions", None) or ApiVersion
+    params = [param(api_version=api_version, **kwargs) for api_version in versions]
+    return functools.partial(parameterized.expand, params, name_func=suffixed_test_name)
 
 
 def suffixed_test_name(testcase_func, param_num, param):

--- a/sdk/keyvault/azure-keyvault-certificates/tests/recordings/test_certificates_client.test_models_2016_10_01.yaml
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/recordings/test_certificates_client.test_models_2016_10_01.yaml
@@ -1,0 +1,333 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.3.0b1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d/create?api-version=2016-10-01
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
+        or PoP token."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '87'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Apr 2021 19:54:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus2
+      x-ms-keyvault-service-version:
+      - 1.2.236.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"policy": {"issuer": {"name": "Self"}, "x509_props": {"sans": {}, "subject":
+      "CN=DefaultPolicy"}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.3.0b1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d/create?api-version=2016-10-01
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d/pending","issuer":{"name":"Self"},"csr":"MIICqDCCAZACAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN2oXCigTUTWg5YTuE4uUCWPBkR5f++T4Z3p6pk8Ma6ae2NRLJ+AqDMh8DqOAuITvD+fO8i9V9oQaJtI1YajwCArKsOsQCHid/ZilE6WQO7AcF7xganNUTQHG2vc1hmLuTrnjzuw8FSgWbLoT7qJ/KSeQ+d6hGj5gQagklVFbO9dnF8qIBMwOWpIfb7xXIuPTnM6bFmxFFt5ZACgGZM8+AfHINQqR3KjQNygvVXzaEtA/NFLmHElkmE7QOffxh0r9DpnMFYIx9PkWBqi+ohQqb96nz2VQe8BDBcHK684k6VdwzomXBgt6uN1I4/oeLa8rXqpJ6kukvqPCgiHOzIn50UCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAba0IDZO2qdWb8Mq8cvGl1x/NLlxI/DVcjMKlUMTBmqEeanGfhEUrUcDqymE5j1nBDPVT2sN3NblM5zWkIdzkJ0haLjJOXKMP3JNL96DPHgta+lPcs2tA2NrT+TeGq8Byj+Nx74FBnWCKD0oUfej6FdksuxBc30ozZYAbVC1+Dpdotr8bdBmMeZp1wjCVxuQnZx4wS9tgOg1Zs/chCN/mKxLnrPfvqGf9X4RSdQYDtRtZnUYkWBiF8yzJxB2yRHQ2jNGbGPZTRPEOaCQp1f/g5tKFTw82k373LFLahuRdVfLSdhGx6ROY07Vevh/LdQGY6BstWzuQtjpF/EGuHbx/u","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"0386ec76ab6e44ea89a7048ecf2d3ccd"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1298'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Apr 2021 19:54:38 GMT
+      expires:
+      - '-1'
+      location:
+      - https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d/pending?api-version=2016-10-01&request_id=0386ec76ab6e44ea89a7048ecf2d3ccd
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus2
+      x-ms-keyvault-service-version:
+      - 1.2.236.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.3.0b1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d/pending?api-version=2016-10-01
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d/pending","issuer":{"name":"Self"},"csr":"MIICqDCCAZACAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN2oXCigTUTWg5YTuE4uUCWPBkR5f++T4Z3p6pk8Ma6ae2NRLJ+AqDMh8DqOAuITvD+fO8i9V9oQaJtI1YajwCArKsOsQCHid/ZilE6WQO7AcF7xganNUTQHG2vc1hmLuTrnjzuw8FSgWbLoT7qJ/KSeQ+d6hGj5gQagklVFbO9dnF8qIBMwOWpIfb7xXIuPTnM6bFmxFFt5ZACgGZM8+AfHINQqR3KjQNygvVXzaEtA/NFLmHElkmE7QOffxh0r9DpnMFYIx9PkWBqi+ohQqb96nz2VQe8BDBcHK684k6VdwzomXBgt6uN1I4/oeLa8rXqpJ6kukvqPCgiHOzIn50UCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAba0IDZO2qdWb8Mq8cvGl1x/NLlxI/DVcjMKlUMTBmqEeanGfhEUrUcDqymE5j1nBDPVT2sN3NblM5zWkIdzkJ0haLjJOXKMP3JNL96DPHgta+lPcs2tA2NrT+TeGq8Byj+Nx74FBnWCKD0oUfej6FdksuxBc30ozZYAbVC1+Dpdotr8bdBmMeZp1wjCVxuQnZx4wS9tgOg1Zs/chCN/mKxLnrPfvqGf9X4RSdQYDtRtZnUYkWBiF8yzJxB2yRHQ2jNGbGPZTRPEOaCQp1f/g5tKFTw82k373LFLahuRdVfLSdhGx6ROY07Vevh/LdQGY6BstWzuQtjpF/EGuHbx/u","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"0386ec76ab6e44ea89a7048ecf2d3ccd"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1298'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Apr 2021 19:54:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus2
+      x-ms-keyvault-service-version:
+      - 1.2.236.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.3.0b1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d/pending?api-version=2016-10-01
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d/pending","issuer":{"name":"Self"},"csr":"MIICqDCCAZACAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN2oXCigTUTWg5YTuE4uUCWPBkR5f++T4Z3p6pk8Ma6ae2NRLJ+AqDMh8DqOAuITvD+fO8i9V9oQaJtI1YajwCArKsOsQCHid/ZilE6WQO7AcF7xganNUTQHG2vc1hmLuTrnjzuw8FSgWbLoT7qJ/KSeQ+d6hGj5gQagklVFbO9dnF8qIBMwOWpIfb7xXIuPTnM6bFmxFFt5ZACgGZM8+AfHINQqR3KjQNygvVXzaEtA/NFLmHElkmE7QOffxh0r9DpnMFYIx9PkWBqi+ohQqb96nz2VQe8BDBcHK684k6VdwzomXBgt6uN1I4/oeLa8rXqpJ6kukvqPCgiHOzIn50UCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAba0IDZO2qdWb8Mq8cvGl1x/NLlxI/DVcjMKlUMTBmqEeanGfhEUrUcDqymE5j1nBDPVT2sN3NblM5zWkIdzkJ0haLjJOXKMP3JNL96DPHgta+lPcs2tA2NrT+TeGq8Byj+Nx74FBnWCKD0oUfej6FdksuxBc30ozZYAbVC1+Dpdotr8bdBmMeZp1wjCVxuQnZx4wS9tgOg1Zs/chCN/mKxLnrPfvqGf9X4RSdQYDtRtZnUYkWBiF8yzJxB2yRHQ2jNGbGPZTRPEOaCQp1f/g5tKFTw82k373LFLahuRdVfLSdhGx6ROY07Vevh/LdQGY6BstWzuQtjpF/EGuHbx/u","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"0386ec76ab6e44ea89a7048ecf2d3ccd"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1298'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Apr 2021 19:54:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus2
+      x-ms-keyvault-service-version:
+      - 1.2.236.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.3.0b1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d/pending?api-version=2016-10-01
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d/pending","issuer":{"name":"Self"},"csr":"MIICqDCCAZACAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN2oXCigTUTWg5YTuE4uUCWPBkR5f++T4Z3p6pk8Ma6ae2NRLJ+AqDMh8DqOAuITvD+fO8i9V9oQaJtI1YajwCArKsOsQCHid/ZilE6WQO7AcF7xganNUTQHG2vc1hmLuTrnjzuw8FSgWbLoT7qJ/KSeQ+d6hGj5gQagklVFbO9dnF8qIBMwOWpIfb7xXIuPTnM6bFmxFFt5ZACgGZM8+AfHINQqR3KjQNygvVXzaEtA/NFLmHElkmE7QOffxh0r9DpnMFYIx9PkWBqi+ohQqb96nz2VQe8BDBcHK684k6VdwzomXBgt6uN1I4/oeLa8rXqpJ6kukvqPCgiHOzIn50UCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAba0IDZO2qdWb8Mq8cvGl1x/NLlxI/DVcjMKlUMTBmqEeanGfhEUrUcDqymE5j1nBDPVT2sN3NblM5zWkIdzkJ0haLjJOXKMP3JNL96DPHgta+lPcs2tA2NrT+TeGq8Byj+Nx74FBnWCKD0oUfej6FdksuxBc30ozZYAbVC1+Dpdotr8bdBmMeZp1wjCVxuQnZx4wS9tgOg1Zs/chCN/mKxLnrPfvqGf9X4RSdQYDtRtZnUYkWBiF8yzJxB2yRHQ2jNGbGPZTRPEOaCQp1f/g5tKFTw82k373LFLahuRdVfLSdhGx6ROY07Vevh/LdQGY6BstWzuQtjpF/EGuHbx/u","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"0386ec76ab6e44ea89a7048ecf2d3ccd"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1298'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Apr 2021 19:54:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus2
+      x-ms-keyvault-service-version:
+      - 1.2.236.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.3.0b1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d/pending?api-version=2016-10-01
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d/pending","issuer":{"name":"Self"},"csr":"MIICqDCCAZACAQAwGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN2oXCigTUTWg5YTuE4uUCWPBkR5f++T4Z3p6pk8Ma6ae2NRLJ+AqDMh8DqOAuITvD+fO8i9V9oQaJtI1YajwCArKsOsQCHid/ZilE6WQO7AcF7xganNUTQHG2vc1hmLuTrnjzuw8FSgWbLoT7qJ/KSeQ+d6hGj5gQagklVFbO9dnF8qIBMwOWpIfb7xXIuPTnM6bFmxFFt5ZACgGZM8+AfHINQqR3KjQNygvVXzaEtA/NFLmHElkmE7QOffxh0r9DpnMFYIx9PkWBqi+ohQqb96nz2VQe8BDBcHK684k6VdwzomXBgt6uN1I4/oeLa8rXqpJ6kukvqPCgiHOzIn50UCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAba0IDZO2qdWb8Mq8cvGl1x/NLlxI/DVcjMKlUMTBmqEeanGfhEUrUcDqymE5j1nBDPVT2sN3NblM5zWkIdzkJ0haLjJOXKMP3JNL96DPHgta+lPcs2tA2NrT+TeGq8Byj+Nx74FBnWCKD0oUfej6FdksuxBc30ozZYAbVC1+Dpdotr8bdBmMeZp1wjCVxuQnZx4wS9tgOg1Zs/chCN/mKxLnrPfvqGf9X4RSdQYDtRtZnUYkWBiF8yzJxB2yRHQ2jNGbGPZTRPEOaCQp1f/g5tKFTw82k373LFLahuRdVfLSdhGx6ROY07Vevh/LdQGY6BstWzuQtjpF/EGuHbx/u","cancellation_requested":false,"status":"completed","target":"https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d","request_id":"0386ec76ab6e44ea89a7048ecf2d3ccd"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1215'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Apr 2021 19:54:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus2
+      x-ms-keyvault-service-version:
+      - 1.2.236.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.3.0b1 Python/3.5.3 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d/?api-version=2016-10-01
+  response:
+    body:
+      string: '{"id":"https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d/57de002451b643bf8af7804983f09c28","kid":"https://vaultname.vault.azure.net/keys/livekvtestcertc543116d/57de002451b643bf8af7804983f09c28","sid":"https://vaultname.vault.azure.net/secrets/livekvtestcertc543116d/57de002451b643bf8af7804983f09c28","x5t":"KSj6V_CZv9n-xfz5CeaKIrmLqZw","cer":"MIIDNjCCAh6gAwIBAgIQF/Ns517STTeXBE6VarMyqjANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1EZWZhdWx0UG9saWN5MB4XDTIxMDQyNjE5NDQ1MVoXDTIyMDQyNjE5NTQ1MVowGDEWMBQGA1UEAxMNRGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN2oXCigTUTWg5YTuE4uUCWPBkR5f++T4Z3p6pk8Ma6ae2NRLJ+AqDMh8DqOAuITvD+fO8i9V9oQaJtI1YajwCArKsOsQCHid/ZilE6WQO7AcF7xganNUTQHG2vc1hmLuTrnjzuw8FSgWbLoT7qJ/KSeQ+d6hGj5gQagklVFbO9dnF8qIBMwOWpIfb7xXIuPTnM6bFmxFFt5ZACgGZM8+AfHINQqR3KjQNygvVXzaEtA/NFLmHElkmE7QOffxh0r9DpnMFYIx9PkWBqi+ohQqb96nz2VQe8BDBcHK684k6VdwzomXBgt6uN1I4/oeLa8rXqpJ6kukvqPCgiHOzIn50UCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFLav/N57JjL7nDUKQ/mZE2NrhMauMB0GA1UdDgQWBBS2r/zeeyYy+5w1CkP5mRNja4TGrjANBgkqhkiG9w0BAQsFAAOCAQEAMIg3CccQV2A42hlo9dC20DH9al/R+P5NxVqk22Y/c6uyOk5uFpkm/vIRF+CpiKOjkBSrIfj8MOGcMSJvEPWmpq/6Xpv7cv/XUS9TWWdqdJFykFaXaYLJjG2gYcompdDZyx5YL3pfgaIAKgDSOJXfdHNrpr72WZjCJWcx9FvcULl4A3H1aoQ1TcCrxJ9rK2B7WiNWkLn0NQcydUsTzHab/IBPdUzolT026f6FtezLOTvybP/R1QMjxV0QMg/Lg7Ecw+JFHeN22MOrle1himkea6zCvESc2SXuz/AAFOc0UAkkrgwEPFUOZk4Qb3X7sEmxxqs670v+EUTWqYHg6myVdA==","attributes":{"enabled":true,"nbf":1619466291,"exp":1651002891,"created":1619466891,"updated":1619466891,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=DefaultPolicy","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1619466879,"updated":1619466879}},"pending":{"id":"https://vaultname.vault.azure.net/certificates/livekvtestcertc543116d/pending"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2346'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Apr 2021 19:54:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=172.92.159.124;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus2
+      x-ms-keyvault-service-version:
+      - 1.2.236.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client_async.py
@@ -26,18 +26,17 @@ from azure.keyvault.certificates import (
     parse_key_vault_certificate_id
 )
 from azure.keyvault.certificates.aio import CertificateClient
-from devtools_testutils import PowerShellPreparer
-from parameterized import parameterized, param
 import pytest
 
 from _shared.test_case_async import KeyVaultTestCase
-from _test_case import CertificatesTestCase, suffixed_test_name
+from _test_case import client_setup, get_decorator, CertificatesTestCase
 
-KeyVaultPreparer = functools.partial(
-    PowerShellPreparer,
-    "keyvault",
-    azure_keyvault_url="https://vaultname.vault.azure.net"
-)
+
+all_api_versions = get_decorator(is_async=True)
+logging_enabled = get_decorator(is_async=True, logging_enable=True)
+logging_disabled = get_decorator(is_async=True, logging_enable=False)
+exclude_2016_10_01 = get_decorator(is_async=True, api_versions=[v for v in ApiVersion if v != ApiVersion.V2016_10_01])
+only_2016_10_01 = get_decorator(is_async=True, api_versions=[ApiVersion.V2016_10_01])
 
 
 class RetryAfterReplacer(RecordingProcessor):
@@ -165,11 +164,9 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
         self.assertEqual(a.name, b.name)
         self.assertEqual(a.provider, b.provider)
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_crud_operations(self, azure_keyvault_url, **kwargs):
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-
+    @all_api_versions()
+    @client_setup
+    async def test_crud_operations(self, client, **kwargs):
         cert_name = self.get_resource_name("cert")
         lifetime_actions = [LifetimeAction(lifetime_percentage=80, action=CertificatePolicyAction.auto_renew)]
         cert_policy = CertificatePolicy(
@@ -220,11 +217,9 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
             if not hasattr(ex, "message") or "not found" not in ex.message.lower():
                 raise ex
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_import_certificate_not_password_encoded_no_policy(self, azure_keyvault_url, **kwargs):
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-
+    @all_api_versions()
+    @client_setup
+    async def test_import_certificate_not_password_encoded_no_policy(self, client, **kwargs):
         # If a certificate is not password encoded, we can import the certificate
         # without passing in 'password'
         certificate = await client.import_certificate(
@@ -233,12 +228,9 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
         )
         self.assertIsNotNone(certificate.policy)
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_import_certificate_password_encoded_no_policy(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-
+    @all_api_versions()
+    @client_setup
+    async def test_import_certificate_password_encoded_no_policy(self, client, **kwargs):
         # If a certificate is password encoded, we have to pass in 'password'
         # when importing the certificate
         certificate = await client.import_certificate(
@@ -248,11 +240,9 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
         )
         self.assertIsNotNone(certificate.policy)
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_list(self, azure_keyvault_url, **kwargs):
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-
+    @all_api_versions()
+    @client_setup
+    async def test_list(self, client, **kwargs):
         max_certificates = self.list_test_size
         expected = {}
 
@@ -278,12 +268,9 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
         returned_certificates = client.list_properties_of_certificates(max_page_size=max_certificates - 1)
         await self._validate_certificate_list(expected, returned_certificates)
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_list_certificate_versions(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-
+    @all_api_versions()
+    @client_setup
+    async def test_list_certificate_versions(self, client, **kwargs):
         cert_name = self.get_resource_name("certver")
 
         max_certificates = self.list_test_size
@@ -313,12 +300,9 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
             ),
         )
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_crud_contacts(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-
+    @all_api_versions()
+    @client_setup
+    async def test_crud_contacts(self, client, **kwargs):
         contact_list = [
             CertificateContact(email="admin@contoso.com", name="John Doe", phone="1111111111"),
             CertificateContact(email="admin2@contoso.com", name="John Doe2", phone="2222222222"),
@@ -344,11 +328,9 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
             if not hasattr(ex, "message") or "not found" not in ex.message.lower():
                 raise ex
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_recover_and_purge(self, azure_keyvault_url, **kwargs):
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-
+    @all_api_versions()
+    @client_setup
+    async def test_recover_and_purge(self, client, **kwargs):
         certs = {}
         # create certificates to recover
         for i in range(self.list_test_size):
@@ -396,13 +378,10 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
             actual[k] = await client.get_certificate_version(certificate_name=k, version="")
         self.assertEqual(len(set(expected.keys()) & set(actual.keys())), len(expected))
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
+    @all_api_versions()
     @pytest.mark.skip("Skipping because service doesn't allow cancellation of certificates with issuer 'Unknown'")
-    @KeyVaultPreparer()
-    async def test_async_request_cancellation_and_deletion(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-
+    @client_setup
+    async def test_async_request_cancellation_and_deletion(self, client, **kwargs):
         cert_name = self.get_resource_name("asyncCanceledDeletedCert")
         cert_policy = CertificatePolicy.get_default()
 
@@ -458,15 +437,9 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
         # delete cancelled certificate
         await client.delete_certificate(cert_name)
 
-    @parameterized.expand(
-        [param(api_version=api_version) for api_version in ApiVersion if api_version != ApiVersion.V2016_10_01],
-        name_func=suffixed_test_name
-    )
-    @KeyVaultPreparer()
-    async def test_policy(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-
+    @exclude_2016_10_01()
+    @client_setup
+    async def test_policy(self, client, **kwargs):
         cert_name = self.get_resource_name("policyCertificate")
         cert_policy = CertificatePolicy(
             issuer_name="Self",
@@ -499,12 +472,9 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
 
         self._validate_certificate_policy(cert_policy, returned_policy)
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_get_pending_certificate_signing_request(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-
+    @all_api_versions()
+    @client_setup
+    async def test_get_pending_certificate_signing_request(self, client, **kwargs):
         cert_name = self.get_resource_name("unknownIssuerCert")
 
         # get pending certificate signing request
@@ -513,14 +483,9 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
         pending_version_csr = operation.csr
         self.assertEqual((await client.get_certificate_operation(certificate_name=cert_name)).csr, pending_version_csr)
 
-    @parameterized.expand(
-        [param(api_version=api_version) for api_version in ApiVersion if api_version != ApiVersion.V2016_10_01],
-        name_func=suffixed_test_name
-    )
-    @KeyVaultPreparer()
-    async def test_backup_restore(self, azure_keyvault_url, **kwargs):
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-
+    @exclude_2016_10_01()
+    @client_setup
+    async def test_backup_restore(self, client, **kwargs):
         cert_name = self.get_resource_name("cert")
         policy = CertificatePolicy.get_default()
         policy._san_user_principal_names = ["john.doe@domain.com"]
@@ -544,12 +509,9 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
         )
         self._validate_certificate_bundle(cert=restored_certificate, cert_name=cert_name, cert_policy=policy)
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_crud_issuer(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-
+    @all_api_versions()
+    @client_setup
+    async def test_crud_issuer(self, client, **kwargs):
         issuer_name = self.get_resource_name("issuer")
         admin_contacts = [
             AdministratorContact(first_name="John", last_name="Doe", email="admin@microsoft.com", phone="4255555555")
@@ -626,12 +588,9 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
             if not hasattr(ex, "message") or "not found" not in ex.message.lower():
                 raise ex
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_logging_enabled(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, is_async=True, logging_enable=True, **kwargs)
-
+    @logging_enabled()
+    @client_setup
+    async def test_logging_enabled(self, client, **kwargs):
         mock_handler = MockHandler()
 
         logger = logging.getLogger("azure")
@@ -653,12 +612,9 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
 
         assert False, "Expected request body wasn't logged"
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_logging_disabled(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, is_async=True, logging_enable=False, **kwargs)
-
+    @logging_disabled()
+    @client_setup
+    async def test_logging_disabled(self, client, **kwargs):
         mock_handler = MockHandler()
 
         logger = logging.getLogger("azure")
@@ -677,12 +633,9 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
                     # this means the message is not JSON or has no kty property
                     pass
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_get_certificate_version(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-
+    @all_api_versions()
+    @client_setup
+    async def test_get_certificate_version(self, client, **kwargs):
         cert_name = self.get_resource_name("cert")
         policy = CertificatePolicy.get_default()
         for _ in range(self.list_test_size):
@@ -706,9 +659,10 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
             assert version_properties.version == cert.properties.version
             assert version_properties.x509_thumbprint == cert.properties.x509_thumbprint
 
-    @KeyVaultPreparer()
-    async def test_list_properties_of_certificates_2016_10_01(self, azure_keyvault_url, **kwargs):
-        client = self.create_client(azure_keyvault_url, is_async=True, api_version=ApiVersion.V2016_10_01)
+    @only_2016_10_01()
+    @client_setup
+    async def test_list_properties_of_certificates(self, client, **kwargs):
+        """Tests API version v2016_10_01"""
 
         certs = client.list_properties_of_certificates()
         async for cert in certs:
@@ -721,9 +675,10 @@ class CertificateClientTests(CertificatesTestCase, KeyVaultTestCase):
 
         assert "The 'include_pending' parameter to `list_properties_of_certificates` is only available for API versions v7.0 and up" in str(excinfo.value)
 
-    @KeyVaultPreparer()
-    async def test_list_deleted_certificates_2016_10_01(self, azure_keyvault_url, **kwargs):
-        client = self.create_client(azure_keyvault_url, is_async=True, api_version=ApiVersion.V2016_10_01)
+    @only_2016_10_01()
+    @client_setup
+    async def test_list_deleted_certificates_2016_10_01(self, client, **kwargs):
+        """Tests API version v2016_10_01"""
 
         certs = client.list_deleted_certificates()
         async for cert in certs:

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from __future__ import print_function
-import functools
 import time
 
 from azure.keyvault.certificates import (
@@ -12,18 +11,14 @@ from azure.keyvault.certificates import (
     CertificateContentType,
     WellKnownIssuerNames,
 )
-from devtools_testutils import PowerShellPreparer
 from parameterized import parameterized, param
-import pytest
 
 from _shared.test_case import KeyVaultTestCase
-from _test_case import CertificatesTestCase, suffixed_test_name
+from _test_case import client_setup, get_decorator, CertificatesTestCase
 
-KeyVaultPreparer = functools.partial(
-    PowerShellPreparer,
-    "keyvault",
-    azure_keyvault_url="https://vaultname.vault.azure.net"
-)
+
+all_api_versions = get_decorator()
+exclude_2016_10_01 = get_decorator(api_versions=[v for v in ApiVersion if v != ApiVersion.V2016_10_01])
 
 
 def print(*args):
@@ -44,12 +39,9 @@ def test_create_certificate_client():
 
 
 class TestExamplesKeyVault(CertificatesTestCase, KeyVaultTestCase):
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    def test_example_certificate_crud_operations(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, **kwargs)
-        certificate_client = client
+    @all_api_versions()
+    @client_setup
+    def test_example_certificate_crud_operations(self, certificate_client, **kwargs):
         cert_name = self.get_resource_name("cert-name")
 
         # [START create_certificate]
@@ -127,13 +119,9 @@ class TestExamplesKeyVault(CertificatesTestCase, KeyVaultTestCase):
         print(deleted_certificate.recovery_id)
         # [END delete_certificate]
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    def test_example_certificate_list_operations(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, **kwargs)
-        certificate_client = client
-
+    @all_api_versions()
+    @client_setup
+    def test_example_certificate_list_operations(self, certificate_client, **kwargs):
         # specify the certificate policy
         cert_policy = CertificatePolicy(
             issuer_name=WellKnownIssuerNames.self,
@@ -189,16 +177,9 @@ class TestExamplesKeyVault(CertificatesTestCase, KeyVaultTestCase):
             print(certificate.deleted_on)
         # [END list_deleted_certificates]
 
-    @parameterized.expand(
-        [param(api_version=api_version) for api_version in ApiVersion if api_version != ApiVersion.V2016_10_01],
-        name_func=suffixed_test_name
-    )
-    @KeyVaultPreparer()
-    def test_example_certificate_backup_restore(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, **kwargs)
-        certificate_client = client
-
+    @exclude_2016_10_01()
+    @client_setup
+    def test_example_certificate_backup_restore(self, certificate_client, **kwargs):
         # specify the certificate policy
         cert_policy = CertificatePolicy(
             issuer_name=WellKnownIssuerNames.self,
@@ -238,13 +219,9 @@ class TestExamplesKeyVault(CertificatesTestCase, KeyVaultTestCase):
         print(restored_certificate.properties.version)
         # [END restore_certificate]
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    def test_example_certificate_recover(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, **kwargs)
-        certificate_client = client
-
+    @all_api_versions()
+    @client_setup
+    def test_example_certificate_recover(self, certificate_client, **kwargs):
         # specify the certificate policy
         cert_policy = CertificatePolicy(
             issuer_name=WellKnownIssuerNames.self,
@@ -284,13 +261,9 @@ class TestExamplesKeyVault(CertificatesTestCase, KeyVaultTestCase):
         print(recovered_certificate.name)
         # [END recover_deleted_certificate]
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    def test_example_contacts(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, **kwargs)
-        certificate_client = client
-
+    @all_api_versions()
+    @client_setup
+    def test_example_contacts(self, certificate_client, **kwargs):
         # [START set_contacts]
         from azure.keyvault.certificates import CertificateContact
 
@@ -326,13 +299,9 @@ class TestExamplesKeyVault(CertificatesTestCase, KeyVaultTestCase):
             print(deleted_contact.phone)
         # [END delete_contacts]
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    def test_example_issuers(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, **kwargs)
-        certificate_client = client
-
+    @all_api_versions()
+    @client_setup
+    def test_example_issuers(self, certificate_client, **kwargs):
         # [START create_issuer]
         from azure.keyvault.certificates import AdministratorContact
 

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_examples_certificates_async.py
@@ -3,21 +3,16 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import asyncio
-import functools
 
 from azure.keyvault.certificates import ApiVersion, CertificatePolicy, CertificateContentType, WellKnownIssuerNames
-from devtools_testutils import PowerShellPreparer
-from parameterized import parameterized, param
 import pytest
 
 from _shared.test_case_async import KeyVaultTestCase
-from _test_case import CertificatesTestCase, suffixed_test_name
+from _test_case import client_setup, get_decorator, CertificatesTestCase
 
-KeyVaultPreparer = functools.partial(
-    PowerShellPreparer,
-    "keyvault",
-    azure_keyvault_url="https://vaultname.vault.azure.net"
-)
+
+all_api_versions = get_decorator(is_async=True)
+exclude_2016_10_01 = get_decorator(is_async=True, api_versions=[v for v in ApiVersion if v != ApiVersion.V2016_10_01])
 
 
 def print(*args):
@@ -44,12 +39,9 @@ async def test_create_certificate():
 
 
 class TestExamplesKeyVault(CertificatesTestCase, KeyVaultTestCase):
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_example_certificate_crud_operations(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-        certificate_client = client
+    @all_api_versions()
+    @client_setup
+    async def test_example_certificate_crud_operations(self, certificate_client, **kwargs):
         cert_name = self.get_resource_name("cert-name")
 
         # [START create_certificate]
@@ -118,13 +110,9 @@ class TestExamplesKeyVault(CertificatesTestCase, KeyVaultTestCase):
         print(deleted_certificate.recovery_id)
         # [END delete_certificate]
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_example_certificate_list_operations(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-        certificate_client = client
-
+    @all_api_versions()
+    @client_setup
+    async def test_example_certificate_list_operations(self, certificate_client, **kwargs):
         # specify the certificate policy
         cert_policy = CertificatePolicy(
             issuer_name=WellKnownIssuerNames.self,
@@ -180,16 +168,9 @@ class TestExamplesKeyVault(CertificatesTestCase, KeyVaultTestCase):
             print(certificate.deleted_on)
         # [END list_deleted_certificates]
 
-    @parameterized.expand(
-        [param(api_version=api_version) for api_version in ApiVersion if api_version != ApiVersion.V2016_10_01],
-        name_func=suffixed_test_name
-    )
-    @KeyVaultPreparer()
-    async def test_example_certificate_backup_restore(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-        certificate_client = client
-
+    @exclude_2016_10_01()
+    @client_setup
+    async def test_example_certificate_backup_restore(self, certificate_client, **kwargs):
         # specify the certificate policy
         cert_policy = CertificatePolicy(
             issuer_name=WellKnownIssuerNames.self,
@@ -232,13 +213,9 @@ class TestExamplesKeyVault(CertificatesTestCase, KeyVaultTestCase):
         print(restored_certificate.properties.version)
         # [END restore_certificate]
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_example_certificate_recover(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-        certificate_client = client
-
+    @all_api_versions()
+    @client_setup
+    async def test_example_certificate_recover(self, certificate_client, **kwargs):
         # specify the certificate policy
         cert_policy = CertificatePolicy(
             issuer_name=WellKnownIssuerNames.self,
@@ -273,13 +250,9 @@ class TestExamplesKeyVault(CertificatesTestCase, KeyVaultTestCase):
         print(recovered_certificate.name)
         # [END recover_deleted_certificate]
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_example_contacts(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-        certificate_client = client
-
+    @all_api_versions()
+    @client_setup
+    async def test_example_contacts(self, certificate_client, **kwargs):
         # [START set_contacts]
         from azure.keyvault.certificates import CertificateContact
 
@@ -315,13 +288,9 @@ class TestExamplesKeyVault(CertificatesTestCase, KeyVaultTestCase):
             print(deleted_contact.phone)
         # [END delete_contacts]
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @KeyVaultPreparer()
-    async def test_example_issuers(self, azure_keyvault_url, **kwargs):
-        self._skip_if_not_configured(**kwargs)
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-        certificate_client = client
-
+    @all_api_versions()
+    @client_setup
+    async def test_example_issuers(self, certificate_client, **kwargs):
         # [START create_issuer]
         from azure.keyvault.certificates import AdministratorContact
 

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_merge_certificate.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_merge_certificate.py
@@ -5,14 +5,15 @@
 import base64
 import os
 
-from azure.keyvault.certificates import ApiVersion, CertificatePolicy, WellKnownIssuerNames
-from devtools_testutils import PowerShellPreparer
+from azure.keyvault.certificates import CertificatePolicy, WellKnownIssuerNames
 from OpenSSL import crypto
-from parameterized import parameterized, param
 
 from _shared.json_attribute_matcher import json_attribute_matcher
 from _shared.test_case import KeyVaultTestCase
-from _test_case import CertificatesTestCase, suffixed_test_name
+from _test_case import client_setup, get_decorator, CertificatesTestCase
+
+
+all_api_versions = get_decorator()
 
 
 class MergeCertificateTest(CertificatesTestCase, KeyVaultTestCase):
@@ -21,11 +22,9 @@ class MergeCertificateTest(CertificatesTestCase, KeyVaultTestCase):
         kwargs["custom_request_matchers"] = [json_attribute_matcher]
         super(MergeCertificateTest, self).__init__(*args, **kwargs)
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @PowerShellPreparer("keyvault", azure_keyvault_url="https://vaultname.vault.azure.net")
-    def test_merge_certificate(self, azure_keyvault_url, **kwargs):
-        client = self.create_client(azure_keyvault_url, **kwargs)
-
+    @all_api_versions()
+    @client_setup
+    def test_merge_certificate(self, client, **kwargs):
         cert_name = self.get_resource_name("mergeCertificate")
         cert_policy = CertificatePolicy(
             issuer_name=WellKnownIssuerNames.unknown, subject="CN=MyCert", certificate_transparency=False

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_merge_certificate_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_merge_certificate_async.py
@@ -5,25 +5,24 @@
 import base64
 import os
 
-from azure.keyvault.certificates import ApiVersion, CertificatePolicy, WellKnownIssuerNames
-from devtools_testutils import PowerShellPreparer
+from azure.keyvault.certificates import CertificatePolicy, WellKnownIssuerNames
 from OpenSSL import crypto
-from parameterized import parameterized, param
 
 from _shared.json_attribute_matcher import json_attribute_matcher
 from _shared.test_case_async import KeyVaultTestCase
-from _test_case import CertificatesTestCase, suffixed_test_name
+from _test_case import client_setup, get_decorator, CertificatesTestCase
+
+
+all_api_versions = get_decorator(is_async=True)
 
 
 class MergeCertificateTest(CertificatesTestCase, KeyVaultTestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, match_body=False, custom_request_matchers=[json_attribute_matcher], **kwargs)
 
-    @parameterized.expand([param(api_version=api_version) for api_version in ApiVersion], name_func=suffixed_test_name)
-    @PowerShellPreparer("keyvault", azure_keyvault_url="https://vaultname.vault.azure.net")
-    async def test_merge_certificate(self, azure_keyvault_url, **kwargs):
-        client = self.create_client(azure_keyvault_url, is_async=True, **kwargs)
-
+    @all_api_versions()
+    @client_setup
+    async def test_merge_certificate(self, client, **kwargs):
         cert_name = self.get_resource_name("mergeCertificate")
         cert_policy = CertificatePolicy(
             issuer_name=WellKnownIssuerNames.unknown, subject="CN=MyCert", certificate_transparency=False


### PR DESCRIPTION
Resolves #12376. This updates certificates tests to align with keys and secrets, using parameterization and client creation decorators.