### PR TITLE
[formrecognizer] update samples to train a model where a model_id is needed

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/README.md
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/README.md
@@ -44,7 +44,7 @@ All of these samples need the endpoint to your Form Recognizer resource ([instru
 1. Install the Azure Form Recognizer client library for Python with [pip][pip]:
 
 ```bash
-pip install azure-ai-formrecognizer --pre
+pip install azure-ai-formrecognizer
 ```
 
 2. Clone or download this sample repository

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_authentication_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_authentication_async.py
@@ -28,7 +28,6 @@ USAGE:
     3) AZURE_CLIENT_ID - the client ID of your active directory application.
     4) AZURE_TENANT_ID - the tenant ID of your active directory application.
     5) AZURE_CLIENT_SECRET - the secret of your active directory application.
-    6) AZURE_FORM_RECOGNIZER_AAD_ENDPOINT - the endpoint to your Form Recognizer resource for using AAD.
 """
 
 import os
@@ -60,7 +59,7 @@ class AuthenticationSampleAsync(object):
         from azure.ai.formrecognizer.aio import FormRecognizerClient
         from azure.identity.aio import DefaultAzureCredential
 
-        endpoint = os.environ["AZURE_FORM_RECOGNIZER_AAD_ENDPOINT"]
+        endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         credential = DefaultAzureCredential()
 
         form_recognizer_client = FormRecognizerClient(endpoint, credential)
@@ -89,7 +88,7 @@ class AuthenticationSampleAsync(object):
         from azure.ai.formrecognizer.aio import FormTrainingClient
         from azure.identity.aio import DefaultAzureCredential
 
-        endpoint = os.environ["AZURE_FORM_RECOGNIZER_AAD_ENDPOINT"]
+        endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         credential = DefaultAzureCredential()
 
         form_training_client = FormTrainingClient(endpoint, credential)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_copy_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_copy_model_async.py
@@ -28,7 +28,7 @@ USAGE:
     5) AZURE_SOURCE_MODEL_ID - the model ID from the source resource to be copied over to the target resource.
         - OR -
        CONTAINER_SAS_URL - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
-       A model will be trained and used to to run the sample.
+       A model will be trained and used to run the sample.
     6) AZURE_FORM_RECOGNIZER_TARGET_REGION - the region the target resource was created in
     7) AZURE_FORM_RECOGNIZER_TARGET_RESOURCE_ID - the entire resource ID to the target resource
 """
@@ -47,7 +47,7 @@ class CopyModelSampleAsync(object):
         source_key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
         target_endpoint = os.environ["AZURE_FORM_RECOGNIZER_TARGET_ENDPOINT"]
         target_key = os.environ["AZURE_FORM_RECOGNIZER_TARGET_KEY"]
-        source_model_id = os.getenv("AZURE_SOURCE_MODEL_ID") or custom_model_id
+        source_model_id = os.getenv("AZURE_SOURCE_MODEL_ID", custom_model_id)
         target_region = os.environ["AZURE_FORM_RECOGNIZER_TARGET_REGION"]
         target_resource_id = os.environ["AZURE_FORM_RECOGNIZER_TARGET_RESOURCE_ID"]
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_copy_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_copy_model_async.py
@@ -14,6 +14,9 @@ DESCRIPTION:
     to a target Form Recognizer resource. The resource id and the resource region can be found
     in the azure portal.
 
+    The model used in this sample can be created in the sample_train_model_with_labels_async.py using the
+    training files in http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+
 USAGE:
     python sample_copy_model_async.py
 
@@ -25,6 +28,7 @@ USAGE:
     5) AZURE_SOURCE_MODEL_ID - the model ID from the source resource to be copied over to the target resource.
         - OR -
        CONTAINER_SAS_URL - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
+       A model will be trained and used to to run the sample.
     6) AZURE_FORM_RECOGNIZER_TARGET_REGION - the region the target resource was created in
     7) AZURE_FORM_RECOGNIZER_TARGET_RESOURCE_ID - the entire resource ID to the target resource
 """
@@ -92,7 +96,8 @@ async def main():
             endpoint=endpoint, credential=AzureKeyCredential(key)
         )
         async with form_training_client:
-            model = await (await form_training_client.begin_training(os.getenv("CONTAINER_SAS_URL"), use_training_labels=True)).result()
+            model = await (await form_training_client.begin_training(
+                os.getenv("CONTAINER_SAS_URL"), use_training_labels=True)).result()
             model_id = model.model_id
 
     await sample.copy_model_async(model_id)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_copy_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_copy_model_async.py
@@ -43,7 +43,7 @@ class CopyModelSampleAsync(object):
         source_key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
         target_endpoint = os.environ["AZURE_FORM_RECOGNIZER_TARGET_ENDPOINT"]
         target_key = os.environ["AZURE_FORM_RECOGNIZER_TARGET_KEY"]
-        source_model_id = os.environ["AZURE_SOURCE_MODEL_ID"] or custom_model_id
+        source_model_id = os.getenv("AZURE_SOURCE_MODEL_ID") or custom_model_id
         target_region = os.environ["AZURE_FORM_RECOGNIZER_TARGET_REGION"]
         target_resource_id = os.environ["AZURE_FORM_RECOGNIZER_TARGET_RESOURCE_ID"]
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_copy_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_copy_model_async.py
@@ -15,7 +15,7 @@ DESCRIPTION:
     in the azure portal.
 
     The model used in this sample can be created in the sample_train_model_with_labels_async.py using the
-    training files in http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+    training files in https://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
 USAGE:
     python sample_copy_model_async.py

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_copy_model_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_copy_model_async.py
@@ -23,6 +23,8 @@ USAGE:
     3) AZURE_FORM_RECOGNIZER_TARGET_ENDPOINT - the endpoint to your target Form Recognizer resource.
     4) AZURE_FORM_RECOGNIZER_TARGET_KEY - your target Form Recognizer API key
     5) AZURE_SOURCE_MODEL_ID - the model ID from the source resource to be copied over to the target resource.
+        - OR -
+       CONTAINER_SAS_URL - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
     6) AZURE_FORM_RECOGNIZER_TARGET_REGION - the region the target resource was created in
     7) AZURE_FORM_RECOGNIZER_TARGET_RESOURCE_ID - the entire resource ID to the target resource
 """
@@ -33,7 +35,7 @@ import asyncio
 
 class CopyModelSampleAsync(object):
 
-    async def copy_model_async(self):
+    async def copy_model_async(self, custom_model_id):
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.formrecognizer.aio import FormTrainingClient
 
@@ -41,7 +43,7 @@ class CopyModelSampleAsync(object):
         source_key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
         target_endpoint = os.environ["AZURE_FORM_RECOGNIZER_TARGET_ENDPOINT"]
         target_key = os.environ["AZURE_FORM_RECOGNIZER_TARGET_KEY"]
-        source_model_id = os.environ["AZURE_SOURCE_MODEL_ID"]
+        source_model_id = os.environ["AZURE_SOURCE_MODEL_ID"] or custom_model_id
         target_region = os.environ["AZURE_FORM_RECOGNIZER_TARGET_REGION"]
         target_resource_id = os.environ["AZURE_FORM_RECOGNIZER_TARGET_RESOURCE_ID"]
 
@@ -74,7 +76,26 @@ class CopyModelSampleAsync(object):
 
 async def main():
     sample = CopyModelSampleAsync()
-    await sample.copy_model_async()
+    model_id = None
+    if os.getenv("CONTAINER_SAS_URL"):
+
+        from azure.core.credentials import AzureKeyCredential
+        from azure.ai.formrecognizer.aio import FormTrainingClient
+
+        endpoint = os.getenv("AZURE_FORM_RECOGNIZER_ENDPOINT")
+        key = os.getenv("AZURE_FORM_RECOGNIZER_KEY")
+
+        if not endpoint or not key:
+            raise ValueError("Please provide endpoint and API key to run the samples.")
+
+        form_training_client = FormTrainingClient(
+            endpoint=endpoint, credential=AzureKeyCredential(key)
+        )
+        async with form_training_client:
+            model = await (await form_training_client.begin_training(os.getenv("CONTAINER_SAS_URL"), use_training_labels=True)).result()
+            model_id = model.model_id
+
+    await sample.copy_model_async(model_id)
 
 
 if __name__ == '__main__':

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_labeled_tables_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_labeled_tables_async.py
@@ -31,11 +31,11 @@ USAGE:
     3) MODEL_ID_FIXED_ROW_TABLES - the ID of your custom model trained with labels on fixed row tables
             -OR-
        CONTAINER_SAS_URL_FIXED - The shared access signature (SAS) Url of your Azure Blob Storage container with
-       your labeled data containing a fixed row table. A model will be trained and used to to run the sample.
+       your labeled data containing a fixed row table. A model will be trained and used to run the sample.
     4) MODEL_ID_DYNAMIC_ROW_TABLES - the ID of your custom model trained with labels on dynamic row tables
             -OR-
        CONTAINER_SAS_URL_DYNAMIC - The shared access signature (SAS) Url of your Azure Blob Storage container with
-       your labeled data containing a dynamic row table. A model will be trained and used to to run the sample.
+       your labeled data containing a dynamic row table. A model will be trained and used to run the sample.
 """
 
 import os
@@ -50,7 +50,7 @@ class TestDifferentiateOutputLabeledTablesAsync(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id_fixed_rows_table = os.getenv("MODEL_ID_FIXED_ROW_TABLES") or custom_model_id
+        model_id_fixed_rows_table = os.getenv("MODEL_ID_FIXED_ROW_TABLES", custom_model_id)
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)
@@ -93,7 +93,7 @@ class TestDifferentiateOutputLabeledTablesAsync(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id_dynamic_rows_table = os.getenv("MODEL_ID_DYNAMIC_ROW_TABLES") or custom_model_id
+        model_id_dynamic_rows_table = os.getenv("MODEL_ID_DYNAMIC_ROW_TABLES", custom_model_id)
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_labeled_tables_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_labeled_tables_async.py
@@ -12,9 +12,8 @@ FILE: sample_differentiate_output_labeled_tables_async.py
 DESCRIPTION:
     This sample demonstrates the differences in output that arise when begin_recognize_custom_forms
     is called with custom models trained with fixed vs. dynamic table tags.
-    The models used in this sample can be created in the sample_train_model_with_labels.py using the
-    training files in
-    https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_forms/labeled_tables
+    The models used in this sample can be created in the sample_train_model_with_labels_async.py using the
+    training files in http://aka.ms/azsdk/formrecognizer/sampletabletrainingfiles
 
     Note that Form Recognizer automatically finds and extracts all tables in your documents whether the tables
     are tagged/labeled or not. Tables extracted automatically by Form Recognizer will be included in the
@@ -31,10 +30,12 @@ USAGE:
     2) AZURE_FORM_RECOGNIZER_KEY - your Form Recognizer API key
     3) MODEL_ID_FIXED_ROW_TABLES - the ID of your custom model trained with labels on fixed row tables
             -OR-
-       CONTAINER_SAS_URL_FIXED - The shared access signature (SAS) Url of your Azure Blob Storage container with your labeled data.
+       CONTAINER_SAS_URL_FIXED - The shared access signature (SAS) Url of your Azure Blob Storage container with
+       your labeled data containing a fixed row table. A model will be trained and used to to run the sample.
     4) MODEL_ID_DYNAMIC_ROW_TABLES - the ID of your custom model trained with labels on dynamic row tables
             -OR-
-       CONTAINER_SAS_URL_DYNAMIC - The shared access signature (SAS) Url of your Azure Blob Storage container with your labeled data.
+       CONTAINER_SAS_URL_DYNAMIC - The shared access signature (SAS) Url of your Azure Blob Storage container with
+       your labeled data containing a dynamic row table. A model will be trained and used to to run the sample.
 """
 
 import os

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_labeled_tables_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_labeled_tables_async.py
@@ -49,7 +49,7 @@ class TestDifferentiateOutputLabeledTablesAsync(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id_fixed_rows_table = os.environ["MODEL_ID_FIXED_ROW_TABLES"] or custom_model_id
+        model_id_fixed_rows_table = os.getenv("MODEL_ID_FIXED_ROW_TABLES") or custom_model_id
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)
@@ -92,7 +92,7 @@ class TestDifferentiateOutputLabeledTablesAsync(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id_dynamic_rows_table = os.environ["MODEL_ID_DYNAMIC_ROW_TABLES"] or custom_model_id
+        model_id_dynamic_rows_table = os.getenv("MODEL_ID_DYNAMIC_ROW_TABLES") or custom_model_id
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_labeled_tables_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_labeled_tables_async.py
@@ -30,7 +30,11 @@ USAGE:
     1) AZURE_FORM_RECOGNIZER_ENDPOINT - the endpoint to your Cognitive Services resource.
     2) AZURE_FORM_RECOGNIZER_KEY - your Form Recognizer API key
     3) MODEL_ID_FIXED_ROW_TABLES - the ID of your custom model trained with labels on fixed row tables
+            -OR-
+       CONTAINER_SAS_URL_FIXED - The shared access signature (SAS) Url of your Azure Blob Storage container with your labeled data.
     4) MODEL_ID_DYNAMIC_ROW_TABLES - the ID of your custom model trained with labels on dynamic row tables
+            -OR-
+       CONTAINER_SAS_URL_DYNAMIC - The shared access signature (SAS) Url of your Azure Blob Storage container with your labeled data.
 """
 
 import os
@@ -39,13 +43,13 @@ import asyncio
 
 class TestDifferentiateOutputLabeledTablesAsync(object):
 
-    async def test_recognize_tables_fixed_rows_async(self):
+    async def test_recognize_tables_fixed_rows_async(self, custom_model_id):
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.formrecognizer.aio import FormRecognizerClient
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id_fixed_rows_table = os.environ["MODEL_ID_FIXED_ROW_TABLES"]
+        model_id_fixed_rows_table = os.environ["MODEL_ID_FIXED_ROW_TABLES"] or custom_model_id
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)
@@ -82,13 +86,13 @@ class TestDifferentiateOutputLabeledTablesAsync(object):
                         field.confidence
                     ))
 
-    async def test_recognize_tables_dynamic_rows_async(self):
+    async def test_recognize_tables_dynamic_rows_async(self, custom_model_id):
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.formrecognizer.aio import FormRecognizerClient
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id_dynamic_rows_table = os.environ["MODEL_ID_DYNAMIC_ROW_TABLES"]
+        model_id_dynamic_rows_table = os.environ["MODEL_ID_DYNAMIC_ROW_TABLES"] or custom_model_id
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)
@@ -128,8 +132,35 @@ class TestDifferentiateOutputLabeledTablesAsync(object):
 
 async def main():
     sample = TestDifferentiateOutputLabeledTablesAsync()
-    await sample.test_recognize_tables_fixed_rows_async()
-    await sample.test_recognize_tables_dynamic_rows_async()
+    fixed_model_id = None
+    dynamic_model_id = None
+    if os.getenv("CONTAINER_SAS_URL_FIXED") or os.getenv("CONTAINER_SAS_URL_DYNAMIC"):
+
+        from azure.core.credentials import AzureKeyCredential
+        from azure.ai.formrecognizer.aio import FormTrainingClient
+
+        endpoint = os.getenv("AZURE_FORM_RECOGNIZER_ENDPOINT")
+        key = os.getenv("AZURE_FORM_RECOGNIZER_KEY")
+        fixed = os.getenv("CONTAINER_SAS_URL_FIXED")
+        dynamic = os.getenv("CONTAINER_SAS_URL_DYNAMIC")
+
+        if not endpoint or not key:
+            raise ValueError("Please provide endpoint and API key to run the samples.")
+
+        form_training_client = FormTrainingClient(
+            endpoint=endpoint, credential=AzureKeyCredential(key)
+        )
+
+        async with form_training_client:
+            if fixed:
+                model = await (await form_training_client.begin_training(fixed, use_training_labels=True)).result()
+                fixed_model_id = model.model_id
+            if dynamic:
+                model = await (await form_training_client.begin_training(dynamic, use_training_labels=True)).result()
+                dynamic_model_id = model.model_id
+
+    await sample.test_recognize_tables_fixed_rows_async(fixed_model_id)
+    await sample.test_recognize_tables_dynamic_rows_async(dynamic_model_id)
 
 
 if __name__ == '__main__':

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_labeled_tables_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_labeled_tables_async.py
@@ -13,7 +13,7 @@ DESCRIPTION:
     This sample demonstrates the differences in output that arise when begin_recognize_custom_forms
     is called with custom models trained with fixed vs. dynamic table tags.
     The models used in this sample can be created in the sample_train_model_with_labels_async.py using the
-    training files in http://aka.ms/azsdk/formrecognizer/sampletabletrainingfiles
+    training files in https://aka.ms/azsdk/formrecognizer/sampletabletrainingfiles
 
     Note that Form Recognizer automatically finds and extracts all tables in your documents whether the tables
     are tagged/labeled or not. Tables extracted automatically by Form Recognizer will be included in the

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_models_trained_with_and_without_labels_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_models_trained_with_and_without_labels_async.py
@@ -26,7 +26,11 @@ USAGE:
     1) AZURE_FORM_RECOGNIZER_ENDPOINT - the endpoint to your Cognitive Services resource.
     2) AZURE_FORM_RECOGNIZER_KEY - your Form Recognizer API key
     3) ID_OF_MODEL_TRAINED_WITH_LABELS - the ID of your custom model trained with labels
+        -OR-
+       CONTAINER_SAS_URL_WITH_LABELS - The shared access signature (SAS) Url of your Azure Blob Storage container with your labeled data.
     4) ID_OF_MODEL_TRAINED_WITHOUT_LABELS - the ID of your custom model trained without labels
+        -OR-
+       CONTAINER_SAS_URL_WITHOUT_LABELS - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
 """
 
 import os
@@ -41,14 +45,14 @@ def format_bounding_box(bounding_box):
 
 class DifferentiateOutputModelsTrainedWithAndWithoutLabelsSampleAsync(object):
 
-    async def recognize_custom_forms(self):
+    async def recognize_custom_forms(self, labeled_model_id, unlabeled_model_id):
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.formrecognizer.aio import FormRecognizerClient
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_trained_with_labels_id = os.environ["ID_OF_MODEL_TRAINED_WITH_LABELS"]
-        model_trained_without_labels_id = os.environ["ID_OF_MODEL_TRAINED_WITHOUT_LABELS"]
+        model_trained_with_labels_id = os.environ["ID_OF_MODEL_TRAINED_WITH_LABELS"] or labeled_model_id
+        model_trained_without_labels_id = os.environ["ID_OF_MODEL_TRAINED_WITHOUT_LABELS"] or unlabeled_model_id
 
         path_to_sample_forms = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", "./sample_forms/forms/Form_1.jpg"))
         async with FormRecognizerClient(
@@ -120,7 +124,34 @@ class DifferentiateOutputModelsTrainedWithAndWithoutLabelsSampleAsync(object):
 
 async def main():
     sample = DifferentiateOutputModelsTrainedWithAndWithoutLabelsSampleAsync()
-    await sample.recognize_custom_forms()
+    labeled_model_id = None
+    unlabeled_model_id = None
+    if os.getenv("CONTAINER_SAS_URL_WITH_LABELS") or os.getenv("CONTAINER_SAS_URL_WITHOUT_LABELS"):
+
+        from azure.core.credentials import AzureKeyCredential
+        from azure.ai.formrecognizer.aio import FormTrainingClient
+
+        endpoint = os.getenv("AZURE_FORM_RECOGNIZER_ENDPOINT")
+        key = os.getenv("AZURE_FORM_RECOGNIZER_KEY")
+        labeled = os.getenv("CONTAINER_SAS_URL_WITH_LABELS")
+        unlabeled = os.getenv("CONTAINER_SAS_URL_WITHOUT_LABELS")
+
+        if not endpoint or not key:
+            raise ValueError("Please provide endpoint and API key to run the samples.")
+
+        form_training_client = FormTrainingClient(
+            endpoint=endpoint, credential=AzureKeyCredential(key)
+        )
+
+        async with form_training_client:
+            if labeled:
+                model = await (await form_training_client.begin_training(labeled, use_training_labels=True)).result()
+                labeled_model_id = model.model_id
+            if unlabeled:
+                model = await (await form_training_client.begin_training(unlabeled, use_training_labels=True)).result()
+                unlabeled_model_id = model.model_id
+
+    await sample.recognize_custom_forms(labeled_model_id, unlabeled_model_id)
 
 
 if __name__ == '__main__':

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_models_trained_with_and_without_labels_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_models_trained_with_and_without_labels_async.py
@@ -51,8 +51,8 @@ class DifferentiateOutputModelsTrainedWithAndWithoutLabelsSampleAsync(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_trained_with_labels_id = os.environ["ID_OF_MODEL_TRAINED_WITH_LABELS"] or labeled_model_id
-        model_trained_without_labels_id = os.environ["ID_OF_MODEL_TRAINED_WITHOUT_LABELS"] or unlabeled_model_id
+        model_trained_with_labels_id = os.getenv("ID_OF_MODEL_TRAINED_WITH_LABELS") or labeled_model_id
+        model_trained_without_labels_id = os.getenv("ID_OF_MODEL_TRAINED_WITHOUT_LABELS") or unlabeled_model_id
 
         path_to_sample_forms = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", "./sample_forms/forms/Form_1.jpg"))
         async with FormRecognizerClient(

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_models_trained_with_and_without_labels_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_models_trained_with_and_without_labels_async.py
@@ -13,6 +13,7 @@ DESCRIPTION:
     This sample demonstrates the differences in output that arise when begin_recognize_custom_forms
     is called with custom models trained with labels and without labels. The models used in this
     sample can be created in sample_train_model_with_labels_async.py and sample_train_model_without_labels_async.py
+    using the training files found here: http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
     For a more general example of recognizing custom forms, see sample_recognize_custom_forms_async.py
 
@@ -27,10 +28,12 @@ USAGE:
     2) AZURE_FORM_RECOGNIZER_KEY - your Form Recognizer API key
     3) ID_OF_MODEL_TRAINED_WITH_LABELS - the ID of your custom model trained with labels
         -OR-
-       CONTAINER_SAS_URL_WITH_LABELS - The shared access signature (SAS) Url of your Azure Blob Storage container with your labeled data.
+       CONTAINER_SAS_URL_WITH_LABELS - The shared access signature (SAS) Url of your Azure Blob Storage container with
+       your labeled data. A model will be trained and used to to run the sample.
     4) ID_OF_MODEL_TRAINED_WITHOUT_LABELS - the ID of your custom model trained without labels
         -OR-
-       CONTAINER_SAS_URL_WITHOUT_LABELS - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
+       CONTAINER_SAS_URL_WITHOUT_LABELS - The shared access signature (SAS) Url of your Azure Blob Storage container with
+        your forms. A model will be trained and used to to run the sample.
 """
 
 import os

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_models_trained_with_and_without_labels_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_models_trained_with_and_without_labels_async.py
@@ -13,7 +13,7 @@ DESCRIPTION:
     This sample demonstrates the differences in output that arise when begin_recognize_custom_forms
     is called with custom models trained with labels and without labels. The models used in this
     sample can be created in sample_train_model_with_labels_async.py and sample_train_model_without_labels_async.py
-    using the training files found here: http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+    using the training files found here: https://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
     For a more general example of recognizing custom forms, see sample_recognize_custom_forms_async.py
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_models_trained_with_and_without_labels_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_models_trained_with_and_without_labels_async.py
@@ -29,11 +29,11 @@ USAGE:
     3) ID_OF_MODEL_TRAINED_WITH_LABELS - the ID of your custom model trained with labels
         -OR-
        CONTAINER_SAS_URL_WITH_LABELS - The shared access signature (SAS) Url of your Azure Blob Storage container with
-       your labeled data. A model will be trained and used to to run the sample.
+       your labeled data. A model will be trained and used to run the sample.
     4) ID_OF_MODEL_TRAINED_WITHOUT_LABELS - the ID of your custom model trained without labels
         -OR-
        CONTAINER_SAS_URL_WITHOUT_LABELS - The shared access signature (SAS) Url of your Azure Blob Storage container with
-        your forms. A model will be trained and used to to run the sample.
+        your forms. A model will be trained and used to run the sample.
 """
 
 import os
@@ -54,8 +54,8 @@ class DifferentiateOutputModelsTrainedWithAndWithoutLabelsSampleAsync(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_trained_with_labels_id = os.getenv("ID_OF_MODEL_TRAINED_WITH_LABELS") or labeled_model_id
-        model_trained_without_labels_id = os.getenv("ID_OF_MODEL_TRAINED_WITHOUT_LABELS") or unlabeled_model_id
+        model_trained_with_labels_id = os.getenv("ID_OF_MODEL_TRAINED_WITH_LABELS", labeled_model_id)
+        model_trained_without_labels_id = os.getenv("ID_OF_MODEL_TRAINED_WITHOUT_LABELS", unlabeled_model_id)
 
         path_to_sample_forms = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", "./sample_forms/forms/Form_1.jpg"))
         async with FormRecognizerClient(

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_models_trained_with_and_without_labels_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_differentiate_output_models_trained_with_and_without_labels_async.py
@@ -148,7 +148,7 @@ async def main():
                 model = await (await form_training_client.begin_training(labeled, use_training_labels=True)).result()
                 labeled_model_id = model.model_id
             if unlabeled:
-                model = await (await form_training_client.begin_training(unlabeled, use_training_labels=True)).result()
+                model = await (await form_training_client.begin_training(unlabeled, use_training_labels=False)).result()
                 unlabeled_model_id = model.model_id
 
     await sample.recognize_custom_forms(labeled_model_id, unlabeled_model_id)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_get_bounding_boxes_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_get_bounding_boxes_async.py
@@ -133,7 +133,7 @@ async def main():
             endpoint=endpoint, credential=AzureKeyCredential(key)
         )
         async with form_training_client:
-            model = await (await form_training_client.begin_training(os.getenv("CONTAINER_SAS_URL"), use_training_labels=True)).result()
+            model = await (await form_training_client.begin_training(os.getenv("CONTAINER_SAS_URL"), use_training_labels=False)).result()
             model_id = model.model_id
     await sample.get_bounding_boxes(model_id)
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_get_bounding_boxes_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_get_bounding_boxes_async.py
@@ -14,7 +14,7 @@ DESCRIPTION:
     form content and fields, which can be used for manual validation and drawing UI as part of an application.
 
     The model used in this sample can be created in the sample_train_model_without_labels_async.py using the
-    training files in http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+    training files in https://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
 USAGE:
     python sample_get_bounding_boxes_async.py

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_get_bounding_boxes_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_get_bounding_boxes_async.py
@@ -43,7 +43,7 @@ class GetBoundingBoxesSampleAsync(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id = os.environ["CUSTOM_TRAINED_MODEL_ID"] or custom_model_id
+        model_id = os.getenv("CUSTOM_TRAINED_MODEL_ID") or custom_model_id
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_get_bounding_boxes_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_get_bounding_boxes_async.py
@@ -19,6 +19,8 @@ USAGE:
     1) AZURE_FORM_RECOGNIZER_ENDPOINT - the endpoint to your Cognitive Services resource.
     2) AZURE_FORM_RECOGNIZER_KEY - your Form Recognizer API key
     3) CUSTOM_TRAINED_MODEL_ID - the ID of your custom trained model
+        -OR-
+       CONTAINER_SAS_URL - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
 """
 
 import os
@@ -35,13 +37,13 @@ def format_bounding_box(bounding_box):
 
 class GetBoundingBoxesSampleAsync(object):
 
-    async def get_bounding_boxes(self):
+    async def get_bounding_boxes(self, custom_model_id):
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.formrecognizer.aio import FormRecognizerClient
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id = os.environ["CUSTOM_TRAINED_MODEL_ID"]
+        model_id = os.environ["CUSTOM_TRAINED_MODEL_ID"] or custom_model_id
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)
@@ -115,7 +117,25 @@ class GetBoundingBoxesSampleAsync(object):
 
 async def main():
     sample = GetBoundingBoxesSampleAsync()
-    await sample.get_bounding_boxes()
+    model_id = None
+    if os.getenv("CONTAINER_SAS_URL"):
+
+        from azure.core.credentials import AzureKeyCredential
+        from azure.ai.formrecognizer.aio import FormTrainingClient
+
+        endpoint = os.getenv("AZURE_FORM_RECOGNIZER_ENDPOINT")
+        key = os.getenv("AZURE_FORM_RECOGNIZER_KEY")
+
+        if not endpoint or not key:
+            raise ValueError("Please provide endpoint and API key to run the samples.")
+
+        form_training_client = FormTrainingClient(
+            endpoint=endpoint, credential=AzureKeyCredential(key)
+        )
+        async with form_training_client:
+            model = await (await form_training_client.begin_training(os.getenv("CONTAINER_SAS_URL"), use_training_labels=True)).result()
+            model_id = model.model_id
+    await sample.get_bounding_boxes(model_id)
 
 
 if __name__ == '__main__':

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_get_bounding_boxes_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_get_bounding_boxes_async.py
@@ -12,6 +12,10 @@ FILE: sample_get_bounding_boxes_async.py
 DESCRIPTION:
     This sample demonstrates how to get detailed information to visualize the outlines of
     form content and fields, which can be used for manual validation and drawing UI as part of an application.
+
+    The model used in this sample can be created in the sample_train_model_without_labels_async.py using the
+    training files in http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+
 USAGE:
     python sample_get_bounding_boxes_async.py
 
@@ -21,6 +25,7 @@ USAGE:
     3) CUSTOM_TRAINED_MODEL_ID - the ID of your custom trained model
         -OR-
        CONTAINER_SAS_URL - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
+       A model will be trained and used to to run the sample.
 """
 
 import os
@@ -133,7 +138,8 @@ async def main():
             endpoint=endpoint, credential=AzureKeyCredential(key)
         )
         async with form_training_client:
-            model = await (await form_training_client.begin_training(os.getenv("CONTAINER_SAS_URL"), use_training_labels=False)).result()
+            model = await (await form_training_client.begin_training(
+                os.getenv("CONTAINER_SAS_URL"), use_training_labels=False)).result()
             model_id = model.model_id
     await sample.get_bounding_boxes(model_id)
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_get_bounding_boxes_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_get_bounding_boxes_async.py
@@ -25,7 +25,7 @@ USAGE:
     3) CUSTOM_TRAINED_MODEL_ID - the ID of your custom trained model
         -OR-
        CONTAINER_SAS_URL - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
-       A model will be trained and used to to run the sample.
+       A model will be trained and used to run the sample.
 """
 
 import os
@@ -48,7 +48,7 @@ class GetBoundingBoxesSampleAsync(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id = os.getenv("CUSTOM_TRAINED_MODEL_ID") or custom_model_id
+        model_id = os.getenv("CUSTOM_TRAINED_MODEL_ID", custom_model_id)
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_custom_forms_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_custom_forms_async.py
@@ -41,7 +41,7 @@ class RecognizeCustomFormsSampleAsync(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id = os.environ["CUSTOM_TRAINED_MODEL_ID"] or custom_model_id
+        model_id = os.getenv("CUSTOM_TRAINED_MODEL_ID") or custom_model_id
 
         async with FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_custom_forms_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_custom_forms_async.py
@@ -16,7 +16,7 @@ DESCRIPTION:
     sample_train_model_without_labels_async.py and sample_train_model_with_labels_async.py
 
     The model can be trained using the training files found here:
-    http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+    https://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
 USAGE:
     python sample_recognize_custom_forms_async.py

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_custom_forms_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_custom_forms_async.py
@@ -22,6 +22,8 @@ USAGE:
     1) AZURE_FORM_RECOGNIZER_ENDPOINT - the endpoint to your Cognitive Services resource.
     2) AZURE_FORM_RECOGNIZER_KEY - your Form Recognizer API key
     3) CUSTOM_TRAINED_MODEL_ID - the ID of your custom trained model
+        -OR-
+       CONTAINER_SAS_URL - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
 """
 
 import os
@@ -30,7 +32,7 @@ import asyncio
 
 class RecognizeCustomFormsSampleAsync(object):
 
-    async def recognize_custom_forms(self):
+    async def recognize_custom_forms(self, custom_model_id):
         path_to_sample_forms = os.path.abspath(os.path.join(os.path.abspath(__file__),
                                                             "..", "..", "./sample_forms/forms/Form_1.jpg"))
         # [START recognize_custom_forms_async]
@@ -39,7 +41,7 @@ class RecognizeCustomFormsSampleAsync(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id = os.environ["CUSTOM_TRAINED_MODEL_ID"]
+        model_id = os.environ["CUSTOM_TRAINED_MODEL_ID"] or custom_model_id
 
         async with FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)
@@ -102,7 +104,26 @@ class RecognizeCustomFormsSampleAsync(object):
 
 async def main():
     sample = RecognizeCustomFormsSampleAsync()
-    await sample.recognize_custom_forms()
+    model_id = None
+    if os.getenv("CONTAINER_SAS_URL"):
+
+        from azure.core.credentials import AzureKeyCredential
+        from azure.ai.formrecognizer.aio import FormTrainingClient
+
+        endpoint = os.getenv("AZURE_FORM_RECOGNIZER_ENDPOINT")
+        key = os.getenv("AZURE_FORM_RECOGNIZER_KEY")
+
+        if not endpoint or not key:
+            raise ValueError("Please provide endpoint and API key to run the samples.")
+
+        form_training_client = FormTrainingClient(
+            endpoint=endpoint, credential=AzureKeyCredential(key)
+        )
+        async with form_training_client:
+            model = await (await form_training_client.begin_training(os.getenv("CONTAINER_SAS_URL"), use_training_labels=True)).result()
+            model_id = model.model_id
+
+    await sample.recognize_custom_forms(model_id)
 
 
 if __name__ == '__main__':

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_custom_forms_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_custom_forms_async.py
@@ -15,6 +15,9 @@ DESCRIPTION:
     was trained on. To learn how to train your own models, look at
     sample_train_model_without_labels_async.py and sample_train_model_with_labels_async.py
 
+    The model can be trained using the training files found here:
+    http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+
 USAGE:
     python sample_recognize_custom_forms_async.py
 
@@ -24,6 +27,7 @@ USAGE:
     3) CUSTOM_TRAINED_MODEL_ID - the ID of your custom trained model
         -OR-
        CONTAINER_SAS_URL - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
+       A model will be trained and used to to run the sample.
 """
 
 import os
@@ -120,7 +124,8 @@ async def main():
             endpoint=endpoint, credential=AzureKeyCredential(key)
         )
         async with form_training_client:
-            model = await (await form_training_client.begin_training(os.getenv("CONTAINER_SAS_URL"), use_training_labels=True)).result()
+            model = await (await form_training_client.begin_training(
+                os.getenv("CONTAINER_SAS_URL"), use_training_labels=True)).result()
             model_id = model.model_id
 
     await sample.recognize_custom_forms(model_id)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_custom_forms_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_recognize_custom_forms_async.py
@@ -27,7 +27,7 @@ USAGE:
     3) CUSTOM_TRAINED_MODEL_ID - the ID of your custom trained model
         -OR-
        CONTAINER_SAS_URL - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
-       A model will be trained and used to to run the sample.
+       A model will be trained and used to run the sample.
 """
 
 import os
@@ -45,7 +45,7 @@ class RecognizeCustomFormsSampleAsync(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id = os.getenv("CUSTOM_TRAINED_MODEL_ID") or custom_model_id
+        model_id = os.getenv("CUSTOM_TRAINED_MODEL_ID", custom_model_id)
 
         async with FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_train_model_with_labels_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_train_model_with_labels_async.py
@@ -11,7 +11,7 @@ FILE: sample_train_model_with_labels_async.py
 
 DESCRIPTION:
     This sample demonstrates how to train a model with labels. For this sample, you can use the training
-    forms found in http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+    forms found in https://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
     Upload the forms to your storage container and then generate a container SAS URL using these instructions:
     https://docs.microsoft.com/azure/cognitive-services/form-recognizer/quickstarts/python-labeled-data#train-a-model-using-labeled-data

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_train_model_with_labels_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_train_model_with_labels_async.py
@@ -11,7 +11,7 @@ FILE: sample_train_model_with_labels_async.py
 
 DESCRIPTION:
     This sample demonstrates how to train a model with labels. For this sample, you can use the training
-    forms found in https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_forms/training
+    forms found in http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
     Upload the forms to your storage container and then generate a container SAS URL using these instructions:
     https://docs.microsoft.com/azure/cognitive-services/form-recognizer/quickstarts/python-labeled-data#train-a-model-using-labeled-data

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_train_model_without_labels_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_train_model_without_labels_async.py
@@ -11,7 +11,7 @@ FILE: sample_train_model_without_labels_async.py
 
 DESCRIPTION:
     This sample demonstrates how to train a model with unlabeled data. For this sample, you can use the training
-    forms found in http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+    forms found in https://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
     Upload the forms to your storage container and then generate a container SAS URL using these instructions:
     https://docs.microsoft.com/azure/cognitive-services/form-recognizer/quickstarts/python-labeled-data#train-a-model-using-labeled-data

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_train_model_without_labels_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/async_samples/sample_train_model_without_labels_async.py
@@ -11,7 +11,7 @@ FILE: sample_train_model_without_labels_async.py
 
 DESCRIPTION:
     This sample demonstrates how to train a model with unlabeled data. For this sample, you can use the training
-    forms found in https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_forms/training
+    forms found in http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
     Upload the forms to your storage container and then generate a container SAS URL using these instructions:
     https://docs.microsoft.com/azure/cognitive-services/form-recognizer/quickstarts/python-labeled-data#train-a-model-using-labeled-data

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_authentication.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_authentication.py
@@ -28,7 +28,6 @@ USAGE:
     3) AZURE_CLIENT_ID - the client ID of your active directory application.
     4) AZURE_TENANT_ID - the tenant ID of your active directory application.
     5) AZURE_CLIENT_SECRET - the secret of your active directory application.
-    6) AZURE_FORM_RECOGNIZER_AAD_ENDPOINT - the endpoint to your Form Recognizer resource for using AAD.
 """
 
 import os
@@ -58,7 +57,7 @@ class AuthenticationSample(object):
         from azure.ai.formrecognizer import FormRecognizerClient
         from azure.identity import DefaultAzureCredential
 
-        endpoint = os.environ["AZURE_FORM_RECOGNIZER_AAD_ENDPOINT"]
+        endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         credential = DefaultAzureCredential()
 
         form_recognizer_client = FormRecognizerClient(endpoint, credential)
@@ -85,7 +84,7 @@ class AuthenticationSample(object):
         from azure.ai.formrecognizer import FormTrainingClient
         from azure.identity import DefaultAzureCredential
 
-        endpoint = os.environ["AZURE_FORM_RECOGNIZER_AAD_ENDPOINT"]
+        endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         credential = DefaultAzureCredential()
 
         form_training_client = FormTrainingClient(endpoint, credential)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_copy_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_copy_model.py
@@ -15,7 +15,7 @@ DESCRIPTION:
     in the azure portal.
 
     The model used in this sample can be created in the sample_train_model_with_labels.py using the
-    training files in http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+    training files in https://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
 USAGE:
     python sample_copy_model.py

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_copy_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_copy_model.py
@@ -28,7 +28,7 @@ USAGE:
     5) AZURE_SOURCE_MODEL_ID - the model ID from the source resource to be copied over to the target resource.
         - OR -
        CONTAINER_SAS_URL - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
-       A model will be trained and used to to run the sample.
+       A model will be trained and used to run the sample.
     6) AZURE_FORM_RECOGNIZER_TARGET_REGION - the region the target resource was created in
     7) AZURE_FORM_RECOGNIZER_TARGET_RESOURCE_ID - the entire resource ID to the target resource
 """
@@ -46,7 +46,7 @@ class CopyModelSample(object):
         source_key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
         target_endpoint = os.environ["AZURE_FORM_RECOGNIZER_TARGET_ENDPOINT"]
         target_key = os.environ["AZURE_FORM_RECOGNIZER_TARGET_KEY"]
-        source_model_id = os.getenv("AZURE_SOURCE_MODEL_ID") or custom_model_id
+        source_model_id = os.getenv("AZURE_SOURCE_MODEL_ID", custom_model_id)
         target_region = os.environ["AZURE_FORM_RECOGNIZER_TARGET_REGION"]
         target_resource_id = os.environ["AZURE_FORM_RECOGNIZER_TARGET_RESOURCE_ID"]
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_copy_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_copy_model.py
@@ -23,6 +23,8 @@ USAGE:
     3) AZURE_FORM_RECOGNIZER_TARGET_ENDPOINT - the endpoint to your target Form Recognizer resource.
     4) AZURE_FORM_RECOGNIZER_TARGET_KEY - your target Form Recognizer API key
     5) AZURE_SOURCE_MODEL_ID - the model ID from the source resource to be copied over to the target resource.
+        - OR -
+       CONTAINER_SAS_URL - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
     6) AZURE_FORM_RECOGNIZER_TARGET_REGION - the region the target resource was created in
     7) AZURE_FORM_RECOGNIZER_TARGET_RESOURCE_ID - the entire resource ID to the target resource
 """
@@ -32,7 +34,7 @@ import os
 
 class CopyModelSample(object):
 
-    def copy_model(self):
+    def copy_model(self, custom_model_id):
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.formrecognizer import FormTrainingClient
 
@@ -40,7 +42,7 @@ class CopyModelSample(object):
         source_key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
         target_endpoint = os.environ["AZURE_FORM_RECOGNIZER_TARGET_ENDPOINT"]
         target_key = os.environ["AZURE_FORM_RECOGNIZER_TARGET_KEY"]
-        source_model_id = os.environ["AZURE_SOURCE_MODEL_ID"]
+        source_model_id = os.environ["AZURE_SOURCE_MODEL_ID"] or custom_model_id
         target_region = os.environ["AZURE_FORM_RECOGNIZER_TARGET_REGION"]
         target_resource_id = os.environ["AZURE_FORM_RECOGNIZER_TARGET_RESOURCE_ID"]
 
@@ -71,4 +73,22 @@ class CopyModelSample(object):
 
 if __name__ == '__main__':
     sample = CopyModelSample()
-    sample.copy_model()
+    model_id = None
+    if os.getenv("CONTAINER_SAS_URL"):
+
+        from azure.core.credentials import AzureKeyCredential
+        from azure.ai.formrecognizer import FormTrainingClient
+
+        endpoint = os.getenv("AZURE_FORM_RECOGNIZER_ENDPOINT")
+        key = os.getenv("AZURE_FORM_RECOGNIZER_KEY")
+
+        if not endpoint or not key:
+            raise ValueError("Please provide endpoint and API key to run the samples.")
+
+        form_training_client = FormTrainingClient(
+            endpoint=endpoint, credential=AzureKeyCredential(key)
+        )
+        model = form_training_client.begin_training(os.getenv("CONTAINER_SAS_URL"), use_training_labels=True).result()
+        model_id = model.model_id
+
+    sample.copy_model(model_id)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_copy_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_copy_model.py
@@ -42,7 +42,7 @@ class CopyModelSample(object):
         source_key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
         target_endpoint = os.environ["AZURE_FORM_RECOGNIZER_TARGET_ENDPOINT"]
         target_key = os.environ["AZURE_FORM_RECOGNIZER_TARGET_KEY"]
-        source_model_id = os.environ["AZURE_SOURCE_MODEL_ID"] or custom_model_id
+        source_model_id = os.getenv("AZURE_SOURCE_MODEL_ID") or custom_model_id
         target_region = os.environ["AZURE_FORM_RECOGNIZER_TARGET_REGION"]
         target_resource_id = os.environ["AZURE_FORM_RECOGNIZER_TARGET_RESOURCE_ID"]
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_copy_model.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_copy_model.py
@@ -14,6 +14,9 @@ DESCRIPTION:
     to a target Form Recognizer resource. The resource id and the resource region can be found
     in the azure portal.
 
+    The model used in this sample can be created in the sample_train_model_with_labels.py using the
+    training files in http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+
 USAGE:
     python sample_copy_model.py
 
@@ -25,6 +28,7 @@ USAGE:
     5) AZURE_SOURCE_MODEL_ID - the model ID from the source resource to be copied over to the target resource.
         - OR -
        CONTAINER_SAS_URL - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
+       A model will be trained and used to to run the sample.
     6) AZURE_FORM_RECOGNIZER_TARGET_REGION - the region the target resource was created in
     7) AZURE_FORM_RECOGNIZER_TARGET_RESOURCE_ID - the entire resource ID to the target resource
 """

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_labeled_tables.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_labeled_tables.py
@@ -13,8 +13,7 @@ DESCRIPTION:
     This sample demonstrates the differences in output that arise when begin_recognize_custom_forms
     is called with custom models trained with fixed vs. dynamic table tags.
     The models used in this sample can be created in the sample_train_model_with_labels.py using the
-    training files in
-    https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_forms/labeled_tables
+    training files in http://aka.ms/azsdk/formrecognizer/sampletabletrainingfiles
 
     Note that Form Recognizer automatically finds and extracts all tables in your documents whether the tables
     are tagged/labeled or not. Tables extracted automatically by Form Recognizer will be included in the
@@ -31,10 +30,12 @@ USAGE:
     2) AZURE_FORM_RECOGNIZER_KEY - your Form Recognizer API key
     3) MODEL_ID_FIXED_ROW_TABLES - the ID of your custom model trained with labels on fixed row tables
             -OR-
-       CONTAINER_SAS_URL_FIXED - The shared access signature (SAS) Url of your Azure Blob Storage container with your labeled data.
+       CONTAINER_SAS_URL_FIXED - The shared access signature (SAS) Url of your Azure Blob Storage container with
+       your labeled data containing a fixed row table. A model will be trained and used to to run the sample.
     4) MODEL_ID_DYNAMIC_ROW_TABLES - the ID of your custom model trained with labels on dynamic row tables
             -OR-
-       CONTAINER_SAS_URL_DYNAMIC - The shared access signature (SAS) Url of your Azure Blob Storage container with your labeled data.
+       CONTAINER_SAS_URL_DYNAMIC - The shared access signature (SAS) Url of your Azure Blob Storage container with
+       your labeled data containing a dynamic row table. A model will be trained and used to to run the sample.
 """
 
 import os

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_labeled_tables.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_labeled_tables.py
@@ -13,7 +13,7 @@ DESCRIPTION:
     This sample demonstrates the differences in output that arise when begin_recognize_custom_forms
     is called with custom models trained with fixed vs. dynamic table tags.
     The models used in this sample can be created in the sample_train_model_with_labels.py using the
-    training files in http://aka.ms/azsdk/formrecognizer/sampletabletrainingfiles
+    training files in https://aka.ms/azsdk/formrecognizer/sampletabletrainingfiles
 
     Note that Form Recognizer automatically finds and extracts all tables in your documents whether the tables
     are tagged/labeled or not. Tables extracted automatically by Form Recognizer will be included in the

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_labeled_tables.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_labeled_tables.py
@@ -30,7 +30,11 @@ USAGE:
     1) AZURE_FORM_RECOGNIZER_ENDPOINT - the endpoint to your Cognitive Services resource.
     2) AZURE_FORM_RECOGNIZER_KEY - your Form Recognizer API key
     3) MODEL_ID_FIXED_ROW_TABLES - the ID of your custom model trained with labels on fixed row tables
+            -OR-
+       CONTAINER_SAS_URL_FIXED - The shared access signature (SAS) Url of your Azure Blob Storage container with your labeled data.
     4) MODEL_ID_DYNAMIC_ROW_TABLES - the ID of your custom model trained with labels on dynamic row tables
+            -OR-
+       CONTAINER_SAS_URL_DYNAMIC - The shared access signature (SAS) Url of your Azure Blob Storage container with your labeled data.
 """
 
 import os
@@ -38,13 +42,13 @@ import os
 
 class TestDifferentiateOutputLabeledTables(object):
 
-    def test_recognize_tables_fixed_rows(self):
+    def test_recognize_tables_fixed_rows(self, custom_model_id):
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.formrecognizer import FormRecognizerClient
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id_fixed_rows_table = os.environ["MODEL_ID_FIXED_ROW_TABLES"]
+        model_id_fixed_rows_table = os.environ["MODEL_ID_FIXED_ROW_TABLES"] or custom_model_id
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)
@@ -80,13 +84,13 @@ class TestDifferentiateOutputLabeledTables(object):
                         field.confidence
                     ))
 
-    def test_recognize_tables_dynamic_rows(self):
+    def test_recognize_tables_dynamic_rows(self, custom_model_id):
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.formrecognizer import FormRecognizerClient
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id_dynamic_rows_table = os.environ["MODEL_ID_DYNAMIC_ROW_TABLES"]
+        model_id_dynamic_rows_table = os.environ["MODEL_ID_DYNAMIC_ROW_TABLES"] or custom_model_id
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)
@@ -125,5 +129,31 @@ class TestDifferentiateOutputLabeledTables(object):
 
 if __name__ == '__main__':
     sample = TestDifferentiateOutputLabeledTables()
-    sample.test_recognize_tables_fixed_rows()
-    sample.test_recognize_tables_dynamic_rows()
+    fixed_model_id = None
+    dynamic_model_id = None
+    if os.getenv("CONTAINER_SAS_URL_FIXED") or os.getenv("CONTAINER_SAS_URL_DYNAMIC"):
+
+        from azure.core.credentials import AzureKeyCredential
+        from azure.ai.formrecognizer import FormTrainingClient
+
+        endpoint = os.getenv("AZURE_FORM_RECOGNIZER_ENDPOINT")
+        key = os.getenv("AZURE_FORM_RECOGNIZER_KEY")
+        fixed = os.getenv("CONTAINER_SAS_URL_FIXED")
+        dynamic = os.getenv("CONTAINER_SAS_URL_DYNAMIC")
+
+        if not endpoint or not key:
+            raise ValueError("Please provide endpoint and API key to run the samples.")
+
+        form_training_client = FormTrainingClient(
+            endpoint=endpoint, credential=AzureKeyCredential(key)
+        )
+
+        if fixed:
+            model = form_training_client.begin_training(fixed, use_training_labels=True).result()
+            fixed_model_id = model.model_id
+        if dynamic:
+            model = form_training_client.begin_training(dynamic, use_training_labels=True).result()
+            dynamic_model_id = model.model_id
+
+    sample.test_recognize_tables_fixed_rows(fixed_model_id)
+    sample.test_recognize_tables_dynamic_rows(dynamic_model_id)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_labeled_tables.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_labeled_tables.py
@@ -48,7 +48,7 @@ class TestDifferentiateOutputLabeledTables(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id_fixed_rows_table = os.environ["MODEL_ID_FIXED_ROW_TABLES"] or custom_model_id
+        model_id_fixed_rows_table = os.getenv("MODEL_ID_FIXED_ROW_TABLES") or custom_model_id
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)
@@ -90,7 +90,7 @@ class TestDifferentiateOutputLabeledTables(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id_dynamic_rows_table = os.environ["MODEL_ID_DYNAMIC_ROW_TABLES"] or custom_model_id
+        model_id_dynamic_rows_table = os.getenv("MODEL_ID_DYNAMIC_ROW_TABLES") or custom_model_id
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_labeled_tables.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_labeled_tables.py
@@ -31,11 +31,11 @@ USAGE:
     3) MODEL_ID_FIXED_ROW_TABLES - the ID of your custom model trained with labels on fixed row tables
             -OR-
        CONTAINER_SAS_URL_FIXED - The shared access signature (SAS) Url of your Azure Blob Storage container with
-       your labeled data containing a fixed row table. A model will be trained and used to to run the sample.
+       your labeled data containing a fixed row table. A model will be trained and used to run the sample.
     4) MODEL_ID_DYNAMIC_ROW_TABLES - the ID of your custom model trained with labels on dynamic row tables
             -OR-
        CONTAINER_SAS_URL_DYNAMIC - The shared access signature (SAS) Url of your Azure Blob Storage container with
-       your labeled data containing a dynamic row table. A model will be trained and used to to run the sample.
+       your labeled data containing a dynamic row table. A model will be trained and used to run the sample.
 """
 
 import os
@@ -49,7 +49,7 @@ class TestDifferentiateOutputLabeledTables(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id_fixed_rows_table = os.getenv("MODEL_ID_FIXED_ROW_TABLES") or custom_model_id
+        model_id_fixed_rows_table = os.getenv("MODEL_ID_FIXED_ROW_TABLES", custom_model_id)
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)
@@ -91,7 +91,7 @@ class TestDifferentiateOutputLabeledTables(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id_dynamic_rows_table = os.getenv("MODEL_ID_DYNAMIC_ROW_TABLES") or custom_model_id
+        model_id_dynamic_rows_table = os.getenv("MODEL_ID_DYNAMIC_ROW_TABLES", custom_model_id)
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_models_trained_with_and_without_labels.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_models_trained_with_and_without_labels.py
@@ -13,6 +13,7 @@ DESCRIPTION:
     This sample demonstrates the differences in output that arise when begin_recognize_custom_forms
     is called with custom models trained with labeled and unlabeled data. The models used in this
     sample can be created in sample_train_model_with_labels.py and sample_train_model_without_labels.py
+    using the training files found here: http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
     For a more general example of recognizing custom forms, see sample_recognize_custom_forms.py
 
@@ -27,10 +28,12 @@ USAGE:
     2) AZURE_FORM_RECOGNIZER_KEY - your Form Recognizer API key
     3) ID_OF_MODEL_TRAINED_WITH_LABELS - the ID of your custom model trained with labels
         -OR-
-       CONTAINER_SAS_URL_WITH_LABELS - The shared access signature (SAS) Url of your Azure Blob Storage container with your labeled data.
+       CONTAINER_SAS_URL_WITH_LABELS - The shared access signature (SAS) Url of your Azure Blob Storage container
+       with your labeled data. A model will be trained and used to to run the sample.
     4) ID_OF_MODEL_TRAINED_WITHOUT_LABELS - the ID of your custom model trained without labels
         -OR-
-       CONTAINER_SAS_URL_WITHOUT_LABELS - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
+       CONTAINER_SAS_URL_WITHOUT_LABELS - The shared access signature (SAS) Url of your Azure Blob Storage container
+       with your forms. A model will be trained and used to to run the sample.
 """
 
 import os

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_models_trained_with_and_without_labels.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_models_trained_with_and_without_labels.py
@@ -26,7 +26,11 @@ USAGE:
     1) AZURE_FORM_RECOGNIZER_ENDPOINT - the endpoint to your Cognitive Services resource.
     2) AZURE_FORM_RECOGNIZER_KEY - your Form Recognizer API key
     3) ID_OF_MODEL_TRAINED_WITH_LABELS - the ID of your custom model trained with labels
+        -OR-
+       CONTAINER_SAS_URL_WITH_LABELS - The shared access signature (SAS) Url of your Azure Blob Storage container with your labeled data.
     4) ID_OF_MODEL_TRAINED_WITHOUT_LABELS - the ID of your custom model trained without labels
+        -OR-
+       CONTAINER_SAS_URL_WITHOUT_LABELS - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
 """
 
 import os
@@ -39,14 +43,14 @@ def format_bounding_box(bounding_box):
 
 class DifferentiateOutputModelsTrainedWithAndWithoutLabels(object):
 
-    def recognize_custom_forms(self):
+    def recognize_custom_forms(self, labeled_model_id, unlabeled_model_id):
         from azure.core.credentials import AzureKeyCredential
         from azure.ai.formrecognizer import FormRecognizerClient
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_trained_with_labels_id = os.environ["ID_OF_MODEL_TRAINED_WITH_LABELS"]
-        model_trained_without_labels_id = os.environ["ID_OF_MODEL_TRAINED_WITHOUT_LABELS"]
+        model_trained_with_labels_id = os.environ["ID_OF_MODEL_TRAINED_WITH_LABELS"] or labeled_model_id
+        model_trained_without_labels_id = os.environ["ID_OF_MODEL_TRAINED_WITHOUT_LABELS"] or unlabeled_model_id
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)
@@ -120,4 +124,30 @@ class DifferentiateOutputModelsTrainedWithAndWithoutLabels(object):
 
 if __name__ == '__main__':
     sample = DifferentiateOutputModelsTrainedWithAndWithoutLabels()
-    sample.recognize_custom_forms()
+    labeled_model_id = None
+    unlabeled_model_id = None
+    if os.getenv("CONTAINER_SAS_URL_WITH_LABELS") or os.getenv("CONTAINER_SAS_URL_WITHOUT_LABELS"):
+
+        from azure.core.credentials import AzureKeyCredential
+        from azure.ai.formrecognizer import FormTrainingClient
+
+        endpoint = os.getenv("AZURE_FORM_RECOGNIZER_ENDPOINT")
+        key = os.getenv("AZURE_FORM_RECOGNIZER_KEY")
+        labeled = os.getenv("CONTAINER_SAS_URL_WITH_LABELS")
+        unlabeled = os.getenv("CONTAINER_SAS_URL_WITHOUT_LABELS")
+
+        if not endpoint or not key:
+            raise ValueError("Please provide endpoint and API key to run the samples.")
+
+        form_training_client = FormTrainingClient(
+            endpoint=endpoint, credential=AzureKeyCredential(key)
+        )
+
+        if labeled:
+            model = form_training_client.begin_training(labeled, use_training_labels=True).result()
+            labeled_model_id = model.model_id
+        if unlabeled:
+            model = form_training_client.begin_training(unlabeled, use_training_labels=True).result()
+            unlabeled_model_id = model.model_id
+
+    sample.recognize_custom_forms(labeled_model_id, unlabeled_model_id)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_models_trained_with_and_without_labels.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_models_trained_with_and_without_labels.py
@@ -13,7 +13,7 @@ DESCRIPTION:
     This sample demonstrates the differences in output that arise when begin_recognize_custom_forms
     is called with custom models trained with labeled and unlabeled data. The models used in this
     sample can be created in sample_train_model_with_labels.py and sample_train_model_without_labels.py
-    using the training files found here: http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+    using the training files found here: https://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
     For a more general example of recognizing custom forms, see sample_recognize_custom_forms.py
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_models_trained_with_and_without_labels.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_models_trained_with_and_without_labels.py
@@ -147,7 +147,7 @@ if __name__ == '__main__':
             model = form_training_client.begin_training(labeled, use_training_labels=True).result()
             labeled_model_id = model.model_id
         if unlabeled:
-            model = form_training_client.begin_training(unlabeled, use_training_labels=True).result()
+            model = form_training_client.begin_training(unlabeled, use_training_labels=False).result()
             unlabeled_model_id = model.model_id
 
     sample.recognize_custom_forms(labeled_model_id, unlabeled_model_id)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_models_trained_with_and_without_labels.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_models_trained_with_and_without_labels.py
@@ -49,8 +49,8 @@ class DifferentiateOutputModelsTrainedWithAndWithoutLabels(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_trained_with_labels_id = os.environ["ID_OF_MODEL_TRAINED_WITH_LABELS"] or labeled_model_id
-        model_trained_without_labels_id = os.environ["ID_OF_MODEL_TRAINED_WITHOUT_LABELS"] or unlabeled_model_id
+        model_trained_with_labels_id = os.getenv("ID_OF_MODEL_TRAINED_WITH_LABELS") or labeled_model_id
+        model_trained_without_labels_id = os.getenv("ID_OF_MODEL_TRAINED_WITHOUT_LABELS") or unlabeled_model_id
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_models_trained_with_and_without_labels.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_differentiate_output_models_trained_with_and_without_labels.py
@@ -29,11 +29,11 @@ USAGE:
     3) ID_OF_MODEL_TRAINED_WITH_LABELS - the ID of your custom model trained with labels
         -OR-
        CONTAINER_SAS_URL_WITH_LABELS - The shared access signature (SAS) Url of your Azure Blob Storage container
-       with your labeled data. A model will be trained and used to to run the sample.
+       with your labeled data. A model will be trained and used to run the sample.
     4) ID_OF_MODEL_TRAINED_WITHOUT_LABELS - the ID of your custom model trained without labels
         -OR-
        CONTAINER_SAS_URL_WITHOUT_LABELS - The shared access signature (SAS) Url of your Azure Blob Storage container
-       with your forms. A model will be trained and used to to run the sample.
+       with your forms. A model will be trained and used to run the sample.
 """
 
 import os
@@ -52,8 +52,8 @@ class DifferentiateOutputModelsTrainedWithAndWithoutLabels(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_trained_with_labels_id = os.getenv("ID_OF_MODEL_TRAINED_WITH_LABELS") or labeled_model_id
-        model_trained_without_labels_id = os.getenv("ID_OF_MODEL_TRAINED_WITHOUT_LABELS") or unlabeled_model_id
+        model_trained_with_labels_id = os.getenv("ID_OF_MODEL_TRAINED_WITH_LABELS", labeled_model_id)
+        model_trained_without_labels_id = os.getenv("ID_OF_MODEL_TRAINED_WITHOUT_LABELS", unlabeled_model_id)
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_get_bounding_boxes.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_get_bounding_boxes.py
@@ -128,7 +128,7 @@ if __name__ == '__main__':
         form_training_client = FormTrainingClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)
         )
-        model = form_training_client.begin_training(os.getenv("CONTAINER_SAS_URL"), use_training_labels=True).result()
+        model = form_training_client.begin_training(os.getenv("CONTAINER_SAS_URL"), use_training_labels=False).result()
         model_id = model.model_id
 
     sample.get_bounding_boxes(model_id)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_get_bounding_boxes.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_get_bounding_boxes.py
@@ -14,7 +14,7 @@ DESCRIPTION:
     form content and fields, which can be used for manual validation and drawing UI as part of an application.
 
     The model used in this sample can be created in the sample_train_model_without_labels.py using the
-    training files in http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+    training files in https://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
 USAGE:
     python sample_get_bounding_boxes.py

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_get_bounding_boxes.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_get_bounding_boxes.py
@@ -42,7 +42,7 @@ class GetBoundingBoxesSample(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id = os.environ["CUSTOM_TRAINED_MODEL_ID"] or custom_model_id
+        model_id = os.getenv("CUSTOM_TRAINED_MODEL_ID") or custom_model_id
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_get_bounding_boxes.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_get_bounding_boxes.py
@@ -12,6 +12,10 @@ FILE: sample_get_bounding_boxes.py
 DESCRIPTION:
     This sample demonstrates how to get detailed information to visualize the outlines of
     form content and fields, which can be used for manual validation and drawing UI as part of an application.
+
+    The model used in this sample can be created in the sample_train_model_without_labels.py using the
+    training files in http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+
 USAGE:
     python sample_get_bounding_boxes.py
 
@@ -21,6 +25,7 @@ USAGE:
     3) CUSTOM_TRAINED_MODEL_ID - the ID of your custom trained model
         -OR-
        CONTAINER_SAS_URL - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
+       A model will be trained and used to to run the sample.
 """
 
 import os

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_get_bounding_boxes.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_get_bounding_boxes.py
@@ -25,7 +25,7 @@ USAGE:
     3) CUSTOM_TRAINED_MODEL_ID - the ID of your custom trained model
         -OR-
        CONTAINER_SAS_URL - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
-       A model will be trained and used to to run the sample.
+       A model will be trained and used to run the sample.
 """
 
 import os
@@ -47,7 +47,7 @@ class GetBoundingBoxesSample(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id = os.getenv("CUSTOM_TRAINED_MODEL_ID") or custom_model_id
+        model_id = os.getenv("CUSTOM_TRAINED_MODEL_ID", custom_model_id)
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_custom_forms.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_custom_forms.py
@@ -27,7 +27,7 @@ USAGE:
     3) CUSTOM_TRAINED_MODEL_ID - the ID of your custom trained model
         -OR-
        CONTAINER_SAS_URL - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
-       A model will be trained and used to to run the sample.
+       A model will be trained and used to run the sample.
 """
 
 import os
@@ -44,7 +44,7 @@ class RecognizeCustomForms(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id = os.getenv("CUSTOM_TRAINED_MODEL_ID") or custom_model_id
+        model_id = os.getenv("CUSTOM_TRAINED_MODEL_ID", custom_model_id)
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_custom_forms.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_custom_forms.py
@@ -40,7 +40,7 @@ class RecognizeCustomForms(object):
 
         endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
         key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
-        model_id = os.environ["CUSTOM_TRAINED_MODEL_ID"] or custom_model_id
+        model_id = os.getenv("CUSTOM_TRAINED_MODEL_ID") or custom_model_id
 
         form_recognizer_client = FormRecognizerClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_custom_forms.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_custom_forms.py
@@ -16,7 +16,7 @@ DESCRIPTION:
     sample_train_model_without_labels.py and sample_train_model_with_labels.py
 
     The model can be trained using the training files found here:
-    http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+    https://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
 USAGE:
     python sample_recognize_custom_forms.py

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_custom_forms.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_recognize_custom_forms.py
@@ -15,6 +15,9 @@ DESCRIPTION:
     was trained on. To learn how to train your own models, look at
     sample_train_model_without_labels.py and sample_train_model_with_labels.py
 
+    The model can be trained using the training files found here:
+    http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+
 USAGE:
     python sample_recognize_custom_forms.py
 
@@ -24,6 +27,7 @@ USAGE:
     3) CUSTOM_TRAINED_MODEL_ID - the ID of your custom trained model
         -OR-
        CONTAINER_SAS_URL - The shared access signature (SAS) Url of your Azure Blob Storage container with your forms.
+       A model will be trained and used to to run the sample.
 """
 
 import os

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_train_model_with_labels.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_train_model_with_labels.py
@@ -11,7 +11,7 @@ FILE: sample_train_model_with_labels.py
 
 DESCRIPTION:
     This sample demonstrates how to train a model with labels. For this sample, you can use the training
-    forms found in http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+    forms found in https://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
     Upload the forms to your storage container and then generate a container SAS URL using these instructions:
     https://docs.microsoft.com/azure/cognitive-services/form-recognizer/quickstarts/python-labeled-data#train-a-model-using-labeled-data

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_train_model_with_labels.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_train_model_with_labels.py
@@ -11,7 +11,7 @@ FILE: sample_train_model_with_labels.py
 
 DESCRIPTION:
     This sample demonstrates how to train a model with labels. For this sample, you can use the training
-    forms found in https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_forms/training
+    forms found in http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
     Upload the forms to your storage container and then generate a container SAS URL using these instructions:
     https://docs.microsoft.com/azure/cognitive-services/form-recognizer/quickstarts/python-labeled-data#train-a-model-using-labeled-data

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_train_model_without_labels.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_train_model_without_labels.py
@@ -11,7 +11,7 @@ FILE: sample_train_model_without_labels.py
 
 DESCRIPTION:
     This sample demonstrates how to train a model with unlabeled data. For this sample, you can use the training
-    forms found in http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
+    forms found in https://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
     Upload the forms to your storage container and then generate a container SAS URL using these instructions:
     https://docs.microsoft.com/azure/cognitive-services/form-recognizer/quickstarts/python-labeled-data#train-a-model-using-labeled-data

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_train_model_without_labels.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_train_model_without_labels.py
@@ -11,7 +11,7 @@ FILE: sample_train_model_without_labels.py
 
 DESCRIPTION:
     This sample demonstrates how to train a model with unlabeled data. For this sample, you can use the training
-    forms found in https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/formrecognizer/azure-ai-formrecognizer/samples/sample_forms/training
+    forms found in http://aka.ms/azsdk/formrecognizer/sampletrainingfiles
 
     Upload the forms to your storage container and then generate a container SAS URL using these instructions:
     https://docs.microsoft.com/azure/cognitive-services/form-recognizer/quickstarts/python-labeled-data#train-a-model-using-labeled-data

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/testcase.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/testcase.py
@@ -9,6 +9,7 @@
 import os
 import six
 import logging
+import pytest
 from azure.core.credentials import AccessToken
 from azure.ai.formrecognizer._helpers import (
     adjust_value_type,
@@ -111,7 +112,7 @@ class FakeTokenCredential(object):
     def get_token(self, *args):
         return self.token
 
-
+@pytest.mark.skip
 class FormRecognizerTest(AzureTestCase):
     FILTER_HEADERS = ReplayableTest.FILTER_HEADERS + ['Ocp-Apim-Subscription-Key']
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/testcase.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/testcase.py
@@ -9,7 +9,6 @@
 import os
 import six
 import logging
-import pytest
 from azure.core.credentials import AccessToken
 from azure.ai.formrecognizer._helpers import (
     adjust_value_type,

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/testcase.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/testcase.py
@@ -112,7 +112,7 @@ class FakeTokenCredential(object):
     def get_token(self, *args):
         return self.token
 
-@pytest.mark.skip
+
 class FormRecognizerTest(AzureTestCase):
     FILTER_HEADERS = ReplayableTest.FILTER_HEADERS + ['Ocp-Apim-Subscription-Key']
 

--- a/sdk/formrecognizer/test-resources.json
+++ b/sdk/formrecognizer/test-resources.json
@@ -260,6 +260,58 @@
         "PURCHASE_ORDER_OFFICE_CLEANING_SUPPLIES_SAS_URL": {
             "type": "string",
             "value": "[concat(reference(parameters('blobResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('trainingDataContainer'), '?', listServiceSas(parameters('blobResourceId'), '2019-06-01', parameters('trainingDataSasProperties')).serviceSasToken)]"
+        },
+        "AZURE_FORM_RECOGNIZER_ENDPOINT": {
+            "type": "string",
+            "value": "[variables('azureFormRecognizerUrl')]"
+        },
+        "AZURE_FORM_RECOGNIZER_KEY": {
+            "type": "string",
+            "value": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', variables('formRecognizerBaseName')), variables('formRecognizerApiVersion')).key1]"
+        },
+        "AZURE_FORM_RECOGNIZER_SOURCE_ENDPOINT": {
+            "type": "string",
+            "value": "[variables('azureFormRecognizerUrl')]"
+        },
+        "AZURE_FORM_RECOGNIZER_SOURCE_KEY": {
+            "type": "string",
+            "value": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', variables('formRecognizerBaseName')), variables('formRecognizerApiVersion')).key1]"
+        },
+        "AZURE_FORM_RECOGNIZER_TARGET_ENDPOINT": {
+            "type": "string",
+            "value": "[variables('azureFormRecognizerUrl')]"
+        },
+        "AZURE_FORM_RECOGNIZER_TARGET_KEY": {
+            "type": "string",
+            "value": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', variables('formRecognizerBaseName')), variables('formRecognizerApiVersion')).key1]"
+        },
+        "AZURE_FORM_RECOGNIZER_TARGET_REGION": {
+            "type": "string",
+            "value": "[parameters('location')]"
+        },
+        "AZURE_FORM_RECOGNIZER_TARGET_RESOURCE_ID": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.CognitiveServices/accounts', variables('formRecognizerBaseName'))]"
+        },
+        "CONTAINER_SAS_URL": {
+            "type": "string",
+            "value": "[concat(reference(parameters('blobResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('trainingDataContainer'), '?', listServiceSas(parameters('blobResourceId'), '2019-06-01', parameters('trainingDataSasProperties')).serviceSasToken)]"
+        },
+        "CONTAINER_SAS_URL_WITH_LABELS": {
+            "type": "string",
+            "value": "[concat(reference(parameters('blobResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('trainingDataContainer'), '?', listServiceSas(parameters('blobResourceId'), '2019-06-01', parameters('trainingDataSasProperties')).serviceSasToken)]"
+        },
+        "CONTAINER_SAS_URL_WITHOUT_LABELS": {
+            "type": "string",
+            "value": "[concat(reference(parameters('blobResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('trainingDataContainer'), '?', listServiceSas(parameters('blobResourceId'), '2019-06-01', parameters('trainingDataSasProperties')).serviceSasToken)]"
+        },
+        "CONTAINER_SAS_URL_FIXED": {
+            "type": "string",
+            "value": "[concat(reference(parameters('blobResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('labelTablesFixedRowsContainer'), '?', listServiceSas(parameters('blobResourceId'), '2019-06-01', parameters('labelTablesFixedRowsSasProperties')).serviceSasToken)]"
+        },
+        "CONTAINER_SAS_URL_DYNAMIC": {
+            "type": "string",
+            "value": "[concat(reference(parameters('blobResourceId'), '2019-06-01').primaryEndpoints.blob, parameters('labelTablesVariableRowsContainer'), '?', listServiceSas(parameters('blobResourceId'), '2019-06-01', parameters('labelTablesVariableRowsSasProperties')).serviceSasToken)]"
         }
     }
 }

--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -30,19 +30,3 @@ stages:
         TEST_MODE: 'RunLiveNoRecord'
         AZURE_SKIP_LIVE_RECORDING: 'True'
         AZURE_TEST_RUN_LIVE: 'true'
-        # EnvVars for samples to run. TODO: These use an existing FR resource. Fix samples so they don't have to
-        AZURE_FORM_RECOGNIZER_AAD_ENDPOINT: $(python-formrecognizer-test-aad-endpoint)
-        AZURE_FORM_RECOGNIZER_ENDPOINT: $(python-formrecognizer-test-endpoint)
-        AZURE_FORM_RECOGNIZER_KEY: $(python-formrecognizer-test-endpoint-key)
-        CUSTOM_TRAINED_MODEL_ID: $(python-formrecognizer-test-model-trained-without-labels)
-        AZURE_SOURCE_MODEL_ID: $(python-formrecognizer-test-model-trained-with-labels)
-        ID_OF_MODEL_TRAINED_WITH_LABELS: $(python-formrecognizer-test-model-trained-with-labels)
-        ID_OF_MODEL_TRAINED_WITHOUT_LABELS: $(python-formrecognizer-test-model-trained-without-labels)
-        AZURE_FORM_RECOGNIZER_SOURCE_ENDPOINT: $(python-formrecognizer-test-endpoint)
-        AZURE_FORM_RECOGNIZER_SOURCE_KEY: $(python-formrecognizer-test-endpoint-key)
-        AZURE_FORM_RECOGNIZER_TARGET_ENDPOINT: $(python-formrecognizer-test-endpoint)
-        AZURE_FORM_RECOGNIZER_TARGET_KEY: $(python-formrecognizer-test-endpoint-key)
-        AZURE_FORM_RECOGNIZER_TARGET_REGION: $(python-formrecognizer-test-target-region)
-        AZURE_FORM_RECOGNIZER_TARGET_RESOURCE_ID: $(python-formrecognizer-test-target-resource-id)
-        MODEL_ID_FIXED_ROW_TABLES: $(python-formrecognizer-test-model-id-fixed-row-tables)
-        MODEL_ID_DYNAMIC_ROW_TABLES: $(python-formrecognizer-test-model-id-dynamic-row-tables)


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/18465

- Adds the option to provide a model_id or train a model for any sample that requires a model_id to run. 
- Improves docs to point to the sample training files location.
- Removes the last of our static environment variables so samples no longer need to rely on an existing FR resource. This means I don't have to maintain said resource and periodically delete models from it. :)