### PR TITLE
[Test Infra] adding operation-location to headers that are scrubbed

### DIFF
--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/recording_processors.py
@@ -216,6 +216,7 @@ class GeneralNameReplacer(RecordingProcessor):
                     body = response['body']['string']
                     response['body']['string'].decode('utf8', 'backslashreplace').replace(old, new).encode('utf8', 'backslashreplace')
             self.replace_header(response, 'location', old, new)
+            self.replace_header(response, 'operation-location', old, new)
             self.replace_header(response, 'azure-asyncoperation', old, new)
 
         return response


### PR DESCRIPTION
Found when working with @iscai-msft that some services provide the next URL in the `operation-location` header, which can leak accounts and specific job details. Adding this to the headers that are scrubbed the same way `location` is.