### PR TITLE
Add spellcheck for modified files

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "language": "en",
+  "languageId": "python",
+  "dictionaries": [
+    "powershell"
+  ],
+  "ignorePaths": [
+ 
+  ],
+  "words": [],
+  "allowCompoundWords": false
+}

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -6,8 +6,8 @@
     "powershell"
   ],
   "ignorePaths": [
- 
+    ".vscode/cspell.json"
   ],
-  "words": [],
+  "words": ["azsdk", "conda"],
   "allowCompoundWords": false
 }

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -8,6 +8,6 @@
   "ignorePaths": [
     ".vscode/cspell.json"
   ],
-  "words": ["azsdk", "conda"],
+  "words": ["azsdk", "conda", "tenvparallel"],
   "allowCompoundWords": false
 }

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -86,6 +86,8 @@ jobs:
       vmImage: MMSUbuntu18.04
 
     steps:
+    - template: /eng/common/pipelines/templates/steps/check-spelling.yml
+
     - template: /eng/common/pipelines/templates/steps/verify-links.yml
       parameters:
         ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:


### PR DESCRIPTION
Example spelling error warning: 

![image](https://user-images.githubusercontent.com/2158838/116761539-ce083900-a9cc-11eb-90b1-331d092534be.png)

Adding this in does not block the build or turn the build yellow/red. Additional information at: https://aka.ms/azsdk/engsys/spellcheck