### PR TITLE
Revert "[pipeline]bump autorest version from '3.3.0' to '3.4.2'"

### DIFF
--- a/swagger_to_sdk_config_autorest.json
+++ b/swagger_to_sdk_config_autorest.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "autorest_options": {
-      "version": "3.4.2",
+      "version": "3.3.0",
       "use": "@autorest/python@5.6.6",
       "python": "",
       "python-mode": "update",


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-python#18659