### PR TITLE
[ServiceBus] AMQPAnnotatedMessage API Review Feedback

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/__init__.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/__init__.py
@@ -17,13 +17,11 @@ from ._common.message import (
     ServiceBusMessage,
     ServiceBusMessageBatch,
     ServiceBusReceivedMessage,
-    AMQPAnnotatedMessage
 )
 from ._common.constants import (
     ServiceBusReceiveMode,
     ServiceBusSubQueue,
     NEXT_AVAILABLE_SESSION,
-    AMQPMessageBodyType
 )
 from ._common.auto_lock_renewer import AutoLockRenewer
 from ._common._connection_string_parser import (
@@ -37,8 +35,6 @@ __all__ = [
     "ServiceBusMessage",
     "ServiceBusMessageBatch",
     "ServiceBusReceivedMessage",
-    "AMQPAnnotatedMessage",
-    "AMQPMessageBodyType",
     "NEXT_AVAILABLE_SESSION",
     "ServiceBusSubQueue",
     "ServiceBusReceiveMode",

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/constants.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/constants.py
@@ -5,7 +5,7 @@
 # -------------------------------------------------------------------------
 from enum import Enum
 
-from uamqp import constants, types, MessageBodyType
+from uamqp import constants, types
 
 VENDOR = b"com.microsoft"
 DATETIMEOFFSET_EPOCH = 621355968000000000
@@ -198,16 +198,3 @@ ANNOTATION_SYMBOL_KEY_MAP = {
 
 
 NEXT_AVAILABLE_SESSION = ServiceBusSessionFilter.NEXT_AVAILABLE
-
-
-class AMQPMessageBodyType(str, Enum):
-    DATA = "data"
-    SEQUENCE = "sequence"
-    VALUE = "value"
-
-
-AMQP_MESSAGE_BODY_TYPE_MAP = {
-    MessageBodyType.Data.value: AMQPMessageBodyType.DATA,
-    MessageBodyType.Sequence.value: AMQPMessageBodyType.SEQUENCE,
-    MessageBodyType.Value.value: AMQPMessageBodyType.VALUE,
-}

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/message.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/message.py
@@ -8,7 +8,6 @@
 import datetime
 import uuid
 import logging
-import copy
 from typing import Optional, List, Union, Iterable, TYPE_CHECKING, Any, Mapping, cast
 
 import six
@@ -34,10 +33,8 @@ from .constants import (
     ANNOTATION_SYMBOL_SCHEDULED_ENQUEUE_TIME,
     ANNOTATION_SYMBOL_KEY_MAP,
     MESSAGE_PROPERTY_MAX_LENGTH,
-    AMQPMessageBodyType,
-    AMQP_MESSAGE_BODY_TYPE_MAP,
 )
-
+from ..amqp import AMQPAnnotatedMessage
 from ..exceptions import MessageSizeExceededError
 from .utils import (
     utc_from_timestamp,
@@ -80,6 +77,7 @@ class ServiceBusMessage(
 
     :ivar AMQPAnnotatedMessage raw_amqp_message: Advanced use only.
         The internal AMQP message payload that is sent or received.
+    :vartype raw_amqp_message: ~azure.servicebus.amqp.AMQPAnnotatedMessage
 
     .. admonition:: Example:
 
@@ -317,30 +315,18 @@ class ServiceBusMessage(
 
     @property
     def body(self):
-        # type: () -> Any
-        """The body of the Message. The format may vary depending
-        on the body type:
-        For ~azure.servicebus.AMQPMessageBodyType.DATA, the body could be bytes or Iterable[bytes]
-        For ~azure.servicebus.AMQPMessageBodyType.SEQUENCE, the body could be List or Iterable[List]
-        For ~azure.servicebus.AMQPMessageBodyType.VALUE, the body could be any type.
-
-        :rtype: Any
+        # type: () -> Optional[Union[bytes, Iterable[bytes]]]
+        """The body of the Message.
+        :rtype: bytes or Iterable[bytes]
         """
-        return self.message.get_data()
-
-    @property
-    def body_type(self):
-        # type: () -> Optional[AMQPMessageBodyType]
-        """The body type of the underlying AMQP message.
-
-        rtype: Optional[~azure.servicebus.AMQPMessageBodyType]
-        """
-        try:
-            return AMQP_MESSAGE_BODY_TYPE_MAP.get(
-                self.message._body.type  # pylint: disable=protected-access
-            )
-        except AttributeError:
+        # pylint: disable=protected-access
+        if not self.message._message or not self.message._body:
             return None
+
+        if self.message._body.type != uamqp.MessageBodyType.Data:
+            return None  # TODO: TBD, raise TypeError vs return None
+
+        return self.message.get_data()
 
     @property
     def content_type(self):
@@ -587,7 +573,7 @@ class ServiceBusMessageBatch(object):
         be raised.
 
         :param message: The Message to be added to the batch.
-        :type message: Union[~azure.servicebus.ServiceBusMessage, ~azure.servicebus.AMQPAnnotatedMessage]
+        :type message: Union[~azure.servicebus.ServiceBusMessage, ~azure.servicebus.amqp.AMQPAnnotatedMessage]
         :rtype: None
         :raises: :class: ~azure.servicebus.exceptions.MessageSizeExceededError, when exceeding the size limit.
         """
@@ -878,253 +864,3 @@ class ServiceBusReceivedMessage(ServiceBusMessage):
             expiry_in_seconds = self.message.annotations[_X_OPT_LOCKED_UNTIL] / 1000
             self._expiry = utc_from_timestamp(expiry_in_seconds)
         return self._expiry
-
-
-class AMQPAnnotatedMessage(object):
-    """
-    The AMQP Annotated Message for advanced sending and receiving scenarios which allows you to
-    access to low-level AMQP message sections.
-    Please refer to the AMQP spec:
-    http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format
-    for more information on the message format.
-
-    :keyword data_body: The body consists of one or more data sections and each section contains opaque binary data.
-    :paramtype data_body: Union[str, bytes, List[Union[str, bytes]]]
-    :keyword sequence_body: The body consists of one or more sequence sections and
-     each section contains an arbitrary number of structured data elements.
-    :paramtype sequence_body: List[Any]
-    :keyword value_body: The body consists of one amqp-value section and the section contains a single AMQP value.
-    :paramtype value_body: Any
-    :keyword header: The amqp message header. This must be a dictionary with the following
-     keys:
-
-        - `delivery_count` (int)
-        - `time_to_live` (int)
-        - `durable` (bool)
-        - `first_acquirer` (bool)
-        - `priority` (int)
-
-    :paramtype header: dict
-    :keyword footer: The amqp message footer.
-    :paramtype footer: dict
-    :keyword properties: Properties to add to the amqp message. This must be a dictionary with the following
-     keys:
-
-        - message_id (str or bytes),
-        - user_id (str or bytes),
-        - to (Any),
-        - subject (str or bytes),
-        - reply_to (Any),
-        - correlation_id (str or bytes),
-        - content_type (str or bytes),
-        - content_encoding (str or bytes),
-        - creation_time (int),
-        - absolute_expiry_time (int),
-        - group_id (str or bytes),
-        - group_sequence (int),
-        - reply_to_group_id (str or bytes)
-
-    :paramtype properties: dict
-    :keyword application_properties: Service specific application properties.
-    :paramtype application_properties: dict
-    :keyword annotations: Service specific message annotations.
-    :paramtype annotations: dict
-    :keyword delivery_annotations: Service specific delivery annotations.
-    :paramtype delivery_annotations: dict
-    """
-
-    def __init__(self, **kwargs):
-        # type: (Any) -> None
-        self._message = kwargs.pop("message", None)
-
-        if self._message:
-            # internal usage only for service bus received message
-            return
-
-        self._data_body = kwargs.pop("data_body", None)
-        self._sequence_body = kwargs.pop("sequence_body", None)
-        self._value_body = kwargs.pop("value_body", None)
-
-        validation = [
-            body
-            for body in (self._value_body, self._data_body, self._sequence_body)
-            if body is not None
-        ]
-        if len(validation) != 1:
-            raise ValueError(
-                "There should be one and only one of either data_body, sequence_body "
-                "or value_body being set as the body of the AMQPAnnotatedMessage."
-            )
-
-        header = kwargs.get("header")
-        footer = kwargs.get("footer")
-        properties = kwargs.get("properties")
-        application_properties = kwargs.get("application_properties")
-        annotations = kwargs.get("annotations")
-        delivery_annotations = kwargs.get("delivery_annotations")
-
-        body_type = (
-            uamqp.MessageBodyType.Data
-            if self._data_body
-            else (
-                uamqp.MessageBodyType.Sequence
-                if self._sequence_body
-                else uamqp.MessageBodyType.Value
-            )
-        )
-        body = self._data_body or self._sequence_body or self._value_body
-
-        message_header = None
-        message_properties = None
-        if header:
-            message_header = uamqp.message.MessageHeader()
-            message_header.delivery_count = header.get("delivery_count", 0)
-            message_header.time_to_live = header.get("time_to_live")
-            message_header.first_acquirer = header.get("first_acquirer")
-            message_header.durable = header.get("durable")
-            message_header.priority = header.get("priority")
-
-        if properties:
-            message_properties = uamqp.message.MessageProperties(**properties)
-
-        self._message = uamqp.message.Message(
-            body=body,
-            body_type=body_type,
-            header=message_header,
-            footer=footer,
-            properties=message_properties,
-            application_properties=application_properties,
-            annotations=annotations,
-            delivery_annotations=delivery_annotations,
-        )
-
-    def _to_service_bus_message(self):
-        return ServiceBusMessage(body=None, message=self._message)
-
-    @property
-    def body(self):
-        # type: () -> Any
-        """The body of the Message. The format may vary depending
-        on the body type:
-        For ~azure.servicebus.AMQPMessageBodyType.DATA, the body could be bytes or Iterable[bytes]
-        For ~azure.servicebus.AMQPMessageBodyType.SEQUENCE, the body could be List or Iterable[List]
-        For ~azure.servicebus.AMQPMessageBodyType.VALUE, the body could be any type.
-
-        :rtype: Any
-        """
-        return self._message.get_data()
-
-    @property
-    def body_type(self):
-        # type: () -> Optional[AMQPMessageBodyType]
-        """The body type of the underlying AMQP message.
-
-        rtype: Optional[~azure.servicebus.AMQPMessageBodyType]
-        """
-        return AMQP_MESSAGE_BODY_TYPE_MAP.get(
-            self._message._body.type  # pylint: disable=protected-access
-        )
-
-    @property
-    def properties(self):
-        # type: () -> uamqp.message.MessageProperties
-        """
-        Properties to add to the message.
-
-        :rtype: ~uamqp.message.MessageProperties
-        """
-        return uamqp.message.MessageProperties(
-            message_id=self._message.properties.message_id,
-            user_id=self._message.properties.user_id,
-            to=self._message.properties.to,
-            subject=self._message.properties.subject,
-            reply_to=self._message.properties.reply_to,
-            correlation_id=self._message.properties.correlation_id,
-            content_type=self._message.properties.content_type,
-            content_encoding=self._message.properties.content_encoding,
-            absolute_expiry_time=self._message.properties.absolute_expiry_time,
-            creation_time=self._message.properties.creation_time,
-            group_id=self._message.properties.group_id,
-            group_sequence=self._message.properties.group_sequence,
-            reply_to_group_id=self._message.properties.reply_to_group_id,
-        )
-
-    # NOTE: These are disabled pending arch. design and cross-sdk consensus on
-    # how we will expose sendability of amqp focused messages. To undo, uncomment and remove deepcopies/workarounds.
-    #
-    # @properties.setter
-    # def properties(self, value):
-    #    self._message.properties = value
-
-    @property
-    def application_properties(self):
-        # type: () -> Optional[dict]
-        """
-        Service specific application properties.
-
-        :rtype: dict
-        """
-        return copy.deepcopy(self._message.application_properties)
-
-    # @application_properties.setter
-    # def application_properties(self, value):
-    #    self._message.application_properties = value
-
-    @property
-    def annotations(self):
-        # type: () -> Optional[dict]
-        """
-        Service specific message annotations. Keys in the dictionary
-        must be `uamqp.types.AMQPSymbol` or `uamqp.types.AMQPuLong`.
-
-        :rtype: dict
-        """
-        return copy.deepcopy(self._message.annotations)
-
-    # @annotations.setter
-    # def annotations(self, value):
-    #    self._message.annotations = value
-
-    @property
-    def delivery_annotations(self):
-        # type: () -> Optional[dict]
-        """
-        Delivery-specific non-standard properties at the head of the message.
-        Delivery annotations convey information from the sending peer to the receiving peer.
-        Keys in the dictionary must be `uamqp.types.AMQPSymbol` or `uamqp.types.AMQPuLong`.
-
-        :rtype: dict
-        """
-        return copy.deepcopy(self._message.delivery_annotations)
-
-    # @delivery_annotations.setter
-    # def delivery_annotations(self, value):
-    #    self._message.delivery_annotations = value
-
-    @property
-    def header(self):
-        # type: () -> uamqp.message.MessageHeader
-        """
-        The message header.
-
-        :rtype: ~uamqp.message.MessageHeader
-        """
-        return uamqp.message.MessageHeader(header=self._message.header)
-
-    # @header.setter
-    # def header(self, value):
-    #    self._message.header = value
-
-    @property
-    def footer(self):
-        # type: () -> Optional[dict]
-        """
-        The message footer.
-
-        :rtype: dict
-        """
-        return copy.deepcopy(self._message.footer)
-
-    # @footer.setter
-    # def footer(self, value):
-    #    self._message.footer = value

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/utils.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/utils.py
@@ -54,12 +54,12 @@ from .constants import (
     SPAN_ENQUEUED_TIME_PROPERTY,
     SPAN_NAME_RECEIVE,
 )
+from ..amqp import AMQPAnnotatedMessage
 
 if TYPE_CHECKING:
     from .message import (
         ServiceBusReceivedMessage,
         ServiceBusMessage,
-        AMQPAnnotatedMessage,
     )
     from azure.core.tracing import AbstractSpan
     from azure.core.credentials import AzureSasCredential
@@ -228,11 +228,8 @@ def transform_messages_to_sendable_if_needed(messages):
 
 def _convert_to_single_service_bus_message(message, message_type):
     # type: (SingleMessageType, Type[ServiceBusMessage]) -> ServiceBusMessage
-    try:
-        # Handle AMQPAnnotatedMessage
-        message = message._to_service_bus_message()  # type: ignore  # pylint: disable=protected-access
-    except AttributeError:
-        pass
+    if isinstance(message, AMQPAnnotatedMessage):
+        message = message_type(body=None, message=message._message)  # pylint: disable=protected-access
 
     if isinstance(message, message_type):
         return message

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_sender.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_sender.py
@@ -16,8 +16,8 @@ from ._common import mgmt_handlers
 from ._common.message import (
     ServiceBusMessage,
     ServiceBusMessageBatch,
-    AMQPAnnotatedMessage,
 )
+from .amqp import AMQPAnnotatedMessage
 from .exceptions import (
     OperationTimeoutError,
     _ServiceBusErrorPolicy,
@@ -269,8 +269,8 @@ class ServiceBusSender(BaseHandler, SenderMixin):
         Returns a list of the sequence numbers of the enqueued messages.
 
         :param messages: The message or list of messages to schedule.
-        :type messages: Union[~azure.servicebus.ServiceBusMessage, ~azure.servicebus.AMQPAnnotatedMessage,
-         List[Union[~azure.servicebus.ServiceBusMessage, ~azure.servicebus.AMQPAnnotatedMessage]]]
+        :type messages: Union[~azure.servicebus.ServiceBusMessage, ~azure.servicebus.amqp.AMQPAnnotatedMessage,
+         List[Union[~azure.servicebus.ServiceBusMessage, ~azure.servicebus.amqp.AMQPAnnotatedMessage]]]
         :param schedule_time_utc: The utc date and time to enqueue the messages.
         :type schedule_time_utc: ~datetime.datetime
         :keyword float timeout: The total operation timeout in seconds including all the retries. The value must be
@@ -363,8 +363,8 @@ class ServiceBusSender(BaseHandler, SenderMixin):
 
         :param message: The ServiceBus message to be sent.
         :type message: Union[~azure.servicebus.ServiceBusMessage, ~azure.servicebus.ServiceBusMessageBatch,
-         ~azure.servicebus.AMQPAnnotatedMessage, List[Union[~azure.servicebus.ServiceBusMessage,
-         ~azure.servicebus.AMQPAnnotatedMessage]]]
+         ~azure.servicebus.amqp.AMQPAnnotatedMessage, List[Union[~azure.servicebus.ServiceBusMessage,
+         ~azure.servicebus.amqp.AMQPAnnotatedMessage]]]
         :keyword Optional[float] timeout: The total operation timeout in seconds including all the retries.
          The value must be greater than 0 if specified. The default value is None, meaning no timeout.
         :rtype: None

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_sender_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_sender_async.py
@@ -14,8 +14,8 @@ from azure.core.credentials import AzureSasCredential
 from .._common.message import (
     ServiceBusMessage,
     ServiceBusMessageBatch,
-    AMQPAnnotatedMessage,
 )
+from ..amqp import AMQPAnnotatedMessage
 from .._servicebus_sender import SenderMixin
 from ._base_handler_async import BaseHandler
 from .._common.constants import (
@@ -209,8 +209,8 @@ class ServiceBusSender(BaseHandler, SenderMixin):
         Returns a list of the sequence numbers of the enqueued messages.
 
         :param messages: The message or list of messages to schedule.
-        :type messages: Union[~azure.servicebus.ServiceBusMessage, ~azure.servicebus.AMQPAnnotatedMessage,
-         List[Union[~azure.servicebus.ServiceBusMessage, ~azure.servicebus.AMQPAnnotatedMessage]]]
+        :type messages: Union[~azure.servicebus.ServiceBusMessage, ~azure.servicebus.amqp.AMQPAnnotatedMessage,
+         List[Union[~azure.servicebus.ServiceBusMessage, ~azure.servicebus.amqp.AMQPAnnotatedMessage]]]
         :param schedule_time_utc: The utc date and time to enqueue the messages.
         :type schedule_time_utc: ~datetime.datetime
         :keyword float timeout: The total operation timeout in seconds including all the retries. The value must be
@@ -304,8 +304,8 @@ class ServiceBusSender(BaseHandler, SenderMixin):
 
         :param message: The ServiceBus message to be sent.
         :type message: Union[~azure.servicebus.ServiceBusMessage, ~azure.servicebus.ServiceBusMessageBatch,
-         ~azure.servicebus.AMQPAnnotatedMessage, List[Union[~azure.servicebus.ServiceBusMessage,
-         ~azure.servicebus.AMQPAnnotatedMessage]]]
+         ~azure.servicebus.amqp.AMQPAnnotatedMessage, List[Union[~azure.servicebus.ServiceBusMessage,
+         ~azure.servicebus.amqp.AMQPAnnotatedMessage]]]
         :keyword Optional[float] timeout: The total operation timeout in seconds including all the retries.
          The value must be greater than 0 if specified. The default value is None, meaning no timeout.
         :rtype: None

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/amqp/__init__.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/amqp/__init__.py
@@ -1,0 +1,20 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+
+from ._amqp_message import (
+    AMQPAnnotatedMessage,
+    AMQPMessageBodyType,
+    AMQPMessageProperties,
+    AMQPMessageHeader,
+)
+
+
+__all__ = [
+    "AMQPAnnotatedMessage",
+    "AMQPMessageBodyType",
+    "AMQPMessageProperties",
+    "AMQPMessageHeader",
+]

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/amqp/_amqp_message.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/amqp/_amqp_message.py
@@ -1,0 +1,450 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+
+import copy
+from typing import Optional, Any
+
+import uamqp
+
+from ._constants import AMQP_MESSAGE_BODY_TYPE_MAP, AMQPMessageBodyType
+
+
+class DictMixin(object):
+    def __setitem__(self, key, item):
+        # type: (Any, Any) -> None
+        self.__dict__[key] = item
+
+    def __getitem__(self, key):
+        # type: (Any) -> Any
+        return self.__dict__[key]
+
+    def __repr__(self):
+        # type: () -> str
+        return str(self)
+
+    def __len__(self):
+        # type: () -> int
+        return len(self.keys())
+
+    def __delitem__(self, key):
+        # type: (Any) -> None
+        self.__dict__[key] = None
+
+    def __eq__(self, other):
+        # type: (Any) -> bool
+        """Compare objects by comparing all attributes."""
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+    def __ne__(self, other):
+        # type: (Any) -> bool
+        """Compare objects by comparing all attributes."""
+        return not self.__eq__(other)
+
+    def __str__(self):
+        # type: () -> str
+        return str({k: v for k, v in self.__dict__.items() if not k.startswith("_")})
+
+    def has_key(self, k):
+        # type: (Any) -> bool
+        return k in self.__dict__
+
+    def update(self, *args, **kwargs):
+        # type: (Any, Any) -> None
+        return self.__dict__.update(*args, **kwargs)
+
+    def keys(self):
+        # type: () -> list
+        return [k for k in self.__dict__ if not k.startswith("_")]
+
+    def values(self):
+        # type: () -> list
+        return [v for k, v in self.__dict__.items() if not k.startswith("_")]
+
+    def items(self):
+        # type: () -> list
+        return [(k, v) for k, v in self.__dict__.items() if not k.startswith("_")]
+
+    def get(self, key, default=None):
+        # type: (Any, Optional[Any]) -> Any
+        if key in self.__dict__:
+            return self.__dict__[key]
+        return default
+
+
+class AMQPAnnotatedMessage(object):
+    """
+    The AMQP Annotated Message for advanced sending and receiving scenarios which allows you to
+    access to low-level AMQP message sections.
+    Please refer to the AMQP spec:
+    http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format
+    for more information on the message format.
+
+    :keyword data_body: The body consists of one or more data sections and each section contains opaque binary data.
+    :paramtype data_body: Optional[Union[str, bytes, List[Union[str, bytes]]]]
+    :keyword sequence_body: The body consists of one or more sequence sections and
+     each section contains an arbitrary number of structured data elements.
+    :paramtype sequence_body: Optional[List[Any]]
+    :keyword value_body: The body consists of one amqp-value section and the section contains a single AMQP value.
+    :paramtype value_body: Any
+    :keyword header: The amqp message header.
+    :paramtype header: Optional[~azure.servicebus.amqp.AMQPMessageHeader]
+    :keyword footer: The amqp message footer.
+    :paramtype footer: Optional[dict]
+    :keyword properties: Properties to add to the amqp message.
+    :paramtype properties: Optional[~azure.servicebus.amqp.AMQPMessageProperties]
+    :keyword application_properties: Service specific application properties.
+    :paramtype application_properties: Optional[dict]
+    :keyword annotations: Service specific message annotations.
+    :paramtype annotations: Optional[dict]
+    :keyword delivery_annotations: Service specific delivery annotations.
+    :paramtype delivery_annotations: Optional[dict]
+    """
+
+    def __init__(self, **kwargs):
+        # type: (Any) -> None
+        self._message = kwargs.pop("message", None)
+
+        if self._message:
+            # internal usage only for service bus received message
+            return
+
+        self._data_body = kwargs.pop("data_body", None)
+        self._sequence_body = kwargs.pop("sequence_body", None)
+        self._value_body = kwargs.pop("value_body", None)
+
+        validation = [
+            body
+            for body in (self._value_body, self._data_body, self._sequence_body)
+            if body is not None
+        ]
+        if len(validation) != 1:
+            raise ValueError(
+                "There should be one and only one of either data_body, sequence_body "
+                "or value_body being set as the body of the AMQPAnnotatedMessage."
+            )
+
+        header = kwargs.get("header")
+        footer = kwargs.get("footer")
+        properties = kwargs.get("properties")
+        application_properties = kwargs.get("application_properties")
+        annotations = kwargs.get("annotations")
+        delivery_annotations = kwargs.get("delivery_annotations")
+
+        body_type = (
+            uamqp.MessageBodyType.Data
+            if self._data_body
+            else (
+                uamqp.MessageBodyType.Sequence
+                if self._sequence_body
+                else uamqp.MessageBodyType.Value
+            )
+        )
+        body = self._data_body or self._sequence_body or self._value_body
+
+        message_header = None
+        message_properties = None
+        if header:
+            message_header = uamqp.message.MessageHeader()
+            message_header.delivery_count = header.get("delivery_count", 0)
+            message_header.time_to_live = header.get("time_to_live")
+            message_header.first_acquirer = header.get("first_acquirer")
+            message_header.durable = header.get("durable")
+            message_header.priority = header.get("priority")
+
+        if properties:
+            message_properties = uamqp.message.MessageProperties(**properties)
+
+        self._message = uamqp.message.Message(
+            body=body,
+            body_type=body_type,
+            header=message_header,
+            footer=footer,
+            properties=message_properties,
+            application_properties=application_properties,
+            annotations=annotations,
+            delivery_annotations=delivery_annotations,
+        )
+
+    @property
+    def body(self):
+        # type: () -> Any
+        """The body of the Message. The format may vary depending
+        on the body type:
+        For ~azure.servicebus.AMQPMessageBodyType.DATA, the body could be bytes or Iterable[bytes]
+        For ~azure.servicebus.AMQPMessageBodyType.SEQUENCE, the body could be List or Iterable[List]
+        For ~azure.servicebus.AMQPMessageBodyType.VALUE, the body could be any type.
+
+        :rtype: Any
+        """
+        return self._message.get_data()
+
+    @property
+    def body_type(self):
+        # type: () -> Optional[AMQPMessageBodyType]
+        """The body type of the underlying AMQP message.
+
+        rtype: Optional[~azure.servicebus.amqp.AMQPMessageBodyType]
+        """
+        return AMQP_MESSAGE_BODY_TYPE_MAP.get(
+            self._message._body.type  # pylint: disable=protected-access
+        )
+
+    @property
+    def properties(self):
+        # type: () -> Optional[AMQPMessageProperties]
+        """
+        Properties to add to the message.
+
+        :rtype: Optional[~azure.servicebus.amqp.AMQPMessageProperties]
+        """
+        return AMQPMessageProperties()
+        # return uamqp.message.MessageProperties(
+        #     message_id=self._message.properties.message_id,
+        #     user_id=self._message.properties.user_id,
+        #     to=self._message.properties.to,
+        #     subject=self._message.properties.subject,
+        #     reply_to=self._message.properties.reply_to,
+        #     correlation_id=self._message.properties.correlation_id,
+        #     content_type=self._message.properties.content_type,
+        #     content_encoding=self._message.properties.content_encoding,
+        #     absolute_expiry_time=self._message.properties.absolute_expiry_time,
+        #     creation_time=self._message.properties.creation_time,
+        #     group_id=self._message.properties.group_id,
+        #     group_sequence=self._message.properties.group_sequence,
+        #     reply_to_group_id=self._message.properties.reply_to_group_id,
+        # )
+
+    # NOTE: These are disabled pending arch. design and cross-sdk consensus on
+    # how we will expose sendability of amqp focused messages. To undo, uncomment and remove deepcopies/workarounds.
+    #
+    # @properties.setter
+    # def properties(self, value):
+    #    self._message.properties = value
+
+    @property
+    def application_properties(self):
+        # type: () -> Optional[dict]
+        """
+        Service specific application properties.
+
+        :rtype: dict
+        """
+        return copy.deepcopy(self._message.application_properties)
+
+    # @application_properties.setter
+    # def application_properties(self, value):
+    #    self._message.application_properties = value
+
+    @property
+    def annotations(self):
+        # type: () -> Optional[dict]
+        """
+        Service specific message annotations.
+
+        :rtype: dict
+        """
+        return copy.deepcopy(self._message.annotations)
+
+    # @annotations.setter
+    # def annotations(self, value):
+    #    self._message.annotations = value
+
+    @property
+    def delivery_annotations(self):
+        # type: () -> Optional[dict]
+        """
+        Delivery-specific non-standard properties at the head of the message.
+        Delivery annotations convey information from the sending peer to the receiving peer.
+
+        :rtype: dict
+        """
+        return copy.deepcopy(self._message.delivery_annotations)
+
+    # @delivery_annotations.setter
+    # def delivery_annotations(self, value):
+    #    self._message.delivery_annotations = value
+
+    @property
+    def header(self):
+        # type: () -> Optional[AMQPMessageHeader]
+        """
+        The message header.
+
+        :rtype: Optional[~azure.servicebus.amqp.AMQPMessageHeader]
+        """
+        return AMQPMessageHeader()
+        # return uamqp.message.MessageHeader(header=self._message.header)
+
+    # @header.setter
+    # def header(self, value):
+    #    self._message.header = value
+
+    @property
+    def footer(self):
+        # type: () -> Optional[dict]
+        """
+        The message footer.
+
+        :rtype: dict
+        """
+        return copy.deepcopy(self._message.footer)
+
+    # @footer.setter
+    # def footer(self, value):
+    #    self._message.footer = value
+
+
+class AMQPMessageHeader(DictMixin):
+    """The Message header.
+    The Message header. This is only used on received message, and not
+    set on messages being sent. The properties set on any given message
+    will depend on the Service and not all messages will have all properties.
+
+    :keyword delivery_count: The number of unsuccessful previous attempts to deliver
+     this message. If this value is non-zero it can be taken as an indication that the
+     delivery might be a duplicate. On first delivery, the value is zero. It is
+     incremented upon an outcome being settled at the sender, according to rules
+     defined for each outcome.
+    :paramtype delivery_count: Optional[int]
+    :keyword time_to_live: Duration in milliseconds for which the message is to be considered "live".
+     If this is set then a message expiration time will be computed based on the time of arrival
+     at an intermediary. Messages that live longer than their expiration time will be discarded
+     (or dead lettered). When a message is transmitted by an intermediary that was received
+     with a ttl, the transmitted message's header SHOULD contain a ttl that is computed as the
+     difference between the current time and the formerly computed message expiration time,
+     i.e., the reduced ttl, so that messages will eventually die if they end up in a delivery loop.
+    :paramtype time_to_live: Optional[int]
+    :keyword durable: Durable messages MUST NOT be lost even if an intermediary is unexpectedly terminated
+     and restarted. A target which is not capable of fulfilling this guarantee MUST NOT accept messages
+     where the durable header is set to `True`: if the source allows the rejected outcome then the
+     message SHOULD be rejected with the precondition-failed error, otherwise the link MUST be detached
+     by the receiver with the same error.
+    :paramtype durable: Optional[bool]
+    :keyword first_acquirer: If this value is `True`, then this message has not been acquired
+     by any other link. If this value is `False`, then this message MAY have previously
+     been acquired by another link or links.
+    :paramtype first_acquirer: Optional[bool]
+    :keyword priority: This field contains the relative message priority. Higher numbers indicate higher
+     priority messages. Messages with higher priorities MAY be delivered before those with lower priorities.
+    :paramtype priority: Optional[int]
+
+    :ivar delivery_count: The number of unsuccessful previous attempts to deliver
+     this message. If this value is non-zero it can be taken as an indication that the
+     delivery might be a duplicate. On first delivery, the value is zero. It is
+     incremented upon an outcome being settled at the sender, according to rules
+     defined for each outcome.
+    :vartype delivery_count: Optional[int]
+    :ivar time_to_live: Duration in milliseconds for which the message is to be considered "live".
+     If this is set then a message expiration time will be computed based on the time of arrival
+     at an intermediary. Messages that live longer than their expiration time will be discarded
+     (or dead lettered). When a message is transmitted by an intermediary that was received
+     with a ttl, the transmitted message's header SHOULD contain a ttl that is computed as the
+     difference between the current time and the formerly computed message expiration time,
+     i.e., the reduced ttl, so that messages will eventually die if they end up in a delivery loop.
+    :vartype time_to_live: Optional[int]
+    :ivar durable: Durable messages MUST NOT be lost even if an intermediary is unexpectedly terminated
+     and restarted. A target which is not capable of fulfilling this guarantee MUST NOT accept messages
+     where the durable header is set to `True`: if the source allows the rejected outcome then the
+     message SHOULD be rejected with the precondition-failed error, otherwise the link MUST be detached
+     by the receiver with the same error.
+    :vartype durable: Optional[bool]
+    :ivar first_acquirer: If this value is `True`, then this message has not been acquired
+     by any other link. If this value is `False`, then this message MAY have previously
+     been acquired by another link or links.
+    :vartype first_acquirer: Optional[bool]
+    :ivar priority: This field contains the relative message priority. Higher numbers indicate higher
+     priority messages. Messages with higher priorities MAY be delivered before those with lower priorities.
+    :vartype priority: Optional[int]
+    """
+    def __init__(self, **kwargs):
+        self.delivery_count = kwargs.get("delivery_count")
+        self.time_to_live = kwargs.get("time_to_live")
+        self.first_acquirer = kwargs.get("first_acquirer")
+        self.durable = kwargs.get("durable")
+        self.priority = kwargs.get("priority")
+
+
+class AMQPMessageProperties(DictMixin):
+    """Message properties.
+    The properties that are actually used will depend on the service implementation.
+    Not all received messages will have all properties, and not all properties
+    will be utilized on a sent message.
+
+    :keyword message_id:
+    :paramtype message_id: Optional[Union[str, bytes, uuid.UUID]]
+    :keyword user_id:
+    :paramtype user_id: Optional[Union[str, bytes]]
+    :keyword to:
+    :paramtype to: Optional[Union[str, bytes]]
+    :keyword subject:
+    :paramtype subject: Optional[Union[str, bytes]]
+    :keyword reply_to:
+    :paramtype reply_to: Optional[Union[str, bytes]]
+    :keyword correlation_id:
+    :paramtype correlation_id: Optional[Union[str, bytes]]
+    :keyword content_type:
+    :paramtype content_type: Optional[Union[str, bytes]]
+    :keyword content_encoding:
+    :paramtype content_encoding: Optional[Union[str, bytes]]
+    :keyword creation_time:
+    :paramtype creation_time: Optional[int]
+    :keyword absolute_expiry_time:
+    :paramtype absolute_expiry_time: Optional[int]
+    :keyword group_id:
+    :paramtype group_id: Optional[Union[str, bytes]]
+    :keyword group_sequence:
+    :paramtype group_sequence: Optional[int]
+    :keyword reply_to_group_id:
+    :paramtype reply_to_group_id: Optional[Union[str, bytes]]
+
+    :ivar message_id: Message-id, if set, uniquely identifies a message within the message system.
+     The message producer is usually responsible for setting the message-id in such a way that it
+     is assured to be globally unique. A broker MAY discard a message as a duplicate if the value
+     of the message-id matches that of a previously received message sent to the same node.
+    :vartype message_id: Optional[Union[str, bytes, uuid.UUID]]
+    :ivar user_id: The identity of the user responsible for producing the message. The client sets
+     this value, and it MAY be authenticated by intermediaries.
+    :vartype user_id: Optional[Union[str, bytes]]
+    :ivar to: The to field identifies the node that is the intended destination of the message.
+     On any given transfer this might not be the node at the receiving end of the link.
+    :vartype to: Optional[Union[str, bytes]]
+    :ivar subject:
+    :vartype subject: Optional[Union[str, bytes]]
+    :ivar reply_to:
+    :vartype reply_to: Optional[Union[str, bytes]]
+    :ivar correlation_id:
+    :vartype correlation_id: Optional[Union[str, bytes]]
+    :ivar content_type:
+    :vartype content_type: Optional[Union[str, bytes]]
+    :ivar content_encoding:
+    :vartype content_encoding: Optional[Union[str, bytes]]
+    :ivar creation_time:
+    :vartype creation_time: Optional[int]
+    :ivar absolute_expiry_time:
+    :vartype absolute_expiry_time: Optional[int]
+    :ivar group_id:
+    :vartype group_id: Optional[Union[str, bytes]]
+    :ivar group_sequence:
+    :vartype group_sequence: Optional[int]
+    :ivar reply_to_group_id:
+    :vartype reply_to_group_id: Optional[Union[str, bytes]]
+    """
+    def __init__(self, **kwargs):
+        self.message_id = kwargs.get("message_id")
+        self.user_id = kwargs.get("user_id")
+        self.to = kwargs.get("to")
+        self.subject = kwargs.get("subject")
+        self.reply_to = kwargs.get("reply_to")
+        self.correlation_id = kwargs.get("correlation_id")
+        self.content_type = kwargs.get("content_type")
+        self.content_encoding = kwargs.get("content_encoding")
+        self.creation_time = kwargs.get("creation_time")
+        self.absolute_expiry_time = kwargs.get("absolute_expiry_time")
+        self.group_id = kwargs.get("group_id")
+        self.group_sequence = kwargs.get("group_sequence")
+        self.reply_to_group_id = kwargs.get("reply_to_group_id")

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/amqp/_constants.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/amqp/_constants.py
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+from enum import Enum
+
+from uamqp import MessageBodyType
+
+
+class AMQPMessageBodyType(str, Enum):
+    DATA = "data"
+    SEQUENCE = "sequence"
+    VALUE = "value"
+
+
+AMQP_MESSAGE_BODY_TYPE_MAP = {
+    MessageBodyType.Data.value: AMQPMessageBodyType.DATA,
+    MessageBodyType.Sequence.value: AMQPMessageBodyType.SEQUENCE,
+    MessageBodyType.Value.value: AMQPMessageBodyType.VALUE,
+}

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/send_and_receive_amqp_annotated_message_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/send_and_receive_amqp_annotated_message_async.py
@@ -13,7 +13,7 @@ Example to show sending, receiving and parsing amqp annotated message(s) to a Se
 
 import os
 import asyncio
-from azure.servicebus import AMQPAnnotatedMessage, AMQPMessageBodyType
+from azure.servicebus.amqp import AMQPAnnotatedMessage, AMQPMessageBodyType
 from azure.servicebus.aio import ServiceBusClient
 
 CONNECTION_STR = os.environ['SERVICE_BUS_CONNECTION_STR']
@@ -65,17 +65,18 @@ async def send_value_message(sender):
 
 async def receive_and_parse_message(receiver):
     async for message in receiver:
-        if message.body_type == AMQPMessageBodyType.DATA:
+        raw_amqp_message = message.raw_amqp_message
+        if raw_amqp_message.body_type == AMQPMessageBodyType.DATA:
             print("Message of data body received. Body is:")
-            for data_section in message.body:
+            for data_section in raw_amqp_message.body:
                 print(data_section)
-        elif message.body_type == AMQPMessageBodyType.SEQUENCE:
+        elif raw_amqp_message.body_type == AMQPMessageBodyType.SEQUENCE:
             print("Message of sequence body received. Body is:")
-            for sequence_section in message.body:
+            for sequence_section in raw_amqp_message.body:
                 print(sequence_section)
-        elif message.body_type == AMQPMessageBodyType.VALUE:
+        elif raw_amqp_message.body_type == AMQPMessageBodyType.VALUE:
             print("Message of value body received. Body is:")
-            print(message.body)
+            print(raw_amqp_message.body)
         await receiver.complete_message(message)
 
 

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/send_and_receive_amqp_annotated_message.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/send_and_receive_amqp_annotated_message.py
@@ -12,7 +12,8 @@ Example to show sending, receiving and parsing amqp annotated message(s) to a Se
 # pylint: disable=C0111
 
 import os
-from azure.servicebus import ServiceBusClient, AMQPAnnotatedMessage, AMQPMessageBodyType
+from azure.servicebus import ServiceBusClient
+from azure.servicebus.amqp import AMQPAnnotatedMessage, AMQPMessageBodyType
 
 
 CONNECTION_STR = os.environ['SERVICE_BUS_CONNECTION_STR']
@@ -64,17 +65,18 @@ def send_value_message(sender):
 
 def receive_and_parse_message(receiver):
     for message in receiver:
-        if message.body_type == AMQPMessageBodyType.DATA:
+        raw_amqp_message = message.raw_amqp_message
+        if raw_amqp_message.body_type == AMQPMessageBodyType.DATA:
             print("Message of data body received. Body is:")
-            for data_section in message.body:
+            for data_section in raw_amqp_message.body:
                 print(data_section)
-        elif message.body_type == AMQPMessageBodyType.SEQUENCE:
+        elif raw_amqp_message.body_type == AMQPMessageBodyType.SEQUENCE:
             print("Message of sequence body received. Body is:")
-            for sequence_section in message.body:
+            for sequence_section in raw_amqp_message.body:
                 print(sequence_section)
-        elif message.body_type == AMQPMessageBodyType.VALUE:
+        elif raw_amqp_message.body_type == AMQPMessageBodyType.VALUE:
             print("Message of value body received. Body is:")
-            print(message.body)
+            print(raw_amqp_message.body)
         receiver.complete_message(message)
 
 


### PR DESCRIPTION
The change is based upon the gist and the discussion:
https://gist.github.com/yunhaoling/4bf19d56fcb9c21c3944eba41d272433

Decision:

1. let's push advanced users to use `ServiceBusReceivedMessage.raw_amqp_message`
  - pull out `body_type` property on `ServiceBusReceivedMessage`
  **- (TBD) body return None vs raise Error**
2. Introduce new classes for header and property, and inherit from DictMixin
  **- (TBD) whether to inherit from uamqp classes as well for backward-compatibility**
3. Introduce new namespace azure.servicebus.amqp


API View is available here:
https://apiview.dev/Assemblies/Review/c4c7244a8c1d4968827e0163db9187c5