### PR TITLE
Retry on storage account preparer to fix live tests

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-blob/tests/_shared/testcase.py
@@ -38,6 +38,7 @@ try:
 except ImportError:
     from io import StringIO
 
+from azure.core.exceptions import ResourceNotFoundError
 from azure.core.credentials import AccessToken
 from azure.storage.blob import generate_account_sas, AccountSasPermissions, ResourceTypes
 from azure.mgmt.storage.models import StorageAccount, Endpoints
@@ -123,6 +124,7 @@ class GlobalStorageAccountPreparer(AzureMgmtPreparer):
             'storage_account_key': StorageTestCase._STORAGE_KEY,
             'storage_account_cs': StorageTestCase._STORAGE_CONNECTION_STRING,
         }
+
 
 class GlobalResourceGroupPreparer(AzureMgmtPreparer):
     def __init__(self):
@@ -496,5 +498,9 @@ def storage_account():
                 )
     finally:
         if i_need_to_create_rg:
-            rg_preparer.remove_resource(rg_name)
+            try:
+                rg_preparer.remove_resource(rg_name)
+            # This covers the case where another test had already removed the resource group
+            except ResourceNotFoundError:
+                pass
         StorageTestCase._RESOURCE_GROUP = None

--- a/sdk/storage/azure-storage-blob/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-blob/tests/_shared/testcase.py
@@ -399,16 +399,9 @@ def storage_account():
     got_storage_info_from_env = existing_storage_name or storage_connection_string
 
     try:
-        retries = 5
         if i_need_to_create_rg:
-            for i in range(retries):
-                try:
-                    time.sleep(i) if i == 0 else time.sleep(2 ** i)
-                    rg_name, rg_kwargs = rg_preparer._prepare_create_resource(test_case)
-                    rg = rg_kwargs['resource_group']
-                    break
-                except HttpResponseError:
-                    continue
+            rg_name, rg_kwargs = rg_preparer._prepare_create_resource(test_case)
+            rg = rg_kwargs['resource_group']
         else:
             rg_name = existing_rg_name or "no_rg_needed"
             rg = FakeResource(

--- a/sdk/storage/azure-storage-blob/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-blob/tests/_shared/testcase.py
@@ -397,9 +397,16 @@ def storage_account():
     got_storage_info_from_env = existing_storage_name or storage_connection_string
 
     try:
+        retries = 5
         if i_need_to_create_rg:
-            rg_name, rg_kwargs = rg_preparer._prepare_create_resource(test_case)
-            rg = rg_kwargs['resource_group']
+            for i in range(retries):
+                try:
+                    time.sleep(i) if i == 0 else time.sleep(i + 3)
+                    rg_name, rg_kwargs = rg_preparer._prepare_create_resource(test_case)
+                    rg = rg_kwargs['resource_group']
+                    break
+                except:
+                    continue
         else:
             rg_name = existing_rg_name or "no_rg_needed"
             rg = FakeResource(

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -410,9 +410,9 @@ class StorageCommonBlobAsyncTest(AsyncStorageTestCase):
     async def test_create_blob_with_requests_async(self, resource_group, location, storage_account, storage_account_key):
         await self._setup(storage_account, storage_account_key)
         # Act
-        uri = "https://www.gutenberg.org/files/59466/59466-0.txt"
+        uri = "https://en.wikipedia.org/wiki/Microsoft"
         data = requests.get(uri, stream=True)
-        blob = self.bsc.get_blob_client(self.container_name, "gutenberg")
+        blob = self.bsc.get_blob_client(self.container_name, "msft")
         resp = await blob.upload_blob(data=data.raw, overwrite=True)
 
         self.assertIsNotNone(resp.get('etag'))

--- a/sdk/storage/azure-storage-file-share/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-file-share/tests/_shared/testcase.py
@@ -383,9 +383,16 @@ def storage_account():
     got_storage_info_from_env = existing_storage_name or storage_connection_string
 
     try:
+        retries = 5
         if i_need_to_create_rg:
-            rg_name, rg_kwargs = rg_preparer._prepare_create_resource(test_case)
-            rg = rg_kwargs['resource_group']
+            for i in range(retries):
+                try:
+                    time.sleep(i) if i == 0 else time.sleep(i + 3)
+                    rg_name, rg_kwargs = rg_preparer._prepare_create_resource(test_case)
+                    rg = rg_kwargs['resource_group']
+                    break
+                except:
+                    continue
         else:
             rg_name = existing_rg_name or "no_rg_needed"
             rg = FakeResource(

--- a/sdk/storage/azure-storage-file-share/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-file-share/tests/_shared/testcase.py
@@ -38,7 +38,7 @@ try:
 except ImportError:
     from io import StringIO
 
-from azure.core.exceptions import ResourceNotFoundError
+from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 from azure.core.credentials import AccessToken
 from azure.storage.fileshare import generate_account_sas, AccountSasPermissions, ResourceTypes
 from azure.mgmt.storage.models import StorageAccount, Endpoints
@@ -386,16 +386,9 @@ def storage_account():
     got_storage_info_from_env = existing_storage_name or storage_connection_string
 
     try:
-        retries = 5
         if i_need_to_create_rg:
-            for i in range(retries):
-                try:
-                    time.sleep(i) if i == 0 else time.sleep(i + 3)
-                    rg_name, rg_kwargs = rg_preparer._prepare_create_resource(test_case)
-                    rg = rg_kwargs['resource_group']
-                    break
-                except:
-                    continue
+                rg_name, rg_kwargs = rg_preparer._prepare_create_resource(test_case)
+                rg = rg_kwargs['resource_group']
         else:
             rg_name = existing_rg_name or "no_rg_needed"
             rg = FakeResource(
@@ -468,7 +461,15 @@ def storage_account():
                     storage_key = storage_connection_string_parts["AccountKey"]
 
             else:
-                storage_name, storage_kwargs = storage_preparer._prepare_create_resource(test_case, **rg_kwargs)
+                for i in range(5):
+                    try:
+                        time.sleep(i) if i == 0 else time.sleep(2 ** i)
+                        storage_name, storage_kwargs = storage_preparer._prepare_create_resource(
+                            test_case, **rg_kwargs)
+                        break
+                        # Some tests may be running on the storage account and a conflict may occur. Backoff & Retry.
+                    except HttpResponseError:
+                        continue
                 storage_account = storage_kwargs['storage_account']
                 storage_key = storage_kwargs['storage_account_key']
                 storage_connection_string = storage_kwargs['storage_account_cs']

--- a/sdk/storage/azure-storage-file-share/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-file-share/tests/_shared/testcase.py
@@ -387,8 +387,8 @@ def storage_account():
 
     try:
         if i_need_to_create_rg:
-                rg_name, rg_kwargs = rg_preparer._prepare_create_resource(test_case)
-                rg = rg_kwargs['resource_group']
+            rg_name, rg_kwargs = rg_preparer._prepare_create_resource(test_case)
+            rg = rg_kwargs['resource_group']
         else:
             rg_name = existing_rg_name or "no_rg_needed"
             rg = FakeResource(

--- a/sdk/storage/azure-storage-file-share/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-file-share/tests/_shared/testcase.py
@@ -38,6 +38,7 @@ try:
 except ImportError:
     from io import StringIO
 
+from azure.core.exceptions import ResourceNotFoundError
 from azure.core.credentials import AccessToken
 from azure.storage.fileshare import generate_account_sas, AccountSasPermissions, ResourceTypes
 from azure.mgmt.storage.models import StorageAccount, Endpoints
@@ -51,6 +52,7 @@ import pytest
 
 
 LOGGING_FORMAT = '%(asctime)s %(name)-20s %(levelname)-5s %(message)s'
+
 
 class FakeTokenCredential(object):
     """Protocol for classes able to provide OAuth tokens.
@@ -108,6 +110,7 @@ class GlobalStorageAccountPreparer(AzureMgmtPreparer):
             'storage_account_key': StorageTestCase._STORAGE_KEY,
             'storage_account_cs': StorageTestCase._STORAGE_CONNECTION_STRING,
         }
+
 
 class GlobalResourceGroupPreparer(AzureMgmtPreparer):
     def __init__(self):
@@ -482,5 +485,9 @@ def storage_account():
                 )
     finally:
         if i_need_to_create_rg:
-            rg_preparer.remove_resource(rg_name)
+            try:
+                rg_preparer.remove_resource(rg_name)
+            # This covers the case where another test had already removed the resource group
+            except ResourceNotFoundError:
+                pass
         StorageTestCase._RESOURCE_GROUP = None

--- a/sdk/storage/azure-storage-queue/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-queue/tests/_shared/testcase.py
@@ -5,9 +5,6 @@
 # license information.
 # --------------------------------------------------------------------------
 from __future__ import division
-from contextlib import contextmanager
-import copy
-import inspect
 import os
 import os.path
 import time
@@ -38,7 +35,7 @@ try:
 except ImportError:
     from io import StringIO
 
-from azure.core.exceptions import ResourceNotFoundError
+from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 from azure.core.credentials import AccessToken
 from azure.storage.queue import generate_account_sas, AccountSasPermissions, ResourceTypes
 from azure.mgmt.storage.models import StorageAccount, Endpoints
@@ -386,16 +383,9 @@ def storage_account():
     got_storage_info_from_env = existing_storage_name or storage_connection_string
 
     try:
-        retries = 5
         if i_need_to_create_rg:
-            for i in range(retries):
-                try:
-                    time.sleep(i) if i == 0 else time.sleep(i + 3)
-                    rg_name, rg_kwargs = rg_preparer._prepare_create_resource(test_case)
-                    rg = rg_kwargs['resource_group']
-                    break
-                except:
-                    continue
+            rg_name, rg_kwargs = rg_preparer._prepare_create_resource(test_case)
+            rg = rg_kwargs['resource_group']
         else:
             rg_name = existing_rg_name or "no_rg_needed"
             rg = FakeResource(
@@ -468,7 +458,15 @@ def storage_account():
                     storage_key = storage_connection_string_parts["AccountKey"]
 
             else:
-                storage_name, storage_kwargs = storage_preparer._prepare_create_resource(test_case, **rg_kwargs)
+                for i in range(5):
+                    try:
+                        time.sleep(i) if i == 0 else time.sleep(2 ** i)
+                        storage_name, storage_kwargs = storage_preparer._prepare_create_resource(
+                            test_case, **rg_kwargs)
+                        break
+                        # Some tests may be running on the storage account and a conflict may occur. Backoff & Retry.
+                    except HttpResponseError:
+                        continue
                 storage_account = storage_kwargs['storage_account']
                 storage_key = storage_kwargs['storage_account_key']
                 storage_connection_string = storage_kwargs['storage_account_cs']

--- a/sdk/storage/azure-storage-queue/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-queue/tests/_shared/testcase.py
@@ -383,9 +383,16 @@ def storage_account():
     got_storage_info_from_env = existing_storage_name or storage_connection_string
 
     try:
+        retries = 5
         if i_need_to_create_rg:
-            rg_name, rg_kwargs = rg_preparer._prepare_create_resource(test_case)
-            rg = rg_kwargs['resource_group']
+            for i in range(retries):
+                try:
+                    time.sleep(i) if i == 0 else time.sleep(i + 3)
+                    rg_name, rg_kwargs = rg_preparer._prepare_create_resource(test_case)
+                    rg = rg_kwargs['resource_group']
+                    break
+                except:
+                    continue
         else:
             rg_name = existing_rg_name or "no_rg_needed"
             rg = FakeResource(

--- a/sdk/storage/azure-storage-queue/tests/_shared/testcase.py
+++ b/sdk/storage/azure-storage-queue/tests/_shared/testcase.py
@@ -38,6 +38,7 @@ try:
 except ImportError:
     from io import StringIO
 
+from azure.core.exceptions import ResourceNotFoundError
 from azure.core.credentials import AccessToken
 from azure.storage.queue import generate_account_sas, AccountSasPermissions, ResourceTypes
 from azure.mgmt.storage.models import StorageAccount, Endpoints
@@ -51,6 +52,7 @@ import pytest
 
 
 LOGGING_FORMAT = '%(asctime)s %(name)-20s %(levelname)-5s %(message)s'
+
 
 class FakeTokenCredential(object):
     """Protocol for classes able to provide OAuth tokens.
@@ -108,6 +110,7 @@ class GlobalStorageAccountPreparer(AzureMgmtPreparer):
             'storage_account_key': StorageTestCase._STORAGE_KEY,
             'storage_account_cs': StorageTestCase._STORAGE_CONNECTION_STRING,
         }
+
 
 class GlobalResourceGroupPreparer(AzureMgmtPreparer):
     def __init__(self):
@@ -482,5 +485,9 @@ def storage_account():
                 )
     finally:
         if i_need_to_create_rg:
-            rg_preparer.remove_resource(rg_name)
+            try:
+                rg_preparer.remove_resource(rg_name)
+            # This covers the case where another test had already removed the resource group
+            except ResourceNotFoundError:
+                pass
         StorageTestCase._RESOURCE_GROUP = None


### PR DESCRIPTION
Currently there is many sporadic live test failures related to using `StorageAccountPreparer()`
Though difficult to reproduce, it appears to be due to these tests attempting to create/write to the same storage account within the same resource group. This leads to a `OperationInProgress - requires exclusive access` error. 
I introduced a simple retry + backoff to give these storage accounts time to be created and used per test. After several pipeline runs it seems that fixed it.