### PR TITLE
Fix sample by truncating iot hub name to 25 chars

### DIFF
--- a/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
+++ b/sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py
@@ -84,7 +84,7 @@ def convert_iothub_to_eventhub_conn_str(iothub_conn_str):
             fully_qualified_name,
             shared_access_key_name,
             shared_access_key,
-            iot_hub_name
+            iot_hub_name[:25]
         )
     except Exception as exp:
         raise ValueError(


### PR DESCRIPTION
I had trouble running the event hub sample for retrieving messages from the built-in endpoint of an IoT hub. An earlier version of the sdk had integrated support to create a receiver from an iot hub connection string (`EventHubClient.from_iothub_connection_string()`) but it seems like that has been removed?

The sample `sdk/eventhub/azure-eventhub/samples/async_samples/iot_hub_connection_string_receive_async.py` has methods to generate an event hub connection string from an iot hub connection string - but apparently there is a bug.

The `EntityPath` part of the connection string has to be truncated to 25 characters, otherwise the sample fails with the following messages:

```shell
Authentication Put-Token failed. Retries exhausted.
Authentication Put-Token failed. Retries exhausted.
Authentication Put-Token failed. Retries exhausted.
Authentication Put-Token failed. Retries exhausted.
EventProcessor instance '<snip>' of eventhub '<snip>-test-iothub' consumer group '$Default'. An error occurred while load-balancing and claiming ownership. The exception is AuthenticationError("The messaging entity 'sb://iothub-ns-<snip>.servicebus.windows.net/<snip>-test-iothub' could not be found. To know more visit https://aka.ms/sbResourceMgrExceptions.  TrackingId:<snip>, Timestamp:2021-05-05T22:15:29
CBS Token authentication failed.
Status code: 404
Description: The messaging entity 'sb://iothub-ns-<snip>.servicebus.windows.net/<snip>-test-iothub' could not be found. To know more visit https://aka.ms/sbResourceMgrExceptions.  TrackingId:<snip>, Timestamp:2021-05-05T22:15:29 occurred during the load balance process.
```

I validated the 25 char limit by manually retrieving the event hub compatible connection string from the iot hub page of the azure portal