### PR TITLE
Retry policies don't sleep after operations time out

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py
@@ -454,11 +454,8 @@ class RetryPolicy(RetryPolicyBase, HTTPPolicy):
                 # the authentication policy failed such that the client's request can't
                 # succeed--we'll never have a response to it, so propagate the exception
                 raise
-            except (ServiceRequestTimeoutError, ServiceResponseTimeoutError):
-                # absolute_timeout <= 0, i.e. the operation has timed out; the policy should not retry
-                raise
             except AzureError as err:
-                if self._is_method_retryable(retry_settings, request.http_request):
+                if absolute_timeout > 0 and self._is_method_retryable(retry_settings, request.http_request):
                     retry_active = self.increment(retry_settings, response=request, error=err)
                     if retry_active:
                         self.sleep(retry_settings, request.context.transport)

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py
@@ -454,6 +454,9 @@ class RetryPolicy(RetryPolicyBase, HTTPPolicy):
                 # the authentication policy failed such that the client's request can't
                 # succeed--we'll never have a response to it, so propagate the exception
                 raise
+            except (ServiceRequestTimeoutError, ServiceResponseTimeoutError):
+                # absolute_timeout <= 0, i.e. the operation has timed out; the policy should not retry
+                raise
             except AzureError as err:
                 if self._is_method_retryable(retry_settings, request.http_request):
                     retry_active = self.increment(retry_settings, response=request, error=err)

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_retry_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_retry_async.py
@@ -35,6 +35,8 @@ from azure.core.exceptions import (
     AzureError,
     ClientAuthenticationError,
     ServiceRequestError,
+    ServiceRequestTimeoutError,
+    ServiceResponseTimeoutError
 )
 from ._base_async import AsyncHTTPPolicy
 from ._retry import RetryPolicyBase
@@ -155,6 +157,9 @@ class AsyncRetryPolicy(RetryPolicyBase, AsyncHTTPPolicy):
             except ClientAuthenticationError:  # pylint:disable=try-except-raise
                 # the authentication policy failed such that the client's request can't
                 # succeed--we'll never have a response to it, so propagate the exception
+                raise
+            except (ServiceRequestTimeoutError, ServiceResponseTimeoutError):
+                # absolute_timeout <= 0, i.e. the operation has timed out; the policy should not retry
                 raise
             except AzureError as err:
                 if self._is_method_retryable(retry_settings, request.http_request):


### PR DESCRIPTION
After an operation times out, `_configure_timeout` raises a subclass of AzureError. Async/RetryPolicy handles AzureError by sleeping and continuing the retry_active loop. The policy won't actually send another request, because `_configure_timeout` will raise at the start of every loop iteration, but it will pointlessly sleep after each iteration until it exhausts its allowed retries.

This PR prevents this pointless sleeping by re-raising `_configure_timeout` exceptions. This is safe today because no other policy raises those exceptions. For example, transports raise ServiceRequest/ResponseError when connections time out. However, in principle something downstream from RetryPolicy could raise e.g. ServiceResponseTimeoutError given a request that should be retried; with this change, the request would not be retried. I don't expect that scenario, but I point out the possibility so you can disagree with me as you like 😸