### PR TITLE
[pipeline]bump autorest version from '3.3.0' to '3.4.2'

### DIFF
--- a/swagger_to_sdk_config_autorest.json
+++ b/swagger_to_sdk_config_autorest.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "autorest_options": {
-      "version": "3.3.0",
+      "version": "3.4.2",
       "use": "@autorest/python@5.6.6",
       "python": "",
       "python-mode": "update",

--- a/tools/azure-sdk-tools/packaging_tools/swaggertosdk/SwaggerToSdkCore.py
+++ b/tools/azure-sdk-tools/packaging_tools/swaggertosdk/SwaggerToSdkCore.py
@@ -231,6 +231,8 @@ def build_swaggertosdk_conf_from_json_readme(readme_file, sdk_git_id, config, ba
     sdk_git_short_id = sdk_git_id.split("/")[-1].lower()
     _LOGGER.info("Looking for tag {} in readme {}".format(sdk_git_short_id, readme_file))
     for swagger_to_sdk_conf in readme_as_conf:
+        if not isinstance(swagger_to_sdk_conf, dict):
+            continue
         repo = swagger_to_sdk_conf.get("repo", "")
         repo = repo.split("/")[-1].lower() # Be sure there is no org/login part
         if repo == sdk_git_short_id:


### PR DESCRIPTION
test link: https://github.com/openapi-env-test/azure-rest-api-specs/pull/2872