### PR TITLE
Amend modelsrepository livetest pipeline config

### DIFF
--- a/sdk/modelsrepository/tests.yml
+++ b/sdk/modelsrepository/tests.yml
@@ -4,7 +4,6 @@ stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       AllocateResourceGroup: 'false'
-      BuildTargetingString: $(BuildTargetingString)
       ServiceDirectory: modelsrepository
       EnvVars:
         TEST_MODE: 'RunLiveNoRecord'

--- a/sdk/template/tests.yml
+++ b/sdk/template/tests.yml
@@ -4,7 +4,6 @@ stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       AllocateResourceGroup: false
-      BuildTargetingString: 'azure-*'
       ServiceDirectory: template
       TestSamples: true
       EnvVars:


### PR DESCRIPTION
What's happening is that it's forcing it to take from the variable `BuildTargetingString`, which isn't actually present on the build definition.

What we **prefer** is to let the defaulting happen [here](https://github.com/Azure/azure-sdk-for-python/blob/master/eng/pipelines/templates/jobs/live.tests.yml#L81) if the variable is not present. Not passing it specifically from `tests.yml` allows the best of both worlds.
