### PR TITLE
Recorded tests for IMDS and App Service managed identity

### DIFF
--- a/sdk/identity/azure-identity/conftest.py
+++ b/sdk/identity/azure-identity/conftest.py
@@ -14,8 +14,12 @@ if sys.version_info < (3, 5, 3):
     collect_ignore_glob = ["*_async.py"]
 
 
+RECORD_IMDS = "--record-imds"
+
+
 def pytest_addoption(parser):
     parser.addoption("--manual", action="store_true", default=False, help="run manual tests")
+    parser.addoption(RECORD_IMDS, action="store_true", default=False, help="record IMDS live tests")
 
 
 def pytest_configure(config):
@@ -37,6 +41,17 @@ def pytest_collection_modifyitems(config, items):
             test.add_marker(skip_manual)
         elif stdout_captured and "prints" in test.keywords:
             test.add_marker(skip_prints)
+
+
+@pytest.fixture(scope="class")
+def record_imds_test(request):
+    """Fixture to control recording IMDS managed identity tests
+
+    Recorded IMDS tests run as expected in playback. However, because they require particular live environments, a
+    custom pytest option ("--record-imds") controls whether they're included in a live test run.
+    """
+    if request.instance.is_live and not request.session.config.getoption(RECORD_IMDS):
+        pytest.skip('Run "pytest {}" to record a live run of this test'.format(RECORD_IMDS))
 
 
 @pytest.fixture()

--- a/sdk/identity/azure-identity/tests/helpers_async.py
+++ b/sdk/identity/azure-identity/tests/helpers_async.py
@@ -10,6 +10,14 @@ from unittest import mock
 from helpers import validating_transport
 
 
+def await_test(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(fn(*args, **kwargs))
+    return wrapper
+
+
 def get_completed_future(result=None):
     future = asyncio.Future()
     future.set_result(result)

--- a/sdk/identity/azure-identity/tests/recorded_test_case.py
+++ b/sdk/identity/azure-identity/tests/recorded_test_case.py
@@ -1,0 +1,39 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import os
+
+from azure_devtools.scenario_tests import GeneralNameReplacer, patch_time_sleep_api, RequestUrlNormalizer
+from devtools_testutils.azure_testcase import AzureTestCase
+import pytest
+
+from recording_processors import RecordingRedactor
+
+PLAYBACK_CLIENT_ID = "client-id"
+
+
+class RecordedTestCase(AzureTestCase):
+    def __init__(self, *args, **kwargs):
+        scrubber = GeneralNameReplacer()
+        super(RecordedTestCase, self).__init__(
+            *args,
+            recording_processors=[RecordingRedactor(), scrubber],
+            replay_processors=[RequestUrlNormalizer()],
+            **kwargs
+        )
+        self.scrubber = scrubber
+        self.replay_patches.append(patch_time_sleep_api)
+        self.user_assigned_identity_client_id = os.environ.get("USER_ASSIGNED_IDENTITY_CLIENT_ID", PLAYBACK_CLIENT_ID)
+
+    @pytest.fixture()
+    def user_assigned_identity_client_id(self):
+        if self.is_live:
+            if self.user_assigned_identity_client_id == PLAYBACK_CLIENT_ID:
+                pytest.skip("Set a value for $USER_ASSIGNED_IDENTITY_CLIENT_ID to record this test")
+            else:
+                self.scrubber.register_name_pair(self.user_assigned_identity_client_id, PLAYBACK_CLIENT_ID)
+
+    @property
+    def scope(self):
+        return "https://management.azure.com/.default"

--- a/sdk/identity/azure-identity/tests/recording_processors.py
+++ b/sdk/identity/azure-identity/tests/recording_processors.py
@@ -45,7 +45,7 @@ class RecordingRedactor(RecordingProcessor):
                 # record a hash of the secret instead of a simple replacement like "redacted"
                 # because some tests (e.g. for CAE) require unique, consistent values
                 digest = hashlib.sha256(six.ensure_binary(body[field])).digest()
-                body[field] = six.ensure_str(binascii.hexlify(digest))
+                body[field] = "redacted-" + six.ensure_str(binascii.hexlify(digest))[:6]
 
         response["body"]["string"] = json.dumps(body)
         return response

--- a/sdk/identity/azure-identity/tests/recording_processors.py
+++ b/sdk/identity/azure-identity/tests/recording_processors.py
@@ -12,22 +12,31 @@ from azure_devtools.scenario_tests import RecordingProcessor
 import six
 
 
-SECRETS = frozenset({
-    "access_token",
-    "client_secret",
-    "code",
-    "device_code",
-    "message",
-    "password",
-    "refresh_token",
-    "user_code",
-})
+SECRET_FIELDS = frozenset(
+    {
+        "access_token",
+        "client_secret",
+        "code",
+        "device_code",
+        "message",
+        "password",
+        "refresh_token",
+        "user_code",
+    }
+)
+
+SECRET_HEADERS = frozenset(
+    {
+        "secret",  # managed identity headers are not dangerous to record but
+        "X-IDENTITY-SECRET",  # redacting them prevents anyone worrying whether they are
+    }
+)
 
 
 class RecordingRedactor(RecordingProcessor):
     """Removes authentication secrets from recordings.
 
-    :keyword bool record_unique_values:
+    :keyword bool record_unique_values: Defaults to False. Set True for tests requiring unique, consistent fake values.
     """
 
     def __init__(self, record_unique_values=False):
@@ -37,6 +46,12 @@ class RecordingRedactor(RecordingProcessor):
     def process_request(self, request):
         # bodies typically contain secrets and are often formed by msal anyway, i.e. not this library's responsibility
         request.body = None
+
+        for header in SECRET_HEADERS:
+            if header in request.headers:
+                fake_value = self._get_fake_value(request.headers[header])
+                request.headers[header] = fake_value
+
         return request
 
     def process_response(self, response):
@@ -46,18 +61,19 @@ class RecordingRedactor(RecordingProcessor):
             return response
 
         for field in body:
-            if field in SECRETS:
-                redacted_value = "redacted"
-                if self._record_unique_values:
-                    # include a hash of the secret instead of a simple replacement
-                    # because some tests (e.g. for CAE) require unique, consistent values
-                    digest = hashlib.sha256(six.ensure_binary(body[field])).digest()
-                    redacted_value += six.ensure_str(binascii.hexlify(digest))[:6]
-                body[field] = redacted_value
+            if field in SECRET_FIELDS:
+                fake_value = self._get_fake_value(body[field])
+                body[field] = fake_value
 
         response["body"]["string"] = json.dumps(body)
         return response
 
+    def _get_fake_value(self, real_value):
+        redacted_value = "redacted"
+        if self._record_unique_values:
+            digest = hashlib.sha256(six.ensure_binary(real_value)).digest()
+            redacted_value += six.ensure_str(binascii.hexlify(digest))[:6]
+        return redacted_value
 
 class IdTokenProcessor(RecordingProcessor):
     def process_response(self, response):

--- a/sdk/identity/azure-identity/tests/recording_processors.py
+++ b/sdk/identity/azure-identity/tests/recording_processors.py
@@ -25,10 +25,11 @@ SECRET_FIELDS = frozenset(
     }
 )
 
+# managed identity headers are not dangerous to record but redacting them prevents anyone worrying whether they are
 SECRET_HEADERS = frozenset(
     {
-        "secret",  # managed identity headers are not dangerous to record but
-        "X-IDENTITY-SECRET",  # redacting them prevents anyone worrying whether they are
+        "secret",
+        "X-IDENTITY-SECRET",
     }
 )
 
@@ -74,6 +75,7 @@ class RecordingRedactor(RecordingProcessor):
             digest = hashlib.sha256(six.ensure_binary(real_value)).digest()
             redacted_value += six.ensure_str(binascii.hexlify(digest))[:6]
         return redacted_value
+
 
 class IdTokenProcessor(RecordingProcessor):
     def process_response(self, response):

--- a/sdk/identity/azure-identity/tests/recordings/test_app_service.test_system_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_app_service.test_system_assigned.yaml
@@ -11,19 +11,19 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.6.0b4 Python/3.8.6 (Linux-4.15.0-135-generic-x86_64-with-glibc2.2.5)
       secret:
-      - e2f10e55-77ce-4cd7-8037-01d5954a0428
+      - redacted
     method: GET
     uri: https://msi-endpoint/token?api-version=2017-09-01&resource=https://management.azure.com
   response:
     body:
-      string: '{"access_token": "redacted", "expires_on": "04/28/2021 22:44:48
-        +00:00", "resource": "https://management.azure.com", "token_type": "Bearer",
-        "client_id": "bdd6fcc1-7805-4948-82e7-ad3c7afec470"}'
+      string: '{"access_token": "redacted", "expires_on": "05/22/2021 17:14:33 +00:00",
+        "resource": "https://management.azure.com", "token_type": "Bearer", "client_id":
+        "6d807b1c-2a6f-41a0-b428-d0e3a08382a0"}'
     headers:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 27 Apr 2021 22:52:00 GMT
+      - Fri, 21 May 2021 17:14:34 GMT
       server:
       - Kestrel
       transfer-encoding:

--- a/sdk/identity/azure-identity/tests/recordings/test_app_service.test_system_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_app_service.test_system_assigned.yaml
@@ -16,7 +16,7 @@ interactions:
     uri: https://msi-endpoint/token?api-version=2017-09-01&resource=https://management.azure.com
   response:
     body:
-      string: '{"access_token": "redacted-89d6d4", "expires_on": "04/28/2021 22:44:48
+      string: '{"access_token": "redacted", "expires_on": "04/28/2021 22:44:48
         +00:00", "resource": "https://management.azure.com", "token_type": "Bearer",
         "client_id": "bdd6fcc1-7805-4948-82e7-ad3c7afec470"}'
     headers:

--- a/sdk/identity/azure-identity/tests/recordings/test_app_service.test_system_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_app_service.test_system_assigned.yaml
@@ -1,0 +1,34 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-identity/1.6.0b4 Python/3.8.6 (Linux-4.15.0-135-generic-x86_64-with-glibc2.2.5)
+      secret:
+      - e2f10e55-77ce-4cd7-8037-01d5954a0428
+    method: GET
+    uri: https://msi-endpoint/token?api-version=2017-09-01&resource=https://management.azure.com
+  response:
+    body:
+      string: '{"access_token": "redacted-89d6d4", "expires_on": "04/28/2021 22:44:48
+        +00:00", "resource": "https://management.azure.com", "token_type": "Bearer",
+        "client_id": "bdd6fcc1-7805-4948-82e7-ad3c7afec470"}'
+    headers:
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Apr 2021 22:52:00 GMT
+      server:
+      - Kestrel
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/identity/azure-identity/tests/recordings/test_app_service.test_user_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_app_service.test_user_assigned.yaml
@@ -1,0 +1,34 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-identity/1.6.0b4 Python/3.8.6 (Linux-4.15.0-135-generic-x86_64-with-glibc2.2.5)
+      secret:
+      - e2f10e55-77ce-4cd7-8037-01d5954a0428
+    method: GET
+    uri: https://msi-endpoint/token?api-version=2017-09-01&resource=https://management.azure.com&clientid=client-id
+  response:
+    body:
+      string: '{"access_token": "redacted-93805a", "expires_on": "04/28/2021 22:45:07
+        +00:00", "resource": "https://management.azure.com", "token_type": "Bearer",
+        "client_id": "client-id"}'
+    headers:
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Apr 2021 22:52:00 GMT
+      server:
+      - Kestrel
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdk/identity/azure-identity/tests/recordings/test_app_service.test_user_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_app_service.test_user_assigned.yaml
@@ -11,19 +11,19 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.6.0b4 Python/3.8.6 (Linux-4.15.0-135-generic-x86_64-with-glibc2.2.5)
       secret:
-      - e2f10e55-77ce-4cd7-8037-01d5954a0428
+      - redacted
     method: GET
     uri: https://msi-endpoint/token?api-version=2017-09-01&resource=https://management.azure.com&clientid=client-id
   response:
     body:
-      string: '{"access_token": "redacted", "expires_on": "04/28/2021 22:45:07
-        +00:00", "resource": "https://management.azure.com", "token_type": "Bearer",
-        "client_id": "client-id"}'
+      string: '{"access_token": "redacted", "expires_on": "05/22/2021 17:18:21 +00:00",
+        "resource": "https://management.azure.com", "token_type": "Bearer", "client_id":
+        "client-id"}'
     headers:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 27 Apr 2021 22:52:00 GMT
+      - Fri, 21 May 2021 17:18:35 GMT
       server:
       - Kestrel
       transfer-encoding:

--- a/sdk/identity/azure-identity/tests/recordings/test_app_service.test_user_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_app_service.test_user_assigned.yaml
@@ -16,7 +16,7 @@ interactions:
     uri: https://msi-endpoint/token?api-version=2017-09-01&resource=https://management.azure.com&clientid=client-id
   response:
     body:
-      string: '{"access_token": "redacted-93805a", "expires_on": "04/28/2021 22:45:07
+      string: '{"access_token": "redacted", "expires_on": "04/28/2021 22:45:07
         +00:00", "resource": "https://management.azure.com", "token_type": "Bearer",
         "client_id": "client-id"}'
     headers:

--- a/sdk/identity/azure-identity/tests/recordings/test_app_service_async.test_system_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_app_service_async.test_system_assigned.yaml
@@ -10,7 +10,7 @@ interactions:
     uri: https://msi-endpoint/token?api-version=2017-09-01&resource=https://management.azure.com
   response:
     body:
-      string: '{"access_token": "redacted-89d6d4", "expires_on": "04/28/2021 22:44:48
+      string: '{"access_token": "redacted", "expires_on": "04/28/2021 22:44:48
         +00:00", "resource": "https://management.azure.com", "token_type": "Bearer",
         "client_id": "bdd6fcc1-7805-4948-82e7-ad3c7afec470"}'
     headers:

--- a/sdk/identity/azure-identity/tests/recordings/test_app_service_async.test_system_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_app_service_async.test_system_assigned.yaml
@@ -1,0 +1,25 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-identity/1.6.0b4 Python/3.8.6 (Linux-4.15.0-135-generic-x86_64-with-glibc2.2.5)
+      secret:
+      - e2f10e55-77ce-4cd7-8037-01d5954a0428
+    method: GET
+    uri: https://msi-endpoint/token?api-version=2017-09-01&resource=https://management.azure.com
+  response:
+    body:
+      string: '{"access_token": "redacted-89d6d4", "expires_on": "04/28/2021 22:44:48
+        +00:00", "resource": "https://management.azure.com", "token_type": "Bearer",
+        "client_id": "bdd6fcc1-7805-4948-82e7-ad3c7afec470"}'
+    headers:
+      content-type: application/json; charset=utf-8
+      date: Tue, 27 Apr 2021 22:52:01 GMT
+      server: Kestrel
+      transfer-encoding: chunked
+    status:
+      code: 200
+      message: OK
+    url: http://172.16.5.2:8081/msi/token?api-version=2017-09-01&resource=https://management.azure.com
+version: 1

--- a/sdk/identity/azure-identity/tests/recordings/test_app_service_async.test_system_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_app_service_async.test_system_assigned.yaml
@@ -5,21 +5,21 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.6.0b4 Python/3.8.6 (Linux-4.15.0-135-generic-x86_64-with-glibc2.2.5)
       secret:
-      - e2f10e55-77ce-4cd7-8037-01d5954a0428
+      - redacted
     method: GET
     uri: https://msi-endpoint/token?api-version=2017-09-01&resource=https://management.azure.com
   response:
     body:
-      string: '{"access_token": "redacted", "expires_on": "04/28/2021 22:44:48
-        +00:00", "resource": "https://management.azure.com", "token_type": "Bearer",
-        "client_id": "bdd6fcc1-7805-4948-82e7-ad3c7afec470"}'
+      string: '{"access_token": "redacted", "expires_on": "05/22/2021 17:18:20 +00:00",
+        "resource": "https://management.azure.com", "token_type": "Bearer", "client_id":
+        "6d807b1c-2a6f-41a0-b428-d0e3a08382a0"}'
     headers:
       content-type: application/json; charset=utf-8
-      date: Tue, 27 Apr 2021 22:52:01 GMT
+      date: Fri, 21 May 2021 17:18:35 GMT
       server: Kestrel
       transfer-encoding: chunked
     status:
       code: 200
       message: OK
-    url: http://172.16.5.2:8081/msi/token?api-version=2017-09-01&resource=https://management.azure.com
+    url: http://172.16.7.2:8081/msi/token?api-version=2017-09-01&resource=https://management.azure.com
 version: 1

--- a/sdk/identity/azure-identity/tests/recordings/test_app_service_async.test_user_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_app_service_async.test_user_assigned.yaml
@@ -10,7 +10,7 @@ interactions:
     uri: https://msi-endpoint/token?api-version=2017-09-01&resource=https://management.azure.com&clientid=client-id
   response:
     body:
-      string: '{"access_token": "redacted-93805a", "expires_on": "04/28/2021 22:45:07
+      string: '{"access_token": "redacted", "expires_on": "04/28/2021 22:45:07
         +00:00", "resource": "https://management.azure.com", "token_type": "Bearer",
         "client_id": "client-id"}'
     headers:

--- a/sdk/identity/azure-identity/tests/recordings/test_app_service_async.test_user_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_app_service_async.test_user_assigned.yaml
@@ -1,0 +1,25 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - azsdk-python-identity/1.6.0b4 Python/3.8.6 (Linux-4.15.0-135-generic-x86_64-with-glibc2.2.5)
+      secret:
+      - e2f10e55-77ce-4cd7-8037-01d5954a0428
+    method: GET
+    uri: https://msi-endpoint/token?api-version=2017-09-01&resource=https://management.azure.com&clientid=client-id
+  response:
+    body:
+      string: '{"access_token": "redacted-93805a", "expires_on": "04/28/2021 22:45:07
+        +00:00", "resource": "https://management.azure.com", "token_type": "Bearer",
+        "client_id": "client-id"}'
+    headers:
+      content-type: application/json; charset=utf-8
+      date: Tue, 27 Apr 2021 22:52:01 GMT
+      server: Kestrel
+      transfer-encoding: chunked
+    status:
+      code: 200
+      message: OK
+    url: http://172.16.5.2:8081/msi/token?api-version=2017-09-01&resource=https://management.azure.com&clientid=b48ae5dc-70d0-488a-8ef5-f30d905cd5ec
+version: 1

--- a/sdk/identity/azure-identity/tests/recordings/test_app_service_async.test_user_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_app_service_async.test_user_assigned.yaml
@@ -5,21 +5,21 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.6.0b4 Python/3.8.6 (Linux-4.15.0-135-generic-x86_64-with-glibc2.2.5)
       secret:
-      - e2f10e55-77ce-4cd7-8037-01d5954a0428
+      - redacted
     method: GET
     uri: https://msi-endpoint/token?api-version=2017-09-01&resource=https://management.azure.com&clientid=client-id
   response:
     body:
-      string: '{"access_token": "redacted", "expires_on": "04/28/2021 22:45:07
-        +00:00", "resource": "https://management.azure.com", "token_type": "Bearer",
-        "client_id": "client-id"}'
+      string: '{"access_token": "redacted", "expires_on": "05/22/2021 17:18:21 +00:00",
+        "resource": "https://management.azure.com", "token_type": "Bearer", "client_id":
+        "client-id"}'
     headers:
       content-type: application/json; charset=utf-8
-      date: Tue, 27 Apr 2021 22:52:01 GMT
+      date: Fri, 21 May 2021 17:18:35 GMT
       server: Kestrel
       transfer-encoding: chunked
     status:
       code: 200
       message: OK
-    url: http://172.16.5.2:8081/msi/token?api-version=2017-09-01&resource=https://management.azure.com&clientid=b48ae5dc-70d0-488a-8ef5-f30d905cd5ec
+    url: http://172.16.7.2:8081/msi/token?api-version=2017-09-01&resource=https://management.azure.com&clientid=b48ae5dc-70d0-488a-8ef5-f30d905cd5ec
 version: 1

--- a/sdk/identity/azure-identity/tests/recordings/test_imds_credential.test_system_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_imds_credential.test_system_assigned.yaml
@@ -1,0 +1,41 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [azsdk-python-identity/1.6.0b4 Python/3.6.9 (Linux-5.4.0-1046-azure-x86_64-with-Ubuntu-18.04-bionic)]
+    method: GET
+    uri: http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com
+  response:
+    body: {string: '{"error": "invalid_request", "error_description": "Required metadata
+        header not specified"}'}
+    headers:
+      content-length: ['88']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 26 Apr 2021 22:13:41 GMT']
+      server: [IMDS/150.870.65.492]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Metadata: ['true']
+      User-Agent: [azsdk-python-identity/1.6.0b4 Python/3.6.9 (Linux-5.4.0-1046-azure-x86_64-with-Ubuntu-18.04-bionic)]
+    method: GET
+    uri: http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com
+  response:
+    body: {string: '{"access_token": "redacted-0d1b65", "client_id": "e15dd129-090a-41d4-add5-bb4b16b2b1a9",
+        "expires_in": "86104", "expires_on": "1619561325", "ext_expires_in": "86399",
+        "not_before": "1619474625", "resource": "https://management.azure.com", "token_type":
+        "Bearer"}'}
+    headers:
+      content-length: ['1692']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 26 Apr 2021 22:13:41 GMT']
+      server: [IMDS/150.870.65.492]
+    status: {code: 200, message: OK}
+version: 1

--- a/sdk/identity/azure-identity/tests/recordings/test_imds_credential.test_system_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_imds_credential.test_system_assigned.yaml
@@ -28,7 +28,7 @@ interactions:
     method: GET
     uri: http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com
   response:
-    body: {string: '{"access_token": "redacted-0d1b65", "client_id": "e15dd129-090a-41d4-add5-bb4b16b2b1a9",
+    body: {string: '{"access_token": "redacted", "client_id": "e15dd129-090a-41d4-add5-bb4b16b2b1a9",
         "expires_in": "86104", "expires_on": "1619561325", "ext_expires_in": "86399",
         "not_before": "1619474625", "resource": "https://management.azure.com", "token_type":
         "Bearer"}'}

--- a/sdk/identity/azure-identity/tests/recordings/test_imds_credential.test_user_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_imds_credential.test_user_assigned.yaml
@@ -1,0 +1,41 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [azsdk-python-identity/1.6.0b4 Python/3.6.9 (Linux-5.4.0-1046-azure-x86_64-with-Ubuntu-18.04-bionic)]
+    method: GET
+    uri: http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com&client_id=client-id
+  response:
+    body: {string: '{"error": "invalid_request", "error_description": "Required metadata
+        header not specified"}'}
+    headers:
+      content-length: ['88']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 26 Apr 2021 22:13:41 GMT']
+      server: [IMDS/150.870.65.492]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Metadata: ['true']
+      User-Agent: [azsdk-python-identity/1.6.0b4 Python/3.6.9 (Linux-5.4.0-1046-azure-x86_64-with-Ubuntu-18.04-bionic)]
+    method: GET
+    uri: http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com&client_id=client-id
+  response:
+    body: {string: '{"access_token": "redacted-65130c", "client_id": "client-id",
+        "expires_in": "86400", "expires_on": "1619561622", "ext_expires_in": "86399",
+        "not_before": "1619474922", "resource": "https://management.azure.com", "token_type":
+        "Bearer"}'}
+    headers:
+      content-length: ['1712']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 26 Apr 2021 22:13:41 GMT']
+      server: [IMDS/150.870.65.492]
+    status: {code: 200, message: OK}
+version: 1

--- a/sdk/identity/azure-identity/tests/recordings/test_imds_credential.test_user_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_imds_credential.test_user_assigned.yaml
@@ -28,7 +28,7 @@ interactions:
     method: GET
     uri: http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com&client_id=client-id
   response:
-    body: {string: '{"access_token": "redacted-65130c", "client_id": "client-id",
+    body: {string: '{"access_token": "redacted", "client_id": "client-id",
         "expires_in": "86400", "expires_on": "1619561622", "ext_expires_in": "86399",
         "not_before": "1619474922", "resource": "https://management.azure.com", "token_type":
         "Bearer"}'}

--- a/sdk/identity/azure-identity/tests/recordings/test_imds_credential_async.test_system_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_imds_credential_async.test_system_assigned.yaml
@@ -1,0 +1,31 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent: [azsdk-python-identity/1.6.0b4 Python/3.6.9 (Linux-5.4.0-1046-azure-x86_64-with-Ubuntu-18.04-bionic)]
+    method: GET
+    uri: http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com
+  response:
+    body: {string: '{"error": "invalid_request", "error_description": "Required metadata
+        header not specified"}'}
+    headers: {content-length: '88', content-type: application/json; charset=utf-8,
+      date: 'Mon, 26 Apr 2021 22:13:42 GMT', server: IMDS/150.870.65.492}
+    status: {code: 400, message: Bad Request}
+    url: http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com
+- request:
+    body: null
+    headers:
+      Metadata: ['true']
+      User-Agent: [azsdk-python-identity/1.6.0b4 Python/3.6.9 (Linux-5.4.0-1046-azure-x86_64-with-Ubuntu-18.04-bionic)]
+    method: GET
+    uri: http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com
+  response:
+    body: {string: '{"access_token": "redacted-0d1b65", "client_id": "e15dd129-090a-41d4-add5-bb4b16b2b1a9",
+        "expires_in": "86102", "expires_on": "1619561325", "ext_expires_in": "86399",
+        "not_before": "1619474625", "resource": "https://management.azure.com", "token_type":
+        "Bearer"}'}
+    headers: {content-length: '1692', content-type: application/json; charset=utf-8,
+      date: 'Mon, 26 Apr 2021 22:13:42 GMT', server: IMDS/150.870.65.492}
+    status: {code: 200, message: OK}
+    url: http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com
+version: 1

--- a/sdk/identity/azure-identity/tests/recordings/test_imds_credential_async.test_system_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_imds_credential_async.test_system_assigned.yaml
@@ -20,7 +20,7 @@ interactions:
     method: GET
     uri: http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com
   response:
-    body: {string: '{"access_token": "redacted-0d1b65", "client_id": "e15dd129-090a-41d4-add5-bb4b16b2b1a9",
+    body: {string: '{"access_token": "redacted", "client_id": "e15dd129-090a-41d4-add5-bb4b16b2b1a9",
         "expires_in": "86102", "expires_on": "1619561325", "ext_expires_in": "86399",
         "not_before": "1619474625", "resource": "https://management.azure.com", "token_type":
         "Bearer"}'}

--- a/sdk/identity/azure-identity/tests/recordings/test_imds_credential_async.test_user_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_imds_credential_async.test_user_assigned.yaml
@@ -1,0 +1,31 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent: [azsdk-python-identity/1.6.0b4 Python/3.6.9 (Linux-5.4.0-1046-azure-x86_64-with-Ubuntu-18.04-bionic)]
+    method: GET
+    uri: http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com&client_id=client-id
+  response:
+    body: {string: '{"error": "invalid_request", "error_description": "Required metadata
+        header not specified"}'}
+    headers: {content-length: '88', content-type: application/json; charset=utf-8,
+      date: 'Mon, 26 Apr 2021 22:13:42 GMT', server: IMDS/150.870.65.492}
+    status: {code: 400, message: Bad Request}
+    url: http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com&client_id=b48ae5dc-70d0-488a-8ef5-f30d905cd5ec
+- request:
+    body: null
+    headers:
+      Metadata: ['true']
+      User-Agent: [azsdk-python-identity/1.6.0b4 Python/3.6.9 (Linux-5.4.0-1046-azure-x86_64-with-Ubuntu-18.04-bionic)]
+    method: GET
+    uri: http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com&client_id=client-id
+  response:
+    body: {string: '{"access_token": "redacted-65130c", "client_id": "client-id",
+        "expires_in": "86399", "expires_on": "1619561622", "ext_expires_in": "86399",
+        "not_before": "1619474922", "resource": "https://management.azure.com", "token_type":
+        "Bearer"}'}
+    headers: {content-length: '1712', content-type: application/json; charset=utf-8,
+      date: 'Mon, 26 Apr 2021 22:13:42 GMT', server: IMDS/150.870.65.492}
+    status: {code: 200, message: OK}
+    url: http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com&client_id=b48ae5dc-70d0-488a-8ef5-f30d905cd5ec
+version: 1

--- a/sdk/identity/azure-identity/tests/recordings/test_imds_credential_async.test_user_assigned.yaml
+++ b/sdk/identity/azure-identity/tests/recordings/test_imds_credential_async.test_user_assigned.yaml
@@ -20,7 +20,7 @@ interactions:
     method: GET
     uri: http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com&client_id=client-id
   response:
-    body: {string: '{"access_token": "redacted-65130c", "client_id": "client-id",
+    body: {string: '{"access_token": "redacted", "client_id": "client-id",
         "expires_in": "86399", "expires_on": "1619561622", "ext_expires_in": "86399",
         "not_before": "1619474922", "resource": "https://management.azure.com", "token_type":
         "Bearer"}'}

--- a/sdk/identity/azure-identity/tests/test_app_service.py
+++ b/sdk/identity/azure-identity/tests/test_app_service.py
@@ -1,0 +1,47 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import os
+
+from azure.identity._credentials.app_service import AppServiceCredential
+from azure.identity._constants import EnvironmentVariables
+import pytest
+
+from helpers import mock
+from recorded_test_case import RecordedTestCase
+
+PLAYBACK_URL = "https://msi-endpoint/token"
+
+
+class RecordedTests(RecordedTestCase):
+    def __init__(self, *args, **kwargs):
+        super(RecordedTests, self).__init__(*args, **kwargs)
+
+        if self.is_live:
+            url = os.environ.get(EnvironmentVariables.MSI_ENDPOINT)
+            if not (url and EnvironmentVariables.MSI_SECRET in os.environ):
+                pytest.skip("Skipping recording because $MSI_ENDPOINT and $MSI_SECRET have no value")
+            else:
+                self.scrubber.register_name_pair(url, PLAYBACK_URL)
+            self.patch = mock.MagicMock()  # don't want to patch anything when recording
+        else:
+            # in playback we need to set environment variables and clear any that would interfere
+            # (MSI_SECRET ends up in a header; default vcr.py behavior is not to match headers)
+            env = {EnvironmentVariables.MSI_ENDPOINT: PLAYBACK_URL, EnvironmentVariables.MSI_SECRET: "secret"}
+            self.patch = mock.patch.dict(os.environ, env, clear=True)
+
+    def test_system_assigned(self):
+        with self.patch:
+            credential = AppServiceCredential()
+        token = credential.get_token(self.scope)
+        assert token.token
+        assert isinstance(token.expires_on, int)
+
+    @pytest.mark.usefixtures("user_assigned_identity_client_id")
+    def test_user_assigned(self):
+        with self.patch:
+            credential = AppServiceCredential(client_id=self.user_assigned_identity_client_id)
+        token = credential.get_token(self.scope)
+        assert token.token
+        assert isinstance(token.expires_on, int)

--- a/sdk/identity/azure-identity/tests/test_app_service.py
+++ b/sdk/identity/azure-identity/tests/test_app_service.py
@@ -21,14 +21,14 @@ class RecordedTests(RecordedTestCase):
         if self.is_live:
             url = os.environ.get(EnvironmentVariables.MSI_ENDPOINT)
             if not (url and EnvironmentVariables.MSI_SECRET in os.environ):
-                pytest.skip("Skipping recording because $MSI_ENDPOINT and $MSI_SECRET have no value")
+                pytest.skip("Recording requires values for $MSI_ENDPOINT and $MSI_SECRET")
             else:
                 self.scrubber.register_name_pair(url, PLAYBACK_URL)
-            self.patch = mock.MagicMock()  # don't want to patch anything when recording
+            self.patch = mock.MagicMock()  # no need to patch anything when recording
         else:
             # in playback we need to set environment variables and clear any that would interfere
-            # (MSI_SECRET ends up in a header; default vcr.py behavior is not to match headers)
-            env = {EnvironmentVariables.MSI_ENDPOINT: PLAYBACK_URL, EnvironmentVariables.MSI_SECRET: "secret"}
+            # (MSI_SECRET ends up in a header; vcr.py behavior doesn't match headers, so the value doesn't matter)
+            env = {EnvironmentVariables.MSI_ENDPOINT: PLAYBACK_URL, EnvironmentVariables.MSI_SECRET: "redacted"}
             self.patch = mock.patch.dict(os.environ, env, clear=True)
 
     def test_system_assigned(self):

--- a/sdk/identity/azure-identity/tests/test_app_service.py
+++ b/sdk/identity/azure-identity/tests/test_app_service.py
@@ -27,7 +27,7 @@ class RecordedTests(RecordedTestCase):
             self.patch = mock.MagicMock()  # no need to patch anything when recording
         else:
             # in playback we need to set environment variables and clear any that would interfere
-            # (MSI_SECRET ends up in a header; vcr.py behavior doesn't match headers, so the value doesn't matter)
+            # (MSI_SECRET ends up in a header; vcr.py doesn't match headers, so the value doesn't matter)
             env = {EnvironmentVariables.MSI_ENDPOINT: PLAYBACK_URL, EnvironmentVariables.MSI_SECRET: "redacted"}
             self.patch = mock.patch.dict(os.environ, env, clear=True)
 

--- a/sdk/identity/azure-identity/tests/test_app_service_async.py
+++ b/sdk/identity/azure-identity/tests/test_app_service_async.py
@@ -21,14 +21,14 @@ class RecordedTests(RecordedTestCase):
         if self.is_live:
             url = os.environ.get(EnvironmentVariables.MSI_ENDPOINT)
             if not (url and EnvironmentVariables.MSI_SECRET in os.environ):
-                pytest.skip("Skipping recording because $MSI_ENDPOINT and $MSI_SECRET have no value")
+                pytest.skip("Recording requires values for $MSI_ENDPOINT and $MSI_SECRET")
             else:
                 self.scrubber.register_name_pair(url, PLAYBACK_URL)
-            self.patch = mock.MagicMock()  # don't want to patch anything when recording
+            self.patch = mock.MagicMock()  # no need to patch anything when recording
         else:
             # in playback we need to set environment variables and clear any that would interfere
-            # (MSI_SECRET ends up in a header; default vcr.py behavior is not to match headers)
-            env = {EnvironmentVariables.MSI_ENDPOINT: PLAYBACK_URL, EnvironmentVariables.MSI_SECRET: "secret"}
+            # (MSI_SECRET ends up in a header; vcr.py doesn't match headers, so the value doesn't matter)
+            env = {EnvironmentVariables.MSI_ENDPOINT: PLAYBACK_URL, EnvironmentVariables.MSI_SECRET: "redacted"}
             self.patch = mock.patch.dict(os.environ, env, clear=True)
 
     @await_test

--- a/sdk/identity/azure-identity/tests/test_app_service_async.py
+++ b/sdk/identity/azure-identity/tests/test_app_service_async.py
@@ -1,0 +1,49 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import os
+from unittest import mock
+
+from azure.identity.aio._credentials.app_service import AppServiceCredential
+from azure.identity._constants import EnvironmentVariables
+import pytest
+
+from helpers_async import await_test
+from recorded_test_case import RecordedTestCase
+from test_app_service import PLAYBACK_URL
+
+
+class RecordedTests(RecordedTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if self.is_live:
+            url = os.environ.get(EnvironmentVariables.MSI_ENDPOINT)
+            if not (url and EnvironmentVariables.MSI_SECRET in os.environ):
+                pytest.skip("Skipping recording because $MSI_ENDPOINT and $MSI_SECRET have no value")
+            else:
+                self.scrubber.register_name_pair(url, PLAYBACK_URL)
+            self.patch = mock.MagicMock()  # don't want to patch anything when recording
+        else:
+            # in playback we need to set environment variables and clear any that would interfere
+            # (MSI_SECRET ends up in a header; default vcr.py behavior is not to match headers)
+            env = {EnvironmentVariables.MSI_ENDPOINT: PLAYBACK_URL, EnvironmentVariables.MSI_SECRET: "secret"}
+            self.patch = mock.patch.dict(os.environ, env, clear=True)
+
+    @await_test
+    async def test_system_assigned(self):
+        with self.patch:
+            credential = AppServiceCredential()
+        token = await credential.get_token(self.scope)
+        assert token.token
+        assert isinstance(token.expires_on, int)
+
+    @pytest.mark.usefixtures("user_assigned_identity_client_id")
+    @await_test
+    async def test_user_assigned(self):
+        with self.patch:
+            credential = AppServiceCredential(client_id=self.user_assigned_identity_client_id)
+        token = await credential.get_token(self.scope)
+        assert token.token
+        assert isinstance(token.expires_on, int)

--- a/sdk/identity/azure-identity/tests/test_cae.py
+++ b/sdk/identity/azure-identity/tests/test_cae.py
@@ -32,7 +32,7 @@ class CaeTestCase(AzureTestCase):
         scrubber = GeneralNameReplacer()
         super(CaeTestCase, self).__init__(
             *args,
-            recording_processors=[RecordingRedactor(), scrubber],
+            recording_processors=[RecordingRedactor(record_unique_values=True), scrubber],
             replay_processors=[RequestUrlNormalizer(), IdTokenProcessor()],
             **kwargs
         )

--- a/sdk/identity/azure-identity/tests/test_imds_credential.py
+++ b/sdk/identity/azure-identity/tests/test_imds_credential.py
@@ -14,6 +14,7 @@ from azure.identity._internal.user_agent import USER_AGENT
 import pytest
 
 from helpers import mock, mock_response, Request, validating_transport
+from recorded_test_case import RecordedTestCase
 
 
 def test_no_scopes():
@@ -173,3 +174,19 @@ def test_identity_config():
     token = credential.get_token(scope)
 
     assert token == expected_token
+
+
+@pytest.mark.usefixtures("record_imds_test")
+class RecordedTests(RecordedTestCase):
+    def test_system_assigned(self):
+        credential = ImdsCredential()
+        token = credential.get_token(self.scope)
+        assert token.token
+        assert isinstance(token.expires_on, int)
+
+    @pytest.mark.usefixtures("user_assigned_identity_client_id")
+    def test_user_assigned(self):
+        credential = ImdsCredential(client_id=self.user_assigned_identity_client_id)
+        token = credential.get_token(self.scope)
+        assert token.token
+        assert isinstance(token.expires_on, int)


### PR DESCRIPTION
Part of #5980. I added a pytest command line flag to make recording the IMDS tests opt-in because we can't tell programmatically whether we should expect that to work.