### PR TITLE
Remove unused parameters in docs-metadata-release template

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -179,13 +179,11 @@ stages:
                           ReleaseSha: $(Build.SourceVersion)
                           RepoId: Azure/azure-sdk-for-python
                           WorkingDirectory: $(System.DefaultWorkingDirectory)
-                          TargetDocRepo: 'MicrosoftDocs/azure-docs-sdk-python'
                           TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
                           TargetDocRepoName: ${{parameters.TargetDocRepoName}}
                           PRBranchName: onboarding-${{artifact.name}}-$(Build.BuildId)
                           ArtifactName: ${{artifact.name}}
                           Language: 'python'
-                          ServiceDirectory: ${{ parameters.ServiceDirectory }}
                           DocRepoDestinationPath: 'docs-ref-services/'
                           GHReviewersVariable: 'OwningGHUser'
                           CIConfigs: $(CIConfigs)


### PR DESCRIPTION
These parameters are unused, and it's causing some template validation errors against https://github.com/Azure/azure-sdk-tools/pull/1585/, which uses a more strict parameter checking syntax.