### PR TITLE
Extend BearerTokenCredentialPolicy to handle auth challenges

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -71,7 +71,7 @@ class _BearerTokenCredentialPolicyBase(object):
         return not self._token or self._token.expires_on - time.time() < 300
 
 
-class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, SansIOHTTPPolicy, HTTPPolicy):
+class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, HTTPPolicy):
     """Adds a bearer token Authorization header to requests.
 
     :param credential: The credential.
@@ -144,6 +144,30 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, SansIOHTTPPo
         :returns: a bool indicating whether the policy should send the request
         """
         # pylint:disable=unused-argument,no-self-use
+        return False
+
+    def on_response(self, request, response):
+        # type: (PipelineRequest, PipelineResponse) -> None
+        """Executed after the request comes back from the next policy.
+
+        :param request: Request to be modified after returning from the policy.
+        :type request: ~azure.core.pipeline.PipelineRequest
+        :param response: Pipeline response object
+        :type response: ~azure.core.pipeline.PipelineResponse
+        """
+
+    def on_exception(self, request):
+        # type: (PipelineRequest) -> bool
+        """Executed when an exception is raised while executing the next policy.
+
+        This method is executed inside the exception handler.
+
+        :param request: The Pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+        :return: False by default, override with True to stop the exception.
+        :rtype: bool
+        """
+        # pylint: disable=no-self-use,unused-argument
         return False
 
 

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -88,6 +88,8 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, SansIOHTTPPo
 
         :param ~azure.core.pipeline.PipelineRequest request: the request
         """
+        self._enforce_https(request)
+
         if self._token is None or self._need_new_token:
             self._token = self._credential.get_token(*self._scopes)
         self._update_headers(request.http_request.headers, self._token.token)
@@ -112,7 +114,6 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, SansIOHTTPPo
         :param request: The pipeline request object
         :type request: ~azure.core.pipeline.PipelineRequest
         """
-        self._enforce_https(request)
         self.on_request(request)
         try:
             response = self.next.send(request)

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -4,14 +4,22 @@
 # license information.
 # -------------------------------------------------------------------------
 import asyncio
+import time
+from typing import TYPE_CHECKING
 
-from azure.core.pipeline import PipelineRequest
-from azure.core.pipeline.policies import SansIOHTTPPolicy
+from azure.core.pipeline.policies import AsyncHTTPPolicy, SansIOHTTPPolicy
 from azure.core.pipeline.policies._authentication import _BearerTokenCredentialPolicyBase
 
+from .._tools_async import await_result
 
-class AsyncBearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, SansIOHTTPPolicy):
-    # pylint:disable=too-few-public-methods
+if TYPE_CHECKING:
+    from typing import Any, Optional
+    from azure.core.credentials import AccessToken
+    from azure.core.credentials_async import AsyncTokenCredential
+    from azure.core.pipeline import PipelineRequest, PipelineResponse
+
+
+class AsyncBearerTokenCredentialPolicy(SansIOHTTPPolicy, AsyncHTTPPolicy):
     """Adds a bearer token Authorization header to requests.
 
     :param credential: The credential.
@@ -19,20 +27,78 @@ class AsyncBearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, SansIOH
     :param str scopes: Lets you specify the type of access needed.
     """
 
-    def __init__(self, credential, *scopes, **kwargs):
-        super().__init__(credential, *scopes, **kwargs)
+    def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs: "Any") -> None:
+        # pylint:disable=unused-argument
+        super().__init__()
+        self._credential = credential
         self._lock = asyncio.Lock()
+        self._scopes = scopes
+        self._token = None  # type: Optional[AccessToken]
 
-    async def on_request(self, request: PipelineRequest):  # pylint:disable=invalid-overridden-method
+    async def on_request(self, request: "PipelineRequest") -> None:  # pylint:disable=invalid-overridden-method
         """Adds a bearer token Authorization header to request and sends request to next policy.
 
         :param request: The pipeline request object to be modified.
         :type request: ~azure.core.pipeline.PipelineRequest
         :raises: :class:`~azure.core.exceptions.ServiceRequestError`
         """
-        self._enforce_https(request)
+        if self._token is None or self._need_new_token():
+            async with self._lock:
+                # double check because another coroutine may have acquired a token while we waited to acquire the lock
+                if self._token is None or self._need_new_token():
+                    self._token = await self._credential.get_token(*self._scopes)
+        request.http_request.headers["Authorization"] = "Bearer " + self._token.token
 
+    async def authorize_request(self, request: "PipelineRequest", *scopes: str, **kwargs: "Any") -> None:
+        """Acquire a token from the credential and authorize the request with it.
+
+        Keyword arguments are passed to the credential's get_token method. The token will be cached and used to
+        authorize future requests.
+
+        :param ~azure.core.pipeline.PipelineRequest request: the request
+        :param str scopes: required scopes of authentication
+        """
         async with self._lock:
-            if self._need_new_token:
-                self._token = await self._credential.get_token(*self._scopes)  # type: ignore
-        self._update_headers(request.http_request.headers, self._token.token)
+            self._token = await self._credential.get_token(*scopes, **kwargs)
+        request.http_request.headers["Authorization"] = "Bearer " + self._token.token
+
+    async def send(self, request: "PipelineRequest") -> "PipelineResponse":
+        """Authorize request with a bearer token and send it to the next policy
+
+        :param request: The pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+        """
+        _BearerTokenCredentialPolicyBase._enforce_https(request)  # pylint:disable=protected-access
+        await await_result(self.on_request, request)
+        try:
+            response = await self.next.send(request)
+            await await_result(self.on_response, request, response)
+        except Exception:  # pylint:disable=broad-except
+            handled = await await_result(self.on_exception, request)
+            if not handled:
+                raise
+        else:
+            if response.http_response.status_code == 401:
+                self._token = None  # any cached token is invalid
+                if "WWW-Authenticate" in response.http_response.headers:
+                    request_authorized = await self.on_challenge(request, response)
+                    if request_authorized:
+                        response = await self.next.send(request)
+                        await await_result(self.on_response, request, response)
+
+        return response
+
+    async def on_challenge(self, request: "PipelineRequest", response: "PipelineResponse") -> bool:
+        """Authorize request according to an authentication challenge
+
+        This method is called when the resource provider responds 401 with a WWW-Authenticate header.
+
+        :param ~azure.core.pipeline.PipelineRequest request: the request which elicited an authentication challenge
+        :param ~azure.core.pipeline.PipelineResponse response: the resource provider's response
+        :returns: a bool indicating whether the policy should send the request
+        """
+        # pylint:disable=unused-argument,no-self-use
+        return False
+
+    def _need_new_token(self) -> bool:
+        return not self._token or self._token.expires_on - time.time() < 300

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -7,19 +7,19 @@ import asyncio
 import time
 from typing import TYPE_CHECKING
 
-from azure.core.pipeline.policies import AsyncHTTPPolicy, SansIOHTTPPolicy
+from azure.core.pipeline.policies import AsyncHTTPPolicy
 from azure.core.pipeline.policies._authentication import _BearerTokenCredentialPolicyBase
 
 from .._tools_async import await_result
 
 if TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Any, Awaitable, Optional, Union
     from azure.core.credentials import AccessToken
     from azure.core.credentials_async import AsyncTokenCredential
     from azure.core.pipeline import PipelineRequest, PipelineResponse
 
 
-class AsyncBearerTokenCredentialPolicy(SansIOHTTPPolicy, AsyncHTTPPolicy):
+class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy):
     """Adds a bearer token Authorization header to requests.
 
     :param credential: The credential.
@@ -99,6 +99,28 @@ class AsyncBearerTokenCredentialPolicy(SansIOHTTPPolicy, AsyncHTTPPolicy):
         :returns: a bool indicating whether the policy should send the request
         """
         # pylint:disable=unused-argument,no-self-use
+        return False
+
+    def on_response(self, request: "PipelineRequest", response: "PipelineResponse") -> "Union[None, Awaitable[None]]":
+        """Executed after the request comes back from the next policy.
+
+        :param request: Request to be modified after returning from the policy.
+        :type request: ~azure.core.pipeline.PipelineRequest
+        :param response: Pipeline response object
+        :type response: ~azure.core.pipeline.PipelineResponse
+        """
+
+    def on_exception(self, request: "PipelineRequest") -> "Union[bool, Awaitable[bool]]":
+        """Executed when an exception is raised while executing the next policy.
+
+        This method is executed inside the exception handler.
+
+        :param request: The Pipeline request object
+        :type request: ~azure.core.pipeline.PipelineRequest
+        :return: False by default, override with True to stop the exception.
+        :rtype: bool
+        """
+        # pylint: disable=no-self-use,unused-argument
         return False
 
     def _need_new_token(self) -> bool:

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -42,6 +42,8 @@ class AsyncBearerTokenCredentialPolicy(SansIOHTTPPolicy, AsyncHTTPPolicy):
         :type request: ~azure.core.pipeline.PipelineRequest
         :raises: :class:`~azure.core.exceptions.ServiceRequestError`
         """
+        _BearerTokenCredentialPolicyBase._enforce_https(request)  # pylint:disable=protected-access
+
         if self._token is None or self._need_new_token():
             async with self._lock:
                 # double check because another coroutine may have acquired a token while we waited to acquire the lock
@@ -68,7 +70,6 @@ class AsyncBearerTokenCredentialPolicy(SansIOHTTPPolicy, AsyncHTTPPolicy):
         :param request: The pipeline request object
         :type request: ~azure.core.pipeline.PipelineRequest
         """
-        _BearerTokenCredentialPolicyBase._enforce_https(request)  # pylint:disable=protected-access
         await await_result(self.on_request, request)
         try:
             response = await self.next.send(request)

--- a/sdk/core/azure-core/tests/test_authentication.py
+++ b/sdk/core/azure-core/tests/test_authentication.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
+import base64
+import itertools
 import time
 
 import azure.core
@@ -10,9 +12,12 @@ from azure.core.credentials import AccessToken, AzureKeyCredential, AzureSasCred
 from azure.core.exceptions import ServiceRequestError
 from azure.core.pipeline import Pipeline
 from azure.core.pipeline.policies import (
-    BearerTokenCredentialPolicy, SansIOHTTPPolicy, AzureKeyCredentialPolicy,
-    AzureSasCredentialPolicy
+    BearerTokenCredentialPolicy,
+    SansIOHTTPPolicy,
+    AzureKeyCredentialPolicy,
+    AzureSasCredentialPolicy,
 )
+from azure.core.pipeline.policies._authentication import _parse_challenges
 from azure.core.pipeline.transport import HttpRequest
 
 import pytest
@@ -31,6 +36,7 @@ def test_bearer_policy_adds_header():
 
     def verify_authorization_header(request):
         assert request.http_request.headers["Authorization"] == "Bearer {}".format(expected_token.token)
+        return Mock()
 
     fake_credential = Mock(get_token=Mock(return_value=expected_token))
     policies = [BearerTokenCredentialPolicy(fake_credential, "scope"), Mock(send=verify_authorization_header)]
@@ -44,6 +50,7 @@ def test_bearer_policy_adds_header():
 
     # Didn't need a new token
     assert fake_credential.get_token.call_count == 1
+
 
 def test_bearer_policy_send():
     """The bearer token policy should invoke the next policy's send method and return the result"""
@@ -89,6 +96,7 @@ def test_bearer_policy_optionally_enforces_https():
 
     def assert_option_popped(request, **kwargs):
         assert "enforce_https" not in kwargs, "BearerTokenCredentialPolicy didn't pop the 'enforce_https' option"
+        return Mock()
 
     credential = Mock(get_token=lambda *_, **__: AccessToken("***", 42))
     pipeline = Pipeline(
@@ -116,8 +124,10 @@ def test_preserves_enforce_https_opt_out():
     class ContextValidator(SansIOHTTPPolicy):
         def on_request(self, request):
             assert "enforce_https" in request.context, "'enforce_https' is not in the request's context"
+            return Mock()
 
-    policies = [BearerTokenCredentialPolicy(credential=Mock(), scope="scope"), ContextValidator()]
+    credential = Mock(get_token=Mock(return_value=AccessToken("***", 42)))
+    policies = [BearerTokenCredentialPolicy(credential, "scope"), ContextValidator()]
     pipeline = Pipeline(transport=Mock(), policies=policies)
 
     pipeline.run(HttpRequest("GET", "http://not.secure"), enforce_https=False)
@@ -130,10 +140,213 @@ def test_context_unmodified_by_default():
         def on_request(self, request):
             assert not any(request.context), "the policy shouldn't add to the request's context"
 
-    policies = [BearerTokenCredentialPolicy(credential=Mock(), scope="scope"), ContextValidator()]
+    credential = Mock(get_token=Mock(return_value=AccessToken("***", 42)))
+    policies = [BearerTokenCredentialPolicy(credential, "scope"), ContextValidator()]
     pipeline = Pipeline(transport=Mock(), policies=policies)
 
     pipeline.run(HttpRequest("GET", "https://secure"))
+
+
+def test_challenge_parsing():
+    challenges = (
+        (  # CAE - insufficient claims
+            'Bearer realm="", authorization_uri="https://login.microsoftonline.com/common/oauth2/authorize", client_id="00000003-0000-0000-c000-000000000000", error="insufficient_claims", claims="eyJhY2Nlc3NfdG9rZW4iOiB7ImZvbyI6ICJiYXIifX0="',
+            {
+                "authorization_uri": "https://login.microsoftonline.com/common/oauth2/authorize",
+                "client_id": "00000003-0000-0000-c000-000000000000",
+                "error": "insufficient_claims",
+                "claims": "eyJhY2Nlc3NfdG9rZW4iOiB7ImZvbyI6ICJiYXIifX0=",
+                "realm": "",
+            },
+        ),
+        (  # CAE - sessions revoked
+            'Bearer authorization_uri="https://login.windows-ppe.net/", error="invalid_token", error_description="User session has been revoked", claims="eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTYwMzc0MjgwMCJ9fX0="',
+            {
+                "authorization_uri": "https://login.windows-ppe.net/",
+                "error": "invalid_token",
+                "error_description": "User session has been revoked",
+                "claims": "eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTYwMzc0MjgwMCJ9fX0=",
+            },
+        ),
+        (  # CAE - IP policy
+            'Bearer authorization_uri="https://login.windows.net/", error="invalid_token", error_description="Tenant IP Policy validate failed.", claims="eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwidmFsdWUiOiIxNjEwNTYzMDA2In0sInhtc19ycF9pcGFkZHIiOnsidmFsdWUiOiIxLjIuMy40In19fQ"',
+            {
+                "authorization_uri": "https://login.windows.net/",
+                "error": "invalid_token",
+                "error_description": "Tenant IP Policy validate failed.",
+                "claims": "eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwidmFsdWUiOiIxNjEwNTYzMDA2In0sInhtc19ycF9pcGFkZHIiOnsidmFsdWUiOiIxLjIuMy40In19fQ"
+            }
+        ),
+        (  # Key Vault
+            'Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47", resource="https://vault.azure.net"',
+            {
+                "authorization": "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "resource": "https://vault.azure.net",
+            },
+        ),
+        (  # ARM
+            'Bearer authorization_uri="https://login.windows.net/", error="invalid_token", error_description="The authentication failed because of missing \'Authorization\' header."',
+            {
+                "authorization_uri": "https://login.windows.net/",
+                "error": "invalid_token",
+                "error_description": "The authentication failed because of missing 'Authorization' header.",
+            },
+        ),
+    )
+
+    for challenge, expected_parameters in challenges:
+        challenge = _parse_challenges(challenge)
+        assert len(challenge) == 1
+        assert challenge[0].scheme == "Bearer"
+        assert challenge[0].parameters == expected_parameters
+
+    for permutation in itertools.permutations(challenge for challenge, _ in challenges):
+        parsed_challenges = _parse_challenges(", ".join(permutation))
+        assert len(parsed_challenges) == len(challenges)
+        expected_parameters = [parameters for _, parameters in challenges]
+        for challenge in parsed_challenges:
+            assert challenge.scheme == "Bearer"
+            expected_parameters.remove(challenge.parameters)
+        assert len(expected_parameters) == 0
+
+
+def test_calls_on_before_request():
+    """BearerTokenCredentialPolicy should call on_before_request before sending a request"""
+
+    transport = Mock()
+
+    class TestPolicy(BearerTokenCredentialPolicy):
+        called = False
+
+        def on_before_request(self, request):
+            assert not transport.send.called
+            self.__class__.called = True
+
+    pipeline = Pipeline(policies=[TestPolicy(Mock(), "scope")], transport=transport)
+    pipeline.run(HttpRequest("GET", "https://localhost"))
+
+    assert TestPolicy.called
+    assert transport.send.call_count == 1
+
+
+def test_calls_on_challenge():
+    """BearerTokenCredentialPolicy should call its on_challenge method when it receives an authentication challenge"""
+
+    class TestPolicy(BearerTokenCredentialPolicy):
+        called = False
+
+        def on_challenge(self, request, challenge):
+            self.__class__.called = True
+            return False
+
+    credential = Mock(get_token=Mock(return_value=AccessToken("***", int(time.time()) + 3600)))
+    policies = [TestPolicy(credential, "scope")]
+    response = Mock(status_code=401, headers={"WWW-Authenticate": 'Basic realm="localhost"'})
+    transport = Mock(send=Mock(return_value=response))
+
+    pipeline = Pipeline(transport=transport, policies=policies)
+    pipeline.run(HttpRequest("GET", "https://localhost"))
+
+    assert TestPolicy.called
+
+
+def test_cannot_complete_challenge():
+    """BearerTokenCredentialPolicy should return the 401 response when it can't complete its challenge"""
+
+    expected_scope = "scope"
+    expected_token = AccessToken("***", int(time.time()) + 3600)
+    credential = Mock(get_token=Mock(return_value=expected_token))
+    expected_response = Mock(status_code=401, headers={"WWW-Authenticate": 'Basic realm="localhost"'})
+    transport = Mock(send=Mock(return_value=expected_response))
+    policies = [BearerTokenCredentialPolicy(credential, expected_scope)]
+
+    pipeline = Pipeline(transport=transport, policies=policies)
+    response = pipeline.run(HttpRequest("GET", "https://localhost"))
+
+    assert response.http_response is expected_response
+    assert transport.send.call_count == 1
+    credential.get_token.assert_called_once_with(expected_scope)
+
+
+def test_claims_challenge():
+    """BearerTokenCredentialPolicy should pass claims from an authentication challenge to its credential"""
+
+    first_token = AccessToken("first", int(time.time()) + 3600)
+    second_token = AccessToken("second", int(time.time()) + 3600)
+    tokens = (t for t in (first_token, second_token))
+
+    expected_claims = '{"access_token": {"essential": "true"}'
+    expected_scope = "scope"
+
+    challenge = 'Bearer claims="{}"'.format(base64.b64encode(expected_claims.encode()).decode())
+    responses = (r for r in (Mock(status_code=401, headers={"WWW-Authenticate": challenge}), Mock(status_code=200)))
+
+    def send(request):
+        res = next(responses)
+        if res.status_code == 401:
+            expected_token = first_token.token
+        else:
+            expected_token = second_token.token
+        assert request.headers["Authorization"] == "Bearer " + expected_token
+
+        return res
+
+    def get_token(*scopes, **kwargs):
+        assert scopes == (expected_scope,)
+        return next(tokens)
+
+    credential = Mock(get_token=Mock(wraps=get_token))
+    transport = Mock(send=Mock(wraps=send))
+    policies = [BearerTokenCredentialPolicy(credential, expected_scope)]
+    pipeline = Pipeline(transport=transport, policies=policies)
+
+    response = pipeline.run(HttpRequest("GET", "https://localhost"))
+
+    assert response.http_response.status_code == 200
+    assert transport.send.call_count == 2
+    assert credential.get_token.call_count == 2
+    credential.get_token.assert_called_with(expected_scope, claims_challenge=expected_claims)
+    with pytest.raises(StopIteration):
+        next(tokens)
+    with pytest.raises(StopIteration):
+        next(responses)
+
+
+def test_calls_prior_base_class_methods():
+    """Backcompat requires BearerTokenCredentialPolicy to behave like SansIOHttpPolicy"""
+
+    class TestPolicy(BearerTokenCredentialPolicy):
+        def __init__(self, *args, **kwargs):
+            super(TestPolicy, self).__init__(*args, **kwargs)
+            self.on_exception = Mock(return_value=None)
+            self.on_request = Mock()
+            self.on_response = Mock()
+
+        def send(self, request):
+            self.request = request
+            self.response = super(TestPolicy, self).send(request)
+            return self.response
+
+    credential = Mock(get_token=Mock(return_value=AccessToken("***", int(time.time()) + 3600)))
+    policy = TestPolicy(credential, "scope")
+    transport = Mock(send=Mock(return_value=Mock(status_code=200)))
+
+    pipeline = Pipeline(transport=transport, policies=[policy])
+    pipeline.run(HttpRequest("GET", "https://localhost"))
+
+    policy.on_request.assert_called_once_with(policy.request)
+    policy.on_response.assert_called_once_with(policy.request, policy.response)
+
+    # on_exception should be called when send() raises
+    class TestException(Exception):
+        pass
+
+    credential = Mock(get_token=Mock(side_effect=TestException))
+    policy = TestPolicy(credential, "scope")
+    pipeline = Pipeline(transport=transport, policies=[policy])
+    with pytest.raises(TestException):
+        pipeline.run(HttpRequest("GET", "https://localhost"))
+    policy.on_exception.assert_called_once_with(policy.request)
 
 
 @pytest.mark.skipif(azure.core.__version__ >= "2", reason="this test applies only to azure-core 1.x")
@@ -156,6 +369,7 @@ def test_key_vault_regression():
     assert not policy._need_new_token
     assert policy._token.token == token
 
+
 def test_azure_key_credential_policy():
     """Tests to see if we can create an AzureKeyCredentialPolicy"""
 
@@ -165,12 +379,13 @@ def test_azure_key_credential_policy():
     def verify_authorization_header(request):
         assert request.headers[key_header] == api_key
 
-    transport=Mock(send=verify_authorization_header)
+    transport = Mock(send=verify_authorization_header)
     credential = AzureKeyCredential(api_key)
     credential_policy = AzureKeyCredentialPolicy(credential=credential, name=key_header)
     pipeline = Pipeline(transport=transport, policies=[credential_policy])
 
     pipeline.run(HttpRequest("GET", "https://test_key_credential"))
+
 
 def test_azure_key_credential_policy_raises():
     """Tests AzureKeyCredential and AzureKeyCredentialPolicy raises with non-string input parameters."""
@@ -182,6 +397,7 @@ def test_azure_key_credential_policy_raises():
     credential = AzureKeyCredential(str(api_key))
     with pytest.raises(TypeError):
         credential_policy = AzureKeyCredentialPolicy(credential=credential, name=key_header)
+
 
 def test_azure_key_credential_updates():
     """Tests AzureKeyCredential updates"""


### PR DESCRIPTION
When its on_challenge method is not overridden, the ChallengeAuthenticationPolicy proposed in #17489 is functionally equivalent to the existing BearerTokenCredentialPolicy. It's reasonable then to wonder how the existing policy would look when extended to handle authentication challenges. Short answer: it would look something like this 😉