### PR TITLE
[EngSys] added to python script to not fail if there is an existing PR

### DIFF
--- a/eng/pipelines/templates/steps/verify-autorest.yml
+++ b/eng/pipelines/templates/steps/verify-autorest.yml
@@ -60,5 +60,5 @@ steps:
       - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
         parameters:
           CommitMsg: "Regenerated code from nightly builds"
-          PRTitle: "Automated autorest generation"
+          PRTitle: "Automated autorest generation for ${{ parameters.ServiceDirectory }}"
           PRBranchName: 'autorest-${{ parameters.ServiceDirectory }}'


### PR DESCRIPTION
This PR adds to the `verify_autorest.py` file to only fail if the autorest is not the same AND there is not an existing PR out for autorest generation.