### PR TITLE
[Service Bus] fix async auth test

### DIFF
--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_auth_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_auth_async.py
@@ -122,9 +122,10 @@ class AsyncEventHubAuthTests(AzureMgmtTestCase):
             batch.add(EventData(body='A single message'))
             await producer_client.send_batch(batch)
 
+        credential = EventHubSharedKeyCredential(eventhub_namespace_key_name, eventhub_namespace_primary_key)
         hostname = "{}.servicebus.windows.net".format(eventhub_namespace.name)
         auth_uri = "sb://{}/{}".format(hostname, eventhub.name)
-        token = (await credential.get_token(auth_uri)).token
+        token = (await credential.get_token(auth_uri)).token.decode()
         producer_client = EventHubProducerClient(fully_qualified_namespace=hostname,
                                                  eventhub_name=eventhub.name,
                                                  credential=AzureSasCredential(token))


### PR DESCRIPTION
found that `test_auth_async/test_client_azure_sas_credential_async` was failing in the uamqp pipeline, but was getting skipped in the eventhub livetest pipeline for some reason.