### PR TITLE
Revert "Temporarily replace macOS CI tests with ubuntu CI tests (#17885)

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -85,14 +85,8 @@ stages:
           - ${{ each config in parameters.AdditionalMatrixConfigs }}:
             -  ${{ config }}
         MatrixFilters: ${{ parameters.MatrixFilters }}
-        MatrixReplace:
-          # Temporarily replace macOS agents with ubuntu agents because of ongoing pool capacity issues
-          - Pool=Azure.Pipelines/azsdk-pool-mms-ubuntu-1804-general
-          - OsVmImage=macOS-10.15/MMSUbuntu18.04
-          - ${{ each replacement in parameters.MatrixReplace }}:
-            - ${{ replacement }}
+        MatrixReplace: ${{ parameters.MatrixReplace }}
         VerifyAutorest: ${{ parameters.VerifyAutorest }}
-
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:


### PR DESCRIPTION
This reverts commit 4e4277271832e7ea3942b994a8c0505ec3d2bcf0.

Azure Pipelines macOS agent capacity seems to be restored now (https://status.dev.azure.com/_event/233282345).