### PR TITLE
Lower retry backoff factor for IMDS managed identity

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/imds.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/imds.py
@@ -25,7 +25,7 @@ IMDS_URL = "http://169.254.169.254/metadata/identity/oauth2/token"
 
 PIPELINE_SETTINGS = {
     "connection_timeout": 2,
-    "retry_backoff_factor": 1.1,
+    "retry_backoff_factor": 2,
     "retry_backoff_max": 60,
     "retry_on_status_codes": [404, 429] + list(range(500, 600)),
     "retry_status": 5,

--- a/sdk/identity/azure-identity/azure/identity/_credentials/imds.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/imds.py
@@ -25,7 +25,7 @@ IMDS_URL = "http://169.254.169.254/metadata/identity/oauth2/token"
 
 PIPELINE_SETTINGS = {
     "connection_timeout": 2,
-    "retry_backoff_factor": 4,
+    "retry_backoff_factor": 1.1,
     "retry_backoff_max": 60,
     "retry_on_status_codes": [404, 429] + list(range(500, 600)),
     "retry_status": 5,


### PR DESCRIPTION
IMDS has [particular retry guidance](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#retry-guidance) which ImdsCredential attempts to follow. However, its current backoff factor is too high. The guidance suggests retrying after approximately 2, 6, 14, 30 seconds but the credential waits 8, 16, 32, 60 seconds. The curve of our retry policy's backoff function doesn't match what IMDS has in mind, so we can't follow the guidance exactly, but we can do better. In particular, we shouldn't wait 8 seconds before the first retry. With this PR, the credential waits 2.2, 4.4, 8.8, 17.6 seconds.