### PR TITLE
Add python to Spell Check dictionaries.

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -3,7 +3,8 @@
   "language": "en",
   "languageId": "python",
   "dictionaries": [
-    "powershell"
+    "powershell",
+    "python"
   ],
   "ignorePaths": [
     "**/tests/recordings/**",


### PR DESCRIPTION
Some words like 'venv' or 'pylint' are not in the python dictionary so they are still gonna show up as a spell error.

Closes #18674