### PR TITLE
[ServiceBus] Fix receiver iterator stops after recovery from error

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Bug Fixes**
 
-* Fixed a bug that the receiver iterator stops receiving and returns after recovery from LinkDetachError (#18795).
+* Fixed a bug that `ServiceBusReceiver` iterator stops iteration after recovery from connection error (#18795).
 
 ## 7.2.0 (2021-05-13)
 

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 7.3.0 (Unreleased)
+
+**Bug Fixes**
+
+* Fixed a bug that the receiver iterator stops receiving and returns after recovery from LinkDetachError (#18795).
+
 ## 7.2.0 (2021-05-13)
 
 The preview features related to AMQPAnnotatedMessage introduced in 7.2.0b1 are not included in this version.

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -503,6 +503,10 @@ class ServiceBusReceiver(
             timeout=timeout,
         )
 
+    def _close_handler(self):
+        self._message_iter = None
+        super(ServiceBusReceiver, self)._close_handler()
+
     @property
     def session(self):
         # type: () -> ServiceBusSession

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_version.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "7.2.0"
+VERSION = "7.3.0"

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
@@ -503,6 +503,10 @@ class ServiceBusReceiver(collections.abc.AsyncIterator, BaseHandler, ReceiverMix
             timeout=timeout,
         )
 
+    async def _close_handler(self):
+        self._message_iter = None
+        await super(ServiceBusReceiver, self)._close_handler()
+
     @property
     def session(self) -> ServiceBusSession:
         """

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -2376,3 +2376,45 @@ class ServiceBusQueueTests(AzureMgmtTestCase):
                         sender.schedule_messages(message_dict, scheduled_enqueue_time)
                     with pytest.raises(TypeError):
                         sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    def test_queue_receive_iterator_resume_after_link_detach(self, servicebus_namespace_connection_string, servicebus_queue, **kwargs):
+
+        def hack_iter_next_mock_error(self):
+            self._open()
+            # when trying to receive the second message (execution_times is 1), raising LinkDetach error to mock 10 mins idle timeout
+            if self.execution_times == 1:
+                from uamqp.errors import LinkDetach
+                from uamqp.constants import ErrorCodes
+                self.execution_times += 1
+                self.error_raised = True
+                raise LinkDetach(ErrorCodes.LinkDetachForced)
+            else:
+                self.execution_times += 1
+            if not self._message_iter:
+                self._message_iter = self._handler.receive_messages_iter()
+            uamqp_message = next(self._message_iter)
+            message = self._build_message(uamqp_message)
+            return message
+
+        with ServiceBusClient.from_connection_string(
+                servicebus_namespace_connection_string, logging_enable=False) as sb_client:
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                sender.send_messages(
+                    [ServiceBusMessage("test1"), ServiceBusMessage("test2"), ServiceBusMessage("test3")]
+                )
+            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+                receiver.execution_times = 0
+                receiver.error_raised = False
+                receiver._iter_next = types.MethodType(hack_iter_next_mock_error, receiver)
+                res = []
+                for msg in receiver:
+                    receiver.complete_message(msg)
+                    res.append(msg)
+                assert len(res) == 3
+                assert receiver.error_raised
+                assert receiver.execution_times >= 4  # at least 1 failure and 3 successful receiving iterator


### PR DESCRIPTION
fixing issue: https://github.com/Azure/azure-sdk-for-python/issues/18795


once we encounter a connection error, we will shutdown the broken amqp handler and create a new one.
however, the internal service bus message iterator hooked with the amqp handler was not cleaned up when we were shutting down the broken amqp handler.

so to fix this, we just need to set the internal service bus message iterator to None when we shutdown the broken amqp handler.