### PR TITLE
Raise CredentialUnavailableError when CLI subprocess times out

### DIFF
--- a/sdk/identity/azure-identity/tests/test_cli_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential_async.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import asyncio
 from datetime import datetime
 import json
 import sys
@@ -168,3 +169,15 @@ async def test_subprocess_error_does_not_expose_token(output):
 
     assert "secret value" not in str(ex.value)
     assert "secret value" not in repr(ex.value)
+
+
+async def test_timeout():
+    """The credential should kill the subprocess after a timeout"""
+
+    proc = mock.Mock(communicate=mock.Mock(side_effect=asyncio.TimeoutError), returncode=None)
+    with mock.patch(SUBPROCESS_EXEC, mock.Mock(return_value=get_completed_future(proc))):
+        with pytest.raises(CredentialUnavailableError):
+            await AzureCliCredential().get_token("scope")
+
+    assert proc.communicate.call_count == 1
+    assert proc.kill.call_count == 1


### PR DESCRIPTION
Currently AzureCliCredential instead raises `subprocess.TimeoutExpired` or `asyncio.TimeoutError`, either of which would cause DefaultAzureCredential to fail rather than try the next credential in its chain. I imagine no one's reported this because AzureCliCredential is the last credential in the default chain. However, it could affect an application using ChainedTokenCredential directly and is incorrect behavior in any event.

While I was at it I also updated the async credential to kill subprocesses that time out.