### PR TITLE
Use built-in matrix components to configure TestSamples behavior

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -44,9 +44,6 @@ parameters:
   - name: TestTimeoutInMinutes
     type: number
     default: 120
-  - name: TestSamples
-    type: boolean
-    default: false
   - name: Location
     type: string
     default: ''
@@ -130,7 +127,6 @@ jobs:
           BuildTargetingString: $(BuildTargetingStringValue)
           ServiceDirectory: ${{ parameters.ServiceDirectory }}
           CoverageArg: $(CoverageArg)
-          TestSamples: ${{ parameters.TestSamples }}
           EnvVars:
             AZURE_RUN_MODE: 'Live' #Record, Playback
             ${{ insert }}: ${{ parameters.EnvVars }}

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -47,9 +47,6 @@ parameters:
   - name: TestTimeoutInMinutes
     type: number
     default: 120
-  - name: TestSamples
-    type: boolean
-    default: false
   - name: Location
     type: string
     default: ''
@@ -129,7 +126,6 @@ stages:
               AllocateResourceGroup: ${{ parameters.AllocateResourceGroup }}
               DeployArmTemplate: ${{ parameters.DeployArmTemplate }}
               TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
-              TestSamples: ${{ parameters.TestSamples }}
             MatrixConfigs:
               # Enumerate platforms and additional platforms based on supported clouds (sparse platform<-->cloud matrix).
               - ${{ each config in parameters.MatrixConfigs }}:

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -1,6 +1,8 @@
 {
   "displayNames": {
-    "--disablecov": ""
+    "--disablecov": "",
+    "false": "",
+    "true": ""
   },
   "matrix": {
     "Agent": {
@@ -9,7 +11,8 @@
       "macOS-10.15": { "OSVmImage": "macOS-10.15", "Pool": "Azure Pipelines" }
     },
     "PythonVersion": [ "pypy3", "2.7", "3.6", "3.7", "3.8" ],
-    "CoverageArg": "--disablecov"
+    "CoverageArg": "--disablecov",
+    "TestSamples": "false"
   },
   "include": [
     {
@@ -18,7 +21,8 @@
           "OSVmImage": "MMSUbuntu18.04",
           "Pool": "azsdk-pool-mms-ubuntu-1804-general",
           "PythonVersion": "3.9",
-          "CoverageArg": ""
+          "CoverageArg": "",
+          "TestSamples": "false"
         }
       }
     }

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -14,7 +14,6 @@ parameters:
   ToxEnvParallel: ''
   InjectedPackages: ''
   DevFeedName: 'public/azure-sdk-for-python'
-  TestSamples: false
 
 steps:
   - pwsh: |
@@ -88,13 +87,13 @@ steps:
       testRunTitle: '$(OSName) Python ${{ parameters.PythonVersion }}'
       failTaskOnFailedTests: true
 
-  - ${{ if eq(parameters['TestSamples'], true) }}:
-    - task: PythonScript@0
-      displayName: 'Test Samples'
-      inputs:
-        scriptPath: 'scripts/devops_tasks/setup_execute_tests.py'
-        arguments: >-
-          "${{ parameters.BuildTargetingString }}"
-          --service="${{ parameters.ServiceDirectory }}"
-          --toxenv="samples"
-      env: ${{ parameters.EnvVars }}
+  - task: PythonScript@0
+    displayName: 'Test Samples'
+    condition: eq(variables['TestSamples'], 'true')
+    inputs:
+      scriptPath: 'scripts/devops_tasks/setup_execute_tests.py'
+      arguments: >-
+        "${{ parameters.BuildTargetingString }}"
+        --service="${{ parameters.ServiceDirectory }}"
+        --toxenv="samples"
+    env: ${{ parameters.EnvVars }}

--- a/sdk/attestation/tests.yml
+++ b/sdk/attestation/tests.yml
@@ -7,4 +7,5 @@ stages:
      ServiceDirectory: attestation
      Location: westus
      DeployArmTemplate: true
-     TestSamples: true
+     MatrixReplace:
+       - TestSamples=.*/true

--- a/sdk/communication/azure-communication-chat/tests.yml
+++ b/sdk/communication/azure-communication-chat/tests.yml
@@ -8,11 +8,12 @@ stages:
       JobName: chat
       ServiceDirectory: communication
       DeployArmTemplate: true
-      TestSamples: true
+      MatrixReplace:
+        - TestSamples=.*/true
       CloudConfig:
         Public:
           SubscriptionConfigurations:
             - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-python)
-      Clouds: Public 
+      Clouds: Public

--- a/sdk/communication/azure-communication-identity/tests.yml
+++ b/sdk/communication/azure-communication-identity/tests.yml
@@ -8,11 +8,12 @@ stages:
       JobName: identity
       ServiceDirectory: communication
       DeployArmTemplate: true
-      TestSamples: true
+      MatrixReplace:
+        - TestSamples=.*/true
       CloudConfig:
         Public:
           SubscriptionConfigurations:
             - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-python)
-      Clouds: Public 
+      Clouds: Public

--- a/sdk/communication/azure-communication-phonenumbers/tests.yml
+++ b/sdk/communication/azure-communication-phonenumbers/tests.yml
@@ -8,11 +8,12 @@ stages:
       JobName: phonenumbers
       ServiceDirectory: communication
       DeployArmTemplate: true
-      TestSamples: true
+      MatrixReplace:
+        - TestSamples=.*/true
       CloudConfig:
         Public:
           SubscriptionConfigurations:
             - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-python)
-      Clouds: Public 
+      Clouds: Public

--- a/sdk/communication/azure-communication-sms/tests.yml
+++ b/sdk/communication/azure-communication-sms/tests.yml
@@ -8,11 +8,12 @@ stages:
       JobName: sms
       ServiceDirectory: communication
       DeployArmTemplate: true
-      TestSamples: true
+      MatrixReplace:
+        - TestSamples=.*/true
       CloudConfig:
         Public:
           SubscriptionConfigurations:
             - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-python)
-      Clouds: Public 
+      Clouds: Public

--- a/sdk/containerregistry/tests.yml
+++ b/sdk/containerregistry/tests.yml
@@ -6,7 +6,8 @@ stages:
       AllocateResourceGroup: false
       BuildTargetingString: azure-containerregistry
       ServiceDirectory: containerregistry
-      TestSamples: true
+      MatrixReplace:
+        - TestSamples=.*/true
       DeployArmTemplate: true
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)

--- a/sdk/eventgrid/tests.yml
+++ b/sdk/eventgrid/tests.yml
@@ -5,7 +5,8 @@ stages:
     parameters:
       ServiceDirectory: eventgrid
       BuildTargetingString: azure-eventgrid*
-      TestSamples: true
+      MatrixReplace:
+        - TestSamples=.*/true
       EnvVars:
         AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -7,7 +7,8 @@ stages:
       ServiceDirectory: eventhub
       BuildTargetingString: azure-eventhub*
       DeployArmTemplate: true
-      TestSamples: true
+      MatrixReplace:
+        - TestSamples=.*/true
       MatrixFilters:
         - PythonVersion=^(?!pypy3).*
       EnvVars:

--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -7,7 +7,8 @@ stages:
       DeployArmTemplate: true
       ServiceDirectory: formrecognizer
       TestTimeoutInMinutes: 200
-      TestSamples: true
+      MatrixReplace:
+        - TestSamples=.*/true
       Clouds: 'Prod,Canary'
       # This is a specific request from the formrecognizer service team
       # their claim is that the full matrix ends up stress-testing their service.

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -6,7 +6,8 @@ stages:
       ServiceDirectory: servicebus
       TestTimeoutInMinutes: 300
       DeployArmTemplate: true
-      TestSamples: true
+      MatrixReplace:
+        - TestSamples=.*/true
       BuildTargetingString: azure-servicebus*
       EnvVars:
         AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)

--- a/sdk/tables/tests.yml
+++ b/sdk/tables/tests.yml
@@ -7,7 +7,8 @@ stages:
       ServiceDirectory: tables
       AllocateResourceGroup: false
       DeployArmTemplate: true
-      TestSamples: true
+      MatrixReplace:
+        - TestSamples=.*/true
       EnvVars:
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
         AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)

--- a/sdk/template/tests.yml
+++ b/sdk/template/tests.yml
@@ -5,7 +5,8 @@ stages:
     parameters:
       AllocateResourceGroup: false
       ServiceDirectory: template
-      TestSamples: true
+      MatrixReplace:
+        - TestSamples=.*/true
       EnvVars:
         TEMPLATE_CONFIG_CONNECTION: $(python-template-connection-string) # Add variables/mappings as appropriate for your service.
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)


### PR DESCRIPTION
While slightly clunkier from a config readability standpoint, this change has the benefit of removing a special case parameter used to flag test behavior in favor of the more globally consistent test matrix method. MatrixReplace is also supported as a parameter that can be specified on a per-cloud/subscription basis in the [CloudConfig](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/389/Configuring-Tests?anchor=cloudconfig-schema).