### PR TITLE
Adding mindependency to the default set of PR tests

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -74,7 +74,7 @@ jobs:
         TestPipeline: ${{ parameters.TestPipeline }}
 
     - pwsh: |
-        $toxenvvar = "whl,sdist"
+        $toxenvvar = "whl,sdist,mindependency"
         if ('$(System.TeamProject)' -eq 'internal') {
           $toxenvvar = "whl,sdist,depends,latestdependency,mindependency,whl_no_aio"
         }


### PR DESCRIPTION
Worst case, this adds 50% extra runtime to the PR process. Before this PR, we were running two environments on dual-core test agents.

Given that we have added a 3rd, it's anywhere south of 50% extra time to complete these extra tests. 