### PR TITLE
ACR - Resolve MSDocs Errors

### DIFF
--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_container_registry_client.py
@@ -202,11 +202,13 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         Example
 
         .. code-block:: python
+
             from azure.containerregistry import ContainerRepositoryClient
             from azure.identity import DefaultAzureCredential
             account_url = os.environ["CONTAINERREGISTRY_ENDPOINT"]
             client = ContainerRegistryClient(account_url, DefaultAzureCredential())
             repository_client = client.get_repository("my_repository")
+
         """
         _pipeline = Pipeline(
             transport=TransportWrapper(self._client._client._pipeline._transport),  # pylint: disable=protected-access

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_registry_artifact.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_registry_artifact.py
@@ -72,11 +72,13 @@ class RegistryArtifact(ContainerRegistryBaseClient):
         Example
 
         .. code-block:: python
+
             from azure.containerregistry import ContainerRepositoryClient
             from azure.identity import DefaultAzureCredential
             account_url = os.environ["CONTAINERREGISTRY_ENDPOINT"]
             client = ContainerRepositoryClient(account_url, "my_repository", DefaultAzureCredential())
             client.delete()
+
         """
         return DeleteRepositoryResult._from_generated(  # pylint: disable=protected-access
             self._client.container_registry.delete_repository(self.repository, **kwargs)
@@ -93,12 +95,14 @@ class RegistryArtifact(ContainerRegistryBaseClient):
         Example
 
         .. code-block:: python
+
             from azure.containerregistry import ContainerRepositoryClient
             from azure.identity import DefaultAzureCredential
             account_url = os.environ["CONTAINERREGISTRY_ENDPOINT"]
             client = ContainerRepositoryClient(account_url, "my_repository", DefaultAzureCredential())
             for artifact in client.list_tags():
                 client.delete_tag(tag.name)
+
         """
         self._client.container_registry.delete_tag(self.repository, tag, **kwargs)
 
@@ -113,12 +117,14 @@ class RegistryArtifact(ContainerRegistryBaseClient):
         Example
 
         .. code-block:: python
+
             from azure.containerregistry import ContainerRepositoryClient
             from azure.identity import DefaultAzureCredential
             account_url = os.environ["CONTAINERREGISTRY_ENDPOINT"]
             client = ContainerRepositoryClient(account_url, "my_repository", DefaultAzureCredential())
             for artifact in client.list_manifests():
                 properties = client.get_registry_artifact_properties(artifact.digest)
+
         """
         if not self._digest:
             self._digest = self.tag_or_digest if not _is_tag(self.tag_or_digest) else self._get_digest_from_tag()
@@ -140,12 +146,14 @@ class RegistryArtifact(ContainerRegistryBaseClient):
         Example
 
         .. code-block:: python
+
             from azure.containerregistry import ContainerRepositoryClient
             from azure.identity import DefaultAzureCredential
             account_url = os.environ["CONTAINERREGISTRY_ENDPOINT"]
             client = ContainerRepositoryClient(account_url, "my_repository", DefaultAzureCredential())
             for tag in client.list_tags():
                 tag_properties = client.get_tag_properties(tag.name)
+
         """
         return ArtifactTagProperties._from_generated(  # pylint: disable=protected-access
             self._client.container_registry.get_tag_properties(self.repository, tag, **kwargs),
@@ -170,12 +178,14 @@ class RegistryArtifact(ContainerRegistryBaseClient):
         Example
 
         .. code-block:: python
+
             from azure.containerregistry import ContainerRepositoryClient
             from azure.identity import DefaultAzureCredential
             account_url = os.environ["CONTAINERREGISTRY_ENDPOINT"]
             client = ContainerRepositoryClient(account_url, "my_repository", DefaultAzureCredential())
             for tag in client.list_tags():
                 tag_properties = client.get_tag_properties(tag.name)
+
         """
         name = self.repository
         last = kwargs.pop("last", None)
@@ -296,6 +306,7 @@ class RegistryArtifact(ContainerRegistryBaseClient):
         Example
 
         .. code-block:: python
+
             from azure.containerregistry import ContainerRepositoryClient
             from azure.identity import DefaultAzureCredential
             account_url = os.environ["CONTAINERREGISTRY_ENDPOINT"]
@@ -310,6 +321,7 @@ class RegistryArtifact(ContainerRegistryBaseClient):
                         can_write=False,
                     ),
                 )
+
         """
         if not self._digest:
             self._digest = self.tag_or_digest if _is_tag(self.tag_or_digest) else self._get_digest_from_tag()
@@ -338,6 +350,7 @@ class RegistryArtifact(ContainerRegistryBaseClient):
         Example
 
         .. code-block:: python
+
             from azure.containerregistry import ContainerRepositoryClient
             from azure.identity import DefaultAzureCredential
             account_url = os.environ["CONTAINERREGISTRY_ENDPOINT"]
@@ -352,6 +365,7 @@ class RegistryArtifact(ContainerRegistryBaseClient):
                     can_write=False,
                 ),
             )
+
         """
         return ArtifactTagProperties._from_generated(  # pylint: disable=protected-access
             self._client.container_registry.update_tag_attributes(

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_container_registry_client.py
@@ -196,11 +196,13 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         Example
 
         .. code-block:: python
+
             from azure.containerregistry.aio import ContainerRepositoryClient
             from azure.identity.aio import DefaultAzureCredential
             account_url = os.environ["CONTAINERREGISTRY_ENDPOINT"]
             client = ContainerRegistryClient(account_url, DefaultAzureCredential())
             repository_client = client.get_repository("my_repository")
+
         """
         _pipeline = AsyncPipeline(
             transport=AsyncTransportWrapper(

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_registry_artifact.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_registry_artifact.py
@@ -86,11 +86,13 @@ class RegistryArtifact(ContainerRegistryBaseClient):
         Example
 
         .. code-block:: python
+
             from azure.containerregistry.aio import ContainerRepositoryClient
             from azure.identity.aio import DefaultAzureCredential
             account_url = os.environ["CONTAINERREGISTRY_ENDPOINT"]
             client = ContainerRepositoryClient(account_url, "my_repository", DefaultAzureCredential())
             await client.delete()
+
         """
         return DeleteRepositoryResult._from_generated(  # pylint: disable=protected-access
             await self._client.container_registry.delete_repository(self.repository, **kwargs)
@@ -106,12 +108,14 @@ class RegistryArtifact(ContainerRegistryBaseClient):
         Example
 
         .. code-block:: python
+
             from azure.containerregistry.aio import ContainerRepositoryClient
             from azure.identity.aio import DefaultAzureCredential
             account_url = os.environ["CONTAINERREGISTRY_ENDPOINT"]
             client = ContainerRepositoryClient(account_url, "my_repository", DefaultAzureCredential())
             async for artifact in client.list_tags():
                 await client.delete_tag(tag.name)
+
         """
         await self._client.container_registry.delete_tag(self.repository, tag, **kwargs)
 
@@ -125,12 +129,14 @@ class RegistryArtifact(ContainerRegistryBaseClient):
         Example
 
         .. code-block:: python
+
             from azure.containerregistry.aio import ContainerRepositoryClient
             from azure.identity.aio import DefaultAzureCredential
             account_url = os.environ["CONTAINERREGISTRY_ENDPOINT"]
             client = ContainerRepositoryClient(account_url, "my_repository", DefaultAzureCredential())
             async for artifact in client.list_manifests():
                 properties = await client.get_registry_artifact_properties(artifact.digest)
+
         """
         if not self._digest:
             self._digest = self.tag_or_digest if not _is_tag(self.tag_or_digest) else await self._get_digest_from_tag()
@@ -151,12 +157,14 @@ class RegistryArtifact(ContainerRegistryBaseClient):
         Example
 
         .. code-block:: python
+
             from azure.containerregistry.aio import ContainerRepositoryClient
             from azure.identity.aio import DefaultAzureCredential
             account_url = os.environ["CONTAINERREGISTRY_ENDPOINT"]
             client = ContainerRepositoryClient(account_url, "my_repository", DefaultAzureCredential())
             async for tag in client.list_tags():
                 tag_properties = await client.get_tag_properties(tag.name)
+
         """
         return ArtifactTagProperties._from_generated(  # pylint: disable=protected-access
             await self._client.container_registry.get_tag_properties(self.repository, tag, **kwargs),
@@ -180,12 +188,14 @@ class RegistryArtifact(ContainerRegistryBaseClient):
         Example
 
         .. code-block:: python
+
             from azure.containerregistry.aio import ContainerRepositoryClient
             from azure.identity.aio import DefaultAzureCredential
             account_url = os.environ["CONTAINERREGISTRY_ENDPOINT"]
             client = ContainerRepositoryClient(account_url, "my_repository", DefaultAzureCredential())
             async for tag in client.list_tags():
                 tag_properties = await client.get_tag_properties(tag.name)
+
         """
         name = self.repository
         last = kwargs.pop("last", None)
@@ -307,6 +317,7 @@ class RegistryArtifact(ContainerRegistryBaseClient):
         Example
 
         .. code-block:: python
+
             from azure.containerregistry.aio import ContainerRepositoryClient
             from azure.identity.aio import DefaultAzureCredential
             account_url = os.environ["CONTAINERREGISTRY_ENDPOINT"]
@@ -321,6 +332,7 @@ class RegistryArtifact(ContainerRegistryBaseClient):
                         can_write=False,
                     ),
                 )
+
         """
         if not self._digest:
             self._digest = self.tag_or_digest if _is_tag(self.tag_or_digest) else self._get_digest_from_tag()
@@ -350,6 +362,7 @@ class RegistryArtifact(ContainerRegistryBaseClient):
         Example
 
         .. code-block:: python
+
             from azure.containerregistry.aio import ContainerRepositoryClient
             from azure.identity.aio import DefaultAzureCredential
             account_url = os.environ["CONTAINERREGISTRY_ENDPOINT"]
@@ -364,6 +377,7 @@ class RegistryArtifact(ContainerRegistryBaseClient):
                     can_write=False,
                 ),
             )
+
         """
         return ArtifactTagProperties._from_generated(  # pylint: disable=protected-access
             await self._client.container_registry.update_tag_attributes(


### PR DESCRIPTION
@seankane-msft I checked our custom pylint plugin and the reason this slipped through is because ACR is using `... codeblock` instead of `... literalinclude`. Our pylint plugin catches the necessary newline because it's not _looking_ at codeblock segments.

I want to submit a PR to add these to our existing pylint checks, but for now, this will getcha online.

Are you comfortable with publishing the current version of this package into our preview docs? (this would be a manually generated 1.0.0b3)
