### PR TITLE
Rename internal _identity_config -> identity_config

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/app_service.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/app_service.py
@@ -63,7 +63,7 @@ def _get_client_args(**kwargs):
     return dict(
         kwargs,
         _content_callback=_parse_app_service_expires_on,
-        _identity_config=identity_config,
+        identity_config=identity_config,
         base_headers={"secret": secret},
         request_factory=functools.partial(_get_request, url),
     )

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_arc.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_arc.py
@@ -42,11 +42,9 @@ class AzureArcCredential(GetTokenMixin):
         imds = os.environ.get(EnvironmentVariables.IMDS_ENDPOINT)
         self._available = url and imds
         if self._available:
-            identity_config = kwargs.pop("_identity_config", None) or {}
             config = _get_configuration()
 
             self._client = ManagedIdentityClient(
-                _identity_config=identity_config,
                 policies=_get_policies(config),
                 request_factory=functools.partial(_get_request, url),
                 **kwargs

--- a/sdk/identity/azure-identity/azure/identity/_credentials/cloud_shell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/cloud_shell.py
@@ -28,7 +28,6 @@ class CloudShellCredential(GetTokenMixin):
             self._client = ManagedIdentityClient(
                 request_factory=functools.partial(_get_request, url),
                 base_headers={"Metadata": "true"},
-                _identity_config=kwargs.pop("identity_config", None),
                 **kwargs
             )
         else:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/imds.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/imds.py
@@ -44,9 +44,7 @@ class ImdsCredential(GetTokenMixin):
         # type: (**Any) -> None
         super(ImdsCredential, self).__init__()
 
-        self._client = ManagedIdentityClient(
-            get_request, _identity_config=kwargs.pop("identity_config", None) or {}, **dict(PIPELINE_SETTINGS, **kwargs)
-        )
+        self._client = ManagedIdentityClient(get_request, **dict(PIPELINE_SETTINGS, **kwargs))
         self._endpoint_available = None  # type: Optional[bool]
         self._user_assigned_identity = "client_id" in kwargs or "identity_config" in kwargs
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/service_fabric.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/service_fabric.py
@@ -49,8 +49,6 @@ class ServiceFabricCredential(GetTokenMixin):
 
 def _get_client_args(**kwargs):
     # type: (**Any) -> Optional[dict]
-    identity_config = kwargs.pop("_identity_config", None) or {}
-
     url = os.environ.get(EnvironmentVariables.IDENTITY_ENDPOINT)
     secret = os.environ.get(EnvironmentVariables.IDENTITY_HEADER)
     thumbprint = os.environ.get(EnvironmentVariables.IDENTITY_SERVER_THUMBPRINT)
@@ -60,7 +58,6 @@ def _get_client_args(**kwargs):
 
     return dict(
         kwargs,
-        _identity_config=identity_config,
         base_headers={"Secret": secret},
         connection_verify=False,
         request_factory=functools.partial(_get_request, url),

--- a/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_client.py
@@ -33,7 +33,7 @@ except AttributeError:  # Python 2.7, abc exists, but not ABC
 
 if TYPE_CHECKING:
     # pylint:disable=ungrouped-imports
-    from typing import Any, Callable, List, Optional, Union
+    from typing import Any, Callable, Dict, List, Optional, Union
     from azure.core.pipeline import PipelineResponse
     from azure.core.pipeline.policies import HTTPPolicy, SansIOHTTPPolicy
     from azure.core.pipeline.transport import HttpTransport, HttpRequest
@@ -43,11 +43,11 @@ if TYPE_CHECKING:
 
 class ManagedIdentityClientBase(ABC):
     # pylint:disable=missing-client-constructor-parameter-credential
-    def __init__(self, request_factory, client_id=None, **kwargs):
-        # type: (Callable[[str, dict], HttpRequest], Optional[str], **Any) -> None
+    def __init__(self, request_factory, client_id=None, identity_config=None, **kwargs):
+        # type: (Callable[[str, dict], HttpRequest], Optional[str], Optional[Dict], **Any) -> None
         self._cache = kwargs.pop("_cache", None) or TokenCache()
         self._content_callback = kwargs.pop("_content_callback", None)
-        self._identity_config = kwargs.pop("_identity_config", None) or {}
+        self._identity_config = identity_config or {}
         if client_id:
             self._identity_config["client_id"] = client_id
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_arc.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_arc.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from azure.core.credentials import AccessToken
     from azure.core.pipeline import PipelineRequest, PipelineResponse
     from azure.core.pipeline.policies import SansIOHTTPPolicy
-    from azure.core.pipeline.transport import AsyncHttpResponse, AsyncHttpTransport
+    from azure.core.pipeline.transport import AsyncHttpTransport
 
     PolicyType = Union[AsyncHTTPPolicy, SansIOHTTPPolicy]
 
@@ -42,14 +42,10 @@ class AzureArcCredential(AsyncContextManager, GetTokenMixin):
         imds = os.environ.get(EnvironmentVariables.IMDS_ENDPOINT)
         self._available = url and imds
         if self._available:
-            identity_config = kwargs.pop("_identity_config", None) or {}
             config = _get_configuration()
 
             self._client = AsyncManagedIdentityClient(
-                _identity_config=identity_config,
-                policies=_get_policies(config),
-                request_factory=functools.partial(_get_request, url),
-                **kwargs
+                policies=_get_policies(config), request_factory=functools.partial(_get_request, url), **kwargs
             )
 
     async def get_token(self, *scopes: str, **kwargs: "Any") -> "AccessToken":

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/cloud_shell.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/cloud_shell.py
@@ -27,7 +27,6 @@ class CloudShellCredential(AsyncContextManager, GetTokenMixin):
             self._client = AsyncManagedIdentityClient(
                 request_factory=functools.partial(_get_request, url),
                 base_headers={"Metadata": "true"},
-                _identity_config=kwargs.pop("identity_config", None),
                 **kwargs,
             )
         else:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/imds.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/imds.py
@@ -24,9 +24,7 @@ class ImdsCredential(AsyncContextManager, GetTokenMixin):
     def __init__(self, **kwargs: "Any") -> None:
         super().__init__()
 
-        self._client = AsyncManagedIdentityClient(
-            get_request, _identity_config=kwargs.pop("identity_config", None) or {}, **PIPELINE_SETTINGS, **kwargs
-        )
+        self._client = AsyncManagedIdentityClient(get_request, **PIPELINE_SETTINGS, **kwargs)
         self._endpoint_available = None  # type: Optional[bool]
         self._user_assigned_identity = "client_id" in kwargs or "identity_config" in kwargs
 


### PR DESCRIPTION
`identity_config` is part of ManagedIdentityCredential's public API now, so the indirection that prevents an application from passing it through to ManagedIdentityClient is unnecessary and just confusing.